### PR TITLE
chore(engine): Clean MultiProofTaskMetrics fields

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -128,41 +128,6 @@ pub(crate) fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostStat
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tree.root")]
 pub(crate) struct MultiProofTaskMetrics {
-    /// Histogram of active storage workers processing proofs.
-    pub active_storage_workers_histogram: Histogram,
-    /// Histogram of active account workers processing proofs.
-    pub active_account_workers_histogram: Histogram,
-    /// Gauge for the maximum number of storage workers in the pool.
-    pub max_storage_workers: Gauge,
-    /// Gauge for the maximum number of account workers in the pool.
-    pub max_account_workers: Gauge,
-    /// Histogram of pending storage multiproofs in the queue.
-    pub pending_storage_multiproofs_histogram: Histogram,
-    /// Histogram of pending account multiproofs in the queue.
-    pub pending_account_multiproofs_histogram: Histogram,
-
-    /// Histogram of the number of prefetch proof target accounts.
-    pub prefetch_proof_targets_accounts_histogram: Histogram,
-    /// Histogram of the number of prefetch proof target storages.
-    pub prefetch_proof_targets_storages_histogram: Histogram,
-    /// Histogram of the number of prefetch proof target chunks.
-    pub prefetch_proof_chunks_histogram: Histogram,
-
-    /// Histogram of the number of state update proof target accounts.
-    pub state_update_proof_targets_accounts_histogram: Histogram,
-    /// Histogram of the number of state update proof target storages.
-    pub state_update_proof_targets_storages_histogram: Histogram,
-    /// Histogram of the number of state update proof target chunks.
-    pub state_update_proof_chunks_histogram: Histogram,
-
-    /// Histogram of prefetch proof batch sizes (number of messages merged).
-    pub prefetch_batch_size_histogram: Histogram,
-
-    /// Histogram of proof calculation durations.
-    pub proof_calculation_duration_histogram: Histogram,
-
-    /// Histogram of sparse trie update durations.
-    pub sparse_trie_update_duration_histogram: Histogram,
     /// Histogram of durations spent revealing multiproof results into the sparse trie.
     pub sparse_trie_reveal_multiproof_duration_histogram: Histogram,
     /// Histogram of durations spent coalescing multiple proof results from the channel.
@@ -175,17 +140,6 @@ pub(crate) struct MultiProofTaskMetrics {
     pub sparse_trie_final_update_duration_histogram: Histogram,
     /// Histogram of sparse trie total durations.
     pub sparse_trie_total_duration_histogram: Histogram,
-
-    /// Histogram of state updates received.
-    pub state_updates_received_histogram: Histogram,
-    /// Histogram of proofs processed.
-    pub proofs_processed_histogram: Histogram,
-    /// Histogram of total time spent in the multiproof task.
-    pub multiproof_task_total_duration_histogram: Histogram,
-    /// Total time spent waiting for the first state update or prefetch request.
-    pub first_update_wait_time_histogram: Histogram,
-    /// Total time spent waiting for the last proof result.
-    pub last_proof_wait_time_histogram: Histogram,
     /// Time spent preparing the sparse trie for reuse after state root computation.
     pub into_trie_for_reuse_duration_histogram: Histogram,
     /// Time spent waiting for preserved sparse trie cache to become available.


### PR DESCRIPTION
PR #22270 removed the legacy proof code paths (-2130 lines) but left 20 metric field definitions in `MultiProofTaskMetrics` that are no longer recorded anywhere. These metrics are registered in Prometheus on every reth node but remain permanently at zero, adding noise to the `/metrics` endpoint.

Removes 20 unused fields: `active_storage_workers_histogram`, `active_account_workers_histogram`, `max_storage_workers`, `max_account_workers`, `pending_storage_multiproofs_histogram`, `pending_account_multiproofs_histogram`, `prefetch_proof_targets_accounts_histogram`, `prefetch_proof_targets_storages_histogram`, `prefetch_proof_chunks_histogram`, `state_update_proof_targets_accounts_histogram`, `state_update_proof_targets_storages_histogram`, `state_update_proof_chunks_histogram`, `prefetch_batch_size_histogram`, `proof_calculation_duration_histogram`, `sparse_trie_update_duration_histogram`, `state_updates_received_histogram`, `proofs_processed_histogram`, `multiproof_task_total_duration_histogram`, `first_update_wait_time_histogram`, `last_proof_wait_time_histogram`.

All 14 actively-used `sparse_trie_*` and `into_trie_for_reuse_*` fields are retained.