### PR TITLE
perf(cli): use sliding window for download ETA calculation

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -683,6 +683,10 @@ pub(crate) struct DownloadProgress {
     total_size: u64,
     last_displayed: Instant,
     started_at: Instant,
+    /// Snapshot of downloaded bytes at the start of the current ETA window.
+    window_downloaded: u64,
+    /// Timestamp when the current ETA window started.
+    window_started: Instant,
 }
 
 #[derive(Debug, Clone)]
@@ -727,7 +731,14 @@ impl DownloadProgress {
     /// Creates new progress tracker with given total size
     fn new(total_size: u64) -> Self {
         let now = Instant::now();
-        Self { downloaded: 0, total_size, last_displayed: now, started_at: now }
+        Self {
+            downloaded: 0,
+            total_size,
+            last_displayed: now,
+            started_at: now,
+            window_downloaded: 0,
+            window_started: now,
+        }
     }
 
     /// Converts bytes to human readable format (B, KB, MB, GB)
@@ -764,15 +775,26 @@ impl DownloadProgress {
             let formatted_total = Self::format_size(self.total_size);
             let progress = (self.downloaded as f64 / self.total_size as f64) * 100.0;
 
-            let elapsed = self.started_at.elapsed();
-            let eta = if self.downloaded > 0 {
-                let remaining = self.total_size.saturating_sub(self.downloaded);
-                let speed = self.downloaded as f64 / elapsed.as_secs_f64();
-                if speed > 0.0 {
-                    Duration::from_secs_f64(remaining as f64 / speed)
-                } else {
-                    Duration::ZERO
-                }
+            let remaining = self.total_size.saturating_sub(self.downloaded);
+            let window_elapsed = self.window_started.elapsed();
+
+            // Use a 30-second sliding window for speed calculation to produce
+            // accurate ETAs when throughput changes (e.g. extraction phase is
+            // slower than download). Falls back to cumulative average during the
+            // first 30 seconds.
+            let speed = if window_elapsed >= Duration::from_secs(30) {
+                let window_bytes = self.downloaded - self.window_downloaded;
+                let speed = window_bytes as f64 / window_elapsed.as_secs_f64();
+                self.window_downloaded = self.downloaded;
+                self.window_started = Instant::now();
+                speed
+            } else {
+                let elapsed = self.started_at.elapsed();
+                self.downloaded as f64 / elapsed.as_secs_f64().max(0.001)
+            };
+
+            let eta = if speed > 0.0 {
+                Duration::from_secs_f64(remaining as f64 / speed)
             } else {
                 Duration::ZERO
             };
@@ -827,6 +849,8 @@ impl SharedProgress {
 fn spawn_progress_display(progress: Arc<SharedProgress>) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let started_at = Instant::now();
+        let mut window_started = Instant::now();
+        let mut window_downloaded: u64 = 0;
         let mut interval = tokio::time::interval(Duration::from_secs(3));
         interval.tick().await; // first tick is immediate, skip it
         loop {
@@ -848,7 +872,6 @@ fn spawn_progress_display(progress: Arc<SharedProgress>) -> tokio::task::JoinHan
             let dl = DownloadProgress::format_size(downloaded);
             let tot = DownloadProgress::format_size(total);
 
-            let elapsed = started_at.elapsed();
             let remaining = total.saturating_sub(downloaded);
 
             if remaining == 0 {
@@ -859,15 +882,21 @@ fn spawn_progress_display(progress: Arc<SharedProgress>) -> tokio::task::JoinHan
                     "Extracting remaining archives"
                 );
             } else {
-                let eta = if downloaded > 0 {
-                    let speed = downloaded as f64 / elapsed.as_secs_f64();
-                    if speed > 0.0 {
-                        DownloadProgress::format_duration(Duration::from_secs_f64(
-                            remaining as f64 / speed,
-                        ))
-                    } else {
-                        "??".to_string()
-                    }
+                let window_elapsed = window_started.elapsed();
+                let speed = if window_elapsed >= Duration::from_secs(30) {
+                    let s = (downloaded - window_downloaded) as f64 / window_elapsed.as_secs_f64();
+                    window_downloaded = downloaded;
+                    window_started = Instant::now();
+                    s
+                } else {
+                    let elapsed = started_at.elapsed();
+                    downloaded as f64 / elapsed.as_secs_f64().max(0.001)
+                };
+
+                let eta = if speed > 0.0 {
+                    DownloadProgress::format_duration(Duration::from_secs_f64(
+                        remaining as f64 / speed,
+                    ))
                 } else {
                     "??".to_string()
                 };

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -682,7 +682,6 @@ pub(crate) struct DownloadProgress {
     downloaded: u64,
     total_size: u64,
     last_displayed: Instant,
-    started_at: Instant,
     /// Snapshot of downloaded bytes at the start of the current ETA window.
     window_downloaded: u64,
     /// Timestamp when the current ETA window started.
@@ -735,7 +734,6 @@ impl DownloadProgress {
             downloaded: 0,
             total_size,
             last_displayed: now,
-            started_at: now,
             window_downloaded: 0,
             window_started: now,
         }
@@ -778,20 +776,17 @@ impl DownloadProgress {
             let remaining = self.total_size.saturating_sub(self.downloaded);
             let window_elapsed = self.window_started.elapsed();
 
-            // Use a 30-second sliding window for speed calculation to produce
-            // accurate ETAs when throughput changes (e.g. extraction phase is
-            // slower than download). Falls back to cumulative average during the
-            // first 30 seconds.
-            let speed = if window_elapsed >= Duration::from_secs(30) {
-                let window_bytes = self.downloaded - self.window_downloaded;
-                let speed = window_bytes as f64 / window_elapsed.as_secs_f64();
+            // Speed is always computed from bytes downloaded within the current
+            // window, not from cumulative totals. This avoids wildly inflated
+            // speed after a resumable download retry (where `downloaded` jumps
+            // instantly to the resume offset). The window resets every 30 s so
+            // the ETA tracks changing throughput.
+            let window_bytes = self.downloaded - self.window_downloaded;
+            let speed = window_bytes as f64 / window_elapsed.as_secs_f64().max(0.001);
+            if window_elapsed >= Duration::from_secs(30) {
                 self.window_downloaded = self.downloaded;
                 self.window_started = Instant::now();
-                speed
-            } else {
-                let elapsed = self.started_at.elapsed();
-                self.downloaded as f64 / elapsed.as_secs_f64().max(0.001)
-            };
+            }
 
             let eta = if speed > 0.0 {
                 Duration::from_secs_f64(remaining as f64 / speed)
@@ -883,15 +878,12 @@ fn spawn_progress_display(progress: Arc<SharedProgress>) -> tokio::task::JoinHan
                 );
             } else {
                 let window_elapsed = window_started.elapsed();
-                let speed = if window_elapsed >= Duration::from_secs(30) {
-                    let s = (downloaded - window_downloaded) as f64 / window_elapsed.as_secs_f64();
+                let window_bytes = downloaded - window_downloaded;
+                let speed = window_bytes as f64 / window_elapsed.as_secs_f64().max(0.001);
+                if window_elapsed >= Duration::from_secs(30) {
                     window_downloaded = downloaded;
                     window_started = Instant::now();
-                    s
-                } else {
-                    let elapsed = started_at.elapsed();
-                    downloaded as f64 / elapsed.as_secs_f64().max(0.001)
-                };
+                }
 
                 let eta = if speed > 0.0 {
                     DownloadProgress::format_duration(Duration::from_secs_f64(
@@ -1225,6 +1217,7 @@ fn resumable_download(
             // Legacy single-download path: local progress bar
             let mut progress = DownloadProgress::new(current_total);
             progress.downloaded = start_offset;
+            progress.window_downloaded = start_offset;
             let mut writer = ProgressWriter { inner: BufWriter::new(file), progress };
             copy_result = io::copy(&mut reader, &mut writer);
             flush_result = writer.inner.flush();


### PR DESCRIPTION
The ETA calculation uses cumulative average speed (`total_downloaded / total_elapsed`), which breaks after a resumable download retry: the downloaded counter jumps instantly to the resume offset while elapsed resets to zero, producing an infinite speed estimate and "ETA: 0s" when minutes of download remain.

Real data from a 239 GB snapshot download with 7 retries (71 min total):

| After Retry | Progress | ETA Displayed | Actual Remaining |
|-------------|----------|---------------|------------------|
| #2 (18.91%) | 45.24 GB | **0s** | ~57 min |
| #3 (39.49%) | 94.48 GB | **0s** | ~42 min |
| #4 (47.06%) | 112.60 GB | **0s** | ~37 min |
| #5 (64.27%) | 153.76 GB | **0s** | ~27 min |
| #6 (82.74%) | 197.95 GB | **0s** | ~16 min |
| #7 (92.36%) | 220.98 GB | **0s** | ~7 min |

Root cause: after retry, `DownloadProgress` is recreated with `downloaded = resume_offset` but `started_at = now`, so `speed = resume_offset / 0.001s = ∞`.

Fix: replace cumulative average with window-relative speed that only counts bytes downloaded within the current 30-second window. On retry, `window_downloaded` is initialized to the resume offset so previously downloaded bytes are excluded from speed calculation entirely. This also simplifies the code into a single unified speed path and removes the now-unused `started_at` field.