### PR TITLE
fix(engine): clamp pending finalized/safe block to persisted height

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -157,6 +157,8 @@ where
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
 
             if let Some(finalized) = pending_finalized {
+                // Clamp to the highest persisted block so that on restart
+                // `last_finalized_block_number` never points past available state.
                 provider_rw.save_finalized_block_number(finalized.min(last.number))?;
                 if finalized > last.number {
                     self.pending_finalized_block = Some(finalized);

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -157,10 +157,23 @@ where
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
 
             if let Some(finalized) = pending_finalized {
-                provider_rw.save_finalized_block_number(finalized)?;
+                // Clamp to the highest persisted block so that on restart
+                // `last_finalized_block_number` never points past available state.
+                // When `memory_block_buffer_target > 0` the batch may not include
+                // the finalized block yet — keep the original value pending for the
+                // next `save_blocks` call.
+                let clamped = finalized.min(last.number);
+                provider_rw.save_finalized_block_number(clamped)?;
+                if finalized > last.number {
+                    self.pending_finalized_block = Some(finalized);
+                }
             }
             if let Some(safe) = pending_safe {
-                provider_rw.save_safe_block_number(safe)?;
+                let clamped = safe.min(last.number);
+                provider_rw.save_safe_block_number(clamped)?;
+                if safe > last.number {
+                    self.pending_safe_block = Some(safe);
+                }
             }
 
             if self.pruner.is_pruning_needed(last.number) {

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -162,15 +162,13 @@ where
                 // When `memory_block_buffer_target > 0` the batch may not include
                 // the finalized block yet — keep the original value pending for the
                 // next `save_blocks` call.
-                let clamped = finalized.min(last.number);
-                provider_rw.save_finalized_block_number(clamped)?;
+                provider_rw.save_finalized_block_number(finalized.min(last.number))?;
                 if finalized > last.number {
                     self.pending_finalized_block = Some(finalized);
                 }
             }
             if let Some(safe) = pending_safe {
-                let clamped = safe.min(last.number);
-                provider_rw.save_safe_block_number(clamped)?;
+                provider_rw.save_safe_block_number(safe.min(last.number))?;
                 if safe > last.number {
                     self.pending_safe_block = Some(safe);
                 }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -157,11 +157,6 @@ where
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
 
             if let Some(finalized) = pending_finalized {
-                // Clamp to the highest persisted block so that on restart
-                // `last_finalized_block_number` never points past available state.
-                // When `memory_block_buffer_target > 0` the batch may not include
-                // the finalized block yet — keep the original value pending for the
-                // next `save_blocks` call.
                 provider_rw.save_finalized_block_number(finalized.min(last.number))?;
                 if finalized > last.number {
                     self.pending_finalized_block = Some(finalized);


### PR DESCRIPTION
When `memory_block_buffer_target > 0`, `on_save_blocks` can write a `ChainState::LastFinalizedBlock` (or `LastSafeBlock`) that points past the highest block with persisted execution state. On crash + restart, [`last_finalized_block_number()`](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/storage/provider/src/providers/database/provider.rs#L3773-L3783) returns a block number whose state only existed in memory.

### How

[`update_finalized_block`](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/engine/tree/src/tree/mod.rs#L2916-L2948) resolves the finalized hash via [`find_canonical_header`](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/engine/tree/src/tree/mod.rs#L2902-L2913) (checks in-memory state first, then DB) and [queues it as `pending_finalized_block`](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/engine/tree/src/persistence.rs#L110-L112). The pending value is only flushed inside [`on_save_blocks`](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/engine/tree/src/persistence.rs#L140-L174), in the same DB transaction as the block writes.

With `memory_block_buffer_target > 0`, [`get_canonical_blocks_to_persist`](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/engine/tree/src/tree/mod.rs#L1908-L1952) targets `canonical_head - buffer_target` ([line 1924](https://github.com/paradigmxyz/reth/blob/fcf66452424b5a2f22db940f544c5a45dc6fc79d/crates/engine/tree/src/tree/mod.rs#L1924)), keeping the most recent blocks in memory only. If the CL finalizes a block in that buffer zone, the pending value gets written alongside a batch that doesn't include it.

**Example** (`persistence_threshold=3, memory_block_buffer_target=2, 1-block finality`):

1. Head=7, last_persisted=2, `should_persist`: 7-2=5 > 3 ✓
2. Batch target = 7-2 = 5, batch = blocks 3–5
3. FCU queued `pending_finalized = 6` (block 6 is in-memory only)
4. `on_save_blocks` writes `finalized=6` + blocks 3–5, commits
5. Crash → DB: state through block 5, `LastFinalizedBlock = 6` ← inconsistent

### Fix

Clamp to `min(pending, last_block_in_batch)`. If pending exceeds the batch, keep it for the next `save_blocks`. Same for safe block.

With `memory_block_buffer_target = 0` (default) this is a no-op.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie