### PR TITLE
feat(net): add snap/2 protocol support with BAL-based healing

### DIFF
--- a/crates/net/eth-wire-types/src/capability.rs
+++ b/crates/net/eth-wire-types/src/capability.rs
@@ -1,6 +1,6 @@
 //! All capability related types
 
-use crate::{EthMessageID, EthVersion};
+use crate::{EthMessageID, EthVersion, SnapVersion};
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use alloy_primitives::bytes::Bytes;
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
@@ -115,6 +115,21 @@ impl Capability {
         Self::eth(EthVersion::Eth71)
     }
 
+    /// Returns the corresponding snap capability for the given version.
+    pub const fn snap(version: SnapVersion) -> Self {
+        Self::new_static("snap", version as usize)
+    }
+
+    /// Returns the snap/1 capability.
+    pub const fn snap_1() -> Self {
+        Self::snap(SnapVersion::Snap1)
+    }
+
+    /// Returns the snap/2 capability.
+    pub const fn snap_2() -> Self {
+        Self::snap(SnapVersion::Snap2)
+    }
+
     /// Whether this is eth v66 protocol.
     #[inline]
     pub fn is_eth_v66(&self) -> bool {
@@ -161,6 +176,24 @@ impl Capability {
             self.is_eth_v70() ||
             self.is_eth_v71()
     }
+
+    /// Whether this is snap/1 protocol.
+    #[inline]
+    pub fn is_snap_v1(&self) -> bool {
+        self.name == "snap" && self.version == 1
+    }
+
+    /// Whether this is snap/2 protocol.
+    #[inline]
+    pub fn is_snap_v2(&self) -> bool {
+        self.name == "snap" && self.version == 2
+    }
+
+    /// Whether this is any snap version.
+    #[inline]
+    pub fn is_snap(&self) -> bool {
+        self.is_snap_v1() || self.is_snap_v2()
+    }
 }
 
 impl fmt::Display for Capability {
@@ -196,6 +229,8 @@ pub struct Capabilities {
     eth_69: bool,
     eth_70: bool,
     eth_71: bool,
+    snap_1: bool,
+    snap_2: bool,
 }
 
 impl Capabilities {
@@ -208,6 +243,8 @@ impl Capabilities {
             eth_69: value.iter().any(Capability::is_eth_v69),
             eth_70: value.iter().any(Capability::is_eth_v70),
             eth_71: value.iter().any(Capability::is_eth_v71),
+            snap_1: value.iter().any(Capability::is_snap_v1),
+            snap_2: value.iter().any(Capability::is_snap_v2),
             inner: value,
         }
     }
@@ -264,6 +301,24 @@ impl Capabilities {
     pub const fn supports_eth_v71(&self) -> bool {
         self.eth_71
     }
+
+    /// Whether the peer supports `snap` sub-protocol.
+    #[inline]
+    pub const fn supports_snap(&self) -> bool {
+        self.snap_1 || self.snap_2
+    }
+
+    /// Whether this peer supports snap/1 protocol.
+    #[inline]
+    pub const fn supports_snap_v1(&self) -> bool {
+        self.snap_1
+    }
+
+    /// Whether this peer supports snap/2 protocol.
+    #[inline]
+    pub const fn supports_snap_v2(&self) -> bool {
+        self.snap_2
+    }
 }
 
 impl From<Vec<Capability>> for Capabilities {
@@ -289,6 +344,8 @@ impl Decodable for Capabilities {
             eth_69: inner.iter().any(Capability::is_eth_v69),
             eth_70: inner.iter().any(Capability::is_eth_v70),
             eth_71: inner.iter().any(Capability::is_eth_v71),
+            snap_1: inner.iter().any(Capability::is_snap_v1),
+            snap_2: inner.iter().any(Capability::is_snap_v2),
             inner,
         })
     }

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -3,12 +3,67 @@
 //! facilitating the exchange of Ethereum state snapshots between peers
 //! Reference: [Ethereum Snapshot Protocol](https://github.com/ethereum/devp2p/blob/master/caps/snap.md#protocol-messages)
 //!
-//! Current version: snap/1
+//! Supported versions: snap/1, snap/2
+//!
+//! snap/2 replaces the trie healing messages (GetTrieNodes/TrieNodes at 0x06/0x07) with
+//! BAL-based healing messages (GetBlockAccessLists/BlockAccessLists), enabling deterministic
+//! state healing via sequential BAL application instead of iterative trie node fetching.
+//! See: <https://ethresear.ch/t/snap-v2-replacing-trie-healing-with-bals/24333>
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Bytes, B256};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
+use core::fmt;
 use reth_codecs_derive::add_arbitrary_tests;
