### PR TITLE
fix(tracing): enable trace context on OTLP log records

### DIFF
--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -41,6 +41,7 @@ otlp = [
 otlp-logs = [
     "otlp",
     "opentelemetry-appender-tracing",
+    "opentelemetry-appender-tracing/experimental_use_tracing_span_context",
     "opentelemetry-otlp/logs",
     "opentelemetry_sdk/logs",
 ]


### PR DESCRIPTION
Enables `experimental_use_tracing_span_context` on `opentelemetry-appender-tracing` so the OTLP log bridge reads the active span's OTel context and stamps `trace_id`/`span_id` on exported log records.

Without this, OTLP log records always have empty trace/span IDs even when both `--tracing-otlp` and `--logs-otlp` are active on the same subscriber — the bridge simply couldn't see span context because the feature gate was off.

Requires `--tracing-otlp` to be active alongside `--logs-otlp` for correlation to work.

Prompted by: joshie