### PR TITLE
perf: use line-tables-only debug info for profiling profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ codegen-units = 16
 # e.g. `cargo build --profile profiling`
 [profile.profiling]
 inherits = "release"
-debug = "full"
+debug = "line-tables-only"
 strip = "none"
 
 # Include debug info in benchmarks too.


### PR DESCRIPTION
Switches the profiling profile from `debug = "full"` to `debug = "line-tables-only"`. Benchmarked on a 48-core machine (reth0):

| Metric | `debug = "full"` | `debug = "line-tables-only"` | Δ |
|---|---|---|---|
| Binary size | 1905 MB | 1039 MB | **−866 MB (45%)** |
| Clean build | 4m17s | 3m34s | **−42s (16%)** |
| Incremental (touch trie-sparse) | 2m41s | 2m08s | **−33s (20%)** |

Line-tables-only keeps file/line info for samply, perf, and Tracy. The only loss is variable/type inspection in gdb/lldb, which is rarely used with this profile.

`maxperf-symbols` is left at `debug = "full"` since that profile is specifically for deep debugging.

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>

Prompted by: pep