+
+/// The snap protocol version.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub enum SnapVersion {
+    /// snap/1: original snap sync with trie healing via GetTrieNodes/TrieNodes.
+    Snap1 = 1,
+    /// snap/2: replaces trie healing with BAL-based healing via
+    /// GetBlockAccessLists/BlockAccessLists.
+    Snap2 = 2,
+}
+
+impl SnapVersion {
+    /// The latest known snap version.
+    pub const LATEST: Self = Self::Snap2;
+
+    /// All supported snap versions, ordered newest first.
+    pub const ALL_VERSIONS: &'static [Self] = &[Self::Snap2, Self::Snap1];
+
+    /// Returns true if this is snap/1.
+    pub const fn is_snap1(&self) -> bool {
+        matches!(self, Self::Snap1)
+    }
+
+    /// Returns true if this is snap/2.
+    pub const fn is_snap2(&self) -> bool {
+        matches!(self, Self::Snap2)
+    }
+}
+
+impl fmt::Display for SnapVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "snap/{}", *self as u8)
+    }
+}
+
+impl TryFrom<u8> for SnapVersion {
+    type Error = String;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Snap1),
+            2 => Ok(Self::Snap2),
+            _ => Err(alloc::format!("unknown snap version: {value}")),
+        }
+    }
+}
 
 /// Message IDs for the snap sync protocol
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -187,7 +242,45 @@ pub struct TrieNodesMessage {
     pub nodes: Vec<Bytes>,
 }
 
+/// Request for block access lists (snap/2, message ID 0x06).
+///
+/// In snap/2, this replaces `GetTrieNodes`. Nodes request BALs for blocks that advanced
+/// during the state download phase, enabling deterministic healing.
+///
+/// Format: `[request-id: P, [blockhash₁: B_32, blockhash₂: B_32, ...]]`
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub struct GetBlockAccessListsSnapMessage {
+    /// Request ID to match up responses with
+    pub request_id: u64,
+    /// Block hashes to retrieve block access lists for
+    pub block_hashes: Vec<B256>,
+}
+
+/// Response containing block access lists (snap/2, message ID 0x07).
+///
+/// In snap/2, this replaces `TrieNodes`. Each BAL can be verified against its header
+/// commitment: `keccak256(rlp(bal)) == header.block_access_list_hash`.
+///
+/// Format: `[request-id: P, [block-access-list₁, block-access-list₂, ...]]`
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[add_arbitrary_tests(rlp)]
+pub struct BlockAccessListsSnapMessage {
+    /// ID of the request this is a response for
+    pub request_id: u64,
+    /// The requested block access lists, in the same order as the request.
+    /// Empty entries (zero-length bytes) indicate unavailable BALs.
+    pub access_lists: Vec<Bytes>,
+}
+
 /// Represents all types of messages in the snap sync protocol.
+///
+/// Messages 0x00–0x05 are shared across snap/1 and snap/2.
+/// Messages 0x06–0x07 differ by version:
+/// - snap/1: `GetTrieNodes` / `TrieNodes`
+/// - snap/2: `GetBlockAccessLists` / `BlockAccessLists`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SnapProtocolMessage {
     /// Request for an account range - see [`GetAccountRangeMessage`]
@@ -202,16 +295,22 @@ pub enum SnapProtocolMessage {
     GetByteCodes(GetByteCodesMessage),
     /// Response with contract codes - see [`ByteCodesMessage`]
     ByteCodes(ByteCodesMessage),
-    /// Request for trie nodes - see [`GetTrieNodesMessage`]
+    /// Request for trie nodes (snap/1 only) - see [`GetTrieNodesMessage`]
     GetTrieNodes(GetTrieNodesMessage),
-    /// Response with trie nodes - see [`TrieNodesMessage`]
+    /// Response with trie nodes (snap/1 only) - see [`TrieNodesMessage`]
     TrieNodes(TrieNodesMessage),
+    /// Request for block access lists (snap/2 only) - see [`GetBlockAccessListsSnapMessage`]
+    GetBlockAccessLists(GetBlockAccessListsSnapMessage),
+    /// Response with block access lists (snap/2 only) - see [`BlockAccessListsSnapMessage`]
+    BlockAccessLists(BlockAccessListsSnapMessage),
 }
 
 impl SnapProtocolMessage {
     /// Returns the protocol message ID for this message type.
     ///
     /// The message ID is used in the `RLPx` protocol to identify different types of messages.
+    /// Note: snap/2's GetBlockAccessLists/BlockAccessLists reuse the same IDs (0x06/0x07)
+    /// as snap/1's GetTrieNodes/TrieNodes.
     pub const fn message_id(&self) -> SnapMessageId {
         match self {
             Self::GetAccountRange(_) => SnapMessageId::GetAccountRange,
@@ -220,8 +319,8 @@ impl SnapProtocolMessage {
             Self::StorageRanges(_) => SnapMessageId::StorageRanges,
             Self::GetByteCodes(_) => SnapMessageId::GetByteCodes,
             Self::ByteCodes(_) => SnapMessageId::ByteCodes,
-            Self::GetTrieNodes(_) => SnapMessageId::GetTrieNodes,
-            Self::TrieNodes(_) => SnapMessageId::TrieNodes,
+            Self::GetTrieNodes(_) | Self::GetBlockAccessLists(_) => SnapMessageId::GetTrieNodes,
+            Self::TrieNodes(_) | Self::BlockAccessLists(_) => SnapMessageId::TrieNodes,
         }
     }
 
@@ -241,81 +340,63 @@ impl SnapProtocolMessage {
             Self::ByteCodes(msg) => msg.encode(&mut buf),
             Self::GetTrieNodes(msg) => msg.encode(&mut buf),
             Self::TrieNodes(msg) => msg.encode(&mut buf),
+            Self::GetBlockAccessLists(msg) => msg.encode(&mut buf),
+            Self::BlockAccessLists(msg) => msg.encode(&mut buf),
         }
 
         Bytes::from(buf)
     }
 
     /// Decodes a SNAP protocol message from its message ID and RLP-encoded body.
-    pub fn decode(message_id: u8, buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-        // Decoding protocol message variants based on message ID
-        macro_rules! decode_snap_message_variant {
-            ($message_id:expr, $buf:expr, $id:expr, $variant:ident, $msg_type:ty) => {
-                if $message_id == $id as u8 {
-                    return Ok(Self::$variant(<$msg_type>::decode($buf)?));
+    ///
+    /// For message IDs 0x06/0x07, the `snap_version` determines the decoded type:
+    /// - snap/1: `GetTrieNodes` / `TrieNodes`
+    /// - snap/2: `GetBlockAccessLists` / `BlockAccessLists`
+    pub fn decode_versioned(
+        snap_version: SnapVersion,
+        message_id: u8,
+        buf: &mut &[u8],
+    ) -> Result<Self, alloy_rlp::Error> {
+        match message_id {
+            id if id == SnapMessageId::GetAccountRange as u8 => {
+                Ok(Self::GetAccountRange(GetAccountRangeMessage::decode(buf)?))
+            }
+            id if id == SnapMessageId::AccountRange as u8 => {
+                Ok(Self::AccountRange(AccountRangeMessage::decode(buf)?))
+            }
+            id if id == SnapMessageId::GetStorageRanges as u8 => {
+                Ok(Self::GetStorageRanges(GetStorageRangesMessage::decode(buf)?))
+            }
+            id if id == SnapMessageId::StorageRanges as u8 => {
+                Ok(Self::StorageRanges(StorageRangesMessage::decode(buf)?))
+            }
+            id if id == SnapMessageId::GetByteCodes as u8 => {
+                Ok(Self::GetByteCodes(GetByteCodesMessage::decode(buf)?))
+            }
+            id if id == SnapMessageId::ByteCodes as u8 => {
+                Ok(Self::ByteCodes(ByteCodesMessage::decode(buf)?))
+            }
+            id if id == SnapMessageId::GetTrieNodes as u8 => match snap_version {
+                SnapVersion::Snap1 => Ok(Self::GetTrieNodes(GetTrieNodesMessage::decode(buf)?)),
+                SnapVersion::Snap2 => {
+                    Ok(Self::GetBlockAccessLists(GetBlockAccessListsSnapMessage::decode(buf)?))
                 }
-            };
+            },
+            id if id == SnapMessageId::TrieNodes as u8 => match snap_version {
+                SnapVersion::Snap1 => Ok(Self::TrieNodes(TrieNodesMessage::decode(buf)?)),
+                SnapVersion::Snap2 => {
+                    Ok(Self::BlockAccessLists(BlockAccessListsSnapMessage::decode(buf)?))
+                }
+            },
+            _ => Err(alloy_rlp::Error::Custom("Unknown message ID")),
         }
+    }
 
-        // Try to decode each message type based on the message ID
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::GetAccountRange,
-            GetAccountRange,
-            GetAccountRangeMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::AccountRange,
-            AccountRange,
-            AccountRangeMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::GetStorageRanges,
-            GetStorageRanges,
-            GetStorageRangesMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::StorageRanges,
-            StorageRanges,
-            StorageRangesMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::GetByteCodes,
-            GetByteCodes,
-            GetByteCodesMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::ByteCodes,
-            ByteCodes,
-            ByteCodesMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::GetTrieNodes,
-            GetTrieNodes,
-            GetTrieNodesMessage
-        );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::TrieNodes,
-            TrieNodes,
-            TrieNodesMessage
-        );
-
-        Err(alloy_rlp::Error::Custom("Unknown message ID"))
+    /// Decodes a SNAP protocol message assuming snap/1.
+    ///
+    /// For backwards compatibility with code that doesn't track snap versions.
+    pub fn decode(message_id: u8, buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+        Self::decode_versioned(SnapVersion::Snap1, message_id, buf)
     }
 }
 
@@ -328,18 +409,24 @@ mod tests {
         B256::left_padding_from(&value.to_be_bytes())
     }
 
-    // Helper function to test roundtrip encoding/decoding
-    fn test_roundtrip(original: SnapProtocolMessage) {
+    // Helper function to test roundtrip encoding/decoding for a specific snap version
+    fn test_roundtrip_versioned(snap_version: SnapVersion, original: SnapProtocolMessage) {
         let encoded = original.encode();
 
         // Verify the first byte matches the expected message ID
         assert_eq!(encoded[0], original.message_id() as u8);
 
         let mut buf = &encoded[1..];
-        let decoded = SnapProtocolMessage::decode(encoded[0], &mut buf).unwrap();
+        let decoded =
+            SnapProtocolMessage::decode_versioned(snap_version, encoded[0], &mut buf).unwrap();
 
         // Verify the match
         assert_eq!(decoded, original);
+    }
+
+    // Helper for snap/1 roundtrip
+    fn test_roundtrip(original: SnapProtocolMessage) {
+        test_roundtrip_versioned(SnapVersion::Snap1, original);
     }
 
     #[test]
@@ -407,17 +494,92 @@ mod tests {
     }
 
     #[test]
+    fn test_snap2_message_roundtrips() {
+        test_roundtrip_versioned(
+            SnapVersion::Snap2,
+            SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsSnapMessage {
+                request_id: 42,
+                block_hashes: vec![b256_from_u64(100), b256_from_u64(101), b256_from_u64(102)],
+            }),
+        );
+
+        test_roundtrip_versioned(
+            SnapVersion::Snap2,
+            SnapProtocolMessage::BlockAccessLists(BlockAccessListsSnapMessage {
+                request_id: 42,
+                access_lists: vec![
+                    Bytes::from(vec![1, 2, 3]),
+                    Bytes::from(vec![4, 5, 6]),
+                    Bytes::new(), // empty = unavailable
+                ],
+            }),
+        );
+    }
+
+    #[test]
+    fn test_snap2_shared_messages_roundtrip() {
+        // Messages 0x00-0x05 should decode identically under both snap/1 and snap/2
+        let msg = SnapProtocolMessage::GetAccountRange(GetAccountRangeMessage {
+            request_id: 1,
+            root_hash: b256_from_u64(1),
+            starting_hash: b256_from_u64(2),
+            limit_hash: b256_from_u64(3),
+            response_bytes: 512,
+        });
+
+        let encoded = msg.encode();
+
+        let mut buf1 = &encoded[1..];
+        let decoded_v1 =
+            SnapProtocolMessage::decode_versioned(SnapVersion::Snap1, encoded[0], &mut buf1)
+                .unwrap();
+
+        let mut buf2 = &encoded[1..];
+        let decoded_v2 =
+            SnapProtocolMessage::decode_versioned(SnapVersion::Snap2, encoded[0], &mut buf2)
+                .unwrap();
+
+        assert_eq!(decoded_v1, decoded_v2);
+    }
+
+    #[test]
+    fn test_snap2_message_id_0x06_is_get_block_access_lists() {
+        let msg = GetBlockAccessListsSnapMessage { request_id: 1, block_hashes: vec![B256::ZERO] };
+        let snap_msg = SnapProtocolMessage::GetBlockAccessLists(msg);
+        assert_eq!(snap_msg.message_id() as u8, 0x06);
+    }
+
+    #[test]
+    fn test_snap2_message_id_0x07_is_block_access_lists() {
+        let msg = BlockAccessListsSnapMessage { request_id: 1, access_lists: vec![Bytes::new()] };
+        let snap_msg = SnapProtocolMessage::BlockAccessLists(msg);
+        assert_eq!(snap_msg.message_id() as u8, 0x07);
+    }
+
+    #[test]
     fn test_unknown_message_id() {
-        // Create some random data
         let data = Bytes::from(vec![1, 2, 3, 4]);
         let mut buf = data.as_ref();
 
-        // Try to decode with an invalid message ID
         let result = SnapProtocolMessage::decode(255, &mut buf);
 
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(e.to_string(), "Unknown message ID");
         }
+    }
+
+    #[test]
+    fn test_snap_version_display() {
+        assert_eq!(SnapVersion::Snap1.to_string(), "snap/1");
+        assert_eq!(SnapVersion::Snap2.to_string(), "snap/2");
+    }
+
+    #[test]
+    fn test_snap_version_try_from() {
+        assert_eq!(SnapVersion::try_from(1u8), Ok(SnapVersion::Snap1));
+        assert_eq!(SnapVersion::try_from(2u8), Ok(SnapVersion::Snap2));
+        assert!(SnapVersion::try_from(0u8).is_err());
+        assert!(SnapVersion::try_from(3u8).is_err());
     }
 }

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -8,10 +8,17 @@ use core::{fmt, str::FromStr};
 use derive_more::Display;
 use reth_codecs_derive::add_arbitrary_tests;
 
