### PR TITLE
feat(primitives): add mix_hash, extra_data, parent_beacon_block_root setters to HeaderMut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,8 +7712,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79b3247ae4fbb1d4d35ce83a11fc596428a4c6ea836c98a75a55340192578a4"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=f72ed5e002c2c4d7d432ca70b9c8cce778b7c236#f72ed5e002c2c4d7d432ca70b9c8cce778b7c236"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7733,8 +7732,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5dbae40c272b8a1b4fcc08ee2d4e77d3b0ccdb187c1313f412a73ff54ff2a2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=f72ed5e002c2c4d7d432ca70b9c8cce778b7c236#f72ed5e002c2c4d7d432ca70b9c8cce778b7c236"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9416,8 +9414,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc759fd87c3f65440e5d3bfa3107fe8a13a61a6807cd485c62c49d63c7bf6717"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=f72ed5e002c2c4d7d432ca70b9c8cce778b7c236#f72ed5e002c2c4d7d432ca70b9c8cce778b7c236"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9961,8 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b766da61ec7c46596386b4bc88d9b57d1939d3da2bc9e927567a8a23650e5ce9"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=f72ed5e002c2c4d7d432ca70b9c8cce778b7c236#f72ed5e002c2c4d7d432ca70b9c8cce778b7c236"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10491,8 +10487,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fa54c341d926ec9b0f7fc0c87f831aa4959de699e69caab1a0bfd914326c09"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=f72ed5e002c2c4d7d432ca70b9c8cce778b7c236#f72ed5e002c2c4d7d432ca70b9c8cce778b7c236"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,8 +326,8 @@ reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { version = "0.3.0", default-features = false }
-reth-codecs-derive = "0.3.0"
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "f72ed5e002c2c4d7d432ca70b9c8cce778b7c236", default-features = false }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "f72ed5e002c2c4d7d432ca70b9c8cce778b7c236" }
 reth-config = { path = "crates/config", default-features = false }
 reth-consensus = { path = "crates/consensus/consensus", default-features = false }
 reth-consensus-common = { path = "crates/consensus/common", default-features = false }
@@ -395,7 +395,7 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives-traits = { version = "0.3.0", default-features = false }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "f72ed5e002c2c4d7d432ca70b9c8cce778b7c236", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
@@ -411,7 +411,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-rpc-traits = { version = "0.3.0", default-features = false }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "f72ed5e002c2c4d7d432ca70b9c8cce778b7c236", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }
@@ -430,7 +430,7 @@ reth-trie-common = { path = "crates/trie/common", default-features = false }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-zstd-compressors = { version = "0.3.0", default-features = false }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "f72ed5e002c2c4d7d432ca70b9c8cce778b7c236", default-features = false }
 
 # revm
 revm = { version = "38.0.0", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -90,6 +90,7 @@ allow-git = [
     "https://github.com/foundry-rs/block-explorers",
     "https://github.com/bluealloy/revm",
     "https://github.com/paradigmxyz/revm-inspectors",
+    "https://github.com/paradigmxyz/reth-core",
     "https://github.com/alloy-rs/evm",
     "https://github.com/alloy-rs/hardforks",
     "https://github.com/paradigmxyz/jsonrpsee",


### PR DESCRIPTION
`reth-primitives-traits` was extracted out of the `reth` workspace after this PR was opened, so this branch now updates the extracted `reth-core` crates (`reth-primitives-traits`, `reth-codecs`, `reth-codecs-derive`, `reth-rpc-traits`, and `reth-zstd-compressors`) to the revision that adds `set_mix_hash`, `set_extra_data`, and `set_parent_beacon_block_root` to `HeaderMut`.

Companion upstream PR: https://github.com/paradigmxyz/reth-core/pull/15
