### PR TITLE
fix(db): set RangeWalker is_done flag when cursor exhausted

### DIFF
--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -288,7 +288,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for RangeWalker<'_, T, CURSOR> {
             },
             Some(res @ Err(_)) => Some(res),
             None => {
-                self.is_done = matches!(self.end_key, Bound::Unbounded);
+                self.is_done = true;
                 None
             }
         }


### PR DESCRIPTION
Fix RangeWalker to always set is_done=true when cursor returns None, regardless of end_key bound type. Previously, is_done was only set for Unbounded ranges, causing redundant cursor.next() calls on subsequent iterations when using Included/Excluded bounds.