### PR TITLE
feat(reth-bench): `--reorg` flag

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -22,7 +22,8 @@ use crate::{
         },
     },
     valid_payload::{
-        block_to_new_payload, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
+        block_to_new_payload_data, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
+        create_reorg_payload,
     },
 };
 use alloy_provider::{ext::DebugApi, Provider};
@@ -95,6 +96,14 @@ pub struct Command {
     )]
     rpc_block_buffer_size: usize,
 
+    /// Simulate 1-block deep reorgs at each height.
+    ///
+    /// When enabled, for each block the benchmark first sends a modified (non-canonical)
+    /// payload and makes it the head via FCU, then sends the canonical payload and
+    /// switches back. This measures how the engine handles chain reorganizations.
+    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    reorg: bool,
+
     #[command(flatten)]
     benchmark: BenchmarkArgs,
 }
@@ -113,6 +122,9 @@ impl Command {
                 self.persistence_threshold + 1,
                 self.persistence_threshold
             );
+        }
+        if self.reorg {
+            info!(target: "reth-bench", "Reorg mode enabled: each block will trigger a 1-block deep reorg");
         }
 
         // Set up waiter based on configured options
@@ -232,6 +244,8 @@ impl Command {
             }
         });
 
+        let reorg = self.reorg;
+
         let mut results = Vec::new();
         let mut blocks_processed = 0u64;
         let total_benchmark_duration = Instant::now();
@@ -256,8 +270,54 @@ impl Command {
                 finalized_block_hash: finalized,
             };
 
-            let (version, params) =
-                block_to_new_payload(block, is_optimism, rlp, use_reth_namespace)?;
+            let payload_data =
+                block_to_new_payload_data(block, is_optimism, rlp, use_reth_namespace)?;
+
+            // Reorg path: send a modified block first, make it head, then send the canonical
+            let mut reorg_new_payload_latency = None;
+            let mut reorg_fcu_latency = None;
+
+            if reorg {
+                if let (Some(payload), Some(sidecar)) =
+                    (&payload_data.payload, &payload_data.sidecar)
+                {
+                    let (reorg_hash, reorg_version, reorg_params) = create_reorg_payload(
+                        payload,
+                        sidecar,
+                        payload_data.is_optimism,
+                        payload_data.withdrawals_root,
+                        use_reth_namespace,
+                    )?;
+
+                    debug!(target: "reth-bench", ?block_number, ?reorg_hash, "Sending reorg payload");
+
+                    let reorg_np_start = Instant::now();
+                    call_new_payload_with_reth(&auth_provider, reorg_version, reorg_params).await?;
+                    reorg_new_payload_latency = Some(reorg_np_start.elapsed());
+
+                    let reorg_fcu_state = ForkchoiceState {
+                        head_block_hash: reorg_hash,
+                        safe_block_hash: safe,
+                        finalized_block_hash: finalized,
+                    };
+                    let reorg_fcu_start = Instant::now();
+                    call_forkchoice_updated_with_reth(
+                        &auth_provider,
+                        reorg_version,
+                        reorg_fcu_state,
+                    )
+                    .await?;
+                    reorg_fcu_latency = Some(reorg_fcu_start.elapsed());
+
+                    debug!(target: "reth-bench", ?block_number, "Reorg block adopted, now sending canonical");
+                } else {
+                    warn!(target: "reth-bench", ?block_number, "Reorg mode skipped: RLP blocks don't support reorg");
+                }
+            }
+
+            let version = payload_data.version;
+            let params = payload_data.params;
+
             let start = Instant::now();
             let server_timings =
                 call_new_payload_with_reth(&auth_provider, version, params).await?;
@@ -297,6 +357,8 @@ impl Command {
                 new_payload_result,
                 fcu_latency,
                 total_latency,
+                reorg_new_payload_latency,
+                reorg_fcu_latency,
             };
 
             // Exclude time spent waiting on the block prefetch channel from the benchmark duration.

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     valid_payload::{
         block_to_new_payload_data, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
-        create_reorg_payload,
+        create_reorg_payload, NewPayloadTimingBreakdown,
     },
 };
 use alloy_provider::{ext::DebugApi, Provider};
