### PR TITLE
fix(ci): resolve PR from feature ref on manual bench dispatch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -111,18 +111,26 @@ jobs:
               samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
               cores = '${{ github.event.inputs.cores }}' || '0';
 
-              // Find PR for the selected branch
-              const branch = '${{ github.ref_name }}';
-              const { data: prs } = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                head: `${context.repo.owner}:${branch}`,
-                state: 'open',
-                per_page: 1,
-              });
-              pr = prs.length ? String(prs[0].number) : '';
+              // Find PR — prefer feature ref, fall back to workflow ref
+              const candidates = [];
+              if (feature) candidates.push(feature);
+              const workflowBranch = '${{ github.ref_name }}';
+              if (!candidates.includes(workflowBranch)) candidates.push(workflowBranch);
+              for (const branch of candidates) {
+                const { data: prs } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  head: `${context.repo.owner}:${branch}`,
+                  state: 'open',
+                  per_page: 1,
+                });
+                if (prs.length) {
+                  pr = String(prs[0].number);
+                  break;
+                }
+              }
               if (!pr) {
-                core.info(`No open PR found for branch '${branch}', results will be in job summary`);
+                core.info(`No open PR found for [${candidates.join(', ')}], results will be in job summary`);
               }
             } else {
               pr = String(context.issue.number);


### PR DESCRIPTION
When `bench.yml` is dispatched manually (e.g. from `main`) with a `feature` input pointing to a branch, the PR lookup now checks the feature branch first before falling back to the workflow ref. This way the ack comment and results land on the correct PR instead of silently going to the job summary.

Prompted by: alexey