### PR TITLE
docs(consensus): document the validation pipeline and trait hierarchy

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -1,4 +1,23 @@
 //! Consensus protocol functions
+//!
+//! # Trait hierarchy
+//!
+//! Consensus validation is split across three traits, each adding a layer:
+//!
+//! - [`HeaderValidator`] — validates a header in isolation and against its parent. Used early in
+//!   the validation pipeline before block execution.
+//!
+//! - [`Consensus`] — extends `HeaderValidator` with block body validation. Checks that the body
+//!   matches the header (tx root, ommer hash, withdrawals) and runs pre-execution checks. Used
+//!   before a block is executed.
+//!
+//! - [`FullConsensus`] — extends `Consensus` with post-execution validation. Checks execution
+//!   results against the header (gas used, receipt root, logs bloom). Used after block execution to
+//!   verify the outcome.
+//!
+//! In the engine, these are applied in order during payload validation (`engine_newPayload`).
+//! Payload attribute validation for block building (`engine_forkchoiceUpdated`) is handled
+//! separately at the engine API layer and does not use these traits.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -117,7 +117,19 @@ pub trait EngineTypes:
         + 'static;
 }
 
-/// Type that validates the payloads processed by the engine API.
+/// Validates engine API requests at the RPC layer, before payloads and attributes
+/// are forwarded to the engine for processing.
+///
+/// - [`validate_version_specific_fields`](Self::validate_version_specific_fields): Enforced in each
+///   `engine_newPayloadVN` RPC handler to verify the payload contains the correct fields for the
+///   engine API version (e.g., blob fields in V3+, requests in V4+).
+///
+/// - [`ensure_well_formed_attributes`](Self::ensure_well_formed_attributes): Enforced in
+///   `engine_forkchoiceUpdatedVN` RPC handlers to validate payload attributes are well-formed for
+///   the given version before forwarding to the engine.
+///
+/// After this validation passes, the engine performs the full consensus validation
+/// pipeline (header, pre-execution, execution, post-execution).
 pub trait EngineApiValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     /// Validates the presence or exclusion of fork-specific fields based on the payload attributes
     /// and the message version.
@@ -136,6 +148,34 @@ pub trait EngineApiValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static
 }
 
 /// Type that validates an [`ExecutionPayload`].
+///
+/// This trait handles validation at the engine API boundary — converting payloads
+/// into blocks and validating payload attributes for block building.
+///
+/// # Methods and when they're used
+///
+/// - [`convert_payload_to_block`](Self::convert_payload_to_block): Used during `engine_newPayload`
+///   processing to decode the payload into a [`SealedBlock`]. Also used to validate payload
+///   structure during backfill buffering. In the engine tree, this runs concurrently with state
+///   setup on a background thread.
+///
+/// - [`ensure_well_formed_payload`](Self::ensure_well_formed_payload): Converts payload and
+///   recovers transaction signatures. Used when recovered senders are needed immediately.
+///
+/// - [`validate_payload_attributes_against_header`](Self::validate_payload_attributes_against_header):
+///   Enforced as part of the engine's `forkchoiceUpdated` handling when payload attributes
+///   are provided. Gates whether a payload build job is started.
+///
+/// - [`validate_block_post_execution_with_hashed_state`](Self::validate_block_post_execution_with_hashed_state):
+///   Called after block execution in the engine's payload validation pipeline.
+///   No-op on L1, used by L2s (e.g., OP Stack) for additional post-execution checks.
+///
+/// # Relationship to consensus traits
+///
+/// This trait does NOT replace the consensus traits (`Consensus`, `FullConsensus` from
+/// `reth-consensus`). Those handle the actual consensus rule
+/// validation (header checks, pre/post-execution). This trait handles engine API-specific
+/// concerns: payload encoding/decoding and attribute validation.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     /// The block type used by the engine.
@@ -191,6 +231,11 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     ///   > of a block referenced by forkchoiceState.headBlockHash.
     ///
     /// See also: <https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#specification-1>
+    ///
+    /// Enforced as part of the engine's `forkchoiceUpdated` handling when the consensus layer
+    /// provides payload attributes. If this returns an error, the forkchoice state update itself
+    /// is NOT rolled back, but no payload build job is started — the response includes
+    /// `INVALID_PAYLOAD_ATTRIBUTES`.
     fn validate_payload_attributes_against_header(
         &self,
         attr: &Types::PayloadAttributes,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3071,6 +3071,17 @@ where
 
     /// Validates the payload attributes with respect to the header and fork choice state.
     ///
+    /// This is called during `engine_forkchoiceUpdated` when the CL provides payload attributes,
+    /// indicating it wants the EL to start building a new block.
+    ///
+    /// Validation:
+    /// - [`PayloadValidator::validate_payload_attributes_against_header`]: ensures
+    ///   `payloadAttributes.timestamp > headBlock.timestamp` per the Engine API spec.
+    ///
+    /// If validation passes, sends the attributes to the payload builder to start a new
+    /// payload job. If it fails, returns `INVALID_PAYLOAD_ATTRIBUTES` without rolling back
+    /// the forkchoice update.
+    ///
     /// Note: At this point, the fork choice update is considered to be VALID, however, we can still
     /// return an error if the payload attributes are invalid.
     fn process_payload_attributes(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3074,9 +3074,8 @@ where
     /// This is called during `engine_forkchoiceUpdated` when the CL provides payload attributes,
     /// indicating it wants the EL to start building a new block.
     ///
-    /// Validation:
-    /// - [`PayloadValidator::validate_payload_attributes_against_header`]: ensures
-    ///   `payloadAttributes.timestamp > headBlock.timestamp` per the Engine API spec.
+    /// Runs [`PayloadValidator::validate_payload_attributes_against_header`] to ensure
+    /// `payloadAttributes.timestamp > headBlock.timestamp` per the Engine API spec.
     ///
     /// If validation passes, sends the attributes to the payload builder to start a new
     /// payload job. If it fails, returns `INVALID_PAYLOAD_ATTRIBUTES` without rolling back

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3074,7 +3074,7 @@ where
     /// This is called during `engine_forkchoiceUpdated` when the CL provides payload attributes,
     /// indicating it wants the EL to start building a new block.
     ///
-    /// Runs [`PayloadValidator::validate_payload_attributes_against_header`] to ensure
+    /// Runs [`PayloadValidator::validate_payload_attributes_against_header`](reth_engine_primitives::PayloadValidator::validate_payload_attributes_against_header) to ensure
     /// `payloadAttributes.timestamp > headBlock.timestamp` per the Engine API spec.
     ///
     /// If validation passes, sends the attributes to the payload builder to start a new

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1,4 +1,42 @@
 //! Types and traits for validating blocks and payloads.
+//!
+//! # Validation pipeline
+//!
+//! When the engine processes a new payload (`engine_newPayload`), validation happens in phases:
+//!
+//! ## Phase 1 – Payload conversion
+//! [`PayloadValidator::convert_payload_to_block`] decodes the execution payload (RLP, hashing)
+//! into a [`SealedBlock`]. This runs on a background thread concurrently with state setup.
+//!
+//! ## Phase 2 – Pre-execution consensus
+//! - [`HeaderValidator::validate_header`] — standalone header checks (hash, gas, base fee,
+//!   fork-specific fields)
+//! - [`Consensus::validate_block_pre_execution`] — body vs header (tx root, ommer hash, withdrawals
+//!   root)
+//! - [`HeaderValidator::validate_header_against_parent`] — sequential checks (block number,
+//!   timestamp, gas limit, base fee vs parent)
+//!
+//! ## Phase 3 – Execution
+//! Block transactions are executed via the EVM. Receipt roots are computed incrementally.
+//!
+//! ## Phase 4 – Post-execution consensus
+//! - [`FullConsensus::validate_block_post_execution`] — gas used, receipt root, logs bloom,
+//!   requests hash
+//! - [`PayloadValidator::validate_block_post_execution_with_hashed_state`] — network-specific
+//!   (no-op on L1, used by OP Stack)
+//!
+//! ## Payload attributes validation (`engine_forkchoiceUpdated`)
+//! When the CL provides payload attributes to start building a block:
+//! - [`PayloadValidator::validate_payload_attributes_against_header`] — ensures timestamp ordering
+//!
+//! If validation passes, a payload build job is started. If it fails,
+//! `INVALID_PAYLOAD_ATTRIBUTES` is returned without rolling back the forkchoice update.
+//!
+//! [`HeaderValidator::validate_header`]: reth_consensus::HeaderValidator::validate_header
+//! [`Consensus::validate_block_pre_execution`]: reth_consensus::Consensus::validate_block_pre_execution
+//! [`HeaderValidator::validate_header_against_parent`]: reth_consensus::HeaderValidator::validate_header_against_parent
+//! [`FullConsensus::validate_block_post_execution`]: reth_consensus::FullConsensus::validate_block_post_execution
+//! [`SealedBlock`]: reth_primitives_traits::SealedBlock
 
 use crate::tree::{
     cached_state::{CacheStats, CachedStateProvider},


### PR DESCRIPTION
Adds module-level and trait-level documentation explaining how consensus validation functions fit together during `engine_newPayload` and `engine_forkchoiceUpdated` processing. The docs are spread across the three relevant crates at the appropriate abstraction level:

- `reth-engine-tree` (`payload_validator.rs`): Full validation pipeline overview with links to all phases — this is the highest-level crate and can reference everything.
- `reth-consensus` (`lib.rs`): Trait hierarchy overview (`HeaderValidator` → `Consensus` → `FullConsensus`) explaining what each layer validates and when.
- `reth-engine-primitives` (`lib.rs`): `PayloadValidator` and `EngineApiValidator` trait docs explaining each method's role in the engine API flow, and `validate_payload_attributes_against_header` docs clarifying the forkchoice update behavior.
- `reth-engine-tree` (`mod.rs`): Expanded `process_payload_attributes` doc explaining the forkchoice updated validation and payload building flow.

Cross-crate references respect the dependency tree — lower-level crates use plain-text descriptions instead of doc links to types they can't depend on.