### PR TITLE
refactor(net): derive DerefMut for NewBlockHashes and NewPooledTransactionHashes66

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -25,6 +25,7 @@ use reth_primitives_traits::{Block, SignedTransaction};
     RlpDecodableWrapper,
     Default,
     Deref,
+    DerefMut,
     IntoIterator,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -238,7 +239,7 @@ impl NewPooledTransactionHashes {
     /// the rest. If `len` is greater than the number of hashes, this has no effect.
     pub fn truncate(&mut self, len: usize) {
         match self {
-            Self::Eth66(msg) => msg.0.truncate(len),
+            Self::Eth66(msg) => msg.truncate(len),
             Self::Eth68(msg) => {
                 msg.types.truncate(len);
                 msg.sizes.truncate(len);
@@ -336,6 +337,7 @@ impl From<NewPooledTransactionHashes68> for NewPooledTransactionHashes {
     RlpDecodableWrapper,
     Default,
     Deref,
+    DerefMut,
     IntoIterator,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -865,8 +867,8 @@ mod tests {
         let latest = blocks.latest().unwrap();
         assert_eq!(latest.number, 0);
 
-        blocks.0.push(BlockHashNumber { hash: B256::random(), number: 100 });
-        blocks.0.push(BlockHashNumber { hash: B256::random(), number: 2 });
+        blocks.push(BlockHashNumber { hash: B256::random(), number: 100 });
+        blocks.push(BlockHashNumber { hash: B256::random(), number: 2 });
         let latest = blocks.latest().unwrap();
         assert_eq!(latest.number, 100);
     }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -637,7 +637,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             PeerMessage::NewBlockHashes(hashes) => {
                 self.within_pow_or_disconnect(peer_id, |this| {
                     // update peer's state, to track what blocks this peer has seen
-                    this.swarm.state_mut().on_new_block_hashes(peer_id, hashes.0.clone());
+                    this.swarm.state_mut().on_new_block_hashes(peer_id, hashes.to_vec());
                     // start block import process for the hashes
                     this.block_import.on_new_block(peer_id, NewBlockEvent::Hashes(hashes));
                 })

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1910,7 +1910,7 @@ impl PooledTransactionsHashesBuilder {
     /// Push a transaction from the pool to the list.
     fn push_pooled<T: PoolTransaction>(&mut self, pooled_tx: Arc<ValidPoolTransaction<T>>) {
         match self {
-            Self::Eth66(msg) => msg.0.push(*pooled_tx.hash()),
+            Self::Eth66(msg) => msg.push(*pooled_tx.hash()),
             Self::Eth68(msg) => {
                 msg.hashes.push(*pooled_tx.hash());
                 msg.sizes.push(pooled_tx.encoded_length());
@@ -1947,7 +1947,7 @@ impl PooledTransactionsHashesBuilder {
 
     fn push<T: SignedTransaction>(&mut self, tx: &PropagateTransaction<T>) {
         match self {
-            Self::Eth66(msg) => msg.0.push(*tx.tx_hash()),
+            Self::Eth66(msg) => msg.push(*tx.tx_hash()),
             Self::Eth68(msg) => {
                 msg.hashes.push(*tx.tx_hash());
                 msg.sizes.push(tx.size);
@@ -1969,7 +1969,7 @@ impl PooledTransactionsHashesBuilder {
     fn build(self) -> NewPooledTransactionHashes {
         match self {
             Self::Eth66(mut msg) => {
-                msg.0.shrink_to_fit();
+                msg.shrink_to_fit();
                 msg.into()
             }
             Self::Eth68(mut msg) => {

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -129,7 +129,7 @@ async fn snoop(peer: NodeRecord, mut eth_stream: AuthedEthStream) {
     while let Some(Ok(update)) = eth_stream.next().await {
         match update {
             EthMessage::NewPooledTransactionHashes66(txs) => {
-                println!("Got {} new tx hashes from peer {}", txs.0.len(), peer.address);
+                println!("Got {} new tx hashes from peer {}", txs.len(), peer.address);
             }
             EthMessage::NewBlock(block) => {
                 println!("Got new block data {:?} from peer {}", block, peer.address);
@@ -138,11 +138,7 @@ async fn snoop(peer: NodeRecord, mut eth_stream: AuthedEthStream) {
                 println!("Got {} new tx hashes from peer {}", txs.hashes.len(), peer.address);
             }
             EthMessage::NewBlockHashes(block_hashes) => {
-                println!(
-                    "Got {} new block hashes from peer {}",
-                    block_hashes.0.len(),
-                    peer.address
-                );
+                println!("Got {} new block hashes from peer {}", block_hashes.len(), peer.address);
             }
             EthMessage::GetNodeData(_) => {
                 println!("Unable to serve GetNodeData request to peer {}", peer.address);


### PR DESCRIPTION
## Summary
- Add `DerefMut` derive to `NewBlockHashes` and `NewPooledTransactionHashes66` — both already had `Deref` but were missing the mutable counterpart, forcing `.0` field access for writes
- Replace all `.0` accesses across the codebase with direct method calls via Deref/DerefMut auto-coercion

## Test plan
- [x] `cargo +nightly fmt --all`
- [x] `cargo +nightly clippy -p reth-eth-wire-types -p reth-network -p example-manual-p2p --all-features` — clean
- No behavioral changes, purely syntactic cleanup