### PR TITLE
feat(metrics): wire tokio-taskdump feature chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12171,6 +12171,7 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
  "mio",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -108,6 +108,10 @@ js-tracer = [
 ]
 
 dev = ["reth-ethereum-cli/dev"]
+tokio-taskdump = [
+    "reth-ethereum-cli/tokio-taskdump",
+    "reth-node-metrics/tokio-taskdump",
+]
 
 asm-keccak = [
     "reth-node-core/asm-keccak",

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -62,6 +62,7 @@ jemalloc-symbols = [
 ]
 tracy-allocator = ["tracy"]
 tracy = ["reth-tracing/tracy", "reth-node-core/tracy"]
+tokio-taskdump = ["reth-node-metrics/tokio-taskdump"]
 
 # Because jemalloc is default and preferred over snmalloc when both features are
 # enabled, `--no-default-features` should be used when enabling snmalloc or

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -39,6 +39,9 @@ tikv-jemalloc-ctl = { workspace = true, optional = true, features = ["stats"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"
 
+[target.'cfg(all(target_os = "linux", any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
+tokio = { workspace = true, features = ["taskdump"] }
+
 [dev-dependencies]
 reqwest.workspace = true
 socket2.workspace = true
@@ -50,3 +53,4 @@ workspace = true
 jemalloc = ["dep:tikv-jemalloc-ctl"]
 jemalloc-prof = ["jemalloc", "dep:jemalloc_pprof", "dep:mappings", "dep:pprof_util", "dep:reth-fs-util", "dep:tempfile"]
 jemalloc-symbols = ["jemalloc-prof", "jemalloc_pprof?/symbolize"]
+tokio-taskdump = []

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -39,7 +39,7 @@ tikv-jemalloc-ctl = { workspace = true, optional = true, features = ["stats"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"
 
-[target.'cfg(all(target_os = "linux", any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
+[target.'cfg(all(tokio_unstable, target_os = "linux", any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
 tokio = { workspace = true, features = ["taskdump"] }
 
 [dev-dependencies]

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -410,7 +410,12 @@ fn handle_pprof_heap(_pprof_dump_dir: &PathBuf) -> Response<Full<Bytes>> {
     response
 }
 
-#[cfg(tokio_unstable)]
+#[cfg(all(
+    tokio_unstable,
+    feature = "tokio-taskdump",
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+))]
 async fn handle_tokio_dump() -> Response<Full<Bytes>> {
     let handle = tokio::runtime::Handle::current();
     let dump = handle.dump().await;
@@ -426,10 +431,15 @@ async fn handle_tokio_dump() -> Response<Full<Bytes>> {
     response
 }
 
-#[cfg(not(tokio_unstable))]
+#[cfg(not(all(
+    tokio_unstable,
+    feature = "tokio-taskdump",
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+)))]
 async fn handle_tokio_dump() -> Response<Full<Bytes>> {
     let mut response = Response::new(Full::new(Bytes::from_static(
-        b"tokio task dump not available. Rebuild with RUSTFLAGS=\"--cfg tokio_unstable\" and tokio's `taskdump` feature.",
+        b"tokio task dump not available. Rebuild on supported Linux targets with RUSTFLAGS=\"--cfg tokio_unstable\" and the `tokio-taskdump` feature.",
     )));
     *response.status_mut() = StatusCode::NOT_IMPLEMENTED;
     response


### PR DESCRIPTION
Wire the `tokio-taskdump` feature through `reth` and `reth-ethereum-cli` into `reth-node-metrics`, and gate `/debug/tokio/dump` on supported Linux targets with a precise fallback message.