### PR TITLE
chore(engine): return -38003 for FCUv2 payloadAttributes mismatch

### DIFF
--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -112,14 +112,11 @@ impl ErrorData {
 impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EngineApiError) -> Self {
         match error {
-            EngineApiError::InvalidBodiesRange { .. } |
+            // Per the Shanghai Engine API spec, FCU V2 must return -38003 when the wrong
+            // PayloadAttributes version is used.
+            // Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md
+            // Change: https://github.com/ethereum/execution-apis/pull/761
             EngineApiError::EngineObjectValidationError(
-                EngineObjectValidationError::Payload(_) |
-                EngineObjectValidationError::InvalidParams(_) |
-                // Per Engine API spec, structure validation errors for PayloadAttributes
-                // (e.g., missing withdrawals post-Shanghai) should return -32602 "Invalid params".
-                // See: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md
-                // Fixes: https://github.com/paradigmxyz/reth/issues/8732
                 EngineObjectValidationError::PayloadAttributes(
                     VersionSpecificValidationError::WithdrawalsNotSupportedInV1 |
                     VersionSpecificValidationError::NoWithdrawalsPostShanghai |
@@ -130,11 +127,20 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                 // Note: the data field is not required by the spec, but is also included by other
                 // clients
                 jsonrpsee_types::error::ErrorObject::owned(
-                    INVALID_PARAMS_CODE,
-                    INVALID_PARAMS_MSG,
+                    INVALID_PAYLOAD_ATTRIBUTES_ERROR,
+                    INVALID_PAYLOAD_ATTRIBUTES_ERROR_MSG,
                     Some(ErrorData::new(error)),
                 )
             }
+            EngineApiError::InvalidBodiesRange { .. } |
+            EngineApiError::EngineObjectValidationError(
+                EngineObjectValidationError::Payload(_) |
+                EngineObjectValidationError::InvalidParams(_),
+            ) => jsonrpsee_types::error::ErrorObject::owned(
+                INVALID_PARAMS_CODE,
+                INVALID_PARAMS_MSG,
+                Some(ErrorData::new(error)),
+            ),
             EngineApiError::UnknownPayload => jsonrpsee_types::error::ErrorObject::owned(
                 UNKNOWN_PAYLOAD_CODE,
                 error.to_string(),
@@ -264,15 +270,42 @@ mod tests {
             EngineApiError::UnknownPayload,
         );
 
-        // PayloadAttributes structure validation errors (e.g., missing withdrawals post-Shanghai)
-        // should return -32602 per the Engine API spec
-        // See: https://github.com/paradigmxyz/reth/issues/8732
+        // Per the Shanghai Engine API spec, FCU V2 must return -38003 when the wrong
+        // PayloadAttributes version is used.
+        // Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md
+        // Change: https://github.com/ethereum/execution-apis/pull/761
         ensure_engine_rpc_error(
-            INVALID_PARAMS_CODE,
-            INVALID_PARAMS_MSG,
+            INVALID_PAYLOAD_ATTRIBUTES_ERROR,
+            INVALID_PAYLOAD_ATTRIBUTES_ERROR_MSG,
             EngineApiError::EngineObjectValidationError(
                 EngineObjectValidationError::PayloadAttributes(
                     VersionSpecificValidationError::NoWithdrawalsPostShanghai,
+                ),
+            ),
+        );
+
+        ensure_engine_rpc_error(
+            INVALID_PARAMS_CODE,
+            INVALID_PARAMS_MSG,
+            EngineApiError::EngineObjectValidationError(EngineObjectValidationError::Payload(
+                VersionSpecificValidationError::NoWithdrawalsPostShanghai,
+            )),
+        );
+
+        ensure_engine_rpc_error(
+            INVALID_PARAMS_CODE,
+            INVALID_PARAMS_MSG,
+            EngineApiError::EngineObjectValidationError(EngineObjectValidationError::Payload(
+                VersionSpecificValidationError::HasWithdrawalsPreShanghai,
+            )),
+        );
+
+        ensure_engine_rpc_error(
+            INVALID_PAYLOAD_ATTRIBUTES_ERROR,
+            INVALID_PAYLOAD_ATTRIBUTES_ERROR_MSG,
+            EngineApiError::EngineObjectValidationError(
+                EngineObjectValidationError::PayloadAttributes(
+                    VersionSpecificValidationError::HasWithdrawalsPreShanghai,
                 ),
             ),
         );


### PR DESCRIPTION
This PR updates `engine_forkchoiceUpdatedV2` to return `-38003: Invalid payload attributes` when the wrong `payloadAttributes` version is used.

  In particular, FCUv2 payload-attribute version mismatches such as:
  - missing `withdrawals` at or after Shanghai
  - unexpected `withdrawals` before Shanghai

  should be treated as `Invalid payload attributes`, not `Invalid params`.

  ## Why

  This change aligns the client with the latest Engine API spec update in:
  - ethereum/execution-apis#761

  It also follows the implementation discussion and prior client-side change in:
  - ethereum/go-ethereum#33918

  The spec was clarified so that FCUv2 now behaves consistently with newer forkchoiceUpdated versions for payloadAttributes structure/version
  mismatches.

  ## What changed

  - Updated FCUv2 payload attributes validation to return `-38003` for payloadAttributes version mismatches.
  - Added/updated regression coverage for the affected FCUv2 cases.

  ## Hive impact

  This fixes the Hive `engine-withdrawals` failure caused by returning the wrong error code for FCUv2 payloadAttributes mismatches.

  Relevant Hive failure:
  - https://hive.ethpandaops.io/#/test/generic/1773131099-6510fb9d5a109803a91a5230c3d6bc6f

  After this change, the client returns the expected error code for the affected FCUv2 cases.

  If my understanding or interpretation of the spec change is incorrect, please let me know and I can adjust the implementation accordingly.