### PR TITLE
perf(net): size-based backpressure for session broadcast messages

### DIFF
--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -93,6 +93,18 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
             Self::Other(_) => 1,
         }
     }
+
+    /// Returns `true` if this message is a broadcast (block/transaction announcement or
+    /// propagation) rather than a request/response.
+    pub const fn is_broadcast(&self) -> bool {
+        matches!(
+            self,
+            Self::NewBlockHashes(_) |
+                Self::NewBlock(_) |
+                Self::SendTransactions(_) |
+                Self::PooledTransactions(_)
+        )
+    }
 }
 
 /// Request Variants that only target block related data.

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -6,7 +6,10 @@ use std::{
     future::Future,
     net::SocketAddr,
     pin::Pin,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize},
+        Arc,
+    },
     task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
@@ -28,7 +31,7 @@ use reth_eth_wire::{
     message::{EthBroadcastMessage, MessageError},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
 };
-use reth_eth_wire_types::{message::RequestPair, RawCapabilityMessage};
+use reth_eth_wire_types::{message::RequestPair, NewPooledTransactionHashes, RawCapabilityMessage};
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::PeerRequest;
 use reth_network_p2p::error::RequestError;
@@ -76,6 +79,17 @@ const TIMEOUT_SCALING: u32 = 3;
 /// before reading any more messages from the remote peer, throttling the peer.
 const MAX_QUEUED_OUTGOING_RESPONSES: usize = 4;
 
+/// Soft limit for the number of queued outgoing broadcast items (e.g. transaction hashes).
+///
+/// Many individual broadcast messages carrying a single tx hash each are equivalent in cost to
+/// one message carrying many hashes. This limit counts the total number of broadcast items
+/// (hashes, transactions, etc.) rather than the number of messages, so that many small messages
+/// don't trigger aggressive backpressure unnecessarily.
+///
+/// Once the number of buffered broadcast items exceeds this limit, new broadcast messages sent via
+/// [`SessionManager::send_message`](super::SessionManager::send_message) will be dropped.
+pub(super) const MAX_QUEUED_BROADCAST_ITEMS: usize = 4096;
+
 /// The type that advances an established session by listening for incoming messages (from local
 /// node or read from connection) and emitting events back to the
 /// [`SessionManager`](super::SessionManager).
@@ -113,6 +127,12 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     pub(crate) received_requests_from_remote: Vec<ReceivedRequest<N>>,
     /// Buffered messages that should be handled and sent to the peer.
     pub(crate) queued_outgoing: QueuedOutgoingMessages<N>,
+    /// Shared counter tracking the total number of buffered broadcast items (e.g. tx hashes).
+    ///
+    /// This is shared with the [`ActiveSessionHandle`](super::handle::ActiveSessionHandle) so the
+    /// [`SessionManager`](super::SessionManager) can apply size-based backpressure without
+    /// relying solely on the command channel capacity.
+    pub(crate) queued_broadcast_items: Arc<AtomicUsize>,
     /// The maximum time we wait for a response from a peer.
     pub(crate) internal_request_timeout: Arc<AtomicU64>,
     /// Interval when to check for timed out requests.
@@ -357,14 +377,22 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     fn on_internal_peer_message(&mut self, msg: PeerMessage<N>) {
         match msg {
             PeerMessage::NewBlockHashes(msg) => {
+                let count = msg.0.len();
                 self.queued_outgoing.push_back(EthMessage::NewBlockHashes(msg).into());
+                self.queued_broadcast_items.fetch_add(count, Ordering::Relaxed);
             }
             PeerMessage::NewBlock(msg) => {
                 self.queued_outgoing.push_back(EthBroadcastMessage::NewBlock(msg.block).into());
+                self.queued_broadcast_items.fetch_add(1, Ordering::Relaxed);
             }
             PeerMessage::PooledTransactions(msg) => {
                 if msg.is_valid_for_version(self.conn.version()) {
-                    self.queued_outgoing.push_back(EthMessage::from(msg).into());
+                    let count = msg.len();
+                    // Try to batch with the last queued message if it's the same announcement type
+                    if !self.queued_outgoing.try_merge_pooled_hashes(&msg) {
+                        self.queued_outgoing.push_back(EthMessage::from(msg).into());
+                    }
+                    self.queued_broadcast_items.fetch_add(count, Ordering::Relaxed);
                 } else {
                     debug!(target: "net", ?msg,  version=?self.conn.version(), "Message is invalid for connection version, skipping");
                 }
@@ -374,7 +402,9 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 self.on_internal_peer_request(req, deadline);
             }
             PeerMessage::SendTransactions(msg) => {
+                let count = msg.len();
                 self.queued_outgoing.push_back(EthBroadcastMessage::Transactions(msg).into());
+                self.queued_broadcast_items.fetch_add(count, Ordering::Relaxed);
             }
             PeerMessage::BlockRangeUpdated(_) => {}
             PeerMessage::ReceivedTransaction(_) => {
@@ -656,6 +686,11 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             while this.conn.poll_ready_unpin(cx).is_ready() {
                 if let Some(msg) = this.queued_outgoing.pop_front() {
                     progress = true;
+                    // Decrement the shared broadcast item counter
+                    let items = msg.broadcast_item_count();
+                    if items > 0 {
+                        this.queued_broadcast_items.fetch_sub(items, Ordering::Relaxed);
+                    }
                     let res = match msg {
                         OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
                         OutgoingMessage::Broadcast(msg) => this.conn.start_send_broadcast(msg),
@@ -894,6 +929,27 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
             _ => false,
         }
     }
+
+    /// Returns the number of broadcast items contained in this message.
+    ///
+    /// For transaction hash announcements this is the number of hashes, for full transaction
+    /// broadcasts it is the number of transactions, and for other broadcast types it is 1.
+    /// Request/response messages return 0.
+    fn broadcast_item_count(&self) -> usize {
+        match self {
+            Self::Eth(msg) => match msg {
+                EthMessage::NewBlockHashes(h) => h.0.len(),
+                EthMessage::NewPooledTransactionHashes66(h) => h.0.len(),
+                EthMessage::NewPooledTransactionHashes68(h) => h.hashes.len(),
+                _ => 0,
+            },
+            Self::Broadcast(msg) => match msg {
+                EthBroadcastMessage::NewBlock(_) => 1,
+                EthBroadcastMessage::Transactions(txs) => txs.len(),
+            },
+            Self::Raw(_) => 0,
+        }
+    }
 }
 
 impl<N: NetworkPrimitives> From<EthMessage<N>> for OutgoingMessage<N> {
@@ -941,6 +997,35 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
 
     pub(crate) fn shrink_to_fit(&mut self) {
         self.messages.shrink_to_fit();
+    }
+
+    /// Tries to merge the given pooled transaction hash announcement into the last queued
+    /// message if it is the same variant (eth66 or eth68).
+    ///
+    /// Returns `true` if the hashes were merged, `false` if a new message must be pushed.
+    fn try_merge_pooled_hashes(&mut self, msg: &NewPooledTransactionHashes) -> bool {
+        let Some(last) = self.messages.back_mut() else { return false };
+        let OutgoingMessage::Eth(last_eth) = last else { return false };
+
+        match (last_eth, msg) {
+            (
+                EthMessage::NewPooledTransactionHashes66(existing),
+                NewPooledTransactionHashes::Eth66(incoming),
+            ) => {
+                existing.0.extend_from_slice(&incoming.0);
+                true
+            }
+            (
+                EthMessage::NewPooledTransactionHashes68(existing),
+                NewPooledTransactionHashes::Eth68(incoming),
+            ) => {
+                existing.hashes.extend_from_slice(&incoming.hashes);
+                existing.sizes.extend_from_slice(&incoming.sizes);
+                existing.types.extend_from_slice(&incoming.types);
+                true
+            }
+            _ => false,
+        }
     }
 }
 
@@ -1086,6 +1171,7 @@ mod tests {
                         inflight_requests: Default::default(),
                         conn,
                         queued_outgoing: QueuedOutgoingMessages::new(Gauge::noop()),
+                        queued_broadcast_items: Arc::new(AtomicUsize::new(0)),
                         received_requests_from_remote: Default::default(),
                         internal_request_timeout_interval: tokio::time::interval(
                             INITIAL_REQUEST_TIMEOUT,

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -13,7 +13,15 @@ use reth_eth_wire::{
 use reth_network_api::PeerInfo;
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::PeerKind;
-use std::{io, net::SocketAddr, sync::Arc, time::Instant};
+use std::{
+    io,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
 use tokio::sync::{
     mpsc::{self, error::SendError},
     oneshot,
@@ -67,6 +75,10 @@ pub struct ActiveSessionHandle<N: NetworkPrimitives> {
     pub(crate) capabilities: Arc<Capabilities>,
     /// Sender half of the command channel used send commands _to_ the spawned session
     pub(crate) commands_to_session: mpsc::Sender<SessionCommand<N>>,
+    /// Shared counter tracking the total number of buffered broadcast items in the session task.
+    ///
+    /// Used by [`SessionManager`](super::SessionManager) for size-based backpressure.
+    pub(crate) queued_broadcast_items: Arc<AtomicUsize>,
     /// The client's name and version
     pub(crate) client_version: Arc<str>,
     /// The address we're connected to
@@ -133,6 +145,11 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
     /// Returns the address we're connected to.
     pub const fn remote_addr(&self) -> SocketAddr {
         self.remote_addr
+    }
+
+    /// Returns the current number of buffered broadcast items in the session task.
+    pub fn queued_broadcast_items(&self) -> usize {
+        self.queued_broadcast_items.load(Ordering::Relaxed)
     }
 
     /// Extracts the [`PeerInfo`] from the session handle.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -35,7 +35,10 @@ use std::{
     collections::HashMap,
     future::Future,
     net::SocketAddr,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize},
+        Arc,
+    },
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -46,7 +49,7 @@ use tokio::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
-use tracing::{debug, instrument, trace};
+use tracing::{instrument, trace};
 
 use crate::session::active::RANGE_UPDATE_INTERVAL;
 pub use conn::EthRlpxConnection;
@@ -372,13 +375,26 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         }
     }
 
-    /// Sends a message to the peer's session
+    /// Sends a message to the peer's session.
+    ///
+    /// Applies size-based backpressure: instead of relying solely on the command channel capacity,
+    /// this checks the total number of buffered broadcast items (e.g. transaction hashes) in the
+    /// session task. Many small messages carrying a single tx hash each are treated equivalently to
+    /// one large message carrying many hashes, avoiding overly aggressive drops when broadcast
+    /// volume is actually modest.
     pub fn send_message(&self, peer_id: &PeerId, msg: PeerMessage<N>) {
         if let Some(session) = self.active_sessions.get(peer_id) {
+            // Check size-based soft limit before sending broadcast messages.
+            if msg.is_broadcast() &&
+                session.queued_broadcast_items() >= active::MAX_QUEUED_BROADCAST_ITEMS
+            {
+                self.metrics.total_outgoing_peer_messages_dropped.increment(1);
+                return;
+            }
             let _ = session.commands_to_session.try_send(SessionCommand::Message(msg)).inspect_err(
                 |e| {
                     if let TrySendError::Full(SessionCommand::Message(msg)) = e {
-                        debug!(
+                        trace!(
                             target: "net::session",
                             ?peer_id,
                             msg_kind = msg.message_kind(),
@@ -537,6 +553,8 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     self.initial_internal_request_timeout.as_millis() as u64,
                 ));
 
+                let queued_broadcast_items = Arc::new(AtomicUsize::new(0));
+
                 // negotiated version
                 let version = conn.version();
 
@@ -566,6 +584,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     queued_outgoing: QueuedOutgoingMessages::new(
                         self.metrics.queued_outgoing_messages.clone(),
                     ),
+                    queued_broadcast_items: Arc::clone(&queued_broadcast_items),
                     received_requests_from_remote: Default::default(),
                     internal_request_timeout_interval: tokio::time::interval(
                         self.initial_internal_request_timeout,
@@ -591,6 +610,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     established: Instant::now(),
                     capabilities: Arc::clone(&capabilities),
                     commands_to_session,
+                    queued_broadcast_items,
                     client_version: Arc::clone(&client_version),
                     remote_addr,
                     local_addr,


### PR DESCRIPTION
Closes #22819 (supersedes the rate-limiting approach with a proper fix)

The `session command buffer full, dropping message` spam (595 lines/sec from a single peer) happens because backpressure is purely count-based: 100 messages with 1 tx hash each fill the channel (capacity 32) just as fast as 1 message with 100 hashes, even though the actual data volume is identical.

This switches to size-based backpressure that tracks the total number of buffered broadcast items (tx hashes, transactions, blocks) across the session boundary via a shared atomic counter. The key changes:

- `ActiveSession` and `ActiveSessionHandle` share an `Arc<AtomicUsize>` counting buffered broadcast items
- `send_message` checks total broadcast items against a soft limit (`MAX_QUEUED_BROADCAST_ITEMS = 4096`) before sending — non-broadcast messages (requests/responses) are unaffected
- Consecutive `NewPooledTransactionHashes` of the same variant (eth66/eth68) are batched into a single outgoing message in `queued_outgoing`, reducing message count without losing any hashes
- The `buffer full` log is downgraded from `debug!` to `trace!` since the metric already tracks drops

Prompted by: mattsse