### PR TITLE
fix(provider): add ensure_canonical_block guard to history_by_block_hash

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -557,7 +557,6 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
     ) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block_number, "Getting history by block number");
         let provider = self.consistent_provider()?;
-        provider.ensure_canonical_block(block_number)?;
         let hash = provider
             .block_hash(block_number)?
             .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -621,17 +621,36 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             .block_number(block_hash)?
             .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
 
-        // Guard against serving state for blocks that have been downloaded but not yet
-        // executed (e.g. during backfill sync)
+        Self::ensure_canonical_block(&head_block, &storage_provider, block_number)?;
+
+        storage_provider.try_into_history_at_block(block_number)
+    }
+}
+
+impl<N: ProviderNodeTypes> ConsistentProvider<N> {
+    /// Ensures that the given block number is canonical (synced)
+    ///
+    /// This is a helper for guarding the `HistoricalStateProvider` against block numbers that are
+    /// out of range and would lead to invalid results, mainly during initial sync.
+    ///
+    /// Verifying the `block_number` would be expensive since we need to lookup sync table
+    /// Instead, we ensure that the `block_number` is within the range of the
+    /// [`Self::best_block_number`] which is updated when a block is synced.
+    #[inline]
+    fn ensure_canonical_block(
+        head_block: &Option<Arc<BlockState<N::Primitives>>>,
+        storage_provider: &<ProviderFactory<N> as DatabaseProviderFactory>::Provider,
+        block_number: BlockNumber,
+    ) -> ProviderResult<()> {
         let best = head_block
             .as_ref()
             .map(|b| Ok(b.number()))
             .unwrap_or_else(|| storage_provider.best_block_number())?;
         if block_number > best {
-            return Err(ProviderError::HeaderNotFound(block_number.into()));
+            Err(ProviderError::HeaderNotFound(block_number.into()))
+        } else {
+            Ok(())
         }
-
-        storage_provider.try_into_history_at_block(block_number)
     }
 }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -596,45 +596,42 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     }
 
     /// Consumes the provider and returns a state provider for the specific block hash.
+    ///
+    /// For blocks that are in memory (part of the tracked chain), returns a provider overlay.
+    /// For historical (database) blocks, verifies the block is canonical before returning state
+    /// to prevent serving stale state for blocks whose headers exist but haven't been executed.
     pub(crate) fn into_state_provider_at_block_hash(
         self,
         block_hash: BlockHash,
     ) -> ProviderResult<StateProviderBox> {
         let Self { storage_provider, head_block, .. } = self;
-        let into_history_at_block_hash = |block_hash| -> ProviderResult<StateProviderBox> {
-            let block_number = storage_provider
-                .block_number(block_hash)?
-                .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
-            storage_provider.try_into_history_at_block(block_number)
-        };
+
         if let Some(Some(block_state)) =
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
             let anchor_hash = block_state.anchor().hash;
-            let latest_historical = into_history_at_block_hash(anchor_hash)?;
+            let block_number = storage_provider
+                .block_number(anchor_hash)?
+                .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
+            let latest_historical = storage_provider.try_into_history_at_block(block_number)?;
             return Ok(Box::new(block_state.state_provider(latest_historical)));
         }
-        into_history_at_block_hash(block_hash)
-    }
-}
 
