### PR TITLE
feat(engine): add --engine.proof-jitter option behind trie-debug

### DIFF
--- a/.changelog/merry-bees-break.md
+++ b/.changelog/merry-bees-break.md
@@ -1,0 +1,8 @@
+---
+reth-engine-primitives: minor
+reth-engine-tree: minor
+reth-node-core: minor
+reth-trie-parallel: minor
+---
+
+Added `--engine.proof-jitter` CLI option behind the `trie-debug` feature flag. When set, each proof worker sleeps for a random duration up to the specified value before starting proof computation, useful for stress-testing timing-sensitive proof logic.

--- a/crates/engine/primitives/Cargo.toml
+++ b/crates/engine/primitives/Cargo.toml
@@ -39,6 +39,7 @@ thiserror.workspace = true
 
 [features]
 default = ["std"]
+trie-debug = []
 std = [
     "reth-execution-types/std",
     "reth-ethereum-primitives/std",

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -151,6 +151,11 @@ pub struct TreeConfig {
     /// computation is spawned in parallel and whichever finishes first is used.
     /// If `None`, the timeout fallback is disabled.
     state_root_task_timeout: Option<Duration>,
+    /// Maximum random jitter applied before each proof computation (trie-debug only).
+    /// When set, each proof worker sleeps for a random duration up to this value
+    /// before starting a proof calculation.
+    #[cfg(feature = "trie-debug")]
+    proof_jitter: Option<Duration>,
 }
 
 impl Default for TreeConfig {
@@ -181,6 +186,8 @@ impl Default for TreeConfig {
             slow_block_threshold: None,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
+            #[cfg(feature = "trie-debug")]
+            proof_jitter: None,
         }
     }
 }
@@ -240,6 +247,8 @@ impl TreeConfig {
             slow_block_threshold,
             disable_sparse_trie_cache_pruning: false,
             state_root_task_timeout,
+            #[cfg(feature = "trie-debug")]
+            proof_jitter: None,
         }
     }
 
@@ -547,6 +556,19 @@ impl TreeConfig {
     /// Setter for state root task timeout.
     pub const fn with_state_root_task_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.state_root_task_timeout = timeout;
+        self
+    }
+
+    /// Returns the proof jitter duration, if configured (trie-debug only).
+    #[cfg(feature = "trie-debug")]
+    pub const fn proof_jitter(&self) -> Option<Duration> {
+        self.proof_jitter
+    }
+
+    /// Setter for proof jitter (trie-debug only).
+    #[cfg(feature = "trie-debug")]
+    pub const fn with_proof_jitter(mut self, proof_jitter: Option<Duration>) -> Self {
+        self.proof_jitter = proof_jitter;
         self
     }
 }

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -133,7 +133,7 @@ test-utils = [
     "reth-evm-ethereum/test-utils",
     "reth-tasks/test-utils",
 ]
-trie-debug = ["reth-trie-sparse/trie-debug", "dep:serde_json"]
+trie-debug = ["reth-trie-sparse/trie-debug", "reth-trie-parallel/trie-debug", "reth-engine-primitives/trie-debug", "dep:serde_json"]
 rocksdb = [
     "reth-provider/rocksdb",
     "reth-prune/rocksdb",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -133,7 +133,12 @@ test-utils = [
     "reth-evm-ethereum/test-utils",
     "reth-tasks/test-utils",
 ]
-trie-debug = ["reth-trie-sparse/trie-debug", "reth-trie-parallel/trie-debug", "reth-engine-primitives/trie-debug", "dep:serde_json"]
+trie-debug = [
+    "reth-trie-sparse/trie-debug",
+    "reth-trie-parallel/trie-debug",
+    "reth-engine-primitives/trie-debug",
+    "dep:serde_json",
+]
 rocksdb = [
     "reth-provider/rocksdb",
     "reth-prune/rocksdb",

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -351,6 +351,8 @@ where
         let (to_multi_proof, from_multi_proof) = crossbeam_channel::unbounded();
 
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
+        #[cfg(feature = "trie-debug")]
+        let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
         let halve_workers = env.transaction_count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD;
         let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
 

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -91,7 +91,7 @@ min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
 # Debug recording for sparse trie mutations
-trie-debug = []
+trie-debug = ["reth-engine-primitives/trie-debug"]
 
 # Route supported tables to RocksDB instead of MDBX
 rocksdb = ["reth-storage-api/rocksdb"]

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -561,6 +561,7 @@ mod tests {
             slow_block_threshold: None,
             disable_sparse_trie_cache_pruning: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
+            #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         };
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -561,6 +561,7 @@ mod tests {
             slow_block_threshold: None,
             disable_sparse_trie_cache_pruning: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
+            proof_jitter: None,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -397,6 +397,19 @@ pub struct EngineArgs {
         default_value = DefaultEngineValues::get_global().state_root_task_timeout.as_deref().unwrap_or("1s"),
     )]
     pub state_root_task_timeout: Option<Duration>,
+
+    /// Add random jitter before each proof computation (trie-debug only).
+    /// Each proof worker sleeps for a random duration up to this value before
+    /// starting work. Useful for stress-testing timing-sensitive proof logic.
+    ///
+    /// --engine.proof-jitter 100ms
+    /// --engine.proof-jitter 1s
+    #[cfg(feature = "trie-debug")]
+    #[arg(
+        long = "engine.proof-jitter",
+        value_parser = humantime::parse_duration,
+    )]
+    pub proof_jitter: Option<Duration>,
 }
 
 #[allow(deprecated)]
@@ -459,6 +472,8 @@ impl Default for EngineArgs {
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
+            #[cfg(feature = "trie-debug")]
+            proof_jitter: None,
         }
     }
 }
@@ -466,7 +481,7 @@ impl Default for EngineArgs {
 impl EngineArgs {
     /// Creates a [`TreeConfig`] from the engine arguments.
     pub fn tree_config(&self) -> TreeConfig {
-        TreeConfig::default()
+        let config = TreeConfig::default()
             .with_persistence_threshold(self.persistence_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
             .with_legacy_state_root(self.legacy_state_root_task_enabled)
@@ -488,7 +503,10 @@ impl EngineArgs {
             .with_sparse_trie_max_hot_accounts(self.sparse_trie_max_hot_accounts)
             .with_slow_block_threshold(self.slow_block_threshold)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
-            .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
+            .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()));
+        #[cfg(feature = "trie-debug")]
+        let config = config.with_proof_jitter(self.proof_jitter);
+        config
     }
 }
 

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -39,6 +39,9 @@ crossbeam-channel.workspace = true
 reth-metrics = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 
+# `trie-debug` feature
+rand = { workspace = true, optional = true }
+
 [dev-dependencies]
 # reth
 reth-primitives-traits.workspace = true
@@ -55,6 +58,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 [features]
 default = ["metrics"]
 metrics = ["reth-metrics", "dep:metrics", "reth-trie/metrics", "reth-trie-sparse/metrics"]
+trie-debug = ["dep:rand"]
 test-utils = [
     "reth-primitives-traits/test-utils",
     "reth-provider/test-utils",

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -723,9 +723,8 @@ where
 
             #[cfg(feature = "trie-debug")]
             if let Some(max_jitter) = self.task_ctx.proof_jitter {
-                let jitter = Duration::from_nanos(
-                    rand::random::<u64>() % (max_jitter.as_nanos() as u64 + 1),
-                );
+                let jitter =
+                    Duration::from_nanos(rand::random_range(0..=max_jitter.as_nanos() as u64));
                 trace!(
                     target: "trie::proof_task",
                     worker_id = self.worker_id,
@@ -1010,9 +1009,8 @@ where
 
             #[cfg(feature = "trie-debug")]
             if let Some(max_jitter) = self.task_ctx.proof_jitter {
-                let jitter = Duration::from_nanos(
-                    rand::random::<u64>() % (max_jitter.as_nanos() as u64 + 1),
-                );
+                let jitter =
+                    Duration::from_nanos(rand::random_range(0..=max_jitter.as_nanos() as u64));
                 trace!(
                     target: "trie::proof_task",
                     worker_id = self.worker_id,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -384,12 +384,26 @@ impl ProofWorkerHandle {
 pub struct ProofTaskCtx<Factory> {
     /// The factory for creating state providers.
     factory: Factory,
+    /// Maximum random jitter to apply before each proof computation (trie-debug only).
+    #[cfg(feature = "trie-debug")]
+    proof_jitter: Option<Duration>,
 }
 
 impl<Factory> ProofTaskCtx<Factory> {
     /// Creates a new [`ProofTaskCtx`] with the given factory.
-    pub const fn new(factory: Factory) -> Self {
-        Self { factory }
+    pub fn new(factory: Factory) -> Self {
+        Self {
+            factory,
+            #[cfg(feature = "trie-debug")]
+            proof_jitter: None,
+        }
+    }
+
+    /// Sets the maximum proof jitter duration (trie-debug only).
+    #[cfg(feature = "trie-debug")]
+    pub const fn with_proof_jitter(mut self, jitter: Option<Duration>) -> Self {
+        self.proof_jitter = jitter;
+        self
     }
 }
 
@@ -707,6 +721,20 @@ where
             // Mark worker as busy.
             self.available_workers.fetch_sub(1, Ordering::Relaxed);
 
+            #[cfg(feature = "trie-debug")]
+            if let Some(max_jitter) = self.task_ctx.proof_jitter {
+                let jitter = Duration::from_nanos(
+                    rand::random::<u64>() % (max_jitter.as_nanos() as u64 + 1),
+                );
+                trace!(
+                    target: "trie::proof_task",
+                    worker_id = self.worker_id,
+                    jitter_us = jitter.as_micros(),
+                    "Storage worker applying proof jitter"
+                );
+                std::thread::sleep(jitter);
+            }
+
             match job {
                 StorageWorkerJob::StorageProof { input, proof_result_sender } => {
                     self.process_storage_proof(
@@ -979,6 +1007,20 @@ where
 
             // Mark worker as busy.
             self.available_workers.fetch_sub(1, Ordering::Relaxed);
+
+            #[cfg(feature = "trie-debug")]
+            if let Some(max_jitter) = self.task_ctx.proof_jitter {
+                let jitter = Duration::from_nanos(
+                    rand::random::<u64>() % (max_jitter.as_nanos() as u64 + 1),
+                );
+                trace!(
+                    target: "trie::proof_task",
+                    worker_id = self.worker_id,
+                    jitter_us = jitter.as_micros(),
+                    "Account worker applying proof jitter"
+                );
+                std::thread::sleep(jitter);
+            }
 
             match job {
                 AccountWorkerJob::AccountMultiproof { input } => {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -391,7 +391,7 @@ pub struct ProofTaskCtx<Factory> {
 
 impl<Factory> ProofTaskCtx<Factory> {
     /// Creates a new [`ProofTaskCtx`] with the given factory.
-    pub fn new(factory: Factory) -> Self {
+    pub const fn new(factory: Factory) -> Self {
         Self {
             factory,
             #[cfg(feature = "trie-debug")]


### PR DESCRIPTION
Adds a random sleep (up to the configured duration) before each proof computation in both storage and account workers. Feature-gated behind trie-debug so there is zero overhead in normal builds. Useful for shaking out race-conditions in the SparseTrieCacheTask.