### PR TITLE
perf(engine): batch MDBX storage reads in BAL prewarming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8348,6 +8348,7 @@ dependencies = [
  "eyre",
  "fixed-cache",
  "futures",
+ "itertools 0.14.0",
  "metrics",
  "metrics-util",
  "moka",

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -158,6 +158,10 @@ pub struct TreeConfig {
     /// When disabled, the BAL hashed post state is not sent to the multiproof task for
     /// early parallel state root computation.
     disable_bal_parallel_state_root: bool,
+    /// Whether to disable BAL (Block Access List) batched IO during prewarming.
+    /// When disabled, falls back to individual per-slot storage reads instead of
+    /// batched cursor reads via `storage_range`.
+    disable_bal_batch_io: bool,
 }
 
 impl Default for TreeConfig {
@@ -190,6 +194,7 @@ impl Default for TreeConfig {
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
             disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
+            disable_bal_batch_io: false,
         }
     }
 }
@@ -251,6 +256,7 @@ impl TreeConfig {
             state_root_task_timeout,
             disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
+            disable_bal_batch_io: false,
         }
     }
 
@@ -586,6 +592,17 @@ impl TreeConfig {
         disable_bal_parallel_state_root: bool,
     ) -> Self {
         self.disable_bal_parallel_state_root = disable_bal_parallel_state_root;
+        self
+    }
+
+    /// Returns whether BAL batched IO is disabled.
+    pub const fn disable_bal_batch_io(&self) -> bool {
+        self.disable_bal_batch_io
+    }
+
+    /// Setter for whether to disable BAL batched IO.
+    pub const fn without_bal_batch_io(mut self, disable_bal_batch_io: bool) -> Self {
+        self.disable_bal_batch_io = disable_bal_batch_io;
         self
     }
 }

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -60,6 +60,7 @@ metrics.workspace = true
 reth-metrics = { workspace = true, features = ["common"] }
 
 # misc
+itertools.workspace = true
 schnellru.workspace = true
 rayon.workspace = true
 tracing.workspace = true

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -458,6 +458,63 @@ impl<S: StateProvider, const PREWARM: bool> StateProvider for CachedStateProvide
             self.state_provider.storage(account, storage_key)
         }
     }
