### PR TITLE
revert: use line-tables-only debug info for profiling profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ codegen-units = 16
 # e.g. `cargo build --profile profiling`
 [profile.profiling]
 inherits = "release"
-debug = "line-tables-only"
+debug = "full"
 strip = "none"
 
 # Include debug info in benchmarks too.


### PR DESCRIPTION
## Summary

Reverts #22891, which switched the `profiling` profile from `debug = "full"` to `debug = "line-tables-only"`.

## Motivation

While `line-tables-only` cuts binary size by 45% and speeds up builds, it degrades samply profile quality in a meaningful way. With `debug = 1`, samply loses access to DWARF's structured type and namespace info (`DW_TAG_namespace`, `DW_TAG_subprogram`, `DW_TAG_inlined_subroutine`, `DW_TAG_structure_type`) and falls back to demangling raw ELF symbol table names. This causes:

1. **Monomorphized generic noise** — function names show fully expanded concrete types instead of clean generic parameters. e.g. `run<reth_node_types::NodeTypesWithDBAdapter<reth_node_ethereum::node::EthereumNode, reth_db::implementation::mdbx::DatabaseEnv>>` instead of `PersistenceService<N>::run`.

2. **Lost qualified paths** — only the bare function name is shown, without the parent module/type path. `in_place_scope<...>` instead of `rayon_core::thread_pool::ThreadPool::in_place_scope`.

3. **Raw mangling artifacts** — closures appear as `{closure#0}`, `{closure#5}` instead of named `{{closure}}` with parent context. Impl blocks show as `{impl#16}` instead of the resolved trait/type.

Visible in the [benchmark profiles from the original PR](https://github.com/paradigmxyz/reth/pull/22891#issuecomment-2835719443) — compare [baseline-1](https://share.firefox.dev/40pEHfY) vs [feature-2](https://share.firefox.dev/3NpCGNW).

The profiling profile exists specifically for profiling — symbol readability is more important here than build speed.

Prompted by: pep