### PR TITLE
fix(cli): distinguish download and extraction phases in progress bar

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -683,6 +683,7 @@ pub(crate) struct DownloadProgress {
     total_size: u64,
     last_displayed: Instant,
     started_at: Instant,
+    phase: &'static str,
 }
 
 #[derive(Debug, Clone)]
@@ -724,10 +725,10 @@ fn summarize_download_startup(
 }
 
 impl DownloadProgress {
-    /// Creates new progress tracker with given total size
-    fn new(total_size: u64) -> Self {
+    /// Creates new progress tracker with given total size and phase label.
+    fn new(total_size: u64, phase: &'static str) -> Self {
         let now = Instant::now();
-        Self { downloaded: 0, total_size, last_displayed: now, started_at: now }
+        Self { downloaded: 0, total_size, last_displayed: now, started_at: now, phase }
     }
 
     /// Converts bytes to human readable format (B, KB, MB, GB)
@@ -778,8 +779,9 @@ impl DownloadProgress {
             };
             let eta_str = Self::format_duration(eta);
 
+            let phase = self.phase;
             print!(
-                "\rDownloading and extracting... {progress:.2}% ({formatted_downloaded} / {formatted_total}) ETA: {eta_str}     ",
+                "\r{phase} {progress:.2}% ({formatted_downloaded} / {formatted_total}) ETA: {eta_str}     ",
             );
             io::stdout().flush()?;
             self.last_displayed = Instant::now();
@@ -904,8 +906,8 @@ struct ProgressReader<R> {
 }
 
 impl<R: Read> ProgressReader<R> {
-    fn new(reader: R, total_size: u64) -> Self {
-        Self { reader, progress: DownloadProgress::new(total_size) }
+    fn new(reader: R, total_size: u64, phase: &'static str) -> Self {
+        Self { reader, progress: DownloadProgress::new(total_size, phase) }
     }
 }
 
@@ -954,7 +956,7 @@ fn extract_archive<R: Read>(
     format: CompressionFormat,
     target_dir: &Path,
 ) -> Result<()> {
-    let progress_reader = ProgressReader::new(reader, total_size);
+    let progress_reader = ProgressReader::new(reader, total_size, "Extracting...");
 
     match format {
         CompressionFormat::Lz4 => {
@@ -1194,7 +1196,7 @@ fn resumable_download(
             flush_result = writer.inner.flush();
         } else {
             // Legacy single-download path: local progress bar
-            let mut progress = DownloadProgress::new(current_total);
+            let mut progress = DownloadProgress::new(current_total, "Downloading...");
             progress.downloaded = start_offset;
             let mut writer = ProgressWriter { inner: BufWriter::new(file), progress };
             copy_result = io::copy(&mut reader, &mut writer);


### PR DESCRIPTION
When using `reth download --resumable`, the progress bar shows "Downloading and extracting..." for both phases. After download completes at ~100%, progress resets to 0% for extraction with the same message, making it look like the download failed.

Encountered this while setting up a mainnet node with `reth download -u <url> --resumable --minimal`:

```
Downloading and extracting... 99.98% (239.19 GB / 239.25 GB) ETA: 0s
Downloading and extracting... 99.99% (239.22 GB / 239.25 GB) ETA: 0s
# progress resets — looks like download restarted
Downloading and extracting... 0.00% (7.41 MB / 239.25 GB) ETA: 55m
Downloading and extracting... 3.91% (9.35 GB / 239.25 GB) ETA: 14m
```

Adds a `phase` field to `DownloadProgress` so each phase displays a distinct label:

```
Downloading... 99.99% (239.22 GB / 239.25 GB) ETA: 0s
Extracting...  0.00% (7.41 MB / 239.25 GB) ETA: 55m
```

The streaming (non-resumable) path is unaffected.