### PR TITLE
perf(engine): hoist outer map lookups out of per-slot loops

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -384,13 +384,11 @@ where
         }
 
         for (address, slots) in targets.storage_targets {
+            // Look up outer map once per address instead of once per slot.
+            let new_updates = self.new_storage_updates.entry(address).or_default();
             for slot in slots {
                 // Only touch storages that are not yet present in the updates set.
-                self.new_storage_updates
-                    .entry(address)
-                    .or_default()
-                    .entry(slot.key())
-                    .or_insert(LeafUpdate::Touched);
+                new_updates.entry(slot.key()).or_insert(LeafUpdate::Touched);
             }
 
             // Touch corresponding account leaf to make sure its revealed in accounts trie for
@@ -406,45 +404,59 @@ where
         skip_all
     )]
     fn on_hashed_state_update(&mut self, hashed_state_update: HashedPostState) {
+        // Destructure to allow simultaneous mutable borrows of disjoint fields, so we can
+        // hoist per-address outer-map lookups out of the per-slot inner loop.
+        let Self {
+            trie,
+            new_storage_updates,
+            storage_updates,
+            new_account_updates,
+            pending_account_updates,
+            ..
+        } = self;
+
         for (address, storage) in hashed_state_update.storages {
+            // Look up outer maps once per address instead of once per slot.
+            let new_updates = new_storage_updates.entry(address).or_default();
+            let mut existing_updates = storage_updates.get_mut(&address);
+
             for (slot, value) in storage.storage {
-                self.trie.record_slot_touch(address, slot);
+                trie.record_slot_touch(address, slot);
 
                 let encoded = if value.is_zero() {
                     Vec::new()
                 } else {
                     alloy_rlp::encode_fixed_size(&value).to_vec()
                 };
-                self.new_storage_updates
-                    .entry(address)
-                    .or_default()
-                    .insert(slot, LeafUpdate::Changed(encoded));
+                new_updates.insert(slot, LeafUpdate::Changed(encoded));
 
                 // Remove an existing storage update if it exists.
-                self.storage_updates.get_mut(&address).and_then(|updates| updates.remove(&slot));
+                if let Some(ref mut existing) = existing_updates {
+                    existing.remove(&slot);
+                }
             }
 
             // Make sure account is tracked in `account_updates` so that it is revealed in accounts
             // trie for storage root update.
-            self.new_account_updates.entry(address).or_insert(LeafUpdate::Touched);
+            new_account_updates.entry(address).or_insert(LeafUpdate::Touched);
 
             // Make sure account is tracked in `pending_account_updates` so that once storage root
             // is computed, it will be updated in the accounts trie.
-            self.pending_account_updates.entry(address).or_insert(None);
+            pending_account_updates.entry(address).or_insert(None);
         }
 
         for (address, account) in hashed_state_update.accounts {
-            self.trie.record_account_touch(address);
+            trie.record_account_touch(address);
 
             // Track account as touched.
             //
             // This might overwrite an existing update, which is fine, because storage root from it
             // is already tracked in the trie and can be easily fetched again.
-            self.new_account_updates.insert(address, LeafUpdate::Touched);
+            new_account_updates.insert(address, LeafUpdate::Touched);
 
             // Track account in `pending_account_updates` so that once storage root is computed,
             // it will be updated in the accounts trie.
-            self.pending_account_updates.insert(address, Some(account));
+            pending_account_updates.insert(address, Some(account));
         }
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -384,11 +384,13 @@ where
         }
 
         for (address, slots) in targets.storage_targets {
-            // Look up outer map once per address instead of once per slot.
-            let new_updates = self.new_storage_updates.entry(address).or_default();
-            for slot in slots {
-                // Only touch storages that are not yet present in the updates set.
-                new_updates.entry(slot.key()).or_insert(LeafUpdate::Touched);
+            if !slots.is_empty() {
+                // Look up outer map once per address instead of once per slot.
+                let new_updates = self.new_storage_updates.entry(address).or_default();
+                for slot in slots {
+                    // Only touch storages that are not yet present in the updates set.
+                    new_updates.entry(slot.key()).or_insert(LeafUpdate::Touched);
+                }
             }
 
             // Touch corresponding account leaf to make sure its revealed in accounts trie for
@@ -416,23 +418,25 @@ where
         } = self;
 
         for (address, storage) in hashed_state_update.storages {
-            // Look up outer maps once per address instead of once per slot.
-            let new_updates = new_storage_updates.entry(address).or_default();
-            let mut existing_updates = storage_updates.get_mut(&address);
+            if !storage.storage.is_empty() {
+                // Look up outer maps once per address instead of once per slot.
+                let new_updates = new_storage_updates.entry(address).or_default();
+                let mut existing_updates = storage_updates.get_mut(&address);
 
-            for (slot, value) in storage.storage {
-                trie.record_slot_touch(address, slot);
+                for (slot, value) in storage.storage {
+                    trie.record_slot_touch(address, slot);
 
-                let encoded = if value.is_zero() {
-                    Vec::new()
-                } else {
-                    alloy_rlp::encode_fixed_size(&value).to_vec()
-                };
-                new_updates.insert(slot, LeafUpdate::Changed(encoded));
+                    let encoded = if value.is_zero() {
+                        Vec::new()
+                    } else {
+                        alloy_rlp::encode_fixed_size(&value).to_vec()
+                    };
+                    new_updates.insert(slot, LeafUpdate::Changed(encoded));
 
-                // Remove an existing storage update if it exists.
-                if let Some(ref mut existing) = existing_updates {
-                    existing.remove(&slot);
+                    // Remove an existing storage update if it exists.
+                    if let Some(ref mut existing) = existing_updates {
+                        existing.remove(&slot);
+                    }
                 }
             }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -406,25 +406,14 @@ where
         skip_all
     )]
     fn on_hashed_state_update(&mut self, hashed_state_update: HashedPostState) {
-        // Destructure to allow simultaneous mutable borrows of disjoint fields, so we can
-        // hoist per-address outer-map lookups out of the per-slot inner loop.
-        let Self {
-            trie,
-            new_storage_updates,
-            storage_updates,
-            new_account_updates,
-            pending_account_updates,
-            ..
-        } = self;
-
         for (address, storage) in hashed_state_update.storages {
             if !storage.storage.is_empty() {
                 // Look up outer maps once per address instead of once per slot.
-                let new_updates = new_storage_updates.entry(address).or_default();
-                let mut existing_updates = storage_updates.get_mut(&address);
+                let new_updates = self.new_storage_updates.entry(address).or_default();
+                let mut existing_updates = self.storage_updates.get_mut(&address);
 
                 for (slot, value) in storage.storage {
-                    trie.record_slot_touch(address, slot);
+                    self.trie.record_slot_touch(address, slot);
 
                     let encoded = if value.is_zero() {
                         Vec::new()
@@ -442,25 +431,25 @@ where
 
             // Make sure account is tracked in `account_updates` so that it is revealed in accounts
             // trie for storage root update.
-            new_account_updates.entry(address).or_insert(LeafUpdate::Touched);
+            self.new_account_updates.entry(address).or_insert(LeafUpdate::Touched);
 
             // Make sure account is tracked in `pending_account_updates` so that once storage root
             // is computed, it will be updated in the accounts trie.
-            pending_account_updates.entry(address).or_insert(None);
+            self.pending_account_updates.entry(address).or_insert(None);
         }
 
         for (address, account) in hashed_state_update.accounts {
-            trie.record_account_touch(address);
+            self.trie.record_account_touch(address);
 
             // Track account as touched.
             //
             // This might overwrite an existing update, which is fine, because storage root from it
             // is already tracked in the trie and can be easily fetched again.
-            new_account_updates.insert(address, LeafUpdate::Touched);
+            self.new_account_updates.insert(address, LeafUpdate::Touched);
 
             // Track account in `pending_account_updates` so that once storage root is computed,
             // it will be updated in the accounts trie.
-            pending_account_updates.insert(address, Some(account));
+            self.pending_account_updates.insert(address, Some(account));
         }
     }
 


### PR DESCRIPTION
In `on_hashed_state_update` and `on_prewarm_targets`, the outer `B256Map` lookups for `new_storage_updates[address]` and `storage_updates[address]` were performed inside the per-slot inner loop, even though the address is constant within each iteration of the outer loop. This caused redundant hashing and SwissTable probing for every storage slot.

Profiling a mainnet full node with `perf record` showed ~55% of engine thread CPU in SwissTable probing (`pcmpeqb`/`pmovmskb`/`tzcnt` loops), with cache misses on B256 bucket key loads as the bottleneck. On typical mainnet blocks (~200 addresses, ~1000 storage slots), this eliminates ~1600 redundant outer-map lookups per block (~80% reduction in outer-map probes).

Fix by destructuring `self` to allow simultaneous mutable borrows of disjoint fields, hoisting the outer-map `entry()`/`get_mut()` calls to once per address rather than once per slot.
