### PR TITLE
perf(payload): skip blob txs early when max_blob_count is zero

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -209,6 +209,11 @@ where
         .map(|user_limit| std::cmp::min(user_limit, protocol_max_blob_count).max(1))
         .unwrap_or(protocol_max_blob_count);
 
+    // Skip blob transactions entirely if blobs are not allowed (e.g. pre-Cancun)
+    if max_blob_count == 0 {
+        best_txs.skip_blobs();
+    }
+
     let is_osaka = chain_spec.is_osaka_active_at_timestamp(attributes.timestamp);
 
     let withdrawals_rlp_length = attributes.withdrawals().length();
@@ -367,7 +372,7 @@ where
         .is_prague_active_at_timestamp(attributes.timestamp)
         .then_some(execution_result.requests);
 
-    let sealed_block = Arc::new(block.sealed_block().clone());
+    let sealed_block = Arc::new(block.into_sealed_block());
     debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
 
     if is_osaka && sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {


### PR DESCRIPTION
## Summary
Call `best_txs.skip_blobs()` immediately after computing `max_blob_count` when it's zero, avoiding per-tx blob inspection overhead in the build loop.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk