### PR TITLE
docs: fix article and grammar errors in rpc and payload comments

### DIFF
--- a/crates/payload/validator/src/cancun.rs
+++ b/crates/payload/validator/src/cancun.rs
@@ -87,9 +87,9 @@ pub fn ensure_well_formed_transactions_field_with_sidecar<T: Transaction + Typed
     Ok(())
 }
 
-/// Ensures that the number of blob versioned hashes of a EIP-4844 transactions in block, matches
-/// the number hashes included in the _separate_ `block_versioned_hashes` of the cancun payload
-/// fields on the sidecar.
+/// Ensures that the number of blob versioned hashes in EIP-4844 transactions in the block
+/// matches the number of hashes included in the _separate_ `block_versioned_hashes` Cancun
+/// payload field on the sidecar.
 pub fn ensure_matching_blob_versioned_hashes<T: Transaction + Typed2718, H>(
     block_body: &BlockBody<T, H>,
     cancun_sidecar_fields: Option<&CancunPayloadFields>,

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -23,7 +23,7 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "getRawBlock")]
     async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
-    /// Returns a EIP-2718 binary-encoded transaction.
+    /// Returns an EIP-2718 binary-encoded transaction.
     ///
     /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
     #[method(name = "getRawTransaction")]

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -136,7 +136,7 @@ pub trait EthApi<
 
     /// Returns the EIP-2718 encoded transaction if it exists.
     ///
-    /// If this is a EIP-4844 transaction that is in the pool it will include the sidecar.
+    /// If this is an EIP-4844 transaction that is in the pool, it will include the sidecar.
     #[method(name = "getRawTransactionByHash")]
     async fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>>;
 

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -52,7 +52,7 @@ where
 
 /// Helper trait to access wrapped core error.
 pub trait AsEthApiError {
-    /// Returns reference to [`EthApiError`], if this an error variant inherited from core
+    /// Returns a reference to [`EthApiError`] if this is an error variant inherited from core
     /// functionality.
     fn as_err(&self) -> Option<&EthApiError>;
 


### PR DESCRIPTION
This addresses minor issues in public API documentation, including incorrect article usage (e.g., "a EIP-2718", "a EIP-4844") and awkward sentence construction. These changes are strictly limited to documentation, preserving all original functionality—no code or API behavior is modified, only improving clarity of RPC and payload documentation.