### PR TITLE
feat(reth-bench): display wait times in reth-bench per-block log

### DIFF
--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -114,16 +114,27 @@ impl CombinedResult {
 
 impl std::fmt::Display for CombinedResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let np = &self.new_payload_result;
         write!(
             f,
             "Block {} processed at {:.4} Ggas/s, used {} total gas. Combined: {:.4} Ggas/s. fcu: {:?}, newPayload: {:?}",
             self.block_number,
-            self.new_payload_result.gas_per_second() / GIGAGAS as f64,
-            self.new_payload_result.gas_used,
+            np.gas_per_second() / GIGAGAS as f64,
+            np.gas_used,
             self.combined_gas_per_second() / GIGAGAS as f64,
             self.fcu_latency,
-            self.new_payload_result.latency
-        )
+            np.latency,
+        )?;
+        if !np.execution_cache_wait.is_zero() {
+            write!(f, ", execution cache wait: {:?}", np.execution_cache_wait)?;
+        }
+        if !np.sparse_trie_wait.is_zero() {
+            write!(f, ", trie cache wait: {:?}", np.sparse_trie_wait)?;
+        }
+        if let Some(d) = np.persistence_wait {
+            write!(f, ", persistence wait: {d:?}")?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Add execution cache, trie cache, and persistence wait durations to the existing per-block info log in reth-bench.

```
Block 6665173 processed at 1.2117 Ggas/s, used 18479617 total gas. Combined: 1.1681 Ggas/s. fcu: 568.95µs, newPayload: 15.251ms, exec_cache_wait: 1.2ms, trie_cache_wait: 800µs, persistence_wait: 2.1ms
```

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey