### PR TITLE
perf(rpc): check cache before hitting DB in `eth_getTransactionReceipt`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -233,6 +233,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: LoadReceipt + 'static,
     {
         async move {
+            // Try the RPC cache first
+            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
+                && let Some(receipt) = cached.into_receipt(self.converter())
+            {
+                return receipt.map_err(Self::Error::from).map(Some);
+            }
+
+            // Cache miss - fall back to DB
             match self.load_transaction_and_receipt(hash).await? {
                 Some((tx, meta, receipt)) => {
                     self.build_transaction_receipt(tx, meta, receipt).await.map(Some)

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -234,8 +234,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     {
         async move {
             // Try the RPC cache first
-            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
-                && let Some(receipt) = cached.into_receipt(self.converter())
+            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await &&
+                let Some(receipt) = cached.into_receipt(self.converter())
             {
                 return receipt.map_err(Self::Error::from).map(Some);
             }


### PR DESCRIPTION
`transaction_by_hash` already checks the RPC cache before going to disk, but `transaction_receipt` skipped straight to two DB calls (`transaction_by_hash_with_meta` + `receipt_by_hash`). `CachedTransaction::into_receipt()` was literally written for this but never wired up. Now it is.