-/// Error thrown when failed to parse a valid [`EthVersion`].
+/// Error thrown when failed to parse a valid [`EthVersion`] or [`SnapVersion`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("Unknown eth protocol version: {0}")]
+#[error("Unknown protocol version: {0}")]
 pub struct ParseVersionError(String);
+
+impl ParseVersionError {
+    /// Creates a new `ParseVersionError` with the given message.
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
 
 /// The `eth` protocol version.
 #[repr(u8)]

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -5,7 +5,7 @@ use crate::{
     p2pstream::MAX_RESERVED_MESSAGE_ID,
     protocol::{ProtoVersion, Protocol},
     version::ParseVersionError,
-    Capability, EthMessageID, EthVersion,
+    Capability, EthMessageID, EthVersion, SnapVersion,
 };
 use derive_more::{Deref, DerefMut};
 use std::{
@@ -29,6 +29,13 @@ pub enum SharedCapability {
         ///
         /// This represents the message ID offset for the first message of the eth capability in
         /// the message id space.
+        offset: u8,
+    },
+    /// The `snap` capability.
+    Snap {
+        /// (Highest) negotiated version of the snap capability.
+        version: SnapVersion,
+        /// The message ID offset for this capability.
         offset: u8,
     },
     /// Any other unknown capability.
@@ -63,6 +70,12 @@ impl SharedCapability {
 
         match name {
             "eth" => Ok(Self::eth(EthVersion::try_from(version)?, offset)),
+            "snap" => {
+                let snap_version = SnapVersion::try_from(version).map_err(|e| {
+                    SharedCapabilityError::UnsupportedVersion(ParseVersionError::new(e))
+                })?;
+                Ok(Self::snap(snap_version, offset))
+            }
             _ => Ok(Self::UnknownCapability {
                 cap: Capability::new(name.to_string(), version as usize),
                 offset,
@@ -76,10 +89,16 @@ impl SharedCapability {
         Self::Eth { version, offset }
     }
 
+    /// Creates a new [`SharedCapability`] for snap with the given version and offset.
+    pub(crate) const fn snap(version: SnapVersion, offset: u8) -> Self {
+        Self::Snap { version, offset }
+    }
+
     /// Returns the capability.
     pub const fn capability(&self) -> Cow<'_, Capability> {
         match self {
             Self::Eth { version, .. } => Cow::Owned(Capability::eth(*version)),
+            Self::Snap { version, .. } => Cow::Owned(Capability::snap(*version)),
             Self::UnknownCapability { cap, .. } => Cow::Borrowed(cap),
         }
     }
@@ -89,6 +108,7 @@ impl SharedCapability {
     pub fn name(&self) -> &str {
         match self {
             Self::Eth { .. } => "eth",
+            Self::Snap { .. } => "snap",
             Self::UnknownCapability { cap, .. } => cap.name.as_ref(),
         }
     }
@@ -99,10 +119,17 @@ impl SharedCapability {
         matches!(self, Self::Eth { .. })
     }
 
+    /// Returns true if the capability is snap.
+    #[inline]
+    pub const fn is_snap(&self) -> bool {
+        matches!(self, Self::Snap { .. })
+    }
+
     /// Returns the version of the capability.
     pub const fn version(&self) -> u8 {
         match self {
             Self::Eth { version, .. } => *version as u8,
+            Self::Snap { version, .. } => *version as u8,
             Self::UnknownCapability { cap, .. } => cap.version as u8,
         }
     }
@@ -115,13 +142,23 @@ impl SharedCapability {
         }
     }
 
+    /// Returns the snap version if it's the `snap` capability.
+    pub const fn snap_version(&self) -> Option<SnapVersion> {
+        match self {
+            Self::Snap { version, .. } => Some(*version),
+            _ => None,
+        }
+    }
+
     /// Returns the message ID offset of the current capability.
     ///
-    /// This represents the message ID offset for the first message of the eth capability in the
+    /// This represents the message ID offset for the first message of the capability in the
     /// message id space.
     pub const fn message_id_offset(&self) -> u8 {
         match self {
-            Self::Eth { offset, .. } | Self::UnknownCapability { offset, .. } => *offset,
+            Self::Eth { offset, .. } |
+            Self::Snap { offset, .. } |
+            Self::UnknownCapability { offset, .. } => *offset,
         }
     }
 
@@ -131,10 +168,14 @@ impl SharedCapability {
         self.message_id_offset() - MAX_RESERVED_MESSAGE_ID - 1
     }
 
+    /// The number of protocol messages in the snap protocol (8 for all versions).
+    const SNAP_MESSAGE_COUNT: u8 = 8;
+
     /// Returns the number of protocol messages supported by this capability.
     pub const fn num_messages(&self) -> u8 {
         match self {
             Self::Eth { version, .. } => EthMessageID::message_count(*version),
+            Self::Snap { .. } => Self::SNAP_MESSAGE_COUNT,
             Self::UnknownCapability { messages, .. } => *messages,
         }
     }
@@ -174,6 +215,18 @@ impl SharedCapabilities {
         self.iter_caps()
             .find_map(SharedCapability::eth_version)
             .ok_or(P2PStreamError::CapabilityNotShared)
+    }
+
+    /// Returns the snap capability if it is shared.
+    #[inline]
+    pub fn snap(&self) -> Option<&SharedCapability> {
+        self.iter_caps().find(|c| c.is_snap())
+    }
+
+    /// Returns the negotiated snap version if it is shared.
+    #[inline]
+    pub fn snap_version(&self) -> Option<SnapVersion> {
+        self.iter_caps().find_map(SharedCapability::snap_version)
     }
 
     /// Returns true if the shared capabilities contain the given capability.

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -7,7 +7,7 @@ use super::message::MAX_MESSAGE_SIZE;
 use crate::{
     message::{EthBroadcastMessage, ProtocolBroadcastMessage},
     EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion, NetworkPrimitives, ProtocolMessage,
-    RawCapabilityMessage, SnapMessageId, SnapProtocolMessage,
+    RawCapabilityMessage, SnapMessageId, SnapProtocolMessage, SnapVersion,
 };
 use alloy_rlp::{Bytes, BytesMut, Encodable};
 use core::fmt::Debug;
@@ -69,15 +69,33 @@ impl<S, N> EthSnapStream<S, N>
 where
     N: NetworkPrimitives,
 {
-    /// Create a new eth and snap protocol stream
+    /// Create a new eth and snap protocol stream.
+    ///
+    /// Defaults to snap/1 for backwards compatibility. Use [`Self::new_with_snap`] to specify
+    /// a snap version explicitly.
     pub const fn new(stream: S, eth_version: EthVersion) -> Self {
-        Self { eth_snap: EthSnapStreamInner::new(eth_version), inner: stream }
+        Self::new_with_snap(stream, eth_version, SnapVersion::Snap1)
+    }
+
+    /// Create a new eth and snap protocol stream with explicit snap version.
+    pub const fn new_with_snap(
+        stream: S,
+        eth_version: EthVersion,
+        snap_version: SnapVersion,
+    ) -> Self {
+        Self { eth_snap: EthSnapStreamInner::new(eth_version, snap_version), inner: stream }
     }
 
     /// Returns the eth version
     #[inline]
     pub const fn eth_version(&self) -> EthVersion {
         self.eth_snap.eth_version()
+    }
+
+    /// Returns the snap version
+    #[inline]
+    pub const fn snap_version(&self) -> SnapVersion {
+        self.eth_snap.snap_version()
     }
 
     /// Returns the underlying stream
@@ -181,13 +199,13 @@ where
     }
 }
 
-/// Stream handling combined eth and snap protocol logic
-/// Snap version is not critical to specify yet,
-/// Only one version, snap/1, does exist.
+/// Stream handling combined eth and snap protocol logic.
 #[derive(Debug, Clone)]
 struct EthSnapStreamInner<N> {
     /// Eth protocol version
     eth_version: EthVersion,
+    /// Snap protocol version
+    snap_version: SnapVersion,
     /// Type marker
     _pd: PhantomData<N>,
 }
@@ -197,13 +215,18 @@ where
     N: NetworkPrimitives,
 {
     /// Create a new eth and snap protocol stream
-    const fn new(eth_version: EthVersion) -> Self {
-        Self { eth_version, _pd: PhantomData }
+    const fn new(eth_version: EthVersion, snap_version: SnapVersion) -> Self {
+        Self { eth_version, snap_version, _pd: PhantomData }
     }
 
     #[inline]
     const fn eth_version(&self) -> EthVersion {
         self.eth_version
+    }
+
+    #[inline]
+    const fn snap_version(&self) -> SnapVersion {
+        self.snap_version
     }
 
     /// Decode a message from the stream
@@ -249,7 +272,11 @@ where
             let adjusted_message_id = message_id - EthMessageID::message_count(self.eth_version);
             let mut buf = &bytes[1..];
 
-            match SnapProtocolMessage::decode(adjusted_message_id, &mut buf) {
+            match SnapProtocolMessage::decode_versioned(
+                self.snap_version,
+                adjusted_message_id,
+                &mut buf,
+            ) {
                 Ok(snap_msg) => Ok(EthSnapMessage::Snap(snap_msg)),
                 Err(err) => Err(EthSnapStreamError::Rlp(err)),
             }
@@ -289,13 +316,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{EthMessage, SnapProtocolMessage};
+    use crate::{EthMessage, SnapProtocolMessage, SnapVersion};
     use alloy_eips::BlockHashOrNumber;
     use alloy_primitives::B256;
     use alloy_rlp::Encodable;
     use reth_eth_wire_types::{
-        message::RequestPair, GetAccountRangeMessage, GetBlockAccessLists, GetBlockHeaders,
-        HeadersDirection,
+        message::RequestPair, GetAccountRangeMessage, GetBlockAccessLists,
+        GetBlockAccessListsSnapMessage, GetBlockHeaders, HeadersDirection,
     };
 
     // Helper to create eth message and its bytes
@@ -327,7 +354,8 @@ mod tests {
             response_bytes: 1000,
         });
 
-        let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67);
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67, SnapVersion::Snap1);
         let encoded = inner.encode_snap_message(snap_msg.clone());
 
         (snap_msg, BytesMut::from(&encoded[..]))
@@ -335,7 +363,8 @@ mod tests {
 
     #[test]
     fn test_eth_message_roundtrip() {
-        let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67);
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67, SnapVersion::Snap1);
         let (eth_msg, eth_bytes) = create_eth_message();
 
         // Verify encoding
@@ -363,7 +392,8 @@ mod tests {
 
     #[test]
     fn test_snap_protocol() {
-        let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67);
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67, SnapVersion::Snap1);
         let (snap_msg, snap_bytes) = create_snap_message();
 
         // Verify encoding
@@ -395,7 +425,8 @@ mod tests {
 
     #[test]
     fn test_message_id_boundaries() {
-        let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67);
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67, SnapVersion::Snap1);
 
         // Create a bytes buffer with eth message ID at the max boundary with minimal content
         let eth_max_id = EthMessageID::max(EthVersion::Eth67);
@@ -423,7 +454,8 @@ mod tests {
 
     #[test]
     fn test_eth70_message_id_0x12_is_snap() {
-        let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth70);
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth70, SnapVersion::Snap1);
         let snap_msg = SnapProtocolMessage::GetAccountRange(GetAccountRangeMessage {
             request_id: 1,
             root_hash: B256::default(),
@@ -441,7 +473,8 @@ mod tests {
 
     #[test]
     fn test_eth71_message_id_0x12_is_eth() {
-        let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth71);
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth71, SnapVersion::Snap1);
         let eth_msg = EthMessage::<EthNetworkPrimitives>::GetBlockAccessLists(RequestPair {
             request_id: 1,
             message: GetBlockAccessLists(vec![B256::ZERO]),
@@ -455,5 +488,40 @@ mod tests {
             panic!("expected eth message");
         };
         assert_eq!(decoded_eth, eth_msg);
+    }
+
+    #[test]
+    fn test_snap2_get_block_access_lists_roundtrip() {
+        let inner =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67, SnapVersion::Snap2);
+        let snap_msg = SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsSnapMessage {
+            request_id: 1,
+            block_hashes: vec![B256::ZERO, B256::repeat_byte(0x01)],
+        });
+
+        let encoded = inner.encode_snap_message(snap_msg.clone());
+        let decoded = inner.decode_message(BytesMut::from(&encoded[..])).unwrap();
+        let EthSnapMessage::Snap(decoded_snap) = decoded else {
+            panic!("expected snap message");
+        };
+        assert_eq!(decoded_snap, snap_msg);
+    }
+
+    #[test]
+    fn test_snap2_0x06_decodes_as_get_block_access_lists() {
+        let inner_v2 =
+            EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67, SnapVersion::Snap2);
+        let snap_msg = SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsSnapMessage {
+            request_id: 1,
+            block_hashes: vec![B256::ZERO],
+        });
+        let encoded = inner_v2.encode_snap_message(snap_msg.clone());
+
+        // Under snap/2, 0x06 should decode as GetBlockAccessLists
+        let decoded = inner_v2.decode_message(BytesMut::from(&encoded[..])).unwrap();
+        assert!(matches!(
+            decoded,
+            EthSnapMessage::Snap(SnapProtocolMessage::GetBlockAccessLists(_))
+        ));
     }
 }

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -1,6 +1,6 @@
 //! A Protocol defines a P2P subprotocol in an `RLPx` connection
 
-use crate::{Capability, EthMessageID, EthVersion};
+use crate::{Capability, EthMessageID, EthVersion, SnapVersion};
 
 /// Type that represents a [Capability] and the number of messages it uses.
 ///
@@ -45,6 +45,24 @@ impl Protocol {
         Self::eth(EthVersion::Eth68)
     }
 
+    /// Returns the corresponding snap capability for the given version.
+    ///
+    /// All snap protocol versions use 8 message IDs (0x00–0x07).
+    pub const fn snap(version: SnapVersion) -> Self {
+        let cap = Capability::snap(version);
+        Self::new(cap, 8)
+    }
+
+    /// Returns the [`SnapVersion::Snap1`] capability.
+    pub const fn snap_1() -> Self {
+        Self::snap(SnapVersion::Snap1)
+    }
+
+    /// Returns the [`SnapVersion::Snap2`] capability.
+    pub const fn snap_2() -> Self {
+        Self::snap(SnapVersion::Snap2)
+    }
+
     /// Consumes the type and returns a tuple of the [Capability] and number of messages.
     #[inline]
     pub(crate) fn split(self) -> (Capability, u8) {
@@ -63,6 +81,12 @@ impl From<EthVersion> for Protocol {
     }
 }
 
+impl From<SnapVersion> for Protocol {
+    fn from(version: SnapVersion) -> Self {
+        Self::snap(version)
+    }
+}
+
 /// A helper type to keep track of the protocol version and number of messages used by the protocol.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct ProtoVersion {
@@ -78,13 +102,17 @@ mod tests {
 
     #[test]
     fn test_protocol_eth_message_count() {
-        // Test that Protocol::eth() returns correct message counts for each version
-        // This ensures that EthMessageID::message_count() produces the expected results
         assert_eq!(Protocol::eth(EthVersion::Eth66).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth67).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth68).messages(), 17);
         assert_eq!(Protocol::eth(EthVersion::Eth69).messages(), 18);
         assert_eq!(Protocol::eth(EthVersion::Eth70).messages(), 18);
         assert_eq!(Protocol::eth(EthVersion::Eth71).messages(), 20);
+    }
+
+    #[test]
+    fn test_protocol_snap_message_count() {
+        assert_eq!(Protocol::snap(SnapVersion::Snap1).messages(), 8);
+        assert_eq!(Protocol::snap(SnapVersion::Snap2).messages(), 8);
     }
 }

