### PR TITLE
fix(rpc): disable EIP-7825 tx gas limit cap in eth_createAccessList 

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -491,6 +491,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // Disabled because eth_createAccessList is sometimes used with non-eoa senders
             evm_env.cfg_env.disable_eip3607 = true;
 
+            // Disable EIP-7825 transaction gas limit cap so that the gas limit
+            // fallback (block gas limit) is not rejected when it exceeds the
+            // per-tx cap (2^24 ≈ 16.7M post-Osaka).
+            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+
             if request.as_ref().gas_limit().is_none() && tx_env.gas_price() > 0 {
                 let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
                 // no gas limit was provided in the request, so we need to cap the request's gas

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -62,10 +62,6 @@ pub trait EstimateCall: Call {
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
         evm_env.cfg_env.disable_base_fee = true;
 
-        // Disable EIP-7825 transaction gas limit cap so that gas estimation
-        // is not capped at 2^24 (~16.7M) post-Osaka.
-        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -62,6 +62,10 @@ pub trait EstimateCall: Call {
         // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
         evm_env.cfg_env.disable_base_fee = true;
 
+        // Disable EIP-7825 transaction gas limit cap so that gas estimation
+        // is not capped at 2^24 (~16.7M) post-Osaka.
+        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
 


### PR DESCRIPTION
Closes #22841

Since Osaka activated on mainnet (Dec 2025), EIP-7825 enforces a per-tx gas limit cap of 2^24 (~16.7M). When `gas` is omitted from `eth_createAccessList`, alloy-evm falls back to `block_env.gas_limit()` (~36M), which exceeds the cap → revm rejects with `TxGasLimitGreaterThanCap` → `"intrinsic gas too high"`. The same cap also limits `eth_estimateGas` binary search upper bound to ~16.7M.

`prepare_call_env` (used by `eth_call`) already disables this via `tx_gas_limit_cap = Some(u64::MAX)`. 

applies the same override to `create_access_list_with` and `estimate_gas_with`.

Verified on a mainnet node — the EIP-7825 boundary is exact: `gas=0x1000000` (2^24) passes, `gas=0x1000001` (2^24+1) fails before the fix, both pass after.

Sorry about the incorrect root cause in #22841