### PR TITLE
refactor(txpool): use ValidPoolTransaction delegate accessors

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -4,7 +4,6 @@ use crate::{
     pool::pending::PendingTransaction,
     PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction,
 };
-use alloy_consensus::Transaction;
 use alloy_primitives::map::AddressSet;
 use core::fmt;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
@@ -57,9 +56,8 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
             let best = Iterator::next(&mut self.best)?;
             // If both the base fee and blob fee (if applicable for EIP-4844) are satisfied, return
             // the transaction
-            if best.transaction.max_fee_per_gas() >= self.base_fee as u128 &&
-                best.transaction
-                    .max_fee_per_blob_gas()
+            if best.max_fee_per_gas() >= self.base_fee as u128 &&
+                best.max_fee_per_blob_gas()
                     .is_none_or(|fee| fee >= self.base_fee_per_blob_gas as u128)
             {
                 return Some(best);
@@ -398,11 +396,10 @@ where
         // If we have space, try prioritizing transactions
         if self.prioritized_gas < self.max_prioritized_gas {
             for item in &mut self.inner {
-                if self.prioritized_senders.contains(&item.transaction.sender()) &&
-                    self.prioritized_gas + item.transaction.gas_limit() <=
-                        self.max_prioritized_gas
+                if self.prioritized_senders.contains(item.sender_ref()) &&
+                    self.prioritized_gas + item.gas_limit() <= self.max_prioritized_gas
                 {
-                    self.prioritized_gas += item.transaction.gas_limit();
+                    self.prioritized_gas += item.gas_limit();
                     return Some(item)
                 }
                 self.buffer.push_back(item);
@@ -432,7 +429,7 @@ where
 
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
         if skip_blobs {
-            self.buffer.retain(|tx| !tx.transaction.is_eip4844())
+            self.buffer.retain(|tx| !tx.is_eip4844())
         }
         self.inner.set_skip_blobs(skip_blobs)
     }
@@ -446,6 +443,7 @@ mod tests {
         test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
         BestTransactions, Priority,
     };
+    use alloy_consensus::Transaction;
 
     #[test]
     fn test_best_iter() {
@@ -552,7 +550,7 @@ mod tests {
         for nonce in 0..num_tx {
             let tx = best.next().expect("Transaction should be returned");
             assert_eq!(tx.nonce(), nonce);
-            assert!(tx.transaction.max_fee_per_gas() >= base_fee as u128);
+            assert!(tx.max_fee_per_gas() >= base_fee as u128);
         }
     }
 
@@ -609,10 +607,8 @@ mod tests {
         for nonce in 0..num_tx {
             let tx = best.next().expect("Transaction should be returned");
             assert_eq!(tx.nonce(), nonce);
-            assert!(tx.transaction.max_fee_per_gas() >= base_fee as u128);
-            assert!(
-                tx.transaction.max_fee_per_blob_gas().unwrap() >= base_fee_per_blob_gas as u128
-            );
+            assert!(tx.max_fee_per_gas() >= base_fee as u128);
+            assert!(tx.max_fee_per_blob_gas().unwrap() >= base_fee_per_blob_gas as u128);
         }
 
         // No more transactions should be returned

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1301,11 +1301,8 @@ where
         &'a self,
         transactions: impl IntoIterator<Item = &'a Arc<ValidPoolTransaction<T::Transaction>>>,
     ) {
-        let blob_txs = transactions
-            .into_iter()
-            .filter(|tx| tx.transaction.is_eip4844())
-            .map(|tx| *tx.hash())
-            .collect();
+        let blob_txs =
+            transactions.into_iter().filter(|tx| tx.is_eip4844()).map(|tx| *tx.hash()).collect();
         self.delete_blobs(blob_txs);
     }
 }
@@ -1452,7 +1449,7 @@ impl<T: PoolTransaction> AddedTransaction<T> {
 
     /// Returns the hash of the replaced transaction if it is a blob transaction.
     pub(crate) fn replaced_blob_transaction(&self) -> Option<B256> {
-        self.replaced().filter(|tx| tx.transaction.is_eip4844()).map(|tx| *tx.transaction.hash())
+        self.replaced().filter(|tx| tx.is_eip4844()).map(|tx| *tx.hash())
     }
 
     /// Returns the hash of the transaction

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -461,10 +461,9 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
             return true
         }
 
-        let existing_max_priority_fee_per_gas =
-            self.transaction.max_priority_fee_per_gas().unwrap_or_default();
+        let existing_max_priority_fee_per_gas = self.max_priority_fee_per_gas().unwrap_or_default();
         let replacement_max_priority_fee_per_gas =
-            maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or_default();
+            maybe_replacement.max_priority_fee_per_gas().unwrap_or_default();
 
         // Check max priority fee per gas (relevant for EIP-1559 transactions only)
         if existing_max_priority_fee_per_gas != 0 &&
@@ -476,10 +475,10 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         }
 
         // Check max blob fee per gas
-        if let Some(existing_max_blob_fee_per_gas) = self.transaction.max_fee_per_blob_gas() {
+        if let Some(existing_max_blob_fee_per_gas) = self.max_fee_per_blob_gas() {
             // This enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
-                maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or_default();
+                maybe_replacement.max_fee_per_blob_gas().unwrap_or_default();
             if replacement_max_blob_fee_per_gas <
                 existing_max_blob_fee_per_gas * (100 + price_bump) / 100
             {


### PR DESCRIPTION

  This PR replaces direct `.transaction` field access with `ValidPoolTransaction` delegate methods in txpool hot paths (`best.rs`, `pool/mod.rs`, `validate/mod.rs`), including fee checks, blob checks, sender/gas access, and hash access.

  Why this is needed: these checks should run through the validated transaction API boundary, not internal fields. Keeping access at the delegate layer reduces coupling, prevents refactor-prone call sites, and avoids subtle type/API misuse.

  Correctness: behavior and thresholds are unchanged; only access paths were normalized. Validation evidence: `cargo +nightly fmt --all --check` passed, `cargo +1.93.1 test -p reth-transaction-pool --all-targets` passed (`225 + 1` tests), and `cargo +1.93.1 clippy -p reth-transaction-pool --all-  targets --locked -- -D warnings` passed.