### PR TITLE
fix(engine): only count precompile cache hit when gas is sufficient

### DIFF
--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -169,8 +169,8 @@ where
     }
 
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
-        if let Some(entry) = &self.cache.get(input.data, self.spec_id.clone())
-            && input.gas >= entry.gas_used()
+        if let Some(entry) = &self.cache.get(input.data, self.spec_id.clone()) &&
+            input.gas >= entry.gas_used()
         {
             self.increment_by_one_precompile_cache_hits();
             return entry.to_precompile_result()

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -170,8 +170,8 @@ where
 
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
         if let Some(entry) = &self.cache.get(input.data, self.spec_id.clone()) {
-            self.increment_by_one_precompile_cache_hits();
             if input.gas >= entry.gas_used() {
+                self.increment_by_one_precompile_cache_hits();
                 return entry.to_precompile_result()
             }
         }

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -169,11 +169,11 @@ where
     }
 
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
-        if let Some(entry) = &self.cache.get(input.data, self.spec_id.clone()) {
-            if input.gas >= entry.gas_used() {
-                self.increment_by_one_precompile_cache_hits();
-                return entry.to_precompile_result()
-            }
+        if let Some(entry) = &self.cache.get(input.data, self.spec_id.clone())
+            && input.gas >= entry.gas_used()
+        {
+            self.increment_by_one_precompile_cache_hits();
+            return entry.to_precompile_result()
         }
 
         let calldata = input.data;


### PR DESCRIPTION
Fix hit metric (fix): precompile_cache_hits was incremented on cache lookup even when gas was insufficient, inflating the reported hit rate.

Previously the hit counter incremented whenever the cache contained a matching entry, even if the caller didn't have enough gas to use it. Move the increment inside the gas check so the metric reflects actual cache utilization.

cc @DaniPopes 