### PR TITLE
feat(observability): fine-grained payload building instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8751,6 +8751,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -280,8 +280,11 @@ where
                         unreachable!("we own the sender half")
                     };
 
+                    self.metrics.proof_calculation_duration_histogram.record(result.elapsed);
+
                     let mut result = result.result?;
                     while let Ok(next) = self.proof_result_rx.try_recv() {
+                        self.metrics.proof_calculation_duration_histogram.record(next.elapsed);
                         let res = next.result?;
                         result.extend(res);
                     }

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -14,7 +14,7 @@ use alloy_primitives::U256;
 use alloy_rlp::Encodable;
 use reth_basic_payload_builder::{
     is_better_payload, BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder,
-    PayloadConfig,
+    PayloadBuilderMetrics, PayloadConfig,
 };
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
@@ -28,7 +28,7 @@ use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
-use reth_primitives_traits::transaction::error::InvalidTransactionError;
+use reth_primitives_traits::{transaction::error::InvalidTransactionError, FastInstant as Instant};
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{
@@ -37,7 +37,7 @@ use reth_transaction_pool::{
     ValidPoolTransaction,
 };
 use revm::context_interface::Block as _;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tracing::{debug, trace, warn};
 
 mod config;
@@ -213,7 +213,13 @@ where
 
     let withdrawals_rlp_length = attributes.withdrawals().length();
 
+    let metrics = PayloadBuilderMetrics::default();
+    let mut total_selection_time = Duration::ZERO;
+    let mut total_evm_time = Duration::ZERO;
+
     while let Some(pool_tx) = best_txs.next() {
+        let selection_start = Instant::now();
+
         // ensure we still have capacity for this transaction
         if cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit {
             // we can't fit this transaction into the block, so we need to mark it as invalid
@@ -223,11 +229,14 @@ where
                 &pool_tx,
                 &InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
             );
+            total_selection_time += selection_start.elapsed();
             continue
         }
 
         // check if the job was cancelled, if so we can exit early
         if cancel.is_cancelled() {
+            metrics.record_tx_selection_duration(total_selection_time.as_secs_f64());
+            metrics.record_evm_execution_duration(total_evm_time.as_secs_f64());
             return Ok(BuildOutcome::Cancelled)
         }
 
@@ -247,6 +256,7 @@ where
                     limit: MAX_RLP_BLOCK_SIZE,
                 },
             );
+            total_selection_time += selection_start.elapsed();
             continue
         }
 
@@ -271,6 +281,7 @@ where
                         },
                     ),
                 );
+                total_selection_time += selection_start.elapsed();
                 continue
             }
 
@@ -298,16 +309,24 @@ where
                 Ok(sidecar) => Some(sidecar),
                 Err(error) => {
                     best_txs.mark_invalid(&pool_tx, &InvalidPoolTransactionError::Eip4844(error));
+                    total_selection_time += selection_start.elapsed();
                     continue
                 }
             };
         }
 
+        total_selection_time += selection_start.elapsed();
+
+        let evm_start = Instant::now();
         let gas_used = match builder.execute_transaction(tx.clone()) {
-            Ok(gas_used) => gas_used,
+            Ok(gas_used) => {
+                total_evm_time += evm_start.elapsed();
+                gas_used
+            }
             Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                 error, ..
             })) => {
+                total_evm_time += evm_start.elapsed();
                 if error.is_nonce_too_low() {
                     // if the nonce is too low, we can skip this transaction
                     trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
@@ -325,7 +344,12 @@ where
                 continue
             }
             // this is an error that we should treat as fatal for this attempt
-            Err(err) => return Err(PayloadBuilderError::evm(err)),
+            Err(err) => {
+                total_evm_time += evm_start.elapsed();
+                metrics.record_tx_selection_duration(total_selection_time.as_secs_f64());
+                metrics.record_evm_execution_duration(total_evm_time.as_secs_f64());
+                return Err(PayloadBuilderError::evm(err))
+            }
         };
 
         // add to the total blob gas used if the transaction successfully executed
@@ -351,6 +375,9 @@ where
             blob_sidecars.push_sidecar_variant(sidecar.as_ref().clone());
         }
     }
