### PR TITLE
fix(rpc): set default gas limit in eth_createAccessList when gas is omitted

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -491,11 +491,16 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // Disabled because eth_createAccessList is sometimes used with non-eoa senders
             evm_env.cfg_env.disable_eip3607 = true;
 
-            if request.as_ref().gas_limit().is_none() && tx_env.gas_price() > 0 {
-                let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
-                // no gas limit was provided in the request, so we need to cap the request's gas
-                // limit
-                tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit()));
+            if request.as_ref().gas_limit().is_none() {
+                if tx_env.gas_price() > 0 {
+                    // caller_gas_allowance caps based on (balance - value) / gas_price
+                    let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
+                    tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit()));
+                } else {
+                    // when gas_price is 0, we can't compute caller allowance (would divide
+                    // by zero), so use block gas limit as default
+                    tx_env.set_gas_limit(evm_env.block_env.gas_limit());
+                }
             }
 
             // can consume the list since we're not using the request anymore


### PR DESCRIPTION
`eth_createAccessList` without a `gas` param fails with "intrinsic gas too high" when `gas_price` is also unset (defaults to 0). This is because the gas limit fallback was gated on `gas_price > 0` to avoid a division by zero in `caller_gas_allowance`. When both are unset, the tx runs with gas limit 0.

Fixes this by always setting a default gas limit when none is provided: uses `caller_gas_allowance` when `gas_price > 0`, and falls back to block gas limit when `gas_price == 0`.

Reproduction:
```bash
# Fails before fix (no gas param):
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_createAccessList","params":[{"from":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","to":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","data":"0x18160ddd"}],"id":1}' http://127.0.0.1:8545
