### PR TITLE
fix: resolve exit future once engine exits

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -416,10 +416,7 @@ impl EngineNodeLauncher {
         ctx.spawn_ethstats(engine_events_for_ethstats).await?;
 
         let handle = NodeHandle {
-            node_exit_future: NodeExitFuture::new(
-                async { rx.await? },
-                full_node.config.debug.terminate,
-            ),
+            node_exit_future: NodeExitFuture::new(async { rx.await? }),
             node: full_node,
         };
 

--- a/crates/node/core/src/exit.rs
+++ b/crates/node/core/src/exit.rs
@@ -13,27 +13,21 @@ pub struct NodeExitFuture {
     /// The consensus engine future.
     /// This can be polled to wait for the consensus engine to exit.
     consensus_engine_fut: Option<BoxFuture<'static, eyre::Result<()>>>,
-
-    /// Flag indicating whether the node should be terminated after the pipeline sync.
-    terminate: bool,
 }
 
 impl fmt::Debug for NodeExitFuture {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NodeExitFuture")
-            .field("consensus_engine_fut", &"...")
-            .field("terminate", &self.terminate)
-            .finish()
+        f.debug_struct("NodeExitFuture").field("consensus_engine_fut", &"...").finish()
     }
 }
 
 impl NodeExitFuture {
     /// Create a new `NodeExitFuture`.
-    pub fn new<F>(consensus_engine_fut: F, terminate: bool) -> Self
+    pub fn new<F>(consensus_engine_fut: F) -> Self
     where
         F: Future<Output = eyre::Result<()>> + 'static + Send,
     {
-        Self { consensus_engine_fut: Some(Box::pin(consensus_engine_fut)), terminate }
+        Self { consensus_engine_fut: Some(Box::pin(consensus_engine_fut)) }
     }
 }
 
@@ -46,11 +40,7 @@ impl Future for NodeExitFuture {
             match ready!(rx.poll_unpin(cx)) {
                 Ok(_) => {
                     this.consensus_engine_fut.take();
-                    if this.terminate {
-                        Poll::Ready(Ok(()))
-                    } else {
-                        Poll::Pending
-                    }
+                    Poll::Ready(Ok(()))
                 }
                 Err(err) => Poll::Ready(Err(err)),
             }
@@ -69,7 +59,7 @@ mod tests {
     async fn test_node_exit_future_terminate_true() {
         let fut = async { Ok(()) };
 
-        let node_exit_future = NodeExitFuture::new(fut, true);
+        let node_exit_future = NodeExitFuture::new(fut);
 
         let res = node_exit_future.await;
 
@@ -80,7 +70,7 @@ mod tests {
     async fn test_node_exit_future_terminate_false() {
         let fut = async { Ok(()) };
 
-        let mut node_exit_future = NodeExitFuture::new(fut, false);
+        let mut node_exit_future = NodeExitFuture::new(fut);
         poll_fn(|cx| {
             assert!(node_exit_future.poll_unpin(cx).is_pending());
             Poll::Ready(())

--- a/crates/node/core/src/exit.rs
+++ b/crates/node/core/src/exit.rs
@@ -53,10 +53,9 @@ impl Future for NodeExitFuture {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::future::poll_fn;
 
     #[tokio::test]
-    async fn test_node_exit_future_terminate_true() {
+    async fn test_node_exit_future() {
         let fut = async { Ok(()) };
 
         let node_exit_future = NodeExitFuture::new(fut);
@@ -64,17 +63,5 @@ mod tests {
         let res = node_exit_future.await;
 
         assert!(res.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_node_exit_future_terminate_false() {
-        let fut = async { Ok(()) };
-
-        let mut node_exit_future = NodeExitFuture::new(fut);
-        poll_fn(|cx| {
-            assert!(node_exit_future.poll_unpin(cx).is_pending());
-            Poll::Ready(())
-        })
-        .await;
     }
 }


### PR DESCRIPTION
Right now if consensus engine exits with an `Ok` outcome the `node_exit_future` will never resolve because it will hit the `terminate == false` branch.

I'm guessing that this logic is a left-over from legacy engine that is no longer relevant because consensus engine always stays alive (unless actually terminated) — maybe relevant PR https://github.com/paradigmxyz/reth/pull/6587

This only became an issue now because https://github.com/paradigmxyz/reth/pull/22698 made the engine exit gracefully on runtime shutdown which wasn't the case before and thus we were always entering the `Err(_)` branch