### PR TITLE
fix(net): log message kind when session command buffer is full

### DIFF
--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -84,11 +84,13 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
     pub fn message_item_count(&self) -> usize {
         match self {
             Self::NewBlockHashes(msg) => msg.len(),
-            Self::NewBlock(_) => 1,
             Self::ReceivedTransaction(msg) => msg.len(),
             Self::SendTransactions(msg) => msg.len(),
             Self::PooledTransactions(msg) => msg.len(),
-            Self::EthRequest(_) | Self::BlockRangeUpdated(_) | Self::Other(_) => 1,
+            Self::NewBlock(_) |
+            Self::EthRequest(_) |
+            Self::BlockRangeUpdated(_) |
+            Self::Other(_) => 1,
         }
     }
 }

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -65,6 +65,22 @@ pub enum PeerMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     Other(RawCapabilityMessage),
 }
 
+impl<N: NetworkPrimitives> PeerMessage<N> {
+    /// Returns a static string identifying the message variant for logging.
+    pub const fn message_kind(&self) -> &'static str {
+        match self {
+            Self::NewBlockHashes(_) => "NewBlockHashes",
+            Self::NewBlock(_) => "NewBlock",
+            Self::ReceivedTransaction(_) => "ReceivedTransaction",
+            Self::SendTransactions(_) => "SendTransactions",
+            Self::PooledTransactions(_) => "PooledTransactions",
+            Self::EthRequest(_) => "EthRequest",
+            Self::BlockRangeUpdated(_) => "BlockRangeUpdated",
+            Self::Other(_) => "Other",
+        }
+    }
+}
+
 /// Request Variants that only target block related data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockRequest {

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -79,6 +79,18 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
             Self::Other(_) => "Other",
         }
     }
+
+    /// Returns the number of items in the message payload, if applicable.
+    pub fn message_item_count(&self) -> usize {
+        match self {
+            Self::NewBlockHashes(msg) => msg.len(),
+            Self::NewBlock(_) => 1,
+            Self::ReceivedTransaction(msg) => msg.len(),
+            Self::SendTransactions(msg) => msg.len(),
+            Self::PooledTransactions(msg) => msg.len(),
+            Self::EthRequest(_) | Self::BlockRangeUpdated(_) | Self::Other(_) => 1,
+        }
+    }
 }
 
 /// Request Variants that only target block related data.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -377,10 +377,11 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         if let Some(session) = self.active_sessions.get(peer_id) {
             let _ = session.commands_to_session.try_send(SessionCommand::Message(msg)).inspect_err(
                 |e| {
-                    if let TrySendError::Full(_) = e {
+                    if let TrySendError::Full(SessionCommand::Message(msg)) = e {
                         debug!(
                             target: "net::session",
                             ?peer_id,
+                            msg_kind = msg.message_kind(),
                             "session command buffer full, dropping message"
                         );
                         self.metrics.total_outgoing_peer_messages_dropped.increment(1);

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -382,6 +382,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                             target: "net::session",
                             ?peer_id,
                             msg_kind = msg.message_kind(),
+                            items = msg.message_item_count(),
                             "session command buffer full, dropping message"
                         );
                         self.metrics.total_outgoing_peer_messages_dropped.increment(1);


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/pull/22819

Adds `PeerMessage::message_kind()` that returns a static string for each variant. The `session command buffer full` debug log now includes `msg_kind` so we can see which message types are being dropped for a given peer.

Co-Authored-By: Matthias Seitz <19890894+mattsse@users.noreply.github.com>

Prompted by: mattsse