### PR TITLE
fix: skip persisted peers without a confirmed fork ID on startup

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -142,6 +142,12 @@ impl PeersManager {
         }
 
         for PersistedPeerInfo { record, kind, fork_id, reputation } in persisted_peers {
+            // When enforce_enr_fork_id is enabled, skip persisted peers that don't have a
+            // confirmed fork ID. These were likely accumulated from a different network during
+            // a prior run without the flag.
+            if enforce_enr_fork_id && fork_id.is_none() {
+                continue
+            }
             let NodeRecord { address, tcp_port, udp_port, id } = record;
             peers.entry(id).or_insert_with(|| {
                 let mut peer = Peer::with_kind(

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -344,9 +344,7 @@ impl NetworkArgs {
             .with_max_inbound_opt(self.resolved_max_inbound_peers())
             .with_max_outbound_opt(self.resolved_max_outbound_peers())
             .with_ip_filter(ip_filter)
-            .with_enforce_enr_fork_id(
-                self.enforce_enr_fork_id || !chain_spec.is_ethereum(),
-            );
+            .with_enforce_enr_fork_id(self.enforce_enr_fork_id || !chain_spec.is_ethereum());
 
         // Configure basic network stack
         NetworkConfigBuilder::<N>::new(secret_key, executor)

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -344,7 +344,9 @@ impl NetworkArgs {
             .with_max_inbound_opt(self.resolved_max_inbound_peers())
             .with_max_outbound_opt(self.resolved_max_outbound_peers())
             .with_ip_filter(ip_filter)
-            .with_enforce_enr_fork_id(self.enforce_enr_fork_id);
+            .with_enforce_enr_fork_id(
+                self.enforce_enr_fork_id || !chain_spec.is_ethereum(),
+            );
 
         // Configure basic network stack
         NetworkConfigBuilder::<N>::new(secret_key, executor)

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -344,7 +344,7 @@ impl NetworkArgs {
             .with_max_inbound_opt(self.resolved_max_inbound_peers())
             .with_max_outbound_opt(self.resolved_max_outbound_peers())
             .with_ip_filter(ip_filter)
-            .with_enforce_enr_fork_id(self.enforce_enr_fork_id || !chain_spec.is_ethereum());
+            .with_enforce_enr_fork_id(self.enforce_enr_fork_id);
 
         // Configure basic network stack
         NetworkConfigBuilder::<N>::new(secret_key, executor)


### PR DESCRIPTION
Skip persisted peers without a confirmed fork ID on startup

fix: peering issue