### PR TITLE
feat(metrics): add /debug/tokio/dump endpoint for tokio task dumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
 rust.rust_2024_incompatible_pat = "warn"
+rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 rustdoc.all = "warn"
 # rust.unnameable-types = "warn"
 

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -148,8 +148,13 @@ impl MetricServer {
             let hook = hook.clone();
             let pprof_dump_dir = pprof_dump_dir.clone();
             let service = tower::service_fn(move |req: Request<_>| {
-                let response = handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir);
-                async move { Ok::<_, Infallible>(response) }
+                let hook = hook.clone();
+                let pprof_dump_dir = pprof_dump_dir.clone();
+                async move {
+                    let response =
+                        handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir).await;
+                    Ok::<_, Infallible>(response)
+                }
             });
 
             let mut shutdown = signal.clone().ignore_guard();
@@ -307,7 +312,7 @@ fn describe_io_stats() {
 #[cfg(not(target_os = "linux"))]
 const fn describe_io_stats() {}
 
-fn handle_request(
+async fn handle_request(
     path: &str,
     hook: impl Fn(),
     handle: &crate::recorder::PrometheusRecorder,
@@ -315,6 +320,7 @@ fn handle_request(
 ) -> Response<Full<Bytes>> {
     match path {
         "/debug/pprof/heap" => handle_pprof_heap(pprof_dump_dir),
+        "/debug/tokio/dump" => handle_tokio_dump().await,
         _ => {
             hook();
             let metrics = handle.handle().render();
@@ -399,6 +405,31 @@ fn jemalloc_pprof_dump(pprof_dump_dir: &PathBuf) -> eyre::Result<Vec<u8>> {
 fn handle_pprof_heap(_pprof_dump_dir: &PathBuf) -> Response<Full<Bytes>> {
     let mut response = Response::new(Full::new(Bytes::from_static(
         b"jemalloc pprof support not compiled. Rebuild with the jemalloc-prof feature.",
+    )));
+    *response.status_mut() = StatusCode::NOT_IMPLEMENTED;
+    response
+}
+
+#[cfg(tokio_unstable)]
+async fn handle_tokio_dump() -> Response<Full<Bytes>> {
+    let handle = tokio::runtime::Handle::current();
+    let dump = handle.dump().await;
+
+    let mut output = String::new();
+    for (i, task) in dump.tasks().iter().enumerate() {
+        let trace = task.trace();
+        output.push_str(&format!("task {i}:\n{trace}\n\n"));
+    }
+
+    let mut response = Response::new(Full::new(Bytes::from(output)));
+    response.headers_mut().insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+    response
+}
+
+#[cfg(not(tokio_unstable))]
+async fn handle_tokio_dump() -> Response<Full<Bytes>> {
+    let mut response = Response::new(Full::new(Bytes::from_static(
+        b"tokio task dump not available. Rebuild with RUSTFLAGS=\"--cfg tokio_unstable\" and tokio's `taskdump` feature.",
     )));
     *response.status_mut() = StatusCode::NOT_IMPLEMENTED;
     response


### PR DESCRIPTION
Adds `/debug/tokio/dump` on the metrics port. Captures a tokio runtime task dump via `Handle::dump()` and returns all spawned tasks with their async stack traces as plain text.

Gated behind `cfg(tokio_unstable)` + the `tokio-taskdump` Cargo feature on `reth-node-metrics`. Returns 501 when not compiled with support.

To enable: `RUSTFLAGS="--cfg tokio_unstable" cargo build --features tokio-taskdump`

Example output:
```console
ubuntu@dev-alexey:~$ curl -s localhost:9001/debug/tokio/dump | head
task 0:
╼ poll<reth_tasks::runtime::{impl#8}::spawn_task_as::{async_block_env#0}<reth_network::session::active::ActiveSession<reth_eth_wire_types::primitives::BasicNetworkPrimitives<reth_ethereum_primitives::EthPrimitives, alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844WithSidecar<alloy_eips::eip7594::sidecar::BlobTransactionSidecarVariant>>, reth_eth_wire_types::broadcast::NewBlock<alloy_consensus::block::Block<alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844>, alloy_consensus::block::header at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-futures-0.2.5/src/lib.rs:283:20
  └╼ {async_block#0}<reth_network::session::active::ActiveSession<reth_eth_wire_types::primitives::BasicNetworkPrimitives<reth_ethereum_primitives::EthPrimitives, alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844WithSidecar<alloy_eips::eip7594::sidecar::BlobTransactionSidecarVariant>>, reth_eth_wire_types::broadcast::NewBlock<alloy_consensus::block::Block<alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844>, alloy_consensus::block::header at /home/ubuntu/reth/crates/tasks/src/runtime.rs:437:50
     ├╼ poll<reth_tasks::shutdown::Shutdown, core::pin::Pin<&mut reth_network::session::active::ActiveSession<reth_eth_wire_types::primitives::BasicNetworkPrimitives<reth_ethereum_primitives::EthPrimitives, alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844WithSidecar<alloy_eips::eip7594::sidecar::BlobTransactionSidecarVariant>>, reth_eth_wire_types::broadcast::NewBlock<alloy_consensus::block::Block<alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844>, alloy_consensus::block::header at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/future/select.rs:117:37
     │  └╼ futures_util::future::future::FutureExt::poll_unpin at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/future/future/mod.rs:556:24
     │     └╼ poll<&mut reth_network::session::active::ActiveSession<reth_eth_wire_types::primitives::BasicNetworkPrimitives<reth_ethereum_primitives::EthPrimitives, alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844WithSidecar<alloy_eips::eip7594::sidecar::BlobTransactionSidecarVariant>>, reth_eth_wire_types::broadcast::NewBlock<alloy_consensus::block::Block<alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844>, alloy_consensus::block::header at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/future/future.rs:133:9
     │        ├╼ poll<reth_eth_wire_types::primitives::BasicNetworkPrimitives<reth_ethereum_primitives::EthPrimitives, alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844WithSidecar<alloy_eips::eip7594::sidecar::BlobTransactionSidecarVariant>>, reth_eth_wire_types::broadcast::NewBlock<alloy_consensus::block::Block<alloy_consensus::transaction::envelope::EthereumTxEnvelope<alloy_consensus::transaction::eip4844::TxEip4844>, alloy_consensus::block::header at /home/ubuntu/reth/crates/net/network/src/session/active.rs:603:40
     │        │  └╼ futures_util::stream::stream::StreamExt::poll_next_unpin at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.32/src/stream/stream/mod.rs:1638:24
     │        │     └╼ <tokio_stream::wrappers::mpsc_bounded::ReceiverStream<T> as futures_core::stream::Stream>::poll_next at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-stream-0.1.18/src/wrappers/mpsc_bounded.rs:68:20
     │        │        └╼ tokio::sync::mpsc::bounded::Receiver<T>::poll_recv at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/sync/mpsc/bounded.rs:651:19
```

Prompted by: alexey