### PR TITLE
feat(engine): add histogram metrics for proof target min_len values

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -135,6 +135,11 @@ pub(crate) struct MultiProofTaskMetrics {
     /// Time spent waiting for preserved sparse trie cache to become available.
     pub sparse_trie_cache_wait_duration_histogram: Histogram,
 
+    /// Histogram of `min_len` values for account proof targets.
+    pub sparse_trie_account_proof_min_len: Histogram,
+    /// Histogram of `min_len` values for storage proof targets.
+    pub sparse_trie_storage_proof_min_len: Histogram,
+
     /// Number of account leaf updates applied without needing a new proof (cache hits).
     pub sparse_trie_account_cache_hits: Histogram,
     /// Number of account leaf updates that required a new proof (cache misses).

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -100,6 +100,10 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     storage_cache_hits: u64,
     /// Accumulated storage leaf update cache misses.
     storage_cache_misses: u64,
+    /// Accumulated `min_len` values for account proof targets dispatched this block.
+    account_proof_min_lens: Vec<u8>,
+    /// Accumulated `min_len` values for storage proof targets dispatched this block.
+    storage_proof_min_lens: Vec<u8>,
     /// Pending proof targets queued for dispatch to proof workers.
     pending_targets: PendingTargets,
     /// Number of pending execution/prewarming updates received but not yet passed to
@@ -154,6 +158,8 @@ where
             account_cache_misses: 0,
             storage_cache_hits: 0,
             storage_cache_misses: 0,
+            account_proof_min_lens: Vec::new(),
+            storage_proof_min_lens: Vec::new(),
             pending_targets: Default::default(),
             pending_updates: Default::default(),
             metrics,
@@ -346,6 +352,12 @@ where
         self.metrics.sparse_trie_account_cache_misses.record(self.account_cache_misses as f64);
         self.metrics.sparse_trie_storage_cache_hits.record(self.storage_cache_hits as f64);
         self.metrics.sparse_trie_storage_cache_misses.record(self.storage_cache_misses as f64);
+        for min_len in self.account_proof_min_lens.drain(..) {
+            self.metrics.sparse_trie_account_proof_min_len.record(min_len as f64);
+        }
+        for min_len in self.storage_proof_min_lens.drain(..) {
+            self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
+        }
         self.account_cache_hits = 0;
         self.account_cache_misses = 0;
         self.storage_cache_hits = 0;
@@ -538,13 +550,13 @@ where
                 Entry::Occupied(mut entry) => {
                     if min_len < *entry.get() {
                         entry.insert(min_len);
-                        self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
+                        self.storage_proof_min_lens.push(min_len);
                         targets.push(ProofV2Target::new(path).with_min_len(min_len));
                     }
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(min_len);
-                    self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
+                    self.storage_proof_min_lens.push(min_len);
                     targets.push(ProofV2Target::new(path).with_min_len(min_len));
                 }
             })?;
@@ -584,14 +596,14 @@ where
                 Entry::Occupied(mut entry) => {
                     if min_len < *entry.get() {
                         entry.insert(min_len);
-                        self.metrics.sparse_trie_account_proof_min_len.record(min_len as f64);
+                        self.account_proof_min_lens.push(min_len);
                         self.pending_targets
                             .push_account_target(ProofV2Target::new(target).with_min_len(min_len));
                     }
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(min_len);
-                    self.metrics.sparse_trie_account_proof_min_len.record(min_len as f64);
+                    self.account_proof_min_lens.push(min_len);
                     self.pending_targets
                         .push_account_target(ProofV2Target::new(target).with_min_len(min_len));
                 }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -534,20 +534,18 @@ where
             let mut targets = Vec::new();
 
             let updates_len_before = updates.len();
-            trie.update_leaves(updates, |path, min_len| {
-                match fetched.entry(path) {
-                    Entry::Occupied(mut entry) => {
-                        if min_len < *entry.get() {
-                            entry.insert(min_len);
-                            self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
-                            targets.push(ProofV2Target::new(path).with_min_len(min_len));
-                        }
-                    }
-                    Entry::Vacant(entry) => {
+            trie.update_leaves(updates, |path, min_len| match fetched.entry(path) {
+                Entry::Occupied(mut entry) => {
+                    if min_len < *entry.get() {
                         entry.insert(min_len);
                         self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
                         targets.push(ProofV2Target::new(path).with_min_len(min_len));
                     }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(min_len);
+                    self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
+                    targets.push(ProofV2Target::new(path).with_min_len(min_len));
                 }
             })?;
             let updates_len_after = updates.len();

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -534,16 +534,20 @@ where
             let mut targets = Vec::new();
 
             let updates_len_before = updates.len();
-            trie.update_leaves(updates, |path, min_len| match fetched.entry(path) {
-                Entry::Occupied(mut entry) => {
-                    if min_len < *entry.get() {
+            trie.update_leaves(updates, |path, min_len| {
+                match fetched.entry(path) {
+                    Entry::Occupied(mut entry) => {
+                        if min_len < *entry.get() {
+                            entry.insert(min_len);
+                            self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
+                            targets.push(ProofV2Target::new(path).with_min_len(min_len));
+                        }
+                    }
+                    Entry::Vacant(entry) => {
                         entry.insert(min_len);
+                        self.metrics.sparse_trie_storage_proof_min_len.record(min_len as f64);
                         targets.push(ProofV2Target::new(path).with_min_len(min_len));
                     }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(min_len);
-                    targets.push(ProofV2Target::new(path).with_min_len(min_len));
                 }
             })?;
             let updates_len_after = updates.len();
@@ -582,12 +586,14 @@ where
                 Entry::Occupied(mut entry) => {
                     if min_len < *entry.get() {
                         entry.insert(min_len);
+                        self.metrics.sparse_trie_account_proof_min_len.record(min_len as f64);
                         self.pending_targets
                             .push_account_target(ProofV2Target::new(target).with_min_len(min_len));
                     }
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(min_len);
+                    self.metrics.sparse_trie_account_proof_min_len.record(min_len as f64);
                     self.pending_targets
                         .push_account_target(ProofV2Target::new(target).with_min_len(min_len));
                 }


### PR DESCRIPTION
## Summary
Add histogram metrics to track the distribution of `min_len` values for proof targets dispatched to proof workers.

## Changes
- Added `sparse_trie_account_proof_min_len` and `sparse_trie_storage_proof_min_len` histograms to `MultiProofTaskMetrics`
- Record `min_len` only when a target is actually enqueued (after dedup), so the metric reflects targets sent to workers
- Values accumulated in vecs during `update_leaves` and recorded once at the end (off the hot path)

## Note on histogram buckets
`min_len` values range from 0 to 64. The default Prometheus histogram buckets are duration-oriented (`0.005, 0.01, ... 10`) so most observations will land in `+Inf`, making the histogram useless with classic buckets. This works fine with native histograms enabled. Otherwise, custom buckets need to be registered for these metrics via `PrometheusBuilder::set_buckets_for_metric`.

## Testing
`cargo check -p reth-engine-tree` passes.

Closes https://linear.app/tempoxyz/issue/RETH-329

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey