### PR TITLE
feat(devnet): add cli flags for the different BAL methods

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -140,9 +140,9 @@ pub struct TreeConfig {
     /// computation is spawned in parallel and whichever finishes first is used.
     /// If `None`, the timeout fallback is disabled.
     state_root_task_timeout: Option<Duration>,
-    /// Whether to disable BAL (Block Access List, EIP-7928) based prewarming.
+    /// Whether to disable BAL (Block Access List, EIP-7928) based parallel execution.
     /// When disabled, falls back to transaction-based prewarming even when a BAL is available.
-    disable_bal_prewarming: bool,
+    disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
     /// When disabled, the BAL hashed post state is not sent to the multiproof task for
     /// early parallel state root computation.
@@ -175,7 +175,7 @@ impl Default for TreeConfig {
             sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
-            disable_bal_prewarming: false,
+            disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
         }
     }
@@ -232,7 +232,7 @@ impl TreeConfig {
             sparse_trie_max_storage_tries,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout,
-            disable_bal_prewarming: false,
+            disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
         }
     }
@@ -515,14 +515,17 @@ impl TreeConfig {
         self
     }
 
-    /// Returns whether BAL-based prewarming is disabled.
-    pub const fn disable_bal_prewarming(&self) -> bool {
-        self.disable_bal_prewarming
+    /// Returns whether BAL-based parallel execution is disabled.
+    pub const fn disable_bal_parallel_execution(&self) -> bool {
+        self.disable_bal_parallel_execution
     }
 
-    /// Setter for whether to disable BAL-based prewarming.
-    pub const fn without_bal_prewarming(mut self, disable_bal_prewarming: bool) -> Self {
-        self.disable_bal_prewarming = disable_bal_prewarming;
+    /// Setter for whether to disable BAL-based parallel execution.
+    pub const fn without_bal_parallel_execution(
+        mut self,
+        disable_bal_parallel_execution: bool,
+    ) -> Self {
+        self.disable_bal_parallel_execution = disable_bal_parallel_execution;
         self
     }
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -140,6 +140,13 @@ pub struct TreeConfig {
     /// computation is spawned in parallel and whichever finishes first is used.
     /// If `None`, the timeout fallback is disabled.
     state_root_task_timeout: Option<Duration>,
+    /// Whether to disable BAL (Block Access List, EIP-7928) based prewarming.
+    /// When disabled, falls back to transaction-based prewarming even when a BAL is available.
+    disable_bal_prewarming: bool,
+    /// Whether to disable BAL-driven parallel state root computation.
+    /// When disabled, the BAL hashed post state is not sent to the multiproof task for
+    /// early parallel state root computation.
+    disable_bal_parallel_state_root: bool,
 }
 
 impl Default for TreeConfig {
@@ -168,6 +175,8 @@ impl Default for TreeConfig {
             sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
+            disable_bal_prewarming: false,
+            disable_bal_parallel_state_root: false,
         }
     }
 }
@@ -223,6 +232,8 @@ impl TreeConfig {
             sparse_trie_max_storage_tries,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout,
+            disable_bal_prewarming: false,
+            disable_bal_parallel_state_root: false,
         }
     }
 
@@ -501,6 +512,31 @@ impl TreeConfig {
     /// Setter for state root task timeout.
     pub const fn with_state_root_task_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.state_root_task_timeout = timeout;
+        self
+    }
+
+    /// Returns whether BAL-based prewarming is disabled.
+    pub const fn disable_bal_prewarming(&self) -> bool {
+        self.disable_bal_prewarming
+    }
+
+    /// Setter for whether to disable BAL-based prewarming.
+    pub const fn without_bal_prewarming(mut self, disable_bal_prewarming: bool) -> Self {
+        self.disable_bal_prewarming = disable_bal_prewarming;
+        self
+    }
+
+    /// Returns whether BAL-driven parallel state root computation is disabled.
+    pub const fn disable_bal_parallel_state_root(&self) -> bool {
+        self.disable_bal_parallel_state_root
+    }
+
+    /// Setter for whether to disable BAL-driven parallel state root computation.
+    pub const fn without_bal_parallel_state_root(
+        mut self,
+        disable_bal_parallel_state_root: bool,
+    ) -> Self {
+        self.disable_bal_parallel_state_root = disable_bal_parallel_state_root;
         self
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -139,8 +139,8 @@ where
     disable_sparse_trie_cache_pruning: bool,
     /// Whether to disable cache metrics recording.
     disable_cache_metrics: bool,
-    /// Whether to disable BAL-based prewarming (falls back to tx-based prewarming).
-    disable_bal_prewarming: bool,
+    /// Whether to disable BAL-based parallel execution (falls back to tx-based prewarming).
+    disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
     disable_bal_parallel_state_root: bool,
 }
@@ -177,7 +177,7 @@ where
             sparse_trie_max_storage_tries: config.sparse_trie_max_storage_tries(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             disable_cache_metrics: config.disable_cache_metrics(),
-            disable_bal_prewarming: config.disable_bal_prewarming(),
+            disable_bal_parallel_execution: config.disable_bal_parallel_execution(),
             disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
         }
     }
@@ -513,11 +513,11 @@ where
 
         {
             let to_prewarm_task = to_prewarm_task.clone();
-            let disable_bal_prewarming = self.disable_bal_prewarming;
+            let disable_bal_parallel_execution = self.disable_bal_parallel_execution;
             self.executor.spawn_blocking_named("prewarm", move || {
                 let mode = if skip_prewarm {
                     PrewarmMode::Skipped
-                } else if let Some(bal) = bal.filter(|_| !disable_bal_prewarming) {
+                } else if let Some(bal) = bal.filter(|_| !disable_bal_parallel_execution) {
                     PrewarmMode::BlockAccessList(bal)
                 } else {
                     PrewarmMode::Transactions(transactions)

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -139,6 +139,10 @@ where
     disable_sparse_trie_cache_pruning: bool,
     /// Whether to disable cache metrics recording.
     disable_cache_metrics: bool,
+    /// Whether to disable BAL-based prewarming (falls back to tx-based prewarming).
+    disable_bal_prewarming: bool,
+    /// Whether to disable BAL-driven parallel state root computation.
+    disable_bal_parallel_state_root: bool,
 }
 
 impl<N, Evm> PayloadProcessor<Evm>
@@ -173,6 +177,8 @@ where
             sparse_trie_max_storage_tries: config.sparse_trie_max_storage_tries(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             disable_cache_metrics: config.disable_cache_metrics(),
+            disable_bal_prewarming: config.disable_bal_prewarming(),
+            disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
         }
     }
 }
@@ -502,14 +508,16 @@ where
             self.execution_cache.clone(),
             prewarm_ctx,
             to_multi_proof,
+            self.disable_bal_parallel_state_root,
         );
 
         {
             let to_prewarm_task = to_prewarm_task.clone();
+            let disable_bal_prewarming = self.disable_bal_prewarming;
             self.executor.spawn_blocking_named("prewarm", move || {
                 let mode = if skip_prewarm {
                     PrewarmMode::Skipped
-                } else if let Some(bal) = bal {
+                } else if let Some(bal) = bal.filter(|_| !disable_bal_prewarming) {
                     PrewarmMode::BlockAccessList(bal)
                 } else {
                     PrewarmMode::Transactions(transactions)

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -75,6 +75,8 @@ where
     actions_rx: Receiver<PrewarmTaskEvent<N::Receipt>>,
     /// Parent span for tracing
     parent_span: Span,
+    /// Whether to disable BAL-driven parallel state root computation.
+    disable_bal_parallel_state_root: bool,
 }
 
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
@@ -89,6 +91,7 @@ where
         execution_cache: PayloadExecutionCache,
         ctx: PrewarmContext<N, P, Evm>,
         to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
+        disable_bal_parallel_state_root: bool,
     ) -> (Self, Sender<PrewarmTaskEvent<N::Receipt>>) {
         let (actions_tx, actions_rx) = channel();
 
@@ -107,6 +110,7 @@ where
                 to_multi_proof,
                 actions_rx,
                 parent_span: Span::current(),
+                disable_bal_parallel_state_root,
             },
             actions_tx,
         )
@@ -371,6 +375,9 @@ where
     /// Converts the BAL to [`HashedPostState`](reth_trie::HashedPostState) and sends it to the
     /// multiproof task.
     fn send_bal_hashed_state(&self, bal: &BlockAccessList) {
+        if self.disable_bal_parallel_state_root {
+            return;
+        }
         let Some(to_multi_proof) = &self.to_multi_proof else { return };
 
         let provider = match self.ctx.provider.build() {

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -43,6 +43,8 @@ pub struct DefaultEngineValues {
     sparse_trie_max_storage_tries: usize,
     disable_sparse_trie_cache_pruning: bool,
     state_root_task_timeout: Option<String>,
+    bal_prewarming_disabled: bool,
+    bal_parallel_state_root_disabled: bool,
 }
 
 impl DefaultEngineValues {
@@ -196,6 +198,18 @@ impl DefaultEngineValues {
         self.state_root_task_timeout = v;
         self
     }
+
+    /// Set whether to disable BAL-based prewarming by default
+    pub const fn with_bal_prewarming_disabled(mut self, v: bool) -> Self {
+        self.bal_prewarming_disabled = v;
+        self
+    }
+
+    /// Set whether to disable BAL-driven parallel state root by default
+    pub const fn with_bal_parallel_state_root_disabled(mut self, v: bool) -> Self {
+        self.bal_parallel_state_root_disabled = v;
+        self
+    }
 }
 
 impl Default for DefaultEngineValues {
@@ -224,6 +238,8 @@ impl Default for DefaultEngineValues {
             sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some("1s".to_string()),
+            bal_prewarming_disabled: false,
+            bal_parallel_state_root_disabled: false,
         }
     }
 }
@@ -377,6 +393,16 @@ pub struct EngineArgs {
         default_value = DefaultEngineValues::get_global().state_root_task_timeout.as_deref().unwrap_or("1s"),
     )]
     pub state_root_task_timeout: Option<Duration>,
+
+    /// Disable BAL (Block Access List, EIP-7928) based prewarming. When set, falls back to
+    /// transaction-based prewarming even when a BAL is available.
+    #[arg(long = "engine.disable-bal-prewarming", default_value_t = DefaultEngineValues::get_global().bal_prewarming_disabled)]
+    pub bal_prewarming_disabled: bool,
+
+    /// Disable BAL-driven parallel state root computation. When set, the BAL hashed post state
+    /// is not sent to the multiproof task for early parallel state root computation.
+    #[arg(long = "engine.disable-bal-parallel-state-root", default_value_t = DefaultEngineValues::get_global().bal_parallel_state_root_disabled)]
+    pub bal_parallel_state_root_disabled: bool,
 }
 
 #[allow(deprecated)]
@@ -406,6 +432,8 @@ impl Default for EngineArgs {
             sparse_trie_max_storage_tries,
             disable_sparse_trie_cache_pruning,
             state_root_task_timeout,
+            bal_prewarming_disabled,
+            bal_parallel_state_root_disabled,
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
@@ -437,6 +465,8 @@ impl Default for EngineArgs {
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
+            bal_prewarming_disabled,
+            bal_parallel_state_root_disabled,
         }
     }
 }
@@ -466,6 +496,8 @@ impl EngineArgs {
             .with_sparse_trie_max_storage_tries(self.sparse_trie_max_storage_tries)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
             .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
+            .without_bal_prewarming(self.bal_prewarming_disabled)
+            .without_bal_parallel_state_root(self.bal_parallel_state_root_disabled)
     }
 }
 
@@ -519,6 +551,8 @@ mod tests {
             sparse_trie_max_storage_tries: 100,
             disable_sparse_trie_cache_pruning: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
+            bal_prewarming_disabled: true,
+            bal_parallel_state_root_disabled: true,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([
@@ -557,6 +591,8 @@ mod tests {
             "--engine.disable-sparse-trie-cache-pruning",
             "--engine.state-root-task-timeout",
             "2s",
+            "--engine.disable-bal-prewarming",
+            "--engine.disable-bal-parallel-state-root",
         ])
         .args;
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -43,7 +43,7 @@ pub struct DefaultEngineValues {
     sparse_trie_max_storage_tries: usize,
     disable_sparse_trie_cache_pruning: bool,
     state_root_task_timeout: Option<String>,
-    bal_prewarming_disabled: bool,
+    bal_parallel_execution_disabled: bool,
     bal_parallel_state_root_disabled: bool,
 }
 
@@ -199,9 +199,9 @@ impl DefaultEngineValues {
         self
     }
 
-    /// Set whether to disable BAL-based prewarming by default
-    pub const fn with_bal_prewarming_disabled(mut self, v: bool) -> Self {
-        self.bal_prewarming_disabled = v;
+    /// Set whether to disable BAL-based parallel execution by default
+    pub const fn with_bal_parallel_execution_disabled(mut self, v: bool) -> Self {
+        self.bal_parallel_execution_disabled = v;
         self
     }
 
@@ -238,7 +238,7 @@ impl Default for DefaultEngineValues {
             sparse_trie_max_storage_tries: DEFAULT_SPARSE_TRIE_MAX_STORAGE_TRIES,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some("1s".to_string()),
-            bal_prewarming_disabled: false,
+            bal_parallel_execution_disabled: false,
             bal_parallel_state_root_disabled: false,
         }
     }
@@ -394,10 +394,10 @@ pub struct EngineArgs {
     )]
     pub state_root_task_timeout: Option<Duration>,
 
-    /// Disable BAL (Block Access List, EIP-7928) based prewarming. When set, falls back to
-    /// transaction-based prewarming even when a BAL is available.
-    #[arg(long = "engine.disable-bal-prewarming", default_value_t = DefaultEngineValues::get_global().bal_prewarming_disabled)]
-    pub bal_prewarming_disabled: bool,
+    /// Disable BAL (Block Access List, EIP-7928) based parallel execution. When set, falls back
+    /// to transaction-based prewarming even when a BAL is available.
+    #[arg(long = "engine.disable-bal-parallel-execution", default_value_t = DefaultEngineValues::get_global().bal_parallel_execution_disabled)]
+    pub bal_parallel_execution_disabled: bool,
 
     /// Disable BAL-driven parallel state root computation. When set, the BAL hashed post state
     /// is not sent to the multiproof task for early parallel state root computation.
@@ -432,7 +432,7 @@ impl Default for EngineArgs {
             sparse_trie_max_storage_tries,
             disable_sparse_trie_cache_pruning,
             state_root_task_timeout,
-            bal_prewarming_disabled,
+            bal_parallel_execution_disabled,
             bal_parallel_state_root_disabled,
         } = DefaultEngineValues::get_global().clone();
         Self {
@@ -465,7 +465,7 @@ impl Default for EngineArgs {
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
-            bal_prewarming_disabled,
+            bal_parallel_execution_disabled,
             bal_parallel_state_root_disabled,
         }
     }
@@ -496,7 +496,7 @@ impl EngineArgs {
             .with_sparse_trie_max_storage_tries(self.sparse_trie_max_storage_tries)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
             .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
-            .without_bal_prewarming(self.bal_prewarming_disabled)
+            .without_bal_parallel_execution(self.bal_parallel_execution_disabled)
             .without_bal_parallel_state_root(self.bal_parallel_state_root_disabled)
     }
 }
@@ -551,7 +551,7 @@ mod tests {
             sparse_trie_max_storage_tries: 100,
             disable_sparse_trie_cache_pruning: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
-            bal_prewarming_disabled: true,
+            bal_parallel_execution_disabled: true,
             bal_parallel_state_root_disabled: true,
         };
 
@@ -591,7 +591,7 @@ mod tests {
             "--engine.disable-sparse-trie-cache-pruning",
             "--engine.state-root-task-timeout",
             "2s",
-            "--engine.disable-bal-prewarming",
+            "--engine.disable-bal-parallel-execution",
             "--engine.disable-bal-parallel-state-root",
         ])
         .args;

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1008,6 +1008,12 @@ Engine:
 
           [default: 1s]
 
+      --engine.disable-bal-parallel-execution
+          Disable BAL (Block Access List, EIP-7928) based parallel execution. When set, falls back to transaction-based prewarming even when a BAL is available
+
+      --engine.disable-bal-parallel-state-root
+          Disable BAL-driven parallel state root computation. When set, the BAL hashed post state is not sent to the multiproof task for early parallel state root computation
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
Adding BAL specific cli flags


| Column | Meaning | Flag | 
| - | -| - |
| Exec Par. | Parallel execution using BAL | --engine.disable-bal-parallel-execution |
| State Par. | Parallel state root using BAL | --engine.disable-bal-parallel-state-root |
| Batch IO | Batched storage reads | Steven's PR #22748 |