### PR TITLE
fix(ethstats): prevent writer starvation by cloning ConnWrapper to drop

### DIFF
--- a/crates/node/ethstats/src/ethstats.rs
+++ b/crates/node/ethstats/src/ethstats.rs
@@ -612,8 +612,11 @@ where
 
             tokio::spawn(async move {
                 loop {
-                    let conn_guard = conn_arc.read().await;
-                    if let Some(conn) = conn_guard.as_ref() {
+                    let conn_clone = {
+                        let conn_guard = conn_arc.read().await;
+                        conn_guard.as_ref().cloned()
+                    };
+                    if let Some(conn) = conn_clone {
                         match conn.read_json().await {
                             Ok(msg) => {
                                 if message_tx.send(msg).await.is_err() {
@@ -626,7 +629,6 @@ where
                                 }
                                 other => {
                                     debug!(target: "ethstats", "Read error: {}", other);
-                                    drop(conn_guard);
                                     if let Some(conn) = conn_arc.write().await.take() {
                                         let _ = conn.close().await;
                                     }


### PR DESCRIPTION
## Description

This PR fixes a highly critical, silent concurrency stall in the `ethstats` service. 

Currently, `EthStatsService` holds a `tokio::sync::RwLockReadGuard` across indeterminate network I/O operations (most notably `conn.read_json().await` in the `read_handle` loop, as well as all `write_json` calls in the reporting functions). 

If the WebSocket connection hangs without explicitly closing, the `.await` yields indefinitely while holding the read lock. If an internal timeout (e.g., `PING_TIMEOUT`) subsequently attempts to clean up the connection via `disconnect()`, it requests the `.write().await` lock. To prevent writer starvation, Tokio immediately queues this write lock request, which acts as a barrier and forcefully blocks all subsequent read lock requests. This permanently stalls the entire `ethstats` reporting loop.

Thanks to the keen observation by @felixfaisal in the original issue, `ConnWrapper` already internally wraps a `SplitStream` and `SplitSink` with `Arc<Mutex<..>>`, making it incredibly cheap to clone.

## The Fix
I simply clone the `ConnWrapper` and immediately drop the outer `RwLockReadGuard` *before* awaiting any network I/O. The outer `RwLock` is now only held for simple memory access, completely eliminating the risk of Tokio writer starvation when `disconnect()` is invoked. 

*(This also allows us to cleanly remove the explicit `drop(conn_guard)` that was previously needed in the `read_handle` error path).*

Closes #22797