### PR TITLE
feat(tasks): add once! macro

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,7 +565,7 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            reth_tasks::once!(|| increase_thread_priority());
+            reth_tasks::once!(increase_thread_priority());
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,7 +565,7 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            increase_thread_priority();
+            reth_tasks::once!(|| increase_thread_priority());
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -9,13 +9,9 @@ pub use thread_priority::{self, *};
 /// be re-entered (e.g. tokio blocking pool).
 #[macro_export]
 macro_rules! once {
-    (|| $body:block) => {{
+    ($e:expr) => {{
         static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| $body);
-    }};
-    (|| $body:expr) => {{
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| { $body });
+        ONCE.call_once(|| $e);
     }};
 }
 

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -2,6 +2,23 @@
 
 pub use thread_priority::{self, *};
 
+/// Runs the given expression exactly once per call site.
+///
+/// Each invocation expands to its own `static Once`, so two `once!` calls in the same function
+/// are independent. Useful for one-time thread setup (priority, affinity) on threads that may
+/// be re-entered (e.g. tokio blocking pool).
+#[macro_export]
+macro_rules! once {
+    (|| $body:block) => {{
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| $body);
+    }};
+    (|| $body:expr) => {{
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| { $body });
+    }};
+}
+
 /// Increases the current thread's priority.
 ///
 /// Tries [`ThreadPriority::Max`] first. If that fails (e.g. missing `CAP_SYS_NICE`),


### PR DESCRIPTION
Adds a `once!` macro that expands to a call-site-scoped `static Once`. Useful for one-time thread setup on threads that get re-entered (e.g. tokio blocking pool).

Used in the sparse-trie spawn to skip redundant `increase_thread_priority` syscalls across payload re-spawns.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes