### PR TITLE
feat(metrics): add transactions_processed_total counter

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -43,18 +43,20 @@ pub struct EngineApiMetrics {
 impl EngineApiMetrics {
     /// Records metrics for block execution.
     ///
-    /// This method updates metrics for execution time, gas usage, and the number
+    /// This method updates metrics for execution time, gas usage, transaction count, and the number
     /// of accounts, storage slots and bytecodes updated.
     pub fn record_block_execution<R>(
         &self,
         output: &BlockExecutionOutput<R>,
         execution_duration: Duration,
+        num_transactions: u64,
     ) {
         let execution_secs = execution_duration.as_secs_f64();
         let gas_used = output.result.gas_used;
 
-        // Update gas metrics
+        // Update gas and transaction metrics
         self.executor.gas_processed_total.increment(gas_used);
+        self.executor.transactions_processed_total.increment(num_transactions);
         self.executor.gas_per_second.set(gas_used as f64 / execution_secs);
         self.executor.gas_used_histogram.record(gas_used as f64);
         self.executor.execution_histogram.record(execution_secs);
@@ -597,7 +599,7 @@ mod tests {
             },
         };
 
-        metrics.record_block_execution(&output, Duration::from_millis(100));
+        metrics.record_block_execution(&output, Duration::from_millis(100), 1);
 
         let snapshot = snapshotter.snapshot().into_vec();
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -948,7 +948,7 @@ where
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
         let execution_duration = execution_start.elapsed();
-        self.metrics.record_block_execution(&output, execution_duration);
+        self.metrics.record_block_execution(&output, execution_duration, transaction_count as u64);
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
 

--- a/crates/evm/evm/src/metrics.rs
+++ b/crates/evm/evm/src/metrics.rs
@@ -2,7 +2,7 @@
 use alloy_consensus::BlockHeader;
 use metrics::{Counter, Gauge, Histogram};
 use reth_metrics::Metrics;
-use reth_primitives_traits::{Block, FastInstant as Instant, RecoveredBlock};
+use reth_primitives_traits::{Block, BlockBody, FastInstant as Instant, RecoveredBlock};
 
 /// Executor metrics.
 #[derive(Metrics, Clone)]
@@ -10,6 +10,8 @@ use reth_primitives_traits::{Block, FastInstant as Instant, RecoveredBlock};
 pub struct ExecutorMetrics {
     /// The total amount of gas processed.
     pub gas_processed_total: Counter,
+    /// The total number of transactions processed.
+    pub transactions_processed_total: Counter,
     /// The instantaneous amount of gas processed per second.
     pub gas_per_second: Gauge,
     /// The Histogram for amount of gas used.
@@ -38,7 +40,7 @@ pub struct ExecutorMetrics {
 
 impl ExecutorMetrics {
     /// Helper function for metered execution
-    fn metered<F, R>(&self, f: F) -> R
+    fn metered<F, R>(&self, num_transactions: u64, f: F) -> R
     where
         F: FnOnce() -> (u64, R),
     {
@@ -49,6 +51,7 @@ impl ExecutorMetrics {
 
         // Update gas metrics.
         self.gas_processed_total.increment(gas_used);
+        self.transactions_processed_total.increment(num_transactions);
         self.gas_per_second.set(gas_used as f64 / execution_duration);
         self.gas_used_histogram.record(gas_used as f64);
         self.execution_histogram.record(execution_duration);
@@ -68,7 +71,8 @@ impl ExecutorMetrics {
         B: Block,
         B::Header: BlockHeader,
     {
-        self.metered(|| (block.header().gas_used(), f(block)))
+        let num_transactions = block.body().transaction_count() as u64;
+        self.metered(num_transactions, || (block.header().gas_used(), f(block)))
     }
 }
 
@@ -109,7 +113,7 @@ mod tests {
     fn test_metered_helper_tracks_timing() {
         let metrics = ExecutorMetrics::default();
 
-        let result = metrics.metered(|| {
+        let result = metrics.metered(5, || {
             // Simulate some work
             std::thread::sleep(std::time::Duration::from_millis(10));
             (500, "test_result")


### PR DESCRIPTION
## Summary
Adds a `sync.execution.transactions_processed_total` counter to `ExecutorMetrics`, tracking the total number of transactions processed — the transaction-count equivalent of `gas_processed_total`.

## Motivation
There's currently no metric to reliably derive network TPS. Gas-based metrics (`gas_per_second`) exist but require knowing average gas per tx to approximate TPS. A direct transaction counter removes that guesswork.

## Changes
- Added `transactions_processed_total: Counter` to `ExecutorMetrics` (`crates/evm/evm/src/metrics.rs`)
- Updated `ExecutorMetrics::metered` to accept and record `num_transactions`
- Updated `ExecutorMetrics::metered_one` to derive tx count from `block.body().transaction_count()`
- Updated `EngineApiMetrics::record_block_execution` to accept and record `num_transactions`
- Updated all call sites and tests

## Testing
```
cargo check -p reth-evm -p reth-engine-tree
cargo clippy -p reth-evm -p reth-engine-tree --all-targets -- -D warnings
cargo test -p reth-evm -p reth-engine-tree -- metrics
```
All pass.

Prompted by: zygis