### PR TITLE
fix(tasks): add panic handler to proof worker rayon pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "futures",
@@ -9590,6 +9590,24 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.1"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "c-kzg",
+ "codspeed-criterion-compat",
+ "once_cell",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "reth-codecs",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-static-file-types",
+]
 
 [[package]]
 name = "reth-primitives-traits"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7532,7 +7532,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7579,7 +7579,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7602,7 +7602,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7649,7 +7649,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench-compare"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7710,7 +7710,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7830,7 +7830,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7860,7 +7860,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7884,7 +7884,7 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7894,7 +7894,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7912,7 +7912,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7924,7 +7924,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8029,7 +8029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8102,7 +8102,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8127,7 +8127,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8193,7 +8193,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8277,7 +8277,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8300,7 +8300,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8354,7 +8354,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8427,7 +8427,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8454,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8494,7 +8494,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8520,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8530,7 +8530,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8568,7 +8568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8593,7 +8593,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8656,7 +8656,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8672,7 +8672,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8690,7 +8690,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8703,7 +8703,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8731,7 +8731,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8792,7 +8792,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8816,7 +8816,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8848,7 +8848,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8893,7 +8893,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8924,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8950,7 +8950,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8983,7 +8983,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9005,7 +9005,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -9031,7 +9031,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "futures",
  "metrics",
@@ -9042,7 +9042,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9064,7 +9064,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9172,7 +9172,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9189,7 +9189,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9243,7 +9243,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9315,7 +9315,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9371,7 +9371,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9454,7 +9454,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9477,7 +9477,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9506,7 +9506,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9517,7 +9517,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9537,7 +9537,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9571,7 +9571,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9589,29 +9589,11 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.11.0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "c-kzg",
- "codspeed-criterion-compat",
- "once_cell",
- "proptest",
- "proptest-arbitrary-interop",
- "reth-codecs",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
+version = "1.11.1"
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9649,7 +9631,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9699,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9732,11 +9714,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "1.11.0"
+version = "1.11.1"
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9756,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9770,7 +9752,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9850,7 +9832,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9880,7 +9862,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9899,7 +9881,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9955,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9979,7 +9961,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9999,7 +9981,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10035,7 +10017,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10078,7 +10060,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10126,7 +10108,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10143,7 +10125,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10158,7 +10140,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10220,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10253,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10269,7 +10251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10292,7 +10274,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10310,7 +10292,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10315,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10349,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10378,7 +10360,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10395,7 +10377,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10411,7 +10393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10420,7 +10402,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10438,7 +10420,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10455,7 +10437,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10506,7 +10488,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10540,7 +10522,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10573,7 +10555,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10604,7 +10586,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10634,7 +10616,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10665,7 +10647,7 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.11.0"
+version = "1.11.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -312,6 +312,11 @@ impl DeferredTrieData {
     /// Given that invariant, circular wait dependencies are impossible.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
+        #[cfg(feature = "rayon")]
+        debug_assert!(
+            rayon::current_thread_index().is_none(),
+            "wait_cloned must not be called from a rayon worker thread"
+        );
         let mut state = self.state.lock();
         match &mut *state {
             // If the deferred trie data is ready, return the cached result.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1411,7 +1411,7 @@ where
         // Spawn a background task to trigger computation so it's ready when the next payload
         // arrives.
         if let Some(overlay) = self.state.tree_state.prepare_canonical_overlay() {
-            rayon::spawn(move || {
+            tokio::task::spawn_blocking(move || {
                 let _ = overlay.get();
             });
         }

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -817,6 +817,17 @@ impl RuntimeBuilder {
             TaskManager::new_parts(handle.clone());
 
         #[cfg(feature = "rayon")]
+        #[allow(clippy::needless_pass_by_value)]
+        fn rayon_panic_handler(payload: Box<dyn std::any::Any + Send>) {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
+                .unwrap_or("(no message)");
+            error!(target: "reth::tasks", %msg, "panic in worker pool thread");
+        }
+
+        #[cfg(feature = "rayon")]
         let (
             cpu_pool,
             rpc_pool,
@@ -853,6 +864,7 @@ impl RuntimeBuilder {
             let proof_storage_worker_pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(proof_storage_worker_threads)
                 .thread_name(|i| format!("proof-strg-{i:02}"))
+                .panic_handler(rayon_panic_handler)
                 .build()?;
 
             let proof_account_worker_threads =
@@ -860,6 +872,7 @@ impl RuntimeBuilder {
             let proof_account_worker_pool = rayon::ThreadPoolBuilder::new()
                 .num_threads(proof_account_worker_threads)
                 .thread_name(|i| format!("proof-acct-{i:02}"))
+                .panic_handler(rayon_panic_handler)
                 .build()?;
 
             debug!(

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v1.11.0',
+      text: 'v1.11.1',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Without a panic handler, a panic on the dedicated `proof-acct` or `proof-strg` rayon pools calls the default handler which aborts the process. This installs a handler that logs the panic instead.

Based on v1.11.1. Only targets the two proof worker pools — other dedicated pools (`cpu`, `rpc`, `storage`) are unchanged.

## Changes
- Added `rayon_panic_handler` fn that extracts the panic message and logs via `tracing::error`
- Applied it to `proof_storage_worker_pool` and `proof_account_worker_pool` builders

## Testing
`cargo test -p reth-tasks` — all 16 tests pass.

Co-Authored-By: Arsenii Kulikov <62447812+klkvr@users.noreply.github.com>

Prompted by: klkvr