### PR TITLE
fix(stages): set block_range in with_block_range

### DIFF
--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -406,7 +406,9 @@ impl StageCheckpoint {
             }
             _ => return self,
         });
-        _ = self.stage_checkpoint.map(|mut checkpoint| checkpoint.set_block_range(from, to));
+        if let Some(ref mut checkpoint) = self.stage_checkpoint {
+            checkpoint.set_block_range(from, to);
+        }
         self
     }
 


### PR DESCRIPTION
`with_block_range` didn't actually set the block range - it modified a copy due to `StageUnitCheckpoint` being `Copy`. Use `if let Some(ref mut ...)` to mutate the original.