### PR TITLE
fix(rpc): use hex block numbers in error messages

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -97,7 +97,7 @@ pub enum EthApiError {
     #[error("invalid block range")]
     InvalidBlockRange,
     /// Requested block number is beyond the head block
-    #[error("request beyond head block: requested {requested}, head {head}")]
+    #[error("request beyond head block: requested {requested:#x}, head {head:#x}")]
     RequestBeyondHead {
         /// The requested block number
         requested: u64,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -51,7 +51,7 @@ pub enum EthSimulateError {
     #[error("Client adjustable limit reached")]
     GasLimitReached,
     /// Block number in sequence did not increase.
-    #[error("block numbers must be in order: {got} <= {parent}")]
+    #[error("block numbers must be in order: {got:#x} <= {parent:#x}")]
     BlockNumberInvalid {
         /// The block number that was provided.
         got: u64,

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -946,7 +946,9 @@ pub enum EthFilterError {
     #[error("query exceeds max block range {0}")]
     QueryExceedsMaxBlocks(u64),
     /// Query result is too large.
-    #[error("query exceeds max results {max_logs}, retry with the range {from_block}-{to_block}")]
+    #[error(
+        "query exceeds max results {max_logs}, retry with the range {from_block:#x}-{to_block:#x}"
+    )]
     QueryExceedsMaxResults {
         /// Maximum number of logs allowed per response
         max_logs: usize,


### PR DESCRIPTION
Ethereum JSON-RPC conventionally represents block numbers in hex. Several error messages in reth return block numbers in decimal, which is inconsistent with the rest of the API and confusing for users who then try to use those numbers in subsequent RPC calls.

Affected errors:
- `eth_getLogs`: "retry with the range 20000000-20010000" → "retry with the range 0x1312d00-0x1314b50"
- `eth_feeHistory`: "request beyond head block: requested 99999999, head 22000000" → "requested 0x5f5e0ff, head 0x14fb180"
- `eth_simulateV1`: "block numbers must be in order: 20000000 <= 19999999" → "0x1312d00 <= 0x1312cff"