### PR TITLE
feat(trie): add sparse trie cache hit rate metrics

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -4,7 +4,7 @@ use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, B256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use derive_more::derive::Deref;
-use metrics::{Counter, Gauge, Histogram};
+use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_revm::state::EvmState;
 use reth_trie::{HashedPostState, HashedStorage};
@@ -192,13 +192,13 @@ pub(crate) struct MultiProofTaskMetrics {
     pub sparse_trie_cache_wait_duration_histogram: Histogram,
 
     /// Number of account leaf updates applied without needing a new proof (cache hits).
-    pub sparse_trie_account_cache_hits: Counter,
+    pub sparse_trie_account_cache_hits: Histogram,
     /// Number of account leaf updates that required a new proof (cache misses).
-    pub sparse_trie_account_cache_misses: Counter,
+    pub sparse_trie_account_cache_misses: Histogram,
     /// Number of storage leaf updates applied without needing a new proof (cache hits).
-    pub sparse_trie_storage_cache_hits: Counter,
+    pub sparse_trie_storage_cache_hits: Histogram,
     /// Number of storage leaf updates that required a new proof (cache misses).
-    pub sparse_trie_storage_cache_misses: Counter,
+    pub sparse_trie_storage_cache_misses: Histogram,
 
     /// Retained memory of the preserved sparse trie cache in bytes.
     pub sparse_trie_retained_memory_bytes: Gauge,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -4,7 +4,7 @@ use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, B256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use derive_more::derive::Deref;
-use metrics::{Gauge, Histogram};
+use metrics::{Counter, Gauge, Histogram};
 use reth_metrics::Metrics;
 use reth_revm::state::EvmState;
 use reth_trie::{HashedPostState, HashedStorage};
@@ -192,13 +192,13 @@ pub(crate) struct MultiProofTaskMetrics {
     pub sparse_trie_cache_wait_duration_histogram: Histogram,
 
     /// Number of account leaf updates applied without needing a new proof (cache hits).
-    pub sparse_trie_account_cache_hits: Histogram,
+    pub sparse_trie_account_cache_hits: Counter,
     /// Number of account leaf updates that required a new proof (cache misses).
-    pub sparse_trie_account_cache_misses: Histogram,
+    pub sparse_trie_account_cache_misses: Counter,
     /// Number of storage leaf updates applied without needing a new proof (cache hits).
-    pub sparse_trie_storage_cache_hits: Histogram,
+    pub sparse_trie_storage_cache_hits: Counter,
     /// Number of storage leaf updates that required a new proof (cache misses).
-    pub sparse_trie_storage_cache_misses: Histogram,
+    pub sparse_trie_storage_cache_misses: Counter,
 
     /// Retained memory of the preserved sparse trie cache in bytes.
     pub sparse_trie_retained_memory_bytes: Gauge,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -191,6 +191,15 @@ pub(crate) struct MultiProofTaskMetrics {
     /// Time spent waiting for preserved sparse trie cache to become available.
     pub sparse_trie_cache_wait_duration_histogram: Histogram,
 
+    /// Number of account leaf updates applied without needing a new proof (cache hits).
+    pub sparse_trie_account_cache_hits: Histogram,
+    /// Number of account leaf updates that required a new proof (cache misses).
+    pub sparse_trie_account_cache_misses: Histogram,
+    /// Number of storage leaf updates applied without needing a new proof (cache hits).
+    pub sparse_trie_storage_cache_hits: Histogram,
+    /// Number of storage leaf updates that required a new proof (cache misses).
+    pub sparse_trie_storage_cache_misses: Histogram,
+
     /// Retained memory of the preserved sparse trie cache in bytes.
     pub sparse_trie_retained_memory_bytes: Gauge,
     /// Number of storage tries retained in the preserved sparse trie cache.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -528,8 +528,8 @@ where
                 self.pending_targets.extend_storage_targets(address, targets);
             }
         }
-        self.metrics.sparse_trie_storage_cache_hits.record(storage_cache_hits as f64);
-        self.metrics.sparse_trie_storage_cache_misses.record(storage_cache_misses as f64);
+        self.metrics.sparse_trie_storage_cache_hits.increment(storage_cache_hits);
+        self.metrics.sparse_trie_storage_cache_misses.increment(storage_cache_misses);
 
         drop(span);
 
@@ -571,10 +571,10 @@ where
         })?;
 
         let updates_len_after = account_updates.len();
-        let cache_hits = (updates_len_before - updates_len_after) as f64;
-        let cache_misses = updates_len_after as f64;
-        self.metrics.sparse_trie_account_cache_hits.record(cache_hits);
-        self.metrics.sparse_trie_account_cache_misses.record(cache_misses);
+        let cache_hits = (updates_len_before - updates_len_after) as u64;
+        let cache_misses = updates_len_after as u64;
+        self.metrics.sparse_trie_account_cache_hits.increment(cache_hits);
+        self.metrics.sparse_trie_account_cache_misses.increment(cache_misses);
 
         Ok(updates_len_after < updates_len_before)
     }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -495,6 +495,8 @@ where
 
         // Process all storage updates, skipping tries with no pending updates.
         let span = debug_span!("process_storage_leaf_updates").entered();
+        let mut storage_cache_hits = 0u64;
+        let mut storage_cache_misses = 0u64;
         for (address, updates) in storage_updates {
             if updates.is_empty() {
                 continue;
@@ -505,6 +507,7 @@ where
             let fetched = self.fetched_storage_targets.entry(*address).or_default();
             let mut targets = Vec::new();
 
+            let updates_len_before = updates.len();
             trie.update_leaves(updates, |path, min_len| match fetched.entry(path) {
                 Entry::Occupied(mut entry) => {
                     if min_len < *entry.get() {
@@ -517,11 +520,16 @@ where
                     targets.push(ProofV2Target::new(path).with_min_len(min_len));
                 }
             })?;
+            let updates_len_after = updates.len();
+            storage_cache_hits += (updates_len_before - updates_len_after) as u64;
+            storage_cache_misses += updates_len_after as u64;
 
             if !targets.is_empty() {
                 self.pending_targets.extend_storage_targets(address, targets);
             }
         }
+        self.metrics.sparse_trie_storage_cache_hits.record(storage_cache_hits as f64);
+        self.metrics.sparse_trie_storage_cache_misses.record(storage_cache_misses as f64);
 
         drop(span);
 
@@ -562,7 +570,13 @@ where
             }
         })?;
 
-        Ok(account_updates.len() < updates_len_before)
+        let updates_len_after = account_updates.len();
+        let cache_hits = (updates_len_before - updates_len_after) as f64;
+        let cache_misses = updates_len_after as f64;
+        self.metrics.sparse_trie_account_cache_hits.record(cache_hits);
+        self.metrics.sparse_trie_account_cache_misses.record(cache_misses);
+
+        Ok(updates_len_after < updates_len_before)
     }
 
     /// Iterates through all storage tries for which all updates were processed, computes their

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -344,10 +344,10 @@ where
         self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
         self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
 
-        self.metrics.sparse_trie_account_cache_hits.increment(self.account_cache_hits);
-        self.metrics.sparse_trie_account_cache_misses.increment(self.account_cache_misses);
-        self.metrics.sparse_trie_storage_cache_hits.increment(self.storage_cache_hits);
-        self.metrics.sparse_trie_storage_cache_misses.increment(self.storage_cache_misses);
+        self.metrics.sparse_trie_account_cache_hits.record(self.account_cache_hits as f64);
+        self.metrics.sparse_trie_account_cache_misses.record(self.account_cache_misses as f64);
+        self.metrics.sparse_trie_storage_cache_hits.record(self.storage_cache_hits as f64);
+        self.metrics.sparse_trie_storage_cache_misses.record(self.storage_cache_misses as f64);
         self.account_cache_hits = 0;
         self.account_cache_misses = 0;
         self.storage_cache_hits = 0;

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -92,6 +92,14 @@ pub(super) struct SparseTrieCacheTask<A = ParallelSparseTrie, S = ParallelSparse
     account_rlp_buf: Vec<u8>,
     /// Whether the last state update has been received.
     finished_state_updates: bool,
+    /// Accumulated account leaf update cache hits.
+    account_cache_hits: u64,
+    /// Accumulated account leaf update cache misses.
+    account_cache_misses: u64,
+    /// Accumulated storage leaf update cache hits.
+    storage_cache_hits: u64,
+    /// Accumulated storage leaf update cache misses.
+    storage_cache_misses: u64,
     /// Pending proof targets queued for dispatch to proof workers.
     pending_targets: PendingTargets,
     /// Number of pending execution/prewarming updates received but not yet passed to
@@ -142,6 +150,10 @@ where
             fetched_storage_targets: Default::default(),
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             finished_state_updates: Default::default(),
+            account_cache_hits: 0,
+            account_cache_misses: 0,
+            storage_cache_hits: 0,
+            storage_cache_misses: 0,
             pending_targets: Default::default(),
             pending_updates: Default::default(),
             metrics,
@@ -332,6 +344,15 @@ where
         self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
         self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
 
+        self.metrics.sparse_trie_account_cache_hits.increment(self.account_cache_hits);
+        self.metrics.sparse_trie_account_cache_misses.increment(self.account_cache_misses);
+        self.metrics.sparse_trie_storage_cache_hits.increment(self.storage_cache_hits);
+        self.metrics.sparse_trie_storage_cache_misses.increment(self.storage_cache_misses);
+        self.account_cache_hits = 0;
+        self.account_cache_misses = 0;
+        self.storage_cache_hits = 0;
+        self.storage_cache_misses = 0;
+
         Ok(StateRootComputeOutcome {
             state_root,
             trie_updates: Arc::new(trie_updates),
@@ -495,8 +516,6 @@ where
 
         // Process all storage updates, skipping tries with no pending updates.
         let span = debug_span!("process_storage_leaf_updates").entered();
-        let mut storage_cache_hits = 0u64;
-        let mut storage_cache_misses = 0u64;
         for (address, updates) in storage_updates {
             if updates.is_empty() {
                 continue;
@@ -521,15 +540,13 @@ where
                 }
             })?;
             let updates_len_after = updates.len();
-            storage_cache_hits += (updates_len_before - updates_len_after) as u64;
-            storage_cache_misses += updates_len_after as u64;
+            self.storage_cache_hits += (updates_len_before - updates_len_after) as u64;
+            self.storage_cache_misses += updates_len_after as u64;
 
             if !targets.is_empty() {
                 self.pending_targets.extend_storage_targets(address, targets);
             }
         }
-        self.metrics.sparse_trie_storage_cache_hits.increment(storage_cache_hits);
-        self.metrics.sparse_trie_storage_cache_misses.increment(storage_cache_misses);
 
         drop(span);
 
@@ -571,10 +588,8 @@ where
         })?;
 
         let updates_len_after = account_updates.len();
-        let cache_hits = (updates_len_before - updates_len_after) as u64;
-        let cache_misses = updates_len_after as u64;
-        self.metrics.sparse_trie_account_cache_hits.increment(cache_hits);
-        self.metrics.sparse_trie_account_cache_misses.increment(cache_misses);
+        self.account_cache_hits += (updates_len_before - updates_len_after) as u64;
+        self.account_cache_misses += updates_len_after as u64;
 
         Ok(updates_len_after < updates_len_before)
     }


### PR DESCRIPTION
## Summary

Add metrics to track sparse trie cache hit rate in `update_leaves`.

## Motivation

We need a proper way to measure how effective the sparse trie cache is, rather than using proxies like revealed node counts. Every key removed from the `updates` map after `update_leaves` is a cache hit (the trie path was already revealed), and every key left behind is a cache miss (required a new proof).

## Changes

- Added 4 histogram metrics to `MultiProofTaskMetrics`: `sparse_trie_{account,storage}_cache_{hits,misses}`
- In `process_leaf_updates`, measure `updates.len()` before/after `update_leaves()` for storage tries and record aggregated hits/misses
- In `process_account_leaf_updates`, do the same for the account trie

## Testing

`cargo check -p reth-engine-tree` passes clean.

Prompted by: alexey