### PR TITLE
fix(rpc): zero parentBeaconBlockRoot in eth_simulateV1

### DIFF
--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -191,7 +191,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// Context required for configuring next block environment.
     ///
     /// Contains values that can't be derived from the parent block.
-    type NextBlockEnvCtx: Debug + Clone;
+    type NextBlockEnvCtx: Debug + Clone + ZeroParentBeaconBlockRoot;
 
     /// Configured [`BlockExecutorFactory`], contains [`EvmFactory`] internally.
     type BlockExecutorFactory: for<'a> BlockExecutorFactory<
@@ -505,6 +505,24 @@ pub struct NextBlockEnvAttributes {
     pub withdrawals: Option<Withdrawals>,
     /// Optional extra data.
     pub extra_data: Bytes,
+}
+
+/// Trait for zeroing the parent beacon block root in simulation contexts.
+///
+/// In `eth_simulateV1`, consensus-layer fields like `parentBeaconBlockRoot` default to zero
+/// (matching `prevRandao`, `mixHash`, `nonce`). This trait allows the simulation code path
+/// to zero the beacon root on a generic `NextBlockEnvCtx` without knowing its concrete type.
+///
+/// The default implementation is a no-op for types that don't have this field.
+pub trait ZeroParentBeaconBlockRoot {
+    /// Sets `parent_beacon_block_root` to `Some(B256::ZERO)` if the field is present.
+    fn zero_parent_beacon_block_root(&mut self) {}
+}
+
+impl ZeroParentBeaconBlockRoot for NextBlockEnvAttributes {
+    fn zero_parent_beacon_block_root(&mut self) {
+        self.parent_beacon_block_root = self.parent_beacon_block_root.map(|_| B256::ZERO);
+    }
 }
 
 /// Abstraction over transaction environment.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -21,7 +21,7 @@ use futures::Future;
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
-    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnv, TxEnvFor,
+    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnv, TxEnvFor, ZeroParentBeaconBlockRoot,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -127,9 +127,16 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         .into());
                     }
 
+                    let mut next_attrs = this.next_env_attributes(&parent)?;
+                    // Zero parentBeaconBlockRoot for simulated blocks by default,
+                    // matching spec behavior where consensus-layer fields default
+                    // to zero. User overrides are applied later via
+                    // apply_block_overrides.
+                    next_attrs.zero_parent_beacon_block_root();
+
                     let mut evm_env = this
                         .evm_config()
-                        .next_evm_env(&parent, &this.next_env_attributes(&parent)?)
+                        .next_evm_env(&parent, &next_attrs)
                         .map_err(RethError::other)
                         .map_err(Self::Error::from_eth_err)?;
 
@@ -205,7 +212,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let ctx = this
                         .evm_config()
-                        .context_for_next_block(&parent, this.next_env_attributes(&parent)?)
+                        .context_for_next_block(&parent, next_attrs)
                         .map_err(RethError::other)
                         .map_err(Self::Error::from_eth_err)?;
                     let map_err = |e: EthApiError| -> Self::Error {


### PR DESCRIPTION
Zeroes `parentBeaconBlockRoot` for simulated blocks in `eth_simulateV1`, 
matching geth behavior and the spec's default block values table where consensus-layer fields default to zero.

Seems this is zero in the first place, and changed in #19645