### PR TITLE
feat(rpc): add reth_forkSchedule RPC method and fork metrics

### DIFF
--- a/.changelog/weak-cows-read.md
+++ b/.changelog/weak-cows-read.md
@@ -1,0 +1,12 @@
+---
+reth-node-metrics: minor
+reth-rpc-api: minor
+reth-rpc: minor
+reth-rpc-builder: patch
+reth-rpc-eth-api: patch
+reth-node-builder: patch
+reth-cli-commands: minor
+reth-e2e-test-utils: patch
+---
+
+Added `reth_forkSchedule` RPC method returning the full hardfork schedule with activation conditions and active status. Extended `ChainSpecInfo` with `from_hardforks` constructor to expose per-fork metrics (block number, timestamp, or TTD) via Prometheus using the generic `Hardforks` trait, supporting both Ethereum and custom chain forks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9435,6 +9435,7 @@ dependencies = [
  "pprof_util",
  "procfs",
  "reqwest",
+ "reth-ethereum-forks",
  "reth-fs-util",
  "reth-metrics",
  "reth-tasks",

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -1,6 +1,6 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_db::version::{get_db_version, DatabaseVersionError, DB_VERSION};
@@ -79,7 +79,7 @@ pub enum Subcommands {
     State(state::Command),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C> {
     /// Execute `db` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -1,6 +1,6 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_db::version::{get_db_version, DatabaseVersionError, DB_VERSION};
@@ -79,7 +79,7 @@ pub enum Subcommands {
     State(state::Command),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>> Command<C> {
     /// Execute `db` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -1,6 +1,6 @@
 use crate::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use clap::{Parser, Subcommand};
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_db::version::{get_db_version, DatabaseVersionError, DB_VERSION};
@@ -79,7 +79,7 @@ pub enum Subcommands {
     State(state::Command),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> Command<C> {
     /// Execute `db` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use metrics::{self, Counter};
-use reth_chainspec::{EthChainSpec, ForkCondition, Hardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_cli_util::parse_socket_address;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
@@ -53,7 +53,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db repair-trie` command
-    pub fn execute<N: ProviderNodeTypes<ChainSpec: Hardforks>>(
+    pub fn execute<N: ProviderNodeTypes<ChainSpec: EthereumHardforks>>(
         self,
         tool: &DbTool<N>,
         task_executor: TaskExecutor,
@@ -67,15 +67,25 @@ impl Command {
                 use reth_node_metrics::chain::ForkActivation;
                 ChainSpecInfo {
                     name: chain_name,
-                    forks: spec.forks_iter().map(|(fork, condition)| {
-                        let (condition_type, activation_value) = match condition {
-                            ForkCondition::Block(block) => ("block".to_string(), Some(block)),
-                            ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
-                            ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
-                            ForkCondition::Never => ("never".to_string(), None),
-                        };
-                        ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
-                    }).collect(),
+                    forks: EthereumHardfork::VARIANTS
+                        .iter()
+                        .map(|fork| {
+                            let condition = spec.ethereum_fork_activation(*fork);
+                            let (condition_type, activation_value) = match condition {
+                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                                ForkCondition::TTD { activation_block_number, .. } => {
+                                    ("ttd".to_string(), Some(activation_block_number))
+                                }
+                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                                ForkCondition::Never => ("never".to_string(), None),
+                            };
+                            ForkActivation {
+                                name: fork.to_string(),
+                                condition_type,
+                                activation_value,
+                            }
+                        })
+                        .collect(),
                 }
             };
             let executor = task_executor.clone();

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use metrics::{self, Counter};
-use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
+use reth_chainspec::EthChainSpec;
 use reth_cli_util::parse_socket_address;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
@@ -53,7 +53,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db repair-trie` command
-    pub fn execute<N: ProviderNodeTypes<ChainSpec: EthereumHardforks>>(
+    pub fn execute<N: ProviderNodeTypes<ChainSpec: reth_chainspec::Hardforks>>(
         self,
         tool: &DbTool<N>,
         task_executor: TaskExecutor,
@@ -63,31 +63,7 @@ impl Command {
         let _metrics_handle = if let Some(listen_addr) = self.metrics {
             let spec = tool.provider_factory.chain_spec();
             let chain_name = spec.chain().to_string();
-            let chain_spec_info = {
-                use reth_node_metrics::chain::ForkActivation;
-                ChainSpecInfo {
-                    name: chain_name,
-                    forks: EthereumHardfork::VARIANTS
-                        .iter()
-                        .map(|fork| {
-                            let condition = spec.ethereum_fork_activation(*fork);
-                            let (condition_type, activation_value) = match condition {
-                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
-                                ForkCondition::TTD { activation_block_number, .. } => {
-                                    ("ttd".to_string(), Some(activation_block_number))
-                                }
-                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
-                                ForkCondition::Never => ("never".to_string(), None),
-                            };
-                            ForkActivation {
-                                name: fork.to_string(),
-                                condition_type,
-                                activation_value,
-                            }
-                        })
-                        .collect(),
-                }
-            };
+            let chain_spec_info = ChainSpecInfo::from_hardforks(chain_name, &*spec);
             let executor = task_executor.clone();
             let pprof_dump_dir = data_dir.pprof_dumps();
 

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use metrics::{self, Counter};
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::{EthChainSpec, ForkCondition, Hardforks};
 use reth_cli_util::parse_socket_address;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
@@ -53,7 +53,7 @@ pub struct Command {
 
 impl Command {
     /// Execute `db repair-trie` command
-    pub fn execute<N: ProviderNodeTypes>(
+    pub fn execute<N: ProviderNodeTypes<ChainSpec: Hardforks>>(
         self,
         tool: &DbTool<N>,
         task_executor: TaskExecutor,
@@ -61,7 +61,23 @@ impl Command {
     ) -> eyre::Result<()> {
         // Set up metrics server if requested
         let _metrics_handle = if let Some(listen_addr) = self.metrics {
-            let chain_name = tool.provider_factory.chain_spec().chain().to_string();
+            let spec = tool.provider_factory.chain_spec();
+            let chain_name = spec.chain().to_string();
+            let chain_spec_info = {
+                use reth_node_metrics::chain::ForkActivation;
+                ChainSpecInfo {
+                    name: chain_name,
+                    forks: spec.forks_iter().map(|(fork, condition)| {
+                        let (condition_type, activation_value) = match condition {
+                            ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                            ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
+                            ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                            ForkCondition::Never => ("never".to_string(), None),
+                        };
+                        ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
+                    }).collect(),
+                }
+            };
             let executor = task_executor.clone();
             let pprof_dump_dir = data_dir.pprof_dumps();
 
@@ -76,7 +92,7 @@ impl Command {
                         target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
                         build_profile: version_metadata().build_profile_name.as_ref(),
                     },
-                    ChainSpecInfo { name: chain_name },
+                    chain_spec_info,
                     executor,
                     Hooks::builder().build(),
                     pprof_dump_dir,

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -1,7 +1,7 @@
 //! Command that runs pruning.
 use crate::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
 use clap::Parser;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::cancellation::CancellationToken;
@@ -30,7 +30,7 @@ pub struct PruneCommand<C: ChainSpecParser> {
     metrics: MetricArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> PruneCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneCommand<C> {
     /// Execute the `prune` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
@@ -56,17 +56,31 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>
                     let spec = provider_factory.chain_spec();
                     ChainSpecInfo {
                         name: spec.chain().to_string(),
-                        forks: spec.forks_iter().map(|(fork, condition)| {
-                            use reth_chainspec::ForkCondition;
-                            use reth_node_metrics::chain::ForkActivation;
-                            let (condition_type, activation_value) = match condition {
-                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
-                                ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
-                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
-                                ForkCondition::Never => ("never".to_string(), None),
-                            };
-                            ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
-                        }).collect(),
+                        forks: EthereumHardfork::VARIANTS
+                            .iter()
+                            .map(|fork| {
+                                use reth_chainspec::ForkCondition;
+                                use reth_node_metrics::chain::ForkActivation;
+                                let condition = spec.ethereum_fork_activation(*fork);
+                                let (condition_type, activation_value) = match condition {
+                                    ForkCondition::Block(block) => {
+                                        ("block".to_string(), Some(block))
+                                    }
+                                    ForkCondition::TTD { activation_block_number, .. } => {
+                                        ("ttd".to_string(), Some(activation_block_number))
+                                    }
+                                    ForkCondition::Timestamp(ts) => {
+                                        ("timestamp".to_string(), Some(ts))
+                                    }
+                                    ForkCondition::Never => ("never".to_string(), None),
+                                };
+                                ForkActivation {
+                                    name: fork.to_string(),
+                                    condition_type,
+                                    activation_value,
+                                }
+                            })
+                            .collect(),
                     }
                 },
                 ctx.task_executor.clone(),

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -1,7 +1,7 @@
 //! Command that runs pruning.
 use crate::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
 use clap::Parser;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardfork, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::cancellation::CancellationToken;
@@ -30,7 +30,7 @@ pub struct PruneCommand<C: ChainSpecParser> {
     metrics: MetricArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks>> PruneCommand<C> {
     /// Execute the `prune` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
@@ -54,34 +54,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
                 },
                 {
                     let spec = provider_factory.chain_spec();
-                    ChainSpecInfo {
-                        name: spec.chain().to_string(),
-                        forks: EthereumHardfork::VARIANTS
-                            .iter()
-                            .map(|fork| {
-                                use reth_chainspec::ForkCondition;
-                                use reth_node_metrics::chain::ForkActivation;
-                                let condition = spec.ethereum_fork_activation(*fork);
-                                let (condition_type, activation_value) = match condition {
-                                    ForkCondition::Block(block) => {
-                                        ("block".to_string(), Some(block))
-                                    }
-                                    ForkCondition::TTD { activation_block_number, .. } => {
-                                        ("ttd".to_string(), Some(activation_block_number))
-                                    }
-                                    ForkCondition::Timestamp(ts) => {
-                                        ("timestamp".to_string(), Some(ts))
-                                    }
-                                    ForkCondition::Never => ("never".to_string(), None),
-                                };
-                                ForkActivation {
-                                    name: fork.to_string(),
-                                    condition_type,
-                                    activation_value,
-                                }
-                            })
-                            .collect(),
-                    }
+                    ChainSpecInfo::from_hardforks(spec.chain().to_string(), &*spec)
                 },
                 ctx.task_executor.clone(),
                 metrics_hooks(&provider_factory),

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -1,7 +1,7 @@
 //! Command that runs pruning.
 use crate::common::{AccessRights, CliNodeTypes, EnvironmentArgs};
 use clap::Parser;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::cancellation::CancellationToken;
@@ -30,7 +30,7 @@ pub struct PruneCommand<C: ChainSpecParser> {
     metrics: MetricArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> PruneCommand<C> {
     /// Execute the `prune` command
     pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
@@ -52,7 +52,23 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
                     target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
                     build_profile: version_metadata().build_profile_name.as_ref(),
                 },
-                ChainSpecInfo { name: provider_factory.chain_spec().chain().to_string() },
+                {
+                    let spec = provider_factory.chain_spec();
+                    ChainSpecInfo {
+                        name: spec.chain().to_string(),
+                        forks: spec.forks_iter().map(|(fork, condition)| {
+                            use reth_chainspec::ForkCondition;
+                            use reth_node_metrics::chain::ForkActivation;
+                            let (condition_type, activation_value) = match condition {
+                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                                ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
+                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                                ForkCondition::Never => ("never".to_string(), None),
+                            };
+                            ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
+                        }).collect(),
+                    }
+                },
                 ctx.task_executor.clone(),
                 metrics_hooks(&provider_factory),
                 data_dir.pprof_dumps(),

--- a/crates/cli/commands/src/stage/mod.rs
+++ b/crates/cli/commands/src/stage/mod.rs
@@ -38,7 +38,7 @@ pub enum Subcommands<C: ChainSpecParser> {
     Unwind(unwind::Command<C>),
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> Command<C> {
     /// Execute `stage` command
     pub async fn execute<N, Comp>(
         self,

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -137,7 +137,23 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
                     build_profile: version_metadata().build_profile_name.as_ref(),
                 },
-                ChainSpecInfo { name: provider_factory.chain_spec().chain().to_string() },
+                {
+                    let spec = provider_factory.chain_spec();
+                    ChainSpecInfo {
+                        name: spec.chain().to_string(),
+                        forks: spec.forks_iter().map(|(fork, condition)| {
+                            use reth_chainspec::ForkCondition;
+                            use reth_node_metrics::chain::ForkActivation;
+                            let (condition_type, activation_value) = match condition {
+                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                                ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
+                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                                ForkCondition::Never => ("never".to_string(), None),
+                            };
+                            ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
+                        }).collect(),
+                    }
+                },
                 ctx.task_executor,
                 metrics_hooks(&provider_factory),
                 data_dir.pprof_dumps(),

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -6,7 +6,7 @@ use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, 
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::Sealable;
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::get_secret_key;
@@ -99,7 +99,7 @@ pub struct Command<C: ChainSpecParser> {
     network: NetworkArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> Command<C> {
     /// Execute `stage` command
     pub async fn execute<N, Comp, F>(self, ctx: CliContext, components: F) -> eyre::Result<()>
     where
@@ -141,17 +141,31 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     let spec = provider_factory.chain_spec();
                     ChainSpecInfo {
                         name: spec.chain().to_string(),
-                        forks: spec.forks_iter().map(|(fork, condition)| {
-                            use reth_chainspec::ForkCondition;
-                            use reth_node_metrics::chain::ForkActivation;
-                            let (condition_type, activation_value) = match condition {
-                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
-                                ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
-                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
-                                ForkCondition::Never => ("never".to_string(), None),
-                            };
-                            ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
-                        }).collect(),
+                        forks: EthereumHardfork::VARIANTS
+                            .iter()
+                            .map(|fork| {
+                                use reth_chainspec::ForkCondition;
+                                use reth_node_metrics::chain::ForkActivation;
+                                let condition = spec.ethereum_fork_activation(*fork);
+                                let (condition_type, activation_value) = match condition {
+                                    ForkCondition::Block(block) => {
+                                        ("block".to_string(), Some(block))
+                                    }
+                                    ForkCondition::TTD { activation_block_number, .. } => {
+                                        ("ttd".to_string(), Some(activation_block_number))
+                                    }
+                                    ForkCondition::Timestamp(ts) => {
+                                        ("timestamp".to_string(), Some(ts))
+                                    }
+                                    ForkCondition::Never => ("never".to_string(), None),
+                                };
+                                ForkActivation {
+                                    name: fork.to_string(),
+                                    condition_type,
+                                    activation_value,
+                                }
+                            })
+                            .collect(),
                     }
                 },
                 ctx.task_executor,

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -6,7 +6,7 @@ use crate::common::{AccessRights, CliNodeComponents, CliNodeTypes, Environment, 
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::Sealable;
 use clap::Parser;
-use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::get_secret_key;
@@ -99,7 +99,7 @@ pub struct Command<C: ChainSpecParser> {
     network: NetworkArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks>> Command<C> {
     /// Execute `stage` command
     pub async fn execute<N, Comp, F>(self, ctx: CliContext, components: F) -> eyre::Result<()>
     where
@@ -139,34 +139,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks + Hardforks>
                 },
                 {
                     let spec = provider_factory.chain_spec();
-                    ChainSpecInfo {
-                        name: spec.chain().to_string(),
-                        forks: EthereumHardfork::VARIANTS
-                            .iter()
-                            .map(|fork| {
-                                use reth_chainspec::ForkCondition;
-                                use reth_node_metrics::chain::ForkActivation;
-                                let condition = spec.ethereum_fork_activation(*fork);
-                                let (condition_type, activation_value) = match condition {
-                                    ForkCondition::Block(block) => {
-                                        ("block".to_string(), Some(block))
-                                    }
-                                    ForkCondition::TTD { activation_block_number, .. } => {
-                                        ("ttd".to_string(), Some(activation_block_number))
-                                    }
-                                    ForkCondition::Timestamp(ts) => {
-                                        ("timestamp".to_string(), Some(ts))
-                                    }
-                                    ForkCondition::Never => ("never".to_string(), None),
-                                };
-                                ForkActivation {
-                                    name: fork.to_string(),
-                                    condition_type,
-                                    activation_value,
-                                }
-                            })
-                            .collect(),
-                    }
+                    ChainSpecInfo::from_hardforks(spec.chain().to_string(), &*spec)
                 },
                 ctx.task_executor,
                 metrics_hooks(&provider_factory),

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 //! Utilities for end-to-end tests.
 
 use node::NodeTestContext;
-use reth_chainspec::{ChainSpec, Hardforks};
+use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_builder::{
@@ -151,7 +151,7 @@ where
             > + EngineValidatorAddOn<
                 Adapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             >,
-            ChainSpec: From<ChainSpec> + Clone + Hardforks,
+            ChainSpec: From<ChainSpec> + Clone + EthereumHardforks,
         >,
 {
 }
@@ -176,7 +176,7 @@ impl<T> NodeBuilderHelper for T where
             > + EngineValidatorAddOn<
                 Adapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             >,
-            ChainSpec: From<ChainSpec> + Clone + Hardforks,
+            ChainSpec: From<ChainSpec> + Clone + EthereumHardforks,
         >
 {
 }

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 //! Utilities for end-to-end tests.
 
 use node::NodeTestContext;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpec, EthereumHardforks, Hardforks};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_builder::{
@@ -151,7 +151,7 @@ where
             > + EngineValidatorAddOn<
                 Adapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             >,
-            ChainSpec: From<ChainSpec> + Clone + EthereumHardforks,
+            ChainSpec: From<ChainSpec> + Clone + Hardforks + EthereumHardforks,
         >,
 {
 }
@@ -176,7 +176,7 @@ impl<T> NodeBuilderHelper for T where
             > + EngineValidatorAddOn<
                 Adapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             >,
-            ChainSpec: From<ChainSpec> + Clone + EthereumHardforks,
+            ChainSpec: From<ChainSpec> + Clone + Hardforks + EthereumHardforks,
         >
 {
 }

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 //! Utilities for end-to-end tests.
 
 use node::NodeTestContext;
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{ChainSpec, Hardforks};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_builder::{
@@ -151,7 +151,7 @@ where
             > + EngineValidatorAddOn<
                 Adapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             >,
-            ChainSpec: From<ChainSpec> + Clone,
+            ChainSpec: From<ChainSpec> + Clone + Hardforks,
         >,
 {
 }
@@ -176,7 +176,7 @@ impl<T> NodeBuilderHelper for T where
             > + EngineValidatorAddOn<
                 Adapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             >,
-            ChainSpec: From<ChainSpec> + Clone,
+            ChainSpec: From<ChainSpec> + Clone + Hardforks,
         >
 {
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -38,7 +38,7 @@ use alloy_eips::eip2124::Head;
 use alloy_primitives::{BlockNumber, B256};
 use eyre::Context;
 use rayon::ThreadPoolBuilder;
-use reth_chainspec::{Chain, EthChainSpec, EthereumHardfork, EthereumHardforks};
+use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks};
 use reth_config::{config::EtlConfig, PruneConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
@@ -612,7 +612,7 @@ where
     /// Convenience function to [`Self::start_prometheus_endpoint`]
     pub async fn with_prometheus_server(self) -> eyre::Result<Self>
     where
-        T::ChainSpec: EthereumHardforks,
+        T::ChainSpec: reth_chainspec::Hardforks,
     {
         self.start_prometheus_endpoint().await?;
         Ok(self)
@@ -621,7 +621,7 @@ where
     /// Starts the prometheus endpoint.
     pub async fn start_prometheus_endpoint(&self) -> eyre::Result<()>
     where
-        T::ChainSpec: EthereumHardforks,
+        T::ChainSpec: reth_chainspec::Hardforks,
     {
         // ensure recorder runs upkeep periodically
         install_prometheus_recorder().spawn_upkeep();
@@ -638,30 +638,7 @@ where
                     target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
                     build_profile: version_metadata().build_profile_name.as_ref(),
                 },
-                ChainSpecInfo {
-                    name: self.chain_id().to_string(),
-                    forks: EthereumHardfork::VARIANTS
-                        .iter()
-                        .map(|fork| {
-                            use reth_chainspec::ForkCondition;
-                            use reth_node_metrics::chain::ForkActivation;
-                            let condition = self.chain_spec().ethereum_fork_activation(*fork);
-                            let (condition_type, activation_value) = match condition {
-                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
-                                ForkCondition::TTD { activation_block_number, .. } => {
-                                    ("ttd".to_string(), Some(activation_block_number))
-                                }
-                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
-                                ForkCondition::Never => ("never".to_string(), None),
-                            };
-                            ForkActivation {
-                                name: fork.name().to_string(),
-                                condition_type,
-                                activation_value,
-                            }
-                        })
-                        .collect(),
-                },
+                ChainSpecInfo::from_hardforks(self.chain_id().to_string(), &*self.chain_spec()),
                 self.task_executor().clone(),
                 metrics_hooks(self.provider_factory()),
                 self.data_dir().pprof_dumps(),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -38,7 +38,7 @@ use alloy_eips::eip2124::Head;
 use alloy_primitives::{BlockNumber, B256};
 use eyre::Context;
 use rayon::ThreadPoolBuilder;
-use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_config::{config::EtlConfig, PruneConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
@@ -610,13 +610,19 @@ where
     /// This launches the prometheus endpoint.
     ///
     /// Convenience function to [`Self::start_prometheus_endpoint`]
-    pub async fn with_prometheus_server(self) -> eyre::Result<Self> {
+    pub async fn with_prometheus_server(self) -> eyre::Result<Self>
+    where
+        T::ChainSpec: Hardforks,
+    {
         self.start_prometheus_endpoint().await?;
         Ok(self)
     }
 
     /// Starts the prometheus endpoint.
-    pub async fn start_prometheus_endpoint(&self) -> eyre::Result<()> {
+    pub async fn start_prometheus_endpoint(&self) -> eyre::Result<()>
+    where
+        T::ChainSpec: Hardforks,
+    {
         // ensure recorder runs upkeep periodically
         install_prometheus_recorder().spawn_upkeep();
 
@@ -632,7 +638,20 @@ where
                     target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
                     build_profile: version_metadata().build_profile_name.as_ref(),
                 },
-                ChainSpecInfo { name: self.chain_id().to_string() },
+                ChainSpecInfo {
+                    name: self.chain_id().to_string(),
+                    forks: self.chain_spec().forks_iter().map(|(fork, condition)| {
+                        use reth_chainspec::ForkCondition;
+                        use reth_node_metrics::chain::ForkActivation;
+                        let (condition_type, activation_value) = match condition {
+                            ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                            ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
+                            ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                            ForkCondition::Never => ("never".to_string(), None),
+                        };
+                        ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
+                    }).collect(),
+                },
                 self.task_executor().clone(),
                 metrics_hooks(self.provider_factory()),
                 self.data_dir().pprof_dumps(),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -38,7 +38,7 @@ use alloy_eips::eip2124::Head;
 use alloy_primitives::{BlockNumber, B256};
 use eyre::Context;
 use rayon::ThreadPoolBuilder;
-use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{Chain, EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_config::{config::EtlConfig, PruneConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
@@ -612,7 +612,7 @@ where
     /// Convenience function to [`Self::start_prometheus_endpoint`]
     pub async fn with_prometheus_server(self) -> eyre::Result<Self>
     where
-        T::ChainSpec: Hardforks,
+        T::ChainSpec: EthereumHardforks,
     {
         self.start_prometheus_endpoint().await?;
         Ok(self)
@@ -621,7 +621,7 @@ where
     /// Starts the prometheus endpoint.
     pub async fn start_prometheus_endpoint(&self) -> eyre::Result<()>
     where
-        T::ChainSpec: Hardforks,
+        T::ChainSpec: EthereumHardforks,
     {
         // ensure recorder runs upkeep periodically
         install_prometheus_recorder().spawn_upkeep();
@@ -640,17 +640,27 @@ where
                 },
                 ChainSpecInfo {
                     name: self.chain_id().to_string(),
-                    forks: self.chain_spec().forks_iter().map(|(fork, condition)| {
-                        use reth_chainspec::ForkCondition;
-                        use reth_node_metrics::chain::ForkActivation;
-                        let (condition_type, activation_value) = match condition {
-                            ForkCondition::Block(block) => ("block".to_string(), Some(block)),
-                            ForkCondition::TTD { activation_block_number, .. } => ("ttd".to_string(), Some(activation_block_number)),
-                            ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
-                            ForkCondition::Never => ("never".to_string(), None),
-                        };
-                        ForkActivation { name: fork.name().to_string(), condition_type, activation_value }
-                    }).collect(),
+                    forks: EthereumHardfork::VARIANTS
+                        .iter()
+                        .map(|fork| {
+                            use reth_chainspec::ForkCondition;
+                            use reth_node_metrics::chain::ForkActivation;
+                            let condition = self.chain_spec().ethereum_fork_activation(*fork);
+                            let (condition_type, activation_value) = match condition {
+                                ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                                ForkCondition::TTD { activation_block_number, .. } => {
+                                    ("ttd".to_string(), Some(activation_block_number))
+                                }
+                                ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                                ForkCondition::Never => ("never".to_string(), None),
+                            };
+                            ForkActivation {
+                                name: fork.name().to_string(),
+                                condition_type,
+                                activation_value,
+                            }
+                        })
+                        .collect(),
                 },
                 self.task_executor().clone(),
                 metrics_hooks(self.provider_factory()),

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use futures::{stream::FusedStream, stream_select, FutureExt, StreamExt};
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_engine_tree::{
     chain::{ChainEvent, FromOrchestrator},
     engine::{EngineApiKind, EngineApiRequest, EngineRequestHandler},
@@ -74,7 +74,7 @@ impl EngineNodeLauncher {
                 NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
             >,
         >,
-        <T::Types as NodeTypes>::ChainSpec: EthereumHardforks,
+        <T::Types as NodeTypes>::ChainSpec: Hardforks + EthereumHardforks,
         CB: NodeComponentsBuilder<T>,
         AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>
             + EngineValidatorAddOn<NodeAdapter<T, CB::Components>>,
@@ -423,7 +423,7 @@ where
             NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
         >,
     >,
-    <T::Types as NodeTypes>::ChainSpec: EthereumHardforks,
+    <T::Types as NodeTypes>::ChainSpec: Hardforks + EthereumHardforks,
     CB: NodeComponentsBuilder<T> + 'static,
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>
         + EngineValidatorAddOn<NodeAdapter<T, CB::Components>>

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use futures::{stream::FusedStream, stream_select, FutureExt, StreamExt};
-use reth_chainspec::{EthChainSpec, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_engine_tree::{
     chain::{ChainEvent, FromOrchestrator},
     engine::{EngineApiKind, EngineApiRequest, EngineRequestHandler},
@@ -74,6 +74,7 @@ impl EngineNodeLauncher {
                 NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
             >,
         >,
+        <T::Types as NodeTypes>::ChainSpec: Hardforks,
         CB: NodeComponentsBuilder<T>,
         AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>
             + EngineValidatorAddOn<NodeAdapter<T, CB::Components>>,
@@ -422,6 +423,7 @@ where
             NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
         >,
     >,
+    <T::Types as NodeTypes>::ChainSpec: Hardforks,
     CB: NodeComponentsBuilder<T> + 'static,
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>
         + EngineValidatorAddOn<NodeAdapter<T, CB::Components>>

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use futures::{stream::FusedStream, stream_select, FutureExt, StreamExt};
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_engine_tree::{
     chain::{ChainEvent, FromOrchestrator},
     engine::{EngineApiKind, EngineApiRequest, EngineRequestHandler},
@@ -74,7 +74,7 @@ impl EngineNodeLauncher {
                 NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
             >,
         >,
-        <T::Types as NodeTypes>::ChainSpec: Hardforks,
+        <T::Types as NodeTypes>::ChainSpec: EthereumHardforks,
         CB: NodeComponentsBuilder<T>,
         AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>
             + EngineValidatorAddOn<NodeAdapter<T, CB::Components>>,
@@ -423,7 +423,7 @@ where
             NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
         >,
     >,
-    <T::Types as NodeTypes>::ChainSpec: Hardforks,
+    <T::Types as NodeTypes>::ChainSpec: EthereumHardforks,
     CB: NodeComponentsBuilder<T> + 'static,
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>
         + EngineValidatorAddOn<NodeAdapter<T, CB::Components>>

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_engine::ExecutionData;
 use jsonrpsee::{core::middleware::layer::Either, RpcModule};
 use parking_lot::Mutex;
 use reth_chain_state::CanonStateSubscriptions;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineApiValidator, EngineTypes, FullNodeComponents, FullNodeTypes,
     NodeAddOns, NodeTypes, PayloadTypes, PayloadValidator, PrimitivesTy, TreeConfig,
@@ -822,7 +822,7 @@ where
 impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    N::Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>,
     EthB: EthApiBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -1124,7 +1124,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
     for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>,
     EthB: EthApiBuilder<N>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
@@ -1177,7 +1177,9 @@ pub struct EthApiCtx<'a, N: FullNodeTypes> {
     pub engine_handle: ConsensusEngineHandle<<N::Types as NodeTypes>::Payload>,
 }
 
-impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>> EthApiCtx<'a, N> {
+impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumHardforks>>>
+    EthApiCtx<'a, N>
+{
     /// Provides a [`EthApiBuilder`] with preconfigured config and components.
     pub fn eth_api_builder(self) -> reth_rpc::EthApiBuilder<N, EthRpcConverterFor<N>> {
         reth_rpc::EthApiBuilder::new_with_components(self.components.clone())

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -822,7 +822,7 @@ where
 impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks + Hardforks>,
     EthB: EthApiBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -1124,7 +1124,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
     for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
+    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks + Hardforks>,
     EthB: EthApiBuilder<N>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_engine::ExecutionData;
 use jsonrpsee::{core::middleware::layer::Either, RpcModule};
 use parking_lot::Mutex;
 use reth_chain_state::CanonStateSubscriptions;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineApiValidator, EngineTypes, FullNodeComponents, FullNodeTypes,
     NodeAddOns, NodeTypes, PayloadTypes, PayloadValidator, PrimitivesTy, TreeConfig,
@@ -822,7 +822,7 @@ where
 impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks + Hardforks>,
+    N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
     EthB: EthApiBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -1124,7 +1124,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
     for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
-    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks + Hardforks>,
+    <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
     EthB: EthApiBuilder<N>,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
@@ -1177,9 +1177,7 @@ pub struct EthApiCtx<'a, N: FullNodeTypes> {
     pub engine_handle: ConsensusEngineHandle<<N::Types as NodeTypes>::Payload>,
 }
 
-impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumHardforks>>>
-    EthApiCtx<'a, N>
-{
+impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>> EthApiCtx<'a, N> {
     /// Provides a [`EthApiBuilder`] with preconfigured config and components.
     pub fn eth_api_builder(self) -> reth_rpc::EthApiBuilder<N, EthRpcConverterFor<N>> {
         reth_rpc::EthApiBuilder::new_with_components(self.components.clone())

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+reth-ethereum-forks.workspace = true
 reth-metrics.workspace = true
 reth-tasks.workspace = true
 

--- a/crates/node/metrics/src/chain.rs
+++ b/crates/node/metrics/src/chain.rs
@@ -1,5 +1,6 @@
 //! This exposes reth's chain information over prometheus.
 use metrics::{describe_gauge, gauge};
+use reth_ethereum_forks::{ForkCondition, Hardforks};
 
 /// Fork activation information for metrics.
 #[derive(Debug, Clone)]
@@ -22,6 +23,32 @@ pub struct ChainSpecInfo {
 }
 
 impl ChainSpecInfo {
+    /// Builds [`ChainSpecInfo`] from any [`Hardforks`] implementation, capturing all configured
+    /// forks including custom ones.
+    pub fn from_hardforks(name: String, hardforks: &impl Hardforks) -> Self {
+        Self {
+            name,
+            forks: hardforks
+                .forks_iter()
+                .map(|(fork, condition)| {
+                    let (condition_type, activation_value) = match condition {
+                        ForkCondition::Block(block) => ("block".to_string(), Some(block)),
+                        ForkCondition::TTD { activation_block_number, .. } => {
+                            ("ttd".to_string(), Some(activation_block_number))
+                        }
+                        ForkCondition::Timestamp(ts) => ("timestamp".to_string(), Some(ts)),
+                        ForkCondition::Never => ("never".to_string(), None),
+                    };
+                    ForkActivation {
+                        name: fork.name().to_string(),
+                        condition_type,
+                        activation_value,
+                    }
+                })
+                .collect(),
+        }
+    }
+
     /// This exposes reth's chain information over prometheus.
     pub fn register_chain_spec_metrics(&self) {
         let labels: [(&str, String); 1] = [("name", self.name.clone())];

--- a/crates/node/metrics/src/chain.rs
+++ b/crates/node/metrics/src/chain.rs
@@ -1,11 +1,24 @@
 //! This exposes reth's chain information over prometheus.
 use metrics::{describe_gauge, gauge};
 
+/// Fork activation information for metrics.
+#[derive(Debug, Clone)]
+pub struct ForkActivation {
+    /// Name of the fork.
+    pub name: String,
+    /// Type of activation condition ("block", "timestamp", "ttd", or "never").
+    pub condition_type: String,
+    /// Activation value (block number or timestamp). None for never-activated forks.
+    pub activation_value: Option<u64>,
+}
+
 /// Contains chain information for the application.
 #[derive(Debug, Clone)]
 pub struct ChainSpecInfo {
     /// The name of the chain.
     pub name: String,
+    /// Fork schedule with activation conditions.
+    pub forks: Vec<ForkActivation>,
 }
 
 impl ChainSpecInfo {
@@ -15,5 +28,21 @@ impl ChainSpecInfo {
 
         describe_gauge!("chain_spec", "Information about the chain");
         let _gauge = gauge!("chain_spec", &labels);
+
+        describe_gauge!(
+            "chain_spec.fork",
+            "Fork activation value (block number or timestamp). Label 'type' indicates block/timestamp/ttd/never."
+        );
+        for fork in &self.forks {
+            let fork_labels: [(&str, String); 3] = [
+                ("fork", fork.name.clone()),
+                ("type", fork.condition_type.clone()),
+                ("chain", self.name.clone()),
+            ];
+            let g = gauge!("chain_spec.fork", &fork_labels);
+            if let Some(value) = fork.activation_value {
+                g.set(value as f64);
+            }
+        }
     }
 }

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -424,7 +424,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_metrics_endpoint() {
-        let chain_spec_info = ChainSpecInfo { name: "test".to_string() };
+        let chain_spec_info = ChainSpecInfo { name: "test".to_string(), forks: vec![] };
         let version_info = VersionInfo {
             version: "test",
             build_timestamp: "test",

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -47,7 +47,7 @@ pub mod servers {
         miner::MinerApiServer,
         net::NetApiServer,
         otterscan::OtterscanServer,
-        reth::{ForkInfo, RethApiServer},
+        reth::{ForkInfo, ForkSchedule, RethApiServer},
         reth_engine::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus},
         rpc::RpcApiServer,
         testing::TestingApiServer,

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -47,7 +47,7 @@ pub mod servers {
         miner::MinerApiServer,
         net::NetApiServer,
         otterscan::OtterscanServer,
-        reth::RethApiServer,
+        reth::{ForkInfo, RethApiServer},
         reth_engine::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus},
         rpc::RpcApiServer,
         testing::TestingApiServer,

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -1,9 +1,25 @@
 use alloy_eips::BlockId;
 use alloy_primitives::{map::AddressMap, U256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use serde::{Deserialize, Serialize};
 
 // Required for the subscription attributes below
 use reth_chain_state as _;
+
+/// Information about a single hardfork in the chain's fork schedule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkInfo {
+    /// Name of the hardfork.
+    pub name: String,
+    /// The type of activation condition.
+    pub condition_type: String,
+    /// The activation value (block number, timestamp, or TTD). None for never-activated forks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activation_value: Option<U256>,
+    /// Whether the fork is currently active at the chain head.
+    pub active: bool,
+}
 
 /// Reth API namespace for reth-specific methods
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "reth"))]
@@ -58,4 +74,9 @@ pub trait RethApi {
     async fn reth_subscribe_finalized_chain_notifications(
         &self,
     ) -> jsonrpsee::core::SubscriptionResult;
+
+    /// Returns the fork schedule showing all hardforks, their activation conditions, and
+    /// whether they are currently active.
+    #[method(name = "forkSchedule")]
+    async fn reth_fork_schedule(&self) -> RpcResult<Vec<ForkInfo>>;
 }

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -6,6 +6,16 @@ use serde::{Deserialize, Serialize};
 // Required for the subscription attributes below
 use reth_chain_state as _;
 
+/// Response for the `reth_forkSchedule` RPC method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkSchedule {
+    /// Ordered list of all hardforks and their activation conditions.
+    pub schedule: Vec<ForkInfo>,
+    /// Name of the latest active hardfork at the chain head.
+    pub active: String,
+}
+
 /// Information about a single hardfork in the chain's fork schedule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -75,8 +85,8 @@ pub trait RethApi {
         &self,
     ) -> jsonrpsee::core::SubscriptionResult;
 
-    /// Returns the fork schedule showing all hardforks, their activation conditions, and
-    /// whether they are currently active.
+    /// Returns the fork schedule showing all hardforks, their activation conditions,
+    /// whether they are currently active, and the name of the latest active fork.
     #[method(name = "forkSchedule")]
-    async fn reth_fork_schedule(&self) -> RpcResult<Vec<ForkInfo>>;
+    async fn reth_fork_schedule(&self) -> RpcResult<ForkSchedule>;
 }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -30,7 +30,7 @@ use jsonrpsee::{
     server::{middleware::rpc::RpcServiceBuilder, AlreadyStoppedError, IdProvider, ServerHandle},
     Methods, RpcModule,
 };
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks, Hardforks};
 use reth_consensus::FullConsensus;
 use reth_engine_primitives::{ConsensusEngineEvent, ConsensusEngineHandle};
 use reth_evm::ConfigureEvm;
@@ -318,6 +318,7 @@ where
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
+    Provider::ChainSpec: Hardforks,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
@@ -762,7 +763,10 @@ where
     /// # Panics
     ///
     /// If called outside of the tokio runtime.
-    pub fn register_reth(&mut self) -> &mut Self {
+    pub fn register_reth(&mut self) -> &mut Self
+    where
+        Provider::ChainSpec: Hardforks,
+    {
         let rethapi = self.reth_api();
         self.modules.insert(RethRpcModule::Reth, rethapi.into_rpc().into());
         self
@@ -871,6 +875,7 @@ where
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
+    Provider::ChainSpec: Hardforks,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: FullEthApiServer,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -30,7 +30,7 @@ use jsonrpsee::{
     server::{middleware::rpc::RpcServiceBuilder, AlreadyStoppedError, IdProvider, ServerHandle},
     Methods, RpcModule,
 };
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks, Hardforks};
 use reth_consensus::FullConsensus;
 use reth_engine_primitives::{ConsensusEngineEvent, ConsensusEngineHandle};
 use reth_evm::ConfigureEvm;
@@ -318,7 +318,7 @@ where
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
-    Provider::ChainSpec: EthereumHardforks,
+    Provider::ChainSpec: Hardforks,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
@@ -765,7 +765,7 @@ where
     /// If called outside of the tokio runtime.
     pub fn register_reth(&mut self) -> &mut Self
     where
-        Provider::ChainSpec: EthereumHardforks,
+        Provider::ChainSpec: Hardforks,
     {
         let rethapi = self.reth_api();
         self.modules.insert(RethRpcModule::Reth, rethapi.into_rpc().into());
@@ -875,7 +875,7 @@ where
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
-    Provider::ChainSpec: EthereumHardforks,
+    Provider::ChainSpec: Hardforks,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: FullEthApiServer,

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -30,7 +30,7 @@ use jsonrpsee::{
     server::{middleware::rpc::RpcServiceBuilder, AlreadyStoppedError, IdProvider, ServerHandle},
     Methods, RpcModule,
 };
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_consensus::FullConsensus;
 use reth_engine_primitives::{ConsensusEngineEvent, ConsensusEngineHandle};
 use reth_evm::ConfigureEvm;
@@ -318,7 +318,7 @@ where
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
-    Provider::ChainSpec: Hardforks,
+    Provider::ChainSpec: EthereumHardforks,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
@@ -765,7 +765,7 @@ where
     /// If called outside of the tokio runtime.
     pub fn register_reth(&mut self) -> &mut Self
     where
-        Provider::ChainSpec: Hardforks,
+        Provider::ChainSpec: EthereumHardforks,
     {
         let rethapi = self.reth_api();
         self.modules.insert(RethRpcModule::Reth, rethapi.into_rpc().into());
@@ -875,7 +875,7 @@ where
         + PersistedBlockSubscriptions
         + AccountReader
         + ChangeSetReader,
-    Provider::ChainSpec: Hardforks,
+    Provider::ChainSpec: EthereumHardforks,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
     EthApi: FullEthApiServer,

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -1,7 +1,7 @@
 //! Helper trait for interfacing with [`FullNodeComponents`].
 
 use reth_chain_state::CanonStateSubscriptions;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_node_api::{FullNodeComponents, NodePrimitives, PrimitivesTy};
@@ -31,7 +31,9 @@ pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
             Header = HeaderTy<Self::Primitives>,
             Transaction = TxTy<Self::Primitives>,
         > + ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = HeaderTy<Self::Primitives>> + EthereumHardforks,
+            ChainSpec: EthChainSpec<Header = HeaderTy<Self::Primitives>>
+                           + Hardforks
+                           + EthereumHardforks,
         > + StateProviderFactory
         + CanonStateSubscriptions<Primitives = Self::Primitives>
         + StageCheckpointReader
@@ -62,7 +64,7 @@ pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
 
 impl<T> RpcNodeCore for T
 where
-    T: FullNodeComponents<Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>>,
+    T: FullNodeComponents<Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>>,
 {
     type Primitives = PrimitivesTy<T::Types>;
     type Provider = T::Provider;
@@ -122,7 +124,9 @@ where
             Header = HeaderTy<Evm::Primitives>,
             Transaction = TxTy<Evm::Primitives>,
         > + ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = HeaderTy<Evm::Primitives>> + EthereumHardforks,
+            ChainSpec: EthChainSpec<Header = HeaderTy<Evm::Primitives>>
+                           + Hardforks
+                           + EthereumHardforks,
         > + StateProviderFactory
         + CanonStateSubscriptions<Primitives = Evm::Primitives>
         + StageCheckpointReader

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -1,7 +1,7 @@
 //! Helper trait for interfacing with [`FullNodeComponents`].
 
 use reth_chain_state::CanonStateSubscriptions;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::ConfigureEvm;
 use reth_network_api::NetworkInfo;
 use reth_node_api::{FullNodeComponents, NodePrimitives, PrimitivesTy};
@@ -31,9 +31,7 @@ pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
             Header = HeaderTy<Self::Primitives>,
             Transaction = TxTy<Self::Primitives>,
         > + ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = HeaderTy<Self::Primitives>>
-                           + Hardforks
-                           + EthereumHardforks,
+            ChainSpec: EthChainSpec<Header = HeaderTy<Self::Primitives>> + EthereumHardforks,
         > + StateProviderFactory
         + CanonStateSubscriptions<Primitives = Self::Primitives>
         + StageCheckpointReader
@@ -64,7 +62,7 @@ pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
 
 impl<T> RpcNodeCore for T
 where
-    T: FullNodeComponents<Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>>,
+    T: FullNodeComponents<Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>>,
 {
     type Primitives = PrimitivesTy<T::Types>;
     type Provider = T::Provider;
@@ -124,9 +122,7 @@ where
             Header = HeaderTy<Evm::Primitives>,
             Transaction = TxTy<Evm::Primitives>,
         > + ChainSpecProvider<
-            ChainSpec: EthChainSpec<Header = HeaderTy<Evm::Primitives>>
-                           + Hardforks
-                           + EthereumHardforks,
+            ChainSpec: EthChainSpec<Header = HeaderTy<Evm::Primitives>> + EthereumHardforks,
         > + StateProviderFactory
         + CanonStateSubscriptions<Primitives = Evm::Primitives>
         + StageCheckpointReader

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -10,11 +10,11 @@ use reth_chain_state::{
     CanonStateNotification, CanonStateSubscriptions, ForkChoiceSubscriptions,
     PersistedBlockSubscriptions,
 };
+use reth_chainspec::{ChainSpecProvider, EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_errors::RethResult;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
-use reth_chainspec::{ChainSpecProvider, ForkCondition, Hardforks};
 use reth_rpc_api::{ForkInfo, ForkSchedule, RethApiServer};
 use reth_rpc_eth_types::{EthApiError, EthResult};
 use reth_storage_api::{
@@ -189,10 +189,13 @@ where
 impl<Provider, EvmConfig> RethApi<Provider, EvmConfig>
 where
     Provider: BlockReaderIdExt + ChainSpecProvider + 'static,
-    Provider::ChainSpec: Hardforks,
+    Provider::ChainSpec: EthereumHardforks,
     EvmConfig: Send + Sync + 'static,
 {
     /// Returns the fork schedule from the chain spec with active status.
+    ///
+    /// Iterates all known [`EthereumHardfork`] variants so that forks not configured
+    /// in the chain spec are included as `"never"`.
     pub fn fork_schedule(&self) -> EthResult<ForkSchedule> {
         let chain_spec = self.provider().chain_spec();
         let chain_info = self.provider().chain_info()?;
@@ -205,26 +208,23 @@ where
 
         let mut latest_active = None;
 
-        let schedule: Vec<ForkInfo> = chain_spec
-            .forks_iter()
-            .map(|(fork, condition)| {
+        let schedule: Vec<ForkInfo> = EthereumHardfork::VARIANTS
+            .iter()
+            .map(|fork| {
+                let condition = chain_spec.ethereum_fork_activation(*fork);
                 let (condition_type, activation_value, active) = match condition {
-                    ForkCondition::Block(block) => (
-                        "block".to_string(),
-                        Some(U256::from(block)),
-                        best_block >= block,
-                    ),
+                    ForkCondition::Block(block) => {
+                        ("block", Some(U256::from(block)), best_block >= block)
+                    }
                     ForkCondition::TTD { activation_block_number, .. } => (
-                        "ttd".to_string(),
+                        "ttd",
                         Some(U256::from(activation_block_number)),
                         best_block >= activation_block_number,
                     ),
-                    ForkCondition::Timestamp(ts) => (
-                        "timestamp".to_string(),
-                        Some(U256::from(ts)),
-                        best_timestamp >= ts,
-                    ),
-                    ForkCondition::Never => ("never".to_string(), None, false),
+                    ForkCondition::Timestamp(ts) => {
+                        ("timestamp", Some(U256::from(ts)), best_timestamp >= ts)
+                    }
+                    ForkCondition::Never => ("never", None, false),
                 };
 
                 let name = fork.name().to_string();
@@ -234,17 +234,14 @@ where
 
                 ForkInfo {
                     name,
-                    condition_type,
+                    condition_type: condition_type.to_string(),
                     activation_value,
                     active,
                 }
             })
             .collect();
 
-        Ok(ForkSchedule {
-            schedule,
-            active: latest_active.unwrap_or_default(),
-        })
+        Ok(ForkSchedule { schedule, active: latest_active.unwrap_or_default() })
     }
 }
 
@@ -260,7 +257,7 @@ where
         + PersistedBlockSubscriptions
         + ChainSpecProvider
         + 'static,
-    Provider::ChainSpec: Hardforks,
+    Provider::ChainSpec: EthereumHardforks,
     EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + 'static,
 {
     /// Handler for `reth_getBalanceChangesInBlock`

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -15,7 +15,7 @@ use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_chainspec::{ChainSpecProvider, ForkCondition, Hardforks};
-use reth_rpc_api::{ForkInfo, RethApiServer};
+use reth_rpc_api::{ForkInfo, ForkSchedule, RethApiServer};
 use reth_rpc_eth_types::{EthApiError, EthResult};
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ChangeSetReader, StateProviderFactory, TransactionVariant,
@@ -193,7 +193,7 @@ where
     EvmConfig: Send + Sync + 'static,
 {
     /// Returns the fork schedule from the chain spec with active status.
-    pub fn fork_schedule(&self) -> EthResult<Vec<ForkInfo>> {
+    pub fn fork_schedule(&self) -> EthResult<ForkSchedule> {
         let chain_spec = self.provider().chain_spec();
         let chain_info = self.provider().chain_info()?;
         let best_block = chain_info.best_number;
@@ -203,7 +203,9 @@ where
             .ok_or(EthApiError::HeaderNotFound(best_block.into()))?;
         let best_timestamp = best_header.timestamp();
 
-        let forks = chain_spec
+        let mut latest_active = None;
+
+        let schedule: Vec<ForkInfo> = chain_spec
             .forks_iter()
             .map(|(fork, condition)| {
                 let (condition_type, activation_value, active) = match condition {
@@ -225,8 +227,13 @@ where
                     ForkCondition::Never => ("never".to_string(), None, false),
                 };
 
+                let name = fork.name().to_string();
+                if active {
+                    latest_active = Some(name.clone());
+                }
+
                 ForkInfo {
-                    name: fork.name().to_string(),
+                    name,
                     condition_type,
                     activation_value,
                     active,
@@ -234,7 +241,10 @@ where
             })
             .collect();
 
-        Ok(forks)
+        Ok(ForkSchedule {
+            schedule,
+            active: latest_active.unwrap_or_default(),
+        })
     }
 }
 
@@ -321,7 +331,7 @@ where
     }
 
     /// Handler for `reth_forkSchedule`
-    async fn reth_fork_schedule(&self) -> RpcResult<Vec<ForkInfo>> {
+    async fn reth_fork_schedule(&self) -> RpcResult<ForkSchedule> {
         Ok(Self::fork_schedule(self)?)
     }
 }

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -10,7 +10,7 @@ use reth_chain_state::{
     CanonStateNotification, CanonStateSubscriptions, ForkChoiceSubscriptions,
     PersistedBlockSubscriptions,
 };
-use reth_chainspec::{ChainSpecProvider, EthereumHardfork, EthereumHardforks, ForkCondition};
+use reth_chainspec::{ChainSpecProvider, ForkCondition, Hardforks};
 use reth_errors::RethResult;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_execution_types::ExecutionOutcome;
@@ -189,13 +189,13 @@ where
 impl<Provider, EvmConfig> RethApi<Provider, EvmConfig>
 where
     Provider: BlockReaderIdExt + ChainSpecProvider + 'static,
-    Provider::ChainSpec: EthereumHardforks,
+    Provider::ChainSpec: Hardforks,
     EvmConfig: Send + Sync + 'static,
 {
     /// Returns the fork schedule from the chain spec with active status.
     ///
-    /// Iterates all known [`EthereumHardfork`] variants so that forks not configured
-    /// in the chain spec are included as `"never"`.
+    /// Iterates all forks via [`Hardforks::forks_iter`], capturing both standard Ethereum
+    /// hardforks and any custom chain forks.
     pub fn fork_schedule(&self) -> EthResult<ForkSchedule> {
         let chain_spec = self.provider().chain_spec();
         let chain_info = self.provider().chain_info()?;
@@ -208,10 +208,9 @@ where
 
         let mut latest_active = None;
 
-        let schedule: Vec<ForkInfo> = EthereumHardfork::VARIANTS
-            .iter()
-            .map(|fork| {
-                let condition = chain_spec.ethereum_fork_activation(*fork);
+        let schedule: Vec<ForkInfo> = chain_spec
+            .forks_iter()
+            .map(|(fork, condition)| {
                 let (condition_type, activation_value, active) = match condition {
                     ForkCondition::Block(block) => {
                         ("block", Some(U256::from(block)), best_block >= block)
@@ -257,7 +256,7 @@ where
         + PersistedBlockSubscriptions
         + ChainSpecProvider
         + 'static,
-    Provider::ChainSpec: EthereumHardforks,
+    Provider::ChainSpec: Hardforks,
     EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + 'static,
 {
     /// Handler for `reth_getBalanceChangesInBlock`

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -14,7 +14,8 @@ use reth_errors::RethResult;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
-use reth_rpc_api::RethApiServer;
+use reth_chainspec::{ChainSpecProvider, ForkCondition, Hardforks};
+use reth_rpc_api::{ForkInfo, RethApiServer};
 use reth_rpc_eth_types::{EthApiError, EthResult};
 use reth_storage_api::{
     BlockReader, BlockReaderIdExt, ChangeSetReader, StateProviderFactory, TransactionVariant,
@@ -185,6 +186,58 @@ where
     }
 }
 
+impl<Provider, EvmConfig> RethApi<Provider, EvmConfig>
+where
+    Provider: BlockReaderIdExt + ChainSpecProvider + 'static,
+    Provider::ChainSpec: Hardforks,
+    EvmConfig: Send + Sync + 'static,
+{
+    /// Returns the fork schedule from the chain spec with active status.
+    pub fn fork_schedule(&self) -> EthResult<Vec<ForkInfo>> {
+        let chain_spec = self.provider().chain_spec();
+        let chain_info = self.provider().chain_info()?;
+        let best_block = chain_info.best_number;
+        let best_header = self
+            .provider()
+            .header_by_number(best_block)?
+            .ok_or(EthApiError::HeaderNotFound(best_block.into()))?;
+        let best_timestamp = best_header.timestamp();
+
+        let forks = chain_spec
+            .forks_iter()
+            .map(|(fork, condition)| {
+                let (condition_type, activation_value, active) = match condition {
+                    ForkCondition::Block(block) => (
+                        "block".to_string(),
+                        Some(U256::from(block)),
+                        best_block >= block,
+                    ),
+                    ForkCondition::TTD { activation_block_number, .. } => (
+                        "ttd".to_string(),
+                        Some(U256::from(activation_block_number)),
+                        best_block >= activation_block_number,
+                    ),
+                    ForkCondition::Timestamp(ts) => (
+                        "timestamp".to_string(),
+                        Some(U256::from(ts)),
+                        best_timestamp >= ts,
+                    ),
+                    ForkCondition::Never => ("never".to_string(), None, false),
+                };
+
+                ForkInfo {
+                    name: fork.name().to_string(),
+                    condition_type,
+                    activation_value,
+                    active,
+                }
+            })
+            .collect();
+
+        Ok(forks)
+    }
+}
+
 #[async_trait]
 impl<Provider, EvmConfig> RethApiServer for RethApi<Provider, EvmConfig>
 where
@@ -195,7 +248,9 @@ where
         + CanonStateSubscriptions
         + ForkChoiceSubscriptions<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>
         + PersistedBlockSubscriptions
+        + ChainSpecProvider
         + 'static,
+    Provider::ChainSpec: Hardforks,
     EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + 'static,
 {
     /// Handler for `reth_getBalanceChangesInBlock`
@@ -263,6 +318,11 @@ where
         ));
 
         Ok(())
+    }
+
+    /// Handler for `reth_forkSchedule`
+    async fn reth_fork_schedule(&self) -> RpcResult<Vec<ForkInfo>> {
+        Ok(Self::fork_schedule(self)?)
     }
 }
 


### PR DESCRIPTION
Adds `reth_forkSchedule` RPC endpoint and Prometheus fork metrics.

Enumerates all known `EthereumHardfork` variants against the chainspec so
unconfigured forks appear as `"never"` — not silently omitted.

Returns `{ schedule: [...], active: "<fork-name>" }` so callers get the
latest active fork in a single RPC call.

### Example response
```json
{
  "schedule": [
    {"name":"Frontier","conditionType":"block","activationValue":"0x0","active":true},
    {"name":"Cancun","conditionType":"timestamp","activationValue":"0x65f1a510","active":true},
    {"name":"Prague","conditionType":"timestamp","activationValue":"0x68424a80","active":false},
    {"name":"Amsterdam","conditionType":"never","active":false}
  ],
  "active": "Cancun"
}
```

### Prometheus metrics
```
chain_spec_fork{fork="Frontier",type="block",chain="mainnet"} 0
chain_spec_fork{fork="Cancun",type="timestamp",chain="mainnet"} 1710338135
chain_spec_fork{fork="Amsterdam",type="never",chain="mainnet"} 0
```

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>
Co-Authored-By: 0xrusowsky <90208954+0xrusowsky@users.noreply.github.com>

Prompted by: zygis