### PR TITLE
chore(provider): remove unnecessary collect in changeset readers

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1413,8 +1413,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
         if let Some(head_block) = &self.head_block {
             database_end = head_block.anchor().number;
 
-            let chain = head_block.chain().collect::<Vec<_>>();
-            for state in chain {
+            for state in head_block.chain() {
                 let block_changesets = state
                     .block_ref()
                     .execution_output
@@ -1593,8 +1592,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
             // the anchor is the end of the db range
             database_end = head_block.anchor().number;
 
-            let chain = head_block.chain().collect::<Vec<_>>();
-            for state in chain {
+            for state in head_block.chain() {
                 // found block in memory, collect its changesets
                 let block_changesets = state
                     .block_ref()


### PR DESCRIPTION
iterate directly over `head_block.chain()` instead of collecting into a `Vec` first, avoiding an unnecessary intermediate allocation.