### PR TITLE
perf(trie): deduplicate prefix set computation

### DIFF
--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{
     keccak256,
     map::{HashMap, HashSet},
-    BlockNumber, B256,
+    Address, BlockNumber, B256,
 };
 use core::ops::RangeInclusive;
 use reth_db_api::{
@@ -39,20 +39,28 @@ where
     // We still need direct access to HashedAccounts table
     let mut account_hashed_state_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
 
+    let mut seen_accounts = HashSet::new();
     for (_, AccountBeforeTx { address, .. }) in account_changesets {
-        let hashed_address = keccak256(address);
-        account_prefix_set.insert(Nibbles::unpack(hashed_address));
+        if seen_accounts.insert(address) {
+            let hashed_address = keccak256(address);
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
 
-        if account_hashed_state_cursor.seek_exact(hashed_address)?.is_none() {
-            destroyed_accounts.insert(hashed_address);
+            if account_hashed_state_cursor.seek_exact(hashed_address)?.is_none() {
+                destroyed_accounts.insert(hashed_address);
+            }
         }
     }
 
     // Walk storage changesets using the provider (handles static files + database)
     let storage_changesets = provider.storage_changesets_range(range)?;
+    let mut last_address: Option<Address> = None;
+    let mut hashed_address = B256::ZERO;
     for (BlockNumberAddress((_, address)), storage_entry) in storage_changesets {
-        let hashed_address = keccak256(address);
-        account_prefix_set.insert(Nibbles::unpack(hashed_address));
+        if last_address != Some(address) {
+            last_address = Some(address);
+            hashed_address = keccak256(address);
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+        }
         storage_prefix_sets
             .entry(hashed_address)
             .or_default()

--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{
     keccak256,
-    map::{HashMap, HashSet},
+    map::{AddressSet, HashMap, HashSet},
     Address, BlockNumber, B256,
 };
 use core::ops::RangeInclusive;
@@ -39,7 +39,7 @@ where
     // We still need direct access to HashedAccounts table
     let mut account_hashed_state_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
 
-    let mut seen_accounts = HashSet::new();
+    let mut seen_accounts = AddressSet::default();
     for (_, AccountBeforeTx { address, .. }) in account_changesets {
         if seen_accounts.insert(address) {
             let hashed_address = keccak256(address);

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -1,5 +1,5 @@
 use crate::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
-use alloy_primitives::{keccak256, map::B256Map, BlockNumber, B256};
+use alloy_primitives::{keccak256, map::B256Map, Address, BlockNumber, B256};
 use reth_db_api::{
     models::{AccountBeforeTx, BlockNumberAddress},
     transaction::DbTx,
@@ -321,11 +321,16 @@ impl DatabaseHashedPostState for HashedPostStateSorted {
 
         if start < end {
             let end_inclusive = end.saturating_sub(1);
+            let mut last_address: Option<Address> = None;
+            let mut hashed_address = B256::ZERO;
             for (BlockNumberAddress((_, address)), storage) in
                 provider.storage_changesets_range(start..=end_inclusive)?
             {
                 if seen_storage_keys.insert((address, storage.key)) {
-                    let hashed_address = keccak256(address);
+                    if last_address != Some(address) {
+                        last_address = Some(address);
+                        hashed_address = keccak256(address);
+                    }
                     storages
                         .entry(hashed_address)
                         .or_default()

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -1,5 +1,9 @@
 use crate::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
-use alloy_primitives::{keccak256, map::B256Map, Address, BlockNumber, B256};
+use alloy_primitives::{
+    keccak256,
+    map::{AddressSet, B256Map},
+    Address, BlockNumber, B256,
+};
 use reth_db_api::{
     models::{AccountBeforeTx, BlockNumberAddress},
     transaction::DbTx,
@@ -305,7 +309,7 @@ impl DatabaseHashedPostState for HashedPostStateSorted {
 
         // Iterate over account changesets and record value before first occurring account change
         let mut accounts = Vec::new();
-        let mut seen_accounts = HashSet::new();
+        let mut seen_accounts = AddressSet::default();
         for entry in provider.account_changesets_range(start..end)? {
             let (_, AccountBeforeTx { address, info }) = entry;
             if seen_accounts.insert(address) {


### PR DESCRIPTION
Avoid redundant keccak256 hashing and DB cursor seeks when building trie prefix sets by deduplicating accounts via a HashSet and caching the last hashed address for consecutive storage changeset entries.