### PR TITLE
feat: conditional eth/70+71 advertisement

### DIFF
--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -35,10 +35,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth71;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -35,11 +35,10 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth71;
+    pub const LATEST: Self = Self::Eth69;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] =
-        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -7,14 +7,14 @@ use crate::{
     NetworkHandle, NetworkManager,
 };
 use alloy_eips::BlockNumHash;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardfork, ForkCondition, Hardforks};
 use reth_discv4::{Discv4Config, Discv4ConfigBuilder, NatResolver, DEFAULT_DISCOVERY_ADDRESS};
 use reth_discv5::NetworkStackId;
 use reth_dns_discovery::DnsDiscoveryConfig;
 use reth_eth_wire::{
     handshake::{EthHandshake, EthRlpxHandshake},
-    EthNetworkPrimitives, HelloMessage, HelloMessageWithProtocols, NetworkPrimitives,
-    UnifiedStatus,
+    EthNetworkPrimitives, EthVersion, HelloMessage, HelloMessageWithProtocols, NetworkPrimitives,
+    UnifiedStatus, protocol::Protocol,
 };
 use reth_ethereum_forks::{ForkFilter, Head};
 use reth_network_peers::{mainnet_nodes, pk2id, sepolia_nodes, PeerId, TrustedPeer};
@@ -641,8 +641,15 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
 
         let listener_addr = listener_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS);
 
-        let mut hello_message =
-            hello_message.unwrap_or_else(|| HelloMessage::builder(peer_id).build());
+        let mut hello_message = hello_message.unwrap_or_else(|| {
+            let mut msg = HelloMessage::builder(peer_id).build();
+            // Advertise eth/70 and eth/71 if the Osaka fork is scheduled for this chain
+            if !matches!(chain_spec.fork(EthereumHardfork::Osaka), ForkCondition::Never) {
+                let _ = msg.try_add_protocol(Protocol::from(EthVersion::Eth70));
+                let _ = msg.try_add_protocol(Protocol::from(EthVersion::Eth71));
+            }
+            msg
+        });
         hello_message.port = listener_addr.port();
 
         // set the status


### PR DESCRIPTION
Added imports: EthereumHardfork, ForkCondition, EthVersion, Protocol

Conditional eth/70+71 advertisement: In NetworkConfigBuilder::build(), when the hello message uses defaults (not explicitly configured), it checks if Osaka is scheduled in the chain spec. If so, it adds Protocol::from(EthVersion::Eth70) and Protocol::from(EthVersion::Eth71) via try_add_protocol.