### PR TITLE
fix(cli): include error details in shutdown log message

### DIFF
--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -71,7 +71,12 @@ impl CliRunner {
     ) -> Result<(), E>
     where
         F: Future<Output = Result<(), E>>,
-        E: Send + Sync + From<std::io::Error> + From<reth_tasks::PanickedTaskError> + 'static,
+        E: Send
+            + Sync
+            + std::fmt::Display
+            + From<std::io::Error>
+            + From<reth_tasks::PanickedTaskError>
+            + 'static,
     {
         let (context, task_manager_handle) = cli_context(&self.runtime);
 
@@ -81,8 +86,8 @@ impl CliRunner {
             run_until_ctrl_c(command(context)),
         ));
 
-        if command_res.is_err() {
-            error!(target: "reth::cli", "shutting down due to error");
+        if let Err(err) = &command_res {
+            error!(target: "reth::cli", %err, "shutting down due to error");
         } else {
             debug!(target: "reth::cli", "shutting down gracefully");
             // after the command has finished or exit signal was received we shutdown the
@@ -105,7 +110,12 @@ impl CliRunner {
     ) -> Result<(), E>
     where
         F: Future<Output = Result<(), E>> + Send + 'static,
-        E: Send + Sync + From<std::io::Error> + From<reth_tasks::PanickedTaskError> + 'static,
+        E: Send
+            + Sync
+            + std::fmt::Display
+            + From<std::io::Error>
+            + From<reth_tasks::PanickedTaskError>
+            + 'static,
     {
         let (context, task_manager_handle) = cli_context(&self.runtime);
 
@@ -122,8 +132,8 @@ impl CliRunner {
             ),
         ));
 
-        if command_res.is_err() {
-            error!(target: "reth::cli", "shutting down due to error");
+        if let Err(err) = &command_res {
+            error!(target: "reth::cli", %err, "shutting down due to error");
         } else {
             debug!(target: "reth::cli", "shutting down gracefully");
             self.runtime.graceful_shutdown_with_timeout(self.config.graceful_shutdown_timeout);


### PR DESCRIPTION
The "shutting down due to error" log message doesn't include the actual error, making log files useless for diagnosing startup failures. The error is only printed to stderr via `eprintln!` in main.rs, which is typically not captured when running under screen/systemd/nohup.

Real example from a node that crashed 4 times during setup — the log file shows:

```
2026-03-05T19:05:08Z ERROR reth::cli: shutting down due to error
2026-03-05T19:30:17Z ERROR reth::cli: shutting down due to error
2026-03-05T19:43:40Z ERROR reth::cli: shutting down due to error
2026-03-05T19:44:34Z ERROR reth::cli: shutting down due to error
```


No indication of what went wrong (JWT file corruption, DB lock, etc). The operator has to guess or reproduce the issue.

This adds the error to the log line by changing `command_res.is_err()` to `if let Err(err) = &command_res` and including `%err` in the tracing event. Requires adding `Display` bound to the generic error type, which all concrete callers (`eyre::Report`) already satisfy.
