### PR TITLE
fix: disable MDBX read transaction timeout in bench

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -90,6 +90,7 @@ RETH_ARGS=(
   --authrpc.port 8551
   --disable-discovery
   --no-persist-peers
+  --db.read-transaction-timeout 0
 )
 
 # Big blocks mode requires the testing API and skip-invalid-transactions


### PR DESCRIPTION
Ref: https://github.com/paradigmxyz/reth/actions/runs/22774607897/job/66064550318

Big blocks with samply profiling can exceed the default 5-minute read transaction timeout, causing the bench to fail with `read transaction has been timed out (-96000)`. The timeout isn't useful during benchmarks — disable it with `--db.read-transaction-timeout 0`.

Prompted by: alexey