### PR TITLE
perf: pin engine and sparse-trie threads to dedicated CPU cores

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -38,7 +38,7 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
+use reth_tasks::{spawn_os_thread, utils::{increase_thread_priority, pin_current_thread_to_core}};
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
 use state::TreeState;
@@ -429,6 +429,7 @@ where
         let incoming = task.incoming_tx.clone();
         spawn_os_thread("engine", || {
             increase_thread_priority();
+            pin_current_thread_to_core();
             task.run()
         });
         (incoming, outgoing)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -38,7 +38,10 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_tasks::{spawn_os_thread, utils::{increase_thread_priority, pin_current_thread_to_core}};
+use reth_tasks::{
+    spawn_os_thread,
+    utils::{increase_thread_priority, pin_current_thread_to_core},
+};
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
 use state::TreeState;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,8 +565,8 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            increase_thread_priority();
-            pin_current_thread_to_core();
+            reth_tasks::once!(|| increase_thread_priority());
+            reth_tasks::once!(|| pin_current_thread_to_core());
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,8 +565,10 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            reth_tasks::once!(|| increase_thread_priority());
-            reth_tasks::once!(|| pin_current_thread_to_core());
+            reth_tasks::once!(|| {
+                increase_thread_priority();
+                pin_current_thread_to_core();
+            });
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,10 +565,8 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            reth_tasks::once!(|| {
-                increase_thread_priority();
-                pin_current_thread_to_core();
-            });
+            increase_thread_priority();
+            pin_current_thread_to_core();
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -32,7 +32,10 @@ use reth_provider::{
     BlockExecutionOutput, BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader,
 };
 use reth_revm::{db::BundleState, state::EvmState};
-use reth_tasks::{utils::{increase_thread_priority, pin_current_thread_to_core}, ForEachOrdered, Runtime};
+use reth_tasks::{
+    utils::{increase_thread_priority, pin_current_thread_to_core},
+    ForEachOrdered, Runtime,
+};
 use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofWorkerHandle},

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -32,7 +32,7 @@ use reth_provider::{
     BlockExecutionOutput, BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader,
 };
 use reth_revm::{db::BundleState, state::EvmState};
-use reth_tasks::{utils::increase_thread_priority, ForEachOrdered, Runtime};
+use reth_tasks::{utils::{increase_thread_priority, pin_current_thread_to_core}, ForEachOrdered, Runtime};
 use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofWorkerHandle},
@@ -566,6 +566,7 @@ where
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
             increase_thread_priority();
+            pin_current_thread_to_core();
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -11,6 +11,10 @@ pub use thread_priority::{self, *};
 /// be re-entered (e.g. tokio blocking pool).
 #[macro_export]
 macro_rules! once {
+    (|| $body:block) => {{
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| $body);
+    }};
     (|| $body:expr) => {{
         static ONCE: std::sync::Once = std::sync::Once::new();
         ONCE.call_once(|| { $body });

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -4,23 +4,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub use thread_priority::{self, *};
 
-/// Runs the given expression exactly once per call site.
-///
-/// Each invocation expands to its own `static Once`, so two `once!` calls in the same function
-/// are independent. Useful for one-time thread setup (priority, affinity) on threads that may
-/// be re-entered (e.g. tokio blocking pool).
-#[macro_export]
-macro_rules! once {
-    (|| $body:block) => {{
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| $body);
-    }};
-    (|| $body:expr) => {{
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| { $body });
-    }};
-}
-
 /// Increases the current thread's priority.
 ///
 /// Tries [`ThreadPriority::Max`] first. If that fails (e.g. missing `CAP_SYS_NICE`),
@@ -55,12 +38,12 @@ pub fn pin_current_thread_to_core() {
     _pin_current_thread_to_core();
 }
 
-/// Counter used to round-robin across available cores.
-static CORE_INDEX: AtomicUsize = AtomicUsize::new(0);
-
 #[cfg(target_os = "linux")]
 fn _pin_current_thread_to_core() {
     use std::mem;
+
+    /// Counter used to round-robin across available cores.
+    static CORE_INDEX: AtomicUsize = AtomicUsize::new(0);
 
     let thread_name = std::thread::current().name().unwrap_or("unnamed").to_string();
 

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -4,6 +4,19 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub use thread_priority::{self, *};
 
+/// Runs the given expression exactly once per call site.
+///
+/// Each invocation expands to its own `static Once`, so two `once!` calls in the same function
+/// are independent. Useful for one-time thread setup (priority, affinity) on threads that may
+/// be re-entered (e.g. tokio blocking pool).
+#[macro_export]
+macro_rules! once {
+    (|| $body:expr) => {{
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| { $body });
+    }};
+}
+
 /// Increases the current thread's priority.
 ///
 /// Tries [`ThreadPriority::Max`] first. If that fails (e.g. missing `CAP_SYS_NICE`),

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -1,5 +1,7 @@
 //! Task utility functions.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 pub use thread_priority::{self, *};
 
 /// Increases the current thread's priority.
@@ -18,6 +20,76 @@ pub fn increase_thread_priority() {
         if let Err(err) = fallback.set_for_current() {
             tracing::debug!(%thread_name, ?err, "failed to set moderate thread priority");
         }
+    }
+}
+
+/// Pins the current thread to a dedicated CPU core.
+///
+/// Each call assigns a different core in round-robin order from the set of available (online) CPUs.
+/// This reduces context-switch overhead and improves cache locality for latency-sensitive threads
+/// like the engine and sparse-trie tasks.
+///
+/// Failures are logged at `debug` level and are not fatal — the thread will simply run unpinned.
+///
+/// No-op on non-Linux platforms.
+#[allow(clippy::missing_const_for_fn)]
+pub fn pin_current_thread_to_core() {
+    #[cfg(target_os = "linux")]
+    _pin_current_thread_to_core();
+}
+
+/// Counter used to round-robin across available cores.
+static CORE_INDEX: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(target_os = "linux")]
+fn _pin_current_thread_to_core() {
+    use std::mem;
+
+    let thread_name = std::thread::current().name().unwrap_or("unnamed").to_string();
+
+    // Get the current process affinity mask (respects cgroups / taskset).
+    let mut current_set: libc::cpu_set_t = unsafe { mem::zeroed() };
+    let ret = unsafe {
+        libc::sched_getaffinity(0, mem::size_of::<libc::cpu_set_t>(), &raw mut current_set)
+    };
+    if ret != 0 {
+        tracing::debug!(
+            %thread_name,
+            err = std::io::Error::last_os_error().to_string(),
+            "failed to get CPU affinity, skipping core pinning"
+        );
+        return;
+    }
+
+    // Collect available CPUs.
+    let available: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
+        .filter(|&cpu| unsafe { libc::CPU_ISSET(cpu, &current_set) })
+        .collect();
+
+    if available.is_empty() {
+        tracing::debug!(%thread_name, "no available CPUs found, skipping core pinning");
+        return;
+    }
+
+    // Pick the next core in round-robin order.
+    let idx = CORE_INDEX.fetch_add(1, Ordering::Relaxed) % available.len();
+    let core = available[idx];
+
+    // Build a single-CPU mask and apply it.
+    let mut set: libc::cpu_set_t = unsafe { mem::zeroed() };
+    unsafe { libc::CPU_SET(core, &mut set) };
+
+    let ret =
+        unsafe { libc::sched_setaffinity(0, mem::size_of::<libc::cpu_set_t>(), &raw const set) };
+    if ret != 0 {
+        tracing::debug!(
+            %thread_name,
+            core,
+            err = std::io::Error::last_os_error().to_string(),
+            "failed to pin thread to core"
+        );
+    } else {
+        tracing::debug!(%thread_name, core, "pinned thread to core");
     }
 }
 


### PR DESCRIPTION
## Summary
Pin the engine and sparse-trie threads to individual CPU cores via `sched_setaffinity`, reducing context-switch overhead and improving cache locality.

## Changes
- Added `pin_current_thread_to_core()` in `crates/tasks/src/utils.rs` — uses `sched_getaffinity`/`sched_setaffinity` to assign each caller a dedicated core in round-robin order from the available CPU set
- Called it in the engine thread spawn (`crates/engine/tree/src/tree/mod.rs`)
- Called it in the sparse-trie thread spawn (`crates/engine/tree/src/tree/payload_processor/mod.rs`)

Respects existing process affinity (cgroups/taskset/isolcpus). No-op on non-Linux. Failures are logged at debug level and are not fatal.

## Testing
`cargo check -p reth-tasks -p reth-engine-tree` — clean
`cargo clippy -p reth-tasks` — clean

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes