### PR TITLE
feat(engine): add tx_index to execute tx span

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1009,6 +1009,7 @@ where
             let _enter = debug_span!(
                 target: "engine::tree",
                 "execute tx",
+                tx_index = senders.len() - 1,
             )
             .entered();
             trace!(target: "engine::tree", "Executing transaction");


### PR DESCRIPTION
Adds `tx_index` field to the `execute tx` debug span in payload validation, making it easier to correlate tracing output with specific transactions in a block.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey