### PR TITLE
chore(trie): remove redundant cfg attributes on evicted_count

### DIFF
--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -853,9 +853,6 @@ impl ChangesetCacheInner {
             self.block_numbers.range(..up_to_block).map(|(num, _)| *num).collect();
 
         // Remove entries for each block number below threshold
-        #[cfg(feature = "metrics")]
-        let mut evicted_count = 0;
-        #[cfg(not(feature = "metrics"))]
         let mut evicted_count = 0;
 
         for block_number in &blocks_to_evict {


### PR DESCRIPTION
Both `#[cfg(feature = "metrics")]` and `#[cfg(not(feature = "metrics"))]` branches declare identical `let mut evicted_count = 0;`. The variable is used unconditionally in the loop and `debug!` log, so the cfg gates serve no purpose.