### PR TITLE
fix(trie): track branch and leaf counts in parallel state root calculation

### DIFF
--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -146,9 +146,11 @@ where
         while let Some(node) = account_node_iter.try_next().map_err(ProviderError::Database)? {
             match node {
                 TrieElement::Branch(node) => {
+                    tracker.inc_branch();
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
+                    tracker.inc_leaf();
                     let storage_root_result = match storage_roots.remove(&hashed_address) {
                         Some(rx) => rx.recv().map_err(|_| {
                             ParallelStateRootError::StorageRoot(StorageRootError::Database(


### PR DESCRIPTION
ParallelStateRoot::calculate never called tracker.inc_branch() / tracker.inc_leaf() during the trie walk, so branches_added and leaves_added were always reported as 0 in logs and metrics. The non-parallel StateRoot::calculate tracks these correctly.