### PR TITLE
ci(docker): add disable_pgo input for workflow dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
     secrets: inherit
 
   build:
-    if: github.repository == 'paradigmxyz/reth'
+    if: github.repository == 'paradigmxyz/reth' && !failure() && !cancelled()
     name: Build Docker images
     runs-on: ubuntu-24.04
     needs: collect-pgo-profile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: boolean
         default: false
+      disable_pgo:
+        description: "Disable PGO profiling entirely"
+        required: false
+        type: boolean
+        default: false
       pgo_blocks:
         description: "Number of blocks to execute for PGO profiling"
         required: false
@@ -36,7 +41,7 @@ on:
 
 jobs:
   collect-pgo-profile:
-    if: github.repository == 'paradigmxyz/reth'
+    if: github.repository == 'paradigmxyz/reth' && !(github.event_name == 'workflow_dispatch' && inputs.disable_pgo)
     uses: ./.github/workflows/pgo-profile.yml
     with:
       pgo_blocks: ${{ github.event_name == 'workflow_dispatch' && inputs.pgo_blocks || '20' }}
@@ -72,6 +77,7 @@ jobs:
           echo "dirty=false" >> "$GITHUB_OUTPUT"
 
       - name: Download pre-collected PGO profile
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.disable_pgo) }}
         uses: actions/download-artifact@v7
         with:
           name: pgo-profdata
@@ -80,13 +86,19 @@ jobs:
       - name: Configure PGO build args
         id: pgo
         run: |
-          if [ ! -f dist/merged.profdata ]; then
-            echo "::error::Expected dist/merged.profdata from collect-pgo-profile job"
-            exit 1
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ inputs.disable_pgo }}" == "true" ]]; then
+            echo "use_pgo_bolt=false" >> "$GITHUB_OUTPUT"
+            echo "pgo_profdata=" >> "$GITHUB_OUTPUT"
+            echo "PGO disabled via workflow input"
+          else
+            if [ ! -f dist/merged.profdata ]; then
+              echo "::error::Expected dist/merged.profdata from collect-pgo-profile job"
+              exit 1
+            fi
+            echo "use_pgo_bolt=true" >> "$GITHUB_OUTPUT"
+            echo "pgo_profdata=dist/merged.profdata" >> "$GITHUB_OUTPUT"
+            echo "Using pre-collected PGO profile from collect-pgo-profile job"
           fi
-          echo "use_pgo_bolt=true" >> "$GITHUB_OUTPUT"
-          echo "pgo_profdata=dist/merged.profdata" >> "$GITHUB_OUTPUT"
-          echo "Using pre-collected PGO profile from collect-pgo-profile job"
 
       - name: Determine build parameters
         id: params


### PR DESCRIPTION
Adds a `disable_pgo` boolean input to the docker workflow dispatch so PGO profiling can be skipped entirely.

When enabled:
- Skips the `collect-pgo-profile` job
- Skips artifact download
- Sets `USE_PGO_BOLT=false` in build args

Prompted by: alexey