### PR TITLE
test(trie): add generic SparseTrie test suite

### DIFF
--- a/.changelog/rare-whales-pack.md
+++ b/.changelog/rare-whales-pack.md
@@ -1,0 +1,5 @@
+---
+reth-trie-sparse: minor
+---
+
+Added a comprehensive generic `SparseTrie` test suite covering `set_root`, `reveal_nodes`, `update_leaves`, `root`, `take_updates`, `commit_updates`, `prune`, `wipe`/`clear`, `get_leaf_value`, `find_leaf`, `size_hint`, and integration lifecycle scenarios. Tests are stamped out for all concrete `SparseTrie` implementations via a macro.

--- a/crates/trie/sparse/tests/suite/commit_updates.rs
+++ b/crates/trie/sparse/tests/suite/commit_updates.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+/// After commit, take_updates reports only delta.
+///
+/// After calling `commit_updates` with taken updates, a subsequent mutation + `root()` +
+/// `take_updates()` should only report the delta from the new baseline — it must NOT
+/// re-report branch nodes from the first round.
+pub(super) fn test_commit_updates_syncs_branch_masks<T: SparseTrie + Default>() {
+    // 5 leaves spread across different subtrie regions.
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let mut key_d = B256::ZERO;
+    key_d.0[0] = 0x40;
+    let mut key_e = B256::ZERO;
+    key_e.0[0] = 0x50;
+
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (key_a, U256::from(1)),
+        (key_b, U256::from(2)),
+        (key_c, U256::from(3)),
+        (key_d, U256::from(4)),
+        (key_e, U256::from(5)),
+    ]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial hashes.
+    let _ = trie.root();
+
+    // Round 1: Update leaf A, take updates, commit.
+    let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset1.insert(key_a, U256::from(100));
+    let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates1);
+
+    let hash1 = trie.root();
+    let updates1 = trie.take_updates();
+    trie.commit_updates(&updates1.updated_nodes, &updates1.removed_nodes);
+
+    // Round 2: Update leaf B, take updates.
+    let mut changeset2: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset2.insert(key_b, U256::from(200));
+    let mut leaf_updates2 = SuiteTestHarness::leaf_updates(&changeset2);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates2);
+
+    let hash2 = trie.root();
+    let updates2 = trie.take_updates();
+
+    // hash2 should differ from hash1 (different leaf values).
+    assert_ne!(hash1, hash2, "root should change after second update");
+
+    // Verify hash2 matches the reference trie.
+    let expected_storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (key_a, U256::from(100)),
+        (key_b, U256::from(200)),
+        (key_c, U256::from(3)),
+        (key_d, U256::from(4)),
+        (key_e, U256::from(5)),
+    ]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(hash2, expected_harness.original_root, "hash2 should match reference trie");
+
+    // updates2 should NOT contain the same paths as updates1 — commit_updates
+    // resets the baseline so only the delta from round 2 is reported.
+    for (path, _) in &updates1.updated_nodes {
+        if updates2.updated_nodes.contains_key(path) {
+            panic!(
+                "path {path:?} was re-reported in updates2 after commit — \
+                 commit_updates should have synced the baseline"
+            );
+        }
+    }
+}
+
+/// Committing empty updated/removed sets should not change trie behavior.
+///
+/// Build a trie, compute root, then commit empty updates. Root should be unchanged.
+pub(super) fn test_commit_updates_empty_is_noop<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    let hash1 = trie.root();
+    assert_eq!(hash1, harness.original_root);
+
+    trie.commit_updates(&HashMap::default(), &HashSet::default());
+
+    let hash2 = trie.root();
+    assert_eq!(hash1, hash2, "empty commit_updates should not change root");
+}

--- a/crates/trie/sparse/tests/suite/commit_updates.rs
+++ b/crates/trie/sparse/tests/suite/commit_updates.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// After commit, take_updates reports only delta.
+/// After commit, `take_updates` reports only delta.
 ///
 /// After calling `commit_updates` with taken updates, a subsequent mutation + `root()` +
 /// `take_updates()` should only report the delta from the new baseline — it must NOT
@@ -67,13 +67,12 @@ pub(super) fn test_commit_updates_syncs_branch_masks<T: SparseTrie + Default>() 
 
     // updates2 should NOT contain the same paths as updates1 — commit_updates
     // resets the baseline so only the delta from round 2 is reported.
-    for (path, _) in &updates1.updated_nodes {
-        if updates2.updated_nodes.contains_key(path) {
-            panic!(
-                "path {path:?} was re-reported in updates2 after commit — \
-                 commit_updates should have synced the baseline"
-            );
-        }
+    for path in updates1.updated_nodes.keys() {
+        assert!(
+            !updates2.updated_nodes.contains_key(path),
+            "path {path:?} was re-reported in updates2 after commit — \
+             commit_updates should have synced the baseline"
+        );
     }
 }
 

--- a/crates/trie/sparse/tests/suite/find_leaf.rs
+++ b/crates/trie/sparse/tests/suite/find_leaf.rs
@@ -21,7 +21,7 @@ pub(super) fn test_find_leaf_exists<T: SparseTrie + Default>() {
     );
 
     // find_leaf with correct expected value → Exists
-    let correct_value = alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec();
+    let correct_value = encode_fixed_size(&U256::from(2)).to_vec();
     assert_eq!(
         trie.find_leaf(&key2_nibbles, Some(&correct_value)).expect("find_leaf should succeed"),
         LeafLookup::Exists,
@@ -105,7 +105,7 @@ pub(super) fn test_find_leaf_value_mismatch<T: SparseTrie + Default>() {
     let trie: T = harness.init_trie_fully_revealed(false);
 
     let key2_nibbles = Nibbles::unpack(key2);
-    let wrong_value = alloy_rlp::encode_fixed_size(&U256::from(999)).to_vec();
+    let wrong_value = encode_fixed_size(&U256::from(999)).to_vec();
 
     let result = trie.find_leaf(&key2_nibbles, Some(&wrong_value));
     assert!(
@@ -162,7 +162,7 @@ pub(super) fn test_find_leaf_nonexistent_extension_divergence<T: SparseTrie + De
     key1.0[1] = 0x34;
     key1.0[2] = 0x56;
 
-    let base_storage: BTreeMap<B256, U256> = std::iter::once((key1, U256::from(1))).collect();
+    let base_storage: BTreeMap<B256, U256> = once((key1, U256::from(1))).collect();
 
     let harness = SuiteTestHarness::new(base_storage);
     let trie: T = harness.init_trie_fully_revealed(false);
@@ -191,8 +191,7 @@ pub(super) fn test_find_leaf_nonexistent_leaf_divergence<T: SparseTrie + Default
     existing_key.0[0] = 0x12;
     existing_key.0[1] = 0x34;
 
-    let base_storage: BTreeMap<B256, U256> =
-        std::iter::once((existing_key, U256::from(1))).collect();
+    let base_storage: BTreeMap<B256, U256> = once((existing_key, U256::from(1))).collect();
 
     let harness = SuiteTestHarness::new(base_storage);
     let trie: T = harness.init_trie_fully_revealed(false);

--- a/crates/trie/sparse/tests/suite/find_leaf.rs
+++ b/crates/trie/sparse/tests/suite/find_leaf.rs
@@ -1,0 +1,212 @@
+use super::*;
+
+pub(super) fn test_find_leaf_exists<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let trie: T = harness.init_trie_fully_revealed(false);
+
+    let key2_nibbles = Nibbles::unpack(key2);
+
+    // find_leaf with no expected value → Exists
+    assert_eq!(
+        trie.find_leaf(&key2_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::Exists,
+        "find_leaf(existing_key, None) should return Exists"
+    );
+
+    // find_leaf with correct expected value → Exists
+    let correct_value = alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec();
+    assert_eq!(
+        trie.find_leaf(&key2_nibbles, Some(&correct_value)).expect("find_leaf should succeed"),
+        LeafLookup::Exists,
+        "find_leaf(existing_key, Some(correct_value)) should return Exists"
+    );
+}
+
+pub(super) fn test_find_leaf_nonexistent<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let trie: T = harness.init_trie_fully_revealed(false);
+
+    let nonexistent_key = B256::with_last_byte(0x99);
+    let nonexistent_nibbles = Nibbles::unpack(nonexistent_key);
+
+    assert_eq!(
+        trie.find_leaf(&nonexistent_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::NonExistent,
+        "find_leaf(nonexistent_key, None) should return NonExistent"
+    );
+}
+
+/// `find_leaf` on a path that traverses a blinded node returns
+/// `Err(LeafLookupError::BlindedNode)`.
+pub(super) fn test_find_leaf_blinded<T: SparseTrie + Default>() {
+    // Use ≥16 keys per nibble group so branch children become hash nodes (>32 bytes RLP),
+    // ensuring partial reveal leaves blinded subtries.
+    let mut base_storage = BTreeMap::new();
+
+    // 16 keys under first nibble 0x1
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    // 16 keys under first nibble 0x2
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only group_a keys, leaving group_b's subtrie blinded.
+    let trie: T = harness.init_trie_with_targets(&group_a_keys, false);
+
+    // Look up a key in group_b — should hit a blinded node.
+    let blinded_key = group_b_keys[0];
+    let blinded_nibbles = Nibbles::unpack(blinded_key);
+
+    let result = trie.find_leaf(&blinded_nibbles, None);
+    assert!(
+        matches!(result, Err(LeafLookupError::BlindedNode { .. })),
+        "find_leaf on a blinded path should return Err(BlindedNode), got: {result:?}"
+    );
+}
+
+/// `find_leaf` with an expected value that doesn't match the actual leaf value
+/// returns `Err(LeafLookupError::ValueMismatch)`.
+pub(super) fn test_find_leaf_value_mismatch<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let trie: T = harness.init_trie_fully_revealed(false);
+
+    let key2_nibbles = Nibbles::unpack(key2);
+    let wrong_value = alloy_rlp::encode_fixed_size(&U256::from(999)).to_vec();
+
+    let result = trie.find_leaf(&key2_nibbles, Some(&wrong_value));
+    assert!(
+        matches!(result, Err(LeafLookupError::ValueMismatch { .. })),
+        "find_leaf with wrong expected value should return Err(ValueMismatch), got: {result:?}"
+    );
+}
+
+/// `find_leaf` on a key whose nibble at a branch node
+/// is not set in the branch's state_mask returns `NonExistent`.
+///
+/// Two leaves sharing prefix 0x12 create a branch with children at nibbles 3 and 5.
+/// Searching for a key with nibble 7 at that branch position should return NonExistent.
+pub(super) fn test_find_leaf_nonexistent_branch_divergence<T: SparseTrie + Default>() {
+    // key1 nibbles: 1,2,3,4,0,0,...  →  B256 = 0x12340000...
+    let mut key1 = B256::ZERO;
+    key1.0[0] = 0x12;
+    key1.0[1] = 0x34;
+
+    // key2 nibbles: 1,2,5,6,0,0,...  →  B256 = 0x12560000...
+    let mut key2 = B256::ZERO;
+    key2.0[0] = 0x12;
+    key2.0[1] = 0x56;
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let trie: T = harness.init_trie_fully_revealed(false);
+
+    // search_path nibbles: 1,2,7,8,0,0,...  →  B256 = 0x12780000...
+    // Nibble 7 is unset at the branch (only 3 and 5 are set).
+    let mut search_key = B256::ZERO;
+    search_key.0[0] = 0x12;
+    search_key.0[1] = 0x78;
+    let search_nibbles = Nibbles::unpack(search_key);
+
+    assert_eq!(
+        trie.find_leaf(&search_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::NonExistent,
+        "find_leaf on key with unset nibble at branch should return NonExistent"
+    );
+}
+
+/// `find_leaf` on a key that diverges from an extension
+/// node's key returns `NonExistent`.
+///
+/// A single leaf at nibbles [1,2,3,4,5,6,...] creates an extension root with key 0x12.
+/// Searching for a key at nibbles [1,2,7,8,...] diverges from that extension.
+pub(super) fn test_find_leaf_nonexistent_extension_divergence<T: SparseTrie + Default>() {
+    // Single leaf: nibbles [1,2,3,4,5,6,0,0,...] → B256 = 0x12345600...
+    let mut key1 = B256::ZERO;
+    key1.0[0] = 0x12;
+    key1.0[1] = 0x34;
+    key1.0[2] = 0x56;
+
+    let base_storage: BTreeMap<B256, U256> = [(key1, U256::from(1))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let trie: T = harness.init_trie_fully_revealed(false);
+
+    // Search path diverges from the extension: nibbles [1,2,7,8,0,0,...] → B256 = 0x12780000...
+    let mut search_key = B256::ZERO;
+    search_key.0[0] = 0x12;
+    search_key.0[1] = 0x78;
+    let search_nibbles = Nibbles::unpack(search_key);
+
+    assert_eq!(
+        trie.find_leaf(&search_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::NonExistent,
+        "find_leaf on key diverging from extension should return NonExistent"
+    );
+}
+
+/// `find_leaf` on a key that shares a prefix with an existing
+/// leaf but has a longer path returns `NonExistent`.
+///
+/// A single leaf at nibbles [1,2,3,4,0,0,...] exists. Searching for a key at nibbles
+/// [1,2,3,4,5,6,0,0,...] extends past the existing leaf — it should return NonExistent.
+pub(super) fn test_find_leaf_nonexistent_leaf_divergence<T: SparseTrie + Default>() {
+    // Existing leaf at short path: nibbles [1,2,3,4,0,0,...] → B256 = 0x12340000...
+    let mut existing_key = B256::ZERO;
+    existing_key.0[0] = 0x12;
+    existing_key.0[1] = 0x34;
+
+    let base_storage: BTreeMap<B256, U256> = [(existing_key, U256::from(1))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let trie: T = harness.init_trie_fully_revealed(false);
+
+    // Search path extends past the existing leaf: nibbles [1,2,3,4,5,6,0,0,...]
+    // → B256 = 0x12345600...
+    let mut search_key = B256::ZERO;
+    search_key.0[0] = 0x12;
+    search_key.0[1] = 0x34;
+    search_key.0[2] = 0x56;
+    let search_nibbles = Nibbles::unpack(search_key);
+
+    assert_eq!(
+        trie.find_leaf(&search_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::NonExistent,
+        "find_leaf on key extending past existing leaf should return NonExistent"
+    );
+}

--- a/crates/trie/sparse/tests/suite/find_leaf.rs
+++ b/crates/trie/sparse/tests/suite/find_leaf.rs
@@ -115,10 +115,10 @@ pub(super) fn test_find_leaf_value_mismatch<T: SparseTrie + Default>() {
 }
 
 /// `find_leaf` on a key whose nibble at a branch node
-/// is not set in the branch's state_mask returns `NonExistent`.
+/// is not set in the branch's `state_mask` returns `NonExistent`.
 ///
 /// Two leaves sharing prefix 0x12 create a branch with children at nibbles 3 and 5.
-/// Searching for a key with nibble 7 at that branch position should return NonExistent.
+/// Searching for a key with nibble 7 at that branch position should return `NonExistent`.
 pub(super) fn test_find_leaf_nonexistent_branch_divergence<T: SparseTrie + Default>() {
     // key1 nibbles: 1,2,3,4,0,0,...  →  B256 = 0x12340000...
     let mut key1 = B256::ZERO;
@@ -162,7 +162,7 @@ pub(super) fn test_find_leaf_nonexistent_extension_divergence<T: SparseTrie + De
     key1.0[1] = 0x34;
     key1.0[2] = 0x56;
 
-    let base_storage: BTreeMap<B256, U256> = [(key1, U256::from(1))].into_iter().collect();
+    let base_storage: BTreeMap<B256, U256> = std::iter::once((key1, U256::from(1))).collect();
 
     let harness = SuiteTestHarness::new(base_storage);
     let trie: T = harness.init_trie_fully_revealed(false);
@@ -184,14 +184,15 @@ pub(super) fn test_find_leaf_nonexistent_extension_divergence<T: SparseTrie + De
 /// leaf but has a longer path returns `NonExistent`.
 ///
 /// A single leaf at nibbles [1,2,3,4,0,0,...] exists. Searching for a key at nibbles
-/// [1,2,3,4,5,6,0,0,...] extends past the existing leaf — it should return NonExistent.
+/// [1,2,3,4,5,6,0,0,...] extends past the existing leaf — it should return `NonExistent`.
 pub(super) fn test_find_leaf_nonexistent_leaf_divergence<T: SparseTrie + Default>() {
     // Existing leaf at short path: nibbles [1,2,3,4,0,0,...] → B256 = 0x12340000...
     let mut existing_key = B256::ZERO;
     existing_key.0[0] = 0x12;
     existing_key.0[1] = 0x34;
 
-    let base_storage: BTreeMap<B256, U256> = [(existing_key, U256::from(1))].into_iter().collect();
+    let base_storage: BTreeMap<B256, U256> =
+        std::iter::once((existing_key, U256::from(1))).collect();
 
     let harness = SuiteTestHarness::new(base_storage);
     let trie: T = harness.init_trie_fully_revealed(false);

--- a/crates/trie/sparse/tests/suite/get_leaf_value.rs
+++ b/crates/trie/sparse/tests/suite/get_leaf_value.rs
@@ -16,9 +16,9 @@ pub(super) fn test_get_leaf_value_after_update<T: SparseTrie + Default>() {
     // Insert a new leaf (key4) with value 42.
     let key4 = B256::with_last_byte(0x40);
     let new_value = U256::from(42);
-    let new_value_rlp = alloy_rlp::encode_fixed_size(&new_value).to_vec();
+    let new_value_rlp = encode_fixed_size(&new_value).to_vec();
     let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((key4, LeafUpdate::Changed(new_value_rlp.clone()))).collect();
+        once((key4, LeafUpdate::Changed(new_value_rlp.clone()))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     assert_eq!(
@@ -29,9 +29,9 @@ pub(super) fn test_get_leaf_value_after_update<T: SparseTrie + Default>() {
 
     // Modify an existing leaf (key2) to value 222.
     let updated_value = U256::from(222);
-    let updated_value_rlp = alloy_rlp::encode_fixed_size(&updated_value).to_vec();
+    let updated_value_rlp = encode_fixed_size(&updated_value).to_vec();
     let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((key2, LeafUpdate::Changed(updated_value_rlp.clone()))).collect();
+        once((key2, LeafUpdate::Changed(updated_value_rlp.clone()))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     assert_eq!(
@@ -54,7 +54,7 @@ pub(super) fn test_get_leaf_value_after_removal<T: SparseTrie + Default>() {
     let mut trie: T = harness.init_trie_fully_revealed(false);
 
     let key2_nibbles = Nibbles::unpack(key2);
-    let expected_value_rlp = alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec();
+    let expected_value_rlp = encode_fixed_size(&U256::from(2)).to_vec();
     assert_eq!(
         trie.get_leaf_value(&key2_nibbles),
         Some(&expected_value_rlp),

--- a/crates/trie/sparse/tests/suite/get_leaf_value.rs
+++ b/crates/trie/sparse/tests/suite/get_leaf_value.rs
@@ -18,7 +18,7 @@ pub(super) fn test_get_leaf_value_after_update<T: SparseTrie + Default>() {
     let new_value = U256::from(42);
     let new_value_rlp = alloy_rlp::encode_fixed_size(&new_value).to_vec();
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(key4, LeafUpdate::Changed(new_value_rlp.clone()))].into_iter().collect();
+        std::iter::once((key4, LeafUpdate::Changed(new_value_rlp.clone()))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     assert_eq!(
@@ -31,7 +31,7 @@ pub(super) fn test_get_leaf_value_after_update<T: SparseTrie + Default>() {
     let updated_value = U256::from(222);
     let updated_value_rlp = alloy_rlp::encode_fixed_size(&updated_value).to_vec();
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(key2, LeafUpdate::Changed(updated_value_rlp.clone()))].into_iter().collect();
+        std::iter::once((key2, LeafUpdate::Changed(updated_value_rlp.clone()))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     assert_eq!(

--- a/crates/trie/sparse/tests/suite/get_leaf_value.rs
+++ b/crates/trie/sparse/tests/suite/get_leaf_value.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+/// After inserting or updating a leaf via `update_leaves`, `get_leaf_value`
+/// should return the new value.
+pub(super) fn test_get_leaf_value_after_update<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Insert a new leaf (key4) with value 42.
+    let key4 = B256::with_last_byte(0x40);
+    let new_value = U256::from(42);
+    let new_value_rlp = alloy_rlp::encode_fixed_size(&new_value).to_vec();
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(key4, LeafUpdate::Changed(new_value_rlp.clone()))].into_iter().collect();
+    trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+
+    assert_eq!(
+        trie.get_leaf_value(&Nibbles::unpack(key4)),
+        Some(&new_value_rlp),
+        "get_leaf_value should return the inserted value"
+    );
+
+    // Modify an existing leaf (key2) to value 222.
+    let updated_value = U256::from(222);
+    let updated_value_rlp = alloy_rlp::encode_fixed_size(&updated_value).to_vec();
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(key2, LeafUpdate::Changed(updated_value_rlp.clone()))].into_iter().collect();
+    trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+
+    assert_eq!(
+        trie.get_leaf_value(&Nibbles::unpack(key2)),
+        Some(&updated_value_rlp),
+        "get_leaf_value should return the modified value"
+    );
+}
+
+/// After removing a leaf via `update_leaves`, `get_leaf_value` should return `None`.
+pub(super) fn test_get_leaf_value_after_removal<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let key2_nibbles = Nibbles::unpack(key2);
+    let expected_value_rlp = alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec();
+    assert_eq!(
+        trie.get_leaf_value(&key2_nibbles),
+        Some(&expected_value_rlp),
+        "get_leaf_value should return Some before removal"
+    );
+
+    // Remove key2 by setting its value to U256::ZERO (produces LeafUpdate::Changed(vec![])).
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key2, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    assert_eq!(
+        trie.get_leaf_value(&key2_nibbles),
+        None,
+        "get_leaf_value should return None after removal"
+    );
+}

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// Standard production lifecycle — update, root, take_updates, commit_updates.
+/// Standard production lifecycle — update, root, `take_updates`, `commit_updates`.
 ///
 /// Build a trie with enough leaves to produce hashed branch children (≥16 per subtrie),
 /// insert 1 new leaf + modify 1 existing, compute root, take updates, commit, then verify
@@ -64,7 +64,7 @@ pub(super) fn test_full_lifecycle_update_root_take_commit<T: SparseTrie + Defaul
     assert_eq!(hash1, hash2, "root should be unchanged after commit_updates");
 }
 
-/// Multiple rounds of (update → root → take_updates → commit_updates), followed by
+/// Multiple rounds of (update → root → `take_updates` → `commit_updates`), followed by
 /// a prune, simulating block processing.
 pub(super) fn test_multi_round_update_commit_prune_cycle<T: SparseTrie + Default>() {
     // Build a trie with 10 leaves.
@@ -179,7 +179,7 @@ pub(super) fn test_reveal_update_root_basic_lifecycle<T: SparseTrie + Default>()
 }
 
 /// Incremental reveal and update with retry loop.
-/// Partial proof → update_leaves hits blinded nodes → reveal more → retry succeeds.
+/// Partial proof → `update_leaves` hits blinded nodes → reveal more → retry succeeds.
 pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie + Default>() {
     // Build 10 leaves across multiple subtries so partial reveal leaves some blinded.
     // Use 16 keys per group so branch children become hash nodes (>32 bytes RLP).
@@ -488,7 +488,7 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<
     // Step 1: Touched on a key in group B's blinded subtrie → callback fires.
     let target_key = group_b_keys[0];
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(target_key, LeafUpdate::Touched)].into_iter().collect();
+        std::iter::once((target_key, LeafUpdate::Touched)).collect();
 
     let mut targets: Vec<ProofV2Target> = Vec::new();
     trie.update_leaves(&mut leaf_updates, |key, min_len| {
@@ -509,11 +509,8 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<
         .insert(target_key, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
 
     // Step 4: update_leaves again — key should now be drained.
-    let mut targets2: Vec<ProofV2Target> = Vec::new();
-    trie.update_leaves(&mut leaf_updates, |key, min_len| {
-        targets2.push(ProofV2Target::new(key).with_min_len(min_len));
-    })
-    .expect("update_leaves with Changed should succeed");
+    trie.update_leaves(&mut leaf_updates, |_, _| {})
+        .expect("update_leaves with Changed should succeed");
 
     assert!(leaf_updates.is_empty(), "Changed key should be drained after reveal");
 
@@ -529,7 +526,7 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<
     );
 }
 
-/// get_leaf_value for storage root lookup.
+/// `get_leaf_value` for storage root lookup.
 ///
 /// Simulates the `SparseStateTrie::update_account` pattern: read existing leaf via
 /// `get_leaf_value`, decode, modify (change one field while preserving another), re-encode,
@@ -565,7 +562,7 @@ pub(super) fn test_get_leaf_value_for_storage_root_lookup<T: SparseTrie + Defaul
 
     // Step 4: Update the leaf with the re-encoded value.
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(key1, LeafUpdate::Changed(new_value_rlp))].into_iter().collect();
+        std::iter::once((key1, LeafUpdate::Changed(new_value_rlp))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 5: Compute root and verify against reference.

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -1,0 +1,710 @@
+use super::*;
+
+/// Standard production lifecycle — update, root, take_updates, commit_updates.
+///
+/// Build a trie with enough leaves to produce hashed branch children (≥16 per subtrie),
+/// insert 1 new leaf + modify 1 existing, compute root, take updates, commit, then verify
+/// root is unchanged (cache hit) and updates are non-empty.
+pub(super) fn test_full_lifecycle_update_root_take_commit<T: SparseTrie + Default>() {
+    // 16 leaves sharing prefix [1,0] to produce hashed branch children.
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+    // Extra leaf under a different nibble.
+    let mut key_extra = B256::ZERO;
+    key_extra.0[0] = 0x20;
+    storage.insert(key_extra, U256::from(100));
+
+    let harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial hashes.
+    let _ = trie.root();
+
+    // Insert 1 new leaf under the same hashed prefix and modify 1 existing leaf.
+    let mut new_key = B256::ZERO;
+    new_key.0[0] = 0x10;
+    new_key.0[1] = 0xFF; // new leaf under the [1,0] prefix
+    let mut modify_key = B256::ZERO;
+    modify_key.0[0] = 0x10;
+    modify_key.0[1] = 0x00; // first key in the group
+
+    let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset.insert(new_key, U256::from(999)); // new leaf
+    changeset.insert(modify_key, U256::from(500)); // modify existing
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let hash1 = trie.root();
+
+    // Verify hash1 matches the reference trie with updated values.
+    let mut expected_storage = storage;
+    expected_storage.insert(new_key, U256::from(999));
+    expected_storage.insert(modify_key, U256::from(500));
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(hash1, expected_harness.original_root, "root should match reference trie");
+
+    // Take updates — should be non-empty with hashed branch children.
+    let updates = trie.take_updates();
+    assert!(
+        !updates.updated_nodes.is_empty() || !updates.removed_nodes.is_empty(),
+        "updates should be non-empty after mutations"
+    );
+
+    // Commit updates.
+    trie.commit_updates(&updates.updated_nodes, &updates.removed_nodes);
+
+    // Post-commit root should still be hash1 (cache hit).
+    let hash2 = trie.root();
+    assert_eq!(hash1, hash2, "root should be unchanged after commit_updates");
+}
+
+/// Multiple rounds of (update → root → take_updates → commit_updates), followed by
+/// a prune, simulating block processing.
+pub(super) fn test_multi_round_update_commit_prune_cycle<T: SparseTrie + Default>() {
+    // Build a trie with 10 leaves.
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    let mut keys = Vec::new();
+    for i in 0u8..10 {
+        let mut key = B256::ZERO;
+        key.0[0] = i * 16; // nibble prefixes: 0x0, 0x1, 0x2, ... 0x9
+        storage.insert(key, U256::from(i as u64 + 1));
+        keys.push(key);
+    }
+
+    let mut harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial hashes.
+    let _ = trie.root();
+
+    // --- Round 1: Update leaves A (keys[0]) and B (keys[1]) ---
+    let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset1.insert(keys[0], U256::from(100));
+    changeset1.insert(keys[1], U256::from(200));
+    let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates1);
+    let root1 = trie.root();
+
+    // Verify root1 matches reference.
+    harness.apply_changeset(changeset1);
+    assert_eq!(root1, harness.original_root, "round 1 root should match reference");
+
+    let updates1 = trie.take_updates();
+    trie.commit_updates(&updates1.updated_nodes, &updates1.removed_nodes);
+
+    // --- Round 2: Update leaves C (keys[2]) and D (keys[3]) ---
+    let mut changeset2: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset2.insert(keys[2], U256::from(300));
+    changeset2.insert(keys[3], U256::from(400));
+    let mut leaf_updates2 = SuiteTestHarness::leaf_updates(&changeset2);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates2);
+    let root2 = trie.root();
+
+    // Verify root2 matches reference.
+    harness.apply_changeset(changeset2);
+    assert_eq!(root2, harness.original_root, "round 2 root should match reference");
+
+    let updates2 = trie.take_updates();
+    trie.commit_updates(&updates2.updated_nodes, &updates2.removed_nodes);
+
+    // --- Prune: retain only keys A,B,C,D ---
+    let retained: Vec<Nibbles> = keys[0..4].iter().map(|k| Nibbles::unpack(*k)).collect();
+    let pre_prune_size = trie.size_hint();
+    trie.prune(&retained);
+    let post_prune_size = trie.size_hint();
+    if pre_prune_size > 0 {
+        assert!(post_prune_size < pre_prune_size, "prune should reduce node count");
+    }
+
+    // Root should still be correct after prune.
+    let root_after_prune = trie.root();
+    assert_eq!(root_after_prune, harness.original_root, "root should be unchanged after prune");
+
+    // --- Round 3: Update leaf E (keys[4]) — needs re-reveal since it was pruned ---
+    let mut changeset3: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset3.insert(keys[4], U256::from(500));
+    let mut leaf_updates3 = SuiteTestHarness::leaf_updates(&changeset3);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates3);
+    let root3 = trie.root();
+
+    // Verify root3 matches reference.
+    harness.apply_changeset(changeset3);
+    assert_eq!(root3, harness.original_root, "round 3 root should match reference after re-reveal");
+}
+
+/// Core production loop: reveal → update → root.
+///
+/// Build a 5-leaf trie, reveal all proofs, apply 2 modifications + 1 removal,
+/// and verify root matches the reference trie with the same mutations.
+pub(super) fn test_reveal_update_root_basic_lifecycle<T: SparseTrie + Default>() {
+    let mut keys = Vec::new();
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..5 {
+        let mut key = B256::ZERO;
+        key.0[0] = (i + 1) * 16; // 0x10, 0x20, 0x30, 0x40, 0x50
+        storage.insert(key, U256::from(i as u64 + 1));
+        keys.push(key);
+    }
+
+    let harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Apply 2 modifications and 1 removal.
+    let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset.insert(keys[0], U256::from(100)); // modify key 0x10
+    changeset.insert(keys[1], U256::from(200)); // modify key 0x20
+    changeset.insert(keys[2], U256::ZERO); // remove key 0x30
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root = trie.root();
+
+    // Build reference trie with same mutations.
+    let mut expected_storage = storage;
+    expected_storage.insert(keys[0], U256::from(100));
+    expected_storage.insert(keys[1], U256::from(200));
+    expected_storage.remove(&keys[2]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference after modifications and removal"
+    );
+}
+
+/// Incremental reveal and update with retry loop.
+/// Partial proof → update_leaves hits blinded nodes → reveal more → retry succeeds.
+pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie + Default>() {
+    // Build 10 leaves across multiple subtries so partial reveal leaves some blinded.
+    // Use 16 keys per group so branch children become hash nodes (>32 bytes RLP).
+    let mut base_storage = BTreeMap::new();
+
+    // Group A: 16 keys under nibble 0x1
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    // Group B: 16 keys under nibble 0x2
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage.clone());
+
+    // Reveal only group A keys, leaving group B's subtrie blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, true);
+
+    // Prepare updates for 5 keys: 3 from group A (covered) + 2 from group B (blinded).
+    let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset.insert(group_a_keys[0], U256::from(500)); // modify covered key
+    changeset.insert(group_a_keys[1], U256::from(600)); // modify covered key
+    changeset.insert(group_a_keys[2], U256::from(700)); // modify covered key
+    changeset.insert(group_b_keys[0], U256::from(800)); // modify blinded key
+    changeset.insert(group_b_keys[1], U256::from(900)); // modify blinded key
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+
+    // First update_leaves: covered keys are drained, blinded keys remain, callback fires.
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    assert!(!targets.is_empty(), "callback should fire for blinded keys");
+    assert!(!leaf_updates.is_empty(), "blinded keys should remain in updates map");
+
+    // Reveal the proof for the requested targets.
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+
+    // Second update_leaves: now all paths are revealed, remaining keys should be drained.
+    let mut targets2: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets2.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed on retry");
+
+    assert!(targets2.is_empty(), "no callback should fire after reveal");
+    assert!(leaf_updates.is_empty(), "all keys should be drained after retry");
+
+    // Root should match reference with all 5 updates applied.
+    let mut expected_storage = base_storage;
+    expected_storage.insert(group_a_keys[0], U256::from(500));
+    expected_storage.insert(group_a_keys[1], U256::from(600));
+    expected_storage.insert(group_a_keys[2], U256::from(700));
+    expected_storage.insert(group_b_keys[0], U256::from(800));
+    expected_storage.insert(group_b_keys[1], U256::from(900));
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+
+    let root = trie.root();
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference after incremental reveal and retry"
+    );
+}
+
+/// End-to-end block processing with storage + account coordination.
+///
+/// Simulates a complete block processing cycle: receive state updates → apply to storage
+/// tries → compute storage roots → promote to account trie → compute state root → take
+/// updates → commit → prune for next block.
+pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie + Default>() {
+    // --- Setup: Build account trie with 5 accounts ---
+    // A1 storage: 5 slots, A2 storage: 3 slots, A3-A5: empty storage.
+    // Account trie leaf values = RLP-encoded storage roots.
+
+    // A1 storage trie: 5 slots
+    let mut a1_storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..5 {
+        let mut key = B256::ZERO;
+        key.0[0] = (i + 1) * 16; // 0x10, 0x20, 0x30, 0x40, 0x50
+        a1_storage.insert(key, U256::from(i as u64 + 1));
+    }
+    let mut a1_harness = SuiteTestHarness::new(a1_storage.clone());
+    let a1_initial_root = a1_harness.original_root;
+
+    // A2 storage trie: 3 slots
+    let mut a2_storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..3 {
+        let mut key = B256::ZERO;
+        key.0[0] = (i + 1) * 16; // 0x10, 0x20, 0x30
+        a2_storage.insert(key, U256::from(i as u64 + 10));
+    }
+    let mut a2_harness = SuiteTestHarness::new(a2_storage.clone());
+    let a2_initial_root = a2_harness.original_root;
+
+    // Account trie keys.
+    let mut acct_keys = Vec::new();
+    for i in 0u8..5 {
+        let mut key = B256::ZERO;
+        key.0[0] = (i + 1) * 16; // 0x10, 0x20, 0x30, 0x40, 0x50
+        acct_keys.push(key);
+    }
+
+    // Account trie leaf values = RLP-encoded storage roots (or EMPTY_ROOT_HASH for A3-A5).
+    let encode_root = |root: B256| -> U256 {
+        // Use the first 32 bytes of the root hash as a U256 value for the account trie leaf.
+        U256::from_be_bytes(root.0)
+    };
+
+    let mut acct_storage: BTreeMap<B256, U256> = BTreeMap::new();
+    acct_storage.insert(acct_keys[0], encode_root(a1_initial_root)); // A1
+    acct_storage.insert(acct_keys[1], encode_root(a2_initial_root)); // A2
+    acct_storage.insert(acct_keys[2], encode_root(EMPTY_ROOT_HASH)); // A3
+    acct_storage.insert(acct_keys[3], encode_root(EMPTY_ROOT_HASH)); // A4
+    acct_storage.insert(acct_keys[4], encode_root(EMPTY_ROOT_HASH)); // A5
+
+    let mut acct_harness = SuiteTestHarness::new(acct_storage.clone());
+
+    // Initialize all tries fully revealed with update tracking.
+    let mut a1_trie: T = a1_harness.init_trie_fully_revealed(true);
+    let mut a2_trie: T = a2_harness.init_trie_fully_revealed(true);
+    let mut acct_trie: T = acct_harness.init_trie_fully_revealed(true);
+
+    // Cache initial hashes for all tries.
+    let _ = a1_trie.root();
+    let _ = a2_trie.root();
+    let _ = acct_trie.root();
+
+    // --- Storage phase ---
+    // A1: modify S1 (key 0x10), remove S2 (key 0x20), add S6 (key 0x60).
+    let mut a1_s1_key = B256::ZERO;
+    a1_s1_key.0[0] = 0x10;
+    let mut a1_s2_key = B256::ZERO;
+    a1_s2_key.0[0] = 0x20;
+    let mut a1_s6_key = B256::ZERO;
+    a1_s6_key.0[0] = 0x60;
+
+    let mut a1_changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    a1_changeset.insert(a1_s1_key, U256::from(100)); // modify S1
+    a1_changeset.insert(a1_s2_key, U256::ZERO); // remove S2
+    a1_changeset.insert(a1_s6_key, U256::from(6)); // add S6
+    let mut a1_leaf_updates = SuiteTestHarness::leaf_updates(&a1_changeset);
+    a1_harness.reveal_and_update(&mut a1_trie, &mut a1_leaf_updates);
+
+    // A2: modify S1 (key 0x10).
+    let mut a2_s1_key = B256::ZERO;
+    a2_s1_key.0[0] = 0x10;
+    let mut a2_changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    a2_changeset.insert(a2_s1_key, U256::from(200)); // modify S1
+    let mut a2_leaf_updates = SuiteTestHarness::leaf_updates(&a2_changeset);
+    a2_harness.reveal_and_update(&mut a2_trie, &mut a2_leaf_updates);
+
+    // --- Storage root phase ---
+    let sr1 = a1_trie.root();
+    let sr2 = a2_trie.root();
+
+    // Verify storage roots match references.
+    a1_harness.apply_changeset(a1_changeset);
+    assert_eq!(sr1, a1_harness.original_root, "A1 storage root should match reference");
+
+    a2_harness.apply_changeset(a2_changeset);
+    assert_eq!(sr2, a2_harness.original_root, "A2 storage root should match reference");
+
+    // --- Account promotion phase ---
+    // Encode A1 with sr1, A2 with sr2, modify A3 (balance change = different value).
+    let mut acct_changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    acct_changeset.insert(acct_keys[0], encode_root(sr1)); // A1 with new storage root
+    acct_changeset.insert(acct_keys[1], encode_root(sr2)); // A2 with new storage root
+    acct_changeset.insert(acct_keys[2], U256::from(42)); // A3 balance change
+    let mut acct_leaf_updates = SuiteTestHarness::leaf_updates(&acct_changeset);
+    acct_harness.reveal_and_update(&mut acct_trie, &mut acct_leaf_updates);
+
+    // --- State root phase ---
+    let state_root = acct_trie.root();
+
+    // Verify state root matches reference.
+    acct_harness.apply_changeset(acct_changeset);
+    assert_eq!(state_root, acct_harness.original_root, "state root should match reference");
+
+    // --- Finalize: take_updates ---
+    let acct_updates = acct_trie.take_updates();
+    let a1_updates = a1_trie.take_updates();
+    let a2_updates = a2_trie.take_updates();
+
+    // --- Reuse: commit + prune ---
+    acct_trie.commit_updates(&acct_updates.updated_nodes, &acct_updates.removed_nodes);
+    a1_trie.commit_updates(&a1_updates.updated_nodes, &a1_updates.removed_nodes);
+    a2_trie.commit_updates(&a2_updates.updated_nodes, &a2_updates.removed_nodes);
+
+    // Post-commit root should still be state_root.
+    let post_commit_root = acct_trie.root();
+    assert_eq!(post_commit_root, state_root, "root should be unchanged after commit_updates");
+
+    // Prune account trie, retaining only A1 and A2 paths.
+    let retained: Vec<Nibbles> = acct_keys[0..2].iter().map(|k| Nibbles::unpack(*k)).collect();
+    acct_trie.prune(&retained);
+
+    // Post-prune root should still be state_root.
+    let post_prune_root = acct_trie.root();
+    assert_eq!(post_prune_root, state_root, "root should be unchanged after prune");
+}
+
+/// Prewarm via `Touched`, then mutate via `Changed`.
+///
+/// `Touched` is used to prewarm accounts/slots before actual state changes arrive.
+/// When the real `Changed` update arrives, it overwrites the `Touched` entry.
+/// This test verifies that prewarming followed by mutation works correctly.
+pub(super) fn test_touched_prewarm_then_changed_update<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+    let key4 = B256::with_last_byte(0x40);
+    let key5 = B256::with_last_byte(0x50);
+
+    let base_storage: BTreeMap<B256, U256> = [
+        (key1, U256::from(1)),
+        (key2, U256::from(2)),
+        (key3, U256::from(3)),
+        (key4, U256::from(4)),
+        (key5, U256::from(5)),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Step 1: Prewarm 3 keys with Touched — all should be drained (paths are revealed).
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(key1, LeafUpdate::Touched), (key2, LeafUpdate::Touched), (key3, LeafUpdate::Touched)]
+            .into_iter()
+            .collect();
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves with Touched should succeed");
+
+    assert!(targets.is_empty(), "no callback should fire for Touched on fully revealed paths");
+    assert!(leaf_updates.is_empty(), "all Touched keys should be drained");
+
+    // Step 2: Now send Changed for 2 of the touched keys + 1 new key.
+    let new_key = B256::with_last_byte(0x60);
+    let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset.insert(key1, U256::from(100)); // modify key1
+    changeset.insert(key2, U256::from(200)); // modify key2
+    changeset.insert(new_key, U256::from(600)); // insert new key
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    // Step 3: Compute root and verify against reference.
+    let root = trie.root();
+
+    harness.apply_changeset(changeset);
+    assert_eq!(root, harness.original_root, "root should match reference after Touched + Changed");
+}
+
+/// Touched on blinded path triggers proof callback, then Changed
+/// for the same key succeeds after reveal.
+///
+/// A `Touched` update hits a blinded node, triggering a proof request. After the proof is
+/// revealed, a `Changed` update for the same key succeeds. This is the prewarm-miss →
+/// reveal → update sequence.
+pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<
+    T: SparseTrie + Default,
+>() {
+    // Two groups of 16 keys each to create blinded subtries.
+    let mut base_storage = BTreeMap::new();
+
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let mut harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only group A — group B's subtrie is blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false);
+
+    // Step 1: Touched on a key in group B's blinded subtrie → callback fires.
+    let target_key = group_b_keys[0];
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(target_key, LeafUpdate::Touched)].into_iter().collect();
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves with Touched should succeed");
+
+    assert!(!targets.is_empty(), "callback should fire for Touched on blinded path");
+    assert!(!leaf_updates.is_empty(), "Touched key should remain in map when blinded");
+
+    // Step 2: Reveal the proof for the requested targets.
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal should succeed");
+
+    // Step 3: Replace Touched with Changed(new_value) in the map.
+    let new_value = U256::from(999);
+    leaf_updates
+        .insert(target_key, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
+
+    // Step 4: update_leaves again — key should now be drained.
+    let mut targets2: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets2.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves with Changed should succeed");
+
+    assert!(leaf_updates.is_empty(), "Changed key should be drained after reveal");
+
+    // Step 5: Compute root and verify against reference.
+    let root = trie.root();
+
+    let mut changeset = BTreeMap::new();
+    changeset.insert(target_key, new_value);
+    harness.apply_changeset(changeset);
+    assert_eq!(
+        root, harness.original_root,
+        "root should match reference after Touched-miss → reveal → Changed"
+    );
+}
+
+/// get_leaf_value for storage root lookup.
+///
+/// Simulates the `SparseStateTrie::update_account` pattern: read existing leaf via
+/// `get_leaf_value`, decode, modify (change one field while preserving another), re-encode,
+/// and update. Verifies that root matches reference.
+pub(super) fn test_get_leaf_value_for_storage_root_lookup<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(100)), (key2, U256::from(200)), (key3, U256::from(300))]
+            .into_iter()
+            .collect();
+
+    let mut harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Step 1: Read existing leaf value via get_leaf_value.
+    let key1_nibbles = Nibbles::unpack(key1);
+    let existing_rlp = trie
+        .get_leaf_value(&key1_nibbles)
+        .expect("get_leaf_value should return Some for existing key")
+        .clone();
+
+    // Step 2: Decode the value and verify it matches expected.
+    let decoded: U256 =
+        alloy_rlp::Decodable::decode(&mut existing_rlp.as_slice()).expect("should decode as U256");
+    assert_eq!(decoded, U256::from(100), "decoded value should match original");
+
+    // Step 3: Modify the value (simulates changing balance while keeping storage root).
+    let new_value = U256::from(999);
+    let new_value_rlp = alloy_rlp::encode_fixed_size(&new_value).to_vec();
+
+    // Step 4: Update the leaf with the re-encoded value.
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(key1, LeafUpdate::Changed(new_value_rlp))].into_iter().collect();
+    trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+
+    // Step 5: Compute root and verify against reference.
+    let root = trie.root();
+
+    let mut changeset = BTreeMap::new();
+    changeset.insert(key1, new_value);
+    harness.apply_changeset(changeset);
+    assert_eq!(
+        root, harness.original_root,
+        "root should match reference after get→decode→re-encode→update"
+    );
+}
+
+/// Before updating, check existence via `find_leaf`, then
+/// insert/modify, and verify `find_leaf` reflects the new state.
+pub(super) fn test_find_leaf_before_update_to_check_existence<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+    let nonexistent_key = B256::with_last_byte(0x40);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let mut harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let key2_nibbles = Nibbles::unpack(key2);
+    let nonexistent_nibbles = Nibbles::unpack(nonexistent_key);
+
+    // Step 1: find_leaf(existing_key, None) → Exists
+    assert_eq!(
+        trie.find_leaf(&key2_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::Exists,
+        "existing key should return Exists before update"
+    );
+
+    // Step 2: find_leaf(nonexistent_key, None) → NonExistent
+    assert_eq!(
+        trie.find_leaf(&nonexistent_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::NonExistent,
+        "nonexistent key should return NonExistent before update"
+    );
+
+    // Step 3: Modify existing key2 and insert nonexistent_key.
+    let new_key2_value = U256::from(222);
+    let new_insert_value = U256::from(444);
+    let mut leaf_updates: B256Map<LeafUpdate> = [
+        (key2, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_key2_value).to_vec())),
+        (
+            nonexistent_key,
+            LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_insert_value).to_vec()),
+        ),
+    ]
+    .into_iter()
+    .collect();
+    trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+
+    // Step 4: Compute root and verify against reference.
+    let root = trie.root();
+
+    let mut changeset = BTreeMap::new();
+    changeset.insert(key2, new_key2_value);
+    changeset.insert(nonexistent_key, new_insert_value);
+    harness.apply_changeset(changeset);
+    assert_eq!(root, harness.original_root, "root should match reference after find→update");
+
+    // Step 5: find_leaf(nonexistent_key, None) → now Exists
+    assert_eq!(
+        trie.find_leaf(&nonexistent_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::Exists,
+        "previously nonexistent key should return Exists after insertion"
+    );
+}
+
+/// After prune, hot leaves update immediately; cold leaves need re-reveal.
+///
+/// Build 10-leaf trie, do Block 1 (update K1,K2,K3 → commit → prune retaining K1,K2),
+/// then Block 2: update K1 (hot, works immediately), update K5 (cold, needs re-reveal).
+pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie + Default>() {
+    // Build a trie with 10 leaves.
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    let mut keys = Vec::new();
+    for i in 0u8..10 {
+        let mut key = B256::ZERO;
+        key.0[0] = i * 16; // nibble prefixes: 0x0, 0x1, ..., 0x9
+        storage.insert(key, U256::from(i as u64 + 1));
+        keys.push(key);
+    }
+
+    let mut harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial hashes.
+    let _ = trie.root();
+
+    // --- Block 1: Update K1 (keys[0]), K2 (keys[1]), K3 (keys[2]) ---
+    let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset1.insert(keys[0], U256::from(100));
+    changeset1.insert(keys[1], U256::from(200));
+    changeset1.insert(keys[2], U256::from(300));
+    let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates1);
+    let root1 = trie.root();
+
+    harness.apply_changeset(changeset1);
+    assert_eq!(root1, harness.original_root, "block 1 root should match reference");
+
+    let updates1 = trie.take_updates();
+    trie.commit_updates(&updates1.updated_nodes, &updates1.removed_nodes);
+
+    // --- Prune: retain only K1 and K2 as "hot" ---
+    let retained: Vec<Nibbles> = [keys[0], keys[1]].iter().map(|k| Nibbles::unpack(*k)).collect();
+    trie.prune(&retained);
+
+    // --- Block 2 — hot path: Update K1 with a new value ---
+    let mut changeset_hot: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset_hot.insert(keys[0], U256::from(999));
+    let mut leaf_updates_hot = SuiteTestHarness::leaf_updates(&changeset_hot);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates_hot);
+    let root_hot = trie.root();
+
+    harness.apply_changeset(changeset_hot);
+    assert_eq!(
+        root_hot, harness.original_root,
+        "hot path root should match reference (K1 updated)"
+    );
+
+    // --- Block 2 — cold path: Update K5 (keys[4], pruned) ---
+    let mut changeset_cold: BTreeMap<B256, U256> = BTreeMap::new();
+    changeset_cold.insert(keys[4], U256::from(555));
+    let mut leaf_updates_cold = SuiteTestHarness::leaf_updates(&changeset_cold);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates_cold);
+    let root_cold = trie.root();
+
+    harness.apply_changeset(changeset_cold);
+    assert_eq!(
+        root_cold, harness.original_root,
+        "cold path root should match reference (K1 and K5 updated)"
+    );
+}

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -487,8 +487,7 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<
 
     // Step 1: Touched on a key in group B's blinded subtrie → callback fires.
     let target_key = group_b_keys[0];
-    let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((target_key, LeafUpdate::Touched)).collect();
+    let mut leaf_updates: B256Map<LeafUpdate> = once((target_key, LeafUpdate::Touched)).collect();
 
     let mut targets: Vec<ProofV2Target> = Vec::new();
     trie.update_leaves(&mut leaf_updates, |key, min_len| {
@@ -505,8 +504,7 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<
 
     // Step 3: Replace Touched with Changed(new_value) in the map.
     let new_value = U256::from(999);
-    leaf_updates
-        .insert(target_key, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
+    leaf_updates.insert(target_key, LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
 
     // Step 4: update_leaves again — key should now be drained.
     trie.update_leaves(&mut leaf_updates, |_, _| {})
@@ -553,16 +551,16 @@ pub(super) fn test_get_leaf_value_for_storage_root_lookup<T: SparseTrie + Defaul
 
     // Step 2: Decode the value and verify it matches expected.
     let decoded: U256 =
-        alloy_rlp::Decodable::decode(&mut existing_rlp.as_slice()).expect("should decode as U256");
+        Decodable::decode(&mut existing_rlp.as_slice()).expect("should decode as U256");
     assert_eq!(decoded, U256::from(100), "decoded value should match original");
 
     // Step 3: Modify the value (simulates changing balance while keeping storage root).
     let new_value = U256::from(999);
-    let new_value_rlp = alloy_rlp::encode_fixed_size(&new_value).to_vec();
+    let new_value_rlp = encode_fixed_size(&new_value).to_vec();
 
     // Step 4: Update the leaf with the re-encoded value.
     let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((key1, LeafUpdate::Changed(new_value_rlp))).collect();
+        once((key1, LeafUpdate::Changed(new_value_rlp))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 5: Compute root and verify against reference.
@@ -612,11 +610,8 @@ pub(super) fn test_find_leaf_before_update_to_check_existence<T: SparseTrie + De
     let new_key2_value = U256::from(222);
     let new_insert_value = U256::from(444);
     let mut leaf_updates: B256Map<LeafUpdate> = [
-        (key2, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_key2_value).to_vec())),
-        (
-            nonexistent_key,
-            LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_insert_value).to_vec()),
-        ),
+        (key2, LeafUpdate::Changed(encode_fixed_size(&new_key2_value).to_vec())),
+        (nonexistent_key, LeafUpdate::Changed(encode_fixed_size(&new_insert_value).to_vec())),
     ]
     .into_iter()
     .collect();

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -1,0 +1,395 @@
+//! Generic SparseTrie test suite.
+//!
+//! Tests are written as generic functions `test_foo<T: SparseTrie + Default>()` and stamped out
+//! for every concrete implementation via the [`sparse_trie_tests`] macro.
+//!
+//! Tests are organized into modules by which `SparseTrie` method is the most likely root cause
+//! of failure for each test case:
+//!
+//! - [`set_root`]: Tests for `set_root` / `with_root`
+//! - [`reveal_nodes`]: Tests for `reveal_nodes` / `reveal_node`
+//! - [`update_leaves`]: Tests for `update_leaves`, including insert, modify, and remove
+//! - [`root`]: Tests for `root()` hash computation
+//! - [`take_updates`]: Tests for `take_updates`
+//! - [`commit_updates`]: Tests for `commit_updates`
+//! - [`prune`]: Tests for `prune`
+//! - [`wipe_clear`]: Tests for `wipe` and `clear`
+//! - [`get_leaf_value`]: Tests for `get_leaf_value`
+//! - [`find_leaf`]: Tests for `find_leaf`
+//! - [`size_hint`]: Tests for `size_hint`
+//! - [`lifecycle`]: Integration tests exercising multiple methods together
+
+use alloy_primitives::{map::B256Map, B256, U256};
+use alloy_trie::EMPTY_ROOT_HASH;
+use reth_trie::{
+    hashed_cursor::{mock::MockHashedCursorFactory, HashedCursorFactory},
+    prefix_set::PrefixSet,
+    proof_v2::StorageProofCalculator,
+    trie_cursor::{mock::MockTrieCursorFactory, TrieCursorFactory},
+    StorageRoot,
+};
+use reth_trie_common::{
+    updates::StorageTrieUpdates, Nibbles, ProofTrieNodeV2, ProofV2Target, TrieNodeV2,
+};
+use reth_trie_sparse::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    iter::once,
+};
+
+mod commit_updates;
+mod find_leaf;
+mod get_leaf_value;
+mod lifecycle;
+mod prune;
+mod reveal_nodes;
+mod root;
+mod set_root;
+mod size_hint;
+mod take_updates;
+mod update_leaves;
+mod wipe_clear;
+
+/// A fixed hashed address used by the harness for all storage trie operations.
+const HASHED_ADDRESS: B256 = B256::ZERO;
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+/// Generic test harness for SparseTrie tests.
+///
+/// Manages a base storage dataset, computes expected roots via `StorageRoot`, and generates
+/// V2 proofs via `StorageProofCalculator` using mock cursors.
+struct SuiteTestHarness {
+    /// The base storage dataset (hashed slot → value). Zero-valued entries are absent.
+    storage: BTreeMap<B256, U256>,
+    /// The expected storage root, calculated by `StorageRoot`.
+    original_root: B256,
+    /// The starting storage trie updates, used for minimization.
+    storage_trie_updates: StorageTrieUpdates,
+    /// Mock factory for trie cursors.
+    trie_cursor_factory: MockTrieCursorFactory,
+    /// Mock factory for hashed cursors.
+    hashed_cursor_factory: MockHashedCursorFactory,
+}
+
+impl SuiteTestHarness {
+    /// Creates a new test harness from a map of hashed storage slots to values.
+    fn new(storage: BTreeMap<B256, U256>) -> Self {
+        let mut harness = Self {
+            storage: BTreeMap::new(),
+            original_root: B256::ZERO,
+            storage_trie_updates: StorageTrieUpdates::default(),
+            trie_cursor_factory: MockTrieCursorFactory::new(BTreeMap::new(), Default::default()),
+            hashed_cursor_factory: MockHashedCursorFactory::new(
+                BTreeMap::new(),
+                Default::default(),
+            ),
+        };
+        harness.apply_changeset(storage);
+        harness
+    }
+
+    /// Merges `changeset` into the base storage (zero values remove entries) and
+    /// recomputes the storage root, trie updates, and cursor factories.
+    fn apply_changeset(&mut self, changeset: BTreeMap<B256, U256>) {
+        for (k, v) in changeset {
+            if v == U256::ZERO {
+                self.storage.remove(&k);
+            } else {
+                self.storage.insert(k, v);
+            }
+        }
+
+        self.hashed_cursor_factory = MockHashedCursorFactory::new(
+            BTreeMap::new(),
+            once((HASHED_ADDRESS, self.storage.clone())).collect(),
+        );
+
+        let empty_trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::new(),
+            once((HASHED_ADDRESS, BTreeMap::new())).collect(),
+        );
+
+        let (original_root, _, storage_trie_updates) = StorageRoot::new_hashed(
+            empty_trie_cursor_factory,
+            self.hashed_cursor_factory.clone(),
+            HASHED_ADDRESS,
+            PrefixSet::default(),
+            #[cfg(feature = "metrics")]
+            reth_trie::metrics::TrieRootMetrics::new(reth_trie::TrieType::Storage),
+        )
+        .root_with_updates()
+        .expect("StorageRoot should succeed");
+
+        self.trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::new(),
+            once((
+                HASHED_ADDRESS,
+                storage_trie_updates.storage_nodes.iter().map(|(k, v)| (*k, v.clone())).collect(),
+            ))
+            .collect(),
+        );
+
+        self.original_root = original_root;
+        self.storage_trie_updates = storage_trie_updates;
+    }
+
+    /// Obtains the root node of the storage trie via `StorageProofCalculator`.
+    fn root_node(&self) -> ProofTrieNodeV2 {
+        let trie_cursor = self
+            .trie_cursor_factory
+            .storage_trie_cursor(HASHED_ADDRESS)
+            .expect("storage trie cursor should succeed");
+        let hashed_cursor = self
+            .hashed_cursor_factory
+            .hashed_storage_cursor(HASHED_ADDRESS)
+            .expect("hashed storage cursor should succeed");
+
+        let mut proof_calculator = StorageProofCalculator::new_storage(trie_cursor, hashed_cursor);
+        proof_calculator
+            .storage_root_node(HASHED_ADDRESS)
+            .expect("storage_root_node should succeed")
+    }
+
+    /// Generates storage proofs for the given targets using `StorageProofCalculator`.
+    fn proof_v2(&self, targets: &mut [ProofV2Target]) -> Vec<ProofTrieNodeV2> {
+        let trie_cursor = self
+            .trie_cursor_factory
+            .storage_trie_cursor(HASHED_ADDRESS)
+            .expect("storage trie cursor should succeed");
+        let hashed_cursor = self
+            .hashed_cursor_factory
+            .hashed_storage_cursor(HASHED_ADDRESS)
+            .expect("hashed storage cursor should succeed");
+
+        let mut proof_calculator = StorageProofCalculator::new_storage(trie_cursor, hashed_cursor);
+        proof_calculator.storage_proof(HASHED_ADDRESS, targets).expect("proof_v2 should succeed")
+    }
+
+    /// Builds leaf updates from a changeset. Non-zero values become inserts/modifies,
+    /// zero values become removals (empty vec).
+    fn leaf_updates(changes: &BTreeMap<B256, U256>) -> B256Map<LeafUpdate> {
+        changes
+            .iter()
+            .map(|(&slot, &value)| {
+                let rlp_value = if value == U256::ZERO {
+                    Vec::new()
+                } else {
+                    alloy_rlp::encode_fixed_size(&value).to_vec()
+                };
+                (slot, LeafUpdate::Changed(rlp_value))
+            })
+            .collect()
+    }
+
+    /// Runs the reveal-update loop on the given trie: repeatedly calls `update_leaves`,
+    /// collects proof targets from the callback, fetches proofs, and reveals them until
+    /// no more proofs are needed.
+    fn reveal_and_update<T: SparseTrie>(
+        &self,
+        trie: &mut T,
+        leaf_updates: &mut B256Map<LeafUpdate>,
+    ) {
+        loop {
+            let mut targets: Vec<ProofV2Target> = Vec::new();
+            trie.update_leaves(leaf_updates, |key, min_len| {
+                targets.push(ProofV2Target::new(key).with_min_len(min_len));
+            })
+            .expect("update_leaves should succeed");
+
+            if targets.is_empty() {
+                break;
+            }
+
+            let mut proof_nodes = self.proof_v2(&mut targets);
+            trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+        }
+    }
+
+    /// Initializes a trie with the harness root node and reveals all proof nodes for the
+    /// given target keys. Returns the initialized trie.
+    fn init_trie_with_targets<T: SparseTrie + Default>(
+        &self,
+        target_keys: &[B256],
+        retain_updates: bool,
+    ) -> T {
+        let root_node = self.root_node();
+        let mut trie = T::default();
+        trie.set_root(root_node.node, root_node.masks, retain_updates)
+            .expect("set_root should succeed");
+
+        if !target_keys.is_empty() {
+            let mut targets: Vec<ProofV2Target> =
+                target_keys.iter().map(|k| ProofV2Target::new(*k)).collect();
+            let mut proof_nodes = self.proof_v2(&mut targets);
+            trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+        }
+
+        trie
+    }
+
+    /// Initializes a trie and reveals proofs for all keys in the base storage.
+    fn init_trie_fully_revealed<T: SparseTrie + Default>(&self, retain_updates: bool) -> T {
+        let keys: Vec<B256> = self.storage.keys().copied().collect();
+        self.init_trie_with_targets(&keys, retain_updates)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Macro: stamp out tests for every SparseTrie impl
+// ---------------------------------------------------------------------------
+
+/// Stamps out `#[test]` functions for each generic test function listed, instantiated
+/// for every concrete `SparseTrie` implementation.
+macro_rules! sparse_trie_tests {
+    ( $( $test_fn:ident ),* $(,)? ) => {
+        mod parallel_sparse_trie {
+            use reth_trie_sparse::ParallelSparseTrie;
+
+            $(
+                #[test]
+                fn $test_fn() {
+                    super::$test_fn::<ParallelSparseTrie>();
+                }
+            )*
+        }
+
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Re-export test functions from submodules for the macro
+// ---------------------------------------------------------------------------
+
+use commit_updates::*;
+use find_leaf::*;
+use get_leaf_value::*;
+use lifecycle::*;
+use prune::*;
+use reveal_nodes::*;
+use root::*;
+use set_root::*;
+use size_hint::*;
+use take_updates::*;
+use update_leaves::*;
+use wipe_clear::*;
+
+// ---------------------------------------------------------------------------
+// Test registration
+// ---------------------------------------------------------------------------
+
+sparse_trie_tests! {
+    // set_root
+    test_set_root_with_branch_node,
+    test_set_root_with_leaf_node,
+    test_set_root_with_extension_node,
+    test_set_root_retains_updates_when_requested,
+    test_set_root_does_not_retain_updates_when_not_requested,
+    test_set_root_with_branch_masks,
+    test_set_root_with_empty_root,
+
+    // reveal_nodes
+    test_reveal_nodes_empty_slice,
+    test_reveal_nodes_single_leaf,
+    test_reveal_nodes_idempotent,
+    test_reveal_nodes_with_branch_masks,
+    test_reveal_nodes_skips_on_empty_root,
+    test_reveal_nodes_filters_unreachable_boundary_leaves,
+    test_reveal_insert_reveal_preserves_branch_state,
+    test_remove_then_reveal_does_not_overwrite_collapsed_node,
+    test_insert_then_reveal_does_not_overwrite_branch,
+
+    // update_leaves
+    test_update_leaves_insert_new_leaf,
+    test_update_leaves_modify_existing_leaf,
+    test_insert_single_leaf_into_empty_trie,
+    test_insert_multiple_leaves_into_empty_trie,
+    test_update_all_leaves_with_new_values,
+    test_two_leaves_at_adjacent_keys_root_correctness,
+    test_update_leaves_remove_leaf,
+    test_remove_leaf_branch_collapses_to_extension,
+    test_remove_leaf_branch_collapses_to_leaf,
+    test_remove_last_leaf_produces_empty_root,
+    test_insert_then_remove_sequence,
+    test_remove_nonexistent_leaf_preserves_hashes,
+    test_update_leaves_blinded_node_requests_proof,
+    test_update_leaves_retry_after_reveal,
+    test_remove_leaf_blinded_sibling_requires_reveal,
+    test_update_leaves_removal_branch_collapse_blinded_sibling,
+    test_update_leaves_subtrie_collapse_requests_proof,
+    test_update_leaves_multiple_keys_same_blinded_node,
+    test_update_leaves_touched_fully_revealed,
+    test_update_leaves_touched_blinded_requests_proof,
+    test_update_leaves_touched_nonexistent_key,
+    test_update_leaves_touched_nonexistent_in_populated_trie,
+    test_update_leaves_multiple_mixed_updates,
+    test_remove_leaf_marks_ancestors_dirty_unconditionally,
+    test_orphaned_value_update_falls_through_to_full_insertion,
+    test_branch_collapse_updates_leaf_key_len_across_subtries,
+    test_remove_leaf_does_not_reveal_blind_subtries,
+
+    // root
+    test_root_empty_trie,
+    test_root_cached_returns_without_recomputation,
+    test_root_after_single_leaf_update,
+    test_root_deterministic_across_update_orders,
+    test_root_handles_small_root_node_without_hash,
+
+    // take_updates
+    test_take_updates_returns_empty_when_not_tracking,
+    test_take_updates_resets_after_take,
+    test_take_updates_contains_updated_and_removed_nodes,
+    test_take_updates_no_duplicate_updated_and_removed_nodes,
+
+    // commit_updates
+    test_commit_updates_syncs_branch_masks,
+    test_commit_updates_empty_is_noop,
+
+    // prune
+    test_prune_retains_specified_leaves,
+    test_prune_reduces_node_count,
+    test_prune_empty_retained_set,
+    test_prune_requires_computed_hashes,
+    test_prune_then_update_and_recompute_root,
+    test_prune_then_reveal_pruned_subtree,
+    test_prune_mixed_embedded_and_hashed_nodes,
+    test_prune_then_update_no_panic,
+    test_prune_only_descends_into_branch_root,
+    test_prune_handles_small_subtrie_root_nodes,
+
+    // wipe / clear
+    test_wipe_resets_to_empty_root,
+    test_clear_resets_trie_but_preserves_update_tracking,
+    test_wipe_produces_wiped_updates,
+    test_clear_then_reuse_trie,
+
+    // get_leaf_value
+    test_get_leaf_value_after_update,
+    test_get_leaf_value_after_removal,
+
+    // find_leaf
+    test_find_leaf_exists,
+    test_find_leaf_nonexistent,
+    test_find_leaf_blinded,
+    test_find_leaf_value_mismatch,
+    test_find_leaf_nonexistent_branch_divergence,
+    test_find_leaf_nonexistent_extension_divergence,
+    test_find_leaf_nonexistent_leaf_divergence,
+
+    // size_hint
+    test_size_hint_reflects_leaf_count,
+
+    // lifecycle (integration tests)
+    test_full_lifecycle_update_root_take_commit,
+    test_multi_round_update_commit_prune_cycle,
+    test_reveal_update_root_basic_lifecycle,
+    test_incremental_reveal_and_update_with_retry,
+    test_full_block_processing_lifecycle,
+    test_touched_prewarm_then_changed_update,
+    test_touched_on_blinded_triggers_proof_then_changed_succeeds,
+    test_get_leaf_value_for_storage_root_lookup,
+    test_find_leaf_before_update_to_check_existence,
+    test_prune_then_reuse_for_next_block,
+}

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -1,4 +1,4 @@
-//! Generic SparseTrie test suite.
+//! Generic `SparseTrie` test suite.
 //!
 //! Tests are written as generic functions `test_foo<T: SparseTrie + Default>()` and stamped out
 //! for every concrete implementation via the [`sparse_trie_tests`] macro.
@@ -57,7 +57,7 @@ const HASHED_ADDRESS: B256 = B256::ZERO;
 // Test harness
 // ---------------------------------------------------------------------------
 
-/// Generic test harness for SparseTrie tests.
+/// Generic test harness for `SparseTrie` tests.
 ///
 /// Manages a base storage dataset, computes expected roots via `StorageRoot`, and generates
 /// V2 proofs via `StorageProofCalculator` using mock cursors.

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -20,6 +20,7 @@
 //! - [`lifecycle`]: Integration tests exercising multiple methods together
 
 use alloy_primitives::{map::B256Map, B256, U256};
+use alloy_rlp::{encode_fixed_size, Decodable};
 use alloy_trie::EMPTY_ROOT_HASH;
 use reth_trie::{
     hashed_cursor::{mock::MockHashedCursorFactory, HashedCursorFactory},
@@ -177,7 +178,7 @@ impl SuiteTestHarness {
                 let rlp_value = if value == U256::ZERO {
                     Vec::new()
                 } else {
-                    alloy_rlp::encode_fixed_size(&value).to_vec()
+                    encode_fixed_size(&value).to_vec()
                 };
                 (slot, LeafUpdate::Changed(rlp_value))
             })

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -320,7 +320,7 @@ pub(super) fn test_prune_only_descends_into_branch_root<T: SparseTrie + Default>
 }
 
 /// Small subtrie root nodes (RLP < 32 bytes) are
-/// handled correctly during prune. After root() + prune(), a subsequent root()
+/// handled correctly during prune. After `root()` + `prune()`, a subsequent `root()`
 /// still returns the same hash.
 pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie + Default>() {
     // Build a trie with two groups of leaves to create a branch root with mixed

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -1,0 +1,355 @@
+use super::*;
+
+pub(super) fn test_prune_retains_specified_leaves<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let mut key_d = B256::ZERO;
+    key_d.0[0] = 0x40;
+    let mut key_e = B256::ZERO;
+    key_e.0[0] = 0x50;
+
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (key_a, U256::from(1)),
+        (key_b, U256::from(2)),
+        (key_c, U256::from(3)),
+        (key_d, U256::from(4)),
+        (key_e, U256::from(5)),
+    ]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Compute root before prune.
+    let hash1 = trie.root();
+
+    // Retain leaves A and B, prune the rest.
+    let retained = [Nibbles::unpack(key_a), Nibbles::unpack(key_b)];
+    trie.prune(&retained);
+
+    // Root must be unchanged after prune.
+    let hash2 = trie.root();
+    assert_eq!(hash1, hash2, "root hash should be unchanged after prune");
+
+    // Retained leaves must still be accessible.
+    let val_a = trie.get_leaf_value(&Nibbles::unpack(key_a));
+    assert!(val_a.is_some(), "retained leaf A should be accessible after prune");
+
+    let val_b = trie.get_leaf_value(&Nibbles::unpack(key_b));
+    assert!(val_b.is_some(), "retained leaf B should be accessible after prune");
+}
+
+/// Pruning should reduce the node count.
+///
+/// Build a trie with 10+ leaves spread across multiple subtries, fully reveal
+/// and compute root. Then prune retaining only 1 leaf. `size_hint()` must
+/// decrease and `prune` must return > 0.
+pub(super) fn test_prune_reduces_node_count<T: SparseTrie + Default>() {
+    // Create 16 keys with different first nibbles to spread across subtries.
+    let keys: Vec<B256> = (0u8..16)
+        .map(|i| {
+            let mut k = B256::ZERO;
+            k.0[0] = (i + 1) << 4; // 0x10, 0x20, ..., 0x00 (wraps, but all distinct)
+            k
+        })
+        .collect();
+
+    let storage: BTreeMap<B256, U256> =
+        keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Compute root to cache hashes (required for pruning).
+    let _root = trie.root();
+
+    let size_before = trie.size_hint();
+
+    // Retain only the first leaf.
+    let retained = [Nibbles::unpack(keys[0])];
+    let pruned_count = trie.prune(&retained);
+
+    let size_after = trie.size_hint();
+
+    assert!(pruned_count > 0, "prune should convert at least one node to a stub");
+    assert!(
+        size_after < size_before,
+        "size_hint should decrease after prune: before={size_before}, after={size_after}"
+    );
+}
+
+/// Pruning with an empty retained set should convert all subtrees to
+/// hash stubs (maximum pruning). Root hash must be unchanged.
+pub(super) fn test_prune_empty_retained_set<T: SparseTrie + Default>() {
+    let keys: Vec<B256> = (0u8..16)
+        .map(|i| {
+            let mut k = B256::ZERO;
+            k.0[0] = (i + 1) << 4;
+            k
+        })
+        .collect();
+
+    let storage: BTreeMap<B256, U256> =
+        keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let hash_before = trie.root();
+
+    let size_before = trie.size_hint();
+
+    // Prune with empty retained set — maximum pruning.
+    let pruned_count = trie.prune(&[]);
+
+    let hash_after = trie.root();
+    let size_after = trie.size_hint();
+
+    assert_eq!(hash_before, hash_after, "root hash should be unchanged after prune");
+    assert!(pruned_count > 0, "prune should convert at least one node to a stub");
+    assert!(
+        size_after < size_before,
+        "size_hint should decrease after max prune: before={size_before}, after={size_after}"
+    );
+}
+
+pub(super) fn test_prune_requires_computed_hashes<T: SparseTrie + Default>() {
+    let keys: Vec<B256> = (0u8..5)
+        .map(|i| {
+            let mut k = B256::ZERO;
+            k.0[0] = (i + 1) << 4;
+            k
+        })
+        .collect();
+
+    let storage: BTreeMap<B256, U256> =
+        keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Dirty the trie by updating a leaf — do NOT call root() to compute hashes.
+    let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
+    leaf_updates.insert(
+        keys[0],
+        LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&U256::from(999)).to_vec()),
+    );
+    trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+
+    // Prune without having called root() — dirty nodes lack cached hashes.
+    let retained = vec![Nibbles::unpack(keys[0])];
+    let pruned_count = trie.prune(&retained);
+
+    // Compare against pruning after root() is called (clean state).
+    // With dirty nodes, pruning is limited because dirty subtrees lack cached hashes.
+    let mut trie_clean: T = harness.init_trie_fully_revealed(false);
+    trie_clean.root();
+    let clean_pruned = trie_clean.prune(&retained);
+
+    assert!(
+        pruned_count <= clean_pruned,
+        "dirty prune ({pruned_count}) should not exceed clean prune ({clean_pruned})"
+    );
+}
+
+pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie + Default>() {
+    let keys: Vec<B256> = (0u8..5)
+        .map(|i| {
+            let mut k = B256::ZERO;
+            k.0[0] = (i + 1) << 4;
+            k
+        })
+        .collect();
+
+    let storage: BTreeMap<B256, U256> =
+        keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();
+
+    let harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    trie.root();
+
+    let retained = vec![Nibbles::unpack(keys[0]), Nibbles::unpack(keys[1])];
+    trie.prune(&retained);
+
+    let new_value = U256::from(999);
+    let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
+    leaf_updates
+        .insert(keys[0], LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root_after = trie.root();
+
+    let mut expected_storage = storage;
+    expected_storage.insert(keys[0], new_value);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    let expected_root = expected_harness.original_root;
+
+    assert_eq!(root_after, expected_root, "root after prune + update should match reference trie");
+}
+
+pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie + Default>() {
+    let keys: Vec<B256> = (0u8..5)
+        .map(|i| {
+            let mut k = B256::ZERO;
+            k.0[0] = (i + 1) << 4;
+            k
+        })
+        .collect();
+
+    let storage: BTreeMap<B256, U256> =
+        keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();
+
+    let harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    trie.root();
+
+    let retained = vec![Nibbles::unpack(keys[0])];
+    trie.prune(&retained);
+
+    let new_value = U256::from(777);
+    let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
+    leaf_updates
+        .insert(keys[2], LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root_after = trie.root();
+
+    let mut expected_storage = storage;
+    expected_storage.insert(keys[2], new_value);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    let expected_root = expected_harness.original_root;
+
+    assert_eq!(
+        root_after, expected_root,
+        "root after prune + reveal pruned subtree + update should match reference trie"
+    );
+}
+
+/// Pruning a trie with both large (hashed) and small (embedded) node values
+/// should preserve the root hash.
+pub(super) fn test_prune_mixed_embedded_and_hashed_nodes<T: SparseTrie + Default>() {
+    let mut storage = BTreeMap::new();
+
+    // 4 keys with large values (produce hashed nodes: RLP ≥ 32 bytes)
+    for i in 0..4u8 {
+        let mut key = B256::ZERO;
+        key.0[0] = i;
+        storage.insert(key, U256::MAX);
+    }
+    // 4 keys with small values (produce embedded nodes: RLP < 32 bytes)
+    for i in 4..8u8 {
+        let mut key = B256::ZERO;
+        key.0[0] = i;
+        storage.insert(key, U256::from(1));
+    }
+
+    let mut trie = T::default();
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&storage);
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected on empty trie");
+    })
+    .expect("update_leaves should succeed");
+
+    let root_before = trie.root();
+    trie.prune(&[]);
+    let root_after = trie.root();
+
+    assert_eq!(root_before, root_after, "root hash must be preserved after pruning mixed trie");
+}
+
+/// After pruning, inserting a new leaf at a
+/// previously-unrevealed path should not panic.
+pub(super) fn test_prune_then_update_no_panic<T: SparseTrie + Default>() {
+    // Build a trie with 64 leaves (16 keys × 4 first-nibble groups).
+    let mut storage = BTreeMap::new();
+    for group in 0..4u8 {
+        for i in 0..16u8 {
+            let mut key = B256::ZERO;
+            key.0[0] = (group << 4) | i;
+            storage.insert(key, U256::from((group as u64) * 16 + i as u64 + 1));
+        }
+    }
+
+    let harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let root_before_prune = trie.root();
+
+    // Prune everything.
+    trie.prune(&[]);
+
+    let hash1 = trie.root();
+    assert_eq!(hash1, root_before_prune, "root after prune must equal root before prune");
+
+    // Insert a brand-new key not previously in the trie.
+    let mut new_key = B256::ZERO;
+    new_key.0[0] = 0xFF;
+    let value_bytes = alloy_rlp::encode_fixed_size(&U256::from(999));
+    let mut leaf_updates =
+        B256Map::from_iter([(new_key, LeafUpdate::Changed(value_bytes.to_vec()))]);
+
+    // The update will hit blinded nodes — the reveal_and_update loop supplies proofs.
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let hash2 = trie.root();
+    assert_ne!(hash2, hash1, "root should change after inserting a new leaf");
+}
+
+/// When the root is not a branch (e.g., a single
+/// leaf or empty root), `prune` should immediately return 0 without walking.
+pub(super) fn test_prune_only_descends_into_branch_root<T: SparseTrie + Default>() {
+    // Single-leaf trie: root is a leaf node, not a branch.
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(B256::with_last_byte(0x10), U256::from(1))]);
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let _root = trie.root();
+    let pruned = trie.prune(&[]);
+    assert_eq!(pruned, 0, "non-branch root should not prune any nodes");
+
+    // Empty root: also not a branch.
+    let mut empty_trie = T::default();
+    let pruned_empty = empty_trie.prune(&[]);
+    assert_eq!(pruned_empty, 0, "empty root should not prune any nodes");
+}
+
+/// Small subtrie root nodes (RLP < 32 bytes) are
+/// handled correctly during prune. After root() + prune(), a subsequent root()
+/// still returns the same hash.
+pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie + Default>() {
+    // Build a trie with two groups of leaves to create a branch root with mixed
+    // subtrie sizes:
+    // - Group A (nibble 0x1): 16 leaves with large values → hashable subtrie root (RLP ≥ 32 bytes)
+    // - Group B (nibble 0x2): 1 leaf with a small value → small subtrie root (RLP < 32 bytes)
+    let mut storage = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | (i & 0x0F);
+        // large value ensures the subtrie root RLP ≥ 32 bytes
+        storage.insert(key, U256::MAX);
+    }
+    // Small subtrie: single small leaf
+    let mut small_key = B256::ZERO;
+    small_key.0[0] = 0x20;
+    storage.insert(small_key, U256::from(1));
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let root_before = trie.root();
+    assert_eq!(root_before, harness.original_root);
+
+    // Prune retaining only the small-subtrie leaf — the large subtrie should
+    // be replaced by hash stubs, and the small subtrie handled gracefully.
+    let retained = vec![Nibbles::unpack(small_key)];
+    trie.prune(&retained);
+
+    let root_after = trie.root();
+    assert_eq!(root_after, root_before, "root must not change after prune");
+}

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -133,10 +133,7 @@ pub(super) fn test_prune_requires_computed_hashes<T: SparseTrie + Default>() {
 
     // Dirty the trie by updating a leaf — do NOT call root() to compute hashes.
     let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
-    leaf_updates.insert(
-        keys[0],
-        LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&U256::from(999)).to_vec()),
-    );
+    leaf_updates.insert(keys[0], LeafUpdate::Changed(encode_fixed_size(&U256::from(999)).to_vec()));
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Prune without having called root() — dirty nodes lack cached hashes.
@@ -177,8 +174,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie + Default>
 
     let new_value = U256::from(999);
     let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
-    leaf_updates
-        .insert(keys[0], LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
+    leaf_updates.insert(keys[0], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     let root_after = trie.root();
@@ -213,8 +209,7 @@ pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie + Default>() {
 
     let new_value = U256::from(777);
     let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
-    leaf_updates
-        .insert(keys[2], LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value).to_vec()));
+    leaf_updates.insert(keys[2], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     let root_after = trie.root();
@@ -289,7 +284,7 @@ pub(super) fn test_prune_then_update_no_panic<T: SparseTrie + Default>() {
     // Insert a brand-new key not previously in the trie.
     let mut new_key = B256::ZERO;
     new_key.0[0] = 0xFF;
-    let value_bytes = alloy_rlp::encode_fixed_size(&U256::from(999));
+    let value_bytes = encode_fixed_size(&U256::from(999));
     let mut leaf_updates =
         B256Map::from_iter([(new_key, LeafUpdate::Changed(value_bytes.to_vec()))]);
 

--- a/crates/trie/sparse/tests/suite/reveal_nodes.rs
+++ b/crates/trie/sparse/tests/suite/reveal_nodes.rs
@@ -1,0 +1,373 @@
+use super::*;
+
+/// Empty slice is a no-op.
+///
+/// Calling `reveal_nodes` with an empty slice should return `Ok(())` and leave
+/// the trie state unchanged.
+pub(super) fn test_reveal_nodes_empty_slice<T: SparseTrie + Default>() {
+    // Set up a trie with a root node.
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let root_node = harness.root_node();
+    let mut trie = T::default();
+    trie.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
+
+    let root_before = trie.root();
+
+    // Call reveal_nodes with an empty slice — should be a no-op.
+    trie.reveal_nodes(&mut []).expect("reveal_nodes with empty slice should succeed");
+
+    let root_after = trie.root();
+    assert_eq!(root_before, root_after, "root should be unchanged after empty reveal_nodes");
+}
+
+/// Single leaf reveal produces correct root.
+///
+/// Revealing a single leaf node within a branch should make it accessible and
+/// produce correct root hashes.
+pub(super) fn test_reveal_nodes_single_leaf<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+
+    // Set root and reveal only one leaf's proof.
+    let mut trie: T = harness.init_trie_with_targets(&[key_a], true);
+    let root = trie.root();
+    assert_eq!(root, harness.original_root);
+}
+
+/// Double reveal doesn't corrupt state.
+///
+/// Revealing the same proof nodes twice should not corrupt the trie or change
+/// the root hash. The second reveal is a no-op.
+pub(super) fn test_reveal_nodes_idempotent<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+
+    // First reveal: set root and reveal all proof nodes.
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+    let root_first = trie.root();
+    assert_eq!(root_first, harness.original_root);
+
+    // Second reveal: reveal the same proof nodes again.
+    let keys: Vec<B256> = harness.storage.keys().copied().collect();
+    let mut targets: Vec<ProofV2Target> = keys.iter().map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("second reveal_nodes should succeed");
+
+    let root_second = trie.root();
+    assert_eq!(root_first, root_second, "root should be unchanged after double reveal");
+}
+
+/// Masks guide update tracking.
+///
+/// Branch node masks provided during reveal should be stored and used for update tracking.
+/// After modifying a leaf and computing the root, `take_updates()` should contain entries
+/// reflecting which branch nodes were updated vs removed, guided by the stored masks.
+pub(super) fn test_reveal_nodes_with_branch_masks<T: SparseTrie + Default>() {
+    // Build a trie with 16 leaves sharing first nibble 0x1 to produce non-root branch nodes
+    // with hashed children (needed for masks to produce InsertUpdated actions).
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let harness = SuiteTestHarness::new(storage);
+
+    // Initialize trie with masks (from proofs) and retain_updates=true.
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute root to cache initial branch hashes.
+    let _ = trie.root();
+
+    // Add a new leaf under the same prefix so non-root branch nodes change.
+    let mut new_key = B256::ZERO;
+    new_key.0[0] = 0x10;
+    new_key.0[1] = 0xFF;
+    let changeset: BTreeMap<B256, U256> = BTreeMap::from([(new_key, U256::from(999))]);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let _ = trie.root();
+
+    // Updates should reflect which branch nodes were updated vs removed,
+    // guided by the masks stored during reveal_nodes.
+    let updates = trie.take_updates();
+    assert!(
+        !updates.updated_nodes.is_empty() || !updates.removed_nodes.is_empty(),
+        "take_updates should be non-empty when masks guide update tracking: updated={}, removed={}",
+        updates.updated_nodes.len(),
+        updates.removed_nodes.len(),
+    );
+}
+
+/// Reveal on empty root is a silent no-op.
+///
+/// Calling `reveal_nodes` when the root is EmptyRoot should return `Ok(())` without
+/// modifying trie state, even when non-empty proof nodes are provided.
+pub(super) fn test_reveal_nodes_skips_on_empty_root<T: SparseTrie + Default>() {
+    // Build a harness with real data so we can obtain non-trivial proof nodes.
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (B256::with_last_byte(1), U256::from(10)),
+        (B256::with_last_byte(2), U256::from(20)),
+    ]);
+    let harness = SuiteTestHarness::new(storage);
+
+    let keys: Vec<B256> = harness.storage.keys().copied().collect();
+    let mut targets: Vec<ProofV2Target> = keys.iter().map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+
+    // Create a trie with an empty root.
+    let mut trie = T::default();
+    trie.set_root(TrieNodeV2::EmptyRoot, None, true).expect("set_root EmptyRoot should succeed");
+
+    // Reveal non-empty proof nodes — should be a no-op on an empty root.
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes on empty root should succeed");
+
+    // Trie should still be empty.
+    assert_eq!(
+        trie.root(),
+        EMPTY_ROOT_HASH,
+        "root should remain EMPTY_ROOT_HASH after reveal on empty root"
+    );
+}
+
+/// Extra/unreachable proof nodes don't corrupt state.
+///
+/// When `reveal_nodes` receives proof nodes that include entries not reachable from the
+/// current trie root (e.g., boundary leaves for unrelated subtries), those nodes should
+/// be silently skipped without corrupting state.
+pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTrie + Default>() {
+    // Create a trie with two groups of keys under different first nibbles.
+    // Group A: 3 keys under nibble 0x1
+    // Group B: 3 keys under nibble 0x2
+    let mut keys_a = Vec::new();
+    for i in 0u8..3 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        keys_a.push(key);
+    }
+    let mut keys_b = Vec::new();
+    for i in 0u8..3 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20;
+        key.0[1] = i * 16;
+        keys_b.push(key);
+    }
+
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for (i, key) in keys_a.iter().enumerate() {
+        storage.insert(*key, U256::from(i as u64 + 1));
+    }
+    for (i, key) in keys_b.iter().enumerate() {
+        storage.insert(*key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(storage);
+
+    // Initialize trie with root and reveal ONLY group A keys.
+    let root_node = harness.root_node();
+    let mut trie = T::default();
+    trie.set_root(root_node.node, root_node.masks, false).expect("set_root should succeed");
+
+    let mut targets_a: Vec<ProofV2Target> = keys_a.iter().map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_a = harness.proof_v2(&mut targets_a);
+    trie.reveal_nodes(&mut proof_a).expect("reveal group A should succeed");
+
+    // Verify root is correct with partial reveal.
+    let root_after_a = trie.root();
+    assert_eq!(root_after_a, harness.original_root, "root after group A reveal should match");
+
+    // Now generate proofs for group B keys and reveal them as extra nodes.
+    // These include boundary leaves that extend the trie into subtries the partial
+    // reveal didn't cover. They should be handled gracefully.
+    let mut targets_b: Vec<ProofV2Target> = keys_b.iter().map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_b = harness.proof_v2(&mut targets_b);
+    trie.reveal_nodes(&mut proof_b).expect("reveal extra group B nodes should succeed");
+
+    // Root must still be correct — extra reveals should not corrupt state.
+    let root_after_b = trie.root();
+    assert_eq!(root_after_b, harness.original_root, "root should be unchanged after extra reveal");
+
+    // Additionally, reveal ALL proofs at once (including duplicates) — still correct.
+    let mut targets_all: Vec<ProofV2Target> =
+        keys_a.iter().chain(keys_b.iter()).map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_all = harness.proof_v2(&mut targets_all);
+    trie.reveal_nodes(&mut proof_all).expect("reveal all nodes should succeed");
+
+    let root_after_all = trie.root();
+    assert_eq!(
+        root_after_all, harness.original_root,
+        "root should be unchanged after revealing all proofs"
+    );
+}
+
+/// Insert between reveals doesn't lose state.
+///
+/// When proofs from a 2-leaf trie are revealed, then a 3rd leaf is inserted, then another
+/// proof from the original 2-leaf trie is revealed, the branch node should not be overwritten
+/// by the stale proof. The root must match a reference trie with all 3 keys.
+pub(super) fn test_reveal_insert_reveal_preserves_branch_state<T: SparseTrie + Default>() {
+    // Two original keys and one to insert.
+    let key_a = B256::with_last_byte(0x00);
+    let key_b = B256::with_last_byte(0x01);
+    let key_c = B256::with_last_byte(0x02);
+
+    let original_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(original_storage);
+
+    // Initialize trie with root, reveal proof for key_a only.
+    let mut trie: T = harness.init_trie_with_targets(&[key_a], false);
+
+    // Insert key_b via update_leaves.
+    let insert_value = U256::from(2);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_b, insert_value)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained after insert");
+
+    // Reveal proof for key_c from the *original* 2-leaf harness (stale proof).
+    let mut targets = vec![ProofV2Target::new(key_c)];
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal stale proof for key_c should succeed");
+
+    // Root must match a reference trie with all 3 keys.
+    let root = trie.root();
+    let expected_storage =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, insert_value), (key_c, U256::from(3))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie with all 3 keys after stale reveal"
+    );
+}
+
+/// After removing a leaf that collapses a branch into an
+/// extension, revealing a stale proof (which had a branch at root) should not overwrite the
+/// extension node.
+pub(super) fn test_remove_then_reveal_does_not_overwrite_collapsed_node<T: SparseTrie + Default>() {
+    // Nibbles [0,0,..], [1,1,..], [1,2,..] — root branch has children at nibbles 0 and 1.
+    // Packed into B256 keys: byte 0x00 → nibbles [0,0], byte 0x11 → nibbles [1,1], etc.
+    let key_a = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x00;
+        k
+    };
+    let key_b = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x11;
+        k
+    };
+    let key_c = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x12;
+        k
+    };
+
+    let original_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(original_storage);
+
+    // Initialize trie with root and reveal proofs for all keys.
+    let mut trie: T = harness.init_trie_with_targets(&[key_a, key_b, key_c], false);
+
+    // Remove key_a (0x0000..) — should collapse root branch into extension (shared prefix 0x01).
+    let removals: BTreeMap<B256, U256> = BTreeMap::from([(key_a, U256::ZERO)]);
+    let mut removal_updates = SuiteTestHarness::leaf_updates(&removals);
+    harness.reveal_and_update(&mut trie, &mut removal_updates);
+    assert!(removal_updates.is_empty(), "removal should be drained");
+
+    // Reveal stale proof for key_b from the *original* 3-key harness (which has a branch at root).
+    let mut targets = vec![ProofV2Target::new(key_b)];
+    let mut stale_proof = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut stale_proof).expect("revealing stale proof should succeed");
+
+    // Root must match a reference trie with only key_b and key_c.
+    let root = trie.root();
+    let expected_storage = BTreeMap::from([(key_b, U256::from(2)), (key_c, U256::from(3))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match 2-key reference after removal + stale reveal"
+    );
+}
+
+/// After inserting a leaf that converts an extension root into
+/// a branch, revealing a stale proof from the original trie (which has an extension at root)
+/// should not overwrite the branch.
+pub(super) fn test_insert_then_reveal_does_not_overwrite_branch<T: SparseTrie + Default>() {
+    // Original trie: keys 0x0001.. and 0x0002.. share prefix 0x00 → extension root.
+    let key_a = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x00;
+        k.0[1] = 0x01;
+        k
+    };
+    let key_b = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x00;
+        k.0[1] = 0x02;
+        k
+    };
+
+    let original_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2))]);
+
+    let harness = SuiteTestHarness::new(original_storage);
+
+    // Initialize trie with root, reveal all proofs.
+    let mut trie: T = harness.init_trie_with_targets(&[key_a, key_b], false);
+
+    // Insert key_c at 0x0100.. — different first nibble, forces extension→branch conversion.
+    let key_c = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x01;
+        k
+    };
+    let insert_value = U256::from(3);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_c, insert_value)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained after insert");
+
+    // Reveal stale proof for key_a from the *original* 2-key harness (which has extension at root).
+    let mut targets = vec![ProofV2Target::new(key_a)];
+    let mut stale_proof = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut stale_proof).expect("revealing stale proof should succeed");
+
+    // Root must match a reference trie with all 3 keys.
+    let root = trie.root();
+    let expected_storage =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, insert_value)]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match 3-key reference after insert + stale reveal"
+    );
+}

--- a/crates/trie/sparse/tests/suite/reveal_nodes.rs
+++ b/crates/trie/sparse/tests/suite/reveal_nodes.rs
@@ -127,7 +127,7 @@ pub(super) fn test_reveal_nodes_with_branch_masks<T: SparseTrie + Default>() {
 
 /// Reveal on empty root is a silent no-op.
 ///
-/// Calling `reveal_nodes` when the root is EmptyRoot should return `Ok(())` without
+/// Calling `reveal_nodes` when the root is `EmptyRoot` should return `Ok(())` without
 /// modifying trie state, even when non-empty proof nodes are provided.
 pub(super) fn test_reveal_nodes_skips_on_empty_root<T: SparseTrie + Default>() {
     // Build a harness with real data so we can obtain non-trivial proof nodes.

--- a/crates/trie/sparse/tests/suite/root.rs
+++ b/crates/trie/sparse/tests/suite/root.rs
@@ -137,7 +137,7 @@ pub(super) fn test_root_handles_small_root_node_without_hash<T: SparseTrie + Def
     let value = U256::from(1);
 
     let storage: BTreeMap<B256, U256> = BTreeMap::from([(key, value)]);
-    let harness = SuiteTestHarness::new(storage.clone());
+    let harness = SuiteTestHarness::new(storage);
 
     let mut trie: T = harness.init_trie_fully_revealed(false);
 

--- a/crates/trie/sparse/tests/suite/root.rs
+++ b/crates/trie/sparse/tests/suite/root.rs
@@ -1,0 +1,149 @@
+use super::*;
+
+/// Calling `root()` on a fresh, empty trie returns `EMPTY_ROOT_HASH`.
+pub(super) fn test_root_empty_trie<T: SparseTrie + Default>() {
+    let mut trie = T::default();
+    assert_eq!(trie.root(), EMPTY_ROOT_HASH, "empty trie should return EMPTY_ROOT_HASH");
+}
+
+/// Second `root()` call returns cached hash without recomputation.
+///
+/// After fully revealing and computing root once, calling `root()` again without
+/// mutations should return the same hash and `is_root_cached()` should be true.
+pub(super) fn test_root_cached_returns_without_recomputation<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    let root1 = trie.root();
+    assert_eq!(root1, harness.original_root, "first root should match reference");
+
+    assert!(trie.is_root_cached(), "root should be cached after first computation");
+
+    let root2 = trie.root();
+    assert_eq!(root2, root1, "second root call should return the same cached hash");
+}
+
+/// Single update changes root.
+///
+/// After modifying one leaf's value, `root()` should differ from the original and
+/// match the reference trie with the updated value.
+pub(super) fn test_root_after_single_leaf_update<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let original_root = trie.root();
+    assert_eq!(original_root, harness.original_root, "initial root should match reference");
+
+    // Modify key_b's value from 2 to 999.
+    let changes: BTreeMap<B256, U256> = BTreeMap::from([(key_b, U256::from(999))]);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changes);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let new_root = trie.root();
+    assert_ne!(new_root, original_root, "root should change after leaf update");
+
+    // Build a reference trie with the updated value and verify.
+    let expected_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(999)), (key_c, U256::from(3))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        new_root, expected_harness.original_root,
+        "root should match updated reference trie"
+    );
+}
+
+/// Insert order doesn't affect root hash.
+///
+/// Two tries built from the same 5 key-value pairs inserted in different orders
+/// must produce the same root hash.
+pub(super) fn test_root_deterministic_across_update_orders<T: SparseTrie + Default>() {
+    // Define 5 key-value pairs spread across different subtrie regions.
+    let mut k1 = B256::ZERO;
+    k1.0[0] = 0x10;
+    let mut k2 = B256::ZERO;
+    k2.0[0] = 0x20;
+    let mut k3 = B256::ZERO;
+    k3.0[0] = 0x30;
+    let mut k4 = B256::ZERO;
+    k4.0[0] = 0x40;
+    let mut k5 = B256::ZERO;
+    k5.0[0] = 0x50;
+
+    let pairs = [
+        (k1, U256::from(1)),
+        (k2, U256::from(2)),
+        (k3, U256::from(3)),
+        (k4, U256::from(4)),
+        (k5, U256::from(5)),
+    ];
+
+    // Build trie A: insert keys in order 1,2,3,4,5.
+    let order_a = [pairs[0], pairs[1], pairs[2], pairs[3], pairs[4]];
+    let root_a = {
+        let mut trie = T::default();
+        for (key, value) in &order_a {
+            let mut leaf_updates =
+                SuiteTestHarness::leaf_updates(&BTreeMap::from([(*key, *value)]));
+            trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+        }
+        trie.root()
+    };
+
+    // Build trie B: insert keys in order 5,3,1,4,2.
+    let order_b = [pairs[4], pairs[2], pairs[0], pairs[3], pairs[1]];
+    let root_b = {
+        let mut trie = T::default();
+        for (key, value) in &order_b {
+            let mut leaf_updates =
+                SuiteTestHarness::leaf_updates(&BTreeMap::from([(*key, *value)]));
+            trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+        }
+        trie.root()
+    };
+
+    assert_eq!(root_a, root_b, "root hash should be deterministic regardless of insert order");
+
+    // Also verify against a reference trie built from sorted storage.
+    let all_storage: BTreeMap<B256, U256> = pairs.iter().copied().collect();
+    let harness = SuiteTestHarness::new(all_storage);
+    assert_eq!(root_a, harness.original_root, "root should match reference trie");
+}
+
+/// Small RLP root (<32 bytes) handled correctly.
+///
+/// When the root node's RLP encoding is smaller than 32 bytes, `root()` must still return the
+/// correct hash. A second `root()` call should use the cached result without panic.
+pub(super) fn test_root_handles_small_root_node_without_hash<T: SparseTrie + Default>() {
+    // A single small leaf produces a root node whose RLP is < 32 bytes.
+    let key = B256::with_last_byte(1);
+    let value = U256::from(1);
+
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([(key, value)]);
+    let harness = SuiteTestHarness::new(storage.clone());
+
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let root1 = trie.root();
+    assert_eq!(root1, harness.original_root, "first root() should match reference trie");
+
+    let root2 = trie.root();
+    assert_eq!(root2, root1, "second root() should return cached result without panic");
+}

--- a/crates/trie/sparse/tests/suite/set_root.rs
+++ b/crates/trie/sparse/tests/suite/set_root.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+/// Branch root initializes correctly and produces correct hash.
+///
+/// Two leaves whose first nibbles differ produce a branch root node.
+/// After set_root + reveal_nodes, root() must match the reference hash.
+pub(super) fn test_set_root_with_branch_node<T: SparseTrie + Default>() {
+    // Keys whose first nibbles differ → branch at root.
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10; // first nibble = 1
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20; // first nibble = 2
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(100)), (key_b, U256::from(200))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+    let root = trie.root();
+    assert_eq!(root, harness.original_root);
+}
+
+/// Single-leaf root initializes correctly.
+///
+/// A single key-value pair produces a leaf root node. After set_root + root(),
+/// the hash must match the reference trie.
+pub(super) fn test_set_root_with_leaf_node<T: SparseTrie + Default>() {
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([(B256::ZERO, U256::from(42))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let root_node = harness.root_node();
+    let mut trie = T::default();
+    trie.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
+    let root = trie.root();
+    assert_eq!(root, harness.original_root);
+}
+
+/// Extension root (shared prefix) initializes correctly.
+///
+/// Two keys sharing a long common prefix produce an extension root node.
+/// After set_root + reveal_nodes, root() must match the reference hash.
+pub(super) fn test_set_root_with_extension_node<T: SparseTrie + Default>() {
+    // Keys that share first byte 0xAB → extension root.
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0xAB;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0xAB;
+    key_b.0[31] = 0x01;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(100)), (key_b, U256::from(200))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+    let root = trie.root();
+    assert_eq!(root, harness.original_root);
+}
+
+/// retain_updates=true enables update tracking.
+///
+/// When `set_root` is called with `retain_updates = true`, subsequent mutations
+/// should be tracked and `take_updates()` should return non-empty results.
+pub(super) fn test_set_root_retains_updates_when_requested<T: SparseTrie + Default>() {
+    // Build a trie with enough leaves to produce non-root branch nodes with hash children.
+    // We need leaves sharing a prefix nibble so that intermediate branch nodes are created,
+    // and enough entries that children are hashed (RLP ≥ 32 bytes).
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10; // shared first nibble → branch at nibble 1
+        key.0[1] = i * 16; // differ in second nibble → branch below
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute root once so branch hashes are cached.
+    let _ = trie.root();
+
+    // Add a new leaf under the same prefix so non-root branch nodes change.
+    let mut new_key = B256::ZERO;
+    new_key.0[0] = 0x10;
+    new_key.0[1] = 0xFF;
+    let changeset: BTreeMap<B256, U256> = BTreeMap::from([(new_key, U256::from(100))]);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    // Compute root to finalize hashes and generate update actions.
+    let _ = trie.root();
+
+    // take_updates should return non-empty updates.
+    let updates = trie.take_updates();
+    assert!(
+        !updates.updated_nodes.is_empty() || !updates.removed_nodes.is_empty(),
+        "take_updates should be non-empty when retain_updates=true: updated={}, removed={}",
+        updates.updated_nodes.len(),
+        updates.removed_nodes.len(),
+    );
+}
+
+/// retain_updates=false disables update tracking.
+///
+/// When `set_root` is called with `retain_updates = false`, `take_updates()` should
+/// return an empty `SparseTrieUpdates` even after mutations.
+pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x30;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    // retain_updates = false
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Modify a leaf.
+    let changeset: BTreeMap<B256, U256> = BTreeMap::from([(key_a, U256::from(99))]);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let _ = trie.root();
+
+    let updates = trie.take_updates();
+    assert!(
+        updates.updated_nodes.is_empty() && updates.removed_nodes.is_empty(),
+        "take_updates should be empty when retain_updates=false: updated={}, removed={}",
+        updates.updated_nodes.len(),
+        updates.removed_nodes.len(),
+    );
+}
+
+/// Branch masks influence removed_nodes detection.
+///
+/// When `BranchNodeMasks` are provided to `set_root`, they inform the trie about
+/// which branch nodes existed in the DB. After mutations that remove leaves (causing
+/// branch nodes to disappear), `take_updates().removed_nodes` should correctly
+/// report nodes that existed per the masks but are now gone.
+pub(super) fn test_set_root_with_branch_masks<T: SparseTrie + Default>() {
+    // Build a trie with enough leaves to produce non-root branch nodes.
+    // 16 leaves sharing first nibble 0x1 (key[0] = 0x10), varying second nibble.
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let harness = SuiteTestHarness::new(storage.clone());
+
+    // Initialize trie with masks and retain_updates=true.
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute root once to cache branch hashes.
+    let _ = trie.root();
+
+    // Take updates from the initial root computation and commit them,
+    // so the masks baseline reflects the current DB state.
+    let initial_updates = trie.take_updates();
+    trie.commit_updates(&initial_updates.updated_nodes, &initial_updates.removed_nodes);
+
+    // Remove all but one leaf, causing intermediate branch nodes to collapse.
+    // This ensures that previously-tracked branch paths (per masks) are now gone.
+    let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 1u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        changeset.insert(key, U256::ZERO); // zero = removal
+    }
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    // Compute root to finalize changes.
+    let _ = trie.root();
+
+    // Take updates — removed_nodes should be non-empty because branch nodes that
+    // existed (per committed masks) are now gone after the removals collapsed
+    // the branch structure.
+    let updates = trie.take_updates();
+    assert!(
+        !updates.removed_nodes.is_empty(),
+        "removed_nodes should be non-empty when masks-tracked branches are removed"
+    );
+}
+
+/// EmptyRoot produces EMPTY_ROOT_HASH.
+///
+/// Setting the root to `TrieNodeV2::EmptyRoot` should leave the trie in its initial
+/// empty state, returning `EMPTY_ROOT_HASH` from `root()`.
+pub(super) fn test_set_root_with_empty_root<T: SparseTrie + Default>() {
+    let mut trie = T::default();
+    trie.set_root(TrieNodeV2::EmptyRoot, None, true).expect("set_root should succeed");
+    assert_eq!(trie.root(), EMPTY_ROOT_HASH);
+}

