### PR TITLE
perf(provider): remove unnecessary clones in changeset readers

### DIFF
--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1419,7 +1419,6 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
                     .execution_output
                     .state
                     .reverts
-                    .clone()
                     .to_plain_state_reverts()
                     .storage
                     .into_iter()
@@ -1471,12 +1470,9 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
                     .execution_output
                     .state
                     .reverts
-                    .clone()
-                    .to_plain_state_reverts()
-                    .storage
-                    .into_iter()
+                    .iter()
                     .flatten()
-                    .map(|revert: PlainStorageRevert| revert.storage_revert.len())
+                    .map(|(_, revert)| revert.storage.len())
                     .sum::<usize>();
             }
         }
@@ -1599,7 +1595,6 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
                     .execution_output
                     .state
                     .reverts
-                    .clone()
                     .to_plain_state_reverts()
                     .accounts
                     .into_iter()
@@ -1642,15 +1637,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
         let mut count = 0;
         if let Some(head_block) = &self.head_block {
             for state in head_block.chain() {
-                count += state
-                    .block_ref()
-                    .execution_output
-                    .state
-                    .reverts
-                    .clone()
-                    .to_plain_state_reverts()
-                    .accounts
-                    .len();
+                count += state.block_ref().execution_output.state.reverts.len();
             }
         }
 


### PR DESCRIPTION
Removes unnecessary `.clone()` calls on `Reverts` in `ConsistentProvider`. `to_plain_state_reverts` takes `&self`, and the count methods can use `.iter()` or `.len()` directly without allocating.