### PR TITLE
fix(payload): clear stale cached payload when new job is created

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -442,6 +442,17 @@ where
                                     new_job = true;
                                     this.payload_jobs.push((job, id));
                                     this.payload_events.send(Events::Attributes(attr)).ok();
+
+                                    // Clear stale cached payload for this id so
+                                    // resolve() never returns an outdated result
+                                    // from a previous job with the same id.
+                                    if let Some((cached_id, _, _)) =
+                                        &*this.cached_payload_rx.borrow()
+                                    {
+                                        if *cached_id == id {
+                                            let _ = this.cached_payload_tx.send(None);
+                                        }
+                                    }
                                 }
                                 Err(err) => {
                                     this.metrics.inc_failed_jobs();


### PR DESCRIPTION
When a proposer is re-elected for consecutive consensus rounds building on the same parent, the payload builder creates a new job with the same `PayloadId` (derived from parent hash). The old job was already resolved and removed, but its result stays in the `cached_payload_rx` watch channel.

`resolve()` checks the cache before active jobs. Cache hit → returns the stale payload from the prior round, never consulting the new job's `resolve_kind()`.

**Observed:** Proposer elected for two consecutive failed views on the same parent. First view built 38M gas. Second view built up to 54M gas (41% more), but proposed the stale 38M gas block because `resolve()` short-circuited on the cache.

**Fix:** Clear `cached_payload_rx` when spawning a new job with a matching `PayloadId`.

Prompted by: joshie