### PR TITLE
refactor: remove standalone rocksdb passthrough feature

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -89,7 +89,7 @@ default = [
     "keccak-cache-global",
     "asm-keccak",
     "min-debug-logs",
-    "rocksdb",
+    "edge",
 ]
 
 otlp = [
@@ -191,8 +191,7 @@ min-trace-logs = [
 ]
 
 trie-debug = ["reth-node-builder/trie-debug", "reth-node-core/trie-debug"]
-rocksdb = ["reth-ethereum-cli/rocksdb", "reth-node-core/rocksdb"]
-edge = ["rocksdb"]
+edge = ["reth-ethereum-cli/edge", "reth-node-core/edge"]
 
 [[bin]]
 name = "reth"

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -136,5 +136,5 @@ arbitrary = [
     "reth-ethereum-primitives/arbitrary",
 ]
 
-rocksdb = ["reth-db-common/rocksdb", "reth-stages/rocksdb", "reth-provider/rocksdb", "reth-prune/rocksdb"]
+rocksdb = ["reth-db-common/edge", "reth-stages/rocksdb", "reth-provider/rocksdb", "reth-prune/rocksdb"]
 edge = ["rocksdb"]

--- a/crates/e2e-test-utils/Cargo.toml
+++ b/crates/e2e-test-utils/Cargo.toml
@@ -75,8 +75,7 @@ path = "tests/e2e-testsuite/main.rs"
 [[test]]
 name = "rocksdb"
 path = "tests/rocksdb/main.rs"
-required-features = ["rocksdb"]
+required-features = ["edge"]
 
 [features]
-rocksdb = ["reth-node-core/rocksdb", "reth-provider/rocksdb", "reth-cli-commands/rocksdb"]
-edge = ["rocksdb"]
+edge = ["reth-node-core/edge", "reth-provider/rocksdb", "reth-cli-commands/edge"]

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -1,6 +1,6 @@
 //! E2E tests for `RocksDB` provider functionality.
 
-#![cfg(all(feature = "rocksdb", unix))]
+#![cfg(all(feature = "edge", unix))]
 
 use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -139,13 +139,12 @@ trie-debug = [
     "reth-engine-primitives/trie-debug",
     "dep:serde_json",
 ]
-rocksdb = [
+edge = [
     "reth-provider/rocksdb",
     "reth-prune/rocksdb",
     "reth-stages?/rocksdb",
-    "reth-e2e-test-utils/rocksdb",
+    "reth-e2e-test-utils/edge",
 ]
-edge = ["rocksdb"]
 
 [[test]]
 name = "e2e_testsuite"

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -90,5 +90,4 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-rocksdb = ["reth-cli-commands/rocksdb"]
-edge = ["rocksdb"]
+edge = ["reth-cli-commands/edge"]

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -93,11 +93,8 @@ min-trace-logs = ["tracing/release_max_level_trace"]
 # Debug recording for sparse trie mutations
 trie-debug = ["reth-engine-primitives/trie-debug"]
 
-# Route supported tables to RocksDB instead of MDBX
-rocksdb = ["reth-storage-api/rocksdb"]
-
 # Marker feature for edge/unstable builds - enables rocksdb and sets v2 defaults
-edge = ["rocksdb"]
+edge = ["reth-storage-api/edge"]
 
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -121,5 +121,5 @@ test-utils = [
     "reth-evm-ethereum/test-utils",
     "reth-tasks/test-utils",
 ]
-rocksdb = ["reth-provider/rocksdb", "reth-db-common/rocksdb"]
+rocksdb = ["reth-provider/rocksdb", "reth-db-common/edge"]
 edge = ["rocksdb"]

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -47,8 +47,7 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
 
 [features]
-rocksdb = ["reth-db-api/rocksdb", "reth-provider/rocksdb"]
-edge = ["rocksdb"]
+edge = ["reth-db-api/rocksdb", "reth-provider/rocksdb"]
 
 [lints]
 workspace = true

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -1051,7 +1051,7 @@ mod tests {
             )
         };
 
-        #[cfg(feature = "rocksdb")]
+        #[cfg(feature = "edge")]
         {
             let settings = factory.cached_storage_settings();
             let rocksdb = factory.rocksdb_provider();
@@ -1080,7 +1080,7 @@ mod tests {
             assert_eq!(storages, expected_storages);
         }
 
-        #[cfg(not(feature = "rocksdb"))]
+        #[cfg(not(feature = "edge"))]
         {
             let (accounts, storages) = collect_from_mdbx(&factory);
             assert_eq!(accounts, expected_accounts);

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -87,7 +87,7 @@ rand.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
-rocksdb = ["reth-storage-api/rocksdb", "dep:rocksdb"]
+rocksdb = ["reth-storage-api/edge", "dep:rocksdb"]
 edge = ["rocksdb"]
 test-utils = [
     "reth-db/test-utils",

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -36,8 +36,7 @@ serde_json = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-rocksdb = ["reth-db-api/rocksdb"]
-edge = ["rocksdb"]
+edge = ["reth-db-api/rocksdb"]
 std = [
     "reth-chainspec/std",
     "alloy-consensus/std",


### PR DESCRIPTION
Since `edge` already enables `rocksdb`, the standalone `rocksdb` feature on passthrough crates was redundant. Folds `rocksdb` deps directly into `edge` for crates that only forwarded the feature without any `#[cfg]` usage in source.

Leaf crates with `#[cfg(feature = "rocksdb")]` in source (`reth-provider`, `reth-db-api`, `reth-prune`, `reth-stages`, `reth-cli-commands`) keep the `rocksdb` feature.

Also makes `edge` a default feature in `bin/reth`, replacing `rocksdb`.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk