### PR TITLE
feat(cli): auto-detect chain ID from snapshot URL filename

### DIFF
--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -533,8 +533,8 @@ async fn stream_and_extract(url: &str, target_dir: &Path) -> Result<()> {
 /// Tries to extract a chain ID from a snapshot URL filename.
 ///
 /// Splits the filename by `-` and checks if the second segment is a valid chain ID.
-/// For example, `tempo-42429-18302466-1772514022.tar.lz4` splits into
-/// `["tempo", "42429", "18302466", "1772514022.tar.lz4"]` and `42429` is parsed as the chain ID.
+/// For example, `reth-1-minimal-edge-24571111-1772470929.tar.zst` splits into
+/// `["reth", "1", "minimal", ...]` and `1` is parsed as the chain ID.
 fn detect_chain_from_url(url: &str) -> Option<Chain> {
     let filename = Url::parse(url)
         .ok()
@@ -629,22 +629,24 @@ mod tests {
     fn test_detect_chain_from_url() {
         // Second `-`-delimited segment is the chain ID
         assert_eq!(
-            detect_chain_from_url("https://host.dev/tempo-42429-18302466-1772514022.tar.lz4"),
-            Some(Chain::from_id(42429))
+            detect_chain_from_url(
+                "https://snapshots-r2.reth.rs/reth-1-minimal-edge-24571111-1772470929.tar.zst"
+            ),
+            Some(Chain::from_id(1))
         );
         assert_eq!(
-            detect_chain_from_url("https://example.com/tempo-4217-100-999.tar.zst"),
-            Some(Chain::from_id(4217))
+            detect_chain_from_url("https://example.com/reth-17000-full-24571111.tar.lz4"),
+            Some(Chain::from_id(17000))
         );
         assert_eq!(
-            detect_chain_from_url("file:///tmp/tempo-42429-18302466-1772514022.tar.lz4"),
-            Some(Chain::from_id(42429))
+            detect_chain_from_url("file:///tmp/reth-1-minimal-edge-24571111.tar.zst"),
+            Some(Chain::from_id(1))
         );
 
         // No second segment or not numeric → None
         assert_eq!(detect_chain_from_url("https://example.com/snapshot.tar.lz4"), None);
-        assert_eq!(detect_chain_from_url("https://example.com/tempo-.tar.lz4"), None);
-        assert_eq!(detect_chain_from_url("https://example.com/tempo-abc-123.tar.lz4"), None);
+        assert_eq!(detect_chain_from_url("https://example.com/reth-.tar.lz4"), None);
+        assert_eq!(detect_chain_from_url("https://example.com/reth-abc-123.tar.lz4"), None);
     }
 
     #[test]

--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -1,4 +1,5 @@
 use crate::common::EnvironmentArgs;
+use alloy_chains::Chain;
 use clap::Parser;
 use eyre::Result;
 use lz4::Decoder;
@@ -153,9 +154,6 @@ pub struct DownloadCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCommand<C> {
     pub async fn execute<N>(self) -> Result<()> {
-        let data_dir = self.env.datadir.resolve_datadir(self.env.chain.chain());
-        fs::create_dir_all(&data_dir)?;
-
         let url = match self.url {
             Some(url) => url,
             None => {
@@ -165,8 +163,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             }
         };
 
+        let chain = detect_chain_from_url(&url).unwrap_or_else(|| self.env.chain.chain());
+
+        let data_dir = self.env.datadir.resolve_datadir(chain);
+        fs::create_dir_all(&data_dir)?;
+
         info!(target: "reth::cli",
-            chain = %self.env.chain.chain(),
+            chain = %chain,
             dir = ?data_dir.data_dir(),
             url = %url,
             "Starting snapshot download and extraction"
@@ -527,6 +530,21 @@ async fn stream_and_extract(url: &str, target_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Tries to extract a chain ID from a snapshot URL filename.
+///
+/// Splits the filename by `-` and checks if the second segment is a valid chain ID.
+/// For example, `tempo-42429-18302466-1772514022.tar.lz4` splits into
+/// `["tempo", "42429", "18302466", "1772514022.tar.lz4"]` and `42429` is parsed as the chain ID.
+fn detect_chain_from_url(url: &str) -> Option<Chain> {
+    let filename = Url::parse(url)
+        .ok()
+        .and_then(|u| u.path_segments()?.next_back().map(|s| s.to_string()))
+        .unwrap_or_default();
+
+    let chain_id: u64 = filename.split('-').nth(1)?.parse().ok()?;
+    Some(Chain::from_id(chain_id))
+}
+
 // Builds default URL for latest mainnet archive snapshot using configured defaults
 async fn get_latest_snapshot_url(chain_id: u64) -> Result<String> {
     let defaults = DownloadDefaults::get_global();
@@ -605,6 +623,28 @@ mod tests {
         assert_eq!(defaults.default_base_url, "https://custom.example.com");
         assert_eq!(defaults.available_snapshots.len(), 4); // 2 defaults + 2 added
         assert_eq!(defaults.long_help, Some("Custom help for snapshots".to_string()));
+    }
+
+    #[test]
+    fn test_detect_chain_from_url() {
+        // Second `-`-delimited segment is the chain ID
+        assert_eq!(
+            detect_chain_from_url("https://host.dev/tempo-42429-18302466-1772514022.tar.lz4"),
+            Some(Chain::from_id(42429))
+        );
+        assert_eq!(
+            detect_chain_from_url("https://example.com/tempo-4217-100-999.tar.zst"),
+            Some(Chain::from_id(4217))
+        );
+        assert_eq!(
+            detect_chain_from_url("file:///tmp/tempo-42429-18302466-1772514022.tar.lz4"),
+            Some(Chain::from_id(42429))
+        );
+
+        // No second segment or not numeric → None
+        assert_eq!(detect_chain_from_url("https://example.com/snapshot.tar.lz4"), None);
+        assert_eq!(detect_chain_from_url("https://example.com/tempo-.tar.lz4"), None);
+        assert_eq!(detect_chain_from_url("https://example.com/tempo-abc-123.tar.lz4"), None);
     }
 
     #[test]

--- a/crates/cli/commands/src/download.rs
+++ b/crates/cli/commands/src/download.rs
@@ -1,4 +1,3 @@
-use crate::common::EnvironmentArgs;
 use alloy_chains::Chain;
 use clap::Parser;
 use eyre::Result;
@@ -7,6 +6,7 @@ use reqwest::{blocking::Client as BlockingClient, header::RANGE, Client, StatusC
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_fs_util as fs;
+use reth_node_core::args::DatadirArgs;
 use std::{
     borrow::Cow,
     fs::OpenOptions,
@@ -145,7 +145,22 @@ impl Default for DownloadDefaults {
 #[derive(Debug, Parser)]
 pub struct DownloadCommand<C: ChainSpecParser> {
     #[command(flatten)]
-    env: EnvironmentArgs<C>,
+    datadir: DatadirArgs,
+
+    /// The chain this node is running.
+    ///
+    /// Possible values are either a built-in chain or the path to a chain specification file.
+    ///
+    /// When omitted, the chain is auto-detected from the snapshot URL filename.
+    /// Defaults to mainnet if the chain cannot be detected.
+    #[arg(
+        long,
+        value_name = "CHAIN_OR_PATH",
+        long_help = C::help_message(),
+        value_parser = C::parser(),
+        global = true
+    )]
+    chain: Option<Arc<C::ChainSpec>>,
 
     /// Custom URL to download the snapshot from
     #[arg(long, short, long_help = DownloadDefaults::get_global().long_help())]
@@ -154,18 +169,22 @@ pub struct DownloadCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCommand<C> {
     pub async fn execute<N>(self) -> Result<()> {
+        let explicit_chain = self.chain.as_ref().map(|c| c.chain());
+
         let url = match self.url {
             Some(url) => url,
             None => {
-                let url = get_latest_snapshot_url(self.env.chain.chain().id()).await?;
+                let chain_id = explicit_chain.unwrap_or_default().id();
+                let url = get_latest_snapshot_url(chain_id).await?;
                 info!(target: "reth::cli", "Using default snapshot URL: {}", url);
                 url
             }
         };
 
-        let chain = detect_chain_from_url(&url).unwrap_or_else(|| self.env.chain.chain());
+        // Explicit --chain takes priority, then URL-derived, then mainnet default.
+        let chain = explicit_chain.or_else(|| detect_chain_from_url(&url)).unwrap_or_default();
 
-        let data_dir = self.env.datadir.resolve_datadir(chain);
+        let data_dir = self.datadir.resolve_datadir(chain);
         fs::create_dir_all(&data_dir)?;
 
         info!(target: "reth::cli",
@@ -185,7 +204,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
 impl<C: ChainSpecParser> DownloadCommand<C> {
     /// Returns the underlying chain being used to run this command
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
-        Some(&self.env.chain)
+        self.chain.as_ref()
     }
 }
 

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -33,93 +33,12 @@ Datadir:
       --datadir.pprof-dumps <PATH>
           The absolute path to store pprof dumps in.
 
-      --config <FILE>
-          The path to the configuration file to use
-
       --chain <CHAIN_OR_PATH>
           The chain this node is running.
           Possible values are either a built-in chain or the path to a chain specification file.
 
           Built-in chains:
               mainnet, sepolia, holesky, hoodi, dev
-
-          [default: mainnet]
-
-Database:
-      --db.log-level <LOG_LEVEL>
-          Database logging level. Levels higher than "notice" require a debug build
-
-          Possible values:
-          - fatal:   Enables logging for critical conditions, i.e. assertion failures
-          - error:   Enables logging for error conditions
-          - warn:    Enables logging for warning conditions
-          - notice:  Enables logging for normal but significant condition
-          - verbose: Enables logging for verbose informational
-          - debug:   Enables logging for debug-level messages
-          - trace:   Enables logging for trace debug-level messages
-          - extra:   Enables logging for extra debug-level messages
-
-      --db.exclusive <EXCLUSIVE>
-          Open environment in exclusive/monopolistic mode. Makes it possible to open a database on an NFS volume
-
-          [possible values: true, false]
-
-      --db.max-size <MAX_SIZE>
-          Maximum database size (e.g., 4TB, 8TB).
-
-          This sets the "map size" of the database. If the database grows beyond this limit, the node will stop with an "environment map size limit reached" error.
-
-          The default value is 8TB.
-
-      --db.page-size <PAGE_SIZE>
-          Database page size (e.g., 4KB, 8KB, 16KB).
-
-          Specifies the page size used by the MDBX database.
-
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
-
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
-
-      --db.growth-step <GROWTH_STEP>
-          Database growth step (e.g., 4GB, 4KB)
-
-      --db.read-transaction-timeout <READ_TRANSACTION_TIMEOUT>
-          Read transaction timeout in seconds, 0 means no timeout
-
-      --db.max-readers <MAX_READERS>
-          Maximum number of readers allowed to access the database concurrently
-
-      --db.sync-mode <SYNC_MODE>
-          Controls how aggressively the database synchronizes data to disk
-
-Static Files:
-      --static-files.blocks-per-file.headers <BLOCKS_PER_FILE_HEADERS>
-          Number of blocks per file for the headers segment
-
-      --static-files.blocks-per-file.transactions <BLOCKS_PER_FILE_TRANSACTIONS>
-          Number of blocks per file for the transactions segment
-
-      --static-files.blocks-per-file.receipts <BLOCKS_PER_FILE_RECEIPTS>
-          Number of blocks per file for the receipts segment
-
-      --static-files.blocks-per-file.transaction-senders <BLOCKS_PER_FILE_TRANSACTION_SENDERS>
-          Number of blocks per file for the transaction senders segment
-
-      --static-files.blocks-per-file.account-change-sets <BLOCKS_PER_FILE_ACCOUNT_CHANGE_SETS>
-          Number of blocks per file for the account changesets segment
-
-      --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
-          Number of blocks per file for the storage changesets segment
-
-Storage:
-      --storage.v2
-          Enable v2 storage defaults (static files + `RocksDB` routing).
-
-          When enabled, the node uses optimized storage settings: - Receipts and transaction senders in static files - History indices in `RocksDB` (accounts, storages, transaction hashes) - Account and storage changesets in static files
-
-          This is a genesis-initialization-only setting: changing it after genesis requires a re-sync.
-
-          Individual settings can still be overridden with `--static-files.*` and `--rocksdb.*` flags.
 
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.


### PR DESCRIPTION
Makes `--chain` optional for the download command. Priority:

1. Explicit `--chain` (highest)
2. Auto-detected from snapshot URL filename
3. Mainnet default

Auto-detection splits the filename by `-` and parses the second segment as a chain ID.

Example: `reth download -u https://snapshots-r2.reth.rs/reth-1-minimal-edge-24571111-1772470929.tar.zst`
auto-detects chain `1` without requiring `--chain mainnet`.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey