### PR TITLE
perf: LFU-based sparse trie cache

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -29,7 +29,7 @@ pub const DEFAULT_SPARSE_TRIE_PRUNE_DEPTH: usize = 4;
 /// Default LFU hot-slot capacity for sparse trie pruning.
 ///
 /// Limits the number of `(address, slot)` pairs retained across prune cycles.
-pub const DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS: usize = 10000;
+pub const DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS: usize = 1500;
 
 /// Default LFU hot-account capacity for sparse trie pruning.
 ///

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -26,10 +26,15 @@ pub const DEFAULT_RESERVED_CPU_CORES: usize = 1;
 /// Depth 4 means we keep roughly 16^4 = 65536 potential branch paths at most.
 pub const DEFAULT_SPARSE_TRIE_PRUNE_DEPTH: usize = 4;
 
-/// Default maximum number of storage tries to keep after pruning.
+/// Default LFU hot-slot capacity for sparse trie pruning.
 ///
-/// Storage tries beyond this limit are cleared (but allocations preserved).
-pub const DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES: usize = 100;
+/// Limits the number of `(address, slot)` pairs retained across prune cycles.
+pub const DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS: usize = 10000;
+
+/// Default LFU hot-account capacity for sparse trie pruning.
+///
+/// Limits the number of account addresses retained across prune cycles.
+pub const DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS: usize = 1000;
 
 /// Default timeout for the state root task before spawning a sequential fallback.
 pub const DEFAULT_STATE_ROOT_TASK_TIMEOUT: Duration = Duration::from_secs(1);
@@ -131,8 +136,10 @@ pub struct TreeConfig {
     disable_cache_metrics: bool,
     /// Depth for sparse trie pruning after state root computation.
     sparse_trie_prune_depth: usize,
-    /// Maximum number of storage tries to retain after pruning.
-    sparse_trie_max_storage_tries: usize,
+    /// LFU hot-slot capacity: max `(address, slot)` pairs retained across prune cycles.
+    sparse_trie_max_hot_slots: usize,
+    /// LFU hot-account capacity: max account addresses retained across prune cycles.
+    sparse_trie_max_hot_accounts: usize,
     /// Whether to fully disable sparse trie cache pruning between blocks.
     disable_sparse_trie_cache_pruning: bool,
     /// Timeout for the state root task before spawning a sequential fallback computation.
@@ -165,7 +172,8 @@ impl Default for TreeConfig {
             allow_unwind_canonical_header: false,
             disable_cache_metrics: false,
             sparse_trie_prune_depth: DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
-            sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
+            sparse_trie_max_hot_slots: DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
+            sparse_trie_max_hot_accounts: DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
         }
@@ -196,7 +204,8 @@ impl TreeConfig {
         allow_unwind_canonical_header: bool,
         disable_cache_metrics: bool,
         sparse_trie_prune_depth: usize,
-        sparse_trie_max_storage_tries: usize,
+        sparse_trie_max_hot_slots: usize,
+        sparse_trie_max_hot_accounts: usize,
         state_root_task_timeout: Option<Duration>,
     ) -> Self {
         Self {
@@ -220,7 +229,8 @@ impl TreeConfig {
             allow_unwind_canonical_header,
             disable_cache_metrics,
             sparse_trie_prune_depth,
-            sparse_trie_max_storage_tries,
+            sparse_trie_max_hot_slots,
+            sparse_trie_max_hot_accounts,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout,
         }
@@ -471,14 +481,25 @@ impl TreeConfig {
         self
     }
 
-    /// Returns the maximum number of storage tries to retain after pruning.
-    pub const fn sparse_trie_max_storage_tries(&self) -> usize {
-        self.sparse_trie_max_storage_tries
+    /// Returns the LFU hot-slot capacity for sparse trie pruning.
+    pub const fn sparse_trie_max_hot_slots(&self) -> usize {
+        self.sparse_trie_max_hot_slots
     }
 
-    /// Setter for maximum storage tries to retain.
-    pub const fn with_sparse_trie_max_storage_tries(mut self, max_tries: usize) -> Self {
-        self.sparse_trie_max_storage_tries = max_tries;
+    /// Setter for LFU hot-slot capacity.
+    pub const fn with_sparse_trie_max_hot_slots(mut self, max_hot_slots: usize) -> Self {
+        self.sparse_trie_max_hot_slots = max_hot_slots;
+        self
+    }
+
+    /// Returns the LFU hot-account capacity for sparse trie pruning.
+    pub const fn sparse_trie_max_hot_accounts(&self) -> usize {
+        self.sparse_trie_max_hot_accounts
+    }
+
+    /// Setter for LFU hot-account capacity.
+    pub const fn with_sparse_trie_max_hot_accounts(mut self, max_hot_accounts: usize) -> Self {
+        self.sparse_trie_max_hot_accounts = max_hot_accounts;
         self
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -133,8 +133,10 @@ where
     sparse_state_trie: SharedPreservedSparseTrie,
     /// Sparse trie prune depth.
     sparse_trie_prune_depth: usize,
-    /// Maximum storage tries to retain after pruning.
-    sparse_trie_max_storage_tries: usize,
+    /// LFU hot-slot capacity: max storage slots retained across prune cycles.
+    sparse_trie_max_hot_slots: usize,
+    /// LFU hot-account capacity: max account addresses retained across prune cycles.
+    sparse_trie_max_hot_accounts: usize,
     /// Whether sparse trie cache pruning is fully disabled.
     disable_sparse_trie_cache_pruning: bool,
     /// Whether to disable cache metrics recording.
@@ -170,7 +172,8 @@ where
             precompile_cache_map,
             sparse_state_trie: SharedPreservedSparseTrie::default(),
             sparse_trie_prune_depth: config.sparse_trie_prune_depth(),
-            sparse_trie_max_storage_tries: config.sparse_trie_max_storage_tries(),
+            sparse_trie_max_hot_slots: config.sparse_trie_max_hot_slots(),
+            sparse_trie_max_hot_accounts: config.sparse_trie_max_hot_accounts(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             disable_cache_metrics: config.disable_cache_metrics(),
         }
@@ -559,7 +562,8 @@ where
         let preserved_sparse_trie = self.sparse_state_trie.clone();
         let trie_metrics = self.trie_metrics.clone();
         let prune_depth = self.sparse_trie_prune_depth;
-        let max_storage_tries = self.sparse_trie_max_storage_tries;
+        let max_hot_slots = self.sparse_trie_max_hot_slots;
+        let max_hot_accounts = self.sparse_trie_max_hot_accounts;
         let disable_cache_pruning = self.disable_sparse_trie_cache_pruning;
         let executor = self.executor.clone();
 
@@ -644,7 +648,8 @@ where
                 let start = Instant::now();
                 let (trie, deferred) = task.into_trie_for_reuse(
                     prune_depth,
-                    max_storage_tries,
+                    max_hot_slots,
+                    max_hot_accounts,
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,
                     SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY,
                     disable_cache_pruning,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -580,7 +580,7 @@ where
                 .sparse_trie_cache_wait_duration_histogram
                 .record(start.elapsed().as_secs_f64());
 
-            let sparse_state_trie = preserved
+            let mut sparse_state_trie = preserved
                 .map(|preserved| preserved.into_trie_for(parent_state_root))
                 .unwrap_or_else(|| {
                     debug!(
@@ -597,6 +597,7 @@ where
                         .with_default_storage_trie(default_trie)
                         .with_updates(true)
                 });
+            sparse_state_trie.set_hot_cache_capacities(max_hot_slots, max_hot_accounts);
 
             let mut task = SparseTrieCacheTask::new_with_trie(
                 &executor,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -131,8 +131,6 @@ where
     /// re-use allocated memory. Stored with the block hash it was computed for to enable trie
     /// preservation across sequential payload validations.
     sparse_state_trie: SharedPreservedSparseTrie,
-    /// Sparse trie prune depth.
-    sparse_trie_prune_depth: usize,
     /// LFU hot-slot capacity: max storage slots retained across prune cycles.
     sparse_trie_max_hot_slots: usize,
     /// LFU hot-account capacity: max account addresses retained across prune cycles.
@@ -171,7 +169,6 @@ where
             precompile_cache_disabled: config.precompile_cache_disabled(),
             precompile_cache_map,
             sparse_state_trie: SharedPreservedSparseTrie::default(),
-            sparse_trie_prune_depth: config.sparse_trie_prune_depth(),
             sparse_trie_max_hot_slots: config.sparse_trie_max_hot_slots(),
             sparse_trie_max_hot_accounts: config.sparse_trie_max_hot_accounts(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
@@ -561,7 +558,6 @@ where
     ) {
         let preserved_sparse_trie = self.sparse_state_trie.clone();
         let trie_metrics = self.trie_metrics.clone();
-        let prune_depth = self.sparse_trie_prune_depth;
         let max_hot_slots = self.sparse_trie_max_hot_slots;
         let max_hot_accounts = self.sparse_trie_max_hot_accounts;
         let disable_cache_pruning = self.disable_sparse_trie_cache_pruning;
@@ -647,7 +643,6 @@ where
             let deferred = if let Some(result) = task_result {
                 let start = Instant::now();
                 let (trie, deferred) = task.into_trie_for_reuse(
-                    prune_depth,
                     max_hot_slots,
                     max_hot_accounts,
                     SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -606,8 +606,12 @@ where
     /// 3. but the storage root hasn't been updated yet,
     ///
     /// we trigger state root computation on a rayon pool.
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor::sparse_trie",
+        skip_all
+    )]
     fn compute_drained_storage_roots(&mut self) {
-        let span = debug_span!("compute_storage_roots").entered();
         let addresses_to_compute_roots: Vec<_> = self
             .storage_updates
             .iter()
@@ -628,10 +632,12 @@ where
                 tries_to_compute_roots.push((address, SendStorageTriePtr(trie)));
             }
         }
+
+        let parent_span = tracing::Span::current();
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
             let _enter = debug_span!(
                 target: "engine::tree::payload_processor::sparse_trie",
-                parent: &span,
+                parent: &parent_span,
                 "storage_root",
                 ?address
             )
@@ -644,7 +650,6 @@ where
             // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
             unsafe { (*trie).root().expect("updates are drained, trie should be revealed by now") };
         });
-        drop(span);
     }
 
     /// Iterates through all storage tries for which all updates were processed, computes their

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -12,8 +12,8 @@ use crate::tree::{
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
-use rayon::iter::ParallelIterator;
-use reth_primitives_traits::{Account, FastInstant as Instant, ParallelBridgeBuffered};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use reth_primitives_traits::{Account, FastInstant as Instant};
 use reth_tasks::Runtime;
 use reth_trie::{
     updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, TrieAccount, EMPTY_ROOT_HASH,
@@ -29,8 +29,8 @@ use reth_trie_parallel::{
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 use reth_trie_sparse::{
-    errors::SparseTrieResult, DeferredDrops, LeafUpdate, ParallelSparseTrie, SparseStateTrie,
-    SparseTrie,
+    errors::SparseTrieResult, DeferredDrops, LeafUpdate, ParallelSparseTrie, RevealableSparseTrie,
+    SparseStateTrie, SparseTrie,
 };
 use revm_primitives::{hash_map::Entry, B256Map};
 use tracing::{debug, debug_span, error, instrument, trace_span};
@@ -598,6 +598,55 @@ where
         Ok(updates_len_after < updates_len_before)
     }
 
+    /// Computes storage roots for accounts whose storage updates are fully drained.
+    ///
+    /// For each storage trie T that:
+    /// 1. was modified in the current block,
+    /// 2. all the storage updates are fully drained,
+    /// 3. but the storage root hasn't been updated yet,
+    ///
+    /// we trigger state root computation on a rayon pool.
+    fn compute_drained_storage_roots(&mut self) {
+        let span = debug_span!("compute_storage_roots").entered();
+        let addresses_to_compute_roots: Vec<_> = self
+            .storage_updates
+            .iter()
+            .filter_map(|(address, updates)| updates.is_empty().then_some(*address))
+            .collect();
+
+        struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);
+        // SAFETY: this wrapper only forwards the pointer across rayon; deref invariants are
+        // documented at the use site below.
+        unsafe impl<S: Send> Send for SendStorageTriePtr<S> {}
+
+        let mut tries_to_compute_roots: Vec<(B256, SendStorageTriePtr<S>)> =
+            Vec::with_capacity(addresses_to_compute_roots.len());
+        for address in addresses_to_compute_roots {
+            if let Some(trie) = self.trie.storage_tries_mut().get_mut(&address) &&
+                !trie.is_root_cached()
+            {
+                tries_to_compute_roots.push((address, SendStorageTriePtr(trie)));
+            }
+        }
+        tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
+            let _enter = debug_span!(
+                target: "engine::tree::payload_processor::sparse_trie",
+                parent: &span,
+                "storage_root",
+                ?address
+            )
+            .entered();
+            // SAFETY:
+            // - pointers are created from `storage_tries_mut().get_mut(address)` above;
+            // - `addresses_to_compute_roots` comes from map iteration, so addresses are unique;
+            // - we do not insert/remove entries between pointer collection and use, so pointers
+            //   stay valid and map reallocation cannot occur;
+            // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
+            unsafe { (*trie).root().expect("updates are drained, trie should be revealed by now") };
+        });
+        drop(span);
+    }
+
     /// Iterates through all storage tries for which all updates were processed, computes their
     /// storage roots, and promotes corresponding pending account updates into proper leaf updates
     /// for accounts trie.
@@ -613,21 +662,7 @@ where
             return Ok(());
         }
 
-        let span = debug_span!("compute_storage_roots").entered();
-        self
-            .trie
-            .storage_tries_mut()
-            .iter_mut()
-            .filter(|(address, trie)| {
-                self.storage_updates.get(*address).is_some_and(|updates| updates.is_empty()) &&
-                    !trie.is_root_cached()
-            })
-            .par_bridge_buffered()
-            .for_each(|(address, trie)| {
-                let _enter = debug_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_root", ?address).entered();
-                trie.root().expect("updates are drained, trie should be revealed by now");
-            });
-        drop(span);
+        self.compute_drained_storage_roots();
 
         loop {
             let span = debug_span!("promote_updates", promoted = tracing::field::Empty).entered();

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -201,8 +201,8 @@ where
     /// benchmarking purposes.
     pub(super) fn into_trie_for_reuse(
         self,
-        prune_depth: usize,
-        max_storage_tries: usize,
+        max_hot_slots: usize,
+        max_hot_accounts: usize,
         max_nodes_capacity: usize,
         max_values_capacity: usize,
         disable_pruning: bool,
@@ -211,7 +211,7 @@ where
         let Self { mut trie, .. } = self;
         trie.commit_updates(updates);
         if !disable_pruning {
-            trie.prune(prune_depth, max_storage_tries);
+            trie.prune(max_hot_slots, max_hot_accounts);
             trie.shrink_to(max_nodes_capacity, max_values_capacity);
         }
         let deferred = trie.take_deferred_drops();
@@ -408,6 +408,8 @@ where
     fn on_hashed_state_update(&mut self, hashed_state_update: HashedPostState) {
         for (address, storage) in hashed_state_update.storages {
             for (slot, value) in storage.storage {
+                self.trie.record_slot_touch(address, slot);
+
                 let encoded = if value.is_zero() {
                     Vec::new()
                 } else {
@@ -432,6 +434,8 @@ where
         }
 
         for (address, account) in hashed_state_update.accounts {
+            self.trie.record_account_touch(address);
+
             // Track account as touched.
             //
             // This might overwrite an existing update, which is fine, because storage root from it

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -273,7 +273,7 @@ async fn test_sparse_trie_reuse_across_blocks() -> eyre::Result<()> {
     let tree_config = TreeConfig::default()
         .with_legacy_state_root(false)
         .with_sparse_trie_prune_depth(2)
-        .with_sparse_trie_max_storage_tries(100);
+        .with_sparse_trie_max_hot_slots(100);
 
     let (mut nodes, _wallet) = setup_engine::<EthereumNode>(
         1,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -2,8 +2,8 @@
 
 use clap::{builder::Resettable, Args};
 use reth_engine_primitives::{
-    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
-    DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
+    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS,
+    DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -39,8 +39,8 @@ pub struct DefaultEngineValues {
     account_worker_count: Option<usize>,
     prewarming_threads: Option<usize>,
     cache_metrics_disabled: bool,
-    sparse_trie_prune_depth: usize,
-    sparse_trie_max_storage_tries: usize,
+    sparse_trie_max_hot_slots: usize,
+    sparse_trie_max_hot_accounts: usize,
     disable_sparse_trie_cache_pruning: bool,
     state_root_task_timeout: Option<String>,
 }
@@ -173,15 +173,15 @@ impl DefaultEngineValues {
         self
     }
 
-    /// Set the sparse trie prune depth by default
-    pub const fn with_sparse_trie_prune_depth(mut self, v: usize) -> Self {
-        self.sparse_trie_prune_depth = v;
+    /// Set the LFU hot-slot capacity for sparse trie pruning by default
+    pub const fn with_sparse_trie_max_hot_slots(mut self, v: usize) -> Self {
+        self.sparse_trie_max_hot_slots = v;
         self
     }
 
-    /// Set the maximum number of storage tries to retain after sparse trie pruning by default
-    pub const fn with_sparse_trie_max_storage_tries(mut self, v: usize) -> Self {
-        self.sparse_trie_max_storage_tries = v;
+    /// Set the LFU hot-account capacity for sparse trie pruning by default
+    pub const fn with_sparse_trie_max_hot_accounts(mut self, v: usize) -> Self {
+        self.sparse_trie_max_hot_accounts = v;
         self
     }
 
@@ -220,8 +220,8 @@ impl Default for DefaultEngineValues {
             account_worker_count: None,
             prewarming_threads: None,
             cache_metrics_disabled: false,
-            sparse_trie_prune_depth: DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
-            sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
+            sparse_trie_max_hot_slots: DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
+            sparse_trie_max_hot_accounts: DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some("1s".to_string()),
         }
@@ -349,13 +349,13 @@ pub struct EngineArgs {
     #[arg(long = "engine.disable-cache-metrics", default_value_t = DefaultEngineValues::get_global().cache_metrics_disabled)]
     pub cache_metrics_disabled: bool,
 
-    /// Sparse trie prune depth.
-    #[arg(long = "engine.sparse-trie-prune-depth", default_value_t = DefaultEngineValues::get_global().sparse_trie_prune_depth)]
-    pub sparse_trie_prune_depth: usize,
+    /// LFU hot-slot capacity: max storage slots retained across sparse trie prune cycles.
+    #[arg(long = "engine.sparse-trie-max-hot-slots", alias = "engine.sparse-trie-max-storage-tries", default_value_t = DefaultEngineValues::get_global().sparse_trie_max_hot_slots)]
+    pub sparse_trie_max_hot_slots: usize,
 
-    /// Maximum number of storage tries to retain after sparse trie pruning.
-    #[arg(long = "engine.sparse-trie-max-storage-tries", default_value_t = DefaultEngineValues::get_global().sparse_trie_max_storage_tries)]
-    pub sparse_trie_max_storage_tries: usize,
+    /// LFU hot-account capacity: max account addresses retained across sparse trie prune cycles.
+    #[arg(long = "engine.sparse-trie-max-hot-accounts", default_value_t = DefaultEngineValues::get_global().sparse_trie_max_hot_accounts)]
+    pub sparse_trie_max_hot_accounts: usize,
 
     /// Fully disable sparse trie cache pruning. When set, the cached sparse trie is preserved
     /// without any node pruning or storage trie eviction between blocks. Useful for benchmarking
@@ -402,8 +402,8 @@ impl Default for EngineArgs {
             account_worker_count,
             prewarming_threads,
             cache_metrics_disabled,
-            sparse_trie_prune_depth,
-            sparse_trie_max_storage_tries,
+            sparse_trie_max_hot_slots,
+            sparse_trie_max_hot_accounts,
             disable_sparse_trie_cache_pruning,
             state_root_task_timeout,
         } = DefaultEngineValues::get_global().clone();
@@ -431,8 +431,8 @@ impl Default for EngineArgs {
             account_worker_count,
             prewarming_threads,
             cache_metrics_disabled,
-            sparse_trie_prune_depth,
-            sparse_trie_max_storage_tries,
+            sparse_trie_max_hot_slots,
+            sparse_trie_max_hot_accounts,
             disable_sparse_trie_cache_pruning,
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
@@ -462,8 +462,8 @@ impl EngineArgs {
             )
             .with_unwind_canonical_header(self.allow_unwind_canonical_header)
             .without_cache_metrics(self.cache_metrics_disabled)
-            .with_sparse_trie_prune_depth(self.sparse_trie_prune_depth)
-            .with_sparse_trie_max_storage_tries(self.sparse_trie_max_storage_tries)
+            .with_sparse_trie_max_hot_slots(self.sparse_trie_max_hot_slots)
+            .with_sparse_trie_max_hot_accounts(self.sparse_trie_max_hot_accounts)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
             .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
     }
@@ -515,8 +515,8 @@ mod tests {
             account_worker_count: Some(8),
             prewarming_threads: Some(4),
             cache_metrics_disabled: true,
-            sparse_trie_prune_depth: 10,
-            sparse_trie_max_storage_tries: 100,
+            sparse_trie_max_hot_slots: 100,
+            sparse_trie_max_hot_accounts: 500,
             disable_sparse_trie_cache_pruning: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
         };
@@ -550,10 +550,10 @@ mod tests {
             "--engine.prewarming-threads",
             "4",
             "--engine.disable-cache-metrics",
-            "--engine.sparse-trie-prune-depth",
-            "10",
-            "--engine.sparse-trie-max-storage-tries",
+            "--engine.sparse-trie-max-hot-slots",
             "100",
+            "--engine.sparse-trie-max-hot-accounts",
+            "500",
             "--engine.disable-sparse-trie-cache-pruning",
             "--engine.state-root-task-timeout",
             "2s",

--- a/crates/trie/sparse/src/lfu.rs
+++ b/crates/trie/sparse/src/lfu.rs
@@ -159,7 +159,7 @@ impl<K: fmt::Debug + Copy + Eq + hash::Hash> BucketedLfu<K> {
 mod tests {
     use super::*;
     use alloc::collections::{BTreeMap, BTreeSet};
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use proptest::prelude::*;
 
     #[derive(Clone, Copy, Debug)]
     enum Op {
@@ -276,24 +276,43 @@ mod tests {
         assert_eq!(lfu.min_freq, actual_min_freq.unwrap_or(1), "min_freq mismatch");
     }
 
-    fn safe_random_op(model: &ModelLfu, rng: &mut StdRng) -> Op {
-        let mut candidates = Vec::new();
+    fn is_safe_op(model: &ModelLfu, op: Op) -> bool {
+        match op {
+            Op::SetCapacity(capacity) => {
+                capacity >= model.entries.len() || model.has_unique_frequencies()
+            }
+            Op::Touch(key) => {
+                if model.capacity == 0 {
+                    return true;
+                }
 
-        for capacity in 0..=4 {
-            if capacity >= model.entries.len() || model.has_unique_frequencies() {
-                candidates.push(Op::SetCapacity(capacity));
+                let is_new_key = !model.entries.contains_key(&key);
+                let would_evict = is_new_key && model.entries.len() >= model.capacity;
+                !would_evict || model.has_unique_frequencies()
+            }
+        }
+    }
+
+    fn sanitize_trace(raw_ops: Vec<Op>) -> Vec<Op> {
+        let mut model = ModelLfu::default();
+        let mut safe_ops = Vec::with_capacity(raw_ops.len());
+
+        for op in raw_ops {
+            if is_safe_op(&model, op) {
+                model.apply(op);
+                safe_ops.push(op);
             }
         }
 
-        for key in 0..=5 {
-            let is_new_key = !model.entries.contains_key(&key);
-            let would_evict = is_new_key && model.entries.len() >= model.capacity;
-            if !would_evict || model.has_unique_frequencies() {
-                candidates.push(Op::Touch(key));
-            }
-        }
+        safe_ops
+    }
 
-        candidates[rng.random_range(0..candidates.len())]
+    fn raw_trace_strategy() -> impl Strategy<Value = Vec<Op>> {
+        prop::collection::vec(
+            prop_oneof![(0usize..=4).prop_map(Op::SetCapacity), (0u8..=5).prop_map(Op::Touch),],
+            0..256,
+        )
+        .prop_map(sanitize_trace)
     }
 
     fn check_trace(ops: &[Op]) {
@@ -378,19 +397,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn bucketed_lfu_model_safe_randomized_traces() {
-        for seed in 0..32 {
-            let mut rng = StdRng::seed_from_u64(seed);
-            let mut ops = Vec::new();
-            let mut model = ModelLfu::default();
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
 
-            for _ in 0..256 {
-                let op = safe_random_op(&model, &mut rng);
-                model.apply(op);
-                ops.push(op);
-            }
-
+        #[test]
+        fn bucketed_lfu_model_safe_proptest_traces(ops in raw_trace_strategy()) {
             check_trace(&ops);
         }
     }

--- a/crates/trie/sparse/src/lfu.rs
+++ b/crates/trie/sparse/src/lfu.rs
@@ -1,0 +1,397 @@
+use core::{fmt, hash};
+
+use alloc::vec::Vec;
+use alloy_primitives::map::HashMap;
+
+/// Maximum frequency value. Frequencies are capped here to bound bucket storage.
+const LFU_MAX_FREQ: u16 = 255;
+
+/// Per-entry metadata stored in the LFU lookup map.
+#[derive(Debug, Clone, Copy)]
+struct LfuEntryMeta {
+    /// Current frequency (1..=`LFU_MAX_FREQ`).
+    freq: u16,
+    /// Index of this key within `buckets[freq]`.
+    pos: usize,
+}
+
+/// Bucketed LFU cache with O(1) eviction and O(1) touch operations.
+///
+/// Generic over the key type `K`.
+#[derive(Debug)]
+pub(crate) struct BucketedLfu<K> {
+    capacity: usize,
+    /// Maps each key to its frequency and bucket position.
+    entries: HashMap<K, LfuEntryMeta>,
+    /// `buckets[f]` holds all keys currently at frequency `f`.
+    /// Index 0 is unused; valid frequencies are 1..=`LFU_MAX_FREQ`.
+    buckets: Vec<Vec<K>>,
+    /// Smallest non-empty frequency bucket.
+    min_freq: u16,
+}
+
+impl<K> Default for BucketedLfu<K> {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+impl<K> BucketedLfu<K> {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: HashMap::default(),
+            buckets: (0..=LFU_MAX_FREQ).map(|_| Vec::new()).collect(),
+            min_freq: 1,
+        }
+    }
+}
+
+impl<K: fmt::Debug + Copy + Eq + hash::Hash> BucketedLfu<K> {
+    /// Updates the capacity and evicts the least-frequently-used entries that exceed it.
+    ///
+    /// Entries accumulate via [`Self::touch`] over time. This method trims the cache
+    /// so that only the `capacity` hottest entries are retained.
+    pub(crate) fn decay_and_evict(&mut self, capacity: usize) {
+        self.capacity = capacity;
+
+        if self.capacity == 0 {
+            self.entries.clear();
+            for b in &mut self.buckets {
+                b.clear();
+            }
+            self.min_freq = 1;
+            return;
+        }
+
+        while self.entries.len() > self.capacity {
+            self.evict_one();
+        }
+    }
+
+    /// Evicts a single entry from the lowest-frequency bucket.
+    fn evict_one(&mut self) {
+        if self.entries.is_empty() {
+            self.min_freq = 1;
+            return;
+        }
+
+        // Advance min_freq to the next non-empty bucket.
+        while (self.min_freq as usize) < self.buckets.len() &&
+            self.buckets[self.min_freq as usize].is_empty()
+        {
+            self.min_freq += 1;
+        }
+
+        if (self.min_freq as usize) >= self.buckets.len() {
+            self.min_freq = 1;
+            return;
+        }
+
+        if let Some(key) = self.buckets[self.min_freq as usize].pop() {
+            self.entries.remove(&key);
+
+            while (self.min_freq as usize) < self.buckets.len() &&
+                self.buckets[self.min_freq as usize].is_empty()
+            {
+                self.min_freq += 1;
+            }
+
+            if (self.min_freq as usize) >= self.buckets.len() {
+                self.min_freq = 1;
+            }
+        }
+    }
+
+    /// Records a key touch. O(1) amortized.
+    pub(crate) fn touch(&mut self, key: K) {
+        if self.capacity == 0 {
+            return;
+        }
+
+        if let Some(meta) = self.entries.get(&key).copied() {
+            debug_assert_eq!(self.buckets[meta.freq as usize][meta.pos], key);
+
+            let old_freq = meta.freq as usize;
+            let new_freq = meta.freq.saturating_add(1).min(LFU_MAX_FREQ);
+
+            if new_freq as usize != old_freq {
+                // Remove from old bucket via swap_remove and fix the swapped element's pos.
+                self.buckets[old_freq].swap_remove(meta.pos);
+                if let Some(&moved_key) = self.buckets[old_freq].get(meta.pos) {
+                    self.entries.get_mut(&moved_key).expect("moved key must exist").pos = meta.pos;
+                }
+
+                // Insert into new bucket.
+                let new_pos = self.buckets[new_freq as usize].len();
+                self.buckets[new_freq as usize].push(key);
+
+                let entry = self.entries.get_mut(&key).expect("key must exist");
+                entry.freq = new_freq;
+                entry.pos = new_pos;
+
+                // Update min_freq if old bucket is now empty.
+                if self.buckets[old_freq].is_empty() && old_freq == self.min_freq as usize {
+                    self.min_freq = new_freq;
+                }
+            }
+        } else {
+            // Evict if at capacity before inserting.
+            if self.entries.len() >= self.capacity {
+                self.evict_one();
+            }
+
+            // New entry at frequency 1.
+            let pos = self.buckets[1].len();
+            self.buckets[1].push(key);
+            self.entries.insert(key, LfuEntryMeta { freq: 1, pos });
+            self.min_freq = 1;
+        }
+    }
+
+    /// Returns an iterator over all retained keys.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &K> {
+        self.entries.keys()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::collections::{BTreeMap, BTreeSet};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+
+    #[derive(Clone, Copy, Debug)]
+    enum Op {
+        SetCapacity(usize),
+        Touch(u8),
+    }
+
+    #[derive(Debug, Default)]
+    struct ModelLfu {
+        capacity: usize,
+        entries: BTreeMap<u8, u16>,
+    }
+
+    impl ModelLfu {
+        fn apply(&mut self, op: Op) {
+            match op {
+                Op::SetCapacity(capacity) => self.set_capacity(capacity),
+                Op::Touch(key) => self.touch(key),
+            }
+        }
+
+        fn set_capacity(&mut self, capacity: usize) {
+            self.capacity = capacity;
+
+            if capacity == 0 {
+                self.entries.clear();
+                return;
+            }
+
+            while self.entries.len() > self.capacity {
+                self.evict_one();
+            }
+        }
+
+        fn touch(&mut self, key: u8) {
+            if self.capacity == 0 {
+                return;
+            }
+
+            if let Some(freq) = self.entries.get_mut(&key) {
+                *freq = freq.saturating_add(1).min(LFU_MAX_FREQ);
+                return;
+            }
+
+            if self.entries.len() >= self.capacity {
+                self.evict_one();
+            }
+
+            self.entries.insert(key, 1);
+        }
+
+        fn evict_one(&mut self) {
+            let victim = self
+                .entries
+                .iter()
+                .min_by_key(|(key, freq)| (**freq, **key))
+                .map(|(key, _)| *key)
+                .expect("model eviction requires a live entry");
+            self.entries.remove(&victim);
+        }
+
+        fn has_unique_frequencies(&self) -> bool {
+            let mut freqs = BTreeSet::new();
+            self.entries.values().all(|freq| freqs.insert(*freq))
+        }
+
+        fn snapshot(&self) -> BTreeMap<u8, u16> {
+            self.entries.clone()
+        }
+    }
+
+    fn apply_real(lfu: &mut BucketedLfu<u8>, op: Op) {
+        match op {
+            Op::SetCapacity(capacity) => lfu.decay_and_evict(capacity),
+            Op::Touch(key) => lfu.touch(key),
+        }
+    }
+
+    fn snapshot(lfu: &BucketedLfu<u8>) -> BTreeMap<u8, u16> {
+        lfu.entries.iter().map(|(key, meta)| (*key, meta.freq)).collect()
+    }
+
+    fn assert_valid(lfu: &BucketedLfu<u8>) {
+        let mut seen = BTreeSet::new();
+        let mut actual_min_freq = None;
+
+        for freq in 1..lfu.buckets.len() {
+            for (pos, key) in lfu.buckets[freq].iter().copied().enumerate() {
+                assert!(seen.insert(key), "duplicate key {key} in buckets");
+
+                let meta =
+                    lfu.entries.get(&key).unwrap_or_else(|| panic!("missing entry for {key}"));
+                assert_eq!(meta.freq as usize, freq, "wrong frequency for key {key}");
+                assert_eq!(meta.pos, pos, "wrong position for key {key}");
+
+                actual_min_freq.get_or_insert(freq as u16);
+            }
+        }
+
+        assert_eq!(seen.len(), lfu.entries.len(), "bucket/entry count mismatch");
+
+        for (key, meta) in &lfu.entries {
+            assert_ne!(meta.freq, 0, "zero frequency for key {key}");
+            assert!(
+                meta.pos < lfu.buckets[meta.freq as usize].len(),
+                "position out of bounds for key {key}"
+            );
+            assert_eq!(
+                lfu.buckets[meta.freq as usize][meta.pos], *key,
+                "bucket position mismatch for key {key}"
+            );
+        }
+
+        assert_eq!(lfu.min_freq, actual_min_freq.unwrap_or(1), "min_freq mismatch");
+    }
+
+    fn safe_random_op(model: &ModelLfu, rng: &mut StdRng) -> Op {
+        let mut candidates = Vec::new();
+
+        for capacity in 0..=4 {
+            if capacity >= model.entries.len() || model.has_unique_frequencies() {
+                candidates.push(Op::SetCapacity(capacity));
+            }
+        }
+
+        for key in 0..=5 {
+            let is_new_key = !model.entries.contains_key(&key);
+            let would_evict = is_new_key && model.entries.len() >= model.capacity;
+            if !would_evict || model.has_unique_frequencies() {
+                candidates.push(Op::Touch(key));
+            }
+        }
+
+        candidates[rng.random_range(0..candidates.len())]
+    }
+
+    fn check_trace(ops: &[Op]) {
+        let mut real = BucketedLfu::new(0);
+        let mut model = ModelLfu::default();
+
+        for (step, &op) in ops.iter().enumerate() {
+            apply_real(&mut real, op);
+            model.apply(op);
+
+            assert_valid(&real);
+            assert_eq!(snapshot(&real), model.snapshot(), "mismatch at step {step}: {op:?}");
+        }
+    }
+
+    #[test]
+    fn bucketed_lfu_zero_capacity_touches_are_ignored() {
+        let mut lfu = BucketedLfu::default();
+
+        lfu.touch(1);
+        lfu.touch(2);
+
+        assert_valid(&lfu);
+        assert!(lfu.entries.is_empty());
+        assert_eq!(lfu.min_freq, 1);
+    }
+
+    #[test]
+    fn bucketed_lfu_retouch_does_not_duplicate_keys() {
+        check_trace(&[Op::SetCapacity(2), Op::Touch(1), Op::Touch(1), Op::Touch(1)]);
+    }
+
+    #[test]
+    fn bucketed_lfu_shrink_keeps_hottest_keys() {
+        check_trace(&[
+            Op::SetCapacity(4),
+            Op::Touch(1),
+            Op::Touch(2),
+            Op::Touch(2),
+            Op::Touch(3),
+            Op::Touch(3),
+            Op::Touch(3),
+            Op::Touch(4),
+            Op::Touch(4),
+            Op::Touch(4),
+            Op::Touch(4),
+            Op::SetCapacity(2),
+        ]);
+    }
+
+    #[test]
+    fn bucketed_lfu_touch_saturates_frequency() {
+        let mut lfu = BucketedLfu::new(1);
+
+        lfu.touch(1);
+        for _ in 0..(LFU_MAX_FREQ as usize + 16) {
+            lfu.touch(1);
+        }
+
+        assert_valid(&lfu);
+        assert_eq!(lfu.entries[&1].freq, LFU_MAX_FREQ);
+        assert_eq!(lfu.buckets[LFU_MAX_FREQ as usize], vec![1]);
+    }
+
+    #[test]
+    fn bucketed_lfu_tie_eviction_keeps_new_key_and_one_old_key_is_dropped() {
+        let mut lfu = BucketedLfu::new(2);
+
+        lfu.touch(1);
+        lfu.touch(2);
+        lfu.touch(3);
+
+        assert_valid(&lfu);
+        assert_eq!(lfu.entries.len(), 2);
+        assert!(lfu.entries.contains_key(&3));
+        assert_eq!(
+            [lfu.entries.contains_key(&1), lfu.entries.contains_key(&2)]
+                .into_iter()
+                .filter(|present| *present)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn bucketed_lfu_model_safe_randomized_traces() {
+        for seed in 0..32 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let mut ops = Vec::new();
+            let mut model = ModelLfu::default();
+
+            for _ in 0..256 {
+                let op = safe_random_op(&model, &mut rng);
+                model.apply(op);
+                ops.push(op);
+            }
+
+            check_trace(&ops);
+        }
+    }
+}

--- a/crates/trie/sparse/src/lfu.rs
+++ b/crates/trie/sparse/src/lfu.rs
@@ -153,6 +153,11 @@ impl<K: fmt::Debug + Copy + Eq + hash::Hash> BucketedLfu<K> {
     pub(crate) fn keys(&self) -> impl Iterator<Item = &K> {
         self.entries.keys()
     }
+
+    /// Returns the number of retained keys.
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
 }
 
 #[cfg(test)]

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -8,6 +8,8 @@ extern crate alloc;
 mod state;
 pub use state::*;
 
+mod lfu;
+
 mod trie;
 pub use trie::*;
 

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -125,9 +125,6 @@ pub struct ParallelSparseTrie {
     update_actions_buffers: Vec<Vec<SparseTrieUpdatesAction>>,
     /// Thresholds controlling when parallelism is enabled for different operations.
     parallelism_thresholds: ParallelismThresholds,
-    /// Tracks heat of lower subtries for smart pruning decisions.
-    /// Hot subtries are skipped during pruning to keep frequently-used data revealed.
-    subtrie_heat: SubtrieModifications,
     /// Metrics for the parallel sparse trie.
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::ParallelSparseTrieMetrics,
@@ -151,7 +148,6 @@ impl Default for ParallelSparseTrie {
             branch_node_masks: BranchNodeMasksMap::default(),
             update_actions_buffers: Vec::default(),
             parallelism_thresholds: Default::default(),
-            subtrie_heat: SubtrieModifications::default(),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
             #[cfg(feature = "trie-debug")]
@@ -308,7 +304,6 @@ impl SparseTrie for ParallelSparseTrie {
                     continue;
                 }
                 self.lower_subtries[idx].reveal(&node.path);
-                self.subtrie_heat.mark_modified(idx);
                 self.lower_subtries[idx].as_revealed_mut().expect("just revealed").reveal_node(
                     node.path,
                     &node.node,
@@ -1004,7 +999,6 @@ impl SparseTrie for ParallelSparseTrie {
         }
         self.prefix_set = PrefixSetMut::all();
         self.updates = self.updates.is_some().then(SparseTrieUpdates::wiped);
-        self.subtrie_heat.clear();
     }
 
     fn clear(&mut self) {
@@ -1016,7 +1010,6 @@ impl SparseTrie for ParallelSparseTrie {
         self.prefix_set.clear();
         self.updates = None;
         self.branch_node_masks.clear();
-        self.subtrie_heat.clear();
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.reset();
         // `update_actions_buffers` doesn't need to be cleared; we want to reuse the Vecs it has
@@ -1157,198 +1150,103 @@ impl SparseTrie for ParallelSparseTrie {
         self.memory_size()
     }
 
-    fn prune(&mut self, max_depth: usize) -> usize {
+    fn prune(&mut self, retained_leaves: &[Nibbles]) -> usize {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.reset();
 
-        // Decay heat for subtries not modified this cycle
-        self.subtrie_heat.decay_and_reset();
+        let mut retained_leaves = retained_leaves.to_vec();
+        retained_leaves.sort_unstable();
+        retained_leaves.dedup();
 
-        // DFS traversal to find nodes at max_depth that can be pruned.
-        // Collects "effective pruned roots" - children of nodes at max_depth with computed hashes.
-        // We replace nodes with Hash stubs inline during traversal.
         let mut effective_pruned_roots = Vec::<Nibbles>::new();
-        let mut stack: SmallVec<[(Nibbles, usize); 32]> = SmallVec::new();
-        stack.push((Nibbles::default(), 0));
+        let mut stack: SmallVec<[Nibbles; 32]> = SmallVec::new();
+        stack.push(Nibbles::default());
 
-        // DFS traversal: pop path and depth, skip if subtrie or node not found.
-        while let Some((path, depth)) = stack.pop() {
-            // Skip traversal into hot lower subtries beyond max_depth.
-            // At max_depth, we still need to process the node to convert children to hashes.
-            // This keeps frequently-modified subtries revealed to avoid expensive re-reveals.
-            if depth > max_depth &&
-                let SparseSubtrieType::Lower(idx) = SparseSubtrieType::from_path(&path) &&
-                self.subtrie_heat.is_hot(idx)
-            {
-                continue;
-            }
-
+        while let Some(path) = stack.pop() {
             let Some(subtrie) = self.subtrie_for_path_mut_untracked(&path) else { continue };
             let Some(node) = subtrie.nodes.get_mut(&path) else { continue };
 
             match node {
                 SparseNode::Empty | SparseNode::Leaf { .. } => {}
                 SparseNode::Extension { key, state, .. } => {
-                    // For extension nodes at max depth, collapse both extension and its child
-                    // branch to preserve invariant of all extension nodes children being revealed.
-                    if depth == max_depth {
-                        let Some(hash) = state.cached_hash() else { continue };
-                        subtrie.nodes.remove(&path);
+                    let mut child = path;
+                    child.extend(key);
 
-                        let parent_path = path.slice(0..path.len() - 1);
-                        let SparseNode::Branch { blinded_mask, blinded_hashes, .. } =
-                            subtrie.nodes.get_mut(&parent_path).unwrap()
-                        else {
-                            panic!("expected branch node at path {parent_path:?}");
-                        };
-
-                        let nibble = path.last().unwrap();
-                        blinded_mask.set_bit(nibble);
-                        blinded_hashes[nibble as usize] = hash;
-
-                        effective_pruned_roots.push(path);
-                    } else {
-                        let mut child = path;
-                        child.extend(key);
-                        stack.push((child, depth + 1));
+                    if has_retained_descendant(&retained_leaves, &child) {
+                        stack.push(child);
+                        continue;
                     }
+
+                    // Root extension has no parent branch edge to blind; keep it as-is.
+                    if path.is_empty() {
+                        continue;
+                    }
+
+                    let Some(hash) = state.cached_hash() else { continue };
+                    subtrie.nodes.remove(&path);
+
+                    let parent_path = path.slice(0..path.len() - 1);
+                    let SparseNode::Branch { blinded_mask, blinded_hashes, .. } =
+                        subtrie.nodes.get_mut(&parent_path).unwrap()
+                    else {
+                        panic!("expected branch node at path {parent_path:?}");
+                    };
+
+                    let nibble = path.last().unwrap();
+                    blinded_mask.set_bit(nibble);
+                    blinded_hashes[nibble as usize] = hash;
+                    effective_pruned_roots.push(path);
                 }
                 SparseNode::Branch { state_mask, blinded_mask, blinded_hashes, .. } => {
-                    // For branch nodes at max depth, collapse all children onto them,
-                    if depth == max_depth {
-                        let mut blinded_mask = *blinded_mask;
-                        let mut blinded_hashes = blinded_hashes.clone();
-                        for nibble in state_mask.iter() {
-                            if blinded_mask.is_bit_set(nibble) {
-                                continue;
-                            }
-                            let mut child = path;
-                            child.push_unchecked(nibble);
-
-                            let Entry::Occupied(entry) = self
-                                .subtrie_for_path_mut_untracked(&child)
-                                .unwrap()
-                                .nodes
-                                .entry(child)
-                            else {
-                                panic!("expected node at path {child:?}");
-                            };
-
-                            let Some(hash) = entry.get().cached_hash() else {
-                                continue;
-                            };
-                            entry.remove();
-                            blinded_mask.set_bit(nibble);
-                            blinded_hashes[nibble as usize] = hash;
-                            effective_pruned_roots.push(child);
+                    let mut blinded_mask = *blinded_mask;
+                    let mut blinded_hashes = blinded_hashes.clone();
+                    for nibble in state_mask.iter() {
+                        if blinded_mask.is_bit_set(nibble) {
+                            continue;
                         }
 
-                        let SparseNode::Branch {
-                            blinded_mask: old_blinded_mask,
-                            blinded_hashes: old_blinded_hashes,
-                            ..
-                        } = self
-                            .subtrie_for_path_mut_untracked(&path)
-                            .unwrap()
-                            .nodes
-                            .get_mut(&path)
-                            .unwrap()
+                        let mut child = path;
+                        child.push_unchecked(nibble);
+                        if has_retained_descendant(&retained_leaves, &child) {
+                            stack.push(child);
+                            continue;
+                        }
+
+                        let Entry::Occupied(entry) =
+                            self.subtrie_for_path_mut_untracked(&child).unwrap().nodes.entry(child)
                         else {
-                            unreachable!("expected branch node at path {path:?}");
+                            panic!("expected node at path {child:?}");
                         };
-                        *old_blinded_mask = blinded_mask;
-                        *old_blinded_hashes = blinded_hashes;
-                    } else {
-                        for nibble in state_mask.iter() {
-                            if blinded_mask.is_bit_set(nibble) {
-                                continue;
-                            }
-                            let mut child = path;
-                            child.push_unchecked(nibble);
-                            stack.push((child, depth + 1));
-                        }
+
+                        let Some(hash) = entry.get().cached_hash() else {
+                            continue;
+                        };
+                        entry.remove();
+                        blinded_mask.set_bit(nibble);
+                        blinded_hashes[nibble as usize] = hash;
+                        effective_pruned_roots.push(child);
                     }
+
+                    let SparseNode::Branch {
+                        blinded_mask: old_blinded_mask,
+                        blinded_hashes: old_blinded_hashes,
+                        ..
+                    } = self
+                        .subtrie_for_path_mut_untracked(&path)
+                        .unwrap()
+                        .nodes
+                        .get_mut(&path)
+                        .unwrap()
+                    else {
+                        unreachable!("expected branch node at path {path:?}");
+                    };
+                    *old_blinded_mask = blinded_mask;
+                    *old_blinded_hashes = blinded_hashes;
                 }
             }
         }
 
-        if effective_pruned_roots.is_empty() {
-            return 0;
-        }
-
-        let nodes_converted = effective_pruned_roots.len();
-
-        // Sort roots by subtrie type (upper first), then by path for efficient partitioning.
-        effective_pruned_roots.sort_unstable_by(|path_a, path_b| {
-            let subtrie_type_a = SparseSubtrieType::from_path(path_a);
-            let subtrie_type_b = SparseSubtrieType::from_path(path_b);
-            subtrie_type_a.cmp(&subtrie_type_b).then(path_a.cmp(path_b))
-        });
-
-        // Split off upper subtrie roots (they come first due to sorting)
-        let num_upper_roots = effective_pruned_roots
-            .iter()
-            .position(|p| !SparseSubtrieType::path_len_is_upper(p.len()))
-            .unwrap_or(effective_pruned_roots.len());
-
-        let roots_upper = &effective_pruned_roots[..num_upper_roots];
-        let roots_lower = &effective_pruned_roots[num_upper_roots..];
-
-        debug_assert!(
-            {
-                let mut all_roots: Vec<_> = effective_pruned_roots.clone();
-                all_roots.sort_unstable();
-                all_roots.windows(2).all(|w| !w[1].starts_with(&w[0]))
-            },
-            "prune roots must be prefix-free"
-        );
-
-        // Upper prune roots that are prefixes of lower subtrie root paths cause the entire
-        // subtrie to be cleared (preserving allocations for reuse).
-        if !roots_upper.is_empty() {
-            for subtrie in &mut *self.lower_subtries {
-                let should_clear = subtrie.as_revealed_ref().is_some_and(|s| {
-                    let search_idx = roots_upper.partition_point(|root| root <= &s.path);
-                    search_idx > 0 && s.path.starts_with(&roots_upper[search_idx - 1])
-                });
-                if should_clear {
-                    subtrie.clear();
-                }
-            }
-        }
-
-        // Upper subtrie: prune nodes and values
-        self.upper_subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_upper, p));
-        self.upper_subtrie.inner.values.retain(|p, _| {
-            !starts_with_pruned_in(roots_upper, p) && !starts_with_pruned_in(roots_lower, p)
-        });
-
-        // Process lower subtries using chunk_by to group roots by subtrie
-        for roots_group in roots_lower.chunk_by(|path_a, path_b| {
-            SparseSubtrieType::from_path(path_a) == SparseSubtrieType::from_path(path_b)
-        }) {
-            let subtrie_idx = path_subtrie_index_unchecked(&roots_group[0]);
-
-            // Skip unrevealed/blinded subtries - nothing to prune
-            let Some(subtrie) = self.lower_subtries[subtrie_idx].as_revealed_mut() else {
-                continue;
-            };
-
-            // Retain only nodes/values not descended from any pruned root.
-            subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_group, p));
-            subtrie.inner.values.retain(|p, _| !starts_with_pruned_in(roots_group, p));
-        }
-
-        // Branch node masks pruning
-        self.branch_node_masks.retain(|p, _| {
-            if SparseSubtrieType::path_len_is_upper(p.len()) {
-                !starts_with_pruned_in(roots_upper, p)
-            } else {
-                !starts_with_pruned_in(roots_lower, p) && !starts_with_pruned_in(roots_upper, p)
-            }
-        });
-
-        nodes_converted
+        Self::finalize_pruned_roots(self, effective_pruned_roots)
     }
 
     fn update_leaves(
@@ -1559,6 +1457,86 @@ impl ParallelSparseTrie {
         Self::default().with_root(root, masks, retain_updates)
     }
 
+    fn finalize_pruned_roots(&mut self, mut effective_pruned_roots: Vec<Nibbles>) -> usize {
+        if effective_pruned_roots.is_empty() {
+            return 0;
+        }
+
+        let nodes_converted = effective_pruned_roots.len();
+
+        // Sort roots by subtrie type (upper first), then by path for efficient partitioning.
+        effective_pruned_roots.sort_unstable_by(|path_a, path_b| {
+            let subtrie_type_a = SparseSubtrieType::from_path(path_a);
+            let subtrie_type_b = SparseSubtrieType::from_path(path_b);
+            subtrie_type_a.cmp(&subtrie_type_b).then(path_a.cmp(path_b))
+        });
+
+        // Split off upper subtrie roots (they come first due to sorting)
+        let num_upper_roots = effective_pruned_roots
+            .iter()
+            .position(|p| !SparseSubtrieType::path_len_is_upper(p.len()))
+            .unwrap_or(effective_pruned_roots.len());
+
+        let roots_upper = &effective_pruned_roots[..num_upper_roots];
+        let roots_lower = &effective_pruned_roots[num_upper_roots..];
+
+        debug_assert!(
+            {
+                let mut all_roots: Vec<_> = effective_pruned_roots.clone();
+                all_roots.sort_unstable();
+                all_roots.windows(2).all(|w| !w[1].starts_with(&w[0]))
+            },
+            "prune roots must be prefix-free"
+        );
+
+        // Upper prune roots that are prefixes of lower subtrie root paths cause the entire
+        // subtrie to be cleared (preserving allocations for reuse).
+        if !roots_upper.is_empty() {
+            for subtrie in &mut *self.lower_subtries {
+                let should_clear = subtrie.as_revealed_ref().is_some_and(|s| {
+                    let search_idx = roots_upper.partition_point(|root| root <= &s.path);
+                    search_idx > 0 && s.path.starts_with(&roots_upper[search_idx - 1])
+                });
+                if should_clear {
+                    subtrie.clear();
+                }
+            }
+        }
+
+        // Upper subtrie: prune nodes and values
+        self.upper_subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_upper, p));
+        self.upper_subtrie.inner.values.retain(|p, _| {
+            !starts_with_pruned_in(roots_upper, p) && !starts_with_pruned_in(roots_lower, p)
+        });
+
+        // Process lower subtries using chunk_by to group roots by subtrie
+        for roots_group in roots_lower.chunk_by(|path_a, path_b| {
+            SparseSubtrieType::from_path(path_a) == SparseSubtrieType::from_path(path_b)
+        }) {
+            let subtrie_idx = path_subtrie_index_unchecked(&roots_group[0]);
+
+            // Skip unrevealed/blinded subtries - nothing to prune
+            let Some(subtrie) = self.lower_subtries[subtrie_idx].as_revealed_mut() else {
+                continue;
+            };
+
+            // Retain only nodes/values not descended from any pruned root.
+            subtrie.nodes.retain(|p, _| !is_strict_descendant_in(roots_group, p));
+            subtrie.inner.values.retain(|p, _| !starts_with_pruned_in(roots_group, p));
+        }
+
+        // Branch node masks pruning
+        self.branch_node_masks.retain(|p, _| {
+            if SparseSubtrieType::path_len_is_upper(p.len()) {
+                !starts_with_pruned_in(roots_upper, p)
+            } else {
+                !starts_with_pruned_in(roots_lower, p) && !starts_with_pruned_in(roots_upper, p)
+            }
+        });
+
+        nodes_converted
+    }
+
     /// Returns a reference to the lower `SparseSubtrie` for the given path, or None if the
     /// path belongs to the upper trie, or if the lower subtrie for the path doesn't exist or is
     /// blinded.
@@ -1580,7 +1558,6 @@ impl ParallelSparseTrie {
             SparseSubtrieType::Upper => None,
             SparseSubtrieType::Lower(idx) => {
                 self.lower_subtries[idx].reveal(path);
-                self.subtrie_heat.mark_modified(idx);
                 Some(self.lower_subtries[idx].as_revealed_mut().expect("just revealed"))
             }
         }
@@ -2183,7 +2160,6 @@ impl ParallelSparseTrie {
             }
 
             self.lower_subtries[index] = LowerSparseSubtrie::Revealed(subtrie);
-            self.subtrie_heat.mark_modified(index);
         }
     }
 
@@ -2325,80 +2301,18 @@ impl ParallelSparseTrie {
 struct SubtriesBitmap(U256);
 
 impl SubtriesBitmap {
-    /// Marks a subtrie index as modified.
+    /// Marks a subtrie index.
     #[inline]
     fn set(&mut self, idx: usize) {
         debug_assert!(idx < NUM_LOWER_SUBTRIES);
         self.0.set_bit(idx, true);
     }
 
-    /// Returns whether a subtrie index is marked as modified.
+    /// Returns whether a subtrie index is set.
     #[inline]
     fn get(&self, idx: usize) -> bool {
         debug_assert!(idx < NUM_LOWER_SUBTRIES);
         self.0.bit(idx)
-    }
-
-    /// Clears all modification flags.
-    #[inline]
-    const fn clear(&mut self) {
-        self.0 = U256::ZERO;
-    }
-}
-
-/// Tracks heat (modification frequency) for each of the 256 lower subtries.
-///
-/// Heat is used to avoid pruning frequently-modified subtries, which would cause
-/// expensive re-reveal operations on subsequent updates.
-///
-/// - Heat is incremented by 2 when a subtrie is modified
-/// - Heat decays by 1 each prune cycle for subtries not modified that cycle
-/// - Subtries with heat > 0 are considered "hot" and skipped during pruning
-#[derive(Clone, PartialEq, Eq, Debug)]
-struct SubtrieModifications {
-    /// Heat level (0-255) for each of the 256 lower subtries.
-    heat: [u8; NUM_LOWER_SUBTRIES],
-    /// Tracks which subtries were modified in the current cycle.
-    modified: SubtriesBitmap,
-}
-
-impl Default for SubtrieModifications {
-    fn default() -> Self {
-        Self { heat: [0; NUM_LOWER_SUBTRIES], modified: SubtriesBitmap::default() }
-    }
-}
-
-impl SubtrieModifications {
-    /// Marks a subtrie as modified, incrementing its heat by 1.
-    #[inline]
-    fn mark_modified(&mut self, idx: usize) {
-        debug_assert!(idx < NUM_LOWER_SUBTRIES);
-        self.modified.set(idx);
-        self.heat[idx] = self.heat[idx].saturating_add(1);
-    }
-
-    /// Returns whether a subtrie is currently hot (heat > 0).
-    #[inline]
-    fn is_hot(&self, idx: usize) -> bool {
-        debug_assert!(idx < NUM_LOWER_SUBTRIES);
-        self.heat[idx] > 0
-    }
-
-    /// Decays heat for subtries not modified this cycle and resets modification tracking.
-    /// Called at the start of each prune cycle.
-    fn decay_and_reset(&mut self) {
-        for (idx, heat) in self.heat.iter_mut().enumerate() {
-            if !self.modified.get(idx) {
-                *heat = heat.saturating_sub(1);
-            }
-        }
-        self.modified.clear();
-    }
-
-    /// Clears all heat tracking state.
-    const fn clear(&mut self) {
-        self.heat = [0; NUM_LOWER_SUBTRIES];
-        self.modified.clear();
     }
 }
 
@@ -3510,6 +3424,18 @@ fn is_strict_descendant_in(roots: &[Nibbles], path: &Nibbles) -> bool {
         }
     }
     false
+}
+
+/// Returns true if any retained leaf path has `prefix` as a prefix.
+///
+/// The `retained` slice must be sorted.
+fn has_retained_descendant(retained: &[Nibbles], prefix: &Nibbles) -> bool {
+    if retained.is_empty() {
+        return false;
+    }
+    debug_assert!(retained.windows(2).all(|w| w[0] <= w[1]), "retained must be sorted by path");
+    let idx = retained.partition_point(|path| path < prefix);
+    idx < retained.len() && retained[idx].starts_with(prefix)
 }
 
 /// Checks if `path` starts with any root in a sorted slice (inclusive).
@@ -7729,8 +7655,8 @@ mod tests {
         // Compute root to get hashes
         let root_before = parallel.root();
 
-        // Prune at depth 0: the children of root become pruned roots
-        parallel.prune(0);
+        // Prune with no retained leaves: all children of root become pruned roots
+        parallel.prune(&[]);
 
         let root_after = parallel.root();
         assert_eq!(root_before, root_after, "root hash must be preserved");
@@ -7748,60 +7674,9 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_at_various_depths() {
-        // Test depths 0 and 1, which are in the Upper subtrie (no heat tracking).
-        // Depth 2 is the boundary where Lower subtries start (UPPER_TRIE_MAX_DEPTH=2),
-        // and with `depth >= max_depth` heat check, hot Lower subtries at depth 2
-        // are protected from pruning traversal.
-        for max_depth in [0, 1] {
-            let provider = DefaultTrieNodeProvider;
-            let mut trie = ParallelSparseTrie::default();
-
-            let value = large_account_value();
-
-            for i in 0..4u8 {
-                for j in 0..4u8 {
-                    for k in 0..4u8 {
-                        trie.update_leaf(
-                            pad_nibbles_right(Nibbles::from_nibbles([i, j, k, 0x1, 0x2, 0x3])),
-                            value.clone(),
-                            &provider,
-                        )
-                        .unwrap();
-                    }
-                }
-            }
-
-            let root_before = trie.root();
-            let nodes_before = trie.size_hint();
-
-            // Prune multiple times to allow heat to fully decay.
-            // Heat starts at 1 and decays by 1 each cycle for unmodified subtries,
-            // so we need 2 prune cycles: 1→0, then actual prune.
-            for _ in 0..2 {
-                trie.prune(max_depth);
-            }
-
-            let root_after = trie.root();
-            assert_eq!(root_before, root_after, "root hash should be preserved after prune");
-
-            let nodes_after = trie.size_hint();
-            assert!(
-                nodes_after < nodes_before,
-                "node count should decrease after prune at depth {max_depth}"
-            );
-
-            if max_depth == 0 {
-                // Root with 4 blinded hashes for children at [0], [1], [2], [3]
-                assert_eq!(nodes_after, 1, "root");
-            }
-        }
-    }
-
-    #[test]
     fn test_prune_empty_trie() {
         let mut trie = ParallelSparseTrie::default();
-        trie.prune(2);
+        trie.prune(&[]);
         let root = trie.root();
         assert_eq!(root, EMPTY_ROOT_HASH, "empty trie should have empty root hash");
     }
@@ -7825,7 +7700,7 @@ mod tests {
         }
 
         let root_before = trie.root();
-        trie.prune(1);
+        trie.prune(&[]);
         let root_after = trie.root();
         assert_eq!(root_before, root_after, "root hash must be preserved after prune");
     }
@@ -7846,68 +7721,11 @@ mod tests {
         let root_before = trie.root();
         let nodes_before = trie.size_hint();
 
-        trie.prune(0);
+        trie.prune(&[]);
 
         let root_after = trie.root();
         assert_eq!(root_before, root_after, "root hash should be preserved");
         assert_eq!(trie.size_hint(), nodes_before, "single leaf trie should not change");
-    }
-
-    #[test]
-    fn test_prune_deep_depth_no_effect() {
-        let provider = DefaultTrieNodeProvider;
-        let mut trie = ParallelSparseTrie::default();
-
-        let value = large_account_value();
-
-        for i in 0..4u8 {
-            trie.update_leaf(
-                pad_nibbles_right(Nibbles::from_nibbles([i, 0x2, 0x3, 0x4])),
-                value.clone(),
-                &provider,
-            )
-            .unwrap();
-        }
-
-        trie.root();
-        let nodes_before = trie.size_hint();
-
-        trie.prune(100);
-
-        assert_eq!(nodes_before, trie.size_hint(), "deep prune should have no effect");
-    }
-
-    #[test]
-    fn test_prune_extension_node_depth_semantics() {
-        let provider = DefaultTrieNodeProvider;
-        let mut trie = ParallelSparseTrie::default();
-
-        let value = large_account_value();
-
-        trie.update_leaf(
-            pad_nibbles_right(Nibbles::from_nibbles([0, 1, 2, 3, 0, 5, 6, 7])),
-            value.clone(),
-            &provider,
-        )
-        .unwrap();
-        trie.update_leaf(
-            pad_nibbles_right(Nibbles::from_nibbles([0, 1, 2, 3, 1, 5, 6, 7])),
-            value,
-            &provider,
-        )
-        .unwrap();
-
-        let root_before = trie.root();
-        // Prune multiple times to allow heat to fully decay.
-        // Heat starts at 1 and decays by 1 each cycle for unmodified subtries,
-        // so we need 2 prune cycles: 1→0, then actual prune.
-        for _ in 0..2 {
-            trie.prune(1);
-        }
-
-        assert_eq!(root_before, trie.root(), "root hash should be preserved");
-        // Root + branch
-        assert_eq!(trie.size_hint(), 2, "root + extension + hash stubs after prune(1)");
     }
 
     #[test]
@@ -7925,7 +7743,7 @@ mod tests {
 
         let root_before = trie.root();
 
-        trie.prune(0);
+        trie.prune(&[]);
 
         assert_eq!(root_before, trie.root(), "root hash must be preserved after pruning");
     }
@@ -7949,12 +7767,12 @@ mod tests {
         }
 
         let root_before = trie.root();
-        trie.prune(0);
+        trie.prune(&[]);
         assert_eq!(root_before, trie.root(), "root hash must be preserved");
     }
 
     #[test]
-    fn test_prune_many_lower_subtries() {
+    fn test_prune_all_lower_subtries() {
         let provider = DefaultTrieNodeProvider;
 
         let large_value = large_account_value();
@@ -7976,12 +7794,7 @@ mod tests {
 
         let root_before = trie.root();
 
-        // Prune multiple times to allow heat to fully decay.
-        // Heat starts at 1 and decays by 1 each cycle for unmodified subtries.
-        let mut total_pruned = 0;
-        for _ in 0..2 {
-            total_pruned += trie.prune(1);
-        }
+        let total_pruned = trie.prune(&[]);
 
         assert!(total_pruned > 0, "should have pruned some nodes");
         assert_eq!(root_before, trie.root(), "root hash should be preserved");
@@ -7992,38 +7805,32 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_max_depth_overflow() {
-        // Verify that max_depth > 255 is not truncated (was u8, now usize)
+    fn test_prune_keeps_only_hot_paths() {
         let provider = DefaultTrieNodeProvider;
         let mut trie = ParallelSparseTrie::default();
 
+        let key_keep = pad_nibbles_right(Nibbles::from_nibbles([0x1, 0x2, 0x3, 0x4]));
+        let key_drop_1 = pad_nibbles_right(Nibbles::from_nibbles([0x5, 0x2, 0x3, 0x4]));
+        let key_drop_2 = pad_nibbles_right(Nibbles::from_nibbles([0x9, 0x2, 0x3, 0x4]));
+
         let value = large_account_value();
+        trie.update_leaf(key_keep, value.clone(), &provider).unwrap();
+        trie.update_leaf(key_drop_1, value.clone(), &provider).unwrap();
+        trie.update_leaf(key_drop_2, value, &provider).unwrap();
 
-        for i in 0..4u8 {
-            trie.update_leaf(
-                pad_nibbles_right(Nibbles::from_nibbles([i, 0x1, 0x2, 0x3])),
-                value.clone(),
-                &provider,
-            )
-            .unwrap();
-        }
+        let root_before = trie.root();
 
-        trie.root();
-        let nodes_before = trie.size_hint();
+        let pruned = trie.prune(&[key_keep]);
+        assert!(pruned > 0, "expected some nodes to be pruned");
+        assert_eq!(root_before, trie.root(), "root hash should be preserved after LFU prune");
 
-        // If depth were truncated to u8, 300 would become 44 and might prune something
-        trie.prune(300);
-
-        assert_eq!(
-            nodes_before,
-            trie.size_hint(),
-            "prune(300) should have no effect on a shallow trie"
-        );
+        assert!(trie.get_leaf_value(&key_keep).is_some(), "retained key must remain revealed");
+        assert!(trie.get_leaf_value(&key_drop_1).is_none(), "non-retained key should be pruned");
+        assert!(trie.get_leaf_value(&key_drop_2).is_none(), "non-retained key should be pruned");
     }
 
     #[test]
-    fn test_prune_fast_path_case2_update_after() {
-        // Test fast-path Case 2: upper prune root is prefix of lower subtrie.
+    fn test_prune_update_after() {
         // After pruning, we should be able to update leaves without panic.
         let provider = DefaultTrieNodeProvider;
         let mut trie = ParallelSparseTrie::default();
@@ -8031,7 +7838,6 @@ mod tests {
         let value = large_account_value();
 
         // Create keys that span into lower subtries (path.len() >= UPPER_TRIE_MAX_DEPTH)
-        // UPPER_TRIE_MAX_DEPTH is typically 2, so paths of length 3+ go to lower subtries
         for first in 0..4u8 {
             for second in 0..4u8 {
                 trie.update_leaf(
@@ -8047,8 +7853,7 @@ mod tests {
 
         let root_before = trie.root();
 
-        // Prune at depth 0 - upper roots become prefixes of lower subtrie paths
-        trie.prune(0);
+        trie.prune(&[]);
 
         let root_after = trie.root();
         assert_eq!(root_before, root_after, "root hash should be preserved");

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1156,7 +1156,6 @@ impl SparseTrie for ParallelSparseTrie {
 
         let mut retained_leaves = retained_leaves.to_vec();
         retained_leaves.sort_unstable();
-        retained_leaves.dedup();
 
         let mut effective_pruned_roots = Vec::<Nibbles>::new();
         let mut stack: SmallVec<[Nibbles; 32]> = SmallVec::new();

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1163,14 +1163,17 @@ impl SparseTrie for ParallelSparseTrie {
         stack.push(Nibbles::default());
 
         while let Some(path) = stack.pop() {
-            let Some(subtrie) = self.subtrie_for_path_mut_untracked(&path) else { continue };
-            let Some(node) = subtrie.nodes.get_mut(&path) else { continue };
+            let Some(node) =
+                self.subtrie_for_path(&path).and_then(|subtrie| subtrie.nodes.get(&path).cloned())
+            else {
+                continue;
+            };
 
             match node {
                 SparseNode::Empty | SparseNode::Leaf { .. } => {}
                 SparseNode::Extension { key, state, .. } => {
                     let mut child = path;
-                    child.extend(key);
+                    child.extend(&key);
 
                     if has_retained_descendant(&retained_leaves, &child) {
                         stack.push(child);
@@ -1183,11 +1186,20 @@ impl SparseTrie for ParallelSparseTrie {
                     }
 
                     let Some(hash) = state.cached_hash() else { continue };
-                    subtrie.nodes.remove(&path);
+                    self.subtrie_for_path_mut_untracked(&path)
+                        .expect("node subtrie exists")
+                        .nodes
+                        .remove(&path);
 
                     let parent_path = path.slice(0..path.len() - 1);
-                    let SparseNode::Branch { blinded_mask, blinded_hashes, .. } =
-                        subtrie.nodes.get_mut(&parent_path).unwrap()
+                    // Parent can live in a different subtrie when `path` is the root of a lower
+                    // subtrie, so resolve it by `parent_path` rather than reusing `path`'s subtrie.
+                    let SparseNode::Branch { blinded_mask, blinded_hashes, .. } = self
+                        .subtrie_for_path_mut_untracked(&parent_path)
+                        .expect("parent subtrie exists")
+                        .nodes
+                        .get_mut(&parent_path)
+                        .expect("expected parent branch node")
                     else {
                         panic!("expected branch node at path {parent_path:?}");
                     };
@@ -1198,8 +1210,8 @@ impl SparseTrie for ParallelSparseTrie {
                     effective_pruned_roots.push(path);
                 }
                 SparseNode::Branch { state_mask, blinded_mask, blinded_hashes, .. } => {
-                    let mut blinded_mask = *blinded_mask;
-                    let mut blinded_hashes = blinded_hashes.clone();
+                    let mut blinded_mask = blinded_mask;
+                    let mut blinded_hashes = blinded_hashes;
                     for nibble in state_mask.iter() {
                         if blinded_mask.is_bit_set(nibble) {
                             continue;

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -996,7 +996,8 @@ struct HotSlotKey {
 impl BucketedLfu<HotSlotKey> {
     /// Returns retained slots grouped by address.
     fn retained_slots_by_address(&self) -> B256Map<Vec<Nibbles>> {
-        let mut grouped = B256Map::<Vec<Nibbles>>::default();
+        let mut grouped =
+            B256Map::<Vec<Nibbles>>::with_capacity_and_hasher(self.len(), Default::default());
         for key in self.keys() {
             grouped.entry(key.address).or_default().push(Nibbles::unpack(key.slot));
         }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -7,22 +7,18 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_primitives::{
-    map::{B256Map, B256Set},
+    map::{B256Map, HashMap},
     B256,
 };
 use alloy_rlp::{Decodable, Encodable};
 use reth_execution_errors::{SparseStateTrieResult, SparseTrieErrorKind};
 use reth_primitives_traits::Account;
-#[cfg(feature = "std")]
-use reth_primitives_traits::FastInstant as Instant;
 use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
     BranchNodeMasks, DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2, TrieAccount,
     TrieNodeV2, EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-#[cfg(feature = "std")]
-use tracing::debug;
-use tracing::{instrument, trace};
+use tracing::{debug, instrument, trace};
 
 /// Holds data that should be dropped after any locks are released.
 ///
@@ -50,6 +46,10 @@ pub struct SparseStateTrie<
     account_rlp_buf: Vec<u8>,
     /// Holds data that should be dropped after final state root is calculated.
     deferred_drops: DeferredDrops,
+    /// Global LFU tracker for hot `(address, slot)` storage entries.
+    hot_slots_lfu: BucketedLfu<HotSlotKey>,
+    /// Global LFU tracker for hot account entries.
+    hot_accounts_lfu: BucketedLfu<B256>,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::SparseStateTrieMetrics,
@@ -67,6 +67,8 @@ where
             retain_updates: false,
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             deferred_drops: DeferredDrops::default(),
+            hot_slots_lfu: BucketedLfu::default(),
+            hot_accounts_lfu: BucketedLfu::default(),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }
@@ -185,6 +187,18 @@ where
         trie.find_leaf(&path, None).is_ok()
     }
 
+    /// Records a storage slot access/update in the global LFU tracker.
+    #[inline]
+    pub fn record_slot_touch(&mut self, account: B256, slot: B256) {
+        self.hot_slots_lfu.touch(HotSlotKey { address: account, slot });
+    }
+
+    /// Records an account access/update in the global LFU tracker.
+    #[inline]
+    pub fn record_account_touch(&mut self, account: B256) {
+        self.hot_accounts_lfu.touch(account);
+    }
+
     /// Returns reference to bytes representing leaf value for the target account.
     pub fn get_account_value(&self, account: &B256) -> Option<&Vec<u8>> {
         self.state.as_revealed_ref()?.get_leaf_value(&Nibbles::unpack(account))
@@ -285,8 +299,6 @@ where
         {
             for (account, storage_proofs) in multiproof.storage_proofs {
                 self.reveal_storage_v2_proof_nodes(account, storage_proofs)?;
-                // Mark this storage trie as hot (accessed this tick)
-                self.storage.modifications.mark_accessed(account);
             }
 
             Ok(())
@@ -327,8 +339,6 @@ where
             let mut any_err = Ok(());
             for (account, result, trie, bufs) in results {
                 self.storage.tries.insert(account, trie);
-                // Mark this storage trie as hot (accessed this tick)
-                self.storage.modifications.mark_accessed(account);
                 if let Ok(_total_nodes) = result {
                     #[cfg(feature = "metrics")]
                     {
@@ -780,10 +790,14 @@ where
         self.storage.shrink_to(storage_nodes, storage_values);
     }
 
-    /// Prunes the account trie and selected storage tries to reduce memory usage.
+    /// Prunes account/storage tries according to global LFU retention.
     ///
-    /// Storage tries not in the top `max_storage_tries` by revealed node count are cleared
-    /// entirely.
+    /// - Top LFU `(address, slot)` entries are retained up to `max_hot_slots`.
+    ///
+    /// - Top LFU `(address, slot)` entries are retained in storage tries.
+    /// - Account trie retains only paths for accounts tracked by the account LFU.
+    /// - Storage tries retain only paths needed for retained slots.
+    /// - All other revealed paths are pruned to hash stubs or fully evicted.
     ///
     /// # Preconditions
     ///
@@ -795,19 +809,39 @@ where
         name = "SparseStateTrie::prune",
         target = "trie::sparse",
         skip_all,
-        fields(%max_depth, %max_storage_tries)
+        fields(%max_hot_slots, %max_hot_accounts)
     )]
-    pub fn prune(&mut self, max_depth: usize, max_storage_tries: usize) {
-        // Prune state and storage tries in parallel
-        rayon::join(
+    pub fn prune(&mut self, max_hot_slots: usize, max_hot_accounts: usize) {
+        self.hot_slots_lfu.decay_and_evict(max_hot_slots);
+        self.hot_accounts_lfu.decay_and_evict(max_hot_accounts);
+        let retained = self.hot_slots_lfu.retained_slots_by_address();
+
+        let retained_account_paths: Vec<Nibbles> =
+            self.hot_accounts_lfu.keys().map(|k| Nibbles::unpack(*k)).collect();
+
+        let retained_accounts = retained_account_paths.len();
+        let retained_storage_tries = retained.len();
+        let total_storage_tries_before = self.storage.tries.len();
+
+        // Prune account and storage tries in parallel using the same LFU-selected set.
+        let (account_nodes_pruned, storage_tries_evicted) = rayon::join(
             || {
-                if let Some(trie) = self.state.as_revealed_mut() {
-                    trie.prune(max_depth);
-                }
+                self.state
+                    .as_revealed_mut()
+                    .map(|trie| trie.prune(&retained_account_paths))
+                    .unwrap_or(0)
             },
-            || {
-                self.storage.prune(max_depth, max_storage_tries);
-            },
+            || self.storage.prune_by_retained_slots(retained),
+        );
+
+        debug!(
+            target: "trie::sparse",
+            retained_accounts,
+            retained_storage_tries,
+            account_nodes_pruned,
+            storage_tries_evicted,
+            storage_tries_after = total_storage_tries_before - storage_tries_evicted,
+            "SparseStateTrie::prune completed"
         );
     }
 
@@ -836,108 +870,37 @@ struct StorageTries<S = ParallelSparseTrie> {
     cleared_tries: Vec<RevealableSparseTrie<S>>,
     /// A default cleared trie instance, which will be cloned when creating new tries.
     default_trie: RevealableSparseTrie<S>,
-    /// Tracks access patterns and modification state of storage tries for smart pruning decisions.
-    modifications: StorageTrieModifications,
 }
 
 #[cfg(feature = "std")]
 impl<S: SparseTrieTrait> StorageTries<S> {
-    /// Prunes and evicts storage tries.
+    /// Prunes storage tries using LFU-retained slots.
     ///
-    /// Keeps the top `max_storage_tries` by a score combining size and heat.
-    /// Evicts lower-scored tries entirely, prunes kept tries to `max_depth`.
-    fn prune(&mut self, max_depth: usize, max_storage_tries: usize) {
-        let fn_start = Instant::now();
-        let mut stats =
-            StorageTriesPruneStats { total_tries_before: self.tries.len(), ..Default::default() };
-
-        // Update heat for accessed tries
-        self.modifications.update_and_reset();
-
-        // Collect (address, size, score) for all tries
-        // Score = size * heat_multiplier
-        // Hot tries (high heat) get boosted weight
-        let mut trie_info: Vec<(B256, usize, usize)> = self
+    /// Tries without retained slots are evicted entirely. Tries with retained slots are pruned to
+    /// those slots.
+    fn prune_by_retained_slots(&mut self, mut retained_slots: B256Map<Vec<Nibbles>>) -> usize {
+        let addresses_to_evict: Vec<B256> = self
             .tries
-            .iter()
-            .map(|(address, trie)| {
-                let size = match trie {
-                    RevealableSparseTrie::Blind(_) => return (*address, 0, 0),
-                    RevealableSparseTrie::Revealed(t) => t.size_hint(),
-                };
-                let heat = self.modifications.heat(address);
-                // Heat multiplier: 1 (cold) to 3 (very hot, heat >= 4)
-                let heat_multiplier = 1 + (heat.min(4) / 2) as usize;
-                (*address, size, size * heat_multiplier)
-            })
+            .keys()
+            .filter(|address| !retained_slots.contains_key(*address))
+            .copied()
             .collect();
 
-        // Use O(n) selection to find top max_storage_tries by score
-        if trie_info.len() > max_storage_tries {
-            trie_info
-                .select_nth_unstable_by(max_storage_tries.saturating_sub(1), |a, b| b.2.cmp(&a.2));
-            trie_info.truncate(max_storage_tries);
-        }
-        let tries_to_keep: B256Map<usize> =
-            trie_info.iter().map(|(address, size, _)| (*address, *size)).collect();
-        stats.tries_to_keep = tries_to_keep.len();
-
-        // Collect keys to evict
-        let tries_to_clear: Vec<B256> =
-            self.tries.keys().filter(|addr| !tries_to_keep.contains_key(*addr)).copied().collect();
-        stats.tries_to_evict = tries_to_clear.len();
-
-        // Evict storage tries that exceeded limit, saving cleared allocations for reuse
-        for address in &tries_to_clear {
+        let evicted = addresses_to_evict.len();
+        for address in &addresses_to_evict {
             if let Some(mut trie) = self.tries.remove(address) {
                 trie.clear();
                 self.cleared_tries.push(trie);
             }
-            self.modifications.remove(address);
         }
 
-        // Prune storage tries that are kept, but only if:
-        // - They haven't been pruned since last access
-        // - They're large enough to be worth pruning
-        const MIN_SIZE_TO_PRUNE: usize = 1000;
-        let prune_start = Instant::now();
-        for (address, size) in &tries_to_keep {
-            if *size < MIN_SIZE_TO_PRUNE {
-                stats.skipped_small += 1;
-                continue; // Small tries aren't worth the DFS cost
-            }
-            let Some(heat_state) = self.modifications.get_mut(address) else {
-                continue; // No heat state = not tracked
-            };
-            // Only prune if backlog >= 2 (skip every other cycle)
-            if heat_state.prune_backlog < 2 {
-                stats.skipped_recently_pruned += 1;
-                continue; // Recently pruned, skip this cycle
-            }
+        for (address, slots) in &mut retained_slots {
             if let Some(trie) = self.tries.get_mut(address).and_then(|t| t.as_revealed_mut()) {
-                trie.prune(max_depth);
-                heat_state.prune_backlog = 0; // Reset backlog after prune
-                stats.pruned_count += 1;
+                trie.prune(slots);
             }
         }
-        stats.prune_elapsed = prune_start.elapsed();
 
-        stats.total_tries_after = self.tries.len();
-        stats.total_elapsed = fn_start.elapsed();
-
-        debug!(
-            target: "trie::sparse",
-            before = stats.total_tries_before,
-            after = stats.total_tries_after,
-            kept = stats.tries_to_keep,
-            evicted = stats.tries_to_evict,
-            pruned = stats.pruned_count,
-            skipped_small = stats.skipped_small,
-            skipped_recent = stats.skipped_recently_pruned,
-            ?stats.prune_elapsed,
-            ?stats.total_elapsed,
-            "StorageTries::prune completed"
-        );
+        evicted
     }
 }
 
@@ -949,7 +912,6 @@ impl<S: SparseTrieTrait> StorageTries<S> {
             trie.clear();
             trie
         }));
-        self.modifications.clear();
     }
 
     /// Shrinks the capacity of all storage tries to the given total sizes.
@@ -997,93 +959,164 @@ impl<S: SparseTrieTrait + Clone> StorageTries<S> {
     }
 }
 
-/// Statistics from a storage tries prune operation.
-#[derive(Debug, Default)]
-#[allow(dead_code)]
-struct StorageTriesPruneStats {
-    total_tries_before: usize,
-    total_tries_after: usize,
-    tries_to_keep: usize,
-    tries_to_evict: usize,
-    pruned_count: usize,
-    skipped_small: usize,
-    skipped_recently_pruned: usize,
-    prune_elapsed: core::time::Duration,
-    total_elapsed: core::time::Duration,
+/// Key for identifying a storage slot in the global LFU cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct HotSlotKey {
+    address: B256,
+    slot: B256,
 }
 
-/// Per-trie access tracking and prune state.
-///
-/// Tracks how frequently a storage trie is accessed and when it was last pruned,
-/// enabling smart pruning decisions that preserve frequently-used tries.
-#[derive(Debug, Clone, Copy, Default)]
-#[allow(dead_code)]
-struct TrieModificationState {
-    /// Access frequency level (0-255). Incremented each cycle the trie is accessed.
-    /// Used for prioritizing which tries to keep during pruning.
-    heat: u8,
-    /// Prune backlog - cycles since last prune. Incremented each cycle,
-    /// reset to 0 when pruned. Used to decide when pruning is needed.
-    prune_backlog: u8,
+/// Maximum frequency value. Frequencies are capped here to bound bucket storage.
+const LFU_MAX_FREQ: u16 = 255;
+
+/// Per-entry metadata stored in the LFU lookup map.
+#[derive(Debug, Clone, Copy)]
+struct LfuEntryMeta {
+    /// Current frequency (1..=`LFU_MAX_FREQ`).
+    freq: u16,
+    /// Index of this key within `buckets[freq]`.
+    pos: usize,
 }
 
-/// Tracks access patterns and modification state of storage tries for smart pruning decisions.
+/// Bucketed LFU cache with O(1) eviction and O(1) touch operations.
 ///
-/// Access-based tracking is more accurate than simple generation counting because it tracks
-/// actual access patterns rather than administrative operations (take/insert).
-///
-/// - Access frequency is incremented when a storage proof is revealed (accessed)
-/// - Access frequency decays each prune cycle for tries not accessed that cycle
-/// - Tries with higher access frequency are prioritized for preservation during pruning
-#[derive(Debug, Default)]
-struct StorageTrieModifications {
-    /// Access frequency and prune state per storage trie address.
-    state: B256Map<TrieModificationState>,
-    /// Tracks which tries were accessed in the current cycle (between prune calls).
-    accessed_this_cycle: B256Set,
+/// Generic over the key type `K`.
+#[derive(Debug)]
+struct BucketedLfu<K> {
+    capacity: usize,
+    /// Maps each key to its frequency and bucket position.
+    entries: HashMap<K, LfuEntryMeta>,
+    /// `buckets[f]` holds all keys currently at frequency `f`.
+    /// Index 0 is unused; valid frequencies are 1..=`LFU_MAX_FREQ`.
+    buckets: Vec<Vec<K>>,
+    /// Smallest non-empty frequency bucket.
+    min_freq: u16,
 }
 
-#[allow(dead_code)]
-impl StorageTrieModifications {
-    /// Marks a storage trie as accessed this cycle.
-    /// Heat and `prune_backlog` are updated in [`Self::update_and_reset`].
-    #[inline]
-    fn mark_accessed(&mut self, address: B256) {
-        self.accessed_this_cycle.insert(address);
+impl<K> Default for BucketedLfu<K> {
+    fn default() -> Self {
+        Self {
+            capacity: 0,
+            entries: HashMap::default(),
+            buckets: (0..=LFU_MAX_FREQ).map(|_| Vec::new()).collect(),
+            min_freq: 1,
+        }
     }
+}
 
-    /// Returns mutable reference to the heat state for a storage trie.
-    #[inline]
-    fn get_mut(&mut self, address: &B256) -> Option<&mut TrieModificationState> {
-        self.state.get_mut(address)
-    }
+impl<K: core::fmt::Debug + Copy + Eq + core::hash::Hash> BucketedLfu<K> {
+    /// Updates the capacity and evicts the least-frequently-used entries that exceed it.
+    ///
+    /// Entries accumulate via [`Self::touch`] over time. This method trims the cache
+    /// so that only the `capacity` hottest entries are retained.
+    fn decay_and_evict(&mut self, capacity: usize) {
+        self.capacity = capacity;
 
-    /// Returns the heat level for a storage trie (0 if not tracked).
-    #[inline]
-    fn heat(&self, address: &B256) -> u8 {
-        self.state.get(address).map_or(0, |s| s.heat)
-    }
+        if self.capacity == 0 {
+            self.entries.clear();
+            for b in &mut self.buckets {
+                b.clear();
+            }
+            self.min_freq = 1;
+            return;
+        }
 
-    /// Updates heat and prune backlog for accessed tries.
-    /// Called at the start of each prune cycle.
-    fn update_and_reset(&mut self) {
-        for address in self.accessed_this_cycle.drain() {
-            let entry = self.state.entry(address).or_default();
-            entry.heat = entry.heat.saturating_add(1);
-            entry.prune_backlog = entry.prune_backlog.saturating_add(1);
+        while self.entries.len() > self.capacity {
+            self.evict_one();
         }
     }
 
-    /// Removes tracking for a specific address (when trie is evicted).
-    fn remove(&mut self, address: &B256) {
-        self.state.remove(address);
-        self.accessed_this_cycle.remove(address);
+    /// Evicts a single entry from the lowest-frequency bucket.
+    fn evict_one(&mut self) {
+        if self.entries.is_empty() {
+            self.min_freq = 1;
+            return;
+        }
+
+        // Advance min_freq to the next non-empty bucket.
+        while (self.min_freq as usize) < self.buckets.len() &&
+            self.buckets[self.min_freq as usize].is_empty()
+        {
+            self.min_freq += 1;
+        }
+
+        if (self.min_freq as usize) >= self.buckets.len() {
+            self.min_freq = 1;
+            return;
+        }
+
+        if let Some(key) = self.buckets[self.min_freq as usize].pop() {
+            self.entries.remove(&key);
+        }
     }
 
-    /// Clears all heat tracking state.
-    fn clear(&mut self) {
-        self.state.clear();
-        self.accessed_this_cycle.clear();
+    /// Records a key touch. O(1) amortized.
+    fn touch(&mut self, key: K) {
+        if self.capacity == 0 {
+            return;
+        }
+
+        if let Some(meta) = self.entries.get(&key).copied() {
+            debug_assert_eq!(self.buckets[meta.freq as usize][meta.pos], key);
+
+            let old_freq = meta.freq as usize;
+            let new_freq = meta.freq.saturating_add(1).min(LFU_MAX_FREQ);
+
+            if new_freq as usize != old_freq {
+                // Remove from old bucket via swap_remove and fix the swapped element's pos.
+                self.buckets[old_freq].swap_remove(meta.pos);
+                if let Some(&moved_key) = self.buckets[old_freq].get(meta.pos) {
+                    self.entries.get_mut(&moved_key).expect("moved key must exist").pos = meta.pos;
+                }
+
+                // Insert into new bucket.
+                let new_pos = self.buckets[new_freq as usize].len();
+                self.buckets[new_freq as usize].push(key);
+
+                let entry = self.entries.get_mut(&key).expect("key must exist");
+                entry.freq = new_freq;
+                entry.pos = new_pos;
+
+                // Update min_freq if old bucket is now empty.
+                if self.buckets[old_freq].is_empty() && old_freq == self.min_freq as usize {
+                    self.min_freq = new_freq;
+                }
+            }
+        } else {
+            // Evict if at capacity before inserting.
+            if self.entries.len() >= self.capacity {
+                self.evict_one();
+            }
+
+            // New entry at frequency 1.
+            let pos = self.buckets[1].len();
+            self.buckets[1].push(key);
+            self.entries.insert(key, LfuEntryMeta { freq: 1, pos });
+            self.min_freq = 1;
+        }
+    }
+
+    /// Returns an iterator over all retained keys.
+    fn keys(&self) -> impl Iterator<Item = &K> {
+        self.entries.keys()
+    }
+}
+
+/// Slot-specific helpers for the `BucketedLfu<HotSlotKey>`.
+impl BucketedLfu<HotSlotKey> {
+    /// Returns retained slots grouped by address.
+    fn retained_slots_by_address(&self) -> B256Map<Vec<Nibbles>> {
+        let mut grouped = B256Map::<Vec<Nibbles>>::default();
+        for key in self.entries.keys() {
+            grouped.entry(key.address).or_default().push(Nibbles::unpack(key.slot));
+        }
+
+        for slots in grouped.values_mut() {
+            slots.sort_unstable();
+            slots.dedup();
+        }
+
+        grouped
     }
 }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1,15 +1,13 @@
 #[cfg(feature = "trie-debug")]
 use crate::debug_recorder::TrieDebugRecorder;
 use crate::{
+    lfu::BucketedLfu,
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
     traits::SparseTrie as SparseTrieTrait,
     ParallelSparseTrie, RevealableSparseTrie,
 };
 use alloc::vec::Vec;
-use alloy_primitives::{
-    map::{B256Map, HashMap},
-    B256,
-};
+use alloy_primitives::{map::B256Map, B256};
 use alloy_rlp::{Decodable, Encodable};
 use reth_execution_errors::{SparseStateTrieResult, SparseTrieErrorKind};
 use reth_primitives_traits::Account;
@@ -975,148 +973,12 @@ struct HotSlotKey {
     slot: B256,
 }
 
-/// Maximum frequency value. Frequencies are capped here to bound bucket storage.
-const LFU_MAX_FREQ: u16 = 255;
-
-/// Per-entry metadata stored in the LFU lookup map.
-#[derive(Debug, Clone, Copy)]
-struct LfuEntryMeta {
-    /// Current frequency (1..=`LFU_MAX_FREQ`).
-    freq: u16,
-    /// Index of this key within `buckets[freq]`.
-    pos: usize,
-}
-
-/// Bucketed LFU cache with O(1) eviction and O(1) touch operations.
-///
-/// Generic over the key type `K`.
-#[derive(Debug)]
-struct BucketedLfu<K> {
-    capacity: usize,
-    /// Maps each key to its frequency and bucket position.
-    entries: HashMap<K, LfuEntryMeta>,
-    /// `buckets[f]` holds all keys currently at frequency `f`.
-    /// Index 0 is unused; valid frequencies are 1..=`LFU_MAX_FREQ`.
-    buckets: Vec<Vec<K>>,
-    /// Smallest non-empty frequency bucket.
-    min_freq: u16,
-}
-
-impl<K> Default for BucketedLfu<K> {
-    fn default() -> Self {
-        Self {
-            capacity: 0,
-            entries: HashMap::default(),
-            buckets: (0..=LFU_MAX_FREQ).map(|_| Vec::new()).collect(),
-            min_freq: 1,
-        }
-    }
-}
-
-impl<K: core::fmt::Debug + Copy + Eq + core::hash::Hash> BucketedLfu<K> {
-    /// Updates the capacity and evicts the least-frequently-used entries that exceed it.
-    ///
-    /// Entries accumulate via [`Self::touch`] over time. This method trims the cache
-    /// so that only the `capacity` hottest entries are retained.
-    fn decay_and_evict(&mut self, capacity: usize) {
-        self.capacity = capacity;
-
-        if self.capacity == 0 {
-            self.entries.clear();
-            for b in &mut self.buckets {
-                b.clear();
-            }
-            self.min_freq = 1;
-            return;
-        }
-
-        while self.entries.len() > self.capacity {
-            self.evict_one();
-        }
-    }
-
-    /// Evicts a single entry from the lowest-frequency bucket.
-    fn evict_one(&mut self) {
-        if self.entries.is_empty() {
-            self.min_freq = 1;
-            return;
-        }
-
-        // Advance min_freq to the next non-empty bucket.
-        while (self.min_freq as usize) < self.buckets.len() &&
-            self.buckets[self.min_freq as usize].is_empty()
-        {
-            self.min_freq += 1;
-        }
-
-        if (self.min_freq as usize) >= self.buckets.len() {
-            self.min_freq = 1;
-            return;
-        }
-
-        if let Some(key) = self.buckets[self.min_freq as usize].pop() {
-            self.entries.remove(&key);
-        }
-    }
-
-    /// Records a key touch. O(1) amortized.
-    fn touch(&mut self, key: K) {
-        if self.capacity == 0 {
-            return;
-        }
-
-        if let Some(meta) = self.entries.get(&key).copied() {
-            debug_assert_eq!(self.buckets[meta.freq as usize][meta.pos], key);
-
-            let old_freq = meta.freq as usize;
-            let new_freq = meta.freq.saturating_add(1).min(LFU_MAX_FREQ);
-
-            if new_freq as usize != old_freq {
-                // Remove from old bucket via swap_remove and fix the swapped element's pos.
-                self.buckets[old_freq].swap_remove(meta.pos);
-                if let Some(&moved_key) = self.buckets[old_freq].get(meta.pos) {
-                    self.entries.get_mut(&moved_key).expect("moved key must exist").pos = meta.pos;
-                }
-
-                // Insert into new bucket.
-                let new_pos = self.buckets[new_freq as usize].len();
-                self.buckets[new_freq as usize].push(key);
-
-                let entry = self.entries.get_mut(&key).expect("key must exist");
-                entry.freq = new_freq;
-                entry.pos = new_pos;
-
-                // Update min_freq if old bucket is now empty.
-                if self.buckets[old_freq].is_empty() && old_freq == self.min_freq as usize {
-                    self.min_freq = new_freq;
-                }
-            }
-        } else {
-            // Evict if at capacity before inserting.
-            if self.entries.len() >= self.capacity {
-                self.evict_one();
-            }
-
-            // New entry at frequency 1.
-            let pos = self.buckets[1].len();
-            self.buckets[1].push(key);
-            self.entries.insert(key, LfuEntryMeta { freq: 1, pos });
-            self.min_freq = 1;
-        }
-    }
-
-    /// Returns an iterator over all retained keys.
-    fn keys(&self) -> impl Iterator<Item = &K> {
-        self.entries.keys()
-    }
-}
-
 /// Slot-specific helpers for the `BucketedLfu<HotSlotKey>`.
 impl BucketedLfu<HotSlotKey> {
     /// Returns retained slots grouped by address.
     fn retained_slots_by_address(&self) -> B256Map<Vec<Nibbles>> {
         let mut grouped = B256Map::<Vec<Nibbles>>::default();
-        for key in self.entries.keys() {
+        for key in self.keys() {
             grouped.entry(key.address).or_default().push(Nibbles::unpack(key.slot));
         }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -93,6 +93,25 @@ impl<A, S> SparseStateTrie<A, S> {
         self
     }
 
+    /// Seeds the hot account/storage LFU caches with their configured capacities.
+    ///
+    /// This must happen before the first `record_*_touch` call, otherwise touches are ignored while
+    /// the LFUs still have zero capacity.
+    pub fn set_hot_cache_capacities(&mut self, max_hot_slots: usize, max_hot_accounts: usize) {
+        self.hot_slots_lfu.decay_and_evict(max_hot_slots);
+        self.hot_accounts_lfu.decay_and_evict(max_hot_accounts);
+    }
+
+    /// Seeds the hot account/storage LFU caches with their configured capacities.
+    pub fn with_hot_cache_capacities(
+        mut self,
+        max_hot_slots: usize,
+        max_hot_accounts: usize,
+    ) -> Self {
+        self.set_hot_cache_capacities(max_hot_slots, max_hot_accounts);
+        self
+    }
+
     /// Set the accounts trie to the given `RevealableSparseTrie`.
     pub fn set_accounts_trie(&mut self, trie: RevealableSparseTrie<A>) {
         self.state = trie;
@@ -1159,6 +1178,24 @@ mod tests {
             .unwrap()
             .get_leaf_value(&full_path_0)
             .is_none());
+    }
+
+    #[test]
+    fn seeded_hot_cache_capacities_preserve_first_cycle_touches() {
+        let account = b256!("0x1000000000000000000000000000000000000000000000000000000000000000");
+        let slot = b256!("0x2000000000000000000000000000000000000000000000000000000000000000");
+        let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default();
+
+        sparse.set_hot_cache_capacities(1, 1);
+        sparse.record_account_touch(account);
+        sparse.record_slot_touch(account, slot);
+        sparse.prune(1, 1);
+
+        assert_eq!(sparse.hot_accounts_lfu.keys().copied().collect::<Vec<_>>(), vec![account]);
+        assert_eq!(
+            sparse.hot_slots_lfu.keys().copied().collect::<Vec<_>>(),
+            vec![HotSlotKey { address: account, slot }]
+        );
     }
 
     #[test]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -878,7 +878,22 @@ impl<S: SparseTrieTrait> StorageTries<S> {
     ///
     /// Tries without retained slots are evicted entirely. Tries with retained slots are pruned to
     /// those slots.
-    fn prune_by_retained_slots(&mut self, mut retained_slots: B256Map<Vec<Nibbles>>) -> usize {
+    fn prune_by_retained_slots(&mut self, retained_slots: B256Map<Vec<Nibbles>>) -> usize {
+        // Parallel pass: prune retained tries and clear evicted ones in place.
+        {
+            use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
+            self.tries.par_iter_mut().for_each(|(address, trie)| {
+                if let Some(slots) = retained_slots.get(address) {
+                    if let Some(t) = trie.as_revealed_mut() {
+                        t.prune(slots);
+                    }
+                } else {
+                    trie.clear();
+                }
+            });
+        }
+
+        // Cheap sequential drain: move already-cleared tries into the reuse pool.
         let addresses_to_evict: Vec<B256> = self
             .tries
             .keys()
@@ -887,16 +902,10 @@ impl<S: SparseTrieTrait> StorageTries<S> {
             .collect();
 
         let evicted = addresses_to_evict.len();
+        self.cleared_tries.reserve(evicted);
         for address in &addresses_to_evict {
-            if let Some(mut trie) = self.tries.remove(address) {
-                trie.clear();
+            if let Some(trie) = self.tries.remove(address) {
                 self.cleared_tries.push(trie);
-            }
-        }
-
-        for (address, slots) in &mut retained_slots {
-            if let Some(trie) = self.tries.get_mut(address).and_then(|t| t.as_revealed_mut()) {
-                trie.prune(slots);
             }
         }
 

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -294,25 +294,21 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// and auxiliary data structures.
     fn memory_size(&self) -> usize;
 
-    /// Replaces nodes beyond `max_depth` with hash stubs and removes their descendants.
+    /// Prunes all subtrees that do not contain retained leaves.
     ///
-    /// Depth counts nodes traversed (not nibbles), so extension nodes count as 1 depth
-    /// regardless of key length. `max_depth == 0` prunes all children of the root node.
+    /// Each retained leaf is a full key path (usually 64 nibbles for hashed keys).
+    /// Any revealed subtree that is not a prefix of at least one retained key is collapsed into
+    /// hash stubs when hashes are available.
     ///
     /// # Preconditions
     ///
     /// Must be called after `root()` to ensure all nodes have computed hashes.
-    /// Calling on a trie without computed hashes will result in no pruning.
-    ///
-    /// # Behavior
-    ///
-    /// - Embedded nodes (RLP < 32 bytes) are preserved since they have no hash
-    /// - Returns 0 if `max_depth` exceeds trie depth or trie is empty
+    /// Calling on a trie without computed hashes will result in limited or no pruning.
     ///
     /// # Returns
     ///
     /// The number of nodes converted to hash stubs.
-    fn prune(&mut self, max_depth: usize) -> usize;
+    fn prune(&mut self, retained_leaves: &[Nibbles]) -> usize;
 
     /// Takes the debug recorder out of this trie, replacing it with an empty one.
     ///

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -991,8 +991,8 @@ Engine:
 
           [default: 4]
 
-      --engine.sparse-trie-max-storage-tries <SPARSE_TRIE_MAX_STORAGE_TRIES>
-          Maximum number of storage tries to retain after sparse trie pruning
+      --engine.sparse-trie-max-hot-slots <SPARSE_TRIE_MAX_HOT_SLOTS>
+          LFU hot-slot capacity: max storage slots retained across sparse trie prune cycles
 
           [default: 100]
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -986,15 +986,15 @@ Engine:
       --engine.disable-cache-metrics
           Disable cache metrics recording, which can take up to 50ms with large cached state
 
-      --engine.sparse-trie-prune-depth <SPARSE_TRIE_PRUNE_DEPTH>
-          Sparse trie prune depth
-
-          [default: 4]
-
       --engine.sparse-trie-max-hot-slots <SPARSE_TRIE_MAX_HOT_SLOTS>
           LFU hot-slot capacity: max storage slots retained across sparse trie prune cycles
 
-          [default: 100]
+          [default: 1500]
+
+      --engine.sparse-trie-max-hot-accounts <SPARSE_TRIE_MAX_HOT_ACCOUNTS>
+          LFU hot-account capacity: max account addresses retained across sparse trie prune cycles
+
+          [default: 1000]
 
       --engine.disable-sparse-trie-cache-pruning
           Fully disable sparse trie cache pruning. When set, the cached sparse trie is preserved without any node pruning or storage trie eviction between blocks. Useful for benchmarking the effects of retaining the full trie cache


### PR DESCRIPTION
## Motivation

The sparse trie cache persists between blocks to avoid expensive re-reveals (DB fetches) of nodes needed again. Pruning bounds memory, but the old strategy poorly predicts what to keep:

1. **Depth-based pruning is blind** — it cuts at a fixed depth regardless of which keys are actually being reused across blocks.
2. **Subtrie-level heat tracking is defeated by hashing at scale** — since keys are keccak256 hashes, updates distribute uniformly across all 256 lower subtries under load. With enough touched slots per block, every subtrie looks equally hot, so the heat mechanism can't distinguish frequently-used regions from cold ones. (It could discriminate with very few updates, but that's exactly when pruning pressure is low and the mechanism isn't needed.)
3. **Whole-trie storage retention is too coarse** — `max_storage_tries` kept the top N whole contract-level storage tries, ranked by `node_count × heat_multiplier`. A massive contract like USDT would dominate by sheer size even if only 1 slot was actually hot, while a smaller contract with many hot slots could get evicted entirely.

The net effect: pruning decisions don't correlate with actual re-use, leading to unnecessary re-reveals (cache misses) and wasted memory (retaining cold data).

## Strategy

Track hotness at the individual key level. Every storage slot write records a `(address, slot)` touch and every account write records an account touch in a `BucketedLfu` frequency cache. At prune time, retain only the top-N hottest slots and top-M hottest accounts, then prune tries to keep exactly the paths leading to retained keys, collapsing everything else to hash stubs. This makes pruning proportional to actual re-use rather than trie topology.
