### PR TITLE
feat(metrics): add PrometheusRecorder::collect_and_render

### DIFF
--- a/crates/node/metrics/src/recorder.rs
+++ b/crates/node/metrics/src/recorder.rs
@@ -1,7 +1,9 @@
 //! Prometheus recorder
 
+use crate::hooks::Hooks;
 use eyre::WrapErr;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_process::Collector;
 use metrics_util::layers::{PrefixLayer, Stack};
 use std::sync::{atomic::AtomicBool, OnceLock};
 
@@ -53,20 +55,43 @@ pub fn try_install_prometheus_recorder_with_builder(
 ///
 /// This is intended to be used as the global recorder.
 /// Callers must ensure that [`PrometheusRecorder::spawn_upkeep`] is called once.
-#[derive(Debug)]
 pub struct PrometheusRecorder {
     handle: PrometheusHandle,
+    hooks: Hooks,
     upkeep: AtomicBool,
 }
 
+impl std::fmt::Debug for PrometheusRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrometheusRecorder")
+            .field("handle", &self.handle)
+            .field("hooks", &self.hooks)
+            .finish()
+    }
+}
+
 impl PrometheusRecorder {
-    const fn new(handle: PrometheusHandle) -> Self {
-        Self { handle, upkeep: AtomicBool::new(false) }
+    fn new(handle: PrometheusHandle) -> Self {
+        let hooks = Hooks::builder().build();
+        // Describe process metrics so they appear even before the first collect.
+        Collector::default().describe();
+        Self { handle, hooks, upkeep: AtomicBool::new(false) }
     }
 
     /// Returns a reference to the [`PrometheusHandle`].
     pub const fn handle(&self) -> &PrometheusHandle {
         &self.handle
+    }
+
+    /// Collects process / system metrics via the registered hooks, then renders
+    /// all metrics in Prometheus exposition format.
+    ///
+    /// Prefer this over [`PrometheusHandle::render`] to ensure process-level
+    /// metrics (`process_start_time_seconds`, IO counters, jemalloc stats, …)
+    /// are always up-to-date.
+    pub fn collect_and_render(&self) -> String {
+        self.hooks.iter().for_each(|hook| hook());
+        self.handle.render()
     }
 
     /// Spawns the upkeep task if there hasn't been one spawned already.
@@ -137,11 +162,7 @@ mod tests {
     fn process_metrics() {
         let recorder = install_prometheus_recorder();
 
-        let process = metrics_process::Collector::default();
-        process.describe();
-        process.collect();
-
-        let metrics = recorder.handle().render();
+        let metrics = recorder.collect_and_render();
         assert!(metrics.contains("process_cpu_seconds_total"), "{metrics:?}");
     }
 }

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -9,7 +9,6 @@ use eyre::WrapErr;
 use http::{header::CONTENT_TYPE, HeaderValue, Request, Response, StatusCode};
 use http_body_util::Full;
 use metrics::describe_gauge;
-use metrics_process::Collector;
 use reqwest::Client;
 use reth_metrics::metrics::Unit;
 use reth_tasks::TaskExecutor;
@@ -98,16 +97,15 @@ impl MetricServer {
             self.start_push_gateway_task(
                 url.clone(),
                 *push_gateway_interval,
-                hooks.clone(),
                 task_executor.clone(),
             )?;
         }
 
-        // Describe metrics after recorder installation
+        // Describe metrics after recorder installation.
+        // Note: process metrics are described by the recorder itself.
         describe_db_metrics();
         describe_static_file_metrics();
         describe_rocksdb_metrics();
-        Collector::default().describe();
         describe_memory_stats();
         describe_io_stats();
 
@@ -173,7 +171,6 @@ impl MetricServer {
         &self,
         url: String,
         interval: Duration,
-        hooks: Hooks,
         task_executor: TaskExecutor,
     ) -> eyre::Result<()> {
         let client = Client::builder()
@@ -189,8 +186,7 @@ impl MetricServer {
                         break;
                     }
                     _ = tokio::time::sleep(interval) => {
-                        hooks.iter().for_each(|hook| hook());
-                        let metrics = handle.handle().render();
+                        let metrics = handle.collect_and_render();
                         match client.put(&url).header("Content-Type", "text/plain").body(metrics).send().await {
                             Ok(response) => {
                                 if !response.status().is_success() {
@@ -323,7 +319,7 @@ async fn handle_request(
         "/debug/tokio/dump" => handle_tokio_dump().await,
         _ => {
             hook();
-            let metrics = handle.handle().render();
+            let metrics = handle.collect_and_render();
             let mut response = Response::new(Full::new(Bytes::from(metrics)));
             response.headers_mut().insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
             response


### PR DESCRIPTION
Bundles the default metric collection hooks (process stats, IO counters, jemalloc) into `PrometheusRecorder` and exposes `collect_and_render()` which runs them before rendering.

Previously, `process_start_time_seconds`, `process_cpu_seconds_total`, IO counters, and jemalloc stats were only collected when something HTTP-scraped the `/metrics` endpoint (the hooks fired per-request in `MetricServer`). Any push-based export path that called `handle().render()` directly would silently miss these metrics.

Now `collect_and_render()` is the single correct way to get a full metrics snapshot — hard to misuse.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>
Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: alexey