### PR TITLE
refactor(rpc): accept Recovered<Tx> in build_transaction_receipt

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -4,7 +4,7 @@
 use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 use alloy_consensus::{transaction::TransactionMeta, TxReceipt};
 use futures::Future;
-use reth_primitives_traits::SignerRecoverable;
+use reth_primitives_traits::Recovered;
 use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert};
 use reth_rpc_eth_types::{
     error::FromEthApiError, utils::calculate_gas_used_and_next_log_index, EthApiError,
@@ -20,7 +20,7 @@ pub trait LoadReceipt:
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
     fn build_transaction_receipt(
         &self,
-        tx: ProviderTx<Self::Provider>,
+        tx: Recovered<ProviderTx<Self::Provider>>,
         meta: TransactionMeta,
         receipt: ProviderReceipt<Self::Provider>,
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send {
@@ -40,10 +40,7 @@ pub trait LoadReceipt:
             Ok(self
                 .converter()
                 .convert_receipts(vec![ConvertReceiptInput {
-                    tx: tx
-                        .try_into_recovered_unchecked()
-                        .map_err(Self::Error::from_eth_err)?
-                        .as_recovered_ref(),
+                    tx: tx.as_recovered_ref(),
                     gas_used: receipt.cumulative_gas_used() - gas_used,
                     receipt,
                     next_log_index,

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -243,13 +243,19 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     }
 
     /// Helper method that loads a transaction and its receipt.
+    ///
+    /// The returned transaction has its sender already recovered.
     #[expect(clippy::complexity)]
     fn load_transaction_and_receipt(
         &self,
         hash: TxHash,
     ) -> impl Future<
         Output = Result<
-            Option<(ProviderTx<Self::Provider>, TransactionMeta, ProviderReceipt<Self::Provider>)>,
+            Option<(
+                Recovered<ProviderTx<Self::Provider>>,
+                TransactionMeta,
+                ProviderReceipt<Self::Provider>,
+            )>,
             Self::Error,
         >,
     > + Send
@@ -258,7 +264,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     {
         async move {
             if let Some(cached) = self.cache().get_transaction_by_hash(hash).await &&
-                let Some(tx) = cached.block.body().transactions().get(cached.tx_index).cloned()
+                let Some(tx) = cached.recovered_transaction().map(|tx| tx.cloned())
             {
                 let meta = cached.transaction_meta(hash);
 
@@ -290,6 +296,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 else {
                     return Ok(None);
                 };
+
+                let tx = tx.try_into_recovered_unchecked().map_err(Self::Error::from_eth_err)?;
 
                 let receipt = provider.receipt_by_hash(hash).map_err(Self::Error::from_eth_err)?;
 


### PR DESCRIPTION
Move sender recovery from `build_transaction_receipt` into `load_transaction_and_receipt` so the receipt builder receives an already-recovered transaction. The cache path now reuses the sender stored in `RecoveredBlock` instead of re-running ecrecover.