### PR TITLE
feat(payload): add resolve and job-creation latency histograms

### DIFF
--- a/.changelog/fair-wolves-smile.md
+++ b/.changelog/fair-wolves-smile.md
@@ -1,0 +1,5 @@
+---
+reth-payload-builder: minor
+---
+
+Added observability metrics for payload resolve latency and new payload job creation latency to the payload builder service.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -27,10 +27,6 @@ pub(crate) struct PayloadBuilderServiceMetrics {
     pub(crate) resolve_duration_seconds: Histogram,
     /// Histogram of new payload job creation latency in seconds
     pub(crate) new_job_duration_seconds: Histogram,
-    /// Total number of times a stale cached payload was cleared for a reused payload id
-    pub(crate) stale_cache_clears: Counter,
-    /// Total number of resolve calls that returned a cached payload
-    pub(crate) resolve_cache_hits: Counter,
 }
 
 impl PayloadBuilderServiceMetrics {

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Payload builder service metrics.
 
 use reth_metrics::{
-    metrics::{Counter, Gauge},
+    metrics::{Counter, Gauge, Histogram},
     Metrics,
 };
 
@@ -23,6 +23,14 @@ pub(crate) struct PayloadBuilderServiceMetrics {
     pub(crate) resolved_revenue: Gauge,
     /// Current block returned as the resolved payload
     pub(crate) resolved_block: Gauge,
+    /// Histogram of payload resolve latency in seconds
+    pub(crate) resolve_duration_seconds: Histogram,
+    /// Histogram of new payload job creation latency in seconds
+    pub(crate) new_job_duration_seconds: Histogram,
+    /// Total number of times a stale cached payload was cleared for a reused payload id
+    pub(crate) stale_cache_clears: Counter,
+    /// Total number of resolve calls that returned a cached payload
+    pub(crate) resolve_cache_hits: Counter,
 }
 
 impl PayloadBuilderServiceMetrics {

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -351,15 +351,7 @@ where
 
         Some(Box::pin(fut))
     }
-}
 
-impl<Gen, St, T> PayloadBuilderService<Gen, St, T>
-where
-    T: PayloadTypes,
-    Gen: PayloadJobGenerator,
-    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
-    <Gen::Job as PayloadJob>::BuiltPayload: Into<T::BuiltPayload>,
-{
     /// Returns the payload timestamp for the given payload.
     fn payload_timestamp(&self, id: PayloadId) -> Option<Result<u64, PayloadBuilderError>> {
         if let Some((cached_id, timestamp, _)) = *self.cached_payload_rx.borrow() &&

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -14,7 +14,7 @@ use futures_util::{future::FutureExt, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;
 use reth_payload_builder_primitives::{Events, PayloadBuilderError, PayloadEvents};
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind, PayloadTypes};
-use reth_primitives_traits::NodePrimitives;
+use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use std::{
     fmt,
     future::Future,
@@ -306,11 +306,14 @@ where
         id: PayloadId,
         kind: PayloadKind,
     ) -> Option<PayloadFuture<T::BuiltPayload>> {
+        let start = Instant::now();
         debug!(target: "payload_builder", %id, "resolving payload job");
 
         if let Some((cached, _, payload)) = &*self.cached_payload_rx.borrow() &&
             *cached == id
         {
+            self.metrics.resolve_cache_hits.increment(1);
+            self.metrics.resolve_duration_seconds.record(start.elapsed());
             return Some(Box::pin(core::future::ready(Ok(payload.clone()))));
         }
 
@@ -331,6 +334,7 @@ where
 
         let fut = async move {
             let res = fut.await;
+            resolved_metrics.resolve_duration_seconds.record(start.elapsed());
             if let Ok(payload) = &res {
                 if payload_events.receiver_count() > 0 {
                     payload_events.send(Events::BuiltPayload(payload.clone().into())).ok();
@@ -440,6 +444,7 @@ where
                             debug!(target: "payload_builder",%id, parent = %attr.parent(), "Payload job already in progress, ignoring.");
                         } else {
                             let parent = attr.parent();
+                            let start = Instant::now();
                             let job_result = {
                                 let _entered = job_span.enter();
                                 this.generator.new_payload_job(attr.clone())
@@ -447,6 +452,7 @@ where
 
                             match job_result {
                                 Ok(job) => {
+                                    this.metrics.new_job_duration_seconds.record(start.elapsed());
                                     info!(target: "payload_builder", %id, %parent, "New payload job created");
                                     this.metrics.inc_initiated_jobs();
                                     new_job = true;
@@ -464,9 +470,11 @@ where
                                     {
                                         trace!(target: "payload_builder", %id, "clearing stale cached payload for reused payload id");
                                         let _ = this.cached_payload_tx.send(None);
+                                        this.metrics.stale_cache_clears.increment(1);
                                     }
                                 }
                                 Err(err) => {
+                                    this.metrics.new_job_duration_seconds.record(start.elapsed());
                                     this.metrics.inc_failed_jobs();
                                     warn!(target: "payload_builder", %err, %id, "Failed to create payload builder job");
                                     res = Err(err);

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -312,7 +312,6 @@ where
         if let Some((cached, _, payload)) = &*self.cached_payload_rx.borrow() &&
             *cached == id
         {
-            self.metrics.resolve_cache_hits.increment(1);
             self.metrics.resolve_duration_seconds.record(start.elapsed());
             return Some(Box::pin(core::future::ready(Ok(payload.clone()))));
         }
@@ -470,7 +469,6 @@ where
                                     {
                                         trace!(target: "payload_builder", %id, "clearing stale cached payload for reused payload id");
                                         let _ = this.cached_payload_tx.send(None);
-                                        this.metrics.stale_cache_clears.increment(1);
                                     }
                                 }
                                 Err(err) => {


### PR DESCRIPTION
Adds latency histograms to the payload builder service that would have made the deadlock in #22971 visible.



| Metric | Type | What it catches |
|---|---|---|
| `payloads.resolve_duration_seconds` | Histogram | Resolve latency — a stalled resolve (deadlock) shows as an outlier or missing observations |
| `payloads.new_job_duration_seconds` | Histogram | Job creation latency — `new_payload_job()` blocking |

The resolve duration histogram covers end-to-end: for cache hits it records inline, for active jobs it records after the payload future completes. 

A deadlock like #22971 would show as observations stopping.


In the future, alerts can be added.

Prompted by: yk