### PR TITLE
fix(debug-client): infinite retry on WS disconnect in follow mode

### DIFF
--- a/crates/consensus/debug-client/src/providers/rpc.rs
+++ b/crates/consensus/debug-client/src/providers/rpc.rs
@@ -5,14 +5,14 @@ use futures::{Stream, StreamExt};
 use reth_node_api::Block;
 use reth_tracing::tracing::{debug, warn};
 use std::sync::Arc;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, RwLock};
 
 /// Block provider that fetches new blocks from an RPC endpoint using a connection that supports
 /// RPC subscriptions.
 #[derive(derive_more::Debug, Clone)]
 pub struct RpcBlockProvider<N: Network, PrimitiveBlock> {
     #[debug(skip)]
-    provider: Arc<dyn Provider<N>>,
+    provider: Arc<RwLock<Arc<dyn Provider<N>>>>,
     url: String,
     #[debug(skip)]
     convert: Arc<dyn Fn(N::BlockResponse) -> PrimitiveBlock + Send + Sync>,
@@ -24,23 +24,48 @@ impl<N: Network, PrimitiveBlock> RpcBlockProvider<N, PrimitiveBlock> {
         rpc_url: &str,
         convert: impl Fn(N::BlockResponse) -> PrimitiveBlock + Send + Sync + 'static,
     ) -> eyre::Result<Self> {
+        let provider = Self::connect(rpc_url).await?;
         Ok(Self {
-            provider: Arc::new(
-                ProviderBuilder::default()
-                    .connect_with_config(
-                        rpc_url,
-                        ConnectionConfig::default().with_max_retries(u32::MAX).with_ws_config(
-                            WebSocketConfig::default()
-                                // allow larger messages/frames for big blocks
-                                .max_frame_size(Some(128 * 1024 * 1024))
-                                .max_message_size(Some(128 * 1024 * 1024)),
-                        ),
-                    )
-                    .await?,
-            ),
+            provider: Arc::new(RwLock::new(provider)),
             url: rpc_url.to_string(),
             convert: Arc::new(convert),
         })
+    }
+
+    /// Establishes a new connection to the RPC endpoint.
+    async fn connect(rpc_url: &str) -> eyre::Result<Arc<dyn Provider<N>>> {
+        Ok(Arc::new(
+            ProviderBuilder::default()
+                .connect_with_config(
+                    rpc_url,
+                    ConnectionConfig::default().with_max_retries(u32::MAX).with_ws_config(
+                        WebSocketConfig::default()
+                            // allow larger messages/frames for big blocks
+                            .max_frame_size(Some(128 * 1024 * 1024))
+                            .max_message_size(Some(128 * 1024 * 1024)),
+                    ),
+                )
+                .await?,
+        ))
+    }
+
+    /// Reconnects to the RPC endpoint, replacing the internal provider with a fresh connection.
+    async fn reconnect(&self) -> bool {
+        match Self::connect(&self.url).await {
+            Ok(new_provider) => {
+                *self.provider.write().await = new_provider;
+                true
+            }
+            Err(err) => {
+                warn!(
+                    target: "consensus::debug-client",
+                    %err,
+                    url=%self.url,
+                    "Failed to reconnect to RPC endpoint",
+                );
+                false
+            }
+        }
     }
 
     /// Obtains a full block stream.
@@ -50,8 +75,9 @@ impl<N: Network, PrimitiveBlock> RpcBlockProvider<N, PrimitiveBlock> {
     async fn full_block_stream(
         &self,
     ) -> TransportResult<impl Stream<Item = TransportResult<N::BlockResponse>>> {
+        let provider = self.provider.read().await.clone();
         // first try to obtain a regular subscription
-        match self.provider.subscribe_full_blocks().full().into_stream().await {
+        match provider.subscribe_full_blocks().full().into_stream().await {
             Ok(sub) => Ok(sub.left_stream()),
             Err(err) => {
                 debug!(
@@ -60,7 +86,7 @@ impl<N: Network, PrimitiveBlock> RpcBlockProvider<N, PrimitiveBlock> {
                     url=%self.url,
                     "Failed to establish block subscription",
                 );
-                Ok(self.provider.watch_full_blocks().await?.full().into_stream().right_stream())
+                Ok(provider.watch_full_blocks().await?.full().into_stream().right_stream())
             }
         }
     }
@@ -73,17 +99,33 @@ where
     type Block = PrimitiveBlock;
 
     async fn subscribe_blocks(&self, tx: Sender<Self::Block>) {
+        let mut retry_delay = std::time::Duration::from_secs(1);
+        const MAX_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
+
         loop {
             let Ok(mut stream) = self.full_block_stream().await.inspect_err(|err| {
                 warn!(
                     target: "consensus::debug-client",
                     %err,
                     url=%self.url,
-                    "Failed to subscribe to blocks",
+                    "Failed to subscribe to blocks, retrying in {:?}",
+                    retry_delay,
                 );
             }) else {
-                return
+                // Reconnect with a fresh provider before retrying
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
+
+                if !self.reconnect().await {
+                    continue;
+                }
+                // Reset delay on successful reconnect
+                retry_delay = std::time::Duration::from_secs(1);
+                continue;
             };
+
+            // Successfully subscribed — reset retry delay
+            retry_delay = std::time::Duration::from_secs(1);
 
             while let Some(res) = stream.next().await {
                 match res {
@@ -103,18 +145,21 @@ where
                     }
                 }
             }
-            // if stream terminated we want to re-establish it again
+            // Stream terminated (e.g. WS disconnect) — reconnect with a fresh provider
             debug!(
                 target: "consensus::debug-client",
                 url=%self.url,
-                "Re-establishing block subscription",
+                "Block subscription stream ended, reconnecting",
             );
+            self.reconnect().await;
         }
     }
 
     async fn get_block(&self, block_number: u64) -> eyre::Result<Self::Block> {
         let block = self
             .provider
+            .read()
+            .await
             .get_block_by_number(block_number.into())
             .full()
             .await?


### PR DESCRIPTION
## Summary
Fixes follow mode nodes becoming permanently stuck after a network connectivity flap severs the WebSocket connection.

## Motivation
When a Tempo node runs with `--follow`, it subscribes to blocks from a remote RPC via WebSocket. If the WS connection drops (e.g. network flap), `full_block_stream()` fails on the dead transport, and `subscribe_blocks` returns — killing the critical task with no recovery. The node stops following new blocks.

## Changes
- Wrapped the provider in `RwLock` so it can be replaced on reconnect
- Added `connect()` and `reconnect()` methods to build a fresh WS transport
- Changed `subscribe_blocks` to retry with exponential backoff (1s-30s) instead of exiting on stream failure
- On stream termination (WS disconnect), reconnects with a fresh provider before re-subscribing

## Testing
`cargo check -p reth-consensus-debug-client` and `cargo check -p reth-node-builder` pass.

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>

Prompted by: zygis