### PR TITLE
feat(bench): add Tracy profiling support

### DIFF
--- a/.github/scripts/bench-reth-build.sh
+++ b/.github/scripts/bench-reth-build.sh
@@ -22,6 +22,25 @@ MODE="$1"
 SOURCE_DIR="$2"
 COMMIT="$3"
 
+# Tracy profiling support: when BENCH_TRACY is "on" or "full", build with
+# tracy features and frame pointers for profiling.
+# Samply and tracy=full are mutually exclusive (both use perf sampling) —
+# samply takes precedence. Samply and tracy=on can coexist.
+TRACY_MODE="${BENCH_TRACY:-off}"
+if [ "${BENCH_SAMPLY:-false}" = "true" ] && [ "$TRACY_MODE" = "full" ]; then
+  echo "Warning: samply and tracy=full are mutually exclusive, disabling tracy"
+  TRACY_MODE="off"
+fi
+
+EXTRA_FEATURES=""
+EXTRA_RUSTFLAGS=""
+if [ "$TRACY_MODE" != "off" ]; then
+  EXTRA_FEATURES="tracy,tracy-client/ondemand"
+  EXTRA_RUSTFLAGS="-Cforce-frame-pointers=yes"
+elif [ "${BENCH_SAMPLY:-false}" = "true" ]; then
+  EXTRA_RUSTFLAGS="-Cforce-frame-pointers=yes"
+fi
+
 # Verify a cached reth binary was built from the expected commit.
 # `reth --version` outputs "Commit SHA: <full-sha>" on its own line.
 verify_binary() {
@@ -42,12 +61,14 @@ verify_binary() {
 
 case "$MODE" in
   baseline|main)
-    BUCKET="minio/reth-binaries/${COMMIT}"
+    CACHE_SUFFIX=""
+    [ -n "$EXTRA_FEATURES" ] && CACHE_SUFFIX="-tracy"
+    BUCKET="minio/reth-binaries/${COMMIT}${CACHE_SUFFIX}"
     mkdir -p "${SOURCE_DIR}/target/profiling"
 
     CACHE_VALID=false
     if $MC stat "${BUCKET}/reth" &>/dev/null; then
-      echo "Cache hit for baseline (${COMMIT}), downloading binary..."
+      echo "Cache hit for baseline (${COMMIT}${CACHE_SUFFIX}), downloading binary..."
       $MC cp "${BUCKET}/reth" "${SOURCE_DIR}/target/profiling/reth"
       chmod +x "${SOURCE_DIR}/target/profiling/reth"
       if verify_binary "${SOURCE_DIR}/target/profiling/reth" "${COMMIT}"; then
@@ -59,18 +80,22 @@ case "$MODE" in
     if [ "$CACHE_VALID" = false ]; then
       echo "Building baseline (${COMMIT}) from source..."
       cd "${SOURCE_DIR}"
-      cargo build --profile profiling --bin reth
+      FEATURES_ARG=""
+      [ -n "$EXTRA_FEATURES" ] && FEATURES_ARG="--features ${EXTRA_FEATURES}"
+      RUSTFLAGS="-C target-cpu=native ${EXTRA_RUSTFLAGS}" cargo build --profile profiling --bin reth $FEATURES_ARG
       $MC cp target/profiling/reth "${BUCKET}/reth"
     fi
     ;;
 
   feature|branch)
     BRANCH_SHA="${4:-$COMMIT}"
-    BUCKET="minio/reth-binaries/${BRANCH_SHA}"
+    CACHE_SUFFIX=""
+    [ -n "$EXTRA_FEATURES" ] && CACHE_SUFFIX="-tracy"
+    BUCKET="minio/reth-binaries/${BRANCH_SHA}${CACHE_SUFFIX}"
 
     CACHE_VALID=false
     if $MC stat "${BUCKET}/reth" &>/dev/null && $MC stat "${BUCKET}/reth-bench" &>/dev/null; then
-      echo "Cache hit for ${BRANCH_SHA}, downloading binaries..."
+      echo "Cache hit for ${BRANCH_SHA}${CACHE_SUFFIX}, downloading binaries..."
       mkdir -p "${SOURCE_DIR}/target/profiling"
       $MC cp "${BUCKET}/reth" "${SOURCE_DIR}/target/profiling/reth"
       $MC cp "${BUCKET}/reth-bench" /home/ubuntu/.cargo/bin/reth-bench
@@ -85,10 +110,12 @@ case "$MODE" in
       echo "Building feature (${COMMIT}) from source..."
       cd "${SOURCE_DIR}"
       rustup show active-toolchain || rustup default stable
-      make profiling
-      make install-reth-bench
+      FEATURES_ARG=""
+      [ -n "$EXTRA_FEATURES" ] && FEATURES_ARG="--features ${EXTRA_FEATURES}"
+      RUSTFLAGS="-C target-cpu=native ${EXTRA_RUSTFLAGS}" cargo build --profile profiling --workspace --bin reth --bin reth-bench $FEATURES_ARG
+      install target/profiling/reth-bench /home/ubuntu/.cargo/bin/reth-bench
       $MC cp target/profiling/reth "${BUCKET}/reth"
-      $MC cp "$(which reth-bench)" "${BUCKET}/reth-bench"
+      $MC cp target/profiling/reth-bench "${BUCKET}/reth-bench"
     fi
     ;;
 

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -15,8 +15,23 @@ DATADIR="$SCHELK_MOUNT/datadir"
 mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
+# Tracy profiling: resolve effective mode (samply+tracy=full are mutually exclusive)
+TRACY_MODE="${BENCH_TRACY:-off}"
+if [ "${BENCH_SAMPLY:-false}" = "true" ] && [ "$TRACY_MODE" = "full" ]; then
+  echo "Warning: samply and tracy=full are mutually exclusive, disabling tracy"
+  TRACY_MODE="off"
+fi
+USE_TRACY=false
+[ "$TRACY_MODE" != "off" ] && USE_TRACY=true
+
+TRACY_CAPTURE_PID=""
+
 cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
+
+  # Stop reth (and samply if profiling) FIRST — tracy-capture auto-exits
+  # when the instrumented process disconnects, so reth must die before we
+  # wait for tracy-capture.
   if [ -n "${RETH_PID:-}" ] && sudo kill -0 "$RETH_PID" 2>/dev/null; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
       # Send SIGINT to the inner reth process by exact name (not -f which
