### PR TITLE
fix(rpc): correct call_many block lookup errors

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -324,12 +324,14 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // if it's not pending, we should always use block_hash over block_number to ensure that
             // different provider calls query data related to the same block.
             if !is_block_target_pending {
-                target_block = self
+                let Some(block_hash) = self
                     .provider()
                     .block_hash_for_id(target_block)
-                    .map_err(|_| EthApiError::HeaderNotFound(target_block))?
-                    .ok_or_else(|| EthApiError::HeaderNotFound(target_block))?
-                    .into();
+                    .map_err(|err| Self::Error::from_eth_err(EthApiError::Internal(err.into())))?
+                else {
+                    return Err(EthApiError::HeaderNotFound(target_block).into())
+                };
+                target_block = block_hash.into();
             }
 
             let ((evm_env, _), block) = futures::try_join!(

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -327,7 +327,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let Some(block_hash) = self
                     .provider()
                     .block_hash_for_id(target_block)
-                    .map_err(|err| Self::Error::from_eth_err(EthApiError::Internal(err.into())))?
+                    .map_err(|err| Self::Error::from_eth_err::<ProviderError>(err))?
                 else {
                     return Err(EthApiError::HeaderNotFound(target_block).into())
                 };

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -327,7 +327,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let Some(block_hash) = self
                     .provider()
                     .block_hash_for_id(target_block)
-                    .map_err(|err| Self::Error::from_eth_err::<ProviderError>(err))?
+                    .map_err(Self::Error::from_eth_err::<ProviderError>)?
                 else {
                     return Err(EthApiError::HeaderNotFound(target_block).into())
                 };

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -566,6 +566,7 @@ mod tests {
     use alloy_eips::BlockNumberOrTag;
     use alloy_primitives::{Signature, B256, U64};
     use alloy_rpc_types::FeeHistory;
+    use alloy_rpc_types_eth::{Bundle, TransactionRequest};
     use jsonrpsee_types::error::INVALID_PARAMS_CODE;
     use rand::Rng;
     use reth_chain_state::CanonStateSubscriptions;
@@ -761,6 +762,53 @@ mod tests {
         assert!(response.is_err());
         let error_object = response.unwrap_err();
         assert_eq!(error_object.code(), INVALID_PARAMS_CODE);
+    }
+
+    #[tokio::test]
+    async fn test_call_many_propagates_provider_error_for_block_lookup() {
+        let eth_api = build_test_eth_api(MockEthProvider::default());
+        let bundles = vec![Bundle {
+            transactions: vec![TransactionRequest::default()],
+            block_override: None,
+        }];
+
+        let response = <EthApi<_, _> as EthApiServer<_, _, _, _, _, _>>::call_many(
+            &eth_api, bundles, None, None,
+        )
+        .await;
+
+        let err = response.expect_err("call_many should fail when latest block lookup errors");
+        let message = err.message().to_ascii_lowercase();
+        assert!(
+            message.contains("best block does not exist"),
+            "expected provider error to propagate, got: {message}"
+        );
+        assert!(
+            !message.contains("block not found"),
+            "provider error must not be rewritten to block-not-found: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_call_many_keeps_header_not_found_when_block_hash_absent() {
+        let eth_api = build_test_eth_api(NoopProvider::default());
+        let bundles = vec![Bundle {
+            transactions: vec![TransactionRequest::default()],
+            block_override: None,
+        }];
+
+        let response = <EthApi<_, _> as EthApiServer<_, _, _, _, _, _>>::call_many(
+            &eth_api, bundles, None, None,
+        )
+        .await;
+
+        let err =
+            response.expect_err("call_many should fail when latest block hash is unavailable");
+        let message = err.message().to_ascii_lowercase();
+        assert!(
+            message.contains("block not found"),
+            "missing block hash should still map to block-not-found: {message}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -765,7 +765,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_call_many_propagates_provider_error_for_block_lookup() {
+    async fn test_call_many_maps_provider_block_lookup_error_with_eth_api_conversion() {
         let eth_api = build_test_eth_api(MockEthProvider::default());
         let bundles = vec![Bundle {
             transactions: vec![TransactionRequest::default()],
@@ -780,12 +780,12 @@ mod tests {
         let err = response.expect_err("call_many should fail when latest block lookup errors");
         let message = err.message().to_ascii_lowercase();
         assert!(
-            message.contains("best block does not exist"),
-            "expected provider error to propagate, got: {message}"
+            message.contains("block not found"),
+            "best block lookup should map via EthApiError::from(ProviderError): {message}"
         );
         assert!(
-            !message.contains("block not found"),
-            "provider error must not be rewritten to block-not-found: {message}"
+            !message.contains("best block does not exist"),
+            "provider implementation detail should not leak from converted error: {message}"
         );
     }
 


### PR DESCRIPTION
Preserve provider lookup failures as internal errors in `eth_callMany` block resolution, keep `HeaderNotFound` only for missing block hash.