+
+    fn storage_range(
+        &self,
+        account: Address,
+        keys: &[StorageKey],
+    ) -> ProviderResult<Vec<(StorageKey, StorageValue)>> {
+        let mut uncached_keys = Vec::new();
+        let mut result = Vec::with_capacity(keys.len());
+
+        if PREWARM {
+            for &key in keys {
+                if let Some(value) = self.caches.0.storage_cache.get(&(account, key)) {
+                    if !value.is_zero() {
+                        result.push((key, value));
+                    }
+                } else {
+                    uncached_keys.push(key);
+                }
+            }
+
+            // Batch-fetch all uncached keys from the inner provider
+            if !uncached_keys.is_empty() {
+                let fetched = self.state_provider.storage_range(account, &uncached_keys)?;
+                for (key, value) in &fetched {
+                    self.caches.insert_storage(account, *key, Some(*value));
+                }
+                // Insert zero entries for keys that weren't found
+                let fetched_set: std::collections::HashSet<StorageKey> =
+                    fetched.iter().map(|(k, _)| *k).collect();
+                for &key in &uncached_keys {
+                    if !fetched_set.contains(&key) {
+                        self.caches.insert_storage(account, key, Some(StorageValue::ZERO));
+                    }
+                }
+                result.extend(fetched);
+            }
+        } else {
+            for &key in keys {
+                if let Some(value) = self.caches.0.storage_cache.get(&(account, key)) {
+                    self.metrics.storage_cache_hits.increment(1);
+                    if !value.is_zero() {
+                        result.push((key, value));
+                    }
+                } else {
+                    self.metrics.storage_cache_misses.increment(1);
+                    uncached_keys.push(key);
+                }
+            }
+
+            if !uncached_keys.is_empty() {
+                let fetched = self.state_provider.storage_range(account, &uncached_keys)?;
+                result.extend(fetched);
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 impl<S: BytecodeReader, const PREWARM: bool> BytecodeReader for CachedStateProvider<S, PREWARM> {

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{
 use fixed_cache::{AnyRef, CacheConfig, Stats, StatsHandler};
 use metrics::{Counter, Gauge, Histogram};
 use parking_lot::Once;
-use reth_errors::ProviderResult;
+use reth_errors::{ProviderError, ProviderResult};
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, Bytecode};
 use reth_provider::{
@@ -469,7 +469,7 @@ impl<S: StateProvider, const PREWARM: bool> StateProvider for CachedStateProvide
 
         if PREWARM {
             for &key in keys {
-                if let Some(value) = self.caches.0.storage_cache.get(&(account, key)) {
+                if let Some(value) = self.caches.get_storage(account, key) {
                     if !value.is_zero() {
                         result.push((key, value));
                     }
@@ -480,37 +480,34 @@ impl<S: StateProvider, const PREWARM: bool> StateProvider for CachedStateProvide
 
             // Batch-fetch all uncached keys from the inner provider
             if !uncached_keys.is_empty() {
-                let fetched = self.state_provider.storage_range(account, &uncached_keys)?;
-                for (key, value) in &fetched {
-                    self.caches.insert_storage(account, *key, Some(*value));
-                }
-                // Insert zero entries for keys that weren't found
-                let fetched_set: std::collections::HashSet<StorageKey> =
-                    fetched.iter().map(|(k, _)| *k).collect();
+                let mut fetched = self.state_provider.storage_range(account, &uncached_keys)?;
+                // Sort by raw key to align with uncached_keys for the merge-join below.
+                // The inner provider may return results in a different order (e.g. hashed state
+                // iterates by hashed slot).
+                fetched.sort_unstable_by_key(|(k, _)| *k);
+                // Merge-join to find zero slots without allocating a HashSet.
+                let mut fetched_iter = fetched.iter();
+                let mut next = fetched_iter.next();
                 for &key in &uncached_keys {
-                    if !fetched_set.contains(&key) {
-                        self.caches.insert_storage(account, key, Some(StorageValue::ZERO));
+                    if let Some(&(fk, fv)) = next &&
+                        fk == key
+                    {
+                        let _ = self.caches.get_or_try_insert_storage_with(account, key, || {
+                            Ok::<_, ProviderError>(fv)
+                        });
+                        result.push((key, fv));
+                        next = fetched_iter.next();
+                        continue;
                     }
+                    // key not returned by inner provider → zero slot
+                    let _ = self.caches.get_or_try_insert_storage_with(account, key, || {
+                        Ok::<_, ProviderError>(StorageValue::ZERO)
+                    });
                 }
-                result.extend(fetched);
             }
         } else {
-            for &key in keys {
-                if let Some(value) = self.caches.0.storage_cache.get(&(account, key)) {
-                    self.metrics.storage_cache_hits.increment(1);
-                    if !value.is_zero() {
-                        result.push((key, value));
-                    }
-                } else {
-                    self.metrics.storage_cache_misses.increment(1);
-                    uncached_keys.push(key);
-                }
-            }
-
-            if !uncached_keys.is_empty() {
-                let fetched = self.state_provider.storage_range(account, &uncached_keys)?;
-                result.extend(fetched);
-            }
+            // Not called on the execution path; delegate directly.
+            return self.state_provider.storage_range(account, keys);
         }
 
         Ok(result)
@@ -803,6 +800,11 @@ impl ExecutionCache {
         } else {
             Ok(CachedStatus::Cached(result))
         }
+    }
+
+    /// Returns a cached storage value if present, without inserting.
+    pub fn get_storage(&self, address: Address, key: StorageKey) -> Option<StorageValue> {
+        self.0.storage_cache.get(&(address, key))
     }
 
     /// Insert storage value into cache.

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -467,47 +467,42 @@ impl<S: StateProvider, const PREWARM: bool> StateProvider for CachedStateProvide
         let mut uncached_keys = Vec::new();
         let mut result = Vec::with_capacity(keys.len());
 
-        if PREWARM {
-            for &key in keys {
-                if let Some(value) = self.caches.get_storage(account, key) {
-                    if !value.is_zero() {
-                        result.push((key, value));
-                    }
-                } else {
-                    uncached_keys.push(key);
+        for &key in keys {
+            if let Some(value) = self.caches.get_storage(account, key) {
+                if !value.is_zero() {
+                    result.push((key, value));
                 }
+            } else {
+                uncached_keys.push(key);
             }
+        }
 
-            // Batch-fetch all uncached keys from the inner provider
-            if !uncached_keys.is_empty() {
-                let mut fetched = self.state_provider.storage_range(account, &uncached_keys)?;
-                // Sort by raw key to align with uncached_keys for the merge-join below.
-                // The inner provider may return results in a different order (e.g. hashed state
-                // iterates by hashed slot).
-                fetched.sort_unstable_by_key(|(k, _)| *k);
-                // Merge-join to find zero slots without allocating a HashSet.
-                let mut fetched_iter = fetched.iter();
-                let mut next = fetched_iter.next();
-                for &key in &uncached_keys {
-                    if let Some(&(fk, fv)) = next &&
-                        fk == key
-                    {
-                        let _ = self.caches.get_or_try_insert_storage_with(account, key, || {
-                            Ok::<_, ProviderError>(fv)
-                        });
-                        result.push((key, fv));
-                        next = fetched_iter.next();
-                        continue;
-                    }
-                    // key not returned by inner provider → zero slot
+        // Batch-fetch all uncached keys from the inner provider
+        if !uncached_keys.is_empty() {
+            let mut fetched = self.state_provider.storage_range(account, &uncached_keys)?;
+            // Sort by raw key to align with uncached_keys for the merge-join below.
+            // The inner provider may return results in a different order (e.g. hashed state
+            // iterates by hashed slot).
+            fetched.sort_unstable_by_key(|(k, _)| *k);
+            // Merge-join to find zero slots without allocating a HashSet.
+            let mut fetched_iter = fetched.iter();
+            let mut next = fetched_iter.next();
+            for &key in &uncached_keys {
+                if let Some(&(fk, fv)) = next &&
+                    fk == key
+                {
                     let _ = self.caches.get_or_try_insert_storage_with(account, key, || {
-                        Ok::<_, ProviderError>(StorageValue::ZERO)
+                        Ok::<_, ProviderError>(fv)
                     });
+                    result.push((key, fv));
+                    next = fetched_iter.next();
+                    continue;
                 }
+                // key not returned by inner provider → zero slot
+                let _ = self.caches.get_or_try_insert_storage_with(account, key, || {
+                    Ok::<_, ProviderError>(StorageValue::ZERO)
+                });
             }
-        } else {
-            // Not called on the execution path; delegate directly.
-            return self.state_provider.storage_range(account, keys);
         }
 
         Ok(result)

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -143,6 +143,8 @@ where
     disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
     disable_bal_parallel_state_root: bool,
+    /// Whether BAL batched IO is disabled.
+    disable_bal_batch_io: bool,
 }
 
 impl<N, Evm> PayloadProcessor<Evm>
@@ -179,6 +181,7 @@ where
             disable_cache_metrics: config.disable_cache_metrics(),
             disable_bal_parallel_execution: config.disable_bal_parallel_execution(),
             disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
+            disable_bal_batch_io: config.disable_bal_batch_io(),
         }
     }
 }
@@ -505,6 +508,7 @@ where
             executed_tx_index: Arc::clone(&executed_tx_index),
             precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),
+            disable_bal_batch_io: self.disable_bal_batch_io,
         };
 
         let (prewarm_task, to_prewarm_task) = PrewarmCacheTask::new(

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -355,7 +355,12 @@ where
         let ctx = self.ctx.clone();
         self.executor.prewarming_pool().install_fn(|| {
             bal.par_iter().for_each_init(
-                || (ctx.clone(), None::<CachedStateProvider<reth_provider::StateProviderBox>>),
+                || {
+                    (
+                        ctx.clone(),
+                        None::<CachedStateProvider<reth_provider::StateProviderBox, true>>,
+                    )
+                },
                 |(ctx, provider), account| {
                     if ctx.should_stop() {
                         return;
@@ -602,7 +607,7 @@ where
     /// thread.
     fn prefetch_bal_account(
         &self,
-        provider: &mut Option<CachedStateProvider<reth_provider::StateProviderBox>>,
+        provider: &mut Option<CachedStateProvider<reth_provider::StateProviderBox, true>>,
         account: &alloy_eip7928::AccountChanges,
     ) {
         let state_provider = match provider {
@@ -623,7 +628,7 @@ where
                     self.saved_cache.as_ref().expect("BAL prewarm should only run with cache");
                 let caches = saved_cache.cache().clone();
                 let cache_metrics = saved_cache.metrics().clone();
-                slot.insert(CachedStateProvider::new(built, caches, cache_metrics))
+                slot.insert(CachedStateProvider::new_prewarm(built, caches, cache_metrics))
             }
         };
 
@@ -631,12 +636,17 @@ where
 
         let _ = state_provider.basic_account(&account.address);
 
+        let mut slots: Vec<StorageKey> =
+            Vec::with_capacity(account.storage_changes.len() + account.storage_reads.len());
         for slot in &account.storage_changes {
-            let _ = state_provider.storage(account.address, StorageKey::from(slot.slot));
+            slots.push(StorageKey::from(slot.slot));
         }
         for &slot in &account.storage_reads {
-            let _ = state_provider.storage(account.address, StorageKey::from(slot));
+            slots.push(StorageKey::from(slot));
         }
+        slots.sort_unstable();
+        slots.dedup();
+        let _ = state_provider.storage_range(account.address, &slots);
 
         self.metrics.bal_slot_iteration_duration.record(start.elapsed().as_secs_f64());
     }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -22,6 +22,7 @@ use alloy_eip7928::BlockAccessList;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{keccak256, StorageKey, B256};
 use crossbeam_channel::Sender as CrossbeamSender;
+use itertools::{EitherOrBoth, Itertools};
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx, SpecFor};
@@ -636,16 +637,15 @@ where
 
         let _ = state_provider.basic_account(&account.address);
 
-        let mut slots: Vec<StorageKey> =
-            Vec::with_capacity(account.storage_changes.len() + account.storage_reads.len());
-        for slot in &account.storage_changes {
-            slots.push(StorageKey::from(slot.slot));
-        }
-        for &slot in &account.storage_reads {
-            slots.push(StorageKey::from(slot));
-        }
-        slots.sort_unstable();
-        slots.dedup();
+        let slots: Vec<StorageKey> = account
+            .storage_changes
+            .iter()
+            .map(|s| StorageKey::from(s.slot))
+            .merge_join_by(account.storage_reads.iter().map(|&s| StorageKey::from(s)), Ord::cmp)
+            .map(|either| match either {
+                EitherOrBoth::Left(k) | EitherOrBoth::Right(k) | EitherOrBoth::Both(k, _) => k,
+            })
+            .collect();
         let _ = state_provider.storage_range(account.address, &slots);
 
         self.metrics.bal_slot_iteration_duration.record(start.elapsed().as_secs_f64());

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -523,6 +523,8 @@ where
     pub precompile_cache_disabled: bool,
     /// The precompile cache map.
     pub precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
+    /// Whether BAL batched IO is disabled.
+    pub disable_bal_batch_io: bool,
 }
 
 /// Per-thread EVM state initialised by [`PrewarmContext::evm_for_ctx`] and stored in
@@ -637,16 +639,25 @@ where
 
         let _ = state_provider.basic_account(&account.address);
 
-        let slots: Vec<StorageKey> = account
-            .storage_changes
-            .iter()
-            .map(|s| StorageKey::from(s.slot))
-            .merge_join_by(account.storage_reads.iter().map(|&s| StorageKey::from(s)), Ord::cmp)
-            .map(|either| match either {
-                EitherOrBoth::Left(k) | EitherOrBoth::Right(k) | EitherOrBoth::Both(k, _) => k,
-            })
-            .collect();
-        let _ = state_provider.storage_range(account.address, &slots);
+        if self.disable_bal_batch_io {
+            for slot in &account.storage_changes {
+                let _ = state_provider.storage(account.address, StorageKey::from(slot.slot));
+            }
+            for &slot in &account.storage_reads {
+                let _ = state_provider.storage(account.address, StorageKey::from(slot));
+            }
+        } else {
+            let slots: Vec<StorageKey> = account
+                .storage_changes
+                .iter()
+                .map(|s| StorageKey::from(s.slot))
+                .merge_join_by(account.storage_reads.iter().map(|&s| StorageKey::from(s)), Ord::cmp)
+                .map(|either| match either {
+                    EitherOrBoth::Left(k) | EitherOrBoth::Right(k) | EitherOrBoth::Both(k, _) => k,
+                })
+                .collect();
+            let _ = state_provider.storage_range(account.address, &slots);
+        }
 
         self.metrics.bal_slot_iteration_duration.record(start.elapsed().as_secs_f64());
     }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -423,6 +423,11 @@ pub struct EngineArgs {
     /// is not sent to the multiproof task for early parallel state root computation.
     #[arg(long = "engine.disable-bal-parallel-state-root", default_value_t = DefaultEngineValues::get_global().bal_parallel_state_root_disabled)]
     pub bal_parallel_state_root_disabled: bool,
+
+    /// Disable BAL (Block Access List) batched IO during prewarming. When set, falls back
+    /// to individual per-slot storage reads instead of batched cursor reads.
+    #[arg(long = "engine.disable-bal-batch-io", default_value_t = false)]
+    pub disable_bal_batch_io: bool,
 }
 
 #[allow(deprecated)]
@@ -489,6 +494,7 @@ impl Default for EngineArgs {
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
             bal_parallel_execution_disabled,
             bal_parallel_state_root_disabled,
+            disable_bal_batch_io: false,
         }
     }
 }
@@ -521,6 +527,7 @@ impl EngineArgs {
             .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
             .without_bal_parallel_execution(self.bal_parallel_execution_disabled)
             .without_bal_parallel_state_root(self.bal_parallel_state_root_disabled)
+            .without_bal_batch_io(self.disable_bal_batch_io)
     }
 }
 
@@ -577,6 +584,7 @@ mod tests {
             state_root_task_timeout: Some(Duration::from_secs(2)),
             bal_parallel_execution_disabled: true,
             bal_parallel_state_root_disabled: true,
+            disable_bal_batch_io: true,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([
@@ -617,6 +625,7 @@ mod tests {
             "2s",
             "--engine.disable-bal-parallel-execution",
             "--engine.disable-bal-parallel-state-root",
+            "--engine.disable-bal-batch-io",
         ])
         .args;
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -273,6 +273,41 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             Ok(None)
         }
     }
+
+    fn storage_range(
+        &self,
+        account: Address,
+        keys: &[StorageKey],
+    ) -> ProviderResult<Vec<(StorageKey, StorageValue)>> {
+        let mut result = Vec::with_capacity(keys.len());
+        if keys.is_empty() {
+            return Ok(result);
+        }
+
+        if self.0.cached_storage_settings().use_hashed_state() {
+            let hashed_address = alloy_primitives::keccak256(account);
+            let mut cursor = self.tx().cursor_dup_read::<tables::HashedStorages>()?;
+            for &key in keys {
+                let hashed_slot = alloy_primitives::keccak256(key);
+                if let Some(entry) = cursor.seek_by_key_subkey(hashed_address, hashed_slot)? &&
+                    entry.key == hashed_slot
+                {
+                    result.push((key, entry.value));
+                }
+            }
+        } else {
+            let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+            for &key in keys {
+                if let Some(entry) = cursor.seek_by_key_subkey(account, key)? &&
+                    entry.key == key
+                {
+                    result.push((key, entry.value));
+                }
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 impl<Provider: DBProvider + BlockHashReader> BytecodeReader

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -287,12 +287,15 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
         if self.0.cached_storage_settings().use_hashed_state() {
             let hashed_address = alloy_primitives::keccak256(account);
             let mut cursor = self.tx().cursor_dup_read::<tables::HashedStorages>()?;
-            for &key in keys {
-                let hashed_slot = alloy_primitives::keccak256(key);
+            // Sort by hashed slot so cursor seeks are sequential (forward-only).
+            let mut hashed_keys: Vec<(B256, StorageKey)> =
+                keys.iter().map(|&k| (alloy_primitives::keccak256(k), k)).collect();
+            hashed_keys.sort_unstable_by_key(|(h, _)| *h);
+            for (hashed_slot, original_key) in hashed_keys {
                 if let Some(entry) = cursor.seek_by_key_subkey(hashed_address, hashed_slot)? &&
                     entry.key == hashed_slot
                 {
-                    result.push((key, entry.value));
+                    result.push((original_key, entry.value));
                 }
             }
         } else {

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -6,7 +6,7 @@
 /// Used to implement provider traits.
 #[macro_export]
 macro_rules! delegate_impls_to_as_ref {
-    (for $target:ty => $($trait:ident $(where [$($generics:tt)*])? {  $(fn $func:ident$(<$($generic_arg:ident: $generic_arg_ty:path),*>)?(&self, $($arg:ident: $argty:ty),*) -> $ret:path;)* })* ) => {
+    (for $target:ty => $($trait:ident $(where [$($generics:tt)*])? {  $(fn $func:ident$(<$($generic_arg:ident: $generic_arg_ty:path),*>)?(&self, $($arg:ident: $argty:ty),*) -> $ret:ty;)* })* ) => {
 
         $(
           impl<'a, $($($generics)*)?> $trait for $target {
@@ -41,6 +41,7 @@ macro_rules! delegate_provider_impls {
             }
             StateProvider $(where [$($generics)*])? {
                 fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_api::errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
+                fn storage_range(&self, account: alloy_primitives::Address, keys: &[alloy_primitives::StorageKey]) -> reth_storage_api::errors::provider::ProviderResult<Vec<(alloy_primitives::StorageKey, alloy_primitives::StorageValue)>>;
             }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -2,7 +2,7 @@ use super::{
     AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider,
     StorageRootProvider,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
@@ -46,6 +46,28 @@ pub trait StateProvider:
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
+
+    /// Get storage values for multiple keys of a given account.
+    ///
+    /// Returns a `Vec` of `(StorageKey, StorageValue)` pairs for keys that exist in storage.
+    /// Keys with no value are omitted from the result.
+    ///
+    /// The default implementation loops over individual [`storage`](Self::storage) calls.
+    /// Providers may override this to batch lookups using a single cursor.
+    /// Overriding implementations must preserve this contract: keys with no value are omitted.
+    fn storage_range(
+        &self,
+        account: Address,
+        keys: &[StorageKey],
+    ) -> ProviderResult<Vec<(StorageKey, StorageValue)>> {
+        let mut result = Vec::with_capacity(keys.len());
+        for &key in keys {
+            if let Some(value) = self.storage(account, key)? {
+                result.push((key, value));
+            }
+        }
+        Ok(result)
+    }
 
     /// Get account code by its address.
     ///

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1023,6 +1023,9 @@ Engine:
       --engine.disable-bal-parallel-state-root
           Disable BAL-driven parallel state root computation. When set, the BAL hashed post state is not sent to the multiproof task for early parallel state root computation
 
+      --engine.disable-bal-batch-io
+          Disable BAL (Block Access List) batched IO during prewarming. When set, falls back to individual per-slot storage reads instead of batched cursor reads
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
Adds `storage_range` to the `StateProvider` trait and uses it in BAL prewarming to batch all storage slot reads into a single cursor per account instead of one cursor per slot.

Also fixes `prefetch_bal_account` using `CachedStateProvider::new` instead of `new_prewarm`, which meant reads during prefetch were not populating the cache.