### PR TITLE
feat(reth-bench): derive --from from engine head when only --to is provided

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -88,9 +88,11 @@ impl BenchContext {
 
         // Computes the block range for the benchmark.
         //
-        // - If `--advance` is provided, fetches the latest block and sets:
+        // - If `--advance` is provided, fetches the latest block from the engine and sets:
         //     - `from = head + 1`
         //     - `to = head + advance`
+        // - If only `--to` is provided, fetches the latest block from the engine and sets:
+        //     - `from = head + 1`
         // - Otherwise, uses the values from `--from` and `--to`.
         let (from, to) = if let Some(advance) = bench_args.advance {
             if advance == 0 {
@@ -103,6 +105,14 @@ impl BenchContext {
                 .ok_or_else(|| eyre::eyre!("Failed to fetch latest block for --advance"))?;
             let head_number = head_block.header.number;
             (Some(head_number), Some(head_number + advance))
+        } else if bench_args.from.is_none() && bench_args.to.is_some() {
+            let head_block = auth_provider
+                .get_block_by_number(BlockNumberOrTag::Latest)
+                .await?
+                .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from engine"))?;
+            let head_number = head_block.header.number;
+            info!(target: "reth-bench", "No --from provided, derived from engine head: {}", head_number);
+            (Some(head_number + 1), bench_args.to)
         } else {
             (bench_args.from, bench_args.to)
         };
@@ -114,7 +124,7 @@ impl BenchContext {
             .full()
             .await?
             .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from RPC"))?;
-        let mut benchmark_mode = BenchMode::new(from, to, latest_block.into_inner().number())?;
+        let mut benchmark_mode = BenchMode::new(from, to, latest_block.into_inner().number());
 
         let first_block = match benchmark_mode {
             BenchMode::Continuous(start) => {

--- a/bin/reth-bench/src/bench_mode.rs
+++ b/bin/reth-bench/src/bench_mode.rs
@@ -34,17 +34,16 @@ impl BenchMode {
     }
 
     /// Create a [`BenchMode`] from optional `from` and `to` fields.
-    pub fn new(from: Option<u64>, to: Option<u64>, latest_block: u64) -> Result<Self, eyre::Error> {
+    ///
+    /// If only `--to` is provided, `from` is derived as `latest_block + 1`.
+    pub const fn new(from: Option<u64>, to: Option<u64>, latest_block: u64) -> Self {
         // If neither `--from` nor `--to` are provided, we will run the benchmark continuously,
         // starting at the latest block.
         match (from, to) {
-            (Some(from), Some(to)) => Ok(Self::Range(from..=to)),
-            (None, None) => Ok(Self::Continuous(latest_block)),
-            (Some(start), None) => Ok(Self::Continuous(start)),
-            _ => {
-                // both or neither are allowed, everything else is ambiguous
-                Err(eyre::eyre!("`from` and `to` must be provided together, or not at all."))
-            }
+            (Some(from), Some(to)) => Self::Range(from..=to),
+            (None, None) => Self::Continuous(latest_block),
+            (Some(start), None) => Self::Continuous(start),
+            (None, Some(to)) => Self::Range(latest_block + 1..=to),
         }
     }
 }


### PR DESCRIPTION
## Summary

Allow passing only `--to` to reth-bench. When `--from` is omitted, it's derived dynamically as `engine_head + 1` by querying the engine RPC.

## Motivation

When benchmarking, you often know the target block (`--to`) but don't want to manually look up the node's current head to set `--from`. This was previously an error.

## Changes

- `BenchMode::new`: handle `(None, Some(to))` by setting `from = latest_block + 1` instead of returning an error
- `BenchMode::new` return type simplified from `Result<Self, eyre::Error>` to `Self` since it can no longer fail
- `BenchContext::new`: when only `--to` is provided, fetch latest block from the engine RPC (same pattern as `--advance`)

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey