### PR TITLE
fix(trie): Handle removed leaves in proof v2 + MaskedTrieCursor

### DIFF
--- a/.changelog/rare-owls-eat.md
+++ b/.changelog/rare-owls-eat.md
@@ -1,0 +1,5 @@
+---
+reth-trie: patch
+---
+
+Fixed handling of removed leaves in `ProofCalculatorV2` by masking out already-processed child nibbles when `uncalculated_lower_bound` advances past a branch, and fixed `MaskedTrieCursor` to clear the last remaining hash bit when all-but-one children of a branch are deleted. Added two regression tests and improved tracing instrumentation.

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -172,6 +172,13 @@ where
     ///
     /// * 0x04 is a prefix of 0x045, and so is retained.
     /// ```
+    #[instrument(
+        target = TRACE_TARGET,
+        level = "trace",
+        skip_all,
+        fields(?path, ?check_min_len),
+        ret,
+    )]
     fn should_retain<'a>(
         &self,
         targets: &mut Option<TargetsCursor<'a>>,
@@ -183,7 +190,6 @@ where
 
         let (mut lower, mut upper) = targets.current();
 
-        trace!(target: TRACE_TARGET, ?path, target = ?lower, "should_retain: called");
         debug_assert!(self.retained_proofs.last().is_none_or(
                 |ProofTrieNodeV2 { path: last_retained_path, .. }| {
                     depth_first::cmp(path, last_retained_path) == Ordering::Greater
@@ -334,6 +340,12 @@ where
     /// `branch_stack` to determine the last child's path. When committing the last child prior to
     /// pushing a new child, it's important to set the new child's `state_mask` bit _after_ the call
     /// to this method.
+    #[instrument(
+        target = TRACE_TARGET,
+        level = "trace",
+        skip_all,
+        fields(child_path = ?self.last_child_path()),
+    )]
     fn commit_last_child<'a>(
         &mut self,
         targets: &mut Option<TargetsCursor<'a>>,
@@ -344,7 +356,8 @@ where
 
         // If the child is already an `RlpNode` then there is nothing to do, push it back on with no
         // changes.
-        if let ProofTrieBranchChild::RlpNode(_) = child {
+        if let ProofTrieBranchChild::RlpNode(_rlp_node) = &child {
+            trace!(target: TRACE_TARGET, ?_rlp_node, "Already RlpNode, pushing onto stack");
             self.child_stack.push(child);
             return Ok(())
         }
@@ -353,8 +366,10 @@ where
         // to pop_branch() to give DeferredEncoder time for async work.
         if self.should_retain(targets, &child_path, true) {
             let child_rlp_node = self.commit_child(targets, child_path, child)?;
+            trace!(target: TRACE_TARGET, ?child_rlp_node, "Pushing commited child RlpNode onto stack");
             self.child_stack.push(ProofTrieBranchChild::RlpNode(child_rlp_node));
         } else {
+            trace!(target: TRACE_TARGET, "Pushing uncommited child onto stack");
             self.child_stack.push(child);
         }
 
@@ -475,6 +490,7 @@ where
     /// # Panics
     ///
     /// This method panics if `branch_stack` is empty.
+    #[instrument(target = TRACE_TARGET, level = "trace", skip_all)]
     fn pop_branch<'a>(
         &mut self,
         targets: &mut Option<TargetsCursor<'a>>,
@@ -484,7 +500,7 @@ where
             branch = ?self.branch_stack.last(),
             branch_path = ?self.branch_path,
             child_stack_len = ?self.child_stack.len(),
-            "pop_branch: called",
+            "called",
         );
 
         // Ensure the final child on the child stack has been committed, as this method expects all
@@ -980,12 +996,46 @@ where
 
             // Determine all child nibbles which are set in the cached branch but not the
             // under-construction branch.
-            let next_child_nibbles = curr_state_mask ^ cached_state_mask;
+            let mut next_child_nibbles = curr_state_mask ^ cached_state_mask;
             debug_assert_eq!(
                 cached_state_mask | next_child_nibbles, cached_state_mask,
                 "curr_branch has state_mask bits set which aren't set on cached_branch. curr_branch:{:?}",
                 curr_state_mask,
             );
+
+            let _orig_next_child_nibbles = next_child_nibbles;
+
+            // Mask out any child nibbles whose ranges have already been fully processed.
+            // This can happen when `calculate_key_range` finds no keys for a child's range,
+            // leaving the child's bit unset in `state_mask`. Without this, re-entering this
+            // function would select the same child again.
+            if let Some(ref lower) = uncalculated_lower_bound {
+                if lower.starts_with(&self.branch_path) && lower.len() > self.branch_path.len() {
+                    let lower_nibble = lower.get_unchecked(self.branch_path.len());
+                    // Clear all nibbles strictly below `lower_nibble` since they've been processed.
+                    let already_processed_mask = TrieMask::new((1u16 << lower_nibble) - 1);
+                    next_child_nibbles = next_child_nibbles & !already_processed_mask;
+                    trace!(
+                        target: TRACE_TARGET,
+                        branch_path = ?self.branch_path,
+                        ?_orig_next_child_nibbles,
+                        ?already_processed_mask,
+                        ?next_child_nibbles,
+                        "Unset already processed key nibbles from next_child_nibbles",
+                    );
+                } else if !lower.starts_with(&self.branch_path) && lower > &self.branch_path {
+                    // The lower bound has moved entirely past this branch (e.g. branch is 0x6 but
+                    // lower is 0x7). All remaining children have been processed.
+                    next_child_nibbles = TrieMask::default();
+                    trace!(
+                        target: TRACE_TARGET,
+                        branch_path = ?self.branch_path,
+                        ?_orig_next_child_nibbles,
+                        ?next_child_nibbles,
+                        "Unset all nibbles from next_child_nibbles due to branch_path being outside this subtrie",
+                    );
+                }
+            }
 
             // If there are no further children to construct for this branch then pop it off both
             // stacks and loop using the parent branch.
@@ -1644,6 +1694,7 @@ mod tests {
         updates::{StorageTrieUpdates, TrieUpdates},
         HashedPostState, MultiProofTargets, ProofTrieNode, TrieNode,
     };
+    use std::collections::BTreeMap;
 
     /// Target to use with the `tracing` crate.
     static TRACE_TARGET: &str = "trie::proof_v2::tests";
@@ -1909,7 +1960,7 @@ mod tests {
         let mut fresh_calculator = ProofCalculator::new(trie_cursor, hashed_cursor);
         let mut value_encoder = SyncAccountValueEncoder::new(
             harness.trie_cursor_factory.clone(),
-            harness.hashed_cursor_factory,
+            harness.hashed_cursor_factory.clone(),
         );
         let fresh_result = fresh_calculator.proof(&mut value_encoder, &mut targets).unwrap();
 
@@ -2044,6 +2095,121 @@ mod tests {
         harness
             .assert_proof(targets.into_iter().map(ProofV2Target::new))
             .expect("Proof generation failed");
+    }
+
+    /// Tests that `root_node` handles a cached branch with a `state_mask` bit set for a child
+    /// that has no corresponding `hash_mask` bit and no leaf data in the hashed cursor.
+    ///
+    /// This scenario occurs when `MaskedTrieCursorFactory` clears a child's `hash_mask` bit
+    /// (because the child's path is in the prefix set) but leaves the `state_mask` bit intact,
+    /// while the `HashedPostStateCursorFactory` overlay has deleted the leaf data for that child.
+    #[test]
+    fn test_node_with_masked_empty_child() {
+        reth_tracing::init_test_tracing();
+
+        let account_addr = B256::ZERO;
+        let val = U256::from(42u64);
+
+        // All storage keys share a common first nibble (0x6), so the branch is at path 0x6. The
+        // second nibble differentiates children: 0,1,3,5,7.
+        let slot_60 = B256::right_padding_from(&[0x60]);
+        let slot_61 = B256::right_padding_from(&[0x61]);
+        let slot_65 = B256::right_padding_from(&[0x65]);
+        let slot_67 = B256::right_padding_from(&[0x67]);
+
+        // Construct a branch node at path 0x6 with state_mask bits 0,1,3,5,7.
+        // hash_mask has bits 0,1,5,7 (NOT 3) — simulating MaskedTrieCursorFactory clearing
+        // nibble 3's hash because it's in the prefix set. Hashes are dummy values.
+        let state_mask = TrieMask::new(0b10101011); // bits 0,1,3,5,7
+        let hash_mask = TrieMask::new(0b10100011); // bits 0,1,5,7 (NOT 3)
+        let hashes = vec![B256::repeat_byte(0xaa); hash_mask.count_ones() as usize];
+        let branch = BranchNodeCompact::new(state_mask, TrieMask::new(0), hash_mask, hashes, None);
+
+        let mut storage_nodes = BTreeMap::new();
+        storage_nodes.insert(Nibbles::from_nibbles([0x6]), branch);
+
+        // Hashed cursor has slots at children 0, 1, 5, 7 — but NOT child 3 (0x63).
+        // This simulates the post-state overlay having deleted the slot at 0x63.
+        let post_state_storage: BTreeMap<B256, U256> =
+            [slot_60, slot_61, slot_65, slot_67].iter().map(|s| (*s, val)).collect();
+        let hashed_cursor_factory = MockHashedCursorFactory::new(
+            BTreeMap::new(),
+            B256Map::from_iter([(account_addr, post_state_storage)]),
+        );
+        let trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::new(),
+            B256Map::from_iter([(account_addr, storage_nodes)]),
+        );
+
+        let storage_trie_cursor = trie_cursor_factory.storage_trie_cursor(account_addr).unwrap();
+        let hashed_storage_cursor =
+            hashed_cursor_factory.hashed_storage_cursor(account_addr).unwrap();
+        let mut calculator =
+            StorageProofCalculator::new_storage(storage_trie_cursor, hashed_storage_cursor);
+        let root_node = calculator
+            .storage_root_node(account_addr)
+            .expect("storage_root_node should succeed with masked empty child");
+
+        let root_hash = calculator.compute_root_hash(core::slice::from_ref(&root_node)).unwrap();
+        assert!(root_hash.is_some(), "should produce a root hash");
+    }
+
+    /// Tests that `root_node` handles the case where `uncalculated_lower_bound` has advanced
+    /// entirely past a cached branch that still has unprocessed children in its `state_mask`.
+    ///
+    /// Branch at `0x6` has `state_mask` bits 0,1,5,f where nibble 5 has its `hash_mask`
+    /// cleared (simulating `MaskedTrieCursorFactory`) and no leaf data. The last child (nibble f)
+    /// causes `calculate_key_range` to be called with range `(0x6f, Some(0x7))`. After that range,
+    /// the hashed cursor still has keys (at `0x70...`), so `proof_subtrie` does not break and
+    /// re-enters `next_uncached_key_range` with `uncalculated_lower_bound = Some(0x7)`.
+    /// Since `0x7` is past `0x6`, all remaining children are skipped and the branch is popped.
+    #[test]
+    fn test_node_with_masked_empty_child_lower_bound_past_branch() {
+        reth_tracing::init_test_tracing();
+
+        let account_addr = B256::ZERO;
+        let val = U256::from(42u64);
+
+        // Leaf keys under 0x6 and one beyond (0x70) to keep the cursor alive after 0x6.
+        let slot_60 = B256::right_padding_from(&[0x60]);
+        let slot_61 = B256::right_padding_from(&[0x61]);
+        let slot_6f = B256::right_padding_from(&[0x6f]);
+        let slot_70 = B256::right_padding_from(&[0x70]);
+
+        // Branch at 0x6: state_mask bits 0,1,5,f; hash_mask bits 0,1 (NOT 5, NOT f).
+        // Nibble 5 has state_mask set but no hash and no leaf data (masked empty child).
+        // Nibble f has state_mask set, no hash, but DOES have leaf data.
+        let state_mask = TrieMask::new(0b1000_0000_0010_0011); // bits 0,1,5,f
+        let hash_mask = TrieMask::new(0b0000_0000_0000_0011); // bits 0,1
+        let hashes = vec![B256::repeat_byte(0xaa); hash_mask.count_ones() as usize];
+        let branch = BranchNodeCompact::new(state_mask, TrieMask::new(0), hash_mask, hashes, None);
+
+        let mut storage_nodes = BTreeMap::new();
+        storage_nodes.insert(Nibbles::from_nibbles([0x6]), branch);
+
+        // Hashed cursor: slots at 0x60, 0x61, 0x6f, 0x70 — but NOT 0x65.
+        let post_state_storage: BTreeMap<B256, U256> =
+            [slot_60, slot_61, slot_6f, slot_70].iter().map(|s| (*s, val)).collect();
+        let hashed_cursor_factory = MockHashedCursorFactory::new(
+            BTreeMap::new(),
+            B256Map::from_iter([(account_addr, post_state_storage)]),
+        );
+        let trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::new(),
+            B256Map::from_iter([(account_addr, storage_nodes)]),
+        );
+
+        let storage_trie_cursor = trie_cursor_factory.storage_trie_cursor(account_addr).unwrap();
+        let hashed_storage_cursor =
+            hashed_cursor_factory.hashed_storage_cursor(account_addr).unwrap();
+        let mut calculator =
+            StorageProofCalculator::new_storage(storage_trie_cursor, hashed_storage_cursor);
+        let root_node = calculator
+            .storage_root_node(account_addr)
+            .expect("storage_root_node should succeed when lower bound advances past branch");
+
+        let root_hash = calculator.compute_root_hash(core::slice::from_ref(&root_node)).unwrap();
+        assert!(root_hash.is_some(), "should produce a root hash");
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1960,7 +1960,7 @@ mod tests {
         let mut fresh_calculator = ProofCalculator::new(trie_cursor, hashed_cursor);
         let mut value_encoder = SyncAccountValueEncoder::new(
             harness.trie_cursor_factory.clone(),
-            harness.hashed_cursor_factory.clone(),
+            harness.hashed_cursor_factory,
         );
         let fresh_result = fresh_calculator.proof(&mut value_encoder, &mut targets).unwrap();
 

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -366,10 +366,10 @@ where
         // to pop_branch() to give DeferredEncoder time for async work.
         if self.should_retain(targets, &child_path, true) {
             let child_rlp_node = self.commit_child(targets, child_path, child)?;
-            trace!(target: TRACE_TARGET, ?child_rlp_node, "Pushing commited child RlpNode onto stack");
+            trace!(target: TRACE_TARGET, ?child_rlp_node, "Pushing committed child RlpNode onto stack");
             self.child_stack.push(ProofTrieBranchChild::RlpNode(child_rlp_node));
         } else {
-            trace!(target: TRACE_TARGET, "Pushing uncommited child onto stack");
+            trace!(target: TRACE_TARGET, "Pushing uncommitted child onto stack");
             self.child_stack.push(child);
         }
 
@@ -1014,7 +1014,7 @@ where
                     let lower_nibble = lower.get_unchecked(self.branch_path.len());
                     // Clear all nibbles strictly below `lower_nibble` since they've been processed.
                     let already_processed_mask = TrieMask::new((1u16 << lower_nibble) - 1);
-                    next_child_nibbles = next_child_nibbles & !already_processed_mask;
+                    next_child_nibbles &= !already_processed_mask;
                     trace!(
                         target: TRACE_TARGET,
                         branch_path = ?self.branch_path,

--- a/crates/trie/trie/src/trie_cursor/masked.rs
+++ b/crates/trie/trie/src/trie_cursor/masked.rs
@@ -109,29 +109,34 @@ impl<C: TrieCursor> MaskedTrieCursor<C> {
             return true;
         }
 
-        let mut new_hash_mask = original_hash_mask;
+        // Build an unset_mask based on state_mask: every child in the state_mask whose path
+        // is in the prefix set is dirty and must not use a cached hash.
+        let mut unset_mask = TrieMask::default();
         let mut child_path = *key;
         let key_len = key.len();
 
-        for nibble in original_hash_mask.iter() {
+        for nibble in node.state_mask.iter() {
             child_path.truncate(key_len);
             child_path.push(nibble);
 
             if self.prefix_set.contains(&child_path) {
-                new_hash_mask.unset_bit(nibble);
+                unset_mask.set_bit(nibble);
             }
         }
 
-        if new_hash_mask != original_hash_mask {
-            // If only one hashed bit survived masking, clear it too. Being inside this block
-            // guarantees bits were unset, so a single remaining bit means the original had
-            // more than one. This handles the case where all but one child of a branch have
-            // been deleted — the remaining child must be revealed to collapse the branch, so
-            // its cached hash cannot be used.
-            if (new_hash_mask & TrieMask::new(new_hash_mask.get().wrapping_sub(1))).is_empty() {
-                new_hash_mask = TrieMask::default();
-            }
+        // If removing dirty children leaves only a single child in the state_mask, that
+        // child must also be unset. A single-child branch is invalid in MPT — the branch
+        // must collapse — so the remaining child's cached hash cannot be reused.
+        let surviving_state = TrieMask::new(node.state_mask.get() & !unset_mask.get());
+        let surviving_bits = surviving_state.get();
+        if surviving_bits != 0 && (surviving_bits & surviving_bits.wrapping_sub(1)) == 0 {
+            unset_mask = TrieMask::new(unset_mask.get() | surviving_bits);
+        }
 
+        // Apply unset_mask to hash_mask.
+        let new_hash_mask = TrieMask::new(original_hash_mask.get() & !unset_mask.get());
+
+        if new_hash_mask != original_hash_mask {
             // Remove hashes for unset bits in-place.
             let hashes = Arc::make_mut(&mut node.hashes);
             let mut write = 0;
@@ -414,11 +419,12 @@ mod tests {
     }
 
     #[test]
-    fn test_last_hash_cleared_when_state_mask_wider_than_hash_mask() {
+    fn test_hash_preserved_when_multiple_state_children_survive() {
         // Branch at [0x1] with children 0 (hashed), 1 (unhashed, state_mask only), 5 (hashed).
         // state_mask has bits 0,1,5; hash_mask has only bits 0,5.
-        // Prefix set marks child 0 as changed → new_hash_mask has only bit 5.
-        // Since only one hashed bit remains, it must be cleared so the branch can collapse.
+        // Prefix set marks child 0 as changed → unset_mask has bit 0.
+        // Surviving state_mask is {1, 5} — two children, so no collapse needed.
+        // Hash for child 5 should be preserved.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
             node_with_tree_mask(
@@ -436,7 +442,35 @@ mod tests {
         let mut cursor = MaskedTrieCursor::new(inner, ps.freeze());
 
         let (_, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
-        // The last remaining hash bit (5) should also be cleared.
+        // Child 0's hash cleared (dirty), child 5's hash preserved (two children survive).
+        assert!(!node.hash_mask.is_bit_set(0));
+        assert!(node.hash_mask.is_bit_set(5));
+        assert_eq!(&*node.hashes, &[hash(5)]);
+    }
+
+    #[test]
+    fn test_hash_cleared_when_single_state_child_survives() {
+        // Branch at [0x1] with children 0 (hashed), 5 (hashed).
+        // state_mask and hash_mask both have bits 0 and 5.
+        // Prefix set marks child 0 as changed → only child 5 survives in state_mask.
+        // Single-child branch must collapse → child 5's hash also cleared.
+        let nodes = vec![(
+            Nibbles::from_nibbles([0x1]),
+            node_with_tree_mask(
+                0b0000_0000_0010_0001, // state_mask: bits 0, 5
+                0b0000_0000_0010_0001, // tree_mask: keeps node alive
+                0b0000_0000_0010_0001, // hash_mask: bits 0, 5
+                vec![hash(0), hash(5)],
+            ),
+        )];
+
+        let mut ps = PrefixSetMut::default();
+        ps.insert(Nibbles::from_nibbles([0x1, 0x0]));
+
+        let inner = make_cursor(nodes);
+        let mut cursor = MaskedTrieCursor::new(inner, ps.freeze());
+
+        let (_, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
         assert!(node.hash_mask.is_empty(), "expected empty hash_mask, got {:?}", node.hash_mask);
         assert!(node.hashes.is_empty());
     }
@@ -588,12 +622,11 @@ mod tests {
     }
 
     #[test]
-    fn test_last_hash_cleared_when_state_mask_wider() {
+    fn test_hash_preserved_when_state_mask_wider_and_multiple_survive() {
         // Node at [0x1] with state_mask bits 0, 3, 7, 9 but only 0, 3, 7 hashed.
         // Prefix set marks children 0 and 7 as changed.
-        // Only child 3's hash would remain, but since it's the last hashed bit it must
-        // also be cleared — the remaining child needs to be revealed to allow branch
-        // collapse.
+        // Surviving state children: {3, 9} — two children, so no collapse needed.
+        // Child 3's hash should be preserved since it's not dirty and the branch is valid.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
             node_with_tree_mask(
@@ -606,6 +639,38 @@ mod tests {
 
         let mut ps = PrefixSetMut::default();
         ps.insert(Nibbles::from_nibbles([0x1, 0x0]));
+        ps.insert(Nibbles::from_nibbles([0x1, 0x7]));
+
+        let inner = make_cursor(nodes);
+        let mut cursor = MaskedTrieCursor::new(inner, ps.freeze());
+
+        let (key, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
+        assert_eq!(key, Nibbles::from_nibbles([0x1]));
+        // Children 0 and 7 are dirty → hashes cleared. Child 3's hash preserved.
+        assert!(!node.hash_mask.is_bit_set(0));
+        assert!(node.hash_mask.is_bit_set(3));
+        assert!(!node.hash_mask.is_bit_set(7));
+        assert_eq!(&*node.hashes, &[hash(3)]);
+    }
+
+    #[test]
+    fn test_unhashed_child_deleted_collapses_branch() {
+        // Reproduces the panic from proof_v2: branch at [0x1] with state_mask bits {3, 7},
+        // hash_mask bit {3} only. Nibble 7 has no hash (computed from leaves).
+        // Prefix set marks child 7 as changed (its leaves were deleted).
+        // After masking, only child 3 survives in state_mask — single-child branch must
+        // collapse, so child 3's cached hash must also be cleared.
+        let nodes = vec![(
+            Nibbles::from_nibbles([0x1]),
+            node_with_tree_mask(
+                0b0000_0000_1000_1000, // state_mask: bits 3, 7
+                0b0000_0000_1000_1000,
+                0b0000_0000_0000_1000, // hash_mask: bit 3 only
+                vec![hash(3)],
+            ),
+        )];
+
+        let mut ps = PrefixSetMut::default();
         ps.insert(Nibbles::from_nibbles([0x1, 0x7]));
 
         let inner = make_cursor(nodes);

--- a/crates/trie/trie/src/trie_cursor/masked.rs
+++ b/crates/trie/trie/src/trie_cursor/masked.rs
@@ -92,7 +92,8 @@ impl<C> MaskedTrieCursor<C> {
 }
 
 impl<C: TrieCursor> MaskedTrieCursor<C> {
-    /// Mask hash bits on a node for children whose paths match the prefix set.
+    /// Mask hash bits on a node for children whose paths match the prefix set, and set
+    /// `state_mask` bits for new children discovered via the prefix set.
     ///
     /// Returns `true` if the node should be kept, `false` if it should be skipped (both
     /// `hash_mask` and `tree_mask` are empty after masking).
@@ -105,38 +106,52 @@ impl<C: TrieCursor> MaskedTrieCursor<C> {
         node.root_hash = None;
 
         let original_hash_mask = node.hash_mask;
-        if original_hash_mask.is_empty() {
-            return true;
-        }
 
-        // Build an unset_mask based on state_mask: every child in the state_mask whose path
-        // is in the prefix set is dirty and must not use a cached hash.
-        let mut unset_mask = TrieMask::default();
+        // Check all 16 nibbles against the prefix set. For nibbles already in the state_mask
+        // that match, we build an unset_hash_mask to clear their cached hashes. For nibbles NOT in
+        // the state_mask that match, we set them on the state_mask so that consumers (e.g.
+        // proof_v2) discover new children that weren't present when the branch was persisted.
+        let mut unset_hash_mask = TrieMask::default();
+        let mut new_state_bits = TrieMask::default();
         let mut child_path = *key;
         let key_len = key.len();
 
-        for nibble in node.state_mask.iter() {
+        for nibble in 0u8..16 {
             child_path.truncate(key_len);
             child_path.push(nibble);
 
             if self.prefix_set.contains(&child_path) {
-                unset_mask.set_bit(nibble);
+                if node.state_mask.is_bit_set(nibble) {
+                    unset_hash_mask.set_bit(nibble);
+                } else {
+                    new_state_bits.set_bit(nibble);
+                }
             }
+        }
+
+        // Add newly discovered children to the state_mask.
+        node.state_mask |= new_state_bits;
+
+        if original_hash_mask.is_empty() {
+            return true;
         }
 
         // We pessimistically assume all leaves matched by the prefix set will be removed.
         //
-        // If removing dirty children leaves only a single child in the state_mask, that
-        // child must also be unset. A single-child branch is invalid in MPT — the branch
+        // If removing dirty children leaves only a single child in the original state_mask,
+        // that child must also be unset. A single-child branch is invalid in MPT — the branch
         // must collapse — so the remaining child must be revealed in order to perform the collapse.
         // Its cached hash cannot be used.
-        let remaining_bits = node.state_mask & !unset_mask;
+        //
+        // New state bits are excluded: they represent children being added, so they cannot
+        // cause the branch to collapse.
+        let remaining_bits = (node.state_mask & !new_state_bits) & !unset_hash_mask;
         if remaining_bits.count_ones() == 1 {
-            unset_mask = node.state_mask;
+            unset_hash_mask = node.state_mask;
         }
 
-        // Apply unset_mask to hash_mask.
-        let new_hash_mask = original_hash_mask & !unset_mask;
+        // Apply unset_hash_mask to hash_mask.
+        let new_hash_mask = original_hash_mask & !unset_hash_mask;
 
         if new_hash_mask != original_hash_mask {
             // Remove hashes for unset bits in-place.

--- a/crates/trie/trie/src/trie_cursor/masked.rs
+++ b/crates/trie/trie/src/trie_cursor/masked.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{map::B256Map, B256};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie_common::{
     prefix_set::{PrefixSet, TriePrefixSets},
-    BranchNodeCompact, Nibbles,
+    BranchNodeCompact, Nibbles, TrieMask,
 };
 use std::sync::Arc;
 
@@ -123,6 +123,19 @@ impl<C: TrieCursor> MaskedTrieCursor<C> {
         }
 
         if new_hash_mask != original_hash_mask {
+            // If all children were originally hashed (state_mask == hash_mask) and only one
+            // hashed bit survived masking, clear it too. Being inside this block guarantees
+            // bits were unset, so a single remaining bit means the original had more than one.
+            // This handles the case where all but one child of a branch have been deleted —
+            // the remaining child must be revealed to collapse the branch, so its cached hash
+            // cannot be used.
+            if ((node.state_mask ^ original_hash_mask) |
+                (new_hash_mask & TrieMask::new(new_hash_mask.get().wrapping_sub(1))))
+            .is_empty()
+            {
+                new_hash_mask = TrieMask::default();
+            }
+
             // Remove hashes for unset bits in-place.
             let hashes = Arc::make_mut(&mut node.hashes);
             let mut write = 0;
@@ -242,11 +255,18 @@ mod tests {
 
     #[test]
     fn test_seek_masks_matching_child_hashes() {
-        // Node at [0x1] with children 2 and 5 hashed.
+        // Node at [0x1] with children 2 and 5 hashed, tree_mask keeps it alive.
         // Prefix set marks child 2 as changed.
+        // Since only one hashed bit (5) would remain and the original had more than one,
+        // that last bit is also cleared.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
-            node_with_hashes(0b0000_0000_0010_0100, 0b0000_0000_0010_0100, vec![hash(2), hash(5)]),
+            node_with_tree_mask(
+                0b0000_0000_0010_0100,
+                0b0000_0000_0010_0100,
+                0b0000_0000_0010_0100,
+                vec![hash(2), hash(5)],
+            ),
         )];
 
         let mut ps = PrefixSetMut::default();
@@ -258,10 +278,9 @@ mod tests {
         let result = cursor.seek(Nibbles::default()).unwrap();
         let (key, node) = result.unwrap();
         assert_eq!(key, Nibbles::from_nibbles([0x1]));
-        // Hash bit 2 should be unset, only bit 5 remains.
         assert!(!node.hash_mask.is_bit_set(2));
-        assert!(node.hash_mask.is_bit_set(5));
-        assert_eq!(&*node.hashes, &[hash(5)]);
+        assert!(!node.hash_mask.is_bit_set(5));
+        assert!(node.hashes.is_empty());
     }
 
     #[test]
@@ -317,6 +336,10 @@ mod tests {
 
     #[test]
     fn test_seek_exact_masks_hash_bits() {
+        // Node at [0x1] with children 2 and 5 hashed.
+        // Prefix set marks child 5 as changed.
+        // Since only one hashed bit (2) would remain and the original had two,
+        // the last remaining bit is also cleared.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
             node_with_tree_mask(
@@ -335,9 +358,9 @@ mod tests {
 
         let result = cursor.seek_exact(Nibbles::from_nibbles([0x1])).unwrap();
         let (_, node) = result.unwrap();
-        assert!(node.hash_mask.is_bit_set(2));
+        assert!(!node.hash_mask.is_bit_set(2));
         assert!(!node.hash_mask.is_bit_set(5));
-        assert_eq!(&*node.hashes, &[hash(2)]);
+        assert!(node.hashes.is_empty());
     }
 
     #[test]
@@ -447,8 +470,12 @@ mod tests {
 
     #[test]
     fn test_root_hash_cleared_on_mask() {
-        let mut n =
-            node_with_hashes(0b0000_0000_0010_0100, 0b0000_0000_0010_0100, vec![hash(2), hash(5)]);
+        let mut n = node_with_tree_mask(
+            0b0000_0000_0010_0100,
+            0b0000_0000_0010_0100,
+            0b0000_0000_0010_0100,
+            vec![hash(2), hash(5)],
+        );
         n.root_hash = Some(hash(0xFF));
 
         let nodes = vec![(Nibbles::from_nibbles([0x1]), n)];
@@ -505,10 +532,11 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_mask_preserves_remaining_hashes() {
+    fn test_partial_mask_clears_last_remaining_hash() {
         // Node at [0x1] with children 0, 3, 7 hashed.
         // Prefix set marks children 0 and 7 as changed.
-        // Only hash for child 3 should remain.
+        // Only child 3 would remain, but since the original had more than one hashed bit,
+        // the single remaining bit is also cleared.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
             node_with_tree_mask(
@@ -529,10 +557,42 @@ mod tests {
         let (key, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
         assert_eq!(key, Nibbles::from_nibbles([0x1]));
         assert!(!node.hash_mask.is_bit_set(0));
+        assert!(!node.hash_mask.is_bit_set(3));
+        assert!(!node.hash_mask.is_bit_set(7));
+        assert!(node.hashes.is_empty());
+        assert_eq!(node.root_hash, None);
+    }
+
+    #[test]
+    fn test_partial_mask_preserves_last_hash_when_state_mask_wider() {
+        // Node at [0x1] with state_mask bits 0, 3, 7, 9 but only 0, 3, 7 hashed.
+        // Prefix set marks children 0 and 7 as changed.
+        // Only child 3's hash remains, but since state_mask != original_hash_mask
+        // (child 9 is a non-hashed child), this is not an all-children-deleted scenario
+        // and the last hash is preserved.
+        let nodes = vec![(
+            Nibbles::from_nibbles([0x1]),
+            node_with_tree_mask(
+                0b0000_0010_1000_1001, // state_mask: bits 0, 3, 7, 9
+                0b0000_0010_1000_1001,
+                0b0000_0000_1000_1001, // hash_mask: bits 0, 3, 7
+                vec![hash(0), hash(3), hash(7)],
+            ),
+        )];
+
+        let mut ps = PrefixSetMut::default();
+        ps.insert(Nibbles::from_nibbles([0x1, 0x0]));
+        ps.insert(Nibbles::from_nibbles([0x1, 0x7]));
+
+        let inner = make_cursor(nodes);
+        let mut cursor = MaskedTrieCursor::new(inner, ps.freeze());
+
+        let (key, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
+        assert_eq!(key, Nibbles::from_nibbles([0x1]));
+        assert!(!node.hash_mask.is_bit_set(0));
         assert!(node.hash_mask.is_bit_set(3));
         assert!(!node.hash_mask.is_bit_set(7));
         assert_eq!(&*node.hashes, &[hash(3)]);
-        assert_eq!(node.root_hash, None);
     }
 
     mod proptest_tests {

--- a/crates/trie/trie/src/trie_cursor/masked.rs
+++ b/crates/trie/trie/src/trie_cursor/masked.rs
@@ -123,16 +123,12 @@ impl<C: TrieCursor> MaskedTrieCursor<C> {
         }
 
         if new_hash_mask != original_hash_mask {
-            // If all children were originally hashed (state_mask == hash_mask) and only one
-            // hashed bit survived masking, clear it too. Being inside this block guarantees
-            // bits were unset, so a single remaining bit means the original had more than one.
-            // This handles the case where all but one child of a branch have been deleted —
-            // the remaining child must be revealed to collapse the branch, so its cached hash
-            // cannot be used.
-            if ((node.state_mask ^ original_hash_mask) |
-                (new_hash_mask & TrieMask::new(new_hash_mask.get().wrapping_sub(1))))
-            .is_empty()
-            {
+            // If only one hashed bit survived masking, clear it too. Being inside this block
+            // guarantees bits were unset, so a single remaining bit means the original had
+            // more than one. This handles the case where all but one child of a branch have
+            // been deleted — the remaining child must be revealed to collapse the branch, so
+            // its cached hash cannot be used.
+            if (new_hash_mask & TrieMask::new(new_hash_mask.get().wrapping_sub(1))).is_empty() {
                 new_hash_mask = TrieMask::default();
             }
 
@@ -418,6 +414,34 @@ mod tests {
     }
 
     #[test]
+    fn test_last_hash_cleared_when_state_mask_wider_than_hash_mask() {
+        // Branch at [0x1] with children 0 (hashed), 1 (unhashed, state_mask only), 5 (hashed).
+        // state_mask has bits 0,1,5; hash_mask has only bits 0,5.
+        // Prefix set marks child 0 as changed → new_hash_mask has only bit 5.
+        // Since only one hashed bit remains, it must be cleared so the branch can collapse.
+        let nodes = vec![(
+            Nibbles::from_nibbles([0x1]),
+            node_with_tree_mask(
+                0b0000_0000_0010_0011, // state_mask: bits 0, 1, 5
+                0b0000_0000_0010_0011, // tree_mask: keeps node alive
+                0b0000_0000_0010_0001, // hash_mask: bits 0, 5 (NOT 1)
+                vec![hash(0), hash(5)],
+            ),
+        )];
+
+        let mut ps = PrefixSetMut::default();
+        ps.insert(Nibbles::from_nibbles([0x1, 0x0]));
+
+        let inner = make_cursor(nodes);
+        let mut cursor = MaskedTrieCursor::new(inner, ps.freeze());
+
+        let (_, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
+        // The last remaining hash bit (5) should also be cleared.
+        assert!(node.hash_mask.is_empty(), "expected empty hash_mask, got {:?}", node.hash_mask);
+        assert!(node.hashes.is_empty());
+    }
+
+    #[test]
     fn test_no_match_returns_unchanged() {
         let nodes = vec![(
             Nibbles::from_nibbles([0x2]),
@@ -564,12 +588,12 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_mask_preserves_last_hash_when_state_mask_wider() {
+    fn test_last_hash_cleared_when_state_mask_wider() {
         // Node at [0x1] with state_mask bits 0, 3, 7, 9 but only 0, 3, 7 hashed.
         // Prefix set marks children 0 and 7 as changed.
-        // Only child 3's hash remains, but since state_mask != original_hash_mask
-        // (child 9 is a non-hashed child), this is not an all-children-deleted scenario
-        // and the last hash is preserved.
+        // Only child 3's hash would remain, but since it's the last hashed bit it must
+        // also be cleared — the remaining child needs to be revealed to allow branch
+        // collapse.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
             node_with_tree_mask(
@@ -589,10 +613,8 @@ mod tests {
 
         let (key, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
         assert_eq!(key, Nibbles::from_nibbles([0x1]));
-        assert!(!node.hash_mask.is_bit_set(0));
-        assert!(node.hash_mask.is_bit_set(3));
-        assert!(!node.hash_mask.is_bit_set(7));
-        assert_eq!(&*node.hashes, &[hash(3)]);
+        assert!(node.hash_mask.is_empty(), "expected empty hash_mask, got {:?}", node.hash_mask);
+        assert!(node.hashes.is_empty());
     }
 
     mod proptest_tests {

--- a/crates/trie/trie/src/trie_cursor/masked.rs
+++ b/crates/trie/trie/src/trie_cursor/masked.rs
@@ -124,17 +124,19 @@ impl<C: TrieCursor> MaskedTrieCursor<C> {
             }
         }
 
+        // We pessimistically assume all leaves matched by the prefix set will be removed.
+        //
         // If removing dirty children leaves only a single child in the state_mask, that
         // child must also be unset. A single-child branch is invalid in MPT — the branch
-        // must collapse — so the remaining child's cached hash cannot be reused.
-        let surviving_state = TrieMask::new(node.state_mask.get() & !unset_mask.get());
-        let surviving_bits = surviving_state.get();
-        if surviving_bits != 0 && (surviving_bits & surviving_bits.wrapping_sub(1)) == 0 {
-            unset_mask = TrieMask::new(unset_mask.get() | surviving_bits);
+        // must collapse — so the remaining child must be revealed in order to perform the collapse.
+        // Its cached hash cannot be used.
+        let remaining_bits = node.state_mask & !unset_mask;
+        if remaining_bits.count_ones() == 1 {
+            unset_mask = node.state_mask;
         }
 
         // Apply unset_mask to hash_mask.
-        let new_hash_mask = TrieMask::new(original_hash_mask.get() & !unset_mask.get());
+        let new_hash_mask = original_hash_mask & !unset_mask;
 
         if new_hash_mask != original_hash_mask {
             // Remove hashes for unset bits in-place.
@@ -419,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_preserved_when_multiple_state_children_survive() {
+    fn test_hash_preserved_when_multiple_state_children_remain() {
         // Branch at [0x1] with children 0 (hashed), 1 (unhashed, state_mask only), 5 (hashed).
         // state_mask has bits 0,1,5; hash_mask has only bits 0,5.
         // Prefix set marks child 0 as changed → unset_mask has bit 0.
@@ -442,17 +444,17 @@ mod tests {
         let mut cursor = MaskedTrieCursor::new(inner, ps.freeze());
 
         let (_, node) = cursor.seek(Nibbles::default()).unwrap().unwrap();
-        // Child 0's hash cleared (dirty), child 5's hash preserved (two children survive).
+        // Child 0's hash cleared (dirty), child 5's hash preserved (two children remain).
         assert!(!node.hash_mask.is_bit_set(0));
         assert!(node.hash_mask.is_bit_set(5));
         assert_eq!(&*node.hashes, &[hash(5)]);
     }
 
     #[test]
-    fn test_hash_cleared_when_single_state_child_survives() {
+    fn test_hash_cleared_when_single_state_child_remains() {
         // Branch at [0x1] with children 0 (hashed), 5 (hashed).
         // state_mask and hash_mask both have bits 0 and 5.
-        // Prefix set marks child 0 as changed → only child 5 survives in state_mask.
+        // Prefix set marks child 0 as changed → only child 5 remains in state_mask.
         // Single-child branch must collapse → child 5's hash also cleared.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),
@@ -622,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_preserved_when_state_mask_wider_and_multiple_survive() {
+    fn test_hash_preserved_when_state_mask_wider_and_multiple_remain() {
         // Node at [0x1] with state_mask bits 0, 3, 7, 9 but only 0, 3, 7 hashed.
         // Prefix set marks children 0 and 7 as changed.
         // Surviving state children: {3, 9} — two children, so no collapse needed.
@@ -658,7 +660,7 @@ mod tests {
         // Reproduces the panic from proof_v2: branch at [0x1] with state_mask bits {3, 7},
         // hash_mask bit {3} only. Nibble 7 has no hash (computed from leaves).
         // Prefix set marks child 7 as changed (its leaves were deleted).
-        // After masking, only child 3 survives in state_mask — single-child branch must
+        // After masking, only child 3 remains in state_mask — single-child branch must
         // collapse, so child 3's cached hash must also be cleared.
         let nodes = vec![(
             Nibbles::from_nibbles([0x1]),


### PR DESCRIPTION
This PR contains a two-part fix for a scenario which occurs when using proof_v2::ProofCalculator with a MaskedTrieCursor. The scenario is:

Underlying database has keys:
* 0x0001
* 0x0002
* 0x0010
* 0x0011

And cached branch:
* 0x00, state_mask:0b11 hash_mask:0b11

Let's say we are applying a database overlay which deletes keys 0x0011 and 0x0012. This would look like:
* HashedPostStateCursor - masks the keys 0x0011 and 0x0012 themselves
* MaskedTrieCursor - holds `PrefixSet{0x0011, 0x0012}`, which would unset the one bit of 0x00's hash_mask.

Passing these cursors to ProofCalculator creates two separate problems:

## Problem 1

The one bit of 0x00's hash_mask is unset, but the one bit of its _state mask_ is not. This is incorrect, since there are no keys at 0x001 according to the hashed keys cursor. So the calculator expects there to be keys there, tries to move the hashed key cursor to 0x001, but it's already passed 0x001 and so the calculator panics.

*Solution*: within the proof_v2::ProofCalculator we explicitly handle the case of state_mask bits being set even though there's no keys for them. We do this by just skipping over those bits, based on where the hashed key cursor is (uncalculated_lower_bound). This handles this situation, and also any future situations where a state_mask bit is incorrectly set.

## Problem 2

Because 0x0011 and 0x0012 are deleted, their branch at 0x001 is deleted. This means that the branch at 0x00 only has a single child, 0x000. Because it only has a single child the branch at 0x00 gets collapsed, such that 0x000's short key gets extended and replaces 0x00 in its parent.

This is a problem because 0x000's hash_mask bit is set, and without knowing that 0x001 will be deleted the ProofCalculator will use that hash rather than descending into that subtrie and computing the real node there. Without having computed the real node for 0x000, the calculator is not able to extend its short key (because it doesn't know it), and so it can't collapse the branch 0x00.

*Solution*: within the MaskedTrieCursor, if the hash_mask bits for all but one of the children have been unset, then the hash_mask bit for that remaining child is also unset, even if it's not in the PrefixSet. This is a pessimistic solution, but since it's only relevant when using MaskedTrieCursor and doesn't affect payload validator it's not significant. Also it should happen rare enough to not be performance impacting.