### PR TITLE
chore(downloader): simplify the canonical blocks check

### DIFF
--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -163,17 +163,10 @@ impl<B: FullBlock> FileClient<B> {
         if self.headers.is_empty() {
             return true
         }
-        let mut nums = self.headers.keys().copied().collect::<Vec<_>>();
-        nums.sort_unstable();
-        let mut iter = nums.into_iter();
-        let mut lowest = iter.next().expect("not empty");
-        for next in iter {
-            if next != lowest + 1 {
-                return false
-            }
-            lowest = next;
-        }
-        true
+        let min = *self.headers.keys().min().expect("not empty");
+        let max = *self.headers.keys().max().expect("not empty");
+        // Contiguous range from min to max means no gaps
+        max - min + 1 == self.headers.len() as u64
     }
 
     /// Use the provided bodies as the file client's block body buffer.

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -163,8 +163,8 @@ impl<B: FullBlock> FileClient<B> {
         if self.headers.is_empty() {
             return true
         }
-        let min = *self.headers.keys().min().expect("not empty");
-        let max = *self.headers.keys().max().expect("not empty");
+        let min = self.min_block().expect("not empty");
+        let max = self.max_block().expect("not empty");
         // Contiguous range from min to max means no gaps
         max - min + 1 == self.headers.len() as u64
     }

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -3,7 +3,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{BlockHash, BlockNumber, Sealable, B256};
 use async_compression::tokio::bufread::GzipDecoder;
 use futures::Future;
-use itertools::Either;
+use itertools::{Either, Itertools};
 use reth_consensus::{Consensus, ConsensusError};
 use reth_network_p2p::{
     bodies::client::{BodiesClient, BodiesFut},
@@ -163,10 +163,9 @@ impl<B: FullBlock> FileClient<B> {
         if self.headers.is_empty() {
             return true
         }
-        let min = self.min_block().expect("not empty");
-        let max = self.max_block().expect("not empty");
+        let (min, max) = self.headers.keys().minmax().into_option().expect("not empty");
         // Contiguous range from min to max means no gaps
-        max - min + 1 == self.headers.len() as u64
+        *max - *min + 1 == self.headers.len() as u64
     }
 
     /// Use the provided bodies as the file client's block body buffer.


### PR DESCRIPTION
replace the collect all header nums into Vec, sort and then iterate checking into a simple `max-min+1` gap check.