### PR TITLE
docs(discv4): fix misleading bootstrap doc comment

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -691,12 +691,9 @@ impl Discv4Service {
     /// own ID in the DHT. This introduces the local node to the other nodes
     /// in the DHT and populates its routing table with the closest proven neighbours.
     ///
-    /// This is similar to adding all bootnodes via [`Self::add_node`], but does not fire a
-    /// [`DiscoveryUpdate::Added`] event for the given bootnodes. So boot nodes don't appear in the
-    /// update stream, which is usually desirable, since bootnodes should not be connected to.
-    ///
-    /// If adding the configured bootnodes should result in a [`DiscoveryUpdate::Added`], see
-    /// [`Self::add_all_nodes`].
+    /// This inserts the configured bootnodes into the routing table and pings them. Once the
+    /// endpoint proof succeeds (pong received), a [`DiscoveryUpdate::Added`] event is emitted,
+    /// same as with [`Self::add_node`].
     ///
     /// **Note:** This is a noop if there are no bootnodes.
     pub fn bootstrap(&mut self) {

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -629,15 +629,9 @@ pub trait LoadTransaction: SpawnBlocking + FullEthApiTypes + RpcNodeCoreExt {
         async move {
             // First, try the RPC cache
             if let Some(cached) = self.cache().get_transaction_by_hash(hash).await &&
-                let Some(tx) = cached.recovered_transaction()
+                let Some(source) = cached.to_transaction_source()
             {
-                return Ok(Some(TransactionSource::Block {
-                    transaction: tx.cloned(),
-                    index: cached.tx_index as u64,
-                    block_hash: cached.block.hash(),
-                    block_number: cached.block.number(),
-                    base_fee: cached.block.base_fee_per_gas(),
-                }));
+                return Ok(Some(source));
             }
 
             // Cache miss - try to find the transaction on disk

--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use alloy_consensus::{transaction::TxHashRef, TxReceipt};
+use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
 use alloy_primitives::TxHash;
 use reth_primitives_traits::{
     Block, BlockBody, BlockTy, IndexedTx, NodePrimitives, ReceiptTy, Recovered, RecoveredBlock,
@@ -10,7 +10,7 @@ use reth_primitives_traits::{
 };
 use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert, RpcTypes};
 
-use crate::utils::calculate_gas_used_and_next_log_index;
+use crate::{utils::calculate_gas_used_and_next_log_index, TransactionSource};
 
 /// Cached data for a transaction lookup.
 #[derive(Debug, Clone)]
@@ -36,6 +36,22 @@ impl<B: Block, R> CachedTransaction<B, R> {
     /// Returns the `Recovered<&T>` transaction at the cached index.
     pub fn recovered_transaction(&self) -> Option<Recovered<&<B::Body as BlockBody>::Transaction>> {
         self.block.recovered_transaction(self.tx_index)
+    }
+
+    /// Converts this cached transaction into a [`TransactionSource::Block`].
+    ///
+    /// Returns `None` if the transaction index is out of bounds.
+    pub fn to_transaction_source(
+        &self,
+    ) -> Option<TransactionSource<<B::Body as BlockBody>::Transaction>> {
+        let tx = self.recovered_transaction()?;
+        Some(TransactionSource::Block {
+            transaction: tx.cloned(),
+            index: self.tx_index as u64,
+            block_hash: self.block.hash(),
+            block_number: self.block.number(),
+            base_fee: self.block.base_fee_per_gas(),
+        })
     }
 
     /// Converts this cached transaction into an RPC receipt using the given converter.


### PR DESCRIPTION
The doc comment on `bootstrap()` claimed it does not emit `DiscoveryUpdate::Added` events for bootnodes, but both the code path (`on_verified_pong` unconditionally notifies `Added`) and the existing test (`test_bootnode_not_in_update_stream`) confirm it does.