### PR TITLE
fix(bench): use bench scripts from main, not PR branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -498,6 +498,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.checkout-ref.outputs.ref }}
 
+      # The checkout above uses the PR head ref, so .github/scripts/
+      # may be outdated. Overlay the bench scripts from main so the
+      # benchmark infrastructure always uses the latest version.
+      - name: Update bench scripts from main
+        run: git checkout origin/main -- .github/scripts/bench-*
+
       - name: Resolve job URL and update status
         if: env.BENCH_COMMENT_ID
         uses: actions/github-script@v8


### PR DESCRIPTION
The workflow checks out the PR head ref for building, so `.github/scripts/bench-*` come from the PR branch. If the branch doesn't have latest bench infra changes (e.g. `baseline-args`/`feature-args` support), they're silently dropped.

Fix: overlay bench scripts from `origin/main` after checkout.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey