### PR TITLE
feat(tracing): enable trace_id on OTLP log records

### DIFF
--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -41,6 +41,7 @@ otlp = [
 otlp-logs = [
     "otlp",
     "opentelemetry-appender-tracing",
+    "opentelemetry-appender-tracing/experimental_use_tracing_span_context",
     "opentelemetry-otlp/logs",
     "opentelemetry_sdk/logs",
 ]


### PR DESCRIPTION
Enable `experimental_use_tracing_span_context` on `opentelemetry-appender-tracing` so log records exported via OTLP include `trace_id` and `span_id` from enclosing `#[instrument]` spans.

Today the `OpenTelemetryTracingBridge` (log layer) only reads trace context from spans created via the native OTel API. Reth uses `tracing` crate spans (`#[instrument]`, `info_span!`), so logs are exported without trace context — making log ↔ trace correlation impossible.

With this feature the bridge reads `OtelData` from `tracing-opentelemetry` span extensions and calls `log_record.set_trace_context(trace_id, span_id)`. No dep version change — same `opentelemetry-appender-tracing 0.31` and `tracing-opentelemetry 0.32` already in the workspace.

Note: this feature is removed in the next upstream release because `tracing-opentelemetry 0.32` now natively activates OTel context on span entry. Next dep bump = drop the flag.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk