### PR TITLE
docs: fix article and grammar errors in network comments

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -264,7 +264,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns an immutable reference to the inner type if this an eth68 announcement.
+    /// Returns an immutable reference to the inner type if this is an eth68 announcement.
     pub const fn as_eth68(&self) -> Option<&NewPooledTransactionHashes68> {
         match self {
             Self::Eth66(_) => None,
@@ -272,7 +272,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns a mutable reference to the inner type if this an eth68 announcement.
+    /// Returns a mutable reference to the inner type if this is an eth68 announcement.
     pub const fn as_eth68_mut(&mut self) -> Option<&mut NewPooledTransactionHashes68> {
         match self {
             Self::Eth66(_) => None,
@@ -280,7 +280,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns a mutable reference to the inner type if this an eth66 announcement.
+    /// Returns a mutable reference to the inner type if this is an eth66 announcement.
     pub const fn as_eth66_mut(&mut self) -> Option<&mut NewPooledTransactionHashes66> {
         match self {
             Self::Eth66(msg) => Some(msg),
@@ -288,7 +288,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns the inner type if this an eth68 announcement.
+    /// Returns the inner type if this is an eth68 announcement.
     pub fn take_eth68(&mut self) -> Option<NewPooledTransactionHashes68> {
         match self {
             Self::Eth66(_) => None,
@@ -296,7 +296,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns the inner type if this an eth66 announcement.
+    /// Returns the inner type if this is an eth66 announcement.
     pub fn take_eth66(&mut self) -> Option<NewPooledTransactionHashes66> {
         match self {
             Self::Eth66(msg) => Some(mem::take(msg)),

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -262,12 +262,12 @@ pub enum Direction {
 }
 
 impl Direction {
-    /// Returns `true` if this an incoming connection.
+    /// Returns `true` if this is an incoming connection.
     pub const fn is_incoming(&self) -> bool {
         matches!(self, Self::Incoming)
     }
 
-    /// Returns `true` if this an outgoing connection.
+    /// Returns `true` if this is an outgoing connection.
     pub const fn is_outgoing(&self) -> bool {
         matches!(self, Self::Outgoing(_))
     }


### PR DESCRIPTION
  This cleans up a few obvious rustdoc grammar issues in the networking layer, including phrases like `if this an eth68 announcement` and `if this an incoming connection`.                                                                                                                                                                                                                                                                 
  The changes are purely comment-level and mechanical, so they do not alter behavior or meaning. They just make the networking docs read correctly and consistently.  