### PR TITLE
fix(reth-bench): off-by-one when deriving --from from engine head

### DIFF
--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -92,7 +92,7 @@ impl BenchContext {
         //     - `from = head + 1`
         //     - `to = head + advance`
         // - If only `--to` is provided, fetches the latest block from the engine and sets:
-        //     - `from = head + 1`
+        //     - `from = head`
         // - Otherwise, uses the values from `--from` and `--to`.
         let (from, to) = if let Some(advance) = bench_args.advance {
             if advance == 0 {
@@ -112,7 +112,7 @@ impl BenchContext {
                 .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from engine"))?;
             let head_number = head_block.header.number;
             info!(target: "reth-bench", "No --from provided, derived from engine head: {}", head_number);
-            (Some(head_number + 1), bench_args.to)
+            (Some(head_number), bench_args.to)
         } else {
             (bench_args.from, bench_args.to)
         };


### PR DESCRIPTION
Fixes #22773

`first_block` is consumed by `range.next()` and only used to compute `next_block = first_block + 1`. With `from = head + 1`, the effective first payload sent was `head + 2`, skipping a block. Uses `head_number` (matching `--advance` behavior) so the effective start is `head + 1`.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey