### PR TITLE
refactor(tasks): change once! macro to take closure

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,7 +565,7 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            reth_tasks::once!(increase_thread_priority());
+            reth_tasks::once!(|| increase_thread_priority());
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -565,7 +565,7 @@ where
 
         let parent_span = Span::current();
         self.executor.spawn_blocking_named("sparse-trie", move || {
-            reth_tasks::once!(|| increase_thread_priority());
+            reth_tasks::once!(increase_thread_priority);
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")
                 .entered();

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -2,7 +2,7 @@
 
 pub use thread_priority::{self, *};
 
-/// Runs the given expression exactly once per call site.
+/// Runs the given closure exactly once per call site.
 ///
 /// Each invocation expands to its own `static Once`, so two `once!` calls in the same function
 /// are independent. Useful for one-time thread setup (priority, affinity) on threads that may
@@ -11,7 +11,7 @@ pub use thread_priority::{self, *};
 macro_rules! once {
     ($e:expr) => {{
         static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| $e);
+        ONCE.call_once($e);
     }};
 }
 


### PR DESCRIPTION
Changes `once!` to take a `|| expr` closure instead of a bare expression, forwarding it directly to `Once::call_once`.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes