### PR TITLE
chore: update alloy-evm with Spec as TryIntoTxEnv trait generic

### DIFF
--- a/.changelog/mild-foxes-cook.md
+++ b/.changelog/mild-foxes-cook.md
@@ -1,0 +1,5 @@
+---
+reth-rpc-convert: patch
+---
+
+Updated `alloy-evm` dependency to git revision `9bc2dba` and adapted `TxEnvConverter` impl to the updated `TryIntoTxEnv` trait signature that now includes a `Spec` generic parameter.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,8 +290,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c987d1ed9d961097ebf881a86a35a2b8adc5cf4625c3a1286c721e07b585d85"
+source = "git+https://github.com/alloy-rs/evm?rev=9bc2dba#9bc2dba600e36b3799f3360e5ead3be685a1a757"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,8 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.29.0"
-source = "git+https://github.com/alloy-rs/evm?rev=9bc2dba#9bc2dba600e36b3799f3360e5ead3be685a1a757"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a33fa6dca2f2c1a93b5824404b49fdc90b9932702f56e8ebac0c18ecd1a7700"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -750,8 +750,6 @@ ipnet = "2.11"
 # jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 # jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 
-# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "df124c0" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "9bc2dba" }
 
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }
-
-# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "072c248" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -455,7 +455,7 @@ alloy-sol-types = { version = "1.5.6", default-features = false }
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.0", default-features = false }
-alloy-evm = { version = "0.29.0", default-features = false }
+alloy-evm = { version = "0.29.1", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
@@ -750,6 +750,6 @@ ipnet = "2.11"
 # jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 # jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "9bc2dba" }
+# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "9bc2dba" }
 
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::{request::TransactionRequest, Transaction, TransactionInfo};
 use core::error;
 use dyn_clone::DynClone;
-use reth_evm::{BlockEnvFor, ConfigureEvm, EvmEnvFor, TxEnvFor};
+use reth_evm::{BlockEnvFor, ConfigureEvm, EvmEnvFor, SpecFor, TxEnvFor};
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, SealedBlock, SealedHeader, SealedHeaderFor, TransactionMeta,
     TxTy,
@@ -442,7 +442,7 @@ pub trait TxEnvConverter<TxReq, Evm: ConfigureEvm>:
 
 impl<TxReq, Evm> TxEnvConverter<TxReq, Evm> for ()
 where
-    TxReq: TryIntoTxEnv<TxEnvFor<Evm>, BlockEnvFor<Evm>>,
+    TxReq: TryIntoTxEnv<TxEnvFor<Evm>, SpecFor<Evm>, BlockEnvFor<Evm>>,
     Evm: ConfigureEvm,
 {
     type Error = TxReq::Err;


### PR DESCRIPTION
Adapts to alloy-rs/evm#306 which moves the `Spec` type parameter from the `try_into_tx_env` method to the `TryIntoTxEnv` trait level, matching `BlockEnv`.

Only one call site needed updating — the blanket `TxEnvConverter` impl for `()` now passes `SpecFor<Evm>` as the new trait generic.

Co-Authored-By: Matthias Seitz <19890894+mattsse@users.noreply.github.com>

Prompted by: mattsse