### PR TITLE
fix: clean up stale schelk state before bench mount

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -60,20 +60,8 @@ trap cleanup EXIT
 
 # Clean up stale schelk state from a previous cancelled run.
 # If schelk thinks it's still mounted (e.g. a cancelled run skipped cleanup),
-# recover first to reset state. Also force-unmount if the mount point is
-# still live but state was partially cleaned.
-if sudo schelk -y status 2>&1 | grep -q "Mounted: yes"; then
-  echo "Stale schelk mount detected from a cancelled run, recovering..."
-  sudo schelk recover -y -k || true
-fi
-if mountpoint -q "$SCHELK_MOUNT"; then
-  echo "Mount point still active after recovery, force-unmounting..."
-  sudo umount -l "$SCHELK_MOUNT" || true
-fi
-if sudo dmsetup info bench_era &>/dev/null; then
-  echo "Stale dm-era device found, removing..."
-  sudo dmsetup remove bench_era || true
-fi
+# recover first to reset state.
+sudo schelk recover -y -k || true
 
 # Mount
 sudo schelk mount -y

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -58,6 +58,23 @@ cleanup() {
 TAIL_PID=
 trap cleanup EXIT
 
+# Clean up stale schelk state from a previous cancelled run.
+# If schelk thinks it's still mounted (e.g. a cancelled run skipped cleanup),
+# recover first to reset state. Also force-unmount if the mount point is
+# still live but state was partially cleaned.
+if sudo schelk -y status 2>&1 | grep -q "Mounted: yes"; then
+  echo "Stale schelk mount detected from a cancelled run, recovering..."
+  sudo schelk recover -y -k || true
+fi
+if mountpoint -q "$SCHELK_MOUNT"; then
+  echo "Mount point still active after recovery, force-unmounting..."
+  sudo umount -l "$SCHELK_MOUNT" || true
+fi
+if sudo dmsetup info bench_era &>/dev/null; then
+  echo "Stale dm-era device found, removing..."
+  sudo dmsetup remove bench_era || true
+fi
+
 # Mount
 sudo schelk mount -y
 sync


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/actions/runs/22764247956/job/66028017294

When a bench run is cancelled mid-flight, the cleanup trap may not execute, leaving schelk's state file with `is_mounted: true` and/or the mount point and dm-era device still active. The next run then fails immediately with `Volume is already mounted`.

This adds a pre-mount cleanup that:
1. Checks `schelk status` for stale mounted state and runs `schelk recover -y -k` to reset it
2. Force-unmounts the mount point if still active
3. Removes stale dm-era device if present

All three are guarded with `|| true` so they never block the fresh mount.

Prompted by: alexey