### PR TITLE
perf(engine): avoid redundant state provider and header lookups

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3143,10 +3143,7 @@ where
 
     /// Checks whether the parent state for the given hash is available, either in memory or in the
     /// database.
-    fn has_parent_state(&self, hash: B256) -> ProviderResult<bool>
-    where
-        P: BlockReader,
-    {
+    fn has_parent_state(&self, hash: B256) -> ProviderResult<bool> {
         // Lookup for in-memory blocks
         if self.state.tree_state.contains_hash(&hash) {
             return Ok(true)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2822,7 +2822,7 @@ where
         }
 
         // Ensure that the parent state is available.
-        match self.has_parent_state(block_id.parent) {
+        match self.has_block(block_id.parent) {
             Err(err) => {
                 let block = convert_to_block(self, input)?;
                 return Err(InsertBlockError::new(block, err.into()).into());
@@ -3141,9 +3141,8 @@ where
         Ok(())
     }
 
-    /// Checks whether the parent state for the given hash is available, either in memory or in the
-    /// database.
-    fn has_parent_state(&self, hash: B256) -> ProviderResult<bool> {
+    /// Checks whether a block with the given hash is known, either in memory or in the database.
+    fn has_block(&self, hash: B256) -> ProviderResult<bool> {
         // Lookup for in-memory blocks
         if self.state.tree_state.contains_hash(&hash) {
             return Ok(true)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2463,17 +2463,24 @@ where
         let mut canonical = self.state.tree_state.current_canonical_head;
         let mut persisted = self.persistence_state.last_persisted_block;
 
-        let parent_num_hash = |num_hash: NumHash| -> ProviderResult<NumHash> {
+        let parent_num_hash = |hash: B256| -> ProviderResult<NumHash> {
+            // Check in-memory blocks first
+            if let Some(block) = self.state.tree_state.executed_block_by_hash(hash) {
+                return Ok(block.recovered_block().parent_num_hash())
+            }
+
+            // Fall back to database
             Ok(self
-                .sealed_header_by_hash(num_hash.hash)?
-                .ok_or(ProviderError::BlockHashNotFound(num_hash.hash))?
+                .provider
+                .header(hash)?
+                .ok_or(ProviderError::BlockHashNotFound(hash))?
                 .parent_num_hash())
         };
 
         // Happy path, canonical chain is ahead or equal to persisted chain.
         // Walk canonical chain back to make sure that it connects to persisted chain.
         while canonical.number > persisted.number {
-            canonical = parent_num_hash(canonical)?;
+            canonical = parent_num_hash(canonical.hash)?;
         }
 
         // If we've reached persisted tip by walking the canonical chain back, everything is fine.
@@ -2487,15 +2494,15 @@ where
 
         // Firstly, walk back until we reach the same height as `canonical`.
         while persisted.number > canonical.number {
-            persisted = parent_num_hash(persisted)?;
+            persisted = parent_num_hash(persisted.hash)?;
         }
 
         debug_assert_eq!(persisted.number, canonical.number);
 
         // Now walk both chains back until we find a common ancestor.
         while persisted.hash != canonical.hash {
-            canonical = parent_num_hash(canonical)?;
-            persisted = parent_num_hash(persisted)?;
+            canonical = parent_num_hash(canonical.hash)?;
+            persisted = parent_num_hash(persisted.hash)?;
         }
 
         debug!(target: "engine::tree", remove_above=persisted.number, "on-disk reorg detected");
@@ -2815,12 +2822,12 @@ where
         }
 
         // Ensure that the parent state is available.
-        match self.state_provider_builder(block_id.parent) {
+        match self.has_parent_state(block_id.parent) {
             Err(err) => {
                 let block = convert_to_block(self, input)?;
                 return Err(InsertBlockError::new(block, err.into()).into());
             }
-            Ok(None) => {
+            Ok(false) => {
                 let block = convert_to_block(self, input)?;
 
                 // we don't have the state required to execute this block, buffering it and find the
@@ -2839,7 +2846,7 @@ where
                     missing_ancestor,
                 }))
             }
-            Ok(Some(_)) => {}
+            Ok(true) => {}
         }
 
         // determine whether we are on a fork chain by comparing the block number with the
@@ -3132,6 +3139,21 @@ where
             num,
         );
         Ok(())
+    }
+
+    /// Checks whether the parent state for the given hash is available, either in memory or in the
+    /// database.
+    fn has_parent_state(&self, hash: B256) -> ProviderResult<bool>
+    where
+        P: BlockReader,
+    {
+        // Lookup for in-memory blocks
+        if self.state.tree_state.contains_hash(&hash) {
+            return Ok(true)
+        }
+
+        // Fall back to DB header lookup
+        Ok(self.provider.header(hash)?.is_some())
     }
 
     /// Returns a builder for creating state providers for the given hash.


### PR DESCRIPTION
- Replace `sealed_header_by_hash(...).is_some()` with `blocks_by_hash.contains_key(...)` in the AlreadySeen check
- Use `executed_block_by_hash` + `provider.header` in `find_disk_reorg` to avoid cloning `SealedHeader`
- Replace `state_provider_builder` with a lightweight `has_parent_state` check the old result was immediately discarded