### PR TITLE
perf(txpool): skip listener locks when no subscribers exist

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -157,8 +157,12 @@ where
     has_event_listeners: AtomicBool,
     /// Listeners for new _full_ pending transactions.
     pending_transaction_listener: RwLock<Vec<PendingTransactionHashListener>>,
+    /// Tracks whether any pending transaction listeners have ever been installed.
+    has_pending_tx_listeners: AtomicBool,
     /// Listeners for new transactions added to the pool.
     transaction_listener: RwLock<Vec<TransactionListener<T::Transaction>>>,
+    /// Tracks whether any transaction listeners have ever been installed.
+    has_tx_listeners: AtomicBool,
     /// Listener for new blob transaction sidecars added to the pool.
     blob_transaction_sidecar_listener: Mutex<Vec<BlobTransactionSidecarListener>>,
     /// Metrics for the blob store
@@ -182,7 +186,9 @@ where
             has_event_listeners: AtomicBool::new(false),
             pool: RwLock::new(TxPool::new(ordering, config.clone())),
             pending_transaction_listener: Default::default(),
+            has_pending_tx_listeners: AtomicBool::new(false),
             transaction_listener: Default::default(),
+            has_tx_listeners: AtomicBool::new(false),
             blob_transaction_sidecar_listener: Default::default(),
             config,
             blob_store,
@@ -266,6 +272,7 @@ where
         // Clean up dead listeners before adding new one
         listeners.retain(|l| !l.sender.is_closed());
         listeners.push(listener);
+        self.has_pending_tx_listeners.store(true, Ordering::Relaxed);
 
         rx
     }
@@ -282,6 +289,7 @@ where
         // Clean up dead listeners before adding new one
         listeners.retain(|l| !l.sender.is_closed());
         listeners.push(listener);
+        self.has_tx_listeners.store(true, Ordering::Relaxed);
 
         rx
     }
@@ -756,6 +764,10 @@ where
     /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
     /// [`TransactionPool::pending_transactions_listener_for`](crate::TransactionPool).
     pub fn on_new_pending_transaction(&self, pending: &AddedPendingTransaction<T::Transaction>) {
+        if !self.has_pending_tx_listeners.load(Ordering::Relaxed) {
+            return
+        }
+
         let mut needs_cleanup = false;
 
         {
@@ -769,9 +781,11 @@ where
 
         // Clean up dead listeners if we detected any closed channels
         if needs_cleanup {
-            self.pending_transaction_listener
-                .write()
-                .retain(|listener| !listener.sender.is_closed());
+            let mut listeners = self.pending_transaction_listener.write();
+            listeners.retain(|listener| !listener.sender.is_closed());
+            if listeners.is_empty() {
+                self.has_pending_tx_listeners.store(false, Ordering::Relaxed);
+            }
         }
     }
 
@@ -784,6 +798,10 @@ where
     /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
     /// [`TransactionPool::new_transactions_listener_for`](crate::TransactionPool).
     pub fn on_new_transaction(&self, event: NewTransactionEvent<T::Transaction>) {
+        if !self.has_tx_listeners.load(Ordering::Relaxed) {
+            return
+        }
+
         let mut needs_cleanup = false;
 
         {
@@ -805,7 +823,11 @@ where
 
         // Clean up dead listeners if we detected any closed channels
         if needs_cleanup {
-            self.transaction_listener.write().retain(|listener| !listener.sender.is_closed());
+            let mut listeners = self.transaction_listener.write();
+            listeners.retain(|listener| !listener.sender.is_closed());
+            if listeners.is_empty() {
+                self.has_tx_listeners.store(false, Ordering::Relaxed);
+            }
         }
     }
 
@@ -841,31 +863,43 @@ where
         trace!(target: "txpool", promoted=outcome.promoted.len(), discarded= outcome.discarded.len() ,"notifying listeners on state change");
 
         // notify about promoted pending transactions - emit hashes
-        let mut needs_pending_cleanup = false;
-        {
-            let listeners = self.pending_transaction_listener.read();
-            for listener in listeners.iter() {
-                if !listener.send_all(outcome.pending_transactions(listener.kind)) {
-                    needs_pending_cleanup = true;
+        if self.has_pending_tx_listeners.load(Ordering::Relaxed) {
+            let mut needs_pending_cleanup = false;
+            {
+                let listeners = self.pending_transaction_listener.read();
+                for listener in listeners.iter() {
+                    if !listener.send_all(outcome.pending_transactions(listener.kind)) {
+                        needs_pending_cleanup = true;
+                    }
                 }
             }
-        }
-        if needs_pending_cleanup {
-            self.pending_transaction_listener.write().retain(|l| !l.sender.is_closed());
+            if needs_pending_cleanup {
+                let mut listeners = self.pending_transaction_listener.write();
+                listeners.retain(|l| !l.sender.is_closed());
+                if listeners.is_empty() {
+                    self.has_pending_tx_listeners.store(false, Ordering::Relaxed);
+                }
+            }
         }
 
         // emit full transactions
-        let mut needs_tx_cleanup = false;
-        {
-            let listeners = self.transaction_listener.read();
-            for listener in listeners.iter() {
-                if !listener.send_all(outcome.full_pending_transactions(listener.kind)) {
-                    needs_tx_cleanup = true;
+        if self.has_tx_listeners.load(Ordering::Relaxed) {
+            let mut needs_tx_cleanup = false;
+            {
+                let listeners = self.transaction_listener.read();
+                for listener in listeners.iter() {
+                    if !listener.send_all(outcome.full_pending_transactions(listener.kind)) {
+                        needs_tx_cleanup = true;
+                    }
                 }
             }
-        }
-        if needs_tx_cleanup {
-            self.transaction_listener.write().retain(|l| !l.sender.is_closed());
+            if needs_tx_cleanup {
+                let mut listeners = self.transaction_listener.write();
+                listeners.retain(|l| !l.sender.is_closed());
+                if listeners.is_empty() {
+                    self.has_tx_listeners.store(false, Ordering::Relaxed);
+                }
+            }
         }
 
         let OnNewCanonicalStateOutcome { mined, promoted, discarded, block_hash } = outcome;
@@ -900,45 +934,57 @@ where
     ) {
         // Notify about promoted pending transactions (similar to notify_on_new_state)
         if !promoted.is_empty() {
-            let mut needs_pending_cleanup = false;
-            {
-                let listeners = self.pending_transaction_listener.read();
-                for listener in listeners.iter() {
-                    let promoted_hashes = promoted.iter().filter_map(|tx| {
-                        if listener.kind.is_propagate_only() && !tx.propagate {
-                            None
-                        } else {
-                            Some(*tx.hash())
+            if self.has_pending_tx_listeners.load(Ordering::Relaxed) {
+                let mut needs_pending_cleanup = false;
+                {
+                    let listeners = self.pending_transaction_listener.read();
+                    for listener in listeners.iter() {
+                        let promoted_hashes = promoted.iter().filter_map(|tx| {
+                            if listener.kind.is_propagate_only() && !tx.propagate {
+                                None
+                            } else {
+                                Some(*tx.hash())
+                            }
+                        });
+                        if !listener.send_all(promoted_hashes) {
+                            needs_pending_cleanup = true;
                         }
-                    });
-                    if !listener.send_all(promoted_hashes) {
-                        needs_pending_cleanup = true;
                     }
                 }
-            }
-            if needs_pending_cleanup {
-                self.pending_transaction_listener.write().retain(|l| !l.sender.is_closed());
+                if needs_pending_cleanup {
+                    let mut listeners = self.pending_transaction_listener.write();
+                    listeners.retain(|l| !l.sender.is_closed());
+                    if listeners.is_empty() {
+                        self.has_pending_tx_listeners.store(false, Ordering::Relaxed);
+                    }
+                }
             }
 
             // in this case we should also emit promoted transactions in full
-            let mut needs_tx_cleanup = false;
-            {
-                let listeners = self.transaction_listener.read();
-                for listener in listeners.iter() {
-                    let promoted_txs = promoted.iter().filter_map(|tx| {
-                        if listener.kind.is_propagate_only() && !tx.propagate {
-                            None
-                        } else {
-                            Some(NewTransactionEvent::pending(tx.clone()))
+            if self.has_tx_listeners.load(Ordering::Relaxed) {
+                let mut needs_tx_cleanup = false;
+                {
+                    let listeners = self.transaction_listener.read();
+                    for listener in listeners.iter() {
+                        let promoted_txs = promoted.iter().filter_map(|tx| {
+                            if listener.kind.is_propagate_only() && !tx.propagate {
+                                None
+                            } else {
+                                Some(NewTransactionEvent::pending(tx.clone()))
+                            }
+                        });
+                        if !listener.send_all(promoted_txs) {
+                            needs_tx_cleanup = true;
                         }
-                    });
-                    if !listener.send_all(promoted_txs) {
-                        needs_tx_cleanup = true;
                     }
                 }
-            }
-            if needs_tx_cleanup {
-                self.transaction_listener.write().retain(|l| !l.sender.is_closed());
+                if needs_tx_cleanup {
+                    let mut listeners = self.transaction_listener.write();
+                    listeners.retain(|l| !l.sender.is_closed());
+                    if listeners.is_empty() {
+                        self.has_tx_listeners.store(false, Ordering::Relaxed);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
`pending_transaction_listener` and `transaction_listener` grab a read lock on every new transaction even when nobody is listening. The same struct already does the `AtomicBool` guard trick for `event_listener` 

Extends it to the other two listener types.

Mostly helps during sync when there are no RPC subscribers.