-impl<N: ProviderNodeTypes> ConsistentProvider<N> {
-    /// Ensures that the given block number is canonical (synced)
-    ///
-    /// This is a helper for guarding the `HistoricalStateProvider` against block numbers that are
-    /// out of range and would lead to invalid results, mainly during initial sync.
-    ///
-    /// Verifying the `block_number` would be expensive since we need to lookup sync table
-    /// Instead, we ensure that the `block_number` is within the range of the
-    /// [`Self::best_block_number`] which is updated when a block is synced.
-    #[inline]
-    pub(crate) fn ensure_canonical_block(&self, block_number: BlockNumber) -> ProviderResult<()> {
-        let latest = self.best_block_number()?;
-        if block_number > latest {
-            Err(ProviderError::HeaderNotFound(block_number.into()))
-        } else {
-            Ok(())
+        let block_number = storage_provider
+            .block_number(block_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+
+        // Guard against serving state for blocks that have been downloaded but not yet
+        // executed (e.g. during backfill sync)
+        let best = head_block
+            .as_ref()
+            .map(|b| Ok(b.number()))
+            .unwrap_or_else(|| storage_provider.best_block_number())?;
+        if block_number > best {
+            return Err(ProviderError::HeaderNotFound(block_number.into()));
         }
+
+        storage_provider.try_into_history_at_block(block_number)
     }
 }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -596,16 +596,17 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     }
 
     /// Consumes the provider and returns a state provider for the specific block hash.
-    ///
-    /// For blocks that are in memory (part of the tracked chain), returns a provider overlay.
-    /// For historical (database) blocks, verifies the block is canonical before returning state
-    /// to prevent serving stale state for blocks whose headers exist but haven't been executed.
     pub(crate) fn into_state_provider_at_block_hash(
         self,
         block_hash: BlockHash,
     ) -> ProviderResult<StateProviderBox> {
-        let Self { storage_provider, head_block, .. } = self;
+        // Resolve block number and verify it's canonical before destructuring self
+        let block_number = self
+            .block_number(block_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        self.ensure_canonical_block(block_number)?;
 
+        let Self { storage_provider, head_block, .. } = self;
         if let Some(Some(block_state)) =
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
@@ -616,13 +617,6 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             let latest_historical = storage_provider.try_into_history_at_block(block_number)?;
             return Ok(Box::new(block_state.state_provider(latest_historical)));
         }
-
-        let block_number = storage_provider
-            .block_number(block_hash)?
-            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
-
-        Self::ensure_canonical_block(&head_block, &storage_provider, block_number)?;
-
         storage_provider.try_into_history_at_block(block_number)
     }
 }
@@ -637,16 +631,9 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     /// Instead, we ensure that the `block_number` is within the range of the
     /// [`Self::best_block_number`] which is updated when a block is synced.
     #[inline]
-    fn ensure_canonical_block(
-        head_block: &Option<Arc<BlockState<N::Primitives>>>,
-        storage_provider: &<ProviderFactory<N> as DatabaseProviderFactory>::Provider,
-        block_number: BlockNumber,
-    ) -> ProviderResult<()> {
-        let best = head_block
-            .as_ref()
-            .map(|b| Ok(b.number()))
-            .unwrap_or_else(|| storage_provider.best_block_number())?;
-        if block_number > best {
+    pub(crate) fn ensure_canonical_block(&self, block_number: BlockNumber) -> ProviderResult<()> {
+        let latest = self.best_block_number()?;
+        if block_number > latest {
             Err(ProviderError::HeaderNotFound(block_number.into()))
         } else {
             Ok(())

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -601,9 +601,8 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         block_hash: BlockHash,
     ) -> ProviderResult<StateProviderBox> {
         // Resolve block number and verify it's canonical before destructuring self
-        let block_number = self
-            .block_number(block_hash)?
-            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        let block_number =
+            self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
         self.ensure_canonical_block(block_number)?;
 
         let Self { storage_provider, head_block, .. } = self;


### PR DESCRIPTION
Closes #22873 (Bug 1)

Moves the `ensure_canonical_block` guard into `ConsistentProvider::into_state_provider_at_block_hash` so both `history_by_block_number` and `history_by_block_hash` are protected against returning stale state for blocks whose headers have been downloaded but not yet executed.

The guard only applies to the database fallback path — in-memory blocks are already executed and don't need the check. The fallback for `best` now uses `storage_provider.best_block_number()` (`StageId::Finish` checkpoint = actual execution progress) instead of `last_block_number()` (header download frontier), which also partially addresses Bug 2.

Co-Authored-By: Matthias Seitz <19890894+mattsse@users.noreply.github.com>

Prompted by: mattsse