--- a/crates/net/p2p/src/snap/client.rs
+++ b/crates/net/p2p/src/snap/client.rs
@@ -1,8 +1,9 @@
 use crate::{download::DownloadClient, error::PeerRequestResult, priority::Priority};
 use futures::Future;
 use reth_eth_wire_types::snap::{
-    AccountRangeMessage, ByteCodesMessage, GetAccountRangeMessage, GetByteCodesMessage,
-    GetStorageRangesMessage, GetTrieNodesMessage, StorageRangesMessage, TrieNodesMessage,
+    AccountRangeMessage, BlockAccessListsSnapMessage, ByteCodesMessage, GetAccountRangeMessage,
+    GetBlockAccessListsSnapMessage, GetByteCodesMessage, GetStorageRangesMessage,
+    GetTrieNodesMessage, StorageRangesMessage, TrieNodesMessage,
 };
 
 /// Response types for snap sync requests
@@ -14,8 +15,10 @@ pub enum SnapResponse {
     StorageRanges(StorageRangesMessage),
     /// Response containing bytecode data
     ByteCodes(ByteCodesMessage),
-    /// Response containing trie node data
+    /// Response containing trie node data (snap/1)
     TrieNodes(TrieNodesMessage),
+    /// Response containing block access lists (snap/2)
+    BlockAccessLists(BlockAccessListsSnapMessage),
 }
 
 /// The snap sync downloader client
@@ -71,6 +74,20 @@ pub trait SnapClient: DownloadClient {
     fn get_trie_nodes_with_priority(
         &self,
         request: GetTrieNodesMessage,
+        priority: Priority,
+    ) -> Self::Output;
+
+    /// Sends the block access lists request to the p2p network (snap/2) and returns
+    /// the block access lists response received from a peer.
+    fn get_block_access_lists(&self, request: GetBlockAccessListsSnapMessage) -> Self::Output {
+        self.get_block_access_lists_with_priority(request, Priority::Normal)
+    }
+
+    /// Sends the block access lists request to the p2p network with priority set (snap/2)
+    /// and returns the block access lists response received from a peer.
+    fn get_block_access_lists_with_priority(
+        &self,
+        request: GetBlockAccessListsSnapMessage,
         priority: Priority,
     ) -> Self::Output;
 }


### PR DESCRIPTION
Implements the [snap/2 protocol](https://ethresear.ch/t/snap-v2-replacing-trie-healing-with-bals/24333) — replaces iterative trie healing with deterministic BAL-based healing using [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) Block Access Lists.

## Motivation

snap/1's trie healing phase is the well-known bottleneck of snap sync: iterative discovery, many round trips, and [nodes stuck healing for days](https://github.com/ethereum/go-ethereum/issues/23191). snap/2 eliminates this by reusing message IDs 0x06/0x07 for `GetBlockAccessLists`/`BlockAccessLists` instead of `GetTrieNodes`/`TrieNodes`, allowing syncing nodes to download BALs for the blocks that advanced during state download and apply diffs locally.

Reth already has BAL infrastructure (eth/71 wire messages, `bal_to_hashed_post_state()`, engine tree prewarming) — this PR adds the snap protocol side.

## Changes

- `SnapVersion` enum (`Snap1 = 1`, `Snap2 = 2`) in `eth-wire-types`
- `GetBlockAccessListsSnapMessage` / `BlockAccessListsSnapMessage` message types
- `SnapProtocolMessage::decode_versioned()` — version-aware decoding of 0x06/0x07
- `Capability`, `Capabilities`, `SharedCapability`, `Protocol` all support `snap/1` and `snap/2`
- `EthSnapStream` is snap-version-aware (constructor accepts `SnapVersion`)
- `SnapClient` trait extended with `get_block_access_lists` / `get_block_access_lists_with_priority`
- `SnapResponse::BlockAccessLists` variant

## Testing

```
cargo test -p reth-eth-wire-types -p reth-eth-wire -p reth-network-p2p
```

All 161+ tests pass, including new snap/2 roundtrip, version parsing, and message ID tests.

Co-Authored-By: Georgios Konstantopoulos <17802178+gakonst@users.noreply.github.com>

Prompted by: georgios