--- a/crates/trie/sparse/tests/suite/set_root.rs
+++ b/crates/trie/sparse/tests/suite/set_root.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Branch root initializes correctly and produces correct hash.
 ///
 /// Two leaves whose first nibbles differ produce a branch root node.
-/// After set_root + reveal_nodes, root() must match the reference hash.
+/// After `set_root` + `reveal_nodes`, `root()` must match the reference hash.
 pub(super) fn test_set_root_with_branch_node<T: SparseTrie + Default>() {
     // Keys whose first nibbles differ → branch at root.
     let mut key_a = B256::ZERO;
@@ -21,7 +21,7 @@ pub(super) fn test_set_root_with_branch_node<T: SparseTrie + Default>() {
 
 /// Single-leaf root initializes correctly.
 ///
-/// A single key-value pair produces a leaf root node. After set_root + root(),
+/// A single key-value pair produces a leaf root node. After `set_root` + `root()`,
 /// the hash must match the reference trie.
 pub(super) fn test_set_root_with_leaf_node<T: SparseTrie + Default>() {
     let storage: BTreeMap<B256, U256> = BTreeMap::from([(B256::ZERO, U256::from(42))]);
@@ -37,7 +37,7 @@ pub(super) fn test_set_root_with_leaf_node<T: SparseTrie + Default>() {
 /// Extension root (shared prefix) initializes correctly.
 ///
 /// Two keys sharing a long common prefix produce an extension root node.
-/// After set_root + reveal_nodes, root() must match the reference hash.
+/// After `set_root` + `reveal_nodes`, `root()` must match the reference hash.
 pub(super) fn test_set_root_with_extension_node<T: SparseTrie + Default>() {
     // Keys that share first byte 0xAB → extension root.
     let mut key_a = B256::ZERO;
@@ -54,7 +54,7 @@ pub(super) fn test_set_root_with_extension_node<T: SparseTrie + Default>() {
     assert_eq!(root, harness.original_root);
 }
 
-/// retain_updates=true enables update tracking.
+/// `retain_updates=true` enables update tracking.
 ///
 /// When `set_root` is called with `retain_updates = true`, subsequent mutations
 /// should be tracked and `take_updates()` should return non-empty results.
@@ -97,7 +97,7 @@ pub(super) fn test_set_root_retains_updates_when_requested<T: SparseTrie + Defau
     );
 }
 
-/// retain_updates=false disables update tracking.
+/// `retain_updates=false` disables update tracking.
 ///
 /// When `set_root` is called with `retain_updates = false`, `take_updates()` should
 /// return an empty `SparseTrieUpdates` even after mutations.
@@ -131,7 +131,7 @@ pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: Sparse
     );
 }
 
-/// Branch masks influence removed_nodes detection.
+/// Branch masks influence `removed_nodes` detection.
 ///
 /// When `BranchNodeMasks` are provided to `set_root`, they inform the trie about
 /// which branch nodes existed in the DB. After mutations that remove leaves (causing
@@ -186,7 +186,7 @@ pub(super) fn test_set_root_with_branch_masks<T: SparseTrie + Default>() {
     );
 }
 
-/// EmptyRoot produces EMPTY_ROOT_HASH.
+/// `EmptyRoot` produces `EMPTY_ROOT_HASH`.
 ///
 /// Setting the root to `TrieNodeV2::EmptyRoot` should leave the trie in its initial
 /// empty state, returning `EMPTY_ROOT_HASH` from `root()`.

--- a/crates/trie/sparse/tests/suite/set_root.rs
+++ b/crates/trie/sparse/tests/suite/set_root.rs
@@ -133,18 +133,25 @@ pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: Sparse
 
 /// Branch masks influence `removed_nodes` detection.
 ///
-/// When `BranchNodeMasks` are provided to `set_root`, they inform the trie about
-/// which branch nodes existed in the DB. After mutations that remove leaves (causing
+/// When proof nodes carry `BranchNodeMasks`, `reveal_nodes` registers them in the
+/// trie's internal `branch_node_masks`. After mutations that remove leaves (causing
 /// branch nodes to disappear), `take_updates().removed_nodes` should correctly
-/// report nodes that existed per the masks but are now gone.
+/// report nodes whose masks were previously registered but are now gone.
 pub(super) fn test_set_root_with_branch_masks<T: SparseTrie + Default>() {
-    // Build a trie with enough leaves to produce non-root branch nodes.
-    // 16 leaves sharing first nibble 0x1 (key[0] = 0x10), varying second nibble.
+    // 256 leaves under key[0]=0x10, varying key[1] across all 256 values.
+    // This creates two levels of branching:
+    //   - A branch at nibble path [1,0] with children at all 16 nibbles (0-F)
+    //   - Each child is itself a branch with 16 leaf children (e.g., [1,0,0], [1,0,1], …)
+    //
+    // When proofs are generated for all 256 keys, the proof includes branch nodes at
+    // [1,0,0] through [1,0,F], each carrying their own masks (hash_mask with bits set
+    // for their 16 hashed leaf children). These masks are registered in the trie's
+    // internal `branch_node_masks` during `reveal_nodes`.
     let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
-    for i in 0u8..16 {
+    for i in 0u16..256 {
         let mut key = B256::ZERO;
         key.0[0] = 0x10;
-        key.0[1] = i * 16;
+        key.0[1] = i as u8;
         storage.insert(key, U256::from(i as u64 + 1));
     }
 
@@ -156,19 +163,19 @@ pub(super) fn test_set_root_with_branch_masks<T: SparseTrie + Default>() {
     // Compute root once to cache branch hashes.
     let _ = trie.root();
 
-    // Take updates from the initial root computation and commit them,
-    // so the masks baseline reflects the current DB state.
+    // Take and commit initial updates so the masks baseline is established.
     let initial_updates = trie.take_updates();
     trie.commit_updates(&initial_updates.updated_nodes, &initial_updates.removed_nodes);
 
-    // Remove all but one leaf, causing intermediate branch nodes to collapse.
-    // This ensures that previously-tracked branch paths (per masks) are now gone.
+    // Remove all 16 leaves from sub-branch [1,0,F] (key[1]=0xF0..0xFF).
+    // This collapses the branch at [1,0,F] entirely — its masks were registered
+    // during reveal, so it should appear in removed_nodes.
     let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
-    for i in 1u8..16 {
+    for i in 0xF0u16..=0xFF {
         let mut key = B256::ZERO;
         key.0[0] = 0x10;
-        key.0[1] = i * 16;
-        changeset.insert(key, U256::ZERO); // zero = removal
+        key.0[1] = i as u8;
+        changeset.insert(key, U256::ZERO);
     }
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
@@ -176,13 +183,31 @@ pub(super) fn test_set_root_with_branch_masks<T: SparseTrie + Default>() {
     // Compute root to finalize changes.
     let _ = trie.root();
 
-    // Take updates — removed_nodes should be non-empty because branch nodes that
-    // existed (per committed masks) are now gone after the removals collapsed
-    // the branch structure.
     let updates = trie.take_updates();
+
+    // The parent branch at [1,0] should be updated: it lost child nibble F,
+    // so state_mask and hash_mask should have bit F (0x8000) cleared.
+    assert_eq!(updates.updated_nodes.len(), 1, "exactly one branch should be updated");
+    let parent = updates.updated_nodes.get(&Nibbles::from_nibbles([0x1, 0x0])).unwrap();
     assert!(
-        !updates.removed_nodes.is_empty(),
-        "removed_nodes should be non-empty when masks-tracked branches are removed"
+        !parent.state_mask.is_bit_set(0xF),
+        "parent branch should no longer have nibble F in state_mask"
+    );
+    assert!(
+        !parent.hash_mask.is_bit_set(0xF),
+        "parent branch should no longer have nibble F in hash_mask"
+    );
+    // Nibbles 0-E should still be present.
+    for nibble in 0u8..0xF {
+        assert!(parent.state_mask.is_bit_set(nibble), "nibble {nibble} should still be set");
+    }
+
+    // The sub-branch at [1,0,F] was fully removed — its masks were registered
+    // during reveal, so it appears in removed_nodes.
+    assert_eq!(updates.removed_nodes.len(), 1, "exactly one path should be removed");
+    assert!(
+        updates.removed_nodes.contains(&Nibbles::from_nibbles([0x1, 0x0, 0xF])),
+        "removed_nodes should contain the collapsed sub-branch [1,0,F]"
     );
 }
 

--- a/crates/trie/sparse/tests/suite/size_hint.rs
+++ b/crates/trie/sparse/tests/suite/size_hint.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// size_hint reflects leaf count changes.
+/// `size_hint` reflects leaf count changes.
 ///
 /// Builds a 5-leaf trie, records `size_hint`, adds 2 leaves, records again,
 /// removes 1 leaf, records again. Asserts s2 > s1 and s3 < s2 (monotonic

--- a/crates/trie/sparse/tests/suite/size_hint.rs
+++ b/crates/trie/sparse/tests/suite/size_hint.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+/// size_hint reflects leaf count changes.
+///
+/// Builds a 5-leaf trie, records `size_hint`, adds 2 leaves, records again,
+/// removes 1 leaf, records again. Asserts s2 > s1 and s3 < s2 (monotonic
+/// relative to leaf count changes).
+pub(super) fn test_size_hint_reflects_leaf_count<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+    let key4 = B256::with_last_byte(0x40);
+    let key5 = B256::with_last_byte(0x50);
+    let new_key1 = B256::with_last_byte(0x60);
+    let new_key2 = B256::with_last_byte(0x70);
+
+    let base_storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (key1, U256::from(1)),
+        (key2, U256::from(2)),
+        (key3, U256::from(3)),
+        (key4, U256::from(4)),
+        (key5, U256::from(5)),
+    ]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Include new key targets so proofs cover them.
+    let all_targets = vec![key1, key2, key3, key4, key5, new_key1, new_key2];
+    let mut trie: T = harness.init_trie_with_targets(&all_targets, false);
+
+    let s1 = trie.size_hint();
+
+    // Add 2 new leaves.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([
+        (new_key1, U256::from(6)),
+        (new_key2, U256::from(7)),
+    ]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained after insert");
+
+    let s2 = trie.size_hint();
+    assert!(s2 > s1, "size_hint should increase after adding leaves: s2={s2} > s1={s1}");
+
+    // Remove 1 leaf (set value to zero).
+    let mut remove_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(new_key2, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut remove_updates);
+    assert!(remove_updates.is_empty(), "leaf_updates should be drained after removal");
+
+    let s3 = trie.size_hint();
+    assert!(s3 < s2, "size_hint should decrease after removing a leaf: s3={s3} < s2={s2}");
+}

--- a/crates/trie/sparse/tests/suite/take_updates.rs
+++ b/crates/trie/sparse/tests/suite/take_updates.rs
@@ -79,20 +79,26 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie + Default>() {
 /// After mutations that cause branch node changes and deletions, `take_updates` should
 /// contain both updated and removed nodes. The two sets must be mutually exclusive.
 pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie + Default>() {
-    // Build a trie with two groups of 16 leaves each under nibbles 0x1 and 0x2.
-    // This creates intermediate branch nodes in both subtries.
+    // Two groups of 256 leaves each, creating two levels of branching per group.
+    // Proofs for all keys register branch masks at [X,0,0] through [X,0,F] in the
+    // trie's internal `branch_node_masks`, making removals trackable.
+    //
+    // Group 0x1: 256 leaves under key[0]=0x10, key[1]=0x00..0xFF
+    //   → branch at [1,0] with sub-branches [1,0,0] through [1,0,F]
+    // Group 0x2: 256 leaves under key[0]=0x20, key[1]=0x00..0xFF
+    //   → branch at [2,0] with sub-branches [2,0,0] through [2,0,F]
     let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
-    for i in 0u8..16 {
+    for i in 0u16..256 {
         let mut key = B256::ZERO;
         key.0[0] = 0x10;
-        key.0[1] = i * 16;
+        key.0[1] = i as u8;
         storage.insert(key, U256::from(i as u64 + 1));
     }
-    for i in 0u8..16 {
+    for i in 0u16..256 {
         let mut key = B256::ZERO;
         key.0[0] = 0x20;
-        key.0[1] = i * 16;
-        storage.insert(key, U256::from(i as u64 + 100));
+        key.0[1] = i as u8;
+        storage.insert(key, U256::from(i as u64 + 1000));
     }
 
     let harness = SuiteTestHarness::new(storage);
@@ -105,13 +111,13 @@ pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie
     let initial_updates = trie.take_updates();
     trie.commit_updates(&initial_updates.updated_nodes, &initial_updates.removed_nodes);
 
-    // Remove all 16 leaves from nibble 0x2 (collapses that entire subtrie → removed_nodes)
-    // and add a new leaf under nibble 0x1 (changes branch hashes → updated_nodes).
+    // Remove all 256 leaves from group 0x2 (collapses that entire subtrie → removed_nodes)
+    // and add a new leaf under group 0x1 (changes branch hashes → updated_nodes).
     let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
-    for i in 0u8..16 {
+    for i in 0u16..256 {
         let mut key = B256::ZERO;
         key.0[0] = 0x20;
-        key.0[1] = i * 16;
+        key.0[1] = i as u8;
         changeset.insert(key, U256::ZERO);
     }
     // Add a new leaf in the 0x1 group to trigger updated_nodes for that subtrie.
@@ -126,14 +132,38 @@ pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie
     let _ = trie.root();
     let updates = trie.take_updates();
 
+    // updated_nodes: the branch at [1,0] is updated because we modified a leaf
+    // in group 0x1 (key[1]=0xFF → value 9999). Its masks remain fully populated
+    // since all 256 leaves in group 0x1 still exist.
+    assert_eq!(updates.updated_nodes.len(), 1, "exactly one branch should be updated");
+    let parent = updates.updated_nodes.get(&Nibbles::from_nibbles([0x1, 0x0])).unwrap();
+    for nibble in 0u8..16 {
+        assert!(parent.state_mask.is_bit_set(nibble), "nibble {nibble} should still be set");
+        assert!(parent.hash_mask.is_bit_set(nibble), "nibble {nibble} hash should still be set");
+    }
+
+    // removed_nodes: removing all 256 leaves from group 0x2 collapses the entire
+    // subtrie. This removes:
+    //   - The root-level branch node [] (previously had children at nibbles 1 and 2, now only has
+    //     nibble 1 so it becomes an extension, not a stored branch)
+    //   - The parent branch at [2,0]
+    //   - All 16 sub-branches [2,0,0] through [2,0,F]
+    // 18 total: root [], parent [2,0], and 16 sub-branches [2,0,0]..[2,0,F]
+    assert_eq!(updates.removed_nodes.len(), 18, "expected 18 removed paths");
     assert!(
-        !updates.updated_nodes.is_empty(),
-        "updated_nodes should be non-empty after branch hash changes"
+        updates.removed_nodes.contains(&Nibbles::default()),
+        "root-level branch [] should be removed (collapsed to extension)"
     );
     assert!(
-        !updates.removed_nodes.is_empty(),
-        "removed_nodes should be non-empty after removing an entire subtrie"
+        updates.removed_nodes.contains(&Nibbles::from_nibbles([0x2, 0x0])),
+        "parent branch [2,0] should be removed"
     );
+    for nibble in 0u8..16 {
+        assert!(
+            updates.removed_nodes.contains(&Nibbles::from_nibbles([0x2, 0x0, nibble])),
+            "sub-branch [2,0,{nibble:x}] should be removed"
+        );
+    }
 
     // The two sets must be mutually exclusive — no path in both.
     for path in &updates.removed_nodes {

--- a/crates/trie/sparse/tests/suite/take_updates.rs
+++ b/crates/trie/sparse/tests/suite/take_updates.rs
@@ -74,7 +74,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie + Default>() {
     );
 }
 
-/// take_updates contains both updated and removed nodes, mutually exclusive.
+/// `take_updates` contains both updated and removed nodes, mutually exclusive.
 ///
 /// After mutations that cause branch node changes and deletions, `take_updates` should
 /// contain both updated and removed nodes. The two sets must be mutually exclusive.

--- a/crates/trie/sparse/tests/suite/take_updates.rs
+++ b/crates/trie/sparse/tests/suite/take_updates.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+pub(super) fn test_take_updates_returns_empty_when_not_tracking<T: SparseTrie + Default>() {
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x20;
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let updates = trie.take_updates();
+    assert!(updates.updated_nodes.is_empty(), "updated_nodes should be empty when not tracking");
+    assert!(updates.removed_nodes.is_empty(), "removed_nodes should be empty when not tracking");
+}
+
+/// Consecutive takes are independent.
+///
+/// After `take_updates()`, subsequent updates should be tracked independently in a fresh
+/// accumulator. updates1 reflects only the A mutation, updates2 reflects only the B mutation.
+pub(super) fn test_take_updates_resets_after_take<T: SparseTrie + Default>() {
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial branch hashes.
+    let _ = trie.root();
+
+    // Round 1: add a new leaf A under the shared prefix, root, take.
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x10;
+    key_a.0[1] = 0xFF;
+    let changeset_a: BTreeMap<B256, U256> = BTreeMap::from([(key_a, U256::from(999))]);
+    let mut leaf_updates_a = SuiteTestHarness::leaf_updates(&changeset_a);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates_a);
+    let _ = trie.root();
+    let updates1 = trie.take_updates();
+
+    assert!(
+        !updates1.updated_nodes.is_empty() || !updates1.removed_nodes.is_empty(),
+        "updates1 should be non-empty after adding leaf A",
+    );
+
+    // Immediately taking again (no new mutations) should yield empty updates,
+    // proving the accumulator was reset by the first take.
+    let updates_empty = trie.take_updates();
+    assert!(
+        updates_empty.updated_nodes.is_empty() && updates_empty.removed_nodes.is_empty(),
+        "take_updates right after a take should be empty (accumulator was reset)",
+    );
+
+    // Round 2: add a new leaf B under the same prefix, root, take.
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x10;
+    key_b.0[1] = 0xFE;
+    let changeset_b: BTreeMap<B256, U256> = BTreeMap::from([(key_b, U256::from(888))]);
+    let mut leaf_updates_b = SuiteTestHarness::leaf_updates(&changeset_b);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates_b);
+    let _ = trie.root();
+    let updates2 = trie.take_updates();
+
+    assert!(
+        !updates2.updated_nodes.is_empty() || !updates2.removed_nodes.is_empty(),
+        "updates2 should be non-empty after adding leaf B",
+    );
+}
+
+/// take_updates contains both updated and removed nodes, mutually exclusive.
+///
+/// After mutations that cause branch node changes and deletions, `take_updates` should
+/// contain both updated and removed nodes. The two sets must be mutually exclusive.
+pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie + Default>() {
+    // Build a trie with two groups of 16 leaves each under nibbles 0x1 and 0x2.
+    // This creates intermediate branch nodes in both subtries.
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial branch hashes.
+    let _ = trie.root();
+
+    // Commit initial updates to establish the masks baseline.
+    let initial_updates = trie.take_updates();
+    trie.commit_updates(&initial_updates.updated_nodes, &initial_updates.removed_nodes);
+
+    // Remove all 16 leaves from nibble 0x2 (collapses that entire subtrie → removed_nodes)
+    // and add a new leaf under nibble 0x1 (changes branch hashes → updated_nodes).
+    let mut changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20;
+        key.0[1] = i * 16;
+        changeset.insert(key, U256::ZERO);
+    }
+    // Add a new leaf in the 0x1 group to trigger updated_nodes for that subtrie.
+    let mut new_key = B256::ZERO;
+    new_key.0[0] = 0x10;
+    new_key.0[1] = 0xFF;
+    changeset.insert(new_key, U256::from(9999));
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let _ = trie.root();
+    let updates = trie.take_updates();
+
+    assert!(
+        !updates.updated_nodes.is_empty(),
+        "updated_nodes should be non-empty after branch hash changes"
+    );
+    assert!(
+        !updates.removed_nodes.is_empty(),
+        "removed_nodes should be non-empty after removing an entire subtrie"
+    );
+
+    // The two sets must be mutually exclusive — no path in both.
+    for path in &updates.removed_nodes {
+        assert!(
+            !updates.updated_nodes.contains_key(path),
+            "path {path:?} appears in both updated_nodes and removed_nodes"
+        );
+    }
+}
+
+/// Remove then re-insert at same path → sets are mutually exclusive.
+///
+/// When a branch collapses (leaf removal) and then a new branch is created at the same path
+/// (leaf insertion), `take_updates` must not report the same path in both `updated_nodes` and
+/// `removed_nodes`. The insertion must win.
+pub(super) fn test_take_updates_no_duplicate_updated_and_removed_nodes<T: SparseTrie + Default>() {
+    // 3 leaves sharing the first nibble → branch at nibble 0x0.
+    let mut key_a = B256::ZERO;
+    key_a.0[0] = 0x00;
+    let mut key_b = B256::ZERO;
+    key_b.0[0] = 0x01;
+    let mut key_c = B256::ZERO;
+    key_c.0[0] = 0x02;
+
+    let storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Cache initial hashes.
+    let _ = trie.root();
+
+    // Step 1: Remove key_c — with only 3 keys under the root branch, removing one causes
+    // structural changes (branch may collapse or lose a child).
+    let mut remove_changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    remove_changeset.insert(key_c, U256::ZERO);
+    let mut remove_updates = SuiteTestHarness::leaf_updates(&remove_changeset);
+    harness.reveal_and_update(&mut trie, &mut remove_updates);
+
+    // Step 2: Insert a new key at 0x03 — re-creates/modifies the branch structure at the
+    // same path that was affected by the removal.
+    let mut key_d = B256::ZERO;
+    key_d.0[0] = 0x03;
+    let mut insert_changeset: BTreeMap<B256, U256> = BTreeMap::new();
+    insert_changeset.insert(key_d, U256::from(4));
+    let mut insert_updates = SuiteTestHarness::leaf_updates(&insert_changeset);
+    harness.reveal_and_update(&mut trie, &mut insert_updates);
+
+    // Finalize and take updates.
+    let _ = trie.root();
+    let updates = trie.take_updates();
+
+    // The two sets must be mutually exclusive — no path in both.
+    for path in &updates.removed_nodes {
+        assert!(
+            !updates.updated_nodes.contains_key(path),
+            "path {path:?} appears in both updated_nodes and removed_nodes"
+        );
+    }
+}

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -819,8 +819,7 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie + Default>
     let root_before = trie.root();
 
     // Call update_leaves with Touched for an existing key.
-    let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((key2, LeafUpdate::Touched)).collect();
+    let mut leaf_updates: B256Map<LeafUpdate> = once((key2, LeafUpdate::Touched)).collect();
 
     let mut targets: Vec<ProofV2Target> = Vec::new();
     trie.update_leaves(&mut leaf_updates, |key, min_len| {
@@ -870,8 +869,7 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie + 
         key.0[0] = 0x20;
         key
     };
-    let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((target_key, LeafUpdate::Touched)).collect();
+    let mut leaf_updates: B256Map<LeafUpdate> = once((target_key, LeafUpdate::Touched)).collect();
 
     let mut targets: Vec<ProofV2Target> = Vec::new();
     trie.update_leaves(&mut leaf_updates, |key, min_len| {
@@ -896,8 +894,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_key<T: SparseTrie + Default
     let mut trie = T::default();
 
     let target_key = B256::with_last_byte(42);
-    let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((target_key, LeafUpdate::Touched)).collect();
+    let mut leaf_updates: B256Map<LeafUpdate> = once((target_key, LeafUpdate::Touched)).collect();
 
     let mut callback_count = 0usize;
     trie.update_leaves(&mut leaf_updates, |_key, _min_len| {
@@ -932,7 +929,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
     // Key 0x50 does not exist in the trie but its path is fully revealed (no blinded nodes).
     let nonexistent_key = B256::with_last_byte(0x50);
     let mut leaf_updates: B256Map<LeafUpdate> =
-        std::iter::once((nonexistent_key, LeafUpdate::Touched)).collect();
+        once((nonexistent_key, LeafUpdate::Touched)).collect();
 
     let mut callback_count = 0usize;
     trie.update_leaves(&mut leaf_updates, |_key, _min_len| {
@@ -978,8 +975,8 @@ pub(super) fn test_update_leaves_multiple_mixed_updates<T: SparseTrie + Default>
     let new_value_a = U256::from(100);
     let updated_value_b = U256::from(999);
     let mut leaf_updates: B256Map<LeafUpdate> = [
-        (key_a, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value_a).to_vec())),
-        (key_b, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&updated_value_b).to_vec())),
+        (key_a, LeafUpdate::Changed(encode_fixed_size(&new_value_a).to_vec())),
+        (key_b, LeafUpdate::Changed(encode_fixed_size(&updated_value_b).to_vec())),
         (key_c, LeafUpdate::Changed(Vec::new())), // removal
         (key_d, LeafUpdate::Touched),
     ]
@@ -1127,7 +1124,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
     assert_eq!(root1, harness.original_root, "initial root should match");
 
     // Step 1: Remove key_c to collapse the branch at 0x10..
-    let removal: BTreeMap<B256, U256> = std::iter::once((key_c, U256::ZERO)).collect();
+    let removal: BTreeMap<B256, U256> = once((key_c, U256::ZERO)).collect();
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
@@ -1135,7 +1132,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
     assert_eq!(root2, harness.original_root, "root after removal should match");
 
     // Step 2: Re-insert key_c with a new value — this re-creates the branch.
-    let reinsert: BTreeMap<B256, U256> = std::iter::once((key_c, U256::from(33))).collect();
+    let reinsert: BTreeMap<B256, U256> = once((key_c, U256::from(33))).collect();
     harness.apply_changeset(reinsert.clone());
     let mut reinsert_updates = SuiteTestHarness::leaf_updates(&reinsert);
     harness.reveal_and_update(&mut trie, &mut reinsert_updates);
@@ -1144,7 +1141,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
 
     // Step 3: Update key_a — previously could be orphaned if branch collapse
     // didn't maintain structural tracking properly.
-    let update: BTreeMap<B256, U256> = std::iter::once((key_a, U256::from(999))).collect();
+    let update: BTreeMap<B256, U256> = once((key_a, U256::from(999))).collect();
     harness.apply_changeset(update.clone());
     let mut update_updates = SuiteTestHarness::leaf_updates(&update);
     harness.reveal_and_update(&mut trie, &mut update_updates);
@@ -1189,7 +1186,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     let mut trie: T = harness.init_trie_fully_revealed(false);
 
     // Step 1: Remove key_a → branch collapses, key_b becomes the sole child.
-    let removal: BTreeMap<B256, U256> = std::iter::once((key_a, U256::ZERO)).collect();
+    let removal: BTreeMap<B256, U256> = once((key_a, U256::ZERO)).collect();
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
@@ -1210,7 +1207,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
 
     // Step 2: Modify the remaining leaf's value — this must succeed after the collapse
     // updated key_len properly.
-    let modification: BTreeMap<B256, U256> = std::iter::once((key_b, U256::from(999))).collect();
+    let modification: BTreeMap<B256, U256> = once((key_b, U256::from(999))).collect();
     harness.apply_changeset(modification.clone());
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);
@@ -1260,7 +1257,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie + De
     // Now remove keys[0] — this leaves keys[1] and all the blinded subtries.
     // The branch at the root still has multiple children (keys[1] + blinded children),
     // so this should not trigger a problematic branch collapse into blinded territory.
-    let removal: BTreeMap<B256, U256> = std::iter::once((keys[0], U256::ZERO)).collect();
+    let removal: BTreeMap<B256, U256> = once((keys[0], U256::ZERO)).collect();
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
@@ -1282,7 +1279,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie + De
     assert_eq!(find_result, LeafLookup::Exists, "retained leaf should still be findable");
 
     // Now update the retained leaf to verify the trie is in a consistent state.
-    let modification: BTreeMap<B256, U256> = std::iter::once((keys[1], U256::from(999))).collect();
+    let modification: BTreeMap<B256, U256> = once((keys[1], U256::from(999))).collect();
     harness.apply_changeset(modification.clone());
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -1,0 +1,1409 @@
+use super::*;
+
+/// Insert a new leaf via `update_leaves` and verify root.
+///
+/// Starting from a 3-leaf trie, inserting a 4th key via `update_leaves` should produce
+/// a root hash matching a reference trie containing all 4 leaves.
+pub(super) fn test_update_leaves_insert_new_leaf<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+    let new_key = B256::with_last_byte(0x40);
+
+    let base_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Initialize trie with all 3 existing keys revealed, plus the new key target.
+    let all_targets = vec![key1, key2, key3, new_key];
+    let mut trie: T = harness.init_trie_with_targets(&all_targets, true);
+
+    // Insert the new leaf.
+    let new_value = U256::from(4);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(new_key, new_value)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    // The update map should be drained on success.
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful insert");
+
+    let root = trie.root();
+
+    // Compute expected root with all 4 leaves.
+    let expected_storage = BTreeMap::from([
+        (key1, U256::from(1)),
+        (key2, U256::from(2)),
+        (key3, U256::from(3)),
+        (new_key, new_value),
+    ]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie with 4 leaves"
+    );
+}
+
+/// Modify an existing leaf's value and verify root.
+///
+/// Starting from a 3-leaf trie, changing one leaf's value via `update_leaves` should
+/// produce a root hash matching a reference trie with the updated value.
+
+/// Modify an existing leaf's value and verify root.
+///
+/// Starting from a 3-leaf trie, changing one leaf's value via `update_leaves` should
+/// produce a root hash matching a reference trie with the updated value.
+pub(super) fn test_update_leaves_modify_existing_leaf<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Modify an existing leaf with a new value.
+    let new_value = U256::from(999);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key2, new_value)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful modify");
+
+    let root = trie.root();
+
+    // Compute expected root with the modified value.
+    let expected_storage =
+        BTreeMap::from([(key1, U256::from(1)), (key2, new_value), (key3, U256::from(3))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie with modified leaf value"
+    );
+}
+
+/// Insert 256 leaves with varied prefix patterns into an empty trie.
+///
+/// All 256 keys are inserted in a single `update_leaves` call. The root must match
+/// a reference trie and `take_updates()` must return non-empty results.
+
+/// Insert a single leaf into an empty trie.
+///
+/// Calling `update_leaves` with one key on a default (empty) trie should produce a root
+/// hash matching a reference trie with that single leaf.
+pub(super) fn test_insert_single_leaf_into_empty_trie<T: SparseTrie + Default>() {
+    let key = B256::with_last_byte(42);
+    let value = U256::from(1);
+
+    let mut trie = T::default();
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key, value)]));
+
+    // Empty trie has no blinded nodes, so update_leaves should succeed in one call.
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected on empty trie");
+    })
+    .expect("update_leaves should succeed");
+
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained");
+
+    let root = trie.root();
+
+    let expected_harness = SuiteTestHarness::new(BTreeMap::from([(key, value)]));
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference single-leaf trie"
+    );
+}
+
+/// Two leaves at adjacent keys produce correct root.
+///
+/// Insert key `0x50..` then key `0x51..` (adjacent first-byte keys that share first nibble `5`),
+/// computing root after each. The final root must match the reference trie with both keys.
+/// `take_updates()` should return empty since no branch masks were set.
+
+/// Insert 256 leaves with varied prefix patterns into an empty trie.
+///
+/// All 256 keys are inserted in a single `update_leaves` call. The root must match
+/// a reference trie and `take_updates()` must return non-empty results.
+pub(super) fn test_insert_multiple_leaves_into_empty_trie<T: SparseTrie + Default>() {
+    // Build 256 keys with alternating prefix patterns (matching original test).
+    let storage: BTreeMap<B256, U256> = (0..=255u8)
+        .map(|b| {
+            let key = if b % 2 == 0 { B256::repeat_byte(b) } else { B256::with_last_byte(b) };
+            (key, U256::from(b as u64 + 1))
+        })
+        .collect();
+
+    let expected_harness = SuiteTestHarness::new(storage.clone());
+
+    let mut trie = T::default();
+    trie.set_updates(true);
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&storage);
+
+    // Empty trie has no blinded nodes, so one call should drain all updates.
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected on empty trie");
+    })
+    .expect("update_leaves should succeed");
+
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained");
+
+    let root = trie.root();
+    assert_eq!(root, expected_harness.original_root, "root should match reference 256-leaf trie");
+
+    let updates = trie.take_updates();
+    assert!(
+        !updates.updated_nodes.is_empty(),
+        "take_updates should contain updated nodes after 256 insertions"
+    );
+}
+
+/// Overwrite all values and verify both root states.
+///
+/// Insert 256 keys with old values, compute root (hash1). Then update all 256 keys with
+/// new values, compute root (hash2). Both must match their respective reference tries,
+/// and hash1 ≠ hash2.
+
+/// Overwrite all values and verify both root states.
+///
+/// Insert 256 keys with old values, compute root (hash1). Then update all 256 keys with
+/// new values, compute root (hash2). Both must match their respective reference tries,
+/// and hash1 ≠ hash2.
+pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie + Default>() {
+    // Build 256 keys with alternating prefix patterns.
+    let keys: Vec<B256> = (0..=255u8)
+        .map(|b| if b % 2 == 0 { B256::repeat_byte(b) } else { B256::with_last_byte(b) })
+        .collect();
+
+    let old_storage: BTreeMap<B256, U256> = keys.iter().map(|&k| (k, U256::from(1))).collect();
+
+    let new_storage: BTreeMap<B256, U256> = keys.iter().map(|&k| (k, U256::from(999))).collect();
+
+    let expected_old = SuiteTestHarness::new(old_storage.clone());
+    let expected_new = SuiteTestHarness::new(new_storage.clone());
+
+    let mut trie = T::default();
+    trie.set_updates(true);
+
+    // Insert all 256 keys with old values.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&old_storage);
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected on empty trie");
+    })
+    .expect("update_leaves should succeed");
+
+    let hash1 = trie.root();
+    assert_eq!(hash1, expected_old.original_root, "hash1 should match reference with old values");
+
+    // Update all 256 keys with new values.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&new_storage);
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected — all paths already revealed");
+    })
+    .expect("update_leaves should succeed");
+
+    let hash2 = trie.root();
+    assert_eq!(hash2, expected_new.original_root, "hash2 should match reference with new values");
+    assert_ne!(hash1, hash2, "roots should differ after updating all values");
+}
+
+/// Insert a single leaf into an empty trie.
+///
+/// Calling `update_leaves` with one key on a default (empty) trie should produce a root
+/// hash matching a reference trie with that single leaf.
+
+/// Two leaves at adjacent keys produce correct root.
+///
+/// Insert key `0x50..` then key `0x51..` (adjacent first-byte keys that share first nibble `5`),
+/// computing root after each. The final root must match the reference trie with both keys.
+/// `take_updates()` should return empty since no branch masks were set.
+pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie + Default>() {
+    let mut key_50 = B256::ZERO;
+    key_50.0[0] = 0x50;
+    let mut key_51 = B256::ZERO;
+    key_51.0[0] = 0x51;
+    let value = U256::from(1);
+
+    let mut trie = T::default();
+    trie.set_updates(true);
+
+    // Insert first leaf and compute root.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_50, value)]));
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected on empty trie");
+    })
+    .expect("update_leaves should succeed");
+    trie.root();
+
+    // Insert second leaf and compute root.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_51, value)]));
+    trie.update_leaves(&mut leaf_updates, |_, _| {
+        panic!("no proof callback expected — all paths already revealed");
+    })
+    .expect("update_leaves should succeed");
+    let root = trie.root();
+
+    let expected = SuiteTestHarness::new(BTreeMap::from([(key_50, value), (key_51, value)]));
+    assert_eq!(root, expected.original_root, "root should match reference two-leaf trie");
+
+    let updates = trie.take_updates();
+    assert!(
+        updates.updated_nodes.is_empty() && updates.removed_nodes.is_empty(),
+        "take_updates should be empty — no branch masks were set"
+    );
+}
+
+/// Remove a leaf via `LeafUpdate::Changed(vec![])` and verify root.
+///
+/// Starting from a 3-leaf trie, removing one key should produce a root hash
+/// matching a reference trie containing only the remaining 2 leaves.
+
+/// Remove a leaf via `LeafUpdate::Changed(vec![])` and verify root.
+///
+/// Starting from a 3-leaf trie, removing one key should produce a root hash
+/// matching a reference trie containing only the remaining 2 leaves.
+pub(super) fn test_update_leaves_remove_leaf<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Remove key2 by setting its value to U256::ZERO (produces LeafUpdate::Changed(vec![])).
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key2, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful removal");
+
+    let root = trie.root();
+
+    // Expected: reference trie with only key1 and key3.
+    let expected_storage = BTreeMap::from([(key1, U256::from(1)), (key3, U256::from(3))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie with removed leaf"
+    );
+}
+
+/// Removing a leaf that causes a branch to collapse into an
+/// extension. Three leaves sharing prefix `0x5` create a branch at nibble 5; removing one
+/// child should collapse the structure. The root hash must match a reference trie with the
+/// remaining two leaves.
+
+/// Removing a leaf that causes a branch to collapse into an
+/// extension. Three leaves sharing prefix `0x5` create a branch at nibble 5; removing one
+/// child should collapse the structure. The root hash must match a reference trie with the
+/// remaining two leaves.
+pub(super) fn test_remove_leaf_branch_collapses_to_extension<T: SparseTrie + Default>() {
+    // Keys sharing prefix 0x5: two share 0x50 (children at 0x502..) and one at 0x53.
+    // This creates a branch at nibble 5 with children at nibbles 0 and 3.
+    let mut key_50231 = B256::ZERO;
+    key_50231.0[0] = 0x50;
+    key_50231.0[1] = 0x23;
+    key_50231.0[2] = 0x10;
+
+    let mut key_50233 = B256::ZERO;
+    key_50233.0[0] = 0x50;
+    key_50233.0[1] = 0x23;
+    key_50233.0[2] = 0x30;
+
+    let mut key_537 = B256::ZERO;
+    key_537.0[0] = 0x53;
+    key_537.0[1] = 0x70;
+
+    let base_storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (key_50231, U256::from(1)),
+        (key_50233, U256::from(2)),
+        (key_537, U256::from(3)),
+    ]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Remove the leaf at key_537 — this collapses the branch at 0x5.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_537, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root = trie.root();
+
+    // Expected: reference trie with only the two remaining leaves.
+    let expected_storage = BTreeMap::from([(key_50231, U256::from(1)), (key_50233, U256::from(2))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie after branch-to-extension collapse"
+    );
+}
+
+/// Removing one of two leaves from a branch should collapse the
+/// branch into a leaf. Update tracking should report the root branch as removed and NOT as
+/// updated.
+
+/// Removing one of two leaves from a branch should collapse the
+/// branch into a leaf. Update tracking should report the root branch as removed and NOT as
+/// updated.
+pub(super) fn test_remove_leaf_branch_collapses_to_leaf<T: SparseTrie + Default>() {
+    // Two leaves with different first nibbles → branch root.
+    let key_a = B256::with_last_byte(0x10); // first nibble = 1
+    let key_b = B256::with_last_byte(0x20); // first nibble = 2
+
+    let base_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(100)), (key_b, U256::from(200))]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute root to cache hashes, take and commit updates to establish baseline masks.
+    let _ = trie.root();
+    let updates = trie.take_updates();
+    trie.commit_updates(&updates.updated_nodes, &updates.removed_nodes);
+
+    // Remove key_a → branch collapses to a single leaf (key_b).
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_a, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root = trie.root();
+
+    // Expected: reference trie with only key_b.
+    let expected_storage = BTreeMap::from([(key_b, U256::from(200))]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie after branch-to-leaf collapse"
+    );
+
+    let updates = trie.take_updates();
+
+    // The root branch path is Nibbles::default() (empty path).
+    let root_path = Nibbles::default();
+
+    // The collapsed root branch should NOT appear in updated_nodes.
+    assert!(
+        !updates.updated_nodes.contains_key(&root_path),
+        "root branch path should NOT be in updated_nodes after collapse"
+    );
+}
+
+/// Removing the only leaf in a trie should produce
+/// `EMPTY_ROOT_HASH`.
+
+/// Removing the only leaf in a trie should produce
+/// `EMPTY_ROOT_HASH`.
+pub(super) fn test_remove_last_leaf_produces_empty_root<T: SparseTrie + Default>() {
+    let key = B256::with_last_byte(0x12);
+    let base_storage: BTreeMap<B256, U256> = BTreeMap::from([(key, U256::from(1))]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Remove the only leaf.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root = trie.root();
+    assert_eq!(root, EMPTY_ROOT_HASH, "removing the only leaf should produce EMPTY_ROOT_HASH");
+}
+
+/// Build 6 leaves then remove one-by-one, verifying root at each
+/// step against a reference trie. Final removal produces EMPTY_ROOT_HASH.
+
+/// Build 6 leaves then remove one-by-one, verifying root at each
+/// step against a reference trie. Final removal produces EMPTY_ROOT_HASH.
+pub(super) fn test_insert_then_remove_sequence<T: SparseTrie + Default>() {
+    // Helper: build a B256 key from a nibble prefix, zero-padded.
+    let key_from_nibbles = |nibbles: &[u8]| -> B256 {
+        let mut bytes = [0u8; 32];
+        for (i, chunk) in nibbles.chunks(2).enumerate() {
+            let hi = chunk[0];
+            let lo = if chunk.len() > 1 { chunk[1] } else { 0 };
+            bytes[i] = (hi << 4) | lo;
+        }
+        B256::from(bytes)
+    };
+
+    // The 6 keys from the original test (nibble prefixes 50231, 50233, 52013, 53102, 53302,
+    // 53320).
+    let k1 = key_from_nibbles(&[0x5, 0x0, 0x2, 0x3, 0x1]);
+    let k2 = key_from_nibbles(&[0x5, 0x0, 0x2, 0x3, 0x3]);
+    let k3 = key_from_nibbles(&[0x5, 0x2, 0x0, 0x1, 0x3]);
+    let k4 = key_from_nibbles(&[0x5, 0x3, 0x1, 0x0, 0x2]);
+    let k5 = key_from_nibbles(&[0x5, 0x3, 0x3, 0x0, 0x2]);
+    let k6 = key_from_nibbles(&[0x5, 0x3, 0x3, 0x2, 0x0]);
+
+    let val = U256::from(1);
+    let all_keys = [k1, k2, k3, k4, k5, k6];
+
+    // Insert all 6 leaves into empty trie.
+    let base_storage: BTreeMap<B256, U256> = all_keys.iter().map(|&k| (k, val)).collect();
+
+    let mut harness = SuiteTestHarness::new(base_storage.clone());
+    let mut trie = T::default();
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&base_storage);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    let root_after_insert = trie.root();
+    assert_eq!(root_after_insert, harness.original_root, "root after inserting all 6 leaves");
+
+    // Remove leaves one at a time in the same order as the original test: k3, k1, k4, k6, k2, k5.
+    let removal_order = [k3, k1, k4, k6, k2, k5];
+    for (i, key) in removal_order.iter().enumerate() {
+        let changeset = BTreeMap::from([(*key, U256::ZERO)]);
+        harness.apply_changeset(changeset.clone());
+        let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+        harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+        let root = trie.root();
+        assert_eq!(
+            root,
+            harness.original_root,
+            "root mismatch after removal step {} (removed key {:?})",
+            i + 1,
+            key
+        );
+    }
+
+    // After all removals, trie should be empty.
+    assert_eq!(trie.root(), EMPTY_ROOT_HASH, "final root should be EMPTY_ROOT_HASH");
+}
+
+/// Removing a nonexistent key should not invalidate cached hashes.
+///
+/// After computing root() (which caches hashes on all nodes), attempting to remove a key
+/// that doesn't exist should leave the cache intact so the next root() call returns the
+/// same hash without recomputation.
+
+/// Removing a nonexistent key should not invalidate cached hashes.
+///
+/// After computing root() (which caches hashes on all nodes), attempting to remove a key
+/// that doesn't exist should leave the cache intact so the next root() call returns the
+/// same hash without recomputation.
+pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie + Default>() {
+    let key_a = B256::with_last_byte(0x10);
+    let key_b = B256::with_last_byte(0x20);
+    let key_c = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, U256::from(3))]);
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Compute root to cache hashes on all nodes.
+    let root_before = trie.root();
+    assert_eq!(root_before, harness.original_root);
+
+    // Try to remove a key that doesn't exist in the trie.
+    let nonexistent_key = B256::with_last_byte(0x50);
+    let mut leaf_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(nonexistent_key, U256::ZERO)]));
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    // Root should be identical — cached hashes should be preserved.
+    let root_after = trie.root();
+    assert_eq!(
+        root_before, root_after,
+        "removing a nonexistent leaf should preserve cached hashes and return the same root"
+    );
+}
+
+/// When `update_leaves` encounters a blinded node (insufficient
+/// proof data), it should invoke the `proof_required_fn` callback with the correct target key
+/// and minimum depth, and leave the key in the updates map for retry.
+
+/// When `update_leaves` encounters a blinded node (insufficient
+/// proof data), it should invoke the `proof_required_fn` callback with the correct target key
+/// and minimum depth, and leave the key in the updates map for retry.
+pub(super) fn test_update_leaves_blinded_node_requests_proof<T: SparseTrie + Default>() {
+    // Use enough keys under two different first nibbles so that branch children become
+    // hash nodes (>32 bytes RLP). This ensures partial reveal leaves blinded subtries.
+    let mut base_storage = BTreeMap::new();
+
+    // 16 keys under first nibble 0x1 (slots 0x10..0x1F)
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    // 16 keys under first nibble 0x2 (slots 0x20..0x2F)
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only group_a keys, leaving group_b's subtrie blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false);
+
+    // Try to modify a key in group_b's blinded subtrie.
+    let target_key = group_b_keys[0];
+    let mut leaf_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(target_key, U256::from(999))]));
+
+    // First update_leaves call: should invoke callback for the blinded node.
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    // The callback should have been invoked.
+    assert!(!targets.is_empty(), "callback should be invoked for a blinded node");
+
+    // The key should remain in the updates map (not drained).
+    assert!(
+        !leaf_updates.is_empty(),
+        "key should remain in updates map when blinded node is encountered"
+    );
+}
+
+pub(super) fn test_update_leaves_retry_after_reveal<T: SparseTrie + Default>() {
+    // Same setup as blinded_node_requests_proof: two groups of 16 keys each under
+    // different first nibbles, so branch children become hash nodes.
+    let mut base_storage = BTreeMap::new();
+
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage.clone());
+
+    // Reveal only group_a keys, leaving group_b's subtrie blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false);
+
+    // Modify a key in group_b's blinded subtrie.
+    let target_key = group_b_keys[0];
+    let new_value = U256::from(999);
+    let mut leaf_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(target_key, new_value)]));
+
+    // First update_leaves: callback fires, key stays in map.
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+    assert!(!targets.is_empty(), "callback should fire for blinded node");
+    assert!(!leaf_updates.is_empty(), "key should remain in map after blinded hit");
+
+    // Reveal the proof for the requested targets.
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+
+    // Second update_leaves: now the path is revealed, key should be drained.
+    let mut targets2: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets2.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed on retry");
+    assert!(targets2.is_empty(), "no callback should fire after reveal");
+    assert!(leaf_updates.is_empty(), "key should be drained after successful retry");
+
+    // Root should match the expected trie with the modified value.
+    let mut expected_storage = base_storage;
+    expected_storage.insert(target_key, new_value);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+
+    let root = trie.root();
+    assert_eq!(root, expected_harness.original_root, "root should match expected trie after retry");
+}
+
+pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie + Default>() {
+    // Build a branch with two children: one revealed leaf at nibble 0x1, and a blinded
+    // subtrie at nibble 0x2 (16 keys so it becomes a hash node > 32 bytes).
+    let mut base_storage = BTreeMap::new();
+
+    // Single key under first nibble 0x1.
+    let revealed_key = {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key
+    };
+    base_storage.insert(revealed_key, U256::from(1));
+
+    // 16 keys under first nibble 0x2 (slots 0x20..0x2F) — enough to produce a hash node.
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage.clone());
+
+    // Reveal only the single key at nibble 0x1, leaving nibble 0x2's subtrie blinded.
+    let mut trie: T = harness.init_trie_with_targets(&[revealed_key], false);
+
+    // Try to remove the revealed leaf. Branch collapse requires the blinded sibling.
+    let mut leaf_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(revealed_key, U256::ZERO)]));
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+    assert!(!targets.is_empty(), "callback should fire for blinded sibling");
+    assert!(!leaf_updates.is_empty(), "key should remain in map after blinded hit");
+
+    // Reveal the blinded sibling subtrie.
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+
+    // Retry removal — now the sibling is revealed, branch can collapse.
+    let mut targets2: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets2.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed on retry");
+    assert!(leaf_updates.is_empty(), "key should be drained after successful removal");
+
+    // Root should match reference trie with only group_b keys.
+    let mut expected_storage = base_storage;
+    expected_storage.remove(&revealed_key);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+
+    let root = trie.root();
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match trie without the removed leaf"
+    );
+}
+
+/// Atomic rollback — node structure and prefix_set unchanged after
+/// removal of a revealed leaf when the sibling is blinded.
+///
+/// Same scenario as the value-preservation test, but additionally checks that
+/// `size_hint` (node count) is unchanged and the update remains in the map.
+
+/// Atomic rollback — node structure and prefix_set unchanged after
+/// removal of a revealed leaf when the sibling is blinded.
+///
+/// Same scenario as the value-preservation test, but additionally checks that
+/// `size_hint` (node count) is unchanged and the update remains in the map.
+pub(super) fn test_update_leaves_removal_branch_collapse_blinded_sibling<
+    T: SparseTrie + Default,
+>() {
+    // Branch: nibble 0x1 = one revealed leaf, nibble 0x2 = 16 blinded keys (hash node).
+    let mut base_storage = BTreeMap::new();
+
+    let revealed_key = {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key
+    };
+    base_storage.insert(revealed_key, U256::from(1));
+
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only the leaf at nibble 0x1, leaving nibble 0x2 blinded.
+    let mut trie: T = harness.init_trie_with_targets(&[revealed_key], false);
+
+    // Snapshot state before the removal attempt.
+    let revealed_path = Nibbles::unpack(revealed_key);
+    let original_value = trie.get_leaf_value(&revealed_path).cloned();
+    assert!(original_value.is_some(), "revealed leaf should exist");
+    let node_count_before = trie.size_hint();
+
+    // Attempt removal — branch collapse needs the blinded sibling, so it fails atomically.
+    let mut leaf_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(revealed_key, U256::ZERO)]));
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    // Callback should have fired for the blinded sibling path.
+    assert!(!targets.is_empty(), "callback should fire for blinded sibling");
+
+    // Update should remain in the map (not drained).
+    assert!(!leaf_updates.is_empty(), "update should remain in map after blinded hit");
+
+    // Node count should be unchanged (no structural modification).
+    assert_eq!(trie.size_hint(), node_count_before, "node count should be unchanged");
+
+    // Leaf value should be preserved (atomic rollback).
+    let value_after = trie.get_leaf_value(&revealed_path);
+    assert_eq!(
+        value_after,
+        original_value.as_ref(),
+        "leaf value should be preserved after failed removal"
+    );
+}
+
+/// Subtrie collapse with blinded sibling triggers callback.
+///
+/// When removals in a subtrie would empty it and collapse the parent branch onto
+/// a blinded sibling, `update_leaves` should detect this and request a proof for
+/// the blinded sibling via the callback, deferring the updates.
+
+/// Subtrie collapse with blinded sibling triggers callback.
+///
+/// When removals in a subtrie would empty it and collapse the parent branch onto
+/// a blinded sibling, `update_leaves` should detect this and request a proof for
+/// the blinded sibling via the callback, deferring the updates.
+pub(super) fn test_update_leaves_subtrie_collapse_requests_proof<T: SparseTrie + Default>() {
+    // Build a branch with two children:
+    //   nibble 0x1 → a subtrie with 2 revealed leaves
+    //   nibble 0x2 → 16 blinded keys (hash node > 32 bytes)
+    let mut base_storage = BTreeMap::new();
+
+    // Two leaves under first nibble 0x1 (will be revealed and then removed).
+    let subtrie_key_a = {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key
+    };
+    let subtrie_key_b = {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x11;
+        key
+    };
+    base_storage.insert(subtrie_key_a, U256::from(1));
+    base_storage.insert(subtrie_key_b, U256::from(2));
+
+    // 16 keys under first nibble 0x2 — enough to produce a hash node.
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only the two subtrie keys at nibble 0x1, leaving nibble 0x2 blinded.
+    let mut trie: T = harness.init_trie_with_targets(&[subtrie_key_a, subtrie_key_b], false);
+
+    // Remove both leaves in the subtrie — this would empty the subtrie and
+    // require collapsing the parent branch onto the blinded sibling at nibble 0x2.
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([
+        (subtrie_key_a, U256::ZERO),
+        (subtrie_key_b, U256::ZERO),
+    ]));
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    // Callback should have fired for the blinded sibling.
+    assert!(
+        !targets.is_empty(),
+        "callback should fire for blinded sibling during subtrie collapse"
+    );
+    // At least one removal key should remain in the map for retry.
+    assert!(!leaf_updates.is_empty(), "removal keys should remain in map after blinded hit");
+}
+
+/// Multiple keys hitting the same blinded node each trigger a callback.
+///
+/// When multiple keys in the update map all route through the same blinded node,
+/// the callback should be invoked once per key (not deduplicated).
+
+/// Multiple keys hitting the same blinded node each trigger a callback.
+///
+/// When multiple keys in the update map all route through the same blinded node,
+/// the callback should be invoked once per key (not deduplicated).
+pub(super) fn test_update_leaves_multiple_keys_same_blinded_node<T: SparseTrie + Default>() {
+    // Branch: nibble 0x1 = 16 revealed keys (hash node), nibble 0x2 = 16 blinded keys.
+    let mut base_storage = BTreeMap::new();
+
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only group_a, leaving nibble 0x2 blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false);
+
+    // Submit 3 keys that all start with nibble 0x2 — they all hit the same blinded node.
+    let blinded_keys: BTreeMap<B256, U256> = (0u8..3)
+        .map(|i| {
+            let mut key = B256::ZERO;
+            key.0[0] = 0x20 | i;
+            (key, U256::from(999))
+        })
+        .collect();
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&blinded_keys);
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    // Callback should fire for each key (3 invocations).
+    assert_eq!(targets.len(), 3, "callback should fire once per key hitting the blinded node");
+    // All updates should remain in the map for retry.
+    assert_eq!(leaf_updates.len(), 3, "all keys should remain in map after blinded hit");
+}
+
+/// `LeafUpdate::Touched` on a fully revealed path should be a no-op.
+
+/// `LeafUpdate::Touched` on a fully revealed path should be a no-op.
+pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let root_before = trie.root();
+
+    // Call update_leaves with Touched for an existing key.
+    let mut leaf_updates: B256Map<LeafUpdate> = [(key2, LeafUpdate::Touched)].into_iter().collect();
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    // No callback should fire.
+    assert!(targets.is_empty(), "no callback should fire for Touched on fully revealed path");
+    // Key should be drained from the map.
+    assert!(leaf_updates.is_empty(), "Touched key should be drained from updates map");
+    // Root should be unchanged.
+    assert_eq!(trie.root(), root_before, "root should be unchanged after Touched no-op");
+}
+
+/// `LeafUpdate::Touched` on a path with a blinded node should
+/// invoke the callback and keep the key in the updates map. No trie mutation should occur.
+
+/// `LeafUpdate::Touched` on a path with a blinded node should
+/// invoke the callback and keep the key in the updates map. No trie mutation should occur.
+pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie + Default>() {
+    // Two groups of 16 keys each under different first nibbles so that branch children
+    // become hash nodes (>32 bytes RLP). Partial reveal leaves one subtrie blinded.
+    let mut base_storage = BTreeMap::new();
+
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+
+    // Reveal only group_a keys, leaving group_b's subtrie blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false);
+
+    let root_before = trie.root();
+
+    // Submit Touched for a key in group_b's blinded subtrie.
+    let target_key = {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20;
+        key
+    };
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(target_key, LeafUpdate::Touched)].into_iter().collect();
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, min_len| {
+        targets.push(ProofV2Target::new(key).with_min_len(min_len));
+    })
+    .expect("update_leaves should succeed");
+
+    // Callback should have been invoked for the blinded node.
+    assert!(!targets.is_empty(), "callback should fire for Touched on blinded path");
+    // Key should remain in the updates map.
+    assert!(!leaf_updates.is_empty(), "Touched key should remain in map when blinded");
+    // Root should be unchanged (no mutation).
+    assert_eq!(trie.root(), root_before, "root should be unchanged after Touched on blinded path");
+}
+
+/// Touched on a nonexistent key in an empty trie is drained silently.
+///
+/// An empty (default) trie has an Empty root — all paths are accessible (no blinded nodes).
+/// `Touched` on a key that doesn't exist should be drained from the map without any
+/// callback invocation or mutation.
+
+/// Touched on a nonexistent key in an empty trie is drained silently.
+///
+/// An empty (default) trie has an Empty root — all paths are accessible (no blinded nodes).
+/// `Touched` on a key that doesn't exist should be drained from the map without any
+/// callback invocation or mutation.
+pub(super) fn test_update_leaves_touched_nonexistent_key<T: SparseTrie + Default>() {
+    let mut trie = T::default();
+
+    let target_key = B256::with_last_byte(42);
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(target_key, LeafUpdate::Touched)].into_iter().collect();
+
+    let mut callback_count = 0usize;
+    trie.update_leaves(&mut leaf_updates, |_key, _min_len| {
+        callback_count += 1;
+    })
+    .expect("update_leaves should succeed");
+
+    assert!(leaf_updates.is_empty(), "Touched key should be drained from map");
+    assert_eq!(callback_count, 0, "no callback should fire for Touched on empty trie");
+    assert_eq!(
+        trie.get_leaf_value(&Nibbles::unpack(target_key)),
+        None,
+        "nonexistent key should return None"
+    );
+}
+
+/// `LeafUpdate::Touched` on a nonexistent key in a fully
+/// revealed, populated trie should be a no-op — no callback, key drained, trie unchanged.
+
+/// `LeafUpdate::Touched` on a nonexistent key in a fully
+/// revealed, populated trie should be a no-op — no callback, key drained, trie unchanged.
+pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: SparseTrie + Default>() {
+    let key1 = B256::with_last_byte(0x10);
+    let key2 = B256::with_last_byte(0x20);
+    let key3 = B256::with_last_byte(0x30);
+
+    let base_storage: BTreeMap<B256, U256> =
+        [(key1, U256::from(1)), (key2, U256::from(2)), (key3, U256::from(3))].into_iter().collect();
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    let root_before = trie.root();
+
+    // Key 0x50 does not exist in the trie but its path is fully revealed (no blinded nodes).
+    let nonexistent_key = B256::with_last_byte(0x50);
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        [(nonexistent_key, LeafUpdate::Touched)].into_iter().collect();
+
+    let mut callback_count = 0usize;
+    trie.update_leaves(&mut leaf_updates, |_key, _min_len| {
+        callback_count += 1;
+    })
+    .expect("update_leaves should succeed");
+
+    assert!(leaf_updates.is_empty(), "Touched key should be drained from updates map");
+    assert_eq!(callback_count, 0, "no callback should fire for Touched on revealed path");
+    assert_eq!(trie.root(), root_before, "root should be unchanged after Touched no-op");
+    assert_eq!(
+        trie.get_leaf_value(&Nibbles::unpack(nonexistent_key)),
+        None,
+        "nonexistent key should return None"
+    );
+}
+
+/// A single `update_leaves` call with a mix of inserts,
+/// modifications, removals, and touched entries should process all correctly.
+
+/// A single `update_leaves` call with a mix of inserts,
+/// modifications, removals, and touched entries should process all correctly.
+pub(super) fn test_update_leaves_multiple_mixed_updates<T: SparseTrie + Default>() {
+    let key_a = B256::with_last_byte(0x10); // will be inserted (new key)
+    let key_b = B256::with_last_byte(0x20); // will be modified
+    let key_c = B256::with_last_byte(0x30); // will be removed
+    let key_d = B256::with_last_byte(0x40); // will be touched (no-op)
+    let key_e = B256::with_last_byte(0x50); // stays unchanged
+
+    let base_storage: BTreeMap<B256, U256> = [
+        (key_b, U256::from(2)),
+        (key_c, U256::from(3)),
+        (key_d, U256::from(4)),
+        (key_e, U256::from(5)),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut harness = SuiteTestHarness::new(base_storage);
+
+    // Fully reveal existing trie, plus proof for key_a (new key to be inserted).
+    let all_keys = vec![key_a, key_b, key_c, key_d, key_e];
+    let mut trie: T = harness.init_trie_with_targets(&all_keys, false);
+
+    // Build mixed leaf updates.
+    let new_value_a = U256::from(100);
+    let updated_value_b = U256::from(999);
+    let mut leaf_updates: B256Map<LeafUpdate> = [
+        (key_a, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&new_value_a).to_vec())),
+        (key_b, LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&updated_value_b).to_vec())),
+        (key_c, LeafUpdate::Changed(Vec::new())), // removal
+        (key_d, LeafUpdate::Touched),
+    ]
+    .into_iter()
+    .collect();
+
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    assert!(leaf_updates.is_empty(), "all keys should be drained from the updates map");
+
+    // Build reference trie: A inserted, B modified, C removed, D and E unchanged.
+    let expected_storage: BTreeMap<B256, U256> = [
+        (key_a, new_value_a),
+        (key_b, updated_value_b),
+        // key_c removed
+        (key_d, U256::from(4)),
+        (key_e, U256::from(5)),
+    ]
+    .into_iter()
+    .collect();
+
+    harness.apply_changeset(expected_storage.clone());
+    // apply_changeset merged into existing storage — need a fresh harness for the expected state.
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+
+    let root = trie.root();
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference trie with mixed updates applied"
+    );
+}
+
+/// Calling `root()` on a fresh, empty trie returns `EMPTY_ROOT_HASH`.
+
+/// Ancestors marked dirty even without cached hashes.
+///
+/// When removing a leaf, all ancestor nodes must be marked dirty unconditionally —
+/// not just those that previously had a cached hash. This test inserts leaves without
+/// calling `root()` (so no hashes are cached), then removes a leaf and verifies
+/// `root()` returns the correct hash.
+pub(super) fn test_remove_leaf_marks_ancestors_dirty_unconditionally<T: SparseTrie + Default>() {
+    // Create a trie with 5 leaves.
+    let mut keys = Vec::new();
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..5 {
+        let mut key = B256::ZERO;
+        key.0[0] = (i + 1) * 16; // 0x10, 0x20, 0x30, 0x40, 0x50
+        storage.insert(key, U256::from(i as u64 + 1));
+        keys.push(key);
+    }
+
+    let harness = SuiteTestHarness::new(storage.clone());
+
+    // Initialize trie: set root and reveal all proofs.
+    let root_node = harness.root_node();
+    let mut trie = T::default();
+    trie.set_root(root_node.node, root_node.masks, false).expect("set_root should succeed");
+
+    let mut targets: Vec<ProofV2Target> = keys.iter().map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_nodes = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+
+    // Insert all leaves via update_leaves — do NOT call root() so no hashes are cached.
+    let mut insert_updates = SuiteTestHarness::leaf_updates(&storage);
+    trie.update_leaves(&mut insert_updates, |_, _| {})
+        .expect("insert update_leaves should succeed");
+
+    // Now remove one leaf WITHOUT having called root() first.
+    let mut removal: BTreeMap<B256, U256> = BTreeMap::new();
+    removal.insert(keys[2], U256::ZERO); // remove key 0x30
+    let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
+    trie.update_leaves(&mut removal_updates, |_, _| {})
+        .expect("removal update_leaves should succeed");
+
+    // Call root() — all ancestors of the removed leaf must be marked dirty
+    // even though no hashes were previously cached.
+    let root = trie.root();
+
+    // Build reference trie with same final state.
+    let mut expected_storage = storage;
+    expected_storage.remove(&keys[2]);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        root, expected_harness.original_root,
+        "root should match reference after removal without prior root() call"
+    );
+}
+
+/// Orphaned value update falls through to full insertion.
+///
+/// After a sequence of insertions and removals that involve branch collapses,
+/// every key with a value must remain findable via `find_leaf` and updatable
+/// via `update_leaves`. This verifies the invariant that structural consistency
+/// is maintained even when branch collapses could orphan value entries.
+
+/// Orphaned value update falls through to full insertion.
+///
+/// After a sequence of insertions and removals that involve branch collapses,
+/// every key with a value must remain findable via `find_leaf` and updatable
+/// via `update_leaves`. This verifies the invariant that structural consistency
+/// is maintained even when branch collapses could orphan value entries.
+pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
+    T: SparseTrie + Default,
+>() {
+    // Create a trie with 3 leaves sharing a branch prefix, plus 2 additional leaves
+    // in different subtries. Keys chosen so removal of key_c collapses the branch
+    // at the shared prefix.
+    let key_a = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x10;
+        k.0[1] = 0x00;
+        k
+    };
+    let key_b = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x10;
+        k.0[1] = 0x10;
+        k
+    };
+    let key_c = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x10;
+        k.0[1] = 0x20;
+        k
+    };
+    let key_d = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x20;
+        k
+    };
+    let key_e = {
+        let mut k = B256::ZERO;
+        k.0[0] = 0x30;
+        k
+    };
+
+    let initial_storage: BTreeMap<B256, U256> = [
+        (key_a, U256::from(1)),
+        (key_b, U256::from(2)),
+        (key_c, U256::from(3)),
+        (key_d, U256::from(4)),
+        (key_e, U256::from(5)),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut harness = SuiteTestHarness::new(initial_storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Insert all leaves.
+    let mut insert_updates = SuiteTestHarness::leaf_updates(&initial_storage);
+    harness.reveal_and_update(&mut trie, &mut insert_updates);
+    let root1 = trie.root();
+    assert_eq!(root1, harness.original_root, "initial root should match");
+
+    // Step 1: Remove key_c to collapse the branch at 0x10..
+    let removal: BTreeMap<B256, U256> = [(key_c, U256::ZERO)].into_iter().collect();
+    harness.apply_changeset(removal.clone());
+    let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
+    harness.reveal_and_update(&mut trie, &mut removal_updates);
+    let root2 = trie.root();
+    assert_eq!(root2, harness.original_root, "root after removal should match");
+
+    // Step 2: Re-insert key_c with a new value — this re-creates the branch.
+    let reinsert: BTreeMap<B256, U256> = [(key_c, U256::from(33))].into_iter().collect();
+    harness.apply_changeset(reinsert.clone());
+    let mut reinsert_updates = SuiteTestHarness::leaf_updates(&reinsert);
+    harness.reveal_and_update(&mut trie, &mut reinsert_updates);
+    let root3 = trie.root();
+    assert_eq!(root3, harness.original_root, "root after re-insert should match");
+
+    // Step 3: Update key_a — previously could be orphaned if branch collapse
+    // didn't maintain structural tracking properly.
+    let update: BTreeMap<B256, U256> = [(key_a, U256::from(999))].into_iter().collect();
+    harness.apply_changeset(update.clone());
+    let mut update_updates = SuiteTestHarness::leaf_updates(&update);
+    harness.reveal_and_update(&mut trie, &mut update_updates);
+    let root4 = trie.root();
+    assert_eq!(root4, harness.original_root, "root after updating key_a should match");
+
+    // Verify the invariant: every key with a value must be findable via find_leaf.
+    let final_keys = [key_a, key_b, key_c, key_d, key_e];
+    for key in &final_keys {
+        let nibbles = Nibbles::unpack(*key);
+        assert_eq!(
+            trie.find_leaf(&nibbles, None).expect("find_leaf should succeed"),
+            LeafLookup::Exists,
+            "key {key} should be findable after collapse-reinsert-update sequence"
+        );
+    }
+
+    // Also verify a nonexistent key is properly reported.
+    let nonexistent = B256::with_last_byte(0xFF);
+    let nonexistent_nibbles = Nibbles::unpack(nonexistent);
+    assert_eq!(
+        trie.find_leaf(&nonexistent_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::NonExistent,
+        "nonexistent key should not be found"
+    );
+}
+
+/// When removing a leaf causes a branch to collapse at a subtrie
+/// boundary, the remaining sibling leaf's `key_len` metadata must be updated. After the
+/// collapse the remaining leaf must be findable, updatable, and contribute to the correct root.
+
+/// When removing a leaf causes a branch to collapse at a subtrie
+/// boundary, the remaining sibling leaf's `key_len` metadata must be updated. After the
+/// collapse the remaining leaf must be findable, updatable, and contribute to the correct root.
+pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: SparseTrie + Default>() {
+    // Create two leaves that share a branch at a subtrie boundary.
+    // Keys share the same first nibble (0x1) so they form a branch one level down,
+    // which is a subtrie boundary for the parallel sparse trie.
+    let key_a = B256::with_last_byte(0x10); // nibbles: ...1, 0
+    let key_b = B256::with_last_byte(0x12); // nibbles: ...1, 2
+
+    let base_storage: BTreeMap<B256, U256> =
+        BTreeMap::from([(key_a, U256::from(100)), (key_b, U256::from(200))]);
+
+    let mut harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Step 1: Remove key_a → branch collapses, key_b becomes the sole child.
+    let removal: BTreeMap<B256, U256> = [(key_a, U256::ZERO)].into_iter().collect();
+    harness.apply_changeset(removal.clone());
+    let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
+    harness.reveal_and_update(&mut trie, &mut removal_updates);
+
+    let root_after_removal = trie.root();
+    assert_eq!(
+        root_after_removal, harness.original_root,
+        "root after branch collapse should match reference"
+    );
+
+    // Verify remaining leaf is findable.
+    let key_b_nibbles = Nibbles::unpack(key_b);
+    assert_eq!(
+        trie.find_leaf(&key_b_nibbles, None).expect("find_leaf should succeed"),
+        LeafLookup::Exists,
+        "remaining leaf (key_b) should be findable after branch collapse"
+    );
+
+    // Step 2: Modify the remaining leaf's value — this must succeed after the collapse
+    // updated key_len properly.
+    let modification: BTreeMap<B256, U256> = [(key_b, U256::from(999))].into_iter().collect();
+    harness.apply_changeset(modification.clone());
+    let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
+    harness.reveal_and_update(&mut trie, &mut mod_updates);
+
+    let root_after_update = trie.root();
+    assert_eq!(
+        root_after_update, harness.original_root,
+        "root after updating remaining leaf should match reference"
+    );
+}
+
+/// Removal of a leaf should never corrupt blinded/pruned subtries.
+///
+/// When a branch collapses during leaf removal and the remaining child's value needs to be
+/// moved between subtries, the operation must not reveal (initialize) blind/unloaded subtries.
+/// Either the removal succeeds cleanly or it requests proofs for the blinded area.
+
+/// Removal of a leaf should never corrupt blinded/pruned subtries.
+///
+/// When a branch collapses during leaf removal and the remaining child's value needs to be
+/// moved between subtries, the operation must not reveal (initialize) blind/unloaded subtries.
+/// Either the removal succeeds cleanly or it requests proofs for the blinded area.
+pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie + Default>() {
+    // Create a trie with 10 leaves across different first-nibble subtries.
+    // We'll prune some subtries, then remove a leaf whose branch collapse
+    // involves a sibling in a pruned (blinded) subtrie.
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    let mut keys = Vec::new();
+    for i in 0u8..10 {
+        let mut key = B256::ZERO;
+        key.0[0] = i * 16; // nibble prefixes: 0x0, 0x1, ..., 0x9
+        storage.insert(key, U256::from(i as u64 + 1));
+        keys.push(key);
+    }
+
+    let mut harness = SuiteTestHarness::new(storage.clone());
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute initial root and commit to establish baseline.
+    let _ = trie.root();
+    let updates = trie.take_updates();
+    trie.commit_updates(&updates.updated_nodes, &updates.removed_nodes);
+
+    // Prune: retain only keys[0] and keys[1] (nibbles 0x0 and 0x1).
+    // All other subtries become blinded.
+    let retained: Vec<Nibbles> = [keys[0], keys[1]].iter().map(|k| Nibbles::unpack(*k)).collect();
+    trie.prune(&retained);
+
+    // Verify root is unchanged after prune.
+    let root_after_prune = trie.root();
+    assert_eq!(root_after_prune, harness.original_root, "root should be unchanged after prune");
+
+    // Now remove keys[0] — this leaves keys[1] and all the blinded subtries.
+    // The branch at the root still has multiple children (keys[1] + blinded children),
+    // so this should not trigger a problematic branch collapse into blinded territory.
+    let removal: BTreeMap<B256, U256> = [(keys[0], U256::ZERO)].into_iter().collect();
+    harness.apply_changeset(removal.clone());
+    let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
+    harness.reveal_and_update(&mut trie, &mut removal_updates);
+
+    let root_after_removal = trie.root();
+    assert_eq!(
+        root_after_removal, harness.original_root,
+        "root after removing a revealed leaf with blinded sibling subtries should match reference"
+    );
+
+    // Verify that the removed leaf is gone.
+    let removed_nibbles = Nibbles::unpack(keys[0]);
+    let find_result = trie.find_leaf(&removed_nibbles, None).expect("find_leaf should succeed");
+    assert_eq!(find_result, LeafLookup::NonExistent, "removed leaf should not be found");
+
+    // Verify that the retained leaf (keys[1]) is still accessible.
+    let retained_nibbles = Nibbles::unpack(keys[1]);
+    let find_result = trie.find_leaf(&retained_nibbles, None).expect("find_leaf should succeed");
+    assert_eq!(find_result, LeafLookup::Exists, "retained leaf should still be findable");
+
+    // Now update the retained leaf to verify the trie is in a consistent state.
+    let modification: BTreeMap<B256, U256> = [(keys[1], U256::from(999))].into_iter().collect();
+    harness.apply_changeset(modification.clone());
+    let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
+    harness.reveal_and_update(&mut trie, &mut mod_updates);
+
+    let root_after_mod = trie.root();
+    assert_eq!(
+        root_after_mod, harness.original_root,
+        "root after modifying retained leaf should match reference"
+    );
+}

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -47,11 +47,6 @@ pub(super) fn test_update_leaves_insert_new_leaf<T: SparseTrie + Default>() {
 ///
 /// Starting from a 3-leaf trie, changing one leaf's value via `update_leaves` should
 /// produce a root hash matching a reference trie with the updated value.
-
-/// Modify an existing leaf's value and verify root.
-///
-/// Starting from a 3-leaf trie, changing one leaf's value via `update_leaves` should
-/// produce a root hash matching a reference trie with the updated value.
 pub(super) fn test_update_leaves_modify_existing_leaf<T: SparseTrie + Default>() {
     let key1 = B256::with_last_byte(0x10);
     let key2 = B256::with_last_byte(0x20);
@@ -82,11 +77,6 @@ pub(super) fn test_update_leaves_modify_existing_leaf<T: SparseTrie + Default>()
     );
 }
 
-/// Insert 256 leaves with varied prefix patterns into an empty trie.
-///
-/// All 256 keys are inserted in a single `update_leaves` call. The root must match
-/// a reference trie and `take_updates()` must return non-empty results.
-
 /// Insert a single leaf into an empty trie.
 ///
 /// Calling `update_leaves` with one key on a default (empty) trie should produce a root
@@ -114,12 +104,6 @@ pub(super) fn test_insert_single_leaf_into_empty_trie<T: SparseTrie + Default>()
         "root should match reference single-leaf trie"
     );
 }
-
-/// Two leaves at adjacent keys produce correct root.
-///
-/// Insert key `0x50..` then key `0x51..` (adjacent first-byte keys that share first nibble `5`),
-/// computing root after each. The final root must match the reference trie with both keys.
-/// `take_updates()` should return empty since no branch masks were set.
 
 /// Insert 256 leaves with varied prefix patterns into an empty trie.
 ///
@@ -164,12 +148,6 @@ pub(super) fn test_insert_multiple_leaves_into_empty_trie<T: SparseTrie + Defaul
 /// Insert 256 keys with old values, compute root (hash1). Then update all 256 keys with
 /// new values, compute root (hash2). Both must match their respective reference tries,
 /// and hash1 ≠ hash2.
-
-/// Overwrite all values and verify both root states.
-///
-/// Insert 256 keys with old values, compute root (hash1). Then update all 256 keys with
-/// new values, compute root (hash2). Both must match their respective reference tries,
-/// and hash1 ≠ hash2.
 pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie + Default>() {
     // Build 256 keys with alternating prefix patterns.
     let keys: Vec<B256> = (0..=255u8)
@@ -207,11 +185,6 @@ pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie + Default>() 
     assert_eq!(hash2, expected_new.original_root, "hash2 should match reference with new values");
     assert_ne!(hash1, hash2, "roots should differ after updating all values");
 }
