### PR TITLE
fix(trie): remove unnecessary double-wrapping of ProviderError in changeset cache

### DIFF
--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -520,8 +520,7 @@ impl ChangesetCache {
         let start = Instant::now();
 
         // Compute changesets
-        let changesets =
-            compute_block_trie_changesets(provider, block_number).map_err(ProviderError::other)?;
+        let changesets = compute_block_trie_changesets(provider, block_number)?;
 
         let changesets = Arc::new(changesets);
         let elapsed = start.elapsed();


### PR DESCRIPTION
`compute_block_trie_changesets` already returns `Result<_, ProviderError>`, so `.map_err(ProviderError::other)` wraps it into `ProviderError::Other(Box<ProviderError>)`, losing the original error variant