### PR TITLE
fix: add -Crelocation-model=pic to PGO instrumentation build

### DIFF
--- a/.github/scripts/build_pgo_bolt_full.sh
+++ b/.github/scripts/build_pgo_bolt_full.sh
@@ -178,7 +178,7 @@ rm -rf "$PGO_DIR"
 mkdir -p "$PGO_DIR"
 
 echo "Building PGO-instrumented binary..."
-RUSTFLAGS="-Cprofile-generate=$PGO_DIR ${EXTRA_RUSTFLAGS:-}" \
+RUSTFLAGS="-Cprofile-generate=$PGO_DIR -Crelocation-model=pic ${EXTRA_RUSTFLAGS:-}" \
     cargo build "${CARGO_ARGS[@]}" --target "$TARGET"
 
 PGO_RETH_BIN="$PWD/target/$TARGET/$PROFILE_DIR/reth"


### PR DESCRIPTION
The PGO instrumentation build (Phase 1) was failing with:

```
rust-lld: error: relocation R_X86_64_32 cannot be used against symbol 'rust_eh_personality'; recompile with -fPIC
```

`rustls-platform-verifier` has a `cdylib` target that requires position-independent code when linking. Adding `-Crelocation-model=pic` to the Phase 1 RUSTFLAGS fixes the linker error.

Phases 2 and 3 already set `-Crelocation-model=static` (needed for BOLT), so this only affects the instrumentation build.

Prompted by: Alexey