### PR TITLE
feat(metrics): add SpanExt trait for unified span + metric recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8998,6 +8998,7 @@ dependencies = [
  "metrics-derive",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -76,16 +76,6 @@ impl EngineApiMetrics {
         &self.executor
     }
 
-    /// Records the duration of block pre-execution changes (e.g., beacon root update).
-    pub fn record_pre_execution(&self, elapsed: Duration) {
-        self.executor.pre_execution_histogram.record(elapsed);
-    }
-
-    /// Records the duration of block post-execution changes (e.g., finalization).
-    pub fn record_post_execution(&self, elapsed: Duration) {
-        self.executor.post_execution_histogram.record(elapsed);
-    }
-
     /// Records execution duration into the gas-bucketed execution histogram.
     pub fn record_block_execution_gas_bucket(&self, gas_used: u64, elapsed: Duration) {
         let idx = GasBucketMetrics::bucket_index(gas_used);
@@ -105,11 +95,6 @@ impl EngineApiMetrics {
     /// Records the time spent waiting for the next transaction from the iterator.
     pub fn record_transaction_wait(&self, elapsed: Duration) {
         self.executor.transaction_wait_histogram.record(elapsed);
-    }
-
-    /// Records the duration of a single transaction execution.
-    pub fn record_transaction_execution(&self, elapsed: Duration) {
-        self.executor.transaction_execution_histogram.record(elapsed);
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -29,6 +29,7 @@ use reth_evm::{
     block::BlockExecutor, execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
     OnStateHook, SpecFor,
 };
+use reth_metrics::SpanExt;
 use reth_payload_primitives::{
     BuiltPayload, InvalidPayloadAttributesError, NewPayloadError, PayloadTypes,
 };
@@ -894,11 +895,10 @@ where
         drop(receipt_tx);
 
         // Finish execution and get the result
-        let post_exec_start = Instant::now();
         let (_evm, result) = debug_span!(target: "engine::tree", "BlockExecutor::finish")
+            .metered(self.metrics.executor.post_execution_histogram.clone())
             .in_scope(|| executor.finish())
             .map(|(evm, result)| (evm.into_db(), result))?;
-        self.metrics.record_post_execution(post_exec_start.elapsed());
 
         // Merge transitions into bundle state
         debug_span!(target: "engine::tree", "merge_transitions")
@@ -940,10 +940,9 @@ where
         let mut senders = Vec::with_capacity(transaction_count);
 
         // Apply pre-execution changes (e.g., beacon root update)
-        let pre_exec_start = Instant::now();
         debug_span!(target: "engine::tree", "pre_execution")
+            .metered(self.metrics.executor.pre_execution_histogram.clone())
             .in_scope(|| executor.apply_pre_execution_changes())?;
-        self.metrics.record_pre_execution(pre_exec_start.elapsed());
 
         // Execute transactions
         let exec_span = debug_span!(target: "engine::tree", "execution").entered();
@@ -969,12 +968,11 @@ where
                 target: "engine::tree",
                 "execute tx",
             )
+            .metered(self.metrics.executor.transaction_execution_histogram.clone())
             .entered();
             trace!(target: "engine::tree", "Executing transaction");
 
-            let tx_start = Instant::now();
             executor.execute_transaction(tx)?;
-            self.metrics.record_transaction_execution(tx_start.elapsed());
 
             // advance the shared counter so prewarm workers skip already-executed txs
             executed_tx_index.store(senders.len(), Ordering::Relaxed);

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -16,6 +16,9 @@ workspace = true
 metrics.workspace = true
 metrics-derive.workspace = true
 
+# tracing
+tracing.workspace = true
+
 # async
 tokio = { workspace = true, features = ["full"], optional = true }
 futures = { workspace = true, optional = true }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -20,5 +20,8 @@ pub use metrics_derive::Metrics;
 #[cfg(feature = "common")]
 pub mod common;
 
+mod span;
+pub use span::{EnteredMeteredSpan, MeteredSpan, SpanExt};
+
 /// Re-export core metrics crate.
 pub use metrics;

--- a/crates/metrics/src/span.rs
+++ b/crates/metrics/src/span.rs
@@ -1,0 +1,113 @@
+use metrics::Histogram;
+use std::time::Instant;
+use tracing::Span;
+
+/// Extension trait for [`Span`] that ties a metrics [`Histogram`] to the span's lifetime.
+///
+/// When the returned [`MeteredSpan`] is dropped, the elapsed time since its creation
+/// is recorded into the histogram as seconds (`f64`).
+///
+/// This eliminates the common pattern of:
+/// ```ignore
+/// let start = Instant::now();
+/// // ... do work ...
+/// histogram.record(start.elapsed().as_secs_f64());
+/// ```
+///
+/// # Example
+///
+/// ```ignore
+/// use tracing::debug_span;
+/// use reth_metrics::SpanExt;
+///
+/// // Without entering the span:
+/// let _metered = debug_span!("my_operation")
+///     .metered(histogram.clone());
+///
+/// // Or, enter the span immediately:
+/// let _metered = debug_span!("my_operation")
+///     .metered(histogram.clone())
+///     .entered();
+///
+/// // ... do work ...
+/// // duration is recorded when `_metered` drops
+/// ```
+pub trait SpanExt {
+    /// Attach a [`Histogram`] to this span. The span's lifetime determines when the duration
+    /// is recorded — no manual [`Instant::now()`] or `.elapsed()` needed.
+    fn metered(self, histogram: Histogram) -> MeteredSpan;
+}
+
+impl SpanExt for Span {
+    fn metered(self, histogram: Histogram) -> MeteredSpan {
+        MeteredSpan { _span: self, start: Instant::now(), histogram: Some(histogram) }
+    }
+}
+
+/// A span that records its lifetime duration into a [`Histogram`] on drop.
+///
+/// Created via [`SpanExt::metered`].
+#[must_use = "the metered span is immediately dropped if not bound to a variable"]
+pub struct MeteredSpan {
+    _span: Span,
+    start: Instant,
+    histogram: Option<Histogram>,
+}
+
+impl MeteredSpan {
+    /// Enter the span, returning an entered guard that keeps the span active.
+    ///
+    /// The metric is recorded when the [`EnteredMeteredSpan`] is dropped.
+    pub fn entered(mut self) -> EnteredMeteredSpan {
+        let entered = self._span.clone().entered();
+        // Take the histogram so `MeteredSpan::drop` becomes a no-op —
+        // `EnteredMeteredSpan` takes over metric recording responsibility.
+        let histogram = self.histogram.take().expect("histogram is always Some before entered()");
+        EnteredMeteredSpan { _entered: entered, start: self.start, histogram }
+    }
+
+    /// Execute a closure within the span, recording the duration into the histogram.
+    ///
+    /// This is the metered equivalent of [`Span::in_scope`].
+    pub fn in_scope<F: FnOnce() -> R, R>(self, f: F) -> R {
+        self._span.in_scope(f)
+        // `self` is dropped here, recording the elapsed time into the histogram
+    }
+}
+
+impl std::fmt::Debug for MeteredSpan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeteredSpan").field("span", &self._span).finish_non_exhaustive()
+    }
+}
+
+impl Drop for MeteredSpan {
+    fn drop(&mut self) {
+        if let Some(histogram) = &self.histogram {
+            histogram.record(self.start.elapsed().as_secs_f64());
+        }
+    }
+}
+
+/// An entered [`MeteredSpan`] that records its duration on drop.
+///
+/// Created via [`MeteredSpan::entered`]. This is the equivalent of
+/// `span.entered()` but with automatic metric recording.
+#[must_use = "the entered metered span is immediately dropped if not bound to a variable"]
+pub struct EnteredMeteredSpan {
+    _entered: tracing::span::EnteredSpan,
+    start: Instant,
+    histogram: Histogram,
+}
+
+impl std::fmt::Debug for EnteredMeteredSpan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EnteredMeteredSpan").finish_non_exhaustive()
+    }
+}
+
+impl Drop for EnteredMeteredSpan {
+    fn drop(&mut self) {
+        self.histogram.record(self.start.elapsed().as_secs_f64());
+    }
+}


### PR DESCRIPTION
Introduces `SpanExt::metered(histogram)` on `tracing::Span` that ties a metrics `Histogram` to the span's lifetime. When the `MeteredSpan` drops, elapsed duration is recorded — no manual `Instant::now()` / `.elapsed()` / `.record()` needed.

### API

```rust
// .entered() — metered guard
let _m = debug_span!("execute tx")
    .metered(histogram.clone())
    .entered();

// .in_scope() — metered closure
debug_span!("pre_execution")
    .metered(histogram.clone())
    .in_scope(|| do_work())?;
```

### Converted call sites

Three places in `payload_validator.rs` that had the `debug_span!() + Instant::now() + histogram.record()` triple:

- `pre_execution` span
- `BlockExecutor::finish` span
- per-transaction `execute tx` span

More conversions can follow incrementally — this PR establishes the primitive and proves it on the hot path.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey