### PR TITLE
feat(payload): add tracing spans and timing histograms to payload building path

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -37,7 +37,7 @@ use reth_transaction_pool::{
     ValidPoolTransaction,
 };
 use revm::context_interface::Block as _;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tracing::{debug, debug_span, trace, warn};
 
 mod config;
@@ -151,13 +151,17 @@ where
 {
     let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
     let PayloadConfig { parent_header, attributes } = config;
-    let metrics = PayloadBuilderMetrics::default();
+
+    // Single process-wide metrics instance, matching how BlockValidationMetrics is stored
+    // as a field in the engine tree handler rather than re-created per call.
+    static METRICS: LazyLock<PayloadBuilderMetrics> = LazyLock::new(PayloadBuilderMetrics::default);
+    let metrics = &*METRICS;
 
     let state_provider = {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "state_provider").entered();
         let res = client.state_by_block_hash(parent_header.hash());
-        metrics.record_state_provider_duration(start.elapsed().as_secs_f64());
+        metrics.state_provider_duration_seconds.record(start.elapsed().as_secs_f64());
         res?
     };
     let mut db = {
@@ -168,7 +172,7 @@ where
             .with_database(cached_reads.as_db_mut(state))
             .with_bundle_update()
             .build();
-        metrics.record_build_state_db_duration(start.elapsed().as_secs_f64());
+        metrics.build_state_db_duration_seconds.record(start.elapsed().as_secs_f64());
         db
     };
 
@@ -190,7 +194,7 @@ where
                 },
             )
             .map_err(PayloadBuilderError::other);
-        metrics.record_create_evm_duration(start.elapsed().as_secs_f64());
+        metrics.create_evm_duration_seconds.record(start.elapsed().as_secs_f64());
         res?
     };
 
@@ -210,11 +214,12 @@ where
     {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
-        builder.apply_pre_execution_changes().map_err(|err| {
+        let res = builder.apply_pre_execution_changes().map_err(|err| {
             warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
             PayloadBuilderError::Internal(err.into())
-        })?;
-        metrics.record_pre_execution_duration(start.elapsed().as_secs_f64());
+        });
+        metrics.pre_execution_duration_seconds.record(start.elapsed().as_secs_f64());
+        res?;
     }
 
     // initialize empty blob sidecars at first. If cancun is active then this will be populated by
@@ -239,151 +244,173 @@ where
 
     let withdrawals_rlp_length = attributes.withdrawals().length();
 
-    let execute_transactions_start = Instant::now();
-    let _execute_span = debug_span!(target: "payload_builder", "execute_transactions").entered();
+    let execute_result = {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "execute_transactions").entered();
 
-    while let Some(pool_tx) = best_txs.next() {
-        // ensure we still have capacity for this transaction
-        if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
-            // we can't fit this transaction into the block, so we need to mark it as invalid
-            // which also removes all dependent transaction from the iterator before we can
-            // continue
-            best_txs.mark_invalid(
-                &pool_tx,
-                &InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
-            );
-            continue
-        }
-
-        // check if the job was cancelled, if so we can exit early
-        if cancel.is_cancelled() {
-            return Ok(BuildOutcome::Cancelled)
-        }
-
-        // convert tx to a signed transaction
-        let tx = pool_tx.to_consensus();
-
-        let tx_rlp_len = tx.inner().length();
-
-        let estimated_block_size_with_tx =
-            block_transactions_rlp_length + tx_rlp_len + withdrawals_rlp_length + 1024; // 1Kb of overhead for the block header
-
-        if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
-            best_txs.mark_invalid(
-                &pool_tx,
-                &InvalidPoolTransactionError::OversizedData {
-                    size: estimated_block_size_with_tx,
-                    limit: MAX_RLP_BLOCK_SIZE,
-                },
-            );
-            continue
-        }
-
-        // There's only limited amount of blob space available per block, so we need to check if
-        // the EIP-4844 can still fit in the block
-        let mut blob_tx_sidecar = None;
-        if let Some(blob_hashes) = tx.blob_versioned_hashes() {
-            let tx_blob_count = blob_hashes.len() as u64;
-
-            if block_blob_count + tx_blob_count > max_blob_count {
-                // we can't fit this _blob_ transaction into the block, so we mark it as
-                // invalid, which removes its dependent transactions from
-                // the iterator. This is similar to the gas limit condition
-                // for regular transactions above.
-                trace!(target: "payload_builder", tx=?tx.hash(), ?block_blob_count, "skipping blob transaction because it would exceed the max blob count per block");
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::Eip4844(
-                        Eip4844PoolTransactionError::TooManyEip4844Blobs {
-                            have: block_blob_count + tx_blob_count,
-                            permitted: max_blob_count,
-                        },
-                    ),
-                );
-                continue
-            }
-
-            let blob_sidecar_result = 'sidecar: {
-                let Some(sidecar) =
-                    pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
-                else {
-                    break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar)
-                };
-
-                if is_osaka {
-                    if sidecar.is_eip7594() {
-                        Ok(sidecar)
-                    } else {
-                        Err(Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka)
-                    }
-                } else if sidecar.is_eip4844() {
-                    Ok(sidecar)
-                } else {
-                    Err(Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka)
-                }
-            };
-
-            blob_tx_sidecar = match blob_sidecar_result {
-                Ok(sidecar) => Some(sidecar),
-                Err(error) => {
-                    best_txs.mark_invalid(&pool_tx, &InvalidPoolTransactionError::Eip4844(error));
-                    continue
-                }
-            };
-        }
-
-        let gas_used = match builder.execute_transaction(tx.clone()) {
-            Ok(gas_used) => gas_used,
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
-                error, ..
-            })) => {
-                if error.is_nonce_too_low() {
-                    // if the nonce is too low, we can skip this transaction
-                    trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
-                } else {
-                    // if the transaction is invalid, we can skip it and all of its
-                    // descendants
-                    trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
+        let res = 'tx_loop: {
+            while let Some(pool_tx) = best_txs.next() {
+                // ensure we still have capacity for this transaction
+                if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
+                    // we can't fit this transaction into the block, so we need to mark it as
+                    // invalid which also removes all dependent transaction from the iterator
+                    // before we can continue
                     best_txs.mark_invalid(
                         &pool_tx,
-                        &InvalidPoolTransactionError::Consensus(
-                            InvalidTransactionError::TxTypeNotSupported,
+                        &InvalidPoolTransactionError::ExceedsGasLimit(
+                            pool_tx.gas_limit(),
+                            block_gas_limit,
                         ),
                     );
+                    continue
                 }
-                continue
+
+                // check if the job was cancelled, if so we can exit early
+                if cancel.is_cancelled() {
+                    break 'tx_loop Ok(Some(BuildOutcome::Cancelled))
+                }
+
+                // convert tx to a signed transaction
+                let tx = pool_tx.to_consensus();
+
+                let tx_rlp_len = tx.inner().length();
+
+                let estimated_block_size_with_tx =
+                    block_transactions_rlp_length + tx_rlp_len + withdrawals_rlp_length + 1024; // 1Kb of overhead for the block header
+
+                if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        &InvalidPoolTransactionError::OversizedData {
+                            size: estimated_block_size_with_tx,
+                            limit: MAX_RLP_BLOCK_SIZE,
+                        },
+                    );
+                    continue
+                }
+
+                // There's only limited amount of blob space available per block, so we need to
+                // check if the EIP-4844 can still fit in the block
+                let mut blob_tx_sidecar = None;
+                if let Some(blob_hashes) = tx.blob_versioned_hashes() {
+                    let tx_blob_count = blob_hashes.len() as u64;
+
+                    if block_blob_count + tx_blob_count > max_blob_count {
+                        // we can't fit this _blob_ transaction into the block, so we mark it
+                        // as invalid, which removes its dependent transactions from
+                        // the iterator. This is similar to the gas limit condition
+                        // for regular transactions above.
+                        trace!(target: "payload_builder", tx=?tx.hash(), ?block_blob_count, "skipping blob transaction because it would exceed the max blob count per block");
+                        best_txs.mark_invalid(
+                            &pool_tx,
+                            &InvalidPoolTransactionError::Eip4844(
+                                Eip4844PoolTransactionError::TooManyEip4844Blobs {
+                                    have: block_blob_count + tx_blob_count,
+                                    permitted: max_blob_count,
+                                },
+                            ),
+                        );
+                        continue
+                    }
+
+                    let blob_sidecar_result = 'sidecar: {
+                        let Some(sidecar) =
+                            pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
+                        else {
+                            break 'sidecar Err(
+                                Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
+                            )
+                        };
+
+                        if is_osaka {
+                            if sidecar.is_eip7594() {
+                                Ok(sidecar)
+                            } else {
+                                Err(Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka)
+                            }
+                        } else if sidecar.is_eip4844() {
+                            Ok(sidecar)
+                        } else {
+                            Err(Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka)
+                        }
+                    };
+
+                    blob_tx_sidecar = match blob_sidecar_result {
+                        Ok(sidecar) => Some(sidecar),
+                        Err(error) => {
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::Eip4844(error),
+                            );
+                            continue
+                        }
+                    };
+                }
+
+                let gas_used = match builder.execute_transaction(tx.clone()) {
+                    Ok(gas_used) => gas_used,
+                    Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                        error,
+                        ..
+                    })) => {
+                        if error.is_nonce_too_low() {
+                            // if the nonce is too low, we can skip this transaction
+                            trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
+                            trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::Consensus(
+                                    InvalidTransactionError::TxTypeNotSupported,
+                                ),
+                            );
+                        }
+                        continue
+                    }
+                    // this is an error that we should treat as fatal for this attempt
+                    Err(err) => break 'tx_loop Err(PayloadBuilderError::evm(err)),
+                };
+
+                // add to the total blob gas used if the transaction successfully executed
+                if let Some(blob_hashes) = tx.blob_versioned_hashes() {
+                    block_blob_count += blob_hashes.len() as u64;
+
+                    // if we've reached the max blob count, we can skip blob txs entirely
+                    if block_blob_count == max_blob_count {
+                        best_txs.skip_blobs();
+                    }
+                }
+
+                block_transactions_rlp_length += tx_rlp_len;
+
+                // update and add to total fees
+                let miner_fee = tx
+                    .effective_tip_per_gas(base_fee)
+                    .expect("fee is always valid; execution succeeded");
+                total_fees += U256::from(miner_fee) * U256::from(gas_used);
+                cumulative_gas_used += gas_used;
+
+                // Add blob tx sidecar to the payload.
+                if let Some(sidecar) = blob_tx_sidecar {
+                    blob_sidecars.push_sidecar_variant(sidecar.as_ref().clone());
+                }
             }
-            // this is an error that we should treat as fatal for this attempt
-            Err(err) => return Err(PayloadBuilderError::evm(err)),
+
+            Ok(None)
         };
 
-        // add to the total blob gas used if the transaction successfully executed
-        if let Some(blob_hashes) = tx.blob_versioned_hashes() {
-            block_blob_count += blob_hashes.len() as u64;
+        metrics.execute_transactions_duration_seconds.record(start.elapsed().as_secs_f64());
+        res
+    };
 
-            // if we've reached the max blob count, we can skip blob txs entirely
-            if block_blob_count == max_blob_count {
-                best_txs.skip_blobs();
-            }
-        }
-
-        block_transactions_rlp_length += tx_rlp_len;
-
-        // update and add to total fees
-        let miner_fee =
-            tx.effective_tip_per_gas(base_fee).expect("fee is always valid; execution succeeded");
-        total_fees += U256::from(miner_fee) * U256::from(gas_used);
-        cumulative_gas_used += gas_used;
-
-        // Add blob tx sidecar to the payload.
-        if let Some(sidecar) = blob_tx_sidecar {
-            blob_sidecars.push_sidecar_variant(sidecar.as_ref().clone());
-        }
+    // Handle early exit from transaction execution (cancellation or fatal error)
+    match execute_result {
+        Ok(Some(outcome)) => return Ok(outcome),
+        Err(err) => return Err(err),
+        Ok(None) => {}
     }
