### PR TITLE
chore(bench): log extra node args in bench-reth-run.sh

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -111,6 +111,7 @@ case "$LABEL" in
   feature*)  EXTRA_NODE_ARGS="${BENCH_FEATURE_ARGS:-}" ;;
 esac
 if [ -n "$EXTRA_NODE_ARGS" ]; then
+  echo "Extra node args for ${LABEL}: ${EXTRA_NODE_ARGS}"
   # Word-split the string into individual args
   # shellcheck disable=SC2206
   RETH_ARGS+=($EXTRA_NODE_ARGS)


### PR DESCRIPTION
Echoes the extra node args when they're appended, so you can verify in CI logs that `baseline-args`/`feature-args` were actually passed to the reth command.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey