### PR TITLE
fix(reth-bench): add missing serde default for GasRampPayloadFile version field

### DIFF
--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -24,7 +24,7 @@ pub(crate) struct GasRampPayloadFile {
     /// Engine API version (1-5).
     ///
     /// `None` indicates that `reth_newPayload` should be used.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) version: Option<u8>,
     /// The block hash for FCU.
     pub(crate) block_hash: B256,


### PR DESCRIPTION
While replaying gas ramp payloads generated with `reth_newPayload` (no versioned Engine API), deserialization fails because the `version` field is absent from the JSON file:

```
Error: Failed to parse "output/payload_block_22045026.json"

Caused by:
missing field version at line 1 column 210
```

The write path in `gas_limit_ramp.rs` correctly skips `version` when it's `None` (via `skip_serializing_if`), but the read path in `replay_payloads.rs` can't deserialize the file back because serde requires all fields to be present by default — even `Option<T>`.
