### PR TITLE
ci(bench): skip wait-time for gas ramp payloads in replay-payloads

### DIFF
--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -292,10 +292,6 @@ impl Command {
 
             info!(target: "reth-bench", gas_ramp_payload = i + 1, "Gas ramp payload executed successfully");
 
-            if let Some(w) = &mut waiter {
-                w.on_block(payload.block_number).await?;
-            }
-
             parent_hash = payload.file.block_hash;
         }
 


### PR DESCRIPTION
Gas ramp payloads warm up the gas limit before the actual benchmark. Applying wait-time to them adds unnecessary delay without improving measurement quality.

Removes the `waiter.on_block()` call from the gas ramp loop in `replay-payloads`, so `--wait-time` only applies to the main benchmark payloads.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey