### PR TITLE
fix(docker): make symbol stripping configurable

### DIFF
--- a/.github/scripts/build_pgo_bolt.sh
+++ b/.github/scripts/build_pgo_bolt.sh
@@ -15,6 +15,7 @@
 #   PGO_BLOCKS      - Number of blocks for PGO profiling (default: 20)
 #   BOLT_BLOCKS     - Number of blocks for BOLT profiling (default: 20)
 #   SKIP_BOLT       - Temporarily skip BOLT phases (default: false)
+#   STRIP_SYMBOLS   - Strip debug symbols from output binary (default: true)
 #   COLLECT_PGO_ONLY - Stop after producing merged.profdata (default: false)
 #   PGO_PROFDATA    - Path to pre-collected merged.profdata (optional)
 #   PROFILE         - Cargo profile (default: maxperf-symbols)
@@ -48,6 +49,7 @@ cd "$(dirname "$0")/../.."
 PGO_BLOCKS="${PGO_BLOCKS:-20}"
 BOLT_BLOCKS="${BOLT_BLOCKS:-20}"
 SKIP_BOLT="${SKIP_BOLT:-false}"
+STRIP_SYMBOLS="${STRIP_SYMBOLS:-true}"
 COLLECT_PGO_ONLY="${COLLECT_PGO_ONLY:-false}"
 PROFILE="${PROFILE:-maxperf-symbols}"
 FEATURES="${FEATURES:-jemalloc,asm-keccak,min-debug-logs}"
@@ -62,6 +64,11 @@ RPC_URL="${RPC_URL:-}"
 SKIP_BOLT_BOOL=false
 if [[ "${SKIP_BOLT,,}" == "true" || "$SKIP_BOLT" == "1" ]]; then
     SKIP_BOLT_BOOL=true
+fi
+
+STRIP_SYMBOLS_BOOL=false
+if [[ "${STRIP_SYMBOLS,,}" == "true" || "$STRIP_SYMBOLS" == "1" ]]; then
+    STRIP_SYMBOLS_BOOL=true
 fi
 
 COLLECT_PGO_ONLY_BOOL=false
@@ -116,6 +123,7 @@ echo "LLVM:        $LLVM_VERSION"
 echo "PGO blocks:  $PGO_BLOCKS"
 echo "BOLT blocks: $BOLT_BLOCKS"
 echo "Skip BOLT:   $SKIP_BOLT"
+echo "Strip symbols: $STRIP_SYMBOLS"
 echo "Collect only: $COLLECT_PGO_ONLY"
 echo "PGO profdata: ${PGO_PROFDATA:-<collect with reth-bench>}"
 echo "RUSTFLAGS:   ${BASE_RUSTFLAGS:-<unset>}"
@@ -314,8 +322,12 @@ if [ "$SKIP_BOLT_BOOL" = true ]; then
         cargo build "${CARGO_ARGS[@]}" --target "$TARGET"
 
     BUILT_BIN="$PWD/target/$TARGET/$PROFILE_DIR/reth"
-    echo "Stripping debug symbols..."
-    strip "$BUILT_BIN"
+    if [ "$STRIP_SYMBOLS_BOOL" = true ]; then
+        echo "Stripping debug symbols..."
+        strip "$BUILT_BIN"
+    else
+        echo "Skipping strip (STRIP_SYMBOLS=$STRIP_SYMBOLS)"
+    fi
     publish_binary "$BUILT_BIN"
     gha_section_end
 else
@@ -386,8 +398,12 @@ else
         -use-gnu-stack \
         --skip-funcs='.*drop_in_place.*'
 
-    echo "Stripping debug symbols..."
-    strip "$OPTIMIZED_BIN"
+    if [ "$STRIP_SYMBOLS_BOOL" = true ]; then
+        echo "Stripping debug symbols..."
+        strip "$OPTIMIZED_BIN"
+    else
+        echo "Skipping strip (STRIP_SYMBOLS=$STRIP_SYMBOLS)"
+    fi
     publish_binary "$OPTIMIZED_BIN"
     gha_section_end
 fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,6 +139,7 @@ jobs:
             ${{ steps.params.outputs.ethereum_set }}
             *.args.USE_PGO_BOLT=${{ steps.pgo.outputs.use_pgo_bolt }}
             *.args.PGO_PROFDATA=${{ steps.pgo.outputs.pgo_profdata }}
+            *.args.STRIP_SYMBOLS=false
 
       - name: Verify image architectures
         env:

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -53,6 +53,10 @@ ENV USE_PGO_BOLT=$USE_PGO_BOLT
 ARG PGO_PROFDATA=""
 ENV PGO_PROFDATA=$PGO_PROFDATA
 
+# Whether to strip debug symbols from PGO-built binaries.
+ARG STRIP_SYMBOLS=true
+ENV STRIP_SYMBOLS=$STRIP_SYMBOLS
+
 # Build application
 # Platform-specific RUSTFLAGS: amd64 uses x86-64-v3 (Haswell+) with pclmulqdq for rocksdb
 ARG TARGETPLATFORM
@@ -65,7 +69,7 @@ RUN --mount=type=secret,id=DEPOT_TOKEN,env=SCCACHE_WEBDAV_TOKEN \
     sccache --start-server && \
     if [ "$USE_PGO_BOLT" = "true" ] && [ "$TARGETPLATFORM" = "linux/amd64" ] && [ -n "$PGO_PROFDATA" ] && [ -f "$PGO_PROFDATA" ]; then \
         apt-get update && apt-get install -y -qq lsb-release wget sudo && \
-        BINARY="$BINARY" PROFILE="$BUILD_PROFILE" FEATURES="$FEATURES" SKIP_BOLT=true PGO_PROFDATA="$PGO_PROFDATA" \
+        BINARY="$BINARY" PROFILE="$BUILD_PROFILE" FEATURES="$FEATURES" SKIP_BOLT=true STRIP_SYMBOLS="$STRIP_SYMBOLS" PGO_PROFDATA="$PGO_PROFDATA" \
             ./.github/scripts/build_pgo_bolt.sh; \
     else \
         if [ "$USE_PGO_BOLT" = "true" ]; then \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -39,6 +39,11 @@ variable "PGO_PROFDATA" {
   default = ""
 }
 
+// Whether to strip debug symbols in PGO build path.
+variable "STRIP_SYMBOLS" {
+  default = "true"
+}
+
 // Common settings for all targets
 group "default" {
   targets = ["ethereum"]
@@ -60,6 +65,7 @@ target "_base" {
     VERGEN_GIT_DIRTY    = "${VERGEN_GIT_DIRTY}"
     USE_PGO_BOLT        = "${USE_PGO_BOLT}"
     PGO_PROFDATA        = "${PGO_PROFDATA}"
+    STRIP_SYMBOLS       = "${STRIP_SYMBOLS}"
   }
   secret = [
     {


### PR DESCRIPTION
Adds a configurable STRIP_SYMBOLS flag for the Docker PGO+BOLT build path instead of hardcoding strip behavior. The flag is plumbed through build_pgo_bolt.sh, Dockerfile.depot, and docker-bake.hcl, and docker.yml now sets STRIP_SYMBOLS=false so Docker images retain symbols by default.

This keeps the behavior explicit and reusable for future builds that may still want stripped artifacts.