### PR TITLE
feat(stages): log incremental merkle chunk progress at info level

### DIFF
--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -311,16 +311,18 @@ where
         } else {
             debug!(target: "sync::stages::merkle::exec", current = ?current_block_number, target = ?to_block, "Updating trie in chunks");
             let mut final_root = None;
-            for start_block in range.step_by(incremental_threshold as usize) {
+            let total_chunks = range.clone().step_by(incremental_threshold as usize).count();
+            for (chunk_idx, start_block) in range.step_by(incremental_threshold as usize).enumerate() {
                 let chunk_to = std::cmp::min(start_block + incremental_threshold, to_block);
                 let chunk_range = start_block..=chunk_to;
-                debug!(
+                info!(
                     target: "sync::stages::merkle::exec",
                     current = ?current_block_number,
                     target = ?to_block,
-                    incremental_threshold,
+                    chunk = chunk_idx + 1,
+                    total_chunks,
                     chunk_range = ?chunk_range,
-                    "Processing chunk"
+                    "Processing incremental chunk"
                 );
                 let (root, updates) = reth_trie_db::with_adapter!(provider, |A| {
                     DbStateRoot::<_, A>::incremental_root_with_updates(provider, chunk_range)

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -312,7 +312,9 @@ where
             debug!(target: "sync::stages::merkle::exec", current = ?current_block_number, target = ?to_block, "Updating trie in chunks");
             let mut final_root = None;
             let total_chunks = range.clone().step_by(incremental_threshold as usize).count();
-            for (chunk_idx, start_block) in range.step_by(incremental_threshold as usize).enumerate() {
+            for (chunk_idx, start_block) in
+                range.step_by(incremental_threshold as usize).enumerate()
+            {
                 let chunk_to = std::cmp::min(start_block + incremental_threshold, to_block);
                 let chunk_range = start_block..=chunk_to;
                 info!(


### PR DESCRIPTION
## Summary

Upgrades the incremental merkle trie computation logging from `debug` to `info` level and adds chunk progress tracking (e.g. "chunk 3/12").

## Motivation

When syncing from an archive snapshot with a gap of <100K blocks, reth takes the incremental merkle path which processes blocks in chunks of 7,000. Currently this only logs at `debug` level, making it appear completely stuck to operators — the stage checkpoint doesn't update between chunks and the `info`-level status line shows no progress for hours.

This was observed on a real node loading a [publicnode.com](http://publicnode.com/) archive snapshot with an ~81K block gap, where MerkleExecute showed zero checkpoint movement for 4+ hours despite actively processing.

## Changes

- Bump `debug!` → `info!` for the incremental chunk processing log
- Add `chunk` and `total_chunks` fields so operators can see progress (e.g. "Processing incremental chunk chunk=3 total_chunks=12")