@@ -45,6 +60,34 @@ cleanup() {
     sudo kill -9 "$RETH_PID" 2>/dev/null || true
     sleep 1
   fi
+
+  # Now wait for tracy-capture to finish writing the profile (it auto-exits
+  # when the Tracy client in reth disconnects).
+  if [ -n "$TRACY_CAPTURE_PID" ]; then
+    echo "Waiting for tracy-capture (pid=$TRACY_CAPTURE_PID)..."
+    for i in $(seq 1 60); do
+      kill -0 "$TRACY_CAPTURE_PID" 2>/dev/null || break
+      if [ $((i % 10)) -eq 0 ]; then
+        echo "tracy-capture still running... (${i}s)"
+      fi
+      sleep 1
+    done
+    if kill -0 "$TRACY_CAPTURE_PID" 2>/dev/null; then
+      echo "tracy-capture still running after 60s, sending SIGKILL..."
+      kill -9 "$TRACY_CAPTURE_PID" 2>/dev/null || true
+    else
+      wait "$TRACY_CAPTURE_PID" 2>/dev/null || true
+    fi
+    echo "tracy-capture exited"
+    # Verify tracy profile
+    if [ -f "$OUTPUT_DIR/tracy-profile.tracy" ]; then
+      TRACY_SIZE=$(du -h "$OUTPUT_DIR/tracy-profile.tracy" | cut -f1)
+      echo "Tracy profile created: ${TRACY_SIZE}"
+    else
+      echo "Warning: Tracy profile was NOT created"
+    fi
+  fi
+
   # Fix ownership of reth-created files (reth runs as root)
   sudo chown -R "$(id -un):$(id -gn)" "$OUTPUT_DIR" 2>/dev/null || true
   if mountpoint -q "$SCHELK_MOUNT"; then
@@ -62,6 +105,18 @@ sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
 echo "=== Cache state after drop ==="
 free -h
 grep Cached /proc/meminfo
+
+# Mount tracefs for tracy=full mode (required for CPU sampling and context
+# switch tracing). In "on" mode we set TRACY_NO_SYS_TRACE=1 so this is not
+# needed.
+if [ "$TRACY_MODE" = "full" ]; then
+  if ! mount | grep -q tracefs; then
+    echo "Mounting tracefs for Tracy CPU sampling..."
+    sudo mount -t tracefs -o mode=755 tracefs /sys/kernel/tracing 2>&1 || true
+  else
+    sudo mount -o remount,mode=755 /sys/kernel/tracing 2>&1 || true
+  fi
+fi
 
 # Start reth
 # CPU layout: core 0 = OS/IRQs/reth-bench/aux, cores 1+ = reth node
@@ -87,13 +142,31 @@ RETH_ARGS=(
   --no-persist-peers
 )
 
+# Add Tracy tracing args to reth if enabled
+if [ "$USE_TRACY" = true ]; then
+  RETH_ARGS+=(--log.tracy --log.tracy.filter debug)
+fi
+
+# Set Tracy environment variables
+TRACY_ENV=""
+if [ "$USE_TRACY" = true ]; then
+  if [ "$TRACY_MODE" = "full" ]; then
+    TRACY_ENV="TRACY_SAMPLING_HZ=1"
+  else
+    TRACY_ENV="TRACY_NO_SYS_TRACE=1"
+  fi
+fi
+
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   RETH_ARGS+=(--log.samply)
   SAMPLY="$(which samply)"
-  sudo taskset -c "$RETH_CPUS" nice -n -20 \
+  sudo env $TRACY_ENV taskset -c "$RETH_CPUS" nice -n -20 \
     "$SAMPLY" record --save-only --presymbolicate --rate 10000 \
     --output "$OUTPUT_DIR/samply-profile.json.gz" \
     -- "$BINARY" "${RETH_ARGS[@]}" \
+    > "$LOG" 2>&1 &
+elif [ -n "$TRACY_ENV" ]; then
+  sudo env $TRACY_ENV taskset -c "$RETH_CPUS" nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &
 else
   sudo taskset -c "$RETH_CPUS" nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
@@ -131,6 +204,15 @@ $BENCH_NICE "$RETH_BENCH" new-payload-fcu \
   --jwt-secret "$DATADIR/jwt.hex" \
   --advance "${BENCH_WARMUP_BLOCKS:-50}" \
   --reth-new-payload 2>&1 | sed -u "s/^/[bench] /"
+
+# Start tracy-capture AFTER warmup so the profile only covers the
+# actual benchmark, not the warmup phase.
+if [ "$USE_TRACY" = true ]; then
+  echo "Starting tracy-capture..."
+  sleep 0.5
+  tracy-capture -f -o "$OUTPUT_DIR/tracy-profile.tracy" &
+  TRACY_CAPTURE_PID=$!
+fi
 
 # Benchmark
 $BENCH_NICE "$RETH_BENCH" new-payload-fcu \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,6 +36,15 @@ on:
         required: false
         default: "false"
         type: boolean
+      tracy:
+        description: "Tracy profiling mode (off/on/full)"
+        required: false
+        default: "off"
+        type: choice
+        options:
+          - "off"
+          - "on"
+          - "full"
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
@@ -72,6 +81,7 @@ jobs:
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
+      tracy: ${{ steps.args.outputs.tracy }}
       cores: ${{ steps.args.outputs.cores }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
     steps:
@@ -100,7 +110,7 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
-            let pr, actor, blocks, warmup, baseline, feature, samply, cores;
+            let pr, actor, blocks, warmup, baseline, feature, samply, tracy, cores;
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
@@ -109,6 +119,7 @@ jobs:
               baseline = '${{ github.event.inputs.baseline }}';
               feature = '${{ github.event.inputs.feature }}';
               samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
+              tracy = '${{ github.event.inputs.tracy }}' || 'off';
               cores = '${{ github.event.inputs.cores }}' || '0';
 
               // Find PR for the selected branch
@@ -132,7 +143,8 @@ jobs:
               const intArgs = new Set(['blocks', 'warmup', 'cores']);
               const refArgs = new Set(['baseline', 'feature']);
               const boolArgs = new Set(['samply']);
-              const defaults = { blocks: '500', warmup: '100', baseline: '', feature: '', samply: 'false', cores: '0' };
+              const choiceArgs = new Map([['tracy', new Set(['off', 'on', 'full'])]]);
+              const defaults = { blocks: '500', warmup: '100', baseline: '', feature: '', samply: 'false', tracy: 'off', cores: '0' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -141,6 +153,9 @@ jobs:
                 if (eq === -1) {
                   if (boolArgs.has(part)) {
                     defaults[part] = 'true';
+                  } else if (choiceArgs.has(part)) {
+                    // bare word "tracy" means "on"
+                    defaults[part] = 'on';
                   } else {
                     unknown.push(part);
                   }
@@ -160,6 +175,12 @@ jobs:
                   } else {
                     defaults[key] = value;
                   }
+                } else if (choiceArgs.has(key)) {
+                  if (!choiceArgs.get(key).has(value)) {
+                    invalid.push(`\`${key}=${value}\` (must be one of: ${[...choiceArgs.get(key)].join(', ')})`);
+                  } else {
+                    defaults[key] = value;
+                  }
                 } else {
                   unknown.push(key);
                 }
@@ -168,7 +189,7 @@ jobs:
               if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
               if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
               if (errors.length) {
-                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [blocks=N] [warmup=N] [baseline=REF] [feature=REF] [samply] [cores=N]\``;
+                const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [blocks=N] [warmup=N] [baseline=REF] [feature=REF] [samply] [tracy[=off|on|full]] [cores=N]\``;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -183,7 +204,14 @@ jobs:
               baseline = defaults.baseline;
               feature = defaults.feature;
               samply = defaults.samply;
+              tracy = defaults.tracy;
               cores = defaults.cores;
+            }
+
+            // samply and tracy=full are mutually exclusive (both use perf sampling)
+            // — samply takes precedence
+            if (samply === 'true' && tracy === 'full') {
+              tracy = 'off';
             }
 
             // Resolve display names for baseline/feature
@@ -211,6 +239,7 @@ jobs:
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
+            core.setOutput('tracy', tracy);
             core.setOutput('cores', cores);
 
       - name: Acknowledge request
@@ -270,9 +299,11 @@ jobs:
             const feature = '${{ steps.args.outputs.feature-name }}';
             const samply = '${{ steps.args.outputs.samply }}' === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracy = '${{ steps.args.outputs.tracy }}';
+            const tracyNote = tracy && tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
             const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
-            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${coresNote}`;
+            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${coresNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -298,9 +329,11 @@ jobs:
             const feature = '${{ steps.args.outputs.feature-name }}';
             const samply = '${{ steps.args.outputs.samply }}' === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracy = '${{ steps.args.outputs.tracy }}';
+            const tracyNote = tracy && tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
             const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
-            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${coresNote}`;
+            const config = `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${coresNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -363,6 +396,7 @@ jobs:
       BENCH_BLOCKS: ${{ needs.reth-bench-ack.outputs.blocks }}
       BENCH_WARMUP_BLOCKS: ${{ needs.reth-bench-ack.outputs.warmup }}
       BENCH_SAMPLY: ${{ needs.reth-bench-ack.outputs.samply }}
+      BENCH_TRACY: ${{ needs.reth-bench-ack.outputs.tracy }}
       BENCH_CORES: ${{ needs.reth-bench-ack.outputs.cores }}
       BENCH_COMMENT_ID: ${{ needs.reth-bench-ack.outputs.comment-id }}
     steps:
@@ -418,9 +452,11 @@ jobs:
             const feature = '${{ needs.reth-bench-ack.outputs.feature-name }}';
             const samply = process.env.BENCH_SAMPLY === 'true';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracy = process.env.BENCH_TRACY || 'off';
+            const tracyNote = tracy !== 'off' ? `, tracy: \`${tracy}\`` : '';
             const cores = process.env.BENCH_CORES || '0';
             const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${coresNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocks} blocks, ${warmup} warmup blocks, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracyNote}${coresNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -478,6 +514,16 @@ jobs:
           if [ "${BENCH_SAMPLY:-false}" = "true" ] && ! sudo sh -c 'command -v samply' &>/dev/null; then
             cargo install samply --git https://github.com/DaniPopes/samply --branch edge --locked
             sudo install "$HOME/.cargo/bin/samply" /usr/local/bin/
+          fi
+
+          # tracy-capture (optional Tracy profiler capture tool)
+          if [ "${BENCH_TRACY:-off}" != "off" ] && ! command -v tracy-capture &>/dev/null; then
+            sudo apt-get install -y --no-install-recommends cmake
+            git clone --depth 1 https://github.com/wolfpld/tracy /tmp/tracy
+            cmake -B /tmp/tracy/capture/build -S /tmp/tracy/capture -DCMAKE_BUILD_TYPE=Release -DNO_ISA_EXTENSIONS=ON
+            cmake --build /tmp/tracy/capture/build --config Release --parallel
+            sudo install /tmp/tracy/capture/build/tracy-capture /usr/local/bin/
+            rm -rf /tmp/tracy
           fi
 
       # Verify all required tools are available
@@ -672,6 +718,7 @@ jobs:
       - name: Pre-flight cleanup
         run: |
           sudo pkill -9 reth || true
+          sudo pkill -9 tracy-capture || true
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then
             sudo umount -l "$SCHELK_MOUNT" || true
@@ -912,6 +959,22 @@ jobs:
               }
               if (links.length > 0) {
                 comment += `\n\n### Samply Profiles\n\n${links.join('\n')}\n`;
+              }
+            }
+
+            // Tracy profile info (profiles are in the workflow artifact)
+            if (process.env.BENCH_TRACY && process.env.BENCH_TRACY !== 'off') {
+              const runs = ['baseline-1', 'feature-1', 'feature-2', 'baseline-2'];
+              const profiles = [];
+              for (const run of runs) {
+                try {
+                  const profilePath = `${process.env.BENCH_WORK_DIR}/${run}/tracy-profile.tracy`;
+                  fs.statSync(profilePath);
+                  profiles.push(`- **${run}**: \`tracy-profile.tracy\``);
+                } catch (e) {}
+              }
+              if (profiles.length > 0) {
+                comment += `\n\n### Tracy Profiles\n\nAvailable in the \`bench-reth-results\` artifact:\n${profiles.join('\n')}\n`;
               }
             }
 


### PR DESCRIPTION
Adds Tracy profiling to the bench workflow, replicating the collection logic from the helm-charts Argo workflow (without the minio upload part).

Three modes: `off` (default), `on` (tracing spans only, no sys trace), `full` (with CPU sampling via perf).

**Usage:**
- Comment: `@decofe bench tracy` (defaults to `on`) or `@decofe bench tracy=full`
- Workflow dispatch: select tracy mode from dropdown

**Build changes:**
- Adds `tracy,tracy-client/ondemand` cargo features when tracy is enabled
- Adds `-Cforce-frame-pointers=yes` RUSTFLAGS for tracy and samply builds
- Uses separate cache keys for tracy builds (`-tracy` suffix) to avoid mixing

**Run changes:**
- Sets `TRACY_NO_SYS_TRACE=1` (on mode) or `TRACY_SAMPLING_HZ=1` (full mode)
- Mounts tracefs for full mode (required for CPU sampling/context switches)
- Passes `--log.tracy --log.tracy.filter debug` to the reth node
- Starts `tracy-capture` after warmup so profile covers only the benchmark
- Stops reth first, then waits for tracy-capture (auto-exits on disconnect)
- Profiles saved in the `bench-reth-results` workflow artifact

**Compatibility:**
- samply + tracy=on can coexist (tracy captures tracing spans, samply captures CPU profile)
- samply + tracy=full are mutually exclusive (both use perf) — samply takes precedence, tracy is disabled
- Default behavior (`tracy=off`) is unchanged

Prompted by: alexey