+
+    metrics.record_tx_selection_duration(total_selection_time.as_secs_f64());
+    metrics.record_evm_execution_duration(total_evm_time.as_secs_f64());
 
     // check if we have a better block
     if !is_better_payload(best_payload.as_ref(), total_fees) {

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -237,6 +237,8 @@ where
         if cancel.is_cancelled() {
             metrics.record_tx_selection_duration(total_selection_time.as_secs_f64());
             metrics.record_evm_execution_duration(total_evm_time.as_secs_f64());
+            drop(builder);
+            metrics.record_cache_stats(&cached_reads.drain_stats());
             return Ok(BuildOutcome::Cancelled)
         }
 
@@ -286,9 +288,18 @@ where
             }
 
             let blob_sidecar_result = 'sidecar: {
-                let Some(sidecar) =
-                    pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
-                else {
+                let blob_result = pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other);
+                let Some(sidecar) = (match blob_result {
+                    Ok(sidecar) => sidecar,
+                    Err(err) => {
+                        total_selection_time += selection_start.elapsed();
+                        metrics.record_tx_selection_duration(total_selection_time.as_secs_f64());
+                        metrics.record_evm_execution_duration(total_evm_time.as_secs_f64());
+                        drop(builder);
+                        metrics.record_cache_stats(&cached_reads.drain_stats());
+                        return Err(err)
+                    }
+                }) else {
                     break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar)
                 };
 
@@ -348,6 +359,8 @@ where
                 total_evm_time += evm_start.elapsed();
                 metrics.record_tx_selection_duration(total_selection_time.as_secs_f64());
                 metrics.record_evm_execution_duration(total_evm_time.as_secs_f64());
+                drop(builder);
+                metrics.record_cache_stats(&cached_reads.drain_stats());
                 return Err(PayloadBuilderError::evm(err))
             }
         };
@@ -383,12 +396,15 @@ where
     if !is_better_payload(best_payload.as_ref(), total_fees) {
         // Release db
         drop(builder);
+        metrics.record_cache_stats(&cached_reads.drain_stats());
         // can skip building the block
         return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }
 
     let BlockBuilderOutcome { execution_result, block, .. } =
         builder.finish(state_provider.as_ref())?;
+
+    metrics.record_cache_stats(&cached_reads.drain_stats());
 
     let requests = chain_spec
         .is_prague_active_at_timestamp(attributes.timestamp)

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -402,7 +402,13 @@ where
     }
 
     let BlockBuilderOutcome { execution_result, block, .. } =
-        builder.finish(state_provider.as_ref())?;
+        match builder.finish(state_provider.as_ref()) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                metrics.record_cache_stats(&cached_reads.drain_stats());
+                return Err(PayloadBuilderError::from(err));
+            }
+        };
 
     metrics.record_cache_stats(&cached_reads.drain_stats());
 

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -31,6 +31,7 @@ alloy-consensus.workspace = true
 auto_impl.workspace = true
 derive_more.workspace = true
 futures-util.workspace = true
+tracing.workspace = true
 metrics = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -56,6 +56,7 @@ std = [
     "reth-storage-api/std",
     "reth-trie-common/std",
     "reth-ethereum-primitives/std",
+    "tracing/std",
 ]
 metrics = ["std", "dep:metrics", "dep:reth-metrics"]
 test-utils = [

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -25,6 +25,7 @@ use revm::{
     context::result::ExecutionResult,
     database::{states::bundle_state::BundleRetention, BundleState, State},
 };
+use tracing::debug_span;
 
 /// A type that knows how to execute a block. It is assumed to operate on a
 /// [`crate::Evm`] internally and use [`State`] as database.
@@ -485,24 +486,31 @@ where
         db.merge_transitions(BundleRetention::Reverts);
 
         // calculate the state root
-        let hashed_state = state.hashed_post_state(&db.bundle_state);
-        let (state_root, trie_updates) = state
-            .state_root_with_updates(hashed_state.clone())
-            .map_err(BlockExecutionError::other)?;
+        let (hashed_state, state_root, trie_updates) = {
+            let _span = debug_span!(target: "evm::execute", "state_root").entered();
+            let hashed_state = state.hashed_post_state(&db.bundle_state);
+            let (state_root, trie_updates) = state
+                .state_root_with_updates(hashed_state.clone())
+                .map_err(BlockExecutionError::other)?;
+            (hashed_state, state_root, trie_updates)
+        };
 
         let (transactions, senders) =
             self.transactions.into_iter().map(|tx| tx.into_parts()).unzip();
 
-        let block = self.assembler.assemble_block(BlockAssemblerInput {
-            evm_env,
-            execution_ctx: self.ctx,
-            parent: self.parent,
-            transactions,
-            output: &result,
-            bundle_state: &db.bundle_state,
-            state_provider: &state,
-            state_root,
-        })?;
+        let block = {
+            let _span = debug_span!(target: "evm::execute", "assemble_block").entered();
+            self.assembler.assemble_block(BlockAssemblerInput {
+                evm_env,
+                execution_ctx: self.ctx,
+                parent: self.parent,
+                transactions,
+                output: &result,
+                bundle_state: &db.bundle_state,
+                state_provider: &state,
+                state_root,
+            })?
+        };
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use crate::metrics::PayloadBuilderMetrics;
+
 use alloy_eips::merge::SLOT_DURATION;
 use alloy_primitives::{B256, U256};
 use futures_core::ready;
@@ -38,6 +38,7 @@ use tracing::{debug, trace, warn};
 
 mod better_payload_emitter;
 mod metrics;
+pub use metrics::PayloadBuilderMetrics;
 mod stack;
 
 pub use better_payload_emitter::BetterPayloadEmitter;

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -8,7 +8,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-
 use alloy_eips::merge::SLOT_DURATION;
 use alloy_primitives::{B256, U256};
 use futures_core::ready;

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -19,6 +19,22 @@ pub struct PayloadBuilderMetrics {
     pub(crate) tx_selection_duration_seconds: Histogram,
     /// Time spent on EVM transaction execution within the execution loop.
     pub(crate) evm_execution_duration_seconds: Histogram,
+    /// Number of account read cache hits during payload building.
+    pub(crate) state_cache_account_hits: Counter,
+    /// Number of account read cache misses during payload building.
+    pub(crate) state_cache_account_misses: Counter,
+    /// Number of storage read cache hits during payload building.
+    pub(crate) state_cache_storage_hits: Counter,
+    /// Number of storage read cache misses during payload building.
+    pub(crate) state_cache_storage_misses: Counter,
+    /// Number of code read cache hits during payload building.
+    pub(crate) state_cache_code_hits: Counter,
+    /// Number of code read cache misses during payload building.
+    pub(crate) state_cache_code_misses: Counter,
+    /// Number of block hash read cache hits during payload building.
+    pub(crate) state_cache_block_hash_hits: Counter,
+    /// Number of block hash read cache misses during payload building.
+    pub(crate) state_cache_block_hash_misses: Counter,
 }
 
 impl PayloadBuilderMetrics {
@@ -42,5 +58,17 @@ impl PayloadBuilderMetrics {
     /// Records the cumulative time spent on EVM transaction execution.
     pub fn record_evm_execution_duration(&self, duration_secs: f64) {
         self.evm_execution_duration_seconds.record(duration_secs);
+    }
+
+    /// Records cache hit/miss statistics from a payload build pass.
+    pub fn record_cache_stats(&self, stats: &reth_revm::cached::CacheStats) {
+        self.state_cache_account_hits.increment(stats.account_hits);
+        self.state_cache_account_misses.increment(stats.account_misses);
+        self.state_cache_storage_hits.increment(stats.storage_hits);
+        self.state_cache_storage_misses.increment(stats.storage_misses);
+        self.state_cache_code_hits.increment(stats.code_hits);
+        self.state_cache_code_misses.increment(stats.code_misses);
+        self.state_cache_block_hash_hits.increment(stats.block_hash_hits);
+        self.state_cache_block_hash_misses.increment(stats.block_hash_misses);
     }
 }

--- a/crates/payload/basic/src/metrics.rs
+++ b/crates/payload/basic/src/metrics.rs
@@ -1,17 +1,24 @@
 //! Metrics for the payload builder impl
 
-use reth_metrics::{metrics::Counter, Metrics};
+use reth_metrics::{
+    metrics::{Counter, Histogram},
+    Metrics,
+};
 
 /// Payload builder metrics
 #[derive(Metrics)]
 #[metrics(scope = "payloads")]
-pub(crate) struct PayloadBuilderMetrics {
+pub struct PayloadBuilderMetrics {
     /// Total number of times an empty payload was returned because a built one was not ready.
     pub(crate) requested_empty_payload: Counter,
     /// Total number of initiated payload build attempts.
     pub(crate) initiated_payload_builds: Counter,
     /// Total number of failed payload build attempts.
     pub(crate) failed_payload_builds: Counter,
+    /// Time spent on transaction selection and validation within the execution loop.
+    pub(crate) tx_selection_duration_seconds: Histogram,
+    /// Time spent on EVM transaction execution within the execution loop.
+    pub(crate) evm_execution_duration_seconds: Histogram,
 }
 
 impl PayloadBuilderMetrics {
@@ -25,5 +32,15 @@ impl PayloadBuilderMetrics {
 
     pub(crate) fn inc_failed_payload_builds(&self) {
         self.failed_payload_builds.increment(1);
+    }
+
+    /// Records the cumulative time spent on transaction selection and validation.
+    pub fn record_tx_selection_duration(&self, duration_secs: f64) {
+        self.tx_selection_duration_seconds.record(duration_secs);
+    }
+
+    /// Records the cumulative time spent on EVM transaction execution.
+    pub fn record_evm_execution_duration(&self, duration_secs: f64) {
+        self.evm_execution_duration_seconds.record(duration_secs);
     }
 }

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -36,6 +36,22 @@ pub struct CachedReads {
     pub contracts: B256Map<Bytecode>,
     /// Block hash mapped to the block number.
     pub block_hashes: HashMap<u64, B256>,
+    /// Number of account read cache hits.
+    pub account_hits: u64,
+    /// Number of account read cache misses.
+    pub account_misses: u64,
+    /// Number of storage read cache hits.
+    pub storage_hits: u64,
+    /// Number of storage read cache misses.
+    pub storage_misses: u64,
+    /// Number of code read cache hits.
+    pub code_hits: u64,
+    /// Number of code read cache misses.
+    pub code_misses: u64,
+    /// Number of block hash read cache hits.
+    pub block_hash_hits: u64,
+    /// Number of block hash read cache misses.
+    pub block_hash_misses: u64,
 }
 
 // === impl CachedReads ===
@@ -63,6 +79,14 @@ impl CachedReads {
         self.accounts.extend(other.accounts);
         self.contracts.extend(other.contracts);
         self.block_hashes.extend(other.block_hashes);
+        self.account_hits += other.account_hits;
+        self.account_misses += other.account_misses;
+        self.storage_hits += other.storage_hits;
+        self.storage_misses += other.storage_misses;
+        self.code_hits += other.code_hits;
+        self.code_misses += other.code_misses;
+        self.block_hash_hits += other.block_hash_hits;
+        self.block_hash_misses += other.block_hash_misses;
     }
 }
 
@@ -106,8 +130,12 @@ impl<DB: DatabaseRef> Database for CachedReadsDbMut<'_, DB> {
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let basic = match self.cached.accounts.entry(address) {
-            Entry::Occupied(entry) => entry.get().info.clone(),
+            Entry::Occupied(entry) => {
+                self.cached.account_hits += 1;
+                entry.get().info.clone()
+            }
             Entry::Vacant(entry) => {
+                self.cached.account_misses += 1;
                 entry.insert(CachedAccount::new(self.db.basic_ref(address)?)).info.clone()
             }
         };
@@ -116,8 +144,14 @@ impl<DB: DatabaseRef> Database for CachedReadsDbMut<'_, DB> {
 
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
         let code = match self.cached.contracts.entry(code_hash) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => entry.insert(self.db.code_by_hash_ref(code_hash)?).clone(),
+            Entry::Occupied(entry) => {
+                self.cached.code_hits += 1;
+                entry.get().clone()
+            }
+            Entry::Vacant(entry) => {
+                self.cached.code_misses += 1;
+                entry.insert(self.db.code_by_hash_ref(code_hash)?).clone()
+            }
         };
         Ok(code)
     }
@@ -125,10 +159,17 @@ impl<DB: DatabaseRef> Database for CachedReadsDbMut<'_, DB> {
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         match self.cached.accounts.entry(address) {
             Entry::Occupied(mut acc_entry) => match acc_entry.get_mut().storage.entry(index) {
-                Entry::Occupied(entry) => Ok(*entry.get()),
-                Entry::Vacant(entry) => Ok(*entry.insert(self.db.storage_ref(address, index)?)),
+                Entry::Occupied(entry) => {
+                    self.cached.storage_hits += 1;
+                    Ok(*entry.get())
+                }
+                Entry::Vacant(entry) => {
+                    self.cached.storage_misses += 1;
+                    Ok(*entry.insert(self.db.storage_ref(address, index)?))
+                }
             },
             Entry::Vacant(acc_entry) => {
+                self.cached.storage_misses += 1;
                 // acc needs to be loaded for us to access slots.
                 let info = self.db.basic_ref(address)?;
                 let (account, value) = if info.is_some() {
@@ -147,8 +188,14 @@ impl<DB: DatabaseRef> Database for CachedReadsDbMut<'_, DB> {
 
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
         let hash = match self.cached.block_hashes.entry(number) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => *entry.insert(self.db.block_hash_ref(number)?),
+            Entry::Occupied(entry) => {
+                self.cached.block_hash_hits += 1;
+                *entry.get()
+            }
+            Entry::Vacant(entry) => {
+                self.cached.block_hash_misses += 1;
+                *entry.insert(self.db.block_hash_ref(number)?)
+            }
         };
         Ok(hash)
     }

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -54,6 +54,27 @@ pub struct CachedReads {
     pub block_hash_misses: u64,
 }
 
+/// Cache hit/miss statistics from a build pass.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CacheStats {
+    /// Number of account read cache hits.
+    pub account_hits: u64,
+    /// Number of account read cache misses.
+    pub account_misses: u64,
+    /// Number of storage read cache hits.
+    pub storage_hits: u64,
+    /// Number of storage read cache misses.
+    pub storage_misses: u64,
+    /// Number of code read cache hits.
+    pub code_hits: u64,
+    /// Number of code read cache misses.
+    pub code_misses: u64,
+    /// Number of block hash read cache hits.
+    pub block_hash_hits: u64,
+    /// Number of block hash read cache misses.
+    pub block_hash_misses: u64,
+}
+
 // === impl CachedReads ===
 
 impl CachedReads {
@@ -87,6 +108,20 @@ impl CachedReads {
         self.code_misses += other.code_misses;
         self.block_hash_hits += other.block_hash_hits;
         self.block_hash_misses += other.block_hash_misses;
+    }
+
+    /// Drains and returns cache hit/miss counters, resetting them to zero.
+    pub fn drain_stats(&mut self) -> CacheStats {
+        CacheStats {
+            account_hits: core::mem::take(&mut self.account_hits),
+            account_misses: core::mem::take(&mut self.account_misses),
+            storage_hits: core::mem::take(&mut self.storage_hits),
+            storage_misses: core::mem::take(&mut self.storage_misses),
+            code_hits: core::mem::take(&mut self.code_hits),
+            code_misses: core::mem::take(&mut self.code_misses),
+            block_hash_hits: core::mem::take(&mut self.block_hash_hits),
+            block_hash_misses: core::mem::take(&mut self.block_hash_misses),
+        }
     }
 }
 
@@ -171,6 +206,7 @@ impl<DB: DatabaseRef> Database for CachedReadsDbMut<'_, DB> {
             Entry::Vacant(acc_entry) => {
                 self.cached.storage_misses += 1;
                 // acc needs to be loaded for us to access slots.
+                self.cached.account_misses += 1;
                 let info = self.db.basic_ref(address)?;
                 let (account, value) = if info.is_some() {
                     let value = self.db.storage_ref(address, index)?;


### PR DESCRIPTION
Companion to #22829. Breaks out the 5 remaining instrumentation targets from the payload building observability :

1. **Transaction selection vs EVM execution** — splits the execute_transactions loop into cumulative `tx_selection_duration_seconds` and `evm_execution_duration_seconds` histograms using `FastInstant`.

2. **State root computation** — wraps `state_root_with_updates` and `assemble_block` in `debug_span!` inside `BasicBlockBuilder::finish()`.

3. **Proof generation** — records `proof_calculation_duration_histogram` for each `ProofResultMessage` in the sparse trie event loop before coalescing/error extraction.

4. **State reads** — adds hit/miss counters (account, storage, code, block_hash) to `CachedReads`, incremented in `CachedReadsDbMut`'s `Database` impl. No metrics dependency — consumers read plain fields.