### PR TITLE
perf(payload): move sealed block instead of cloning

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -367,7 +367,7 @@ where
         .is_prague_active_at_timestamp(attributes.timestamp)
         .then_some(execution_result.requests);
 
-    let sealed_block = Arc::new(block.sealed_block().clone());
+    let sealed_block = Arc::new(block.into_sealed_block());
     debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
 
     if is_osaka && sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {


### PR DESCRIPTION
## Summary
Move owned `RecoveredBlock` into `Arc<SealedBlock>` instead of cloning via `.sealed_block().clone()`.

## Motivation
`default_ethereum_payload` runs every ~1s during a 12s slot. The `block` returned by `builder.finish()` is owned and not referenced after the sealed block extraction — the clone is unnecessary overhead.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk