### PR TITLE
fix(codecs): return advanced buf from AlloyHeader::from_compact

### DIFF
--- a/crates/storage/codecs/src/alloy/header.rs
+++ b/crates/storage/codecs/src/alloy/header.rs
@@ -110,7 +110,7 @@ impl Compact for AlloyHeader {
     }
 
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
-        let (header, _) = Header::from_compact(buf, len);
+        let (header, buf) = Header::from_compact(buf, len);
         let alloy_header = Self {
             parent_hash: header.parent_hash,
             ommers_hash: header.ommers_hash,


### PR DESCRIPTION
`AlloyHeader::from_compact` was discarding the advanced buffer returned by the inner `Header::from_compact` call and returning the original unconsumed `buf`. This violates the `Compact` trait contract which requires the returned buffer to be advanced past the consumed bytes.

Any composite struct containing `AlloyHeader` (or `Option<AlloyHeader>`) as a field would read subsequent fields from the wrong offset, leading to silent data corruption.