### PR TITLE
fix(payload): use metrics singleton and fix inconsistent timing on error paths

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -37,7 +37,7 @@ use reth_transaction_pool::{
     ValidPoolTransaction,
 };
 use revm::context_interface::Block as _;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tracing::{debug, debug_span, trace, warn};
 
 mod config;
@@ -151,13 +151,17 @@ where
 {
     let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
     let PayloadConfig { parent_header, attributes } = config;
-    let metrics = PayloadBuilderMetrics::default();
+
+    // Single process-wide metrics instance, matching how BlockValidationMetrics is stored
+    // as a field in the engine tree handler rather than re-created per call.
+    static METRICS: LazyLock<PayloadBuilderMetrics> = LazyLock::new(PayloadBuilderMetrics::default);
+    let metrics = &*METRICS;
 
     let state_provider = {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "state_provider").entered();
         let res = client.state_by_block_hash(parent_header.hash());
-        metrics.record_state_provider_duration(start.elapsed().as_secs_f64());
+        metrics.state_provider_duration_seconds.record(start.elapsed().as_secs_f64());
         res?
     };
     let mut db = {
@@ -168,7 +172,7 @@ where
             .with_database(cached_reads.as_db_mut(state))
             .with_bundle_update()
             .build();
-        metrics.record_build_state_db_duration(start.elapsed().as_secs_f64());
+        metrics.build_state_db_duration_seconds.record(start.elapsed().as_secs_f64());
         db
     };
 
@@ -190,7 +194,7 @@ where
                 },
             )
             .map_err(PayloadBuilderError::other);
-        metrics.record_create_evm_duration(start.elapsed().as_secs_f64());
+        metrics.create_evm_duration_seconds.record(start.elapsed().as_secs_f64());
         res?
     };
 
@@ -210,11 +214,12 @@ where
     {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "pre_execution").entered();
-        builder.apply_pre_execution_changes().map_err(|err| {
+        let res = builder.apply_pre_execution_changes().map_err(|err| {
             warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
             PayloadBuilderError::Internal(err.into())
-        })?;
-        metrics.record_pre_execution_duration(start.elapsed().as_secs_f64());
+        });
+        metrics.pre_execution_duration_seconds.record(start.elapsed().as_secs_f64());
+        res?;
     }
 
     // initialize empty blob sidecars at first. If cancun is active then this will be populated by
@@ -239,151 +244,173 @@ where
 
     let withdrawals_rlp_length = attributes.withdrawals().length();
 
-    let execute_transactions_start = Instant::now();
-    let _execute_span = debug_span!(target: "payload_builder", "execute_transactions").entered();
+    let execute_result = {
+        let start = Instant::now();
+        let _span = debug_span!(target: "payload_builder", "execute_transactions").entered();
 
-    while let Some(pool_tx) = best_txs.next() {
-        // ensure we still have capacity for this transaction
-        if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
-            // we can't fit this transaction into the block, so we need to mark it as invalid
-            // which also removes all dependent transaction from the iterator before we can
-            // continue
-            best_txs.mark_invalid(
-                &pool_tx,
-                &InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
-            );
-            continue
-        }
-
-        // check if the job was cancelled, if so we can exit early
-        if cancel.is_cancelled() {
-            return Ok(BuildOutcome::Cancelled)
-        }
-
-        // convert tx to a signed transaction
-        let tx = pool_tx.to_consensus();
-
-        let tx_rlp_len = tx.inner().length();
-
-        let estimated_block_size_with_tx =
-            block_transactions_rlp_length + tx_rlp_len + withdrawals_rlp_length + 1024; // 1Kb of overhead for the block header
-
-        if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
-            best_txs.mark_invalid(
-                &pool_tx,
-                &InvalidPoolTransactionError::OversizedData {
-                    size: estimated_block_size_with_tx,
-                    limit: MAX_RLP_BLOCK_SIZE,
-                },
-            );
-            continue
-        }
-
-        // There's only limited amount of blob space available per block, so we need to check if
-        // the EIP-4844 can still fit in the block
-        let mut blob_tx_sidecar = None;
-        if let Some(blob_hashes) = tx.blob_versioned_hashes() {
-            let tx_blob_count = blob_hashes.len() as u64;
-
-            if block_blob_count + tx_blob_count > max_blob_count {
-                // we can't fit this _blob_ transaction into the block, so we mark it as
-                // invalid, which removes its dependent transactions from
-                // the iterator. This is similar to the gas limit condition
-                // for regular transactions above.
-                trace!(target: "payload_builder", tx=?tx.hash(), ?block_blob_count, "skipping blob transaction because it would exceed the max blob count per block");
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    &InvalidPoolTransactionError::Eip4844(
-                        Eip4844PoolTransactionError::TooManyEip4844Blobs {
-                            have: block_blob_count + tx_blob_count,
-                            permitted: max_blob_count,
-                        },
-                    ),
-                );
-                continue
-            }
-
-            let blob_sidecar_result = 'sidecar: {
-                let Some(sidecar) =
-                    pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
-                else {
-                    break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar)
-                };
-
-                if is_osaka {
-                    if sidecar.is_eip7594() {
-                        Ok(sidecar)
-                    } else {
-                        Err(Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka)
-                    }
-                } else if sidecar.is_eip4844() {
-                    Ok(sidecar)
-                } else {
-                    Err(Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka)
-                }
-            };
-
-            blob_tx_sidecar = match blob_sidecar_result {
-                Ok(sidecar) => Some(sidecar),
-                Err(error) => {
-                    best_txs.mark_invalid(&pool_tx, &InvalidPoolTransactionError::Eip4844(error));
-                    continue
-                }
-            };
-        }
-
-        let gas_used = match builder.execute_transaction(tx.clone()) {
-            Ok(gas_used) => gas_used,
-            Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
-                error, ..
-            })) => {
-                if error.is_nonce_too_low() {
-                    // if the nonce is too low, we can skip this transaction
-                    trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
-                } else {
-                    // if the transaction is invalid, we can skip it and all of its
-                    // descendants
-                    trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
+        let res = 'tx_loop: {
+            while let Some(pool_tx) = best_txs.next() {
+                // ensure we still have capacity for this transaction
+                if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
+                    // we can't fit this transaction into the block, so we need to mark it as
+                    // invalid which also removes all dependent transaction from the iterator
+                    // before we can continue
                     best_txs.mark_invalid(
                         &pool_tx,
-                        &InvalidPoolTransactionError::Consensus(
-                            InvalidTransactionError::TxTypeNotSupported,
+                        &InvalidPoolTransactionError::ExceedsGasLimit(
+                            pool_tx.gas_limit(),
+                            block_gas_limit,
                         ),
                     );
+                    continue
                 }
-                continue
+
+                // check if the job was cancelled, if so we can exit early
+                if cancel.is_cancelled() {
+                    break 'tx_loop Ok(Some(BuildOutcome::Cancelled))
+                }
+
+                // convert tx to a signed transaction
+                let tx = pool_tx.to_consensus();
+
+                let tx_rlp_len = tx.inner().length();
+
+                let estimated_block_size_with_tx =
+                    block_transactions_rlp_length + tx_rlp_len + withdrawals_rlp_length + 1024; // 1Kb of overhead for the block header
+
+                if is_osaka && estimated_block_size_with_tx > MAX_RLP_BLOCK_SIZE {
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        &InvalidPoolTransactionError::OversizedData {
+                            size: estimated_block_size_with_tx,
+                            limit: MAX_RLP_BLOCK_SIZE,
+                        },
+                    );
+                    continue
+                }
+
+                // There's only limited amount of blob space available per block, so we need to
+                // check if the EIP-4844 can still fit in the block
+                let mut blob_tx_sidecar = None;
+                if let Some(blob_hashes) = tx.blob_versioned_hashes() {
+                    let tx_blob_count = blob_hashes.len() as u64;
+
+                    if block_blob_count + tx_blob_count > max_blob_count {
+                        // we can't fit this _blob_ transaction into the block, so we mark it
+                        // as invalid, which removes its dependent transactions from
+                        // the iterator. This is similar to the gas limit condition
+                        // for regular transactions above.
+                        trace!(target: "payload_builder", tx=?tx.hash(), ?block_blob_count, "skipping blob transaction because it would exceed the max blob count per block");
+                        best_txs.mark_invalid(
+                            &pool_tx,
+                            &InvalidPoolTransactionError::Eip4844(
+                                Eip4844PoolTransactionError::TooManyEip4844Blobs {
+                                    have: block_blob_count + tx_blob_count,
+                                    permitted: max_blob_count,
+                                },
+                            ),
+                        );
+                        continue
+                    }
+
+                    let blob_sidecar_result = 'sidecar: {
+                        let Some(sidecar) =
+                            pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
+                        else {
+                            break 'sidecar Err(
+                                Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
+                            )
+                        };
+
+                        if is_osaka {
+                            if sidecar.is_eip7594() {
+                                Ok(sidecar)
+                            } else {
+                                Err(Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka)
+                            }
+                        } else if sidecar.is_eip4844() {
+                            Ok(sidecar)
+                        } else {
+                            Err(Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka)
+                        }
+                    };
+
+                    blob_tx_sidecar = match blob_sidecar_result {
+                        Ok(sidecar) => Some(sidecar),
+                        Err(error) => {
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::Eip4844(error),
+                            );
+                            continue
+                        }
+                    };
+                }
+
+                let gas_used = match builder.execute_transaction(tx.clone()) {
+                    Ok(gas_used) => gas_used,
+                    Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                        error,
+                        ..
+                    })) => {
+                        if error.is_nonce_too_low() {
+                            // if the nonce is too low, we can skip this transaction
+                            trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
+                            trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                &InvalidPoolTransactionError::Consensus(
+                                    InvalidTransactionError::TxTypeNotSupported,
+                                ),
+                            );
+                        }
+                        continue
+                    }
+                    // this is an error that we should treat as fatal for this attempt
+                    Err(err) => break 'tx_loop Err(PayloadBuilderError::evm(err)),
+                };
+
+                // add to the total blob gas used if the transaction successfully executed
+                if let Some(blob_hashes) = tx.blob_versioned_hashes() {
+                    block_blob_count += blob_hashes.len() as u64;
+
+                    // if we've reached the max blob count, we can skip blob txs entirely
+                    if block_blob_count == max_blob_count {
+                        best_txs.skip_blobs();
+                    }
+                }
+
+                block_transactions_rlp_length += tx_rlp_len;
+
+                // update and add to total fees
+                let miner_fee = tx
+                    .effective_tip_per_gas(base_fee)
+                    .expect("fee is always valid; execution succeeded");
+                total_fees += U256::from(miner_fee) * U256::from(gas_used);
+                cumulative_gas_used += gas_used;
+
+                // Add blob tx sidecar to the payload.
+                if let Some(sidecar) = blob_tx_sidecar {
+                    blob_sidecars.push_sidecar_variant(sidecar.as_ref().clone());
+                }
             }
-            // this is an error that we should treat as fatal for this attempt
-            Err(err) => return Err(PayloadBuilderError::evm(err)),
+
+            Ok(None)
         };
 
-        // add to the total blob gas used if the transaction successfully executed
-        if let Some(blob_hashes) = tx.blob_versioned_hashes() {
-            block_blob_count += blob_hashes.len() as u64;
+        metrics.execute_transactions_duration_seconds.record(start.elapsed().as_secs_f64());
+        res
+    };
 
-            // if we've reached the max blob count, we can skip blob txs entirely
-            if block_blob_count == max_blob_count {
-                best_txs.skip_blobs();
-            }
-        }
-
-        block_transactions_rlp_length += tx_rlp_len;
-
-        // update and add to total fees
-        let miner_fee =
-            tx.effective_tip_per_gas(base_fee).expect("fee is always valid; execution succeeded");
-        total_fees += U256::from(miner_fee) * U256::from(gas_used);
-        cumulative_gas_used += gas_used;
-
-        // Add blob tx sidecar to the payload.
-        if let Some(sidecar) = blob_tx_sidecar {
-            blob_sidecars.push_sidecar_variant(sidecar.as_ref().clone());
-        }
+    // Handle early exit from transaction execution (cancellation or fatal error)
+    match execute_result {
+        Ok(Some(outcome)) => return Ok(outcome),
+        Err(err) => return Err(err),
+        Ok(None) => {}
     }
-
-    drop(_execute_span);
-    metrics
-        .record_execute_transactions_duration(execute_transactions_start.elapsed().as_secs_f64());
 
     // check if we have a better block
     if !is_better_payload(best_payload.as_ref(), total_fees) {
@@ -397,7 +424,7 @@ where
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "finish_block").entered();
         let res = builder.finish(state_provider.as_ref());
-        metrics.record_finish_block_duration(start.elapsed().as_secs_f64());
+        metrics.finish_block_duration_seconds.record(start.elapsed().as_secs_f64());
         res?
     };
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -313,10 +313,15 @@ where
                         continue
                     }
 
+                    // Avoid `?` inside 'tx_loop — use `break` so duration
+                    // metrics are always recorded.
+                    let maybe_sidecar = match pool.get_blob(*tx.hash()) {
+                        Ok(sidecar) => sidecar,
+                        Err(err) => break 'tx_loop Err(PayloadBuilderError::other(err)),
+                    };
+
                     let blob_sidecar_result = 'sidecar: {
-                        let Some(sidecar) =
-                            pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
-                        else {
+                        let Some(sidecar) = maybe_sidecar else {
                             break 'sidecar Err(
                                 Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
                             )

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -16,17 +16,17 @@ pub struct PayloadBuilderMetrics {
     /// Total number of failed payload build attempts.
     pub(crate) failed_payload_builds: Counter,
     /// Time spent fetching the parent state provider.
-    pub(crate) state_provider_duration_seconds: Histogram,
+    pub state_provider_duration_seconds: Histogram,
     /// Time spent constructing the state DB wrapper.
-    pub(crate) build_state_db_duration_seconds: Histogram,
+    pub build_state_db_duration_seconds: Histogram,
     /// Time spent creating the EVM/block builder.
-    pub(crate) create_evm_duration_seconds: Histogram,
+    pub create_evm_duration_seconds: Histogram,
     /// Time spent applying pre-execution changes.
-    pub(crate) pre_execution_duration_seconds: Histogram,
+    pub pre_execution_duration_seconds: Histogram,
     /// Time spent selecting and executing transactions.
-    pub(crate) execute_transactions_duration_seconds: Histogram,
+    pub execute_transactions_duration_seconds: Histogram,
     /// Time spent finalizing and sealing the block.
-    pub(crate) finish_block_duration_seconds: Histogram,
+    pub finish_block_duration_seconds: Histogram,
 }
 
 impl PayloadBuilderMetrics {
@@ -40,35 +40,5 @@ impl PayloadBuilderMetrics {
 
     pub(crate) fn inc_failed_payload_builds(&self) {
         self.failed_payload_builds.increment(1);
-    }
-
-    /// Records the time spent fetching the parent state provider.
-    pub fn record_state_provider_duration(&self, duration_secs: f64) {
-        self.state_provider_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent constructing the state DB wrapper.
-    pub fn record_build_state_db_duration(&self, duration_secs: f64) {
-        self.build_state_db_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent creating the EVM/block builder.
-    pub fn record_create_evm_duration(&self, duration_secs: f64) {
-        self.create_evm_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent applying pre-execution changes.
-    pub fn record_pre_execution_duration(&self, duration_secs: f64) {
-        self.pre_execution_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent selecting and executing transactions.
-    pub fn record_execute_transactions_duration(&self, duration_secs: f64) {
-        self.execute_transactions_duration_seconds.record(duration_secs);
-    }
-
-    /// Records the time spent finalizing and sealing the block.
-    pub fn record_finish_block_duration(&self, duration_secs: f64) {
-        self.finish_block_duration_seconds.record(duration_secs);
     }
 }


### PR DESCRIPTION
Fixes three issues flagged in review of #22829:

1. **Metrics re-registration churn**: `PayloadBuilderMetrics::default()` was called per build, re-running `describe_*` each time. Now uses a `LazyLock` singleton — matching how `BlockValidationMetrics` is stored as a field in the engine tree handler.

2. **Inconsistent error-path recording**: `pre_execution` only recorded on success while `state_provider`/`create_evm`/`finish_block` recorded regardless. Fixed to always record (helps diagnose slow failures in dashboards).

3. **Missing histogram on early return**: The `execute_transactions` loop used bare `return` for cancellation and fatal EVM errors, skipping the histogram entirely. Wrapped in a scoped block with `break 'tx_loop` so the histogram always fires.

Also removed the boilerplate `record_*` wrapper methods in favor of direct `pub` histogram field access — consistent with how `BlockValidationMetrics` exposes its histograms.

Prompted by: yk