### PR TITLE
perf(engine): reuse BlockHashCache across block validations

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -534,6 +534,8 @@ pub struct BlockValidationMetrics {
     pub anchored_overlay_trie_updates_size: Histogram,
     /// Size of `AnchoredTrieInput` overlay `HashedPostStateSorted` (`total_len`)
     pub anchored_overlay_hashed_state_size: Histogram,
+    /// Number of block hashes cached after execution (BLOCKHASH opcode usage).
+    pub block_hash_cache_size: Histogram,
 }
 
 impl BlockValidationMetrics {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -44,7 +44,10 @@ use reth_provider::{
     ProviderError, PruneCheckpointReader, StageCheckpointReader, StateProvider,
     StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
+use reth_revm::db::{
+    states::{block_hash_cache::BlockHashCache, bundle_state::BundleRetention},
+    BundleAccount, State,
+};
 use reth_trie::{trie_cursor::TrieCursorFactory, updates::TrieUpdates, HashedPostState, StateRoot};
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
@@ -156,6 +159,9 @@ where
     validator: V,
     /// Changeset cache for in-memory trie changesets
     changeset_cache: ChangesetCache,
+    /// Block hash cache reused across block validations to avoid redundant DB lookups for the
+    /// `BLOCKHASH` opcode. Consecutive blocks share most of the 256-block window.
+    block_hash_cache: BlockHashCache,
     /// Task runtime for spawning parallel work.
     runtime: reth_tasks::Runtime,
 }
@@ -212,6 +218,7 @@ where
             metrics: EngineApiMetrics::default(),
             validator,
             changeset_cache,
+            block_hash_cache: BlockHashCache::default(),
             runtime,
         }
     }
@@ -873,6 +880,7 @@ where
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
                 .with_bundle_update()
+                .with_block_hashes(self.block_hash_cache.clone())
                 .build()
         });
 
@@ -946,6 +954,9 @@ where
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
+
+        // Preserve block hashes learned during execution for subsequent blocks.
+        self.block_hash_cache = std::mem::take(&mut db.block_hashes);
 
         let execution_duration = execution_start.elapsed();
         self.metrics.record_block_execution(&output, execution_duration);

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -957,6 +957,10 @@ where
 
         // Preserve block hashes learned during execution for subsequent blocks.
         self.block_hash_cache = std::mem::take(&mut db.block_hashes);
+        self.metrics
+            .block_validation
+            .block_hash_cache_size
+            .record(self.block_hash_cache.iter().count() as f64);
 
         let execution_duration = execution_start.elapsed();
         self.metrics.record_block_execution(&output, execution_duration);


### PR DESCRIPTION
Closes #22913

Reuses the revm `BlockHashCache` across consecutive block validations in `BasicEngineValidator`. Consecutive blocks share 255/256 of the BLOCKHASH window, so persisting the cache eliminates redundant DB lookups for the `BLOCKHASH` opcode.

The cache is a fixed 256-slot array (~10KB), so the clone cost per block is negligible.

Also adds a `sync.block_validation.block_hash_cache_size` metric to track how many block hashes are cached per block, providing visibility into BLOCKHASH opcode usage frequency.