### PR TITLE
feat(node): log hardfork activation events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9480,6 +9480,7 @@ dependencies = [
  "humantime",
  "pin-project",
  "reth-engine-primitives",
+ "reth-ethereum-forks",
  "reth-network-api",
  "reth-primitives-traits",
  "reth-prune-types",

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{ChainSpec, DepositContract};
+use crate::{ChainHardforks, ChainSpec, DepositContract};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
@@ -40,6 +40,9 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
 
     /// Returns a string representation of the hardforks.
     fn display_hardforks(&self) -> Box<dyn Display>;
+
+    /// Returns the chain's configured hardfork activation set.
+    fn hardforks(&self) -> ChainHardforks;
 
     /// The genesis header.
     fn genesis_header(&self) -> &Self::Header;
@@ -113,6 +116,10 @@ impl<H: BlockHeader> EthChainSpec for ChainSpec<H> {
 
     fn display_hardforks(&self) -> Box<dyn Display> {
         Box::new(Self::display_hardforks(self))
+    }
+
+    fn hardforks(&self) -> ChainHardforks {
+        self.hardforks.clone()
     }
 
     fn genesis_header(&self) -> &Self::Header {

--- a/crates/cli/commands/src/import_core.rs
+++ b/crates/cli/commands/src/import_core.rs
@@ -1,5 +1,6 @@
 //! Core import functionality without CLI dependencies.
 
+use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use futures::StreamExt;
 use reth_config::Config;
@@ -157,7 +158,20 @@ where
 
         let latest_block_number =
             provider_factory.get_stage_checkpoint(StageId::Finish)?.map(|ch| ch.block_number);
-        tokio::spawn(reth_node_events::node::handle_events(None, latest_block_number, events));
+        let latest_canonical_head = if let Some(number) = latest_block_number {
+            let header = provider_factory
+                .sealed_header(number)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(number.into()))?;
+            Some(reth_node_events::node::CanonicalHeadInfo::new(number, header.timestamp()))
+        } else {
+            None
+        };
+        tokio::spawn(reth_node_events::node::handle_events(
+            None,
+            latest_canonical_head,
+            None,
+            events,
+        ));
 
         // Run pipeline
         info!(target: "reth::import", "Starting sync pipeline");

--- a/crates/ethereum/hardforks/src/hardforks/mod.rs
+++ b/crates/ethereum/hardforks/src/hardforks/mod.rs
@@ -111,6 +111,38 @@ impl ChainHardforks {
         self.fork(fork).active_at_block(block_number)
     }
 
+    /// Returns hardforks that transition on the given block or timestamp boundary.
+    ///
+    /// Block-based and TTD-based forks are detected by checking whether they become active at
+    /// `block_number` after not being active on the previous block.
+    ///
+    /// Timestamp-based forks use `parent_timestamp` when it is available. If the parent timestamp
+    /// is unknown, the timestamp must exactly match the activation time to be considered a
+    /// transition.
+    pub fn transitions_at_block_or_timestamp(
+        &self,
+        block_number: u64,
+        timestamp: u64,
+        parent_timestamp: Option<u64>,
+    ) -> impl Iterator<Item = &dyn Hardfork> {
+        self.forks_iter().filter_map(move |(fork, condition)| {
+            let transitioned = match condition {
+                ForkCondition::Block(_) | ForkCondition::TTD { .. } => {
+                    condition.active_at_block(block_number) &&
+                        !condition.active_at_block(block_number.saturating_sub(1))
+                }
+                ForkCondition::Timestamp(activation_timestamp) => {
+                    parent_timestamp.map_or(timestamp == activation_timestamp, |parent_timestamp| {
+                        condition.transitions_at_timestamp(timestamp, parent_timestamp)
+                    })
+                }
+                ForkCondition::Never => false,
+            };
+
+            transitioned.then_some(fork)
+        })
+    }
+
     /// Inserts a fork with the given [`ForkCondition`], maintaining forks in ascending order
     /// based on the `Ord` implementation of [`ForkCondition`].
     ///
@@ -206,6 +238,7 @@ impl<T: Hardfork, const N: usize> From<[(T, ForkCondition); N]> for ChainHardfor
 mod tests {
     use super::*;
     use alloy_hardforks::hardfork;
+    use alloy_primitives::U256;
 
     hardfork!(AHardfork { A1, A2, A3 });
     hardfork!(BHardfork { B1, B2 });
@@ -318,5 +351,53 @@ mod tests {
         assert_eq!(fork_list[1].0.name(), "B1");
         assert_eq!(fork_list[2].0.name(), "A2");
         assert_eq!(fork_list[2].1, ForkCondition::Timestamp(3000));
+    }
+
+    #[test]
+    fn detects_hardfork_transitions_at_block_and_timestamp_boundaries() {
+        let forks = ChainHardforks::new(vec![
+            (AHardfork::A1.boxed(), ForkCondition::Block(10)),
+            (
+                AHardfork::A2.boxed(),
+                ForkCondition::TTD {
+                    activation_block_number: 20,
+                    fork_block: Some(20),
+                    total_difficulty: U256::from(1_000),
+                },
+            ),
+            (BHardfork::B1.boxed(), ForkCondition::Timestamp(100)),
+        ]);
+
+        let transitions: Vec<_> = forks
+            .transitions_at_block_or_timestamp(10, 99, Some(98))
+            .map(|fork| fork.name())
+            .collect();
+        assert_eq!(transitions, vec!["A1"]);
+
+        let transitions: Vec<_> = forks
+            .transitions_at_block_or_timestamp(20, 99, Some(98))
+            .map(|fork| fork.name())
+            .collect();
+        assert_eq!(transitions, vec!["A2"]);
+
+        let transitions: Vec<_> = forks
+            .transitions_at_block_or_timestamp(21, 100, Some(99))
+            .map(|fork| fork.name())
+            .collect();
+        assert_eq!(transitions, vec!["B1"]);
+    }
+
+    #[test]
+    fn falls_back_to_exact_timestamp_when_parent_timestamp_is_unknown() {
+        let forks =
+            ChainHardforks::new(vec![(BHardfork::B1.boxed(), ForkCondition::Timestamp(100))]);
+
+        let transitions: Vec<_> =
+            forks.transitions_at_block_or_timestamp(1, 100, None).map(|fork| fork.name()).collect();
+        assert_eq!(transitions, vec!["B1"]);
+
+        let transitions: Vec<_> =
+            forks.transitions_at_block_or_timestamp(2, 101, None).map(|fork| fork.name()).collect();
+        assert!(transitions.is_empty());
     }
 }

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -259,7 +259,8 @@ impl EngineNodeLauncher {
             "events task",
             node::handle_events(
                 Some(Box::new(ctx.components().network().clone())),
-                Some(ctx.head().number),
+                Some(node::CanonicalHeadInfo::new(ctx.head().number, ctx.head().timestamp)),
+                Some(ctx.chain_spec().hardforks()),
                 events,
             ),
         );

--- a/crates/node/events/Cargo.toml
+++ b/crates/node/events/Cargo.toml
@@ -19,6 +19,7 @@ reth-prune-types.workspace = true
 reth-static-file-types.workspace = true
 reth-primitives-traits.workspace = true
 reth-engine-primitives.workspace = true
+reth-ethereum-forks.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -9,6 +9,7 @@ use alloy_primitives::{BlockNumber, B256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use futures::Stream;
 use reth_engine_primitives::{ConsensusEngineEvent, ForkchoiceStatus, SlowBlockInfo};
+use reth_ethereum_forks::ChainHardforks;
 use reth_network_api::PeersInfo;
 use reth_primitives_traits::{format_gas, format_gas_throughput, BlockBody, NodePrimitives};
 use reth_prune_types::PrunerEvent;
@@ -27,6 +28,22 @@ use tracing::{debug, info, warn};
 /// Interval of reporting node state.
 const INFO_MESSAGE_INTERVAL: Duration = Duration::from_secs(25);
 
+/// The current canonical head known when the event handler starts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CanonicalHeadInfo {
+    /// The canonical block number.
+    pub number: BlockNumber,
+    /// The canonical block timestamp.
+    pub timestamp: u64,
+}
+
+impl CanonicalHeadInfo {
+    /// Creates a new canonical head snapshot.
+    pub const fn new(number: BlockNumber, timestamp: u64) -> Self {
+        Self { number, timestamp }
+    }
+}
+
 /// The current high-level state of the node, including the node's database environment, network
 /// connections, current processing stage, and the latest block information. It provides
 /// methods to handle different types of events that affect the node's state, such as pipeline
@@ -38,6 +55,10 @@ struct NodeState {
     current_stage: Option<CurrentStage>,
     /// The latest block reached by either pipeline or consensus engine.
     latest_block: Option<BlockNumber>,
+    /// Timestamp of the latest canonical block seen by the event handler.
+    last_canonical_block_timestamp: Option<u64>,
+    /// Hardfork activation data for the active chain.
+    hardforks: Option<ChainHardforks>,
     /// Hash of the head block last set by fork choice update
     head_block_hash: Option<B256>,
     /// Hash of the safe block last set by fork choice update
@@ -49,14 +70,17 @@ struct NodeState {
 }
 
 impl NodeState {
-    const fn new(
+    fn new(
         peers_info: Option<Box<dyn PeersInfo>>,
-        latest_block: Option<BlockNumber>,
+        latest_canonical_head: Option<CanonicalHeadInfo>,
+        hardforks: Option<ChainHardforks>,
     ) -> Self {
         Self {
             peers_info,
             current_stage: None,
-            latest_block,
+            latest_block: latest_canonical_head.map(|head| head.number),
+            last_canonical_block_timestamp: latest_canonical_head.map(|head| head.timestamp),
+            hardforks,
             head_block_hash: None,
             safe_block_hash: None,
             finalized_block_hash: None,
@@ -66,6 +90,19 @@ impl NodeState {
 
     fn num_connected_peers(&self) -> usize {
         self.peers_info.as_ref().map(|info| info.num_connected_peers()).unwrap_or_default()
+    }
+
+    fn activated_hardforks(&self, block_number: BlockNumber, timestamp: u64) -> Vec<&'static str> {
+        let Some(hardforks) = self.hardforks.as_ref() else { return Vec::new() };
+
+        hardforks
+            .transitions_at_block_or_timestamp(
+                block_number,
+                timestamp,
+                self.last_canonical_block_timestamp,
+            )
+            .map(|fork| fork.name())
+            .collect()
     }
 
     fn build_current_stage(
@@ -240,6 +277,8 @@ impl NodeState {
             }
             ConsensusEngineEvent::CanonicalBlockAdded(executed, elapsed) => {
                 let block = executed.sealed_block();
+                let activated_hardforks =
+                    self.activated_hardforks(block.number(), block.timestamp());
                 let mut full = block.gas_used() as f64 * 100.0 / block.gas_limit() as f64;
                 if full.is_nan() {
                     full = 0.0;
@@ -259,9 +298,20 @@ impl NodeState {
                     ?elapsed,
                     "Block added to canonical chain"
                 );
+                if !activated_hardforks.is_empty() {
+                    info!(
+                        number = block.number(),
+                        hash = ?block.hash(),
+                        timestamp = block.timestamp(),
+                        hardforks = ?activated_hardforks,
+                        "Hardfork activated"
+                    );
+                }
+                self.last_canonical_block_timestamp = Some(block.timestamp());
             }
             ConsensusEngineEvent::CanonicalChainCommitted(head, elapsed) => {
                 self.latest_block = Some(head.number());
+                self.last_canonical_block_timestamp = Some(head.timestamp());
                 info!(number=head.number(), hash=?head.hash(), ?elapsed, "Canonical chain committed");
             }
             ConsensusEngineEvent::ForkBlockAdded(executed, elapsed) => {
@@ -432,12 +482,13 @@ pub enum NodeEvent<N: NodePrimitives> {
 /// displays the high-level status of the node.
 pub async fn handle_events<E, N: NodePrimitives>(
     peers_info: Option<Box<dyn PeersInfo>>,
-    latest_block_number: Option<BlockNumber>,
+    latest_canonical_head: Option<CanonicalHeadInfo>,
+    hardforks: Option<ChainHardforks>,
     events: E,
 ) where
     E: Stream<Item = NodeEvent<N>> + Unpin,
 {
-    let state = NodeState::new(peers_info, latest_block_number);
+    let state = NodeState::new(peers_info, latest_canonical_head, hardforks);
 
     let start = tokio::time::Instant::now() + Duration::from_secs(3);
     let mut info_interval = tokio::time::interval_at(start, INFO_MESSAGE_INTERVAL);


### PR DESCRIPTION
## Summary
- add a helper for detecting hardfork transitions on block and timestamp boundaries
- thread canonical head metadata and hardfork configuration into node event handling
- emit a dedicated `Hardfork activated` log when a canonical block crosses a hardfork activation

## Testing
- cargo +nightly fmt --all
- cargo test -p reth-ethereum-forks
- cargo check -p reth-node-events -p reth-node-builder -p reth-cli-commands
- cargo test -p reth-node-events

Closes #20350
Refs SYM-2