### PR TITLE
fix(op): implement is_system_tx for OpTxEnvelope

### DIFF
--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -154,5 +154,9 @@ mod op {
 
     impl SignedTransaction for OpPooledTransaction {}
 
-    impl SignedTransaction for OpTxEnvelope {}
+    impl SignedTransaction for OpTxEnvelope {
+        fn is_system_tx(&self) -> bool {
+            self.is_system_transaction()
+        }
+    }
 }


### PR DESCRIPTION
The `SignedTransaction` impl for `OpTxEnvelope` was using the default `is_system_tx()` which always returns `false`. This delegates to `OpTxEnvelope::is_system_transaction()` which correctly checks whether a deposit transaction has the system transaction flag set.

`OpPooledTransaction` keeps the default since deposit transactions cannot be pooled.