### PR TITLE
fix(txpool): treat NotFound as success in blob store cleanup

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -179,6 +179,10 @@ impl BlobStore for DiskFileBlobStore {
                     stat.delete_succeed += 1;
                     subsize += filesize;
                 }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Already deleted by a concurrent cleanup task
+                    stat.delete_succeed += 1;
+                }
                 Err(e) => {
                     stat.delete_failed += 1;
                     let err = DiskFileBlobStoreError::DeleteFile(tx, path, e);
@@ -931,5 +935,31 @@ mod tests {
 
         let v3 = store.get_by_versioned_hashes_v3(&[versioned_hash]).unwrap();
         assert_eq!(v3, vec![Some(expected)]);
+    }
+
+    #[test]
+    fn disk_double_cleanup_no_failure() {
+        let (store, _dir) = tmp_store();
+
+        let blobs = rng_blobs(5);
+        let all_hashes: Vec<_> = blobs.iter().map(|(tx, _)| *tx).collect();
+        store.insert_all(blobs).unwrap();
+        store.clear_cache();
+
+        // Schedule blobs for deletion
+        store.delete_all(all_hashes.clone()).unwrap();
+
+        // First cleanup: files exist, all should succeed
+        let stat1 = store.cleanup();
+        assert_eq!(stat1.delete_succeed, 5);
+        assert_eq!(stat1.delete_failed, 0);
+
+        // Manually re-enqueue the same hashes to simulate a concurrent cleanup race
+        store.inner.txs_to_delete.write().extend(all_hashes);
+
+        // Second cleanup: files already deleted, should still report success (NotFound)
+        let stat2 = store.cleanup();
+        assert_eq!(stat2.delete_succeed, 5);
+        assert_eq!(stat2.delete_failed, 0);
     }
 }


### PR DESCRIPTION
Observed on a mainnet full node: ~30 "No such file or directory" errors per day from blob store cleanup, with `blobstore_failed_deletes` metric steadily increasing. The errors come from concurrent cleanup tasks (e.g. triggered by both `on_canonical_state_change` and the periodic maintenance task) racing to delete the same expired blob files — the second task fails with `NotFound` for files already removed by the first.

Since the desired outcome (file removed) is already achieved, `NotFound` should count as a successful delete rather than a failure. This avoids inflating the `blobstore_failed_deletes` metric and eliminates spurious debug log noise.

Example log line: `[<tx_hash>] failed to delete blob file at /data/blobstore/<hash>.blob: No such file or directory (os error 2)`
