### PR TITLE
fix: fix clippy warnings

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -187,19 +187,22 @@ impl Command {
                     }
                 };
 
-                let rlp = if rlp_blocks {
-                    let rlp = match block_provider.debug_get_raw_block(next_block.into()).await {
-                        Ok(rlp) => rlp,
-                        Err(e) => {
-                            tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
-                            let _ = error_sender
-                                .send(eyre::eyre!("Failed to fetch raw block {next_block}: {e}"));
-                            break;
-                        }
-                    };
-                    Some(rlp)
-                } else {
-                    None
+                let rlp = match rlp_blocks {
+                    true => {
+                        let rlp = match block_provider.debug_get_raw_block(next_block.into()).await
+                        {
+                            Ok(rlp) => rlp,
+                            Err(e) => {
+                                tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
+                                let _ = error_sender.send(eyre::eyre!(
+                                    "Failed to fetch raw block {next_block}: {e}"
+                                ));
+                                break;
+                            }
+                        };
+                        Some(rlp)
+                    }
+                    false => None,
                 };
 
                 let head_block_hash = block.header.hash;

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -84,17 +84,18 @@ impl Command {
                     }
                 };
 
-                let rlp = if rlp_blocks {
-                    let Ok(rlp) = block_provider.debug_get_raw_block(next_block.into()).await
-                    else {
-                        tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}");
-                        let _ = error_sender
-                            .send(eyre::eyre!("Failed to fetch raw block {next_block}"));
-                        break;
-                    };
-                    Some(rlp)
-                } else {
-                    None
+                let rlp = match rlp_blocks {
+                    true => {
+                        let Ok(rlp) = block_provider.debug_get_raw_block(next_block.into()).await
+                        else {
+                            tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}");
+                            let _ = error_sender
+                                .send(eyre::eyre!("Failed to fetch raw block {next_block}"));
+                            break;
+                        };
+                        Some(rlp)
+                    }
+                    false => None,
                 };
 
                 next_block += 1;


### PR DESCRIPTION
fix clippy warnings when running `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked`