### PR TITLE
fix(net): mark transactions as seen in propagate_hashes_to

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -980,6 +980,7 @@ where
                     propagated.record(hash, PropagateKind::Hash(peer_id));
                     peer.seen_transactions.insert(hash);
                 }
+            }
 
             trace!(target: "net::tx::propagation", ?peer_id, ?new_pooled_hashes, "Propagating transactions to peer");
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -975,9 +975,11 @@ where
                 return
             }
 
-            for hash in new_pooled_hashes.iter_hashes().copied() {
-                propagated.record(hash, PropagateKind::Hash(peer_id));
-            }
+            if let Some(peer) = self.peers.get_mut(&peer_id) {
+                for hash in new_pooled_hashes.iter_hashes().copied() {
+                    propagated.record(hash, PropagateKind::Hash(peer_id));
+                    peer.seen_transactions.insert(hash);
+                }
 
             trace!(target: "net::tx::propagation", ?peer_id, ?new_pooled_hashes, "Propagating transactions to peer");
 


### PR DESCRIPTION
Add missing `peer.seen_transactions.insert()` in `propagate_hashes_to`, matching the pattern in `propagate_full_transactions_to_peer` and `propagate_transactions`. Without this, transactions manually propagated as hashes were not marked as seen, so subsequent `propagate_transactions` calls would redundantly re-send them to the same peer.