-
-/// Insert a single leaf into an empty trie.
-///
-/// Calling `update_leaves` with one key on a default (empty) trie should produce a root
-/// hash matching a reference trie with that single leaf.
 
 /// Two leaves at adjacent keys produce correct root.
 ///
@@ -258,11 +231,6 @@ pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie + 
 ///
 /// Starting from a 3-leaf trie, removing one key should produce a root hash
 /// matching a reference trie containing only the remaining 2 leaves.
-
-/// Remove a leaf via `LeafUpdate::Changed(vec![])` and verify root.
-///
-/// Starting from a 3-leaf trie, removing one key should produce a root hash
-/// matching a reference trie containing only the remaining 2 leaves.
 pub(super) fn test_update_leaves_remove_leaf<T: SparseTrie + Default>() {
     let key1 = B256::with_last_byte(0x10);
     let key2 = B256::with_last_byte(0x20);
@@ -290,11 +258,6 @@ pub(super) fn test_update_leaves_remove_leaf<T: SparseTrie + Default>() {
         "root should match reference trie with removed leaf"
     );
 }
-
-/// Removing a leaf that causes a branch to collapse into an
-/// extension. Three leaves sharing prefix `0x5` create a branch at nibble 5; removing one
-/// child should collapse the structure. The root hash must match a reference trie with the
-/// remaining two leaves.
 
 /// Removing a leaf that causes a branch to collapse into an
 /// extension. Three leaves sharing prefix `0x5` create a branch at nibble 5; removing one
@@ -344,10 +307,6 @@ pub(super) fn test_remove_leaf_branch_collapses_to_extension<T: SparseTrie + Def
 /// Removing one of two leaves from a branch should collapse the
 /// branch into a leaf. Update tracking should report the root branch as removed and NOT as
 /// updated.
-
-/// Removing one of two leaves from a branch should collapse the
-/// branch into a leaf. Update tracking should report the root branch as removed and NOT as
-/// updated.
 pub(super) fn test_remove_leaf_branch_collapses_to_leaf<T: SparseTrie + Default>() {
     // Two leaves with different first nibbles → branch root.
     let key_a = B256::with_last_byte(0x10); // first nibble = 1
@@ -392,9 +351,6 @@ pub(super) fn test_remove_leaf_branch_collapses_to_leaf<T: SparseTrie + Default>
 
 /// Removing the only leaf in a trie should produce
 /// `EMPTY_ROOT_HASH`.
-
-/// Removing the only leaf in a trie should produce
-/// `EMPTY_ROOT_HASH`.
 pub(super) fn test_remove_last_leaf_produces_empty_root<T: SparseTrie + Default>() {
     let key = B256::with_last_byte(0x12);
     let base_storage: BTreeMap<B256, U256> = BTreeMap::from([(key, U256::from(1))]);
@@ -411,10 +367,7 @@ pub(super) fn test_remove_last_leaf_produces_empty_root<T: SparseTrie + Default>
 }
 
 /// Build 6 leaves then remove one-by-one, verifying root at each
-/// step against a reference trie. Final removal produces EMPTY_ROOT_HASH.
-
-/// Build 6 leaves then remove one-by-one, verifying root at each
-/// step against a reference trie. Final removal produces EMPTY_ROOT_HASH.
+/// step against a reference trie. Final removal produces `EMPTY_ROOT_HASH`.
 pub(super) fn test_insert_then_remove_sequence<T: SparseTrie + Default>() {
     // Helper: build a B256 key from a nibble prefix, zero-padded.
     let key_from_nibbles = |nibbles: &[u8]| -> B256 {
@@ -474,14 +427,8 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie + Default>() {
 
 /// Removing a nonexistent key should not invalidate cached hashes.
 ///
-/// After computing root() (which caches hashes on all nodes), attempting to remove a key
-/// that doesn't exist should leave the cache intact so the next root() call returns the
-/// same hash without recomputation.
-
-/// Removing a nonexistent key should not invalidate cached hashes.
-///
-/// After computing root() (which caches hashes on all nodes), attempting to remove a key
-/// that doesn't exist should leave the cache intact so the next root() call returns the
+/// After computing `root()` (which caches hashes on all nodes), attempting to remove a key
+/// that doesn't exist should leave the cache intact so the next `root()` call returns the
 /// same hash without recomputation.
 pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie + Default>() {
     let key_a = B256::with_last_byte(0x10);
@@ -511,10 +458,6 @@ pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie + Defa
         "removing a nonexistent leaf should preserve cached hashes and return the same root"
     );
 }
-
-/// When `update_leaves` encounters a blinded node (insufficient
-/// proof data), it should invoke the `proof_required_fn` callback with the correct target key
-/// and minimum depth, and leave the key in the updates map for retry.
 
 /// When `update_leaves` encounters a blinded node (insufficient
 /// proof data), it should invoke the `proof_required_fn` callback with the correct target key
@@ -646,11 +589,9 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie + D
     base_storage.insert(revealed_key, U256::from(1));
 
     // 16 keys under first nibble 0x2 (slots 0x20..0x2F) — enough to produce a hash node.
-    let mut group_b_keys = Vec::new();
     for i in 0u8..16 {
         let mut key = B256::ZERO;
         key.0[0] = 0x20 | i;
-        group_b_keys.push(key);
         base_storage.insert(key, U256::from(i as u64 + 100));
     }
 
@@ -676,11 +617,8 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie + D
     trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
 
     // Retry removal — now the sibling is revealed, branch can collapse.
-    let mut targets2: Vec<ProofV2Target> = Vec::new();
-    trie.update_leaves(&mut leaf_updates, |key, min_len| {
-        targets2.push(ProofV2Target::new(key).with_min_len(min_len));
-    })
-    .expect("update_leaves should succeed on retry");
+    trie.update_leaves(&mut leaf_updates, |_, _| {})
+        .expect("update_leaves should succeed on retry");
     assert!(leaf_updates.is_empty(), "key should be drained after successful removal");
 
     // Root should match reference trie with only group_b keys.
@@ -695,13 +633,7 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie + D
     );
 }
 
-/// Atomic rollback — node structure and prefix_set unchanged after
-/// removal of a revealed leaf when the sibling is blinded.
-///
-/// Same scenario as the value-preservation test, but additionally checks that
-/// `size_hint` (node count) is unchanged and the update remains in the map.
-
-/// Atomic rollback — node structure and prefix_set unchanged after
+/// Atomic rollback — node structure and `prefix_set` unchanged after
 /// removal of a revealed leaf when the sibling is blinded.
 ///
 /// Same scenario as the value-preservation test, but additionally checks that
@@ -769,12 +701,6 @@ pub(super) fn test_update_leaves_removal_branch_collapse_blinded_sibling<
 /// When removals in a subtrie would empty it and collapse the parent branch onto
 /// a blinded sibling, `update_leaves` should detect this and request a proof for
 /// the blinded sibling via the callback, deferring the updates.
-
-/// Subtrie collapse with blinded sibling triggers callback.
-///
-/// When removals in a subtrie would empty it and collapse the parent branch onto
-/// a blinded sibling, `update_leaves` should detect this and request a proof for
-/// the blinded sibling via the callback, deferring the updates.
 pub(super) fn test_update_leaves_subtrie_collapse_requests_proof<T: SparseTrie + Default>() {
     // Build a branch with two children:
     //   nibble 0x1 → a subtrie with 2 revealed leaves
@@ -833,11 +759,6 @@ pub(super) fn test_update_leaves_subtrie_collapse_requests_proof<T: SparseTrie +
 ///
 /// When multiple keys in the update map all route through the same blinded node,
 /// the callback should be invoked once per key (not deduplicated).
-
-/// Multiple keys hitting the same blinded node each trigger a callback.
-///
-/// When multiple keys in the update map all route through the same blinded node,
-/// the callback should be invoked once per key (not deduplicated).
 pub(super) fn test_update_leaves_multiple_keys_same_blinded_node<T: SparseTrie + Default>() {
     // Branch: nibble 0x1 = 16 revealed keys (hash node), nibble 0x2 = 16 blinded keys.
     let mut base_storage = BTreeMap::new();
@@ -884,8 +805,6 @@ pub(super) fn test_update_leaves_multiple_keys_same_blinded_node<T: SparseTrie +
 }
 
 /// `LeafUpdate::Touched` on a fully revealed path should be a no-op.
-
-/// `LeafUpdate::Touched` on a fully revealed path should be a no-op.
 pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie + Default>() {
     let key1 = B256::with_last_byte(0x10);
     let key2 = B256::with_last_byte(0x20);
@@ -900,7 +819,8 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie + Default>
     let root_before = trie.root();
 
     // Call update_leaves with Touched for an existing key.
-    let mut leaf_updates: B256Map<LeafUpdate> = [(key2, LeafUpdate::Touched)].into_iter().collect();
+    let mut leaf_updates: B256Map<LeafUpdate> =
+        std::iter::once((key2, LeafUpdate::Touched)).collect();
 
     let mut targets: Vec<ProofV2Target> = Vec::new();
     trie.update_leaves(&mut leaf_updates, |key, min_len| {
@@ -915,9 +835,6 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie + Default>
     // Root should be unchanged.
     assert_eq!(trie.root(), root_before, "root should be unchanged after Touched no-op");
 }
-
-/// `LeafUpdate::Touched` on a path with a blinded node should
-/// invoke the callback and keep the key in the updates map. No trie mutation should occur.
 
 /// `LeafUpdate::Touched` on a path with a blinded node should
 /// invoke the callback and keep the key in the updates map. No trie mutation should occur.
@@ -954,7 +871,7 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie + 
         key
     };
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(target_key, LeafUpdate::Touched)].into_iter().collect();
+        std::iter::once((target_key, LeafUpdate::Touched)).collect();
 
     let mut targets: Vec<ProofV2Target> = Vec::new();
     trie.update_leaves(&mut leaf_updates, |key, min_len| {
@@ -975,18 +892,12 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie + 
 /// An empty (default) trie has an Empty root — all paths are accessible (no blinded nodes).
 /// `Touched` on a key that doesn't exist should be drained from the map without any
 /// callback invocation or mutation.
-
-/// Touched on a nonexistent key in an empty trie is drained silently.
-///
-/// An empty (default) trie has an Empty root — all paths are accessible (no blinded nodes).
-/// `Touched` on a key that doesn't exist should be drained from the map without any
-/// callback invocation or mutation.
 pub(super) fn test_update_leaves_touched_nonexistent_key<T: SparseTrie + Default>() {
     let mut trie = T::default();
 
     let target_key = B256::with_last_byte(42);
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(target_key, LeafUpdate::Touched)].into_iter().collect();
+        std::iter::once((target_key, LeafUpdate::Touched)).collect();
 
     let mut callback_count = 0usize;
     trie.update_leaves(&mut leaf_updates, |_key, _min_len| {
@@ -1002,9 +913,6 @@ pub(super) fn test_update_leaves_touched_nonexistent_key<T: SparseTrie + Default
         "nonexistent key should return None"
     );
 }
-
-/// `LeafUpdate::Touched` on a nonexistent key in a fully
-/// revealed, populated trie should be a no-op — no callback, key drained, trie unchanged.
 
 /// `LeafUpdate::Touched` on a nonexistent key in a fully
 /// revealed, populated trie should be a no-op — no callback, key drained, trie unchanged.
@@ -1024,7 +932,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
     // Key 0x50 does not exist in the trie but its path is fully revealed (no blinded nodes).
     let nonexistent_key = B256::with_last_byte(0x50);
     let mut leaf_updates: B256Map<LeafUpdate> =
-        [(nonexistent_key, LeafUpdate::Touched)].into_iter().collect();
+        std::iter::once((nonexistent_key, LeafUpdate::Touched)).collect();
 
     let mut callback_count = 0usize;
     trie.update_leaves(&mut leaf_updates, |_key, _min_len| {
@@ -1041,9 +949,6 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
         "nonexistent key should return None"
     );
 }
-
-/// A single `update_leaves` call with a mix of inserts,
-/// modifications, removals, and touched entries should process all correctly.
 
 /// A single `update_leaves` call with a mix of inserts,
 /// modifications, removals, and touched entries should process all correctly.
@@ -1107,8 +1012,6 @@ pub(super) fn test_update_leaves_multiple_mixed_updates<T: SparseTrie + Default>
     );
 }
 
-/// Calling `root()` on a fresh, empty trie returns `EMPTY_ROOT_HASH`.
-
 /// Ancestors marked dirty even without cached hashes.
 ///
 /// When removing a leaf, all ancestor nodes must be marked dirty unconditionally —
@@ -1162,13 +1065,6 @@ pub(super) fn test_remove_leaf_marks_ancestors_dirty_unconditionally<T: SparseTr
         "root should match reference after removal without prior root() call"
     );
 }
-
-/// Orphaned value update falls through to full insertion.
-///
-/// After a sequence of insertions and removals that involve branch collapses,
-/// every key with a value must remain findable via `find_leaf` and updatable
-/// via `update_leaves`. This verifies the invariant that structural consistency
-/// is maintained even when branch collapses could orphan value entries.
 
 /// Orphaned value update falls through to full insertion.
 ///
@@ -1231,7 +1127,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
     assert_eq!(root1, harness.original_root, "initial root should match");
 
     // Step 1: Remove key_c to collapse the branch at 0x10..
-    let removal: BTreeMap<B256, U256> = [(key_c, U256::ZERO)].into_iter().collect();
+    let removal: BTreeMap<B256, U256> = std::iter::once((key_c, U256::ZERO)).collect();
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
@@ -1239,7 +1135,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
     assert_eq!(root2, harness.original_root, "root after removal should match");
 
     // Step 2: Re-insert key_c with a new value — this re-creates the branch.
-    let reinsert: BTreeMap<B256, U256> = [(key_c, U256::from(33))].into_iter().collect();
+    let reinsert: BTreeMap<B256, U256> = std::iter::once((key_c, U256::from(33))).collect();
     harness.apply_changeset(reinsert.clone());
     let mut reinsert_updates = SuiteTestHarness::leaf_updates(&reinsert);
     harness.reveal_and_update(&mut trie, &mut reinsert_updates);
@@ -1248,7 +1144,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
 
     // Step 3: Update key_a — previously could be orphaned if branch collapse
     // didn't maintain structural tracking properly.
-    let update: BTreeMap<B256, U256> = [(key_a, U256::from(999))].into_iter().collect();
+    let update: BTreeMap<B256, U256> = std::iter::once((key_a, U256::from(999))).collect();
     harness.apply_changeset(update.clone());
     let mut update_updates = SuiteTestHarness::leaf_updates(&update);
     harness.reveal_and_update(&mut trie, &mut update_updates);
@@ -1279,10 +1175,6 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<
 /// When removing a leaf causes a branch to collapse at a subtrie
 /// boundary, the remaining sibling leaf's `key_len` metadata must be updated. After the
 /// collapse the remaining leaf must be findable, updatable, and contribute to the correct root.
-
-/// When removing a leaf causes a branch to collapse at a subtrie
-/// boundary, the remaining sibling leaf's `key_len` metadata must be updated. After the
-/// collapse the remaining leaf must be findable, updatable, and contribute to the correct root.
 pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: SparseTrie + Default>() {
     // Create two leaves that share a branch at a subtrie boundary.
     // Keys share the same first nibble (0x1) so they form a branch one level down,
@@ -1297,7 +1189,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     let mut trie: T = harness.init_trie_fully_revealed(false);
 
     // Step 1: Remove key_a → branch collapses, key_b becomes the sole child.
-    let removal: BTreeMap<B256, U256> = [(key_a, U256::ZERO)].into_iter().collect();
+    let removal: BTreeMap<B256, U256> = std::iter::once((key_a, U256::ZERO)).collect();
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
@@ -1318,7 +1210,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
 
     // Step 2: Modify the remaining leaf's value — this must succeed after the collapse
     // updated key_len properly.
-    let modification: BTreeMap<B256, U256> = [(key_b, U256::from(999))].into_iter().collect();
+    let modification: BTreeMap<B256, U256> = std::iter::once((key_b, U256::from(999))).collect();
     harness.apply_changeset(modification.clone());
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);
@@ -1329,12 +1221,6 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
         "root after updating remaining leaf should match reference"
     );
 }
-
-/// Removal of a leaf should never corrupt blinded/pruned subtries.
-///
-/// When a branch collapses during leaf removal and the remaining child's value needs to be
-/// moved between subtries, the operation must not reveal (initialize) blind/unloaded subtries.
-/// Either the removal succeeds cleanly or it requests proofs for the blinded area.
 
 /// Removal of a leaf should never corrupt blinded/pruned subtries.
 ///
@@ -1374,7 +1260,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie + De
     // Now remove keys[0] — this leaves keys[1] and all the blinded subtries.
     // The branch at the root still has multiple children (keys[1] + blinded children),
     // so this should not trigger a problematic branch collapse into blinded territory.
-    let removal: BTreeMap<B256, U256> = [(keys[0], U256::ZERO)].into_iter().collect();
+    let removal: BTreeMap<B256, U256> = std::iter::once((keys[0], U256::ZERO)).collect();
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
@@ -1396,7 +1282,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie + De
     assert_eq!(find_result, LeafLookup::Exists, "retained leaf should still be findable");
 
     // Now update the retained leaf to verify the trie is in a consistent state.
-    let modification: BTreeMap<B256, U256> = [(keys[1], U256::from(999))].into_iter().collect();
+    let modification: BTreeMap<B256, U256> = std::iter::once((keys[1], U256::from(999))).collect();
     harness.apply_changeset(modification.clone());
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);

--- a/crates/trie/sparse/tests/suite/wipe_clear.rs
+++ b/crates/trie/sparse/tests/suite/wipe_clear.rs
@@ -1,0 +1,146 @@
+use super::*;
+
+/// Calling `wipe()` resets the trie so that
+/// `root()` returns `EMPTY_ROOT_HASH`.
+pub(super) fn test_wipe_resets_to_empty_root<T: SparseTrie + Default>() {
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (B256::with_last_byte(0x10), U256::from(1)),
+        (B256::with_last_byte(0x20), U256::from(2)),
+        (B256::with_last_byte(0x30), U256::from(3)),
+        (B256::with_last_byte(0x40), U256::from(4)),
+        (B256::with_last_byte(0x50), U256::from(5)),
+    ]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false);
+
+    // Compute root to confirm the trie is populated.
+    let root_before = trie.root();
+    assert_eq!(root_before, harness.original_root);
+    assert_ne!(root_before, EMPTY_ROOT_HASH);
+
+    // Wipe and verify empty root.
+    trie.wipe();
+    let root_after = trie.root();
+    assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
+}
+
+/// `clear()` resets the trie to empty but preserves
+/// update tracking mode. After clear, `root()` returns `EMPTY_ROOT_HASH` and
+/// `take_updates()` returns empty (non-wiped) updates.
+pub(super) fn test_clear_resets_trie_but_preserves_update_tracking<T: SparseTrie + Default>() {
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (B256::with_last_byte(0x10), U256::from(1)),
+        (B256::with_last_byte(0x20), U256::from(2)),
+        (B256::with_last_byte(0x30), U256::from(3)),
+    ]);
+
+    let harness = SuiteTestHarness::new(storage);
+    // retain_updates = true so update tracking is active
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute root to populate the trie fully.
+    let root_before = trie.root();
+    assert_eq!(root_before, harness.original_root);
+    assert_ne!(root_before, EMPTY_ROOT_HASH);
+
+    // Clear and verify empty root.
+    trie.clear();
+    let root_after = trie.root();
+    assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
+
+    // take_updates should return empty (non-wiped) updates since tracking is preserved.
+    let updates = trie.take_updates();
+    assert!(!updates.wiped, "clear should not produce wiped updates");
+    assert!(updates.updated_nodes.is_empty(), "clear should produce empty updated_nodes");
+    assert!(updates.removed_nodes.is_empty(), "clear should produce empty removed_nodes");
+}
+
+/// `wipe()` produces special "wiped" updates distinct
+/// from normal empty updates. After wipe, `take_updates()` returns updates with
+/// the wiped flag set and `root()` returns `EMPTY_ROOT_HASH`.
+pub(super) fn test_wipe_produces_wiped_updates<T: SparseTrie + Default>() {
+    let storage: BTreeMap<B256, U256> = BTreeMap::from([
+        (B256::with_last_byte(0x10), U256::from(1)),
+        (B256::with_last_byte(0x20), U256::from(2)),
+        (B256::with_last_byte(0x30), U256::from(3)),
+    ]);
+
+    let harness = SuiteTestHarness::new(storage);
+    // retain_updates = true so update tracking is active
+    let mut trie: T = harness.init_trie_fully_revealed(true);
+
+    // Compute root to populate the trie fully.
+    let root_before = trie.root();
+    assert_eq!(root_before, harness.original_root);
+    assert_ne!(root_before, EMPTY_ROOT_HASH);
+
+    // Wipe the trie.
+    trie.wipe();
+
+    // Root should be EMPTY_ROOT_HASH after wipe.
+    let root_after = trie.root();
+    assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
+
+    // take_updates should return updates with the wiped flag set.
+    let updates = trie.take_updates();
+    assert!(updates.wiped, "wipe should produce wiped updates");
+}
+
+/// A cleared trie can be fully re-initialized and used
+/// normally. After `clear()`, set a new root from a different dataset, reveal
+/// nodes, insert a leaf, and verify `root()` matches the reference.
+pub(super) fn test_clear_then_reuse_trie<T: SparseTrie + Default>() {
+    // Phase 1: build a trie with 5 leaves and compute root.
+    let storage_1: BTreeMap<B256, U256> = BTreeMap::from([
+        (B256::with_last_byte(0x10), U256::from(1)),
+        (B256::with_last_byte(0x20), U256::from(2)),
+        (B256::with_last_byte(0x30), U256::from(3)),
+        (B256::with_last_byte(0x40), U256::from(4)),
+        (B256::with_last_byte(0x50), U256::from(5)),
+    ]);
+    let harness_1 = SuiteTestHarness::new(storage_1);
+    let mut trie: T = harness_1.init_trie_fully_revealed(false);
+
+    let root_1 = trie.root();
+    assert_eq!(root_1, harness_1.original_root);
+    assert_ne!(root_1, EMPTY_ROOT_HASH);
+
+    // Phase 2: clear the trie and verify empty.
+    trie.clear();
+    assert_eq!(trie.root(), EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
+
+    // Phase 3: build a completely different dataset with 3 leaves.
+    let storage_2: BTreeMap<B256, U256> = BTreeMap::from([
+        (B256::with_last_byte(0xA0), U256::from(100)),
+        (B256::with_last_byte(0xB0), U256::from(200)),
+        (B256::with_last_byte(0xC0), U256::from(300)),
+    ]);
+    let mut harness_2 = SuiteTestHarness::new(storage_2.clone());
+
+    // Re-initialize the trie with the new root and reveal all proof nodes.
+    let root_node_2 = harness_2.root_node();
+    trie.set_root(root_node_2.node, root_node_2.masks, false)
+        .expect("set_root should succeed on cleared trie");
+
+    let keys_2: Vec<B256> = storage_2.keys().copied().collect();
+    let mut targets: Vec<ProofV2Target> = keys_2.iter().map(|k| ProofV2Target::new(*k)).collect();
+    let mut proof_nodes = harness_2.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed on cleared trie");
+
+    // Phase 4: insert a 4th leaf.
+    let new_key = B256::with_last_byte(0xD0);
+    let new_value = U256::from(400);
+    let changeset = BTreeMap::from([(new_key, new_value)]);
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness_2.reveal_and_update(&mut trie, &mut leaf_updates);
+
+    // Compute root and verify against reference.
+    let root_2 = trie.root();
+
+    // Update the reference harness with the 4th leaf.
+    harness_2.apply_changeset(changeset);
+    assert_eq!(root_2, harness_2.original_root, "root after clear+reuse must match reference");
+    assert_ne!(root_2, root_1, "new root must differ from pre-clear root");
+    assert_ne!(root_2, EMPTY_ROOT_HASH, "new root must not be empty");
+}


### PR DESCRIPTION
Adds a comprehensive integration test suite for the `SparseTrie` trait, exercising both `ParallelSparseTrie`  through 88 generic test functions.

This test suite will be applied to the upcoming `ArenaParallelSparseTrie` implementation (#22381).

### Structure

Tests live in `crates/trie/sparse/tests/suite/` and are organized by the `SparseTrie` method most likely to be the root cause of failure:

| Module | Tests | Covers |
|---|---|---|
| `set_root` | 7 | Trie initialization, branch/leaf/extension roots, update tracking |
| `reveal_nodes` | 9 | Proof revelation, idempotency, interaction with inserts/removes |
| `update_leaves` | 27 | Insert, modify, remove, blinded-node callbacks, branch collapse, atomicity |
| `root` | 5 | Hash computation, caching, determinism, small-RLP edge case |
| `take_updates` | 4 | Change tracking, reset-after-take, mutual exclusivity |
| `commit_updates` | 2 | Branch mask sync, empty-commit no-op |
| `prune` | 9 | Retention, node reduction, re-reveal after prune, embedded vs hashed |
| `wipe_clear` | 4 | Reset semantics, update preservation, reuse after clear |
| `get_leaf_value` | 2 | Read-after-write, read-after-remove |
| `find_leaf` | 6 | Existence checks, blinded paths, divergence at branch/extension/leaf |
| `size_hint` | 1 | Node count accounting |
| `lifecycle` | 12 | End-to-end block processing, multi-round commit/prune, prewarm via Touched |

### Harness

A `SuiteTestHarness` in `main.rs` manages mock storage, computes reference roots via `StorageRoot`, and generates V2 proofs via `StorageProofCalculator` with mock cursors. It provides helpers like `reveal_and_update` that handle the iterative reveal-update loop automatically.

### Macro

The `sparse_trie_tests!` macro stamps out `#[test]` functions for each generic `test_foo<T: SparseTrie + Default>()` function, instantiated for the existing concrete implementation.