### PR TITLE
fix(reth-bench): preserve RequestsOrHash for engine_newPayloadV4

### DIFF
--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -235,8 +235,8 @@ pub(crate) fn payload_to_new_payload(
                         ))?,
                     )
                 } else {
-                    // Extract actual Requests from RequestsOrHash
-                    let requests = prague.requests.requests_hash();
+                    // Preserve the original RequestsOrHash payload for engine_newPayloadV4.
+                    let requests = prague.requests.clone();
                     (
                         version,
                         serde_json::to_value((


### PR DESCRIPTION
Preserve the original RequestsOrHash when building engine_newPayloadV4 params, so benchmarks send full requests when available and keep hash fallback otherwise.