### PR TITLE
fix(cli): improve error message when snapshot manifest is unavailable

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -7,7 +7,7 @@ use crate::common::EnvironmentArgs;
 use blake3::Hasher;
 use clap::Parser;
 use config_gen::{config_for_selections, write_config};
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use futures::stream::{self, StreamExt};
 use lz4::Decoder;
 use manifest::{
@@ -1524,7 +1524,23 @@ async fn fetch_manifest_from_source(source: &str) -> Result<SnapshotManifest> {
     if let Ok(parsed) = Url::parse(source) {
         return match parsed.scheme() {
             "http" | "https" => {
-                Ok(Client::new().get(source).send().await?.error_for_status()?.json().await?)
+                let response = Client::new()
+                    .get(source)
+                    .send()
+                    .await
+                    .and_then(|r| r.error_for_status())
+                    .wrap_err_with(|| {
+                        format!(
+                            "Failed to fetch snapshot manifest from {source}\n\n\
+                             The manifest endpoint may not be available for this snapshot source.\n\
+                             You can use a direct snapshot URL instead:\n\n\
+                             \treth download -u <snapshot-url>\n\n\
+                             Available snapshot sources:\n\
+                             \t- https://www.merkle.io/snapshots\n\
+                             \t- https://publicnode.com/snapshots"
+                        )
+                    })?;
+                Ok(response.json().await?)
             }
             "file" => {
                 let path = parsed


### PR DESCRIPTION
When running `reth download` without `-u`, it fetches a manifest from the default base URL (`downloads.merkle.io/manifest.json`). If the endpoint returns 404 or is unreachable, the error is a raw reqwest HTTP error with no guidance on what to do next.

Encountered this while setting up a fresh mainnet node — `reth download --minimal -y` failed immediately:

```
ERROR Failed to fetch snapshot manifest
Caused by: HTTP status client error (404 Not Found) for url (https://downloads.merkle.io/manifest.json)
```

The modular download system (merged in #22246) expects snapshot providers to host a `manifest.json` endpoint, but this isn't widely deployed yet. Users hitting this error have no idea they can use `-u <url>` for direct downloads instead.

Wraps the manifest fetch error with actionable guidance:

```
Failed to fetch snapshot manifest from https://downloads.merkle.io/manifest.json

The manifest endpoint may not be available for this snapshot source.
You can use a direct snapshot URL instead:

	reth download -u <snapshot-url>

Available snapshot sources:
	- https://www.merkle.io/snapshots
	- https://publicnode.com/snapshots
```
