### PR TITLE
feat(otlp): set client-side timestamp on OTLP log records

### DIFF
--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -95,10 +95,37 @@ pub fn log_layer(
 
     let logger_provider = SdkLoggerProvider::builder()
         .with_resource(resource)
+        .with_log_processor(TimestampLogProcessor)
         .with_batch_exporter(log_exporter)
         .build();
 
     Ok(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&logger_provider))
+}
+
+/// Sets `timestamp` on every log record so backends receive a stable client-side
+/// event time. The `opentelemetry-appender-tracing` bridge only sets
+/// `observed_timestamp`, which means backends that don't fall back to it (e.g.
+/// VictoriaLogs receiving OTLP directly) use ingestion time instead. If the same
+/// log is delivered twice (retry, duplicate exporter), the two copies get
+/// different ingestion times, making deduplication impossible.
+#[cfg(feature = "otlp-logs")]
+#[derive(Debug)]
+struct TimestampLogProcessor;
+
+#[cfg(feature = "otlp-logs")]
+impl opentelemetry_sdk::logs::LogProcessor for TimestampLogProcessor {
+    fn emit(
+        &self,
+        record: &mut opentelemetry_sdk::logs::SdkLogRecord,
+        _instrumentation: &opentelemetry::InstrumentationScope,
+    ) {
+        use opentelemetry::logs::LogRecord;
+        record.set_timestamp(std::time::SystemTime::now());
+    }
+
+    fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        Ok(())
+    }
 }
 
 /// Configuration for OTLP trace export.


### PR DESCRIPTION
## Summary
Sets `timestamp` (TimeUnixNano) on OTLP log records via a `TimestampLogProcessor`.

## Motivation
The `opentelemetry-appender-tracing` bridge [intentionally](https://github.com/open-telemetry/opentelemetry-rust/issues/1479) only sets `observed_timestamp`, not `timestamp`. Backends that receive OTLP logs directly (without a collector in between) — like our VictoriaLogs setup — use ingestion time as `_time`. If the same log arrives twice (sender retry, duplicate exporter), each copy gets a different ingestion timestamp, making deduplication impossible.

## Changes
- Added `TimestampLogProcessor` in `reth-tracing-otlp` that calls `set_timestamp(SystemTime::now())` on each log record
- Registered it before the batch exporter in the `SdkLoggerProvider` pipeline

`SystemTime::now()` is a vDSO call on Linux (~25ns), negligible vs the rest of the log pipeline.

## Testing
`cargo check -p reth-tracing-otlp --features otlp-logs` passes.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie