### PR TITLE
feat(rpc): implement debug_storageRangeAt

### DIFF
--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -1,4 +1,5 @@
 use crate::primitives::alloy_primitives::{BlockNumber, StorageKey, StorageValue};
+use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, U256};
 use core::ops::{Deref, DerefMut};
 use reth_primitives_traits::Account;
@@ -31,6 +32,19 @@ pub trait EvmStateProvider {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
+
+    /// Get a range of storage entries for a given account, starting from the given key
+    /// (inclusive).
+    #[allow(clippy::type_complexity)]
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: B256,
+        max_result: u64,
+    ) -> ProviderResult<(Vec<(StorageKey, StorageValue)>, Option<B256>)> {
+        let _ = (account, start_key, max_result);
+        Ok((Vec::new(), None))
+    }
 }
 
 // Blanket implementation of EvmStateProvider for any type that implements StateProvider.
@@ -56,6 +70,16 @@ impl<T: StateProvider> EvmStateProvider for T {
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
         <T as StateProvider>::storage(self, account, storage_key)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: B256,
+        max_result: u64,
+    ) -> ProviderResult<(Vec<(StorageKey, StorageValue)>, Option<B256>)> {
+        <T as StateProvider>::storage_range(self, account, start_key, max_result)
     }
 }
 

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -3,7 +3,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, U64};
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult};
 use alloy_rpc_types_eth::{Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -394,7 +394,7 @@ pub trait DebugApi<TxReq: RpcObject> {
         contract_address: Address,
         key_start: B256,
         max_result: u64,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<StorageRangeResult>;
 
     /// Returns the structured logs created during the execution of EVM against a block pulled
     /// from the pool of bad ones and returns them as a JSON object. For the second parameter see

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -154,6 +154,18 @@ impl StateProvider for StateProviderTraitObjWrapper {
         self.0.storage(account, storage_key)
     }
 
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: B256,
+        max_result: u64,
+    ) -> reth_errors::ProviderResult<(
+        Vec<(alloy_primitives::StorageKey, alloy_primitives::StorageValue)>,
+        Option<B256>,
+    )> {
+        self.0.storage_range(account, start_key, max_result)
+    }
+
     fn account_code(
         &self,
         addr: &Address,

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,12 +1,12 @@
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
-use alloy_evm::env::BlockEnvironment;
+use alloy_evm::{env::BlockEnvironment, Evm};
 use alloy_genesis::ChainConfig;
 use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -27,7 +27,7 @@ use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
-    FromEthApiError, RpcConvert, RpcNodeCore,
+    FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
@@ -625,6 +625,111 @@ where
             })
             .await
     }
+
+    /// Returns the storage range for a contract after replaying `tx_idx` transactions in the
+    /// given block.
+    pub async fn storage_range_at(
+        &self,
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> Result<StorageRangeResult, Eth::Error> {
+        let ((evm_env, _), block) = futures::try_join!(
+            self.eth_api().evm_env_at(block_hash.into()),
+            self.eth_api().recovered_block(block_hash.into()),
+        )?;
+
+        let block = block.ok_or(EthApiError::HeaderNotFound(block_hash.into()))?;
+
+        self.eth_api()
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
+                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+
+                // Replay transactions up to tx_idx
+                {
+                    let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
+                    for (idx, tx) in block.transactions_recovered().enumerate() {
+                        if idx >= tx_idx {
+                            break;
+                        }
+                        let tx_env = eth_api.evm_config().tx_env(tx);
+                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+                    }
+                }
+
+                // Collect in-memory storage modifications from execution cache
+                let cache_storage: std::collections::BTreeMap<B256, alloy_primitives::U256> = db
+                    .cache
+                    .accounts
+                    .get(&contract_address)
+                    .and_then(|a| a.account.as_ref())
+                    .map(|plain| {
+                        plain
+                            .storage
+                            .iter()
+                            .map(|(k, v)| (B256::new(k.to_be_bytes()), *v))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                // Fetch base storage entries with extra buffer for cache overrides
+                let fetch_count =
+                    max_result.saturating_add(cache_storage.len() as u64).saturating_add(1);
+                let (base_entries, _) = reth_storage_api::StateProvider::storage_range(
+                    &*db.database,
+                    contract_address,
+                    key_start,
+                    fetch_count,
+                )
+                .map_err(Eth::Error::from_eth_err)?;
+
+                // Merge base entries with cache overrides
+                let mut merged = std::collections::BTreeMap::new();
+                for (key, value) in base_entries {
+                    if let Some(&cached) = cache_storage.get(&key) {
+                        // Use cached value if non-zero (zero means deleted)
+                        if !cached.is_zero() {
+                            merged.insert(key, cached);
+                        }
+                    } else {
+                        merged.insert(key, value);
+                    }
+                }
+
+                // Add new entries from cache that weren't in base
+                for (&key, &value) in &cache_storage {
+                    if key >= key_start && !value.is_zero() && !merged.contains_key(&key) {
+                        merged.insert(key, value);
+                    }
+                }
+
+                // Build paginated result
+                let mut storage = std::collections::BTreeMap::new();
+                let mut next_key = None;
+
+                for (count, (&key, &value)) in merged.iter().enumerate() {
+                    if count as u64 >= max_result {
+                        next_key = Some(key);
+                        break;
+                    }
+                    storage.insert(
+                        alloy_primitives::keccak256(key),
+                        alloy_rpc_types_debug::StorageResult {
+                            key,
+                            value: B256::from(value.to_be_bytes()),
+                        },
+                    );
+                }
+
+                Ok(StorageRangeResult {
+                    storage: alloy_rpc_types_debug::StorageMap(storage),
+                    next_key,
+                })
+            })
+            .await
+    }
 }
 
 #[async_trait]
@@ -1059,13 +1164,16 @@ where
 
     async fn debug_storage_range_at(
         &self,
-        _block_hash: B256,
-        _tx_idx: usize,
-        _contract_address: Address,
-        _key_start: B256,
-        _max_result: u64,
-    ) -> RpcResult<()> {
-        Ok(())
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> RpcResult<StorageRangeResult> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::storage_range_at(self, block_hash, tx_idx, contract_address, key_start, max_result)
+            .await
+            .map_err(Into::into)
     }
 
     async fn debug_trace_bad_block(

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -263,6 +263,32 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             Ok(None)
         }
     }
+
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: B256,
+        max_result: u64,
+    ) -> ProviderResult<(Vec<(StorageKey, StorageValue)>, Option<B256>)> {
+        let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+        let mut entries = Vec::new();
+
+        // Seek to the first entry >= start_key for this account (inclusive)
+        let mut current = cursor.seek_by_key_subkey(account, start_key)?;
+
+        while let Some(entry) = current {
+            if entries.len() as u64 >= max_result {
+                // There are more entries, return next_key for pagination
+                return Ok((entries, Some(entry.key)));
+            }
+            if !entry.value.is_zero() {
+                entries.push((entry.key, entry.value));
+            }
+            current = cursor.next_dup_val()?;
+        }
+
+        Ok((entries, None))
+    }
 }
 
 impl<Provider: DBProvider + BlockHashReader> BytecodeReader

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -41,6 +41,7 @@ macro_rules! delegate_provider_impls {
             }
             StateProvider $(where [$($generics)*])? {
                 fn storage(&self, account: alloy_primitives::Address, storage_key: alloy_primitives::StorageKey) -> reth_storage_api::errors::provider::ProviderResult<Option<alloy_primitives::StorageValue>>;
+                fn storage_range(&self, account: alloy_primitives::Address, start_key: alloy_primitives::B256, max_result: u64) -> reth_storage_api::errors::provider::ProviderResult<(Vec<(alloy_primitives::StorageKey, alloy_primitives::StorageValue)>, Option<alloy_primitives::B256>)>;
             }
             BytecodeReader $(where [$($generics)*])? {
                 fn bytecode_by_hash(&self, code_hash: &alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_primitives_traits::Bytecode>>;

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -47,6 +47,23 @@ pub trait StateProvider:
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
 
+    /// Get a range of storage entries for a given account, starting from the given key (inclusive).
+    ///
+    /// Returns up to `max_result` entries as `(StorageKey, StorageValue)` pairs, plus a `next_key`
+    /// if there are more entries beyond the returned range.
+    ///
+    /// The default implementation returns an empty result. Providers backed by a database should
+    /// override this for efficient cursor-based iteration.
+    #[allow(clippy::type_complexity)]
+    fn storage_range(
+        &self,
+        _account: Address,
+        _start_key: B256,
+        _max_result: u64,
+    ) -> ProviderResult<(Vec<(StorageKey, StorageValue)>, Option<B256>)> {
+        Ok((Vec::new(), None))
+    }
+
     /// Get account code by its address.
     ///
     /// Returns `None` if the account doesn't exist or account is not a contract

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -2,7 +2,7 @@ use super::{
     AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider,
     StorageRootProvider,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};


### PR DESCRIPTION
Wanted to use `debug_storageRangeAt` to inspect contract storage at a specific transaction index, found it was a noop returning `Ok(())`.

The main challenge was that `StateProvider` only had single-key `storage()`, no range iteration. So I added `storage_range()` through the full storage abstraction chain (`StateProvider` → `EvmStateProvider` → `StateProviderTraitObjWrapper`), with an efficient cursor-based implementation in `LatestStateProviderRef` using the `PlainStorageState` DupSort table.

The RPC handler replays transactions up to `tx_idx`, then merges the in-memory execution cache (modified/deleted slots) with the base storage from the provider to build the paginated result.