### PR TITLE
fix(rpc): exclude Testing module from default IPC modules

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -32,7 +32,7 @@ pub trait LoadReceipt:
                 .get_receipts(hash)
                 .await
                 .map_err(Self::Error::from_eth_err)?
-                .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
+                .ok_or(EthApiError::ReceiptsNotFound(hash.into()))?;
 
             let (gas_used, next_log_index) =
                 calculate_gas_used_and_next_log_index(meta.index, &all_receipts);

--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -349,7 +349,6 @@ impl RethRpcModule {
         Self::Flashbots,
         Self::Miner,
         Self::Mev,
-        Self::Testing,
     ];
 
     /// Returns the number of standard variants (excludes Other)
@@ -557,6 +556,8 @@ mod test {
     fn test_default_ipc_modules() {
         let default_ipc_modules = RpcModuleSelection::default_ipc_modules();
         assert_eq!(default_ipc_modules, RpcModuleSelection::all_modules());
+        // Testing module should not be included by default
+        assert!(!default_ipc_modules.contains(&RethRpcModule::Testing));
     }
 
     #[test]
@@ -883,13 +884,14 @@ mod test {
         // Verify "other" is not in the list
         assert!(!standard_names.contains(&"other"));
 
-        // Should have exactly as many names as STANDARD_VARIANTS
-        assert_eq!(standard_names.len(), RethRpcModule::STANDARD_VARIANTS.len());
-
-        // Verify all standard variants have their names in the list
+        // All STANDARD_VARIANTS should have their names in the list
         for variant in RethRpcModule::STANDARD_VARIANTS {
             assert!(standard_names.contains(&variant.as_ref()));
         }
+
+        // Testing is a valid variant name (for explicit CLI usage) but not a standard variant
+        assert!(standard_names.contains(&"testing"));
+        assert!(!RethRpcModule::STANDARD_VARIANTS.contains(&RethRpcModule::Testing));
     }
 
     #[test]


### PR DESCRIPTION
`Testing` was listed in `STANDARD_VARIANTS`, causing `default_ipc_modules()` to include it via `all_modules()`. Since IPC is enabled by default, the `testing_buildBlockV1` endpoint was silently registered on every node startup without any user configuration — contradicting the comment in `node.rs` that states it should only be wired "when the hidden testing module is explicitly requested on any transport".

Removes `Testing` from `STANDARD_VARIANTS` so it is excluded from `All`, `all_modules()`, and `default_ipc_modules()`. Users can still explicitly enable it via CLI flags (e.g. `--http.api testing`). `FromStr` parsing is unaffected.
