### PR TITLE
refactor(trie): use par_iter sum directly in arena prune

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2538,11 +2538,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
             } else {
                 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
-                let parallel_pruned: Vec<usize> = taken
+                pruned += taken
                     .par_iter_mut()
                     .map(|(_, subtrie, range)| subtrie.prune(&retained_leaves[range.clone()]))
-                    .collect();
-                pruned += parallel_pruned.into_iter().sum::<usize>();
+                    .sum::<usize>();
             }
 
             // Restore taken subtries into the upper arena.


### PR DESCRIPTION
Follow-up to [#22381](https://github.com/paradigmxyz/reth/pull/22381).

Replaces the intermediate `Vec<usize>` collect + sequential sum with a direct
`par_iter().sum::<usize>()` in the parallel prune path.