### PR TITLE
fix(payload): enter job span in resolve to propagate tracing context

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -315,7 +315,11 @@ where
         }
 
         let job = self.payload_jobs.iter().position(|(_, job_id, _)| *job_id == id)?;
-        let (fut, keep_alive) = self.payload_jobs[job].0.resolve_kind(kind);
+        let job_span = self.payload_jobs[job].2.clone();
+        let (fut, keep_alive) = {
+            let _entered = job_span.enter();
+            self.payload_jobs[job].0.resolve_kind(kind)
+        };
         let payload_timestamp = self.payload_jobs[job].0.payload_timestamp();
 
         if keep_alive == KeepPayloadJobAlive::No {


### PR DESCRIPTION
`resolve_kind` can trigger `spawn_build_job`, which relies on `Span::current()`
to propagate the caller's trace into the blocking task (via `spawn_task_as`'s
`.in_current_span()`). Without entering the stored `job_span` first, the blocking
task loses its parent span.

The service already propagates the span correctly for the initial build (`new_payload_job`)
and interval re-triggers (`poll`), but `resolve` was the one path that didn't enter
the span before calling into the job.

Prompted by: joshie