### PR TITLE
docs: fix typos and grammar errors across crates

### DIFF
--- a/crates/cli/cli/src/lib.rs
+++ b/crates/cli/cli/src/lib.rs
@@ -21,7 +21,7 @@ use crate::chainspec::ChainSpecParser;
 ///
 /// This trait is supposed to be implemented by the main struct of the CLI.
 ///
-/// It provides commonly used functionality for running commands and information about the CL, such
+/// It provides commonly used functionality for running commands and information about the CLI, such
 /// as the name and version.
 pub trait RethCli: Sized {
     /// The associated `ChainSpecParser` type

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -102,14 +102,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         let static_files_path = data_dir.static_files();
         let exex_wal_path = data_dir.exex_wal();
 
-        // ensure the provided datadir exist
+        // ensure the provided datadir exists
         eyre::ensure!(
             data_dir.data_dir().is_dir(),
             "Datadir does not exist: {:?}",
             data_dir.data_dir()
         );
 
-        // ensure the provided database exist
+        // ensure the provided database exists
         eyre::ensure!(db_path.is_dir(), "Database does not exist: {:?}", db_path);
 
         match self.command {

--- a/crates/cli/commands/src/db/state.rs
+++ b/crates/cli/commands/src/db/state.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use tracing::info;
 
-/// Log progress every 5 seconds
+/// Log progress every 30 seconds
 const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
 /// The arguments for the `reth db state` command

--- a/crates/cli/commands/src/init_state/mod.rs
+++ b/crates/cli/commands/src/init_state/mod.rs
@@ -47,7 +47,7 @@ pub struct InitStateCommand<C: ChainSpecParser> {
     /// Specifies whether to initialize the state without relying on EVM historical data.
     ///
     /// When enabled, and before inserting the state, it creates a dummy chain up to the last EVM
-    /// block specified. It then, appends the first block provided block.
+    /// block specified. It then appends the first provided block.
     ///
     /// - **Note**: **Do not** import receipts and blocks beforehand, or this will fail or be
     ///   ignored.

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -125,12 +125,12 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
 }
 
 impl<C: ChainSpecParser> NodeCommand<C> {
-    /// Parsers only the default CLI arguments
+    /// Parses only the default CLI arguments
     pub fn parse_args() -> Self {
         Self::parse()
     }
 
-    /// Parsers only the default [`NodeCommand`] arguments from the given iterator
+    /// Parses only the default [`NodeCommand`] arguments from the given iterator
     pub fn try_parse_args_from<I, T>(itr: I) -> Result<Self, clap::error::Error>
     where
         I: IntoIterator<Item = T>,

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -107,7 +107,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         Comp: CliNodeComponents<N>,
         F: FnOnce(Arc<C::ChainSpec>) -> Comp,
     {
-        // Quit early if the stages requires a commit and `--commit` is not provided.
+        // Quit early if the stage requires a commit and `--commit` is not provided.
         if self.requires_commit() && !self.commit {
             return Err(eyre::eyre!(
                 "The stage {} requires overwriting existing static files and must commit, but `--commit` was not provided. Please pass `--commit` and try again.",

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -264,7 +264,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns an immutable reference to the inner type if this an eth68 announcement.
+    /// Returns an immutable reference to the inner type if this is an eth68 announcement.
     pub const fn as_eth68(&self) -> Option<&NewPooledTransactionHashes68> {
         match self {
             Self::Eth66(_) => None,
@@ -272,7 +272,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns a mutable reference to the inner type if this an eth68 announcement.
+    /// Returns a mutable reference to the inner type if this is an eth68 announcement.
     pub const fn as_eth68_mut(&mut self) -> Option<&mut NewPooledTransactionHashes68> {
         match self {
             Self::Eth66(_) => None,
@@ -280,7 +280,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns a mutable reference to the inner type if this an eth66 announcement.
+    /// Returns a mutable reference to the inner type if this is an eth66 announcement.
     pub const fn as_eth66_mut(&mut self) -> Option<&mut NewPooledTransactionHashes66> {
         match self {
             Self::Eth66(msg) => Some(msg),
@@ -288,7 +288,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns the inner type if this an eth68 announcement.
+    /// Returns the inner type if this is an eth68 announcement.
     pub fn take_eth68(&mut self) -> Option<NewPooledTransactionHashes68> {
         match self {
             Self::Eth66(_) => None,
@@ -296,7 +296,7 @@ impl NewPooledTransactionHashes {
         }
     }
 
-    /// Returns the inner type if this an eth66 announcement.
+    /// Returns the inner type if this is an eth66 announcement.
     pub fn take_eth66(&mut self) -> Option<NewPooledTransactionHashes66> {
         match self {
             Self::Eth66(msg) => Some(mem::take(msg)),

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -262,12 +262,12 @@ pub enum Direction {
 }
 
 impl Direction {
-    /// Returns `true` if this an incoming connection.
+    /// Returns `true` if this is an incoming connection.
     pub const fn is_incoming(&self) -> bool {
         matches!(self, Self::Incoming)
     }
 
-    /// Returns `true` if this an outgoing connection.
+    /// Returns `true` if this is an outgoing connection.
     pub const fn is_outgoing(&self) -> bool {
         matches!(self, Self::Outgoing(_))
     }

--- a/crates/payload/validator/src/cancun.rs
+++ b/crates/payload/validator/src/cancun.rs
@@ -87,9 +87,9 @@ pub fn ensure_well_formed_transactions_field_with_sidecar<T: Transaction + Typed
     Ok(())
 }
 
-/// Ensures that the number of blob versioned hashes of a EIP-4844 transactions in block, matches
-/// the number hashes included in the _separate_ `block_versioned_hashes` of the cancun payload
-/// fields on the sidecar.
+/// Ensures that the number of blob versioned hashes in EIP-4844 transactions in the block
+/// matches the number of hashes included in the _separate_ `block_versioned_hashes` Cancun
+/// payload field on the sidecar.
 pub fn ensure_matching_blob_versioned_hashes<T: Transaction + Typed2718, H>(
     block_body: &BlockBody<T, H>,
     cancun_sidecar_fields: Option<&CancunPayloadFields>,

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -78,7 +78,7 @@ impl<PF> Pruner<PF::ProviderRW, PF>
 where
     PF: DatabaseProviderFactory,
 {
-    /// Crates a new pruner with the given provider factory.
+    /// Creates a new pruner with the given provider factory.
     pub fn new_with_factory(
         provider_factory: PF,
         segments: Vec<Box<dyn Segment<PF::ProviderRW>>>,

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -23,7 +23,7 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "getRawBlock")]
     async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
-    /// Returns a EIP-2718 binary-encoded transaction.
+    /// Returns an EIP-2718 binary-encoded transaction.
     ///
     /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
     #[method(name = "getRawTransaction")]

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -136,7 +136,7 @@ pub trait EthApi<
 
     /// Returns the EIP-2718 encoded transaction if it exists.
     ///
-    /// If this is a EIP-4844 transaction that is in the pool it will include the sidecar.
+    /// If this is an EIP-4844 transaction that is in the pool, it will include the sidecar.
     #[method(name = "getRawTransactionByHash")]
     async fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>>;
 

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -52,7 +52,7 @@ where
 
 /// Helper trait to access wrapped core error.
 pub trait AsEthApiError {
-    /// Returns reference to [`EthApiError`], if this an error variant inherited from core
+    /// Returns a reference to [`EthApiError`] if this is an error variant inherited from core
     /// functionality.
     fn as_err(&self) -> Option<&EthApiError>;
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -124,7 +124,7 @@ Storage:
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 
-          When enabled, and before inserting the state, it creates a dummy chain up to the last EVM block specified. It then, appends the first block provided block.
+          When enabled, and before inserting the state, it creates a dummy chain up to the last EVM block specified. It then appends the first provided block.
 
           - **Note**: **Do not** import receipts and blocks beforehand, or this will fail or be ignored.
 


### PR DESCRIPTION
Batch of spelling and grammar fixes collected from closed typofarming PRs labeled `Spelling`. Fixes article usage ("a EIP" → "an EIP"), missing words, verb conjugation ("Parsers" → "Parses"), and a comment that said "5 seconds" when the constant is 30 seconds.