### PR TITLE
chore: remove stale entries from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -57,17 +57,11 @@ allow = [
     # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style
     "LicenseRef-rustls-webpki",
     "CDLA-Permissive-2.0",
-    "MPL-2.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # TODO: decide on MPL-2.0 handling
-    # These dependencies are grandfathered in https://github.com/paradigmxyz/reth/pull/6980
-    { allow = ["MPL-2.0"], name = "option-ext" },
-    { allow = ["MPL-2.0"], name = "webpki-root-certs" },
-]
+exceptions = []
 
 [[licenses.clarify]]
 name = "rustls-webpki"
@@ -84,13 +78,4 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = [
-    # TODO: Please avoid adding new entries to this list.
-    "https://github.com/alloy-rs/alloy",
-    "https://github.com/foundry-rs/block-explorers",
-    "https://github.com/bluealloy/revm",
-    "https://github.com/paradigmxyz/revm-inspectors",
-    "https://github.com/alloy-rs/evm",
-    "https://github.com/alloy-rs/hardforks",
-    "https://github.com/paradigmxyz/jsonrpsee",
-]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -78,4 +78,14 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = []
+unused-allowed-source = "allow"
+# Frequently patched dependencies
+allow-git = [
+    "https://github.com/alloy-rs/alloy",
+    "https://github.com/foundry-rs/block-explorers",
+    "https://github.com/bluealloy/revm",
+    "https://github.com/paradigmxyz/revm-inspectors",
+    "https://github.com/alloy-rs/evm",
+    "https://github.com/alloy-rs/hardforks",
+    "https://github.com/paradigmxyz/jsonrpsee",
+]


### PR DESCRIPTION
Remove unused MPL-2.0 license allowance and stale exceptions for `option-ext`
and `webpki-root-certs` which are no longer dependencies. Keep the `allow-git`
list for frequently patched deps but suppress the unmatched-source warnings
via `unused-allowed-source = "allow"`.