### PR TITLE
perf(net): size-based backpressure for session broadcast messages

### DIFF
--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -80,6 +80,18 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
         }
     }
 
+    /// Returns `true` if this message is a broadcast (block/transaction announcement or
+    /// propagation) rather than a request/response.
+    pub const fn is_broadcast(&self) -> bool {
+        matches!(
+            self,
+            Self::NewBlockHashes(_) |
+                Self::NewBlock(_) |
+                Self::SendTransactions(_) |
+                Self::PooledTransactions(_)
+        )
+    }
+
     /// Returns the number of items in the message payload, if applicable.
     pub fn message_item_count(&self) -> usize {
         match self {

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -143,6 +143,8 @@ pub struct SessionManagerMetrics {
     pub(crate) total_outgoing_peer_messages_dropped: Counter,
     /// Number of queued outgoing messages
     pub(crate) queued_outgoing_messages: Gauge,
+    /// Total number of broadcast messages sent via the unbounded overflow channel.
+    pub(crate) total_unbounded_broadcast_msgs: Counter,
 }
 
 /// Metrics for the [`TransactionsManager`](crate::transactions::TransactionsManager).

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -6,7 +6,10 @@ use std::{
     future::Future,
     net::SocketAddr,
     pin::Pin,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize},
+        Arc,
+    },
     task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
@@ -28,7 +31,7 @@ use reth_eth_wire::{
     message::{EthBroadcastMessage, MessageError},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
 };
-use reth_eth_wire_types::{message::RequestPair, RawCapabilityMessage};
+use reth_eth_wire_types::{message::RequestPair, NewPooledTransactionHashes, RawCapabilityMessage};
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::PeerRequest;
 use reth_network_p2p::error::RequestError;
@@ -37,7 +40,7 @@ use reth_network_types::session::config::INITIAL_REQUEST_TIMEOUT;
 use reth_primitives_traits::Block;
 use rustc_hash::FxHashMap;
 use tokio::{
-    sync::{mpsc::error::TrySendError, oneshot},
+    sync::{mpsc, mpsc::error::TrySendError, oneshot},
     time::Interval,
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -76,6 +79,13 @@ const TIMEOUT_SCALING: u32 = 3;
 /// before reading any more messages from the remote peer, throttling the peer.
 const MAX_QUEUED_OUTGOING_RESPONSES: usize = 4;
 
+/// Soft limit for the total number of buffered outgoing broadcast items (e.g. transaction hashes).
+///
+/// Many small broadcast messages carrying a single tx hash each are equivalent in cost to one
+/// message carrying many hashes. This limit counts individual items (hashes, transactions, blocks)
+/// rather than messages, so that many small messages don't trigger aggressive drops unnecessarily.
+pub(super) const MAX_QUEUED_BROADCAST_ITEMS: usize = 4096;
+
 /// The type that advances an established session by listening for incoming messages (from local
 /// node or read from connection) and emitting events back to the
 /// [`SessionManager`](super::SessionManager).
@@ -101,6 +111,8 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     pub(crate) session_id: SessionId,
     /// Incoming commands from the manager
     pub(crate) commands_rx: ReceiverStream<SessionCommand<N>>,
+    /// Overflow channel for broadcast messages that couldn't fit in the bounded command channel.
+    pub(crate) broadcast_overflow_rx: mpsc::UnboundedReceiver<PeerMessage<N>>,
     /// Sink to send messages to the [`SessionManager`](super::SessionManager).
     pub(crate) to_session_manager: MeteredPollSender<ActiveSessionMessage<N>>,
     /// A message that needs to be delivered to the session manager
@@ -364,7 +376,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             }
             PeerMessage::PooledTransactions(msg) => {
                 if msg.is_valid_for_version(self.conn.version()) {
-                    self.queued_outgoing.push_back(EthMessage::from(msg).into());
+                    self.queued_outgoing.push_pooled_hashes(msg);
                 } else {
                     debug!(target: "net", ?msg,  version=?self.conn.version(), "Message is invalid for connection version, skipping");
                 }
@@ -628,6 +640,12 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         }
                     }
                 }
+            }
+
+            // Drain broadcast overflow messages (sent when the bounded command channel was full)
+            while let Poll::Ready(Some(msg)) = this.broadcast_overflow_rx.poll_recv(cx) {
+                progress = true;
+                this.on_internal_peer_message(msg);
             }
 
             let deadline = this.request_deadline();
@@ -894,6 +912,55 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
             _ => false,
         }
     }
+
+    /// Returns the number of broadcast items in this message.
+    ///
+    /// For transaction hash announcements this is the number of hashes, for full transaction
+    /// broadcasts it is the number of transactions, and for blocks it is 1.
+    /// Request/response messages return 0.
+    fn broadcast_item_count(&self) -> usize {
+        match self {
+            Self::Eth(msg) => match msg {
+                EthMessage::NewBlockHashes(h) => h.len(),
+                EthMessage::NewPooledTransactionHashes66(h) => h.len(),
+                EthMessage::NewPooledTransactionHashes68(h) => h.hashes.len(),
+                _ => 0,
+            },
+            Self::Broadcast(msg) => match msg {
+                EthBroadcastMessage::NewBlock(_) => 1,
+                EthBroadcastMessage::Transactions(txs) => txs.len(),
+            },
+            Self::Raw(_) => 0,
+        }
+    }
+
+    /// Tries to merge pooled transaction hash announcements into this message, consuming the
+    /// incoming hashes. Returns `Some(incoming)` back if the variants don't match.
+    fn try_merge_hashes(
+        &mut self,
+        incoming: NewPooledTransactionHashes,
+    ) -> Option<NewPooledTransactionHashes> {
+        let Self::Eth(eth) = self else { return Some(incoming) };
+        match (eth, incoming) {
+            (
+                EthMessage::NewPooledTransactionHashes66(existing),
+                NewPooledTransactionHashes::Eth66(inc),
+            ) => {
+                existing.extend(inc);
+                None
+            }
+            (
+                EthMessage::NewPooledTransactionHashes68(existing),
+                NewPooledTransactionHashes::Eth68(inc),
+            ) => {
+                existing.hashes.extend(inc.hashes);
+                existing.sizes.extend(inc.sizes);
+                existing.types.extend(inc.types);
+                None
+            }
+            (_, incoming) => Some(incoming),
+        }
+    }
 }
 
 impl<N: NetworkPrimitives> From<EthMessage<N>> for OutgoingMessage<N> {
@@ -919,15 +986,22 @@ fn calculate_new_timeout(current_timeout: Duration, estimated_rtt: Duration) -> 
     smoothened_timeout.clamp(MINIMUM_TIMEOUT, MAXIMUM_TIMEOUT)
 }
 
-/// A helper struct that wraps the queue of outgoing messages and a metric to track their count
+/// A helper struct that wraps the queue of outgoing messages with broadcast-aware tracking.
+///
+/// Tracks both the total number of queued messages (via a metric gauge) and the total number of
+/// broadcast items (tx hashes, transactions, blocks) via a shared atomic counter. The atomic
+/// counter is shared with [`ActiveSessionHandle`](super::handle::ActiveSessionHandle) so the
+/// [`SessionManager`](super::SessionManager) can apply size-based backpressure.
 pub(crate) struct QueuedOutgoingMessages<N: NetworkPrimitives> {
     messages: VecDeque<OutgoingMessage<N>>,
     count: Gauge,
+    /// Shared counter of buffered broadcast items for size-based backpressure.
+    broadcast_items: Arc<AtomicUsize>,
 }
 
 impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
-    pub(crate) const fn new(metric: Gauge) -> Self {
-        Self { messages: VecDeque::new(), count: metric }
+    pub(crate) const fn new(metric: Gauge, broadcast_items: Arc<AtomicUsize>) -> Self {
+        Self { messages: VecDeque::new(), count: metric, broadcast_items }
     }
 
     pub(crate) fn push_back(&mut self, message: OutgoingMessage<N>) {
@@ -936,7 +1010,28 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     }
 
     pub(crate) fn pop_front(&mut self) -> Option<OutgoingMessage<N>> {
-        self.messages.pop_front().inspect(|_| self.count.decrement(1))
+        self.messages.pop_front().inspect(|msg| {
+            self.count.decrement(1);
+            let items = msg.broadcast_item_count();
+            if items > 0 {
+                self.broadcast_items.fetch_sub(items, Ordering::Relaxed);
+            }
+        })
+    }
+
+    /// Pushes a pooled transaction hash announcement, merging into the last queued message if
+    /// it is the same variant (eth66 or eth68).
+    pub(crate) fn push_pooled_hashes(&mut self, msg: NewPooledTransactionHashes) {
+        let msg = if let Some(last) = self.messages.back_mut() {
+            match last.try_merge_hashes(msg) {
+                None => return,
+                Some(msg) => msg,
+            }
+        } else {
+            msg
+        };
+        self.messages.push_back(EthMessage::from(msg).into());
+        self.count.increment(1);
     }
 
     pub(crate) fn shrink_to_fit(&mut self) {
@@ -946,7 +1041,6 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
 
 impl<N: NetworkPrimitives> Drop for QueuedOutgoingMessages<N> {
     fn drop(&mut self) {
-        // Ensure gauge is decremented for any remaining items to avoid metric leak on teardown.
         let remaining = self.messages.len();
         if remaining > 0 {
             self.count.decrement(remaining as f64);
@@ -1066,6 +1160,7 @@ mod tests {
                 } => {
                     let (_to_session_tx, messages_rx) = mpsc::channel(10);
                     let (commands_to_session, commands_rx) = mpsc::channel(10);
+                    let (_broadcast_overflow_tx, broadcast_overflow_rx) = mpsc::unbounded_channel();
                     let poll_sender = PollSender::new(self.active_session_tx.clone());
 
                     self.to_sessions.push(commands_to_session);
@@ -1077,6 +1172,7 @@ mod tests {
                         remote_capabilities: Arc::clone(&capabilities),
                         session_id,
                         commands_rx: ReceiverStream::new(commands_rx),
+                        broadcast_overflow_rx,
                         to_session_manager: MeteredPollSender::new(
                             poll_sender,
                             "network_active_session",
@@ -1085,7 +1181,10 @@ mod tests {
                         internal_request_rx: ReceiverStream::new(messages_rx).fuse(),
                         inflight_requests: Default::default(),
                         conn,
-                        queued_outgoing: QueuedOutgoingMessages::new(Gauge::noop()),
+                        queued_outgoing: QueuedOutgoingMessages::new(
+                            Gauge::noop(),
+                            Arc::new(AtomicUsize::new(0)),
+                        ),
                         received_requests_from_remote: Default::default(),
                         internal_request_timeout_interval: tokio::time::interval(
                             INITIAL_REQUEST_TIMEOUT,

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -25,7 +25,7 @@ use crate::{
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::Sealable;
 use futures::{stream::Fuse, SinkExt, StreamExt};
-use metrics::Gauge;
+use metrics::{Counter, Gauge};
 use reth_eth_wire::{
     errors::{EthHandshakeError, EthStreamError},
     message::{EthBroadcastMessage, MessageError},
@@ -150,6 +150,8 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     /// Unbounded channel for commands that couldn't fit in the bounded channel (broadcast
     /// overflow) and for disconnect commands that must never be dropped.
     pub(crate) unbounded_rx: mpsc::UnboundedReceiver<SessionCommand<N>>,
+    /// Counter for broadcast messages received via the unbounded overflow channel.
+    pub(crate) unbounded_broadcast_msgs: Counter,
     /// Sink to send messages to the [`SessionManager`](super::SessionManager).
     pub(crate) to_session_manager: MeteredPollSender<ActiveSessionMessage<N>>,
     /// A message that needs to be delivered to the session manager
@@ -684,7 +686,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             while let Poll::Ready(Some(cmd)) = this.unbounded_rx.poll_recv(cx) {
                 progress = true;
                 match cmd {
-                    SessionCommand::Message(msg) => this.on_internal_peer_message(msg),
+                    SessionCommand::Message(msg) => {
+                        this.unbounded_broadcast_msgs.increment(1);
+                        this.on_internal_peer_message(msg);
+                    }
                     SessionCommand::Disconnect { reason } => {
                         let reason = reason.unwrap_or(DisconnectReason::DisconnectRequested);
                         return this.try_disconnect(reason, cx)
@@ -1218,6 +1223,7 @@ mod tests {
                         session_id,
                         commands_rx: ReceiverStream::new(commands_rx),
                         unbounded_rx,
+                        unbounded_broadcast_msgs: Counter::noop(),
                         to_session_manager: MeteredPollSender::new(
                             poll_sender,
                             "network_active_session",

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -84,7 +84,43 @@ const MAX_QUEUED_OUTGOING_RESPONSES: usize = 4;
 /// Many small broadcast messages carrying a single tx hash each are equivalent in cost to one
 /// message carrying many hashes. This limit counts individual items (hashes, transactions, blocks)
 /// rather than messages, so that many small messages don't trigger aggressive drops unnecessarily.
-pub(super) const MAX_QUEUED_BROADCAST_ITEMS: usize = 4096;
+const MAX_QUEUED_BROADCAST_ITEMS: usize = 4096;
+
+/// Shared counter for in-flight broadcast items (tx hashes, transactions, blocks) across the
+/// bounded command channel, unbounded overflow channel, and session outgoing queue.
+///
+/// Wrapped in a newtype so the backing storage can be changed later (e.g. to track memory) without
+/// touching every call-site.
+#[derive(Debug, Clone)]
+pub(crate) struct BroadcastItemCounter(Arc<AtomicUsize>);
+
+impl BroadcastItemCounter {
+    /// Creates a new counter starting at zero.
+    pub(crate) fn new() -> Self {
+        Self(Arc::new(AtomicUsize::new(0)))
+    }
+
+    /// Returns the current count.
+    pub(crate) fn get(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    /// Attempts to add `n` items. Returns `true` if under the limit, `false` if over (no change).
+    pub(crate) fn try_add(&self, n: usize) -> bool {
+        let prev = self.0.fetch_add(n, Ordering::Relaxed);
+        if prev >= MAX_QUEUED_BROADCAST_ITEMS {
+            self.0.fetch_sub(n, Ordering::Relaxed);
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Subtracts `n` items from the counter.
+    pub(crate) fn sub(&self, n: usize) {
+        self.0.fetch_sub(n, Ordering::Relaxed);
+    }
+}
 
 /// The type that advances an established session by listening for incoming messages (from local
 /// node or read from connection) and emitting events back to the
@@ -111,8 +147,9 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     pub(crate) session_id: SessionId,
     /// Incoming commands from the manager
     pub(crate) commands_rx: ReceiverStream<SessionCommand<N>>,
-    /// Overflow channel for broadcast messages that couldn't fit in the bounded command channel.
-    pub(crate) broadcast_overflow_rx: mpsc::UnboundedReceiver<PeerMessage<N>>,
+    /// Unbounded channel for commands that couldn't fit in the bounded channel (broadcast
+    /// overflow) and for disconnect commands that must never be dropped.
+    pub(crate) unbounded_rx: mpsc::UnboundedReceiver<SessionCommand<N>>,
     /// Sink to send messages to the [`SessionManager`](super::SessionManager).
     pub(crate) to_session_manager: MeteredPollSender<ActiveSessionMessage<N>>,
     /// A message that needs to be delivered to the session manager
@@ -642,10 +679,16 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
             }
 
-            // Drain broadcast overflow messages (sent when the bounded command channel was full)
-            while let Poll::Ready(Some(msg)) = this.broadcast_overflow_rx.poll_recv(cx) {
+            // Drain the unbounded channel (broadcast overflow + disconnect commands)
+            while let Poll::Ready(Some(cmd)) = this.unbounded_rx.poll_recv(cx) {
                 progress = true;
-                this.on_internal_peer_message(msg);
+                match cmd {
+                    SessionCommand::Message(msg) => this.on_internal_peer_message(msg),
+                    SessionCommand::Disconnect { reason } => {
+                        let reason = reason.unwrap_or(DisconnectReason::DisconnectRequested);
+                        return this.try_disconnect(reason, cx)
+                    }
+                }
             }
 
             let deadline = this.request_deadline();
@@ -996,11 +1039,11 @@ pub(crate) struct QueuedOutgoingMessages<N: NetworkPrimitives> {
     messages: VecDeque<OutgoingMessage<N>>,
     count: Gauge,
     /// Shared counter of buffered broadcast items for size-based backpressure.
-    broadcast_items: Arc<AtomicUsize>,
+    broadcast_items: BroadcastItemCounter,
 }
 
 impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
-    pub(crate) const fn new(metric: Gauge, broadcast_items: Arc<AtomicUsize>) -> Self {
+    pub(crate) const fn new(metric: Gauge, broadcast_items: BroadcastItemCounter) -> Self {
         Self { messages: VecDeque::new(), count: metric, broadcast_items }
     }
 
@@ -1014,7 +1057,7 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
             self.count.decrement(1);
             let items = msg.broadcast_item_count();
             if items > 0 {
-                self.broadcast_items.fetch_sub(items, Ordering::Relaxed);
+                self.broadcast_items.sub(items);
             }
         })
     }
@@ -1041,6 +1084,7 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
 
 impl<N: NetworkPrimitives> Drop for QueuedOutgoingMessages<N> {
     fn drop(&mut self) {
+        // Ensure gauge is decremented for any remaining items to avoid metric leak on teardown.
         let remaining = self.messages.len();
         if remaining > 0 {
             self.count.decrement(remaining as f64);
@@ -1160,7 +1204,7 @@ mod tests {
                 } => {
                     let (_to_session_tx, messages_rx) = mpsc::channel(10);
                     let (commands_to_session, commands_rx) = mpsc::channel(10);
-                    let (_broadcast_overflow_tx, broadcast_overflow_rx) = mpsc::unbounded_channel();
+                    let (_unbounded_tx, unbounded_rx) = mpsc::unbounded_channel();
                     let poll_sender = PollSender::new(self.active_session_tx.clone());
 
                     self.to_sessions.push(commands_to_session);
@@ -1172,7 +1216,7 @@ mod tests {
                         remote_capabilities: Arc::clone(&capabilities),
                         session_id,
                         commands_rx: ReceiverStream::new(commands_rx),
-                        broadcast_overflow_rx,
+                        unbounded_rx,
                         to_session_manager: MeteredPollSender::new(
                             poll_sender,
                             "network_active_session",
@@ -1183,7 +1227,7 @@ mod tests {
                         conn,
                         queued_outgoing: QueuedOutgoingMessages::new(
                             Gauge::noop(),
-                            Arc::new(AtomicUsize::new(0)),
+                            BroadcastItemCounter::new(),
                         ),
                         received_requests_from_remote: Default::default(),
                         internal_request_timeout_interval: tokio::time::interval(

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -415,6 +415,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 if msg.is_valid_for_version(self.conn.version()) {
                     self.queued_outgoing.push_pooled_hashes(msg);
                 } else {
+                    self.queued_outgoing.broadcast_items.sub(msg.len());
                     debug!(target: "net", ?msg,  version=?self.conn.version(), "Message is invalid for connection version, skipping");
                 }
             }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     message::PeerMessage,
-    session::{conn::EthRlpxConnection, Direction, SessionId},
+    session::{active::MAX_QUEUED_BROADCAST_ITEMS, conn::EthRlpxConnection, Direction, SessionId},
     PendingSessionHandshakeError,
 };
 use reth_ecies::ECIESError;
@@ -13,11 +13,20 @@ use reth_eth_wire::{
 use reth_network_api::PeerInfo;
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::PeerKind;
-use std::{io, net::SocketAddr, sync::Arc, time::Instant};
+use std::{
+    io,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
 use tokio::sync::{
     mpsc::{self, error::SendError},
     oneshot,
 };
+use tracing::trace;
 
 /// A handler attached to a peer session that's not authenticated yet, pending Handshake and hello
 /// message which exchanges the `capabilities` of the peer.
@@ -65,8 +74,8 @@ pub struct ActiveSessionHandle<N: NetworkPrimitives> {
     pub(crate) established: Instant,
     /// Announced capabilities of the peer.
     pub(crate) capabilities: Arc<Capabilities>,
-    /// Sender half of the command channel used send commands _to_ the spawned session
-    pub(crate) commands_to_session: mpsc::Sender<SessionCommand<N>>,
+    /// Sender for commands to the spawned session with broadcast-aware backpressure.
+    pub(crate) commands: SessionCommandSender<N>,
     /// The client's name and version
     pub(crate) client_version: Arc<str>,
     /// The address we're connected to
@@ -82,8 +91,7 @@ pub struct ActiveSessionHandle<N: NetworkPrimitives> {
 impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
     /// Sends a disconnect command to the session.
     pub fn disconnect(&self, reason: Option<DisconnectReason>) {
-        // Note: we clone the sender which ensures the channel has capacity to send the message
-        let _ = self.commands_to_session.clone().try_send(SessionCommand::Disconnect { reason });
+        self.commands.disconnect(reason);
     }
 
     /// Sends a disconnect command to the session, awaiting the command channel for available
@@ -92,7 +100,7 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
         &self,
         reason: Option<DisconnectReason>,
     ) -> Result<(), SendError<SessionCommand<N>>> {
-        self.commands_to_session.clone().send(SessionCommand::Disconnect { reason }).await
+        self.commands.try_disconnect(reason).await
     }
 
     /// Returns the direction of the active session (inbound or outbound).
@@ -135,6 +143,11 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
         self.remote_addr
     }
 
+    /// Returns the current number of in-flight broadcast items.
+    pub fn queued_broadcast_items(&self) -> usize {
+        self.commands.queued_broadcast_items()
+    }
+
     /// Extracts the [`PeerInfo`] from the session handle.
     pub(crate) fn peer_info(&self, record: &NodeRecord, kind: PeerKind) -> PeerInfo {
         PeerInfo {
@@ -151,6 +164,106 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
             session_established: self.established,
             kind,
         }
+    }
+}
+
+/// Sender half of the session command channel with broadcast-aware backpressure.
+///
+/// Commands are first sent through a bounded channel. If the bounded channel is full and the
+/// message is a broadcast with room under the broadcast item limit, it overflows to a dedicated
+/// unbounded channel that the session task drains alongside the bounded one.
+///
+/// The shared `broadcast_items` counter tracks items across **all** buffers (bounded channel,
+/// overflow channel, and the session's outgoing queue), so the
+/// [`SessionManager`](super::SessionManager) has an accurate view of total in-flight broadcast
+/// pressure.
+#[derive(Debug)]
+pub(crate) struct SessionCommandSender<N: NetworkPrimitives> {
+    /// Bounded channel for all commands (primary path).
+    tx: mpsc::Sender<SessionCommand<N>>,
+    /// Unbounded overflow for broadcasts when the bounded channel is full.
+    broadcast_overflow_tx: mpsc::UnboundedSender<PeerMessage<N>>,
+    /// Shared counter of in-flight broadcast items (channels + outgoing queue).
+    broadcast_items: Arc<AtomicUsize>,
+}
+
+impl<N: NetworkPrimitives> SessionCommandSender<N> {
+    /// Creates a new sender with the given bounded channel, overflow channel, and shared counter.
+    pub(crate) const fn new(
+        tx: mpsc::Sender<SessionCommand<N>>,
+        broadcast_overflow_tx: mpsc::UnboundedSender<PeerMessage<N>>,
+        broadcast_items: Arc<AtomicUsize>,
+    ) -> Self {
+        Self { tx, broadcast_overflow_tx, broadcast_items }
+    }
+
+    /// Sends a disconnect command, cloning the sender to reserve capacity.
+    pub(crate) fn disconnect(&self, reason: Option<DisconnectReason>) {
+        let _ = self.tx.clone().try_send(SessionCommand::Disconnect { reason });
+    }
+
+    /// Sends a disconnect command, awaiting channel capacity.
+    pub(crate) async fn try_disconnect(
+        &self,
+        reason: Option<DisconnectReason>,
+    ) -> Result<(), SendError<SessionCommand<N>>> {
+        self.tx.clone().send(SessionCommand::Disconnect { reason }).await
+    }
+
+    /// Sends a message to the session with broadcast-aware backpressure.
+    ///
+    /// For broadcast messages, the broadcast item counter is incremented **before** the message
+    /// enters any channel, ensuring the counter always reflects the true in-flight count.
+    /// If the bounded channel is full, broadcasts overflow to the unbounded channel (up to the
+    /// item limit). Non-broadcast messages that cannot fit in the bounded channel are dropped.
+    ///
+    /// Returns `true` if the message was accepted, `false` if it was dropped.
+    pub(crate) fn send_message(&self, msg: PeerMessage<N>) -> bool {
+        if msg.is_broadcast() {
+            let items = msg.message_item_count();
+
+            // Check + increment atomically (optimistic)
+            let prev = self.broadcast_items.fetch_add(items, Ordering::Relaxed);
+            if prev >= MAX_QUEUED_BROADCAST_ITEMS {
+                // Over limit, undo and drop
+                self.broadcast_items.fetch_sub(items, Ordering::Relaxed);
+                return false;
+            }
+
+            // Try bounded channel first
+            match self.tx.try_send(SessionCommand::Message(msg)) {
+                Ok(()) => true,
+                Err(mpsc::error::TrySendError::Full(SessionCommand::Message(msg))) => {
+                    // Overflow to unbounded broadcast channel (counter already incremented)
+                    let _ = self.broadcast_overflow_tx.send(msg);
+                    true
+                }
+                Err(_) => {
+                    // Channel closed, undo increment
+                    self.broadcast_items.fetch_sub(items, Ordering::Relaxed);
+                    false
+                }
+            }
+        } else {
+            // Non-broadcast: bounded channel only
+            match self.tx.try_send(SessionCommand::Message(msg)) {
+                Ok(()) => true,
+                Err(mpsc::error::TrySendError::Full(SessionCommand::Message(msg))) => {
+                    trace!(
+                        target: "net::session",
+                        msg_kind = msg.message_kind(),
+                        "session command buffer full, dropping non-broadcast message"
+                    );
+                    false
+                }
+                Err(_) => false,
+            }
+        }
+    }
+
+    /// Returns the current number of in-flight broadcast items.
+    pub(crate) fn queued_broadcast_items(&self) -> usize {
+        self.broadcast_items.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     message::PeerMessage,
-    session::{active::MAX_QUEUED_BROADCAST_ITEMS, conn::EthRlpxConnection, Direction, SessionId},
+    session::{active::BroadcastItemCounter, conn::EthRlpxConnection, Direction, SessionId},
     PendingSessionHandshakeError,
 };
 use reth_ecies::ECIESError;
@@ -13,15 +13,7 @@ use reth_eth_wire::{
 use reth_network_api::PeerInfo;
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::PeerKind;
-use std::{
-    io,
-    net::SocketAddr,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    time::Instant,
-};
+use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 use tokio::sync::{
     mpsc::{self, error::SendError},
     oneshot,
@@ -94,13 +86,12 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
         self.commands.disconnect(reason);
     }
 
-    /// Sends a disconnect command to the session, awaiting the command channel for available
-    /// capacity.
-    pub async fn try_disconnect(
+    /// Sends a disconnect command to the session via the unbounded channel.
+    pub fn try_disconnect(
         &self,
         reason: Option<DisconnectReason>,
     ) -> Result<(), SendError<SessionCommand<N>>> {
-        self.commands.try_disconnect(reason).await
+        self.commands.try_disconnect(reason)
     }
 
     /// Returns the direction of the active session (inbound or outbound).
@@ -181,33 +172,38 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
 pub(crate) struct SessionCommandSender<N: NetworkPrimitives> {
     /// Bounded channel for all commands (primary path).
     tx: mpsc::Sender<SessionCommand<N>>,
-    /// Unbounded overflow for broadcasts when the bounded channel is full.
-    broadcast_overflow_tx: mpsc::UnboundedSender<PeerMessage<N>>,
+    /// Unbounded channel used for broadcasts that overflow the bounded channel, and for
+    /// disconnect commands (which must never be dropped due to backpressure).
+    unbounded_tx: mpsc::UnboundedSender<SessionCommand<N>>,
     /// Shared counter of in-flight broadcast items (channels + outgoing queue).
-    broadcast_items: Arc<AtomicUsize>,
+    broadcast_items: BroadcastItemCounter,
 }
 
 impl<N: NetworkPrimitives> SessionCommandSender<N> {
-    /// Creates a new sender with the given bounded channel, overflow channel, and shared counter.
+    /// Creates a new sender with the given bounded channel, unbounded channel, and shared counter.
     pub(crate) const fn new(
         tx: mpsc::Sender<SessionCommand<N>>,
-        broadcast_overflow_tx: mpsc::UnboundedSender<PeerMessage<N>>,
-        broadcast_items: Arc<AtomicUsize>,
+        unbounded_tx: mpsc::UnboundedSender<SessionCommand<N>>,
+        broadcast_items: BroadcastItemCounter,
     ) -> Self {
-        Self { tx, broadcast_overflow_tx, broadcast_items }
+        Self { tx, unbounded_tx, broadcast_items }
     }
 
-    /// Sends a disconnect command, cloning the sender to reserve capacity.
+    /// Sends a disconnect command via the unbounded channel so it is never dropped due to
+    /// backpressure.
     pub(crate) fn disconnect(&self, reason: Option<DisconnectReason>) {
-        let _ = self.tx.clone().try_send(SessionCommand::Disconnect { reason });
+        let _ = self.unbounded_tx.send(SessionCommand::Disconnect { reason });
     }
 
-    /// Sends a disconnect command, awaiting channel capacity.
-    pub(crate) async fn try_disconnect(
+    /// Sends a disconnect command via the unbounded channel.
+    ///
+    /// This is infallible from a capacity standpoint (unbounded), but will fail if the
+    /// receiver has been dropped (session closed).
+    pub(crate) fn try_disconnect(
         &self,
         reason: Option<DisconnectReason>,
     ) -> Result<(), SendError<SessionCommand<N>>> {
-        self.tx.clone().send(SessionCommand::Disconnect { reason }).await
+        self.unbounded_tx.send(SessionCommand::Disconnect { reason }).map_err(|e| SendError(e.0))
     }
 
     /// Sends a message to the session with broadcast-aware backpressure.
@@ -223,24 +219,21 @@ impl<N: NetworkPrimitives> SessionCommandSender<N> {
             let items = msg.message_item_count();
 
             // Check + increment atomically (optimistic)
-            let prev = self.broadcast_items.fetch_add(items, Ordering::Relaxed);
-            if prev >= MAX_QUEUED_BROADCAST_ITEMS {
-                // Over limit, undo and drop
-                self.broadcast_items.fetch_sub(items, Ordering::Relaxed);
+            if !self.broadcast_items.try_add(items) {
                 return false;
             }
 
             // Try bounded channel first
             match self.tx.try_send(SessionCommand::Message(msg)) {
                 Ok(()) => true,
-                Err(mpsc::error::TrySendError::Full(SessionCommand::Message(msg))) => {
-                    // Overflow to unbounded broadcast channel (counter already incremented)
-                    let _ = self.broadcast_overflow_tx.send(msg);
+                Err(mpsc::error::TrySendError::Full(cmd)) => {
+                    // Overflow to unbounded channel (counter already incremented)
+                    let _ = self.unbounded_tx.send(cmd);
                     true
                 }
                 Err(_) => {
                     // Channel closed, undo increment
-                    self.broadcast_items.fetch_sub(items, Ordering::Relaxed);
+                    self.broadcast_items.sub(items);
                     false
                 }
             }
@@ -263,7 +256,7 @@ impl<N: NetworkPrimitives> SessionCommandSender<N> {
 
     /// Returns the current number of in-flight broadcast items.
     pub(crate) fn queued_broadcast_items(&self) -> usize {
-        self.broadcast_items.load(Ordering::Relaxed)
+        self.broadcast_items.get()
     }
 }
 

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -35,21 +35,25 @@ use std::{
     collections::HashMap,
     future::Future,
     net::SocketAddr,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize},
+        Arc,
+    },
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,
-    sync::{mpsc, mpsc::error::TrySendError, oneshot},
+    sync::{mpsc, oneshot},
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
-use tracing::{debug, instrument, trace};
+use tracing::{instrument, trace};
 
 use crate::session::active::RANGE_UPDATE_INTERVAL;
 pub use conn::EthRlpxConnection;
+use handle::SessionCommandSender;
 pub use handle::{
     ActiveSessionHandle, ActiveSessionMessage, PendingSessionEvent, PendingSessionHandle,
     SessionCommand,
@@ -372,23 +376,17 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         }
     }
 
-    /// Sends a message to the peer's session
+    /// Sends a message to the peer's session.
+    ///
+    /// Broadcast messages use size-based backpressure: the total number of in-flight broadcast
+    /// items (across the command channel, overflow channel, and session outgoing queue) is tracked
+    /// by a shared atomic counter. If the bounded command channel is full but the broadcast limit
+    /// hasn't been reached, the message overflows to a dedicated unbounded channel.
     pub fn send_message(&self, peer_id: &PeerId, msg: PeerMessage<N>) {
-        if let Some(session) = self.active_sessions.get(peer_id) {
-            let _ = session.commands_to_session.try_send(SessionCommand::Message(msg)).inspect_err(
-                |e| {
-                    if let TrySendError::Full(SessionCommand::Message(msg)) = e {
-                        debug!(
-                            target: "net::session",
-                            ?peer_id,
-                            msg_kind = msg.message_kind(),
-                            items = msg.message_item_count(),
-                            "session command buffer full, dropping message"
-                        );
-                        self.metrics.total_outgoing_peer_messages_dropped.increment(1);
-                    }
-                },
-            );
+        if let Some(session) = self.active_sessions.get(peer_id) &&
+            !session.commands.send_message(msg)
+        {
+            self.metrics.total_outgoing_peer_messages_dropped.increment(1);
         }
     }
 
@@ -527,7 +525,8 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     })
                 }
 
-                let (commands_to_session, commands_rx) = mpsc::channel(self.session_command_buffer);
+                let (commands_tx, commands_rx) = mpsc::channel(self.session_command_buffer);
+                let (broadcast_overflow_tx, broadcast_overflow_rx) = mpsc::unbounded_channel();
 
                 let (to_session_tx, messages_rx) = mpsc::channel(self.session_command_buffer);
 
@@ -551,6 +550,8 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     interval
                 });
 
+                let broadcast_items = Arc::new(AtomicUsize::new(0));
+
                 let session = ActiveSession {
                     next_id: 0,
                     remote_peer_id: peer_id,
@@ -558,6 +559,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     remote_capabilities: Arc::clone(&capabilities),
                     session_id,
                     commands_rx: ReceiverStream::new(commands_rx),
+                    broadcast_overflow_rx,
                     to_session_manager: self.active_session_tx.clone(),
                     pending_message_to_session: None,
                     internal_request_rx: ReceiverStream::new(messages_rx).fuse(),
@@ -565,6 +567,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     conn,
                     queued_outgoing: QueuedOutgoingMessages::new(
                         self.metrics.queued_outgoing_messages.clone(),
+                        Arc::clone(&broadcast_items),
                     ),
                     received_requests_from_remote: Default::default(),
                     internal_request_timeout_interval: tokio::time::interval(
@@ -590,7 +593,11 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     version,
                     established: Instant::now(),
                     capabilities: Arc::clone(&capabilities),
-                    commands_to_session,
+                    commands: SessionCommandSender::new(
+                        commands_tx,
+                        broadcast_overflow_tx,
+                        broadcast_items,
+                    ),
                     client_version: Arc::clone(&client_version),
                     remote_addr,
                     local_addr,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -562,6 +562,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     session_id,
                     commands_rx: ReceiverStream::new(commands_rx),
                     unbounded_rx,
+                    unbounded_broadcast_msgs: self.metrics.total_unbounded_broadcast_msgs.clone(),
                     to_session_manager: self.active_session_tx.clone(),
                     pending_message_to_session: None,
                     internal_request_rx: ReceiverStream::new(messages_rx).fuse(),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -35,10 +35,7 @@ use std::{
     collections::HashMap,
     future::Future,
     net::SocketAddr,
-    sync::{
-        atomic::{AtomicU64, AtomicUsize},
-        Arc,
-    },
+    sync::{atomic::AtomicU64, Arc},
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -51,7 +48,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
 use tracing::{instrument, trace};
 
-use crate::session::active::RANGE_UPDATE_INTERVAL;
+use crate::session::active::{BroadcastItemCounter, RANGE_UPDATE_INTERVAL};
 pub use conn::EthRlpxConnection;
 use handle::SessionCommandSender;
 pub use handle::{
@@ -526,7 +523,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 }
 
                 let (commands_tx, commands_rx) = mpsc::channel(self.session_command_buffer);
-                let (broadcast_overflow_tx, broadcast_overflow_rx) = mpsc::unbounded_channel();
+                let (unbounded_tx, unbounded_rx) = mpsc::unbounded_channel();
 
                 let (to_session_tx, messages_rx) = mpsc::channel(self.session_command_buffer);
 
@@ -550,7 +547,12 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     interval
                 });
 
-                let broadcast_items = Arc::new(AtomicUsize::new(0));
+                // Shared counter of in-flight broadcast items. The session task must decrement
+                // this when it pops messages from the outgoing queue, and the
+                // `SessionCommandSender` increments it before enqueuing. This invariant ensures
+                // the `SessionManager` always has an accurate view of total buffered broadcast
+                // pressure for a peer.
+                let broadcast_items = BroadcastItemCounter::new();
 
                 let session = ActiveSession {
                     next_id: 0,
@@ -559,7 +561,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     remote_capabilities: Arc::clone(&capabilities),
                     session_id,
                     commands_rx: ReceiverStream::new(commands_rx),
-                    broadcast_overflow_rx,
+                    unbounded_rx,
                     to_session_manager: self.active_session_tx.clone(),
                     pending_message_to_session: None,
                     internal_request_rx: ReceiverStream::new(messages_rx).fuse(),
@@ -567,7 +569,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     conn,
                     queued_outgoing: QueuedOutgoingMessages::new(
                         self.metrics.queued_outgoing_messages.clone(),
-                        Arc::clone(&broadcast_items),
+                        broadcast_items.clone(),
                     ),
                     received_requests_from_remote: Default::default(),
                     internal_request_timeout_interval: tokio::time::interval(
@@ -593,11 +595,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     version,
                     established: Instant::now(),
                     capabilities: Arc::clone(&capabilities),
-                    commands: SessionCommandSender::new(
-                        commands_tx,
-                        broadcast_overflow_tx,
-                        broadcast_items,
-                    ),
+                    commands: SessionCommandSender::new(commands_tx, unbounded_tx, broadcast_items),
                     client_version: Arc::clone(&client_version),
                     remote_addr,
                     local_addr,


### PR DESCRIPTION
The `session command buffer full, dropping message` spam happens because backpressure is count-based: 100 messages with 1 tx hash each fill the channel just as fast as 1 message with 100 hashes. This switches to size-based backpressure that tracks the total number of buffered broadcast items (tx hashes, transactions, blocks).

cc: @mattsse 
#22824