### PR TITLE
fix(grafana): use correct metric for block buffer blocks panel

### DIFF
--- a/etc/grafana/dashboards/overview.json
+++ b/etc/grafana/dashboards/overview.json
@@ -7411,7 +7411,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "builder",
-          "expr": "reth_blockchain_tree_block_buffer_blocks{$instance_label=\"$instance\"}",
+          "expr": "reth_blockchain_tree_in_mem_state_num_blocks{$instance_label=\"$instance\"}",
           "hide": false,
           "legendFormat": "Buffered blocks",
           "range": true,


### PR DESCRIPTION
The "Block buffer blocks" panel in the Grafana overview dashboard uses the old `reth_blockchain_tree_block_buffer_blocks` metric. Updates it to `reth_blockchain_tree_in_mem_state_num_blocks`.

Prompted by: brian