### PR TITLE
feat(rpc): early check gas_limit in bundle api

### DIFF
--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -77,6 +77,16 @@ where
             .into())
         }
 
+        // Validate gas limit against the configured call gas limit before any DB calls
+        let call_gas_limit = self.inner.eth_api.call_gas_limit();
+        if let Some(gas_limit) = gas_limit &&
+            gas_limit > call_gas_limit
+        {
+            return Err(
+                EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
+            )
+        }
+
         let transactions = txs
             .into_iter()
             .map(|tx| recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(&tx))
@@ -120,16 +130,8 @@ where
             }
         }
 
-        // default to call gas limit unless user requests a smaller limit
-        evm_env.block_env.inner_mut().gas_limit = self.inner.eth_api.call_gas_limit();
-        if let Some(gas_limit) = gas_limit {
-            if gas_limit > evm_env.block_env.gas_limit() {
-                return Err(
-                    EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
-                )
-            }
-            evm_env.block_env.inner_mut().gas_limit = gas_limit;
-        }
+        // Apply gas limit: default to call gas limit unless user requests a smaller limit
+        evm_env.block_env.inner_mut().gas_limit = gas_limit.unwrap_or(call_gas_limit);
 
         if let Some(base_fee) = base_fee {
             evm_env.block_env.inner_mut().basefee = base_fee.try_into().unwrap_or(u64::MAX);


### PR DESCRIPTION
check user's gas_limit against configured first, this avoids wasting a db lookup with `evm_env_at.await?` when gas_limit is invalid:

https://github.com/paradigmxyz/reth/blob/0a2f4f2babc62a23072ab331554c8275c0692b90/crates/rpc/rpc/src/eth/bundle.rs#L97

And this change also avoids double write on the `block_env.block_limit`