@@ -274,7 +274,7 @@ impl Command {
                 block_to_new_payload_data(block, is_optimism, rlp, use_reth_namespace)?;
 
             // Reorg path: send a modified block first, make it head, then send the canonical
-            let mut reorg_new_payload_latency = None;
+            let mut reorg_new_payload_timings = None;
             let mut reorg_fcu_latency = None;
 
             if reorg {
@@ -292,8 +292,14 @@ impl Command {
                     debug!(target: "reth-bench", ?block_number, ?reorg_hash, "Sending reorg payload");
 
                     let reorg_np_start = Instant::now();
-                    call_new_payload_with_reth(&auth_provider, reorg_version, reorg_params).await?;
-                    reorg_new_payload_latency = Some(reorg_np_start.elapsed());
+                    let reorg_server_timings =
+                        call_new_payload_with_reth(&auth_provider, reorg_version, reorg_params)
+                            .await?;
+                    reorg_new_payload_timings =
+                        Some(reorg_server_timings.unwrap_or_else(|| NewPayloadTimingBreakdown {
+                            latency: reorg_np_start.elapsed(),
+                            ..Default::default()
+                        }));
 
                     let reorg_fcu_state = ForkchoiceState {
                         head_block_hash: reorg_hash,
@@ -357,7 +363,7 @@ impl Command {
                 new_payload_result,
                 fcu_latency,
                 total_latency,
-                reorg_new_payload_latency,
+                reorg_new_payload_timings,
                 reorg_fcu_latency,
             };
 

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -103,6 +103,10 @@ pub(crate) struct CombinedResult {
     pub(crate) fcu_latency: Duration,
     /// The latency of both calls combined.
     pub(crate) total_latency: Duration,
+    /// Latency of the reorg `newPayload` call (only when `--reorg` is enabled).
+    pub(crate) reorg_new_payload_latency: Option<Duration>,
+    /// Latency of the reorg `forkchoiceUpdated` call (only when `--reorg` is enabled).
+    pub(crate) reorg_fcu_latency: Option<Duration>,
 }
 
 impl CombinedResult {
@@ -134,6 +138,12 @@ impl std::fmt::Display for CombinedResult {
         if let Some(d) = np.persistence_wait {
             write!(f, ", persistence wait: {d:?}")?;
         }
+        if let Some(d) = self.reorg_new_payload_latency {
+            write!(f, ", reorg newPayload: {d:?}")?;
+        }
+        if let Some(d) = self.reorg_fcu_latency {
+            write!(f, ", reorg fcu: {d:?}")?;
+        }
         Ok(())
     }
 }
@@ -149,7 +159,7 @@ impl Serialize for CombinedResult {
         let fcu_latency = self.fcu_latency.as_micros();
         let new_payload_latency = self.new_payload_result.latency.as_micros();
         let total_latency = self.total_latency.as_micros();
-        let mut state = serializer.serialize_struct("CombinedResult", 10)?;
+        let mut state = serializer.serialize_struct("CombinedResult", 12)?;
 
         // flatten the new payload result because this is meant for CSV writing
         state.serialize_field("block_number", &self.block_number)?;
@@ -171,6 +181,12 @@ impl Serialize for CombinedResult {
             "sparse_trie_wait",
             &self.new_payload_result.sparse_trie_wait.as_micros(),
         )?;
+        state.serialize_field(
+            "reorg_new_payload_latency",
+            &self.reorg_new_payload_latency.map(|d| d.as_micros()),
+        )?;
+        state
+            .serialize_field("reorg_fcu_latency", &self.reorg_fcu_latency.map(|d| d.as_micros()))?;
         state.end()
     }
 }

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -1,6 +1,7 @@
 //! Contains various benchmark output formats, either for logging or for
 //! serialization to / from files.
 
+use crate::valid_payload::NewPayloadTimingBreakdown;
 use alloy_primitives::B256;
 use csv::Writer;
 use eyre::OptionExt;
@@ -103,8 +104,9 @@ pub(crate) struct CombinedResult {
     pub(crate) fcu_latency: Duration,
     /// The latency of both calls combined.
     pub(crate) total_latency: Duration,
-    /// Latency of the reorg `newPayload` call (only when `--reorg` is enabled).
-    pub(crate) reorg_new_payload_latency: Option<Duration>,
+    /// Server-side timing breakdown for the reorg `newPayload` call (only when `--reorg` is
+    /// enabled).
+    pub(crate) reorg_new_payload_timings: Option<NewPayloadTimingBreakdown>,
     /// Latency of the reorg `forkchoiceUpdated` call (only when `--reorg` is enabled).
     pub(crate) reorg_fcu_latency: Option<Duration>,
 }
@@ -138,8 +140,17 @@ impl std::fmt::Display for CombinedResult {
         if let Some(d) = np.persistence_wait {
             write!(f, ", persistence wait: {d:?}")?;
         }
-        if let Some(d) = self.reorg_new_payload_latency {
-            write!(f, ", reorg newPayload: {d:?}")?;
+        if let Some(ref reorg) = self.reorg_new_payload_timings {
+            write!(f, ", reorg newPayload: {:?}", reorg.latency)?;
+            if !reorg.execution_cache_wait.is_zero() {
+                write!(f, ", reorg execution cache wait: {:?}", reorg.execution_cache_wait)?;
+            }
+            if !reorg.sparse_trie_wait.is_zero() {
+                write!(f, ", reorg trie cache wait: {:?}", reorg.sparse_trie_wait)?;
+            }
+            if let Some(d) = reorg.persistence_wait {
+                write!(f, ", reorg persistence wait: {d:?}")?;
+            }
         }
         if let Some(d) = self.reorg_fcu_latency {
             write!(f, ", reorg fcu: {d:?}")?;
@@ -159,7 +170,7 @@ impl Serialize for CombinedResult {
         let fcu_latency = self.fcu_latency.as_micros();
         let new_payload_latency = self.new_payload_result.latency.as_micros();
         let total_latency = self.total_latency.as_micros();
-        let mut state = serializer.serialize_struct("CombinedResult", 12)?;
+        let mut state = serializer.serialize_struct("CombinedResult", 15)?;
 
         // flatten the new payload result because this is meant for CSV writing
         state.serialize_field("block_number", &self.block_number)?;
@@ -183,7 +194,22 @@ impl Serialize for CombinedResult {
         )?;
         state.serialize_field(
             "reorg_new_payload_latency",
-            &self.reorg_new_payload_latency.map(|d| d.as_micros()),
+            &self.reorg_new_payload_timings.as_ref().map(|t| t.latency.as_micros()),
+        )?;
+        state.serialize_field(
+            "reorg_persistence_wait",
+            &self
+                .reorg_new_payload_timings
+                .as_ref()
+                .and_then(|t| t.persistence_wait.map(|d| d.as_micros())),
+        )?;
+        state.serialize_field(
+            "reorg_execution_cache_wait",
+            &self.reorg_new_payload_timings.as_ref().map(|t| t.execution_cache_wait.as_micros()),
+        )?;
+        state.serialize_field(
+            "reorg_sparse_trie_wait",
+            &self.reorg_new_payload_timings.as_ref().map(|t| t.sparse_trie_wait.as_micros()),
         )?;
         state
             .serialize_field("reorg_fcu_latency", &self.reorg_fcu_latency.map(|d| d.as_micros()))?;

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -401,6 +401,8 @@ impl Command {
                 new_payload_result,
                 fcu_latency,
                 total_latency,
+                reorg_new_payload_latency: None,
+                reorg_fcu_latency: None,
             };
 
             let current_duration = total_benchmark_duration.elapsed();

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -401,7 +401,7 @@ impl Command {
                 new_payload_result,
                 fcu_latency,
                 total_latency,
-                reorg_new_payload_latency: None,
+                reorg_new_payload_timings: None,
                 reorg_fcu_latency: None,
             };
 

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -164,6 +164,25 @@ where
     }
 }
 
+/// Intermediate data from converting an RPC block to engine API params.
+///
+/// Contains both the final versioned params and the intermediate payload/sidecar
+/// needed for creating reorg variants.
+pub(crate) struct NewPayloadData {
+    /// Engine API version. `None` when using `reth_newPayload`.
+    pub(crate) version: Option<EngineApiMessageVersion>,
+    /// Serialized params for the engine API call.
+    pub(crate) params: serde_json::Value,
+    /// The execution payload (for creating reorg variants). `None` when using RLP blocks.
+    pub(crate) payload: Option<ExecutionPayload>,
+    /// The execution payload sidecar. `None` when using RLP blocks.
+    pub(crate) sidecar: Option<ExecutionPayloadSidecar>,
+    /// Whether this is an Optimism payload.
+    pub(crate) is_optimism: bool,
+    /// The withdrawals root from the original block.
+    pub(crate) withdrawals_root: Option<B256>,
+}
+
 /// Converts an RPC block into versioned engine API params and an [`ExecutionData`].
 ///
 /// Returns `(version, versioned_params, execution_data)`.
@@ -173,11 +192,27 @@ pub(crate) fn block_to_new_payload(
     rlp: Option<Bytes>,
     reth_new_payload: bool,
 ) -> eyre::Result<(Option<EngineApiMessageVersion>, serde_json::Value)> {
+    let data = block_to_new_payload_data(block, is_optimism, rlp, reth_new_payload)?;
+    Ok((data.version, data.params))
+}
+
+/// Converts an RPC block into [`NewPayloadData`] containing both the versioned params
+/// and the intermediate payload/sidecar needed for creating reorg variants.
+pub(crate) fn block_to_new_payload_data(
+    block: AnyRpcBlock,
+    is_optimism: bool,
+    rlp: Option<Bytes>,
+    reth_new_payload: bool,
+) -> eyre::Result<NewPayloadData> {
     if let Some(rlp) = rlp {
-        return Ok((
-            None,
-            serde_json::to_value((RethNewPayloadInput::<ExecutionData>::BlockRlp(rlp),))?,
-        ));
+        return Ok(NewPayloadData {
+            version: None,
+            params: serde_json::to_value((RethNewPayloadInput::<ExecutionData>::BlockRlp(rlp),))?,
+            payload: None,
+            sidecar: None,
+            is_optimism,
+            withdrawals_root: None,
+        });
     }
     let block = block
         .into_inner()
@@ -189,15 +224,71 @@ pub(crate) fn block_to_new_payload(
         .into_consensus();
 
     // Convert to execution payload
+    let withdrawals_root = block.withdrawals_root;
     let (payload, sidecar) = ExecutionPayload::from_block_slow(&block);
-    let (version, params, execution_data) =
-        payload_to_new_payload(payload, sidecar, is_optimism, block.withdrawals_root, None)?;
+    let (version, params, execution_data) = payload_to_new_payload(
+        payload.clone(),
+        sidecar.clone(),
+        is_optimism,
+        withdrawals_root,
+        None,
+    )?;
 
-    if reth_new_payload {
-        Ok((None, serde_json::to_value((RethNewPayloadInput::ExecutionData(execution_data),))?))
+    let (version, params) = if reth_new_payload {
+        (None, serde_json::to_value((RethNewPayloadInput::ExecutionData(execution_data),))?)
     } else {
-        Ok((Some(version), params))
+        (Some(version), params)
+    };
+
+    Ok(NewPayloadData {
+        version,
+        params,
+        payload: Some(payload),
+        sidecar: Some(sidecar),
+        is_optimism,
+        withdrawals_root,
+    })
+}
+
+/// Creates a reorg variant of the given payload by modifying `extra_data` and recomputing
+/// the block hash.
+///
+/// Returns the new block hash and versioned params for the engine API call.
+pub(crate) fn create_reorg_payload(
+    payload: &ExecutionPayload,
+    sidecar: &ExecutionPayloadSidecar,
+    is_optimism: bool,
+    withdrawals_root: Option<B256>,
+    reth_new_payload: bool,
+) -> eyre::Result<(B256, Option<EngineApiMessageVersion>, serde_json::Value)> {
+    let mut payload = payload.clone();
+
+    // Modify extra_data to produce a different block hash
+    let v1 = payload.as_v1_mut();
+    let mut extra = v1.extra_data.to_vec();
+    if extra.is_empty() {
+        extra.push(0x00);
+    } else {
+        extra[0] ^= 0xFF;
     }
+    v1.extra_data = extra.into();
+
+    // Recompute block hash from the modified payload
+    let block = payload.clone().into_block_with_sidecar_raw(sidecar)?;
+    let new_hash = block.header.hash_slow();
+    payload.as_v1_mut().block_hash = new_hash;
+
+    // Convert to versioned params
+    let (version, params, execution_data) =
+        payload_to_new_payload(payload, sidecar.clone(), is_optimism, withdrawals_root, None)?;
+
+    let (version, params) = if reth_new_payload {
+        (None, serde_json::to_value((RethNewPayloadInput::ExecutionData(execution_data),))?)
+    } else {
+        (Some(version), params)
+    };
+
+    Ok((new_hash, version, params))
 }
 
 /// Converts an execution payload and sidecar into versioned engine API params and an


### PR DESCRIPTION
Adds support for simulating 1-block deep chain reorgs during newPayload/FCU benchmarks.

When `--reorg` is enabled, each block height triggers: send modified payload-> FCU to make it head -> send canonical payload -> FCU to reorg back. The modified block differs only in extra_data (XOR first byte), keeping execution results identical.