### PR TITLE
perf(rpc): skip block construction in rpc_block_header

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -39,7 +39,12 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
     where
         Self: FullEthApiTypes,
     {
-        async move { Ok(self.rpc_block(block_id, false).await?.map(|block| block.header)) }
+        async move {
+            let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
+            let header =
+                self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
+            Ok(Some(header))
+        }
     }
 
     /// Returns the populated rpc block object for the given block id.


### PR DESCRIPTION
`rpc_block_header` called `rpc_block(block_id, false)` which built a full RPC block (collected tx hashes, computed ommer hashes, assembled `Block` struct) only to discard everything except `.header`.

Now calls `recovered_block` + `convert_header` directly, skipping the unnecessary work. Same inputs to `convert_header` (`clone_sealed_header()`, `rlp_length()`) as the old path through `to_rpc_block_with_tx_hashes`.