-
-    drop(_execute_span);
-    metrics
-        .record_execute_transactions_duration(execute_transactions_start.elapsed().as_secs_f64());
 
     // check if we have a better block
     if !is_better_payload(best_payload.as_ref(), total_fees) {
@@ -397,7 +424,7 @@ where
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "finish_block").entered();
         let res = builder.finish(state_provider.as_ref());
-        metrics.record_finish_block_duration(start.elapsed().as_secs_f64());
+        metrics.finish_block_duration_seconds.record(start.elapsed().as_secs_f64());
         res?
     };
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -313,10 +313,15 @@ where
                         continue
                     }
 
+                    // Avoid `?` inside 'tx_loop — use `break` so duration
+                    // metrics are always recorded.
+                    let maybe_sidecar = match pool.get_blob(*tx.hash()) {
+                        Ok(sidecar) => sidecar,
+                        Err(err) => break 'tx_loop Err(PayloadBuilderError::other(err)),
+                    };
+
                     let blob_sidecar_result = 'sidecar: {
-                        let Some(sidecar) =
-                            pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
-                        else {
+                        let Some(sidecar) = maybe_sidecar else {
                             break 'sidecar Err(
                                 Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
                             )

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -14,7 +14,7 @@ use alloy_primitives::U256;
 use alloy_rlp::Encodable;
 use reth_basic_payload_builder::{
     is_better_payload, BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder,
-    PayloadConfig,
+    PayloadBuilderMetrics, PayloadConfig,
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
@@ -28,7 +28,7 @@ use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
-use reth_primitives_traits::transaction::error::InvalidTransactionError;
+use reth_primitives_traits::{transaction::error::InvalidTransactionError, FastInstant as Instant};
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{
@@ -38,7 +38,7 @@ use reth_transaction_pool::{
 };
 use revm::context_interface::Block as _;
 use std::sync::Arc;
-use tracing::{debug, trace, warn};
+use tracing::{debug, debug_span, trace, warn};
 
 mod config;
 pub use config::*;
@@ -151,27 +151,48 @@ where
 {
     let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
     let PayloadConfig { parent_header, attributes } = config;
+    let metrics = PayloadBuilderMetrics::default();
 
-    let state_provider = client.state_by_block_hash(parent_header.hash())?;
-    let state = StateProviderDatabase::new(state_provider.as_ref());
-    let mut db =
-        State::builder().with_database(cached_reads.as_db_mut(state)).with_bundle_update().build();
+    let state_provider = {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "state_provider").entered();
+        let res = client.state_by_block_hash(parent_header.hash());
+        metrics.record_state_provider_duration(start.elapsed().as_secs_f64());
+        res?
+    };
+    let mut db = {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "build_state_db").entered();
+        let state = StateProviderDatabase::new(state_provider.as_ref());
+        let db = State::builder()
+            .with_database(cached_reads.as_db_mut(state))
+            .with_bundle_update()
+            .build();
+        metrics.record_build_state_db_duration(start.elapsed().as_secs_f64());
+        db
+    };
 
-    let mut builder = evm_config
-        .builder_for_next_block(
-            &mut db,
-            &parent_header,
-            NextBlockEnvAttributes {
-                timestamp: attributes.timestamp(),
-                suggested_fee_recipient: attributes.suggested_fee_recipient(),
-                prev_randao: attributes.prev_randao(),
-                gas_limit: builder_config.gas_limit(parent_header.gas_limit),
-                parent_beacon_block_root: attributes.parent_beacon_block_root(),
-                withdrawals: Some(attributes.withdrawals().clone()),
-                extra_data: builder_config.extra_data,
-            },
-        )
-        .map_err(PayloadBuilderError::other)?;
+    let mut builder = {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "create_evm").entered();
+        let res = evm_config
+            .builder_for_next_block(
+                &mut db,
+                &parent_header,
+                NextBlockEnvAttributes {
+                    timestamp: attributes.timestamp(),
+                    suggested_fee_recipient: attributes.suggested_fee_recipient(),
+                    prev_randao: attributes.prev_randao(),
+                    gas_limit: builder_config.gas_limit(parent_header.gas_limit),
+                    parent_beacon_block_root: attributes.parent_beacon_block_root(),
+                    withdrawals: Some(attributes.withdrawals().clone()),
+                    extra_data: builder_config.extra_data,
+                },
+            )
+            .map_err(PayloadBuilderError::other);
+        metrics.record_create_evm_duration(start.elapsed().as_secs_f64());
+        res?
+    };
 
     let chain_spec = client.chain_spec();
 
@@ -186,10 +207,15 @@ where
     ));
     let mut total_fees = U256::ZERO;
 
-    builder.apply_pre_execution_changes().map_err(|err| {
-        warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
-        PayloadBuilderError::Internal(err.into())
-    })?;
+    {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
+        builder.apply_pre_execution_changes().map_err(|err| {
+            warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
+            PayloadBuilderError::Internal(err.into())
+        })?;
+        metrics.record_pre_execution_duration(start.elapsed().as_secs_f64());
+    }
 
     // initialize empty blob sidecars at first. If cancun is active then this will be populated by
     // blob sidecars if any.
@@ -212,6 +238,9 @@ where
     let is_osaka = chain_spec.is_osaka_active_at_timestamp(attributes.timestamp);
 
     let withdrawals_rlp_length = attributes.withdrawals().length();
+
+    let execute_transactions_start = Instant::now();
+    let _execute_span = debug_span!(target: "payload_builder", "execute_transactions").entered();
 
     while let Some(pool_tx) = best_txs.next() {
         // ensure we still have capacity for this transaction
@@ -352,6 +381,10 @@ where
         }
     }
 
+    drop(_execute_span);
+    metrics
+        .record_execute_transactions_duration(execute_transactions_start.elapsed().as_secs_f64());
+
     // check if we have a better block
     if !is_better_payload(best_payload.as_ref(), total_fees) {
         // Release db
@@ -360,8 +393,13 @@ where
         return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }
 
-    let BlockBuilderOutcome { execution_result, block, .. } =
-        builder.finish(state_provider.as_ref())?;
+    let BlockBuilderOutcome { execution_result, block, .. } = {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "finish_block").entered();
+        let res = builder.finish(state_provider.as_ref());
+        metrics.record_finish_block_duration(start.elapsed().as_secs_f64());
+        res?
+    };
 
     let requests = chain_spec
         .is_prague_active_at_timestamp(attributes.timestamp)

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -8,7 +8,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use crate::metrics::PayloadBuilderMetrics;
 use alloy_eips::merge::SLOT_DURATION;
 use alloy_primitives::{B256, U256};
 use futures_core::ready;
@@ -34,7 +33,7 @@ use tokio::{
     sync::{oneshot, Semaphore},
     time::{Interval, Sleep},
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, debug_span, trace, warn, Span};
 
 mod better_payload_emitter;
 mod metrics;
@@ -42,6 +41,8 @@ mod stack;
 
 pub use better_payload_emitter::BetterPayloadEmitter;
 pub use stack::PayloadBuilderStack;
+
+pub use metrics::PayloadBuilderMetrics;
 
 /// Helper to access [`NodePrimitives::BlockHeader`] from [`PayloadBuilder::BuiltPayload`].
 pub type HeaderForPayload<P> = <<P as BuiltPayload>::Primitives as NodePrimitives>::BlockHeader;
@@ -346,9 +347,18 @@ where
         self.metrics.inc_initiated_payload_builds();
         let cached_reads = self.cached_reads.take().unwrap_or_default();
         let builder = self.builder.clone();
+        let parent_span = Span::current();
         self.executor.spawn_blocking_task(async move {
             // acquire the permit for executing the task
             let _permit = guard.acquire().await;
+            // span intentionally starts after semaphore acquisition to exclude wait time
+            let _span = debug_span!(
+                target: "payload_builder",
+                parent: parent_span,
+                "build_job",
+                id = %payload_config.payload_id()
+            )
+            .entered();
             let args =
                 BuildArguments { cached_reads, config: payload_config, cancel, best_payload };
             let result = builder.try_build(args);

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -1,17 +1,32 @@
 //! Metrics for the payload builder impl
 
-use reth_metrics::{metrics::Counter, Metrics};
+use reth_metrics::{
+    metrics::{Counter, Histogram},
+    Metrics,
+};
 
 /// Payload builder metrics
 #[derive(Metrics)]
 #[metrics(scope = "payloads")]
-pub(crate) struct PayloadBuilderMetrics {
+pub struct PayloadBuilderMetrics {
     /// Total number of times an empty payload was returned because a built one was not ready.
     pub(crate) requested_empty_payload: Counter,
     /// Total number of initiated payload build attempts.
     pub(crate) initiated_payload_builds: Counter,
     /// Total number of failed payload build attempts.
     pub(crate) failed_payload_builds: Counter,
+    /// Time spent fetching the parent state provider.
+    pub(crate) state_provider_duration_seconds: Histogram,
+    /// Time spent constructing the state DB wrapper.
+    pub(crate) build_state_db_duration_seconds: Histogram,
+    /// Time spent creating the EVM/block builder.
+    pub(crate) create_evm_duration_seconds: Histogram,
+    /// Time spent applying pre-execution changes.
+    pub(crate) pre_execution_duration_seconds: Histogram,
+    /// Time spent selecting and executing transactions.
+    pub(crate) execute_transactions_duration_seconds: Histogram,
+    /// Time spent finalizing and sealing the block.
+    pub(crate) finish_block_duration_seconds: Histogram,
 }
 
 impl PayloadBuilderMetrics {
@@ -25,5 +40,35 @@ impl PayloadBuilderMetrics {
 
     pub(crate) fn inc_failed_payload_builds(&self) {
         self.failed_payload_builds.increment(1);
+    }
+
+    /// Records the time spent fetching the parent state provider.
+    pub fn record_state_provider_duration(&self, duration_secs: f64) {
+        self.state_provider_duration_seconds.record(duration_secs);
+    }
+
+    /// Records the time spent constructing the state DB wrapper.
+    pub fn record_build_state_db_duration(&self, duration_secs: f64) {
+        self.build_state_db_duration_seconds.record(duration_secs);
+    }
+
+    /// Records the time spent creating the EVM/block builder.
+    pub fn record_create_evm_duration(&self, duration_secs: f64) {
+        self.create_evm_duration_seconds.record(duration_secs);
+    }
+
+    /// Records the time spent applying pre-execution changes.
+    pub fn record_pre_execution_duration(&self, duration_secs: f64) {
+        self.pre_execution_duration_seconds.record(duration_secs);
+    }
+
+    /// Records the time spent selecting and executing transactions.
+    pub fn record_execute_transactions_duration(&self, duration_secs: f64) {
+        self.execute_transactions_duration_seconds.record(duration_secs);
+    }
+
+    /// Records the time spent finalizing and sealing the block.
+    pub fn record_finish_block_duration(&self, duration_secs: f64) {
+        self.finish_block_duration_seconds.record(duration_secs);
     }
 }

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -16,17 +16,17 @@ pub struct PayloadBuilderMetrics {
     /// Total number of failed payload build attempts.
     pub(crate) failed_payload_builds: Counter,
     /// Time spent fetching the parent state provider.
-    pub(crate) state_provider_duration_seconds: Histogram,
+    pub state_provider_duration_seconds: Histogram,
     /// Time spent constructing the state DB wrapper.
-    pub(crate) build_state_db_duration_seconds: Histogram,
+    pub build_state_db_duration_seconds: Histogram,
     /// Time spent creating the EVM/block builder.
-    pub(crate) create_evm_duration_seconds: Histogram,
+    pub create_evm_duration_seconds: Histogram,
     /// Time spent applying pre-execution changes.
-    pub(crate) pre_execution_duration_seconds: Histogram,
+    pub pre_execution_duration_seconds: Histogram,
     /// Time spent selecting and executing transactions.
-    pub(crate) execute_transactions_duration_seconds: Histogram,
+    pub execute_transactions_duration_seconds: Histogram,
     /// Time spent finalizing and sealing the block.
-    pub(crate) finish_block_duration_seconds: Histogram,
+    pub finish_block_duration_seconds: Histogram,
 }
 
 impl PayloadBuilderMetrics {
@@ -40,35 +40,5 @@ impl PayloadBuilderMetrics {
 
     pub(crate) fn inc_failed_payload_builds(&self) {
         self.failed_payload_builds.increment(1);
-    }
-
-    /// Records the time spent fetching the parent state provider.
-    pub fn record_state_provider_duration(&self, duration_secs: f64) {
-        self.state_provider_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent constructing the state DB wrapper.
-    pub fn record_build_state_db_duration(&self, duration_secs: f64) {
-        self.build_state_db_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent creating the EVM/block builder.
-    pub fn record_create_evm_duration(&self, duration_secs: f64) {
-        self.create_evm_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent applying pre-execution changes.
-    pub fn record_pre_execution_duration(&self, duration_secs: f64) {
-        self.pre_execution_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent selecting and executing transactions.
-    pub fn record_execute_transactions_duration(&self, duration_secs: f64) {
-        self.execute_transactions_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent finalizing and sealing the block.
-    pub fn record_finish_block_duration(&self, duration_secs: f64) {
-        self.finish_block_duration_seconds.record(duration_secs);
     }
 }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -28,7 +28,7 @@ use tokio::sync::{
     watch,
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, debug_span, info, trace, warn};
 
 type PayloadFuture<P> = Pin<Box<dyn Future<Output = Result<P, PayloadBuilderError>> + Send>>;
 
@@ -303,6 +303,13 @@ where
         id: PayloadId,
         kind: PayloadKind,
     ) -> Option<PayloadFuture<T::BuiltPayload>> {
+        let _span = debug_span!(
+            target: "payload_builder",
+            "resolve",
+            %id,
+            ?kind,
+        )
+        .entered();
         debug!(target: "payload_builder", %id, "resolving payload job");
 
         if let Some((cached, _, payload)) = &*self.cached_payload_rx.borrow() &&
@@ -428,6 +435,13 @@ where
                 match cmd {
                     PayloadServiceCommand::BuildNewPayload(attr, tx) => {
                         let id = attr.payload_id();
+                        let _span = debug_span!(
+                            target: "payload_builder",
+                            "new_payload_job",
+                            %id,
+                            parent_hash = %attr.parent(),
+                        )
+                        .entered();
                         let mut res = Ok(id);
 
                         if this.contains_payload(id) {

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -439,7 +439,7 @@ where
                             target: "payload_builder",
                             "new_payload_job",
                             %id,
-                            parent_hash = %attr.parent(),
+                            parent = %attr.parent(),
                         )
                         .entered();
                         let mut res = Ok(id);


### PR DESCRIPTION
**Summary**
The payload building path had no tracing spans and no timing metrics. This adds phase-level spans and histograms so builds are visible in traces and dashboards.

- 6 histogram metrics (`state_provider`, `build_state_db`, `create_evm`, `pre_execution`, `execute_transactions`, `finish_block`) and `debug_span!` wrappers for each phase, with parent-span propagation into the spawned blocking task.

**Remaining (follow-up PRs)**
- Split `execute_transactions` into separate tx selection vs EVM execution spans
- Isolate state root computation from block assembly inside `finish_block`
- Instrument proof generation in the parallel state root pipeline (`crates/engine/tree/`)

Testing: https://github.com/paradigmxyz/reth/pull/22829#issuecomment-4009928190