### PR TITLE
fix(net): re-buffer pending hashes when peer disconnects during fetch

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -442,8 +442,14 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             search_durations.find_idle_peer
         );
 
-        // peer should always exist since `is_session_active` already checked
-        let Some(peer) = peers.get(&peer_id) else { return false };
+        // peer may have disconnected between finding it idle and requesting here
+        let Some(peer) = peers.get(&peer_id) else {
+            // put hashes back into pending fetch so they can be retried with another peer
+            for hash in &hashes_to_request {
+                self.hashes_pending_fetch.insert(*hash);
+            }
+            return false
+        };
         let conn_eth_version = peer.version;
 
         // fill the request with more hashes pending fetch that have been announced by the peer.


### PR DESCRIPTION
`find_any_idle_fallback_peer_for_any_pending_hash` can select a disconnected peer as idle — `remove_peer` clears `active_peers` but not `fallback_peers`, and `is_idle` treats unknown peers as idle. The hash gets popped from `hashes_pending_fetch`, but the subsequent `peers.get()` fails, so no request goes out and the hash is lost.

Re-insert the hashes when the peer lookup fails so they can be picked up on the next round.