### PR TITLE
fix(bench): show gas ramp blocks instead of warmup/blocks for big-blocks mode

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -151,6 +151,10 @@ fi
 if [ "$BIG_BLOCKS" = "true" ]; then
   # Big blocks mode: replay pre-generated payloads with gas ramp
   BIG_BLOCKS_DIR="${BENCH_WORK_DIR}/big-blocks"
+  # Count gas ramp blocks for reporting
+  GAS_RAMP_COUNT=$(find "$BIG_BLOCKS_DIR/gas-ramp-dir" -name '*.json' | wc -l)
+  echo "$GAS_RAMP_COUNT" > "$OUTPUT_DIR/gas_ramp_blocks.txt"
+  echo "Gas ramp blocks: $GAS_RAMP_COUNT"
   echo "Running big blocks benchmark (replay-payloads)..."
   $BENCH_NICE "$RETH_BENCH" replay-payloads \
     "${EXTRA_BENCH_ARGS[@]}" \

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -468,6 +468,7 @@ def main():
     parser.add_argument("--feature-ref", "--branch-sha", "--feature-sha", default=None, help="Feature commit SHA")
     parser.add_argument("--behind-baseline", "--behind-main", type=int, default=0, help="Commits behind baseline")
     parser.add_argument("--big-blocks", action="store_true", default=False, help="Big blocks mode")
+    parser.add_argument("--gas-ramp-blocks", type=int, default=0, help="Number of gas ramp blocks (big blocks mode)")
     args = parser.parse_args()
 
     if len(args.baseline_csv) != len(args.feature_csv):
@@ -547,6 +548,8 @@ def main():
 
     summary = {
         "blocks": paired_stats["blocks"],
+        "big_blocks": args.big_blocks,
+        "gas_ramp_blocks": args.gas_ramp_blocks,
         "baseline": {
             "name": baseline_name,
             "ref": baseline_ref,

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -122,8 +122,8 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
   const countsParts = [];
   if (summary.big_blocks) {
     const gasRamp = summary.gas_ramp_blocks || 0;
-    if (gasRamp > 0) countsParts.push(`*Gas ramp blocks:* ${gasRamp}`);
-    countsParts.push(`*Payloads:* ${summary.blocks}`);
+    if (gasRamp > 0) countsParts.push(`*Gas Ramp:* ${gasRamp}`);
+    countsParts.push(`*Big Blocks:* ${summary.blocks}`);
   } else {
     const warmup = summary.warmup_blocks || process.env.BENCH_WARMUP_BLOCKS || '';
     if (warmup) countsParts.push(`*Warmup:* ${warmup}`);

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -118,11 +118,17 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
   if (fl1) featureLine += ` | <${fl1}|Samply 1>`;
   if (fl2) featureLine += ` | <${fl2}|Samply 2>`;
 
-  const warmup = summary.warmup_blocks || process.env.BENCH_WARMUP_BLOCKS || '';
   const cores = process.env.BENCH_CORES || '0';
   const countsParts = [];
-  if (warmup) countsParts.push(`*Warmup:* ${warmup}`);
-  countsParts.push(`*Blocks:* ${summary.blocks}`);
+  if (summary.big_blocks) {
+    const gasRamp = summary.gas_ramp_blocks || 0;
+    if (gasRamp > 0) countsParts.push(`*Gas ramp blocks:* ${gasRamp}`);
+    countsParts.push(`*Payloads:* ${summary.blocks}`);
+  } else {
+    const warmup = summary.warmup_blocks || process.env.BENCH_WARMUP_BLOCKS || '';
+    if (warmup) countsParts.push(`*Warmup:* ${warmup}`);
+    countsParts.push(`*Blocks:* ${summary.blocks}`);
+  }
   if (cores !== '0') countsParts.push(`*Cores:* ${cores}`);
   const countsLine = countsParts.join(' | ');
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -901,6 +901,11 @@ jobs:
           fi
           if [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --big-blocks"
+            # Read gas ramp blocks count from first baseline run (same for all runs)
+            GAS_RAMP_FILE="$BENCH_WORK_DIR/baseline-1/gas_ramp_blocks.txt"
+            if [ -f "$GAS_RAMP_FILE" ]; then
+              SUMMARY_ARGS="$SUMMARY_ARGS --gas-ramp-blocks $(cat "$GAS_RAMP_FILE" | tr -d '[:space:]')"
+            fi
           fi
           # shellcheck disable=SC2086
           python3 .github/scripts/bench-reth-summary.py $SUMMARY_ARGS


### PR DESCRIPTION
Big blocks bench Slack notifications showed `*Warmup:* 100 | *Blocks:* 45` — these are normal-mode params that don't apply to big blocks. Now shows `*Gas ramp blocks:* N | *Payloads:* M` instead.

- `bench-reth-run.sh`: Count gas ramp block files and write to `gas_ramp_blocks.txt`
- `bench-reth-summary.py`: Accept `--gas-ramp-blocks` and include `big_blocks`/`gas_ramp_blocks` in summary.json
- `bench-slack-notify.js`: Show gas ramp blocks + payloads for big-blocks mode
- `bench.yml`: Pass gas ramp count from run output to summary script

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey