### PR TITLE
fix(primitives): enable `serde` for RPC receipt test in `reth-ethereum-primitives`

### DIFF
--- a/crates/ethereum/primitives/Cargo.toml
+++ b/crates/ethereum/primitives/Cargo.toml
@@ -85,4 +85,7 @@ serde = [
     "alloy-rpc-types-eth?/serde",
     "rand/serde",
 ]
-rpc = ["dep:alloy-rpc-types-eth"]
+rpc = [
+    "dep:alloy-rpc-types-eth",
+    "alloy-rpc-types-eth?/serde"
+]

--- a/crates/ethereum/primitives/Cargo.toml
+++ b/crates/ethereum/primitives/Cargo.toml
@@ -87,5 +87,5 @@ serde = [
 ]
 rpc = [
     "dep:alloy-rpc-types-eth",
-    "alloy-rpc-types-eth?/serde"
+    "alloy-rpc-types-eth?/serde",
 ]


### PR DESCRIPTION
This PR enables the `serde` feature for `alloy-rpc-types-eth`, allowing
`alloy_rpc_types_eth::Log` to implement `Serialize` and `Deserialize` and
fixing the failing receipt RPC serde tests.

<details><summary>Test Error (before fix)</summary>

```
cargo t -p reth-ethereum-primitives -F rpc -- receipt::tests::test_receipt_serde --show-output                                               ⏎
   Compiling reth-ethereum-primitives v1.11.1 (/Users/abhi3700/F/coding/github_repos/reth/crates/ethereum/primitives)
error[E0277]: the trait bound `alloy_rpc_types_eth::Log: serde::Deserialize<'de>` is not satisfied
    --> crates/ethereum/primitives/src/receipt.rs:253:35
     |
 253 |         let receipt: RpcReceipt = serde_json::from_str(input).unwrap();
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `alloy_rpc_types_eth::Log`
     |
     = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `alloy_rpc_types_eth::Log` type
     = note: for types from other crates check whether the crate offers a `serde` feature flag
     = help: the following other types implement trait `Deserialize<'de>`:
               &'a Path
               &'a [u8]
               &'a str
               ()
               (T,)
               (T0, T1)
               (T0, T1, T2)
               (T0, T1, T2, T3)
             and 226 others
     = note: required for `EthereumReceipt<TxType, alloy_rpc_types_eth::Log>` to implement `Deserialize<'_>`
note: required by a bound in `serde_json::from_str`
    --> /Users/abhi3700/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.149/src/de.rs:2701:8
     |
2699 | pub fn from_str<'a, T>(s: &'a str) -> Result<T>
     |        -------- required by a bound in this function
2700 | where
2701 |     T: de::Deserialize<'a>,
     |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `from_str`

error[E0277]: the trait bound `alloy_rpc_types_eth::Log: serde::Deserialize<'de>` is not satisfied
    --> crates/ethereum/primitives/src/receipt.rs:255:13
     |
 255 |             serde_json::from_str(input).unwrap();
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `alloy_rpc_types_eth::Log`
     |
     = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `alloy_rpc_types_eth::Log` type
     = note: for types from other crates check whether the crate offers a `serde` feature flag
     = help: the following other types implement trait `Deserialize<'de>`:
               &'a Path
               &'a [u8]
               &'a str
               ()
               (T,)
               (T0, T1)
               (T0, T1, T2)
               (T0, T1, T2, T3)
             and 226 others
     = note: required for `ReceiptEnvelope<alloy_rpc_types_eth::Log>` to implement `Deserialize<'_>`
note: required by a bound in `serde_json::from_str`
    --> /Users/abhi3700/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.149/src/de.rs:2701:8
     |
2699 | pub fn from_str<'a, T>(s: &'a str) -> Result<T>
     |        -------- required by a bound in this function
2700 | where
2701 |     T: de::Deserialize<'a>,
     |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `from_str`

error[E0277]: the trait bound `alloy_rpc_types_eth::Log: serde::Serialize` is not satisfied
   --> crates/ethereum/primitives/src/receipt.rs:259:51
    |
259 |         let json_envelope = serde_json::to_value(&envelope).unwrap();
    |                             --------------------  ^^^^^^^^ the trait `Serialize` is not implemented for `alloy_rpc_types_eth::Log`
    |                             |
    |                             required by a bound introduced by this call
    |
    = note: for local types consider adding `#[derive(serde::Serialize)]` to your `alloy_rpc_types_eth::Log` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `Serialize`:
              &'a T
              &'a mut T
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
            and 216 others
    = note: required for `ReceiptEnvelope<alloy_rpc_types_eth::Log>` to implement `Serialize`
    = note: 1 redundant requirement hidden
    = note: required for `&ReceiptEnvelope<alloy_rpc_types_eth::Log>` to implement `Serialize`
note: required by a bound in `to_value`
   --> /Users/abhi3700/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.149/src/value/mod.rs:997:8
    |
995 | pub fn to_value<T>(value: T) -> Result<Value, Error>
    |        -------- required by a bound in this function
996 | where
997 |     T: Serialize,
    |        ^^^^^^^^^ required by this bound in `to_value`

error[E0277]: the trait bound `alloy_rpc_types_eth::Log: serde::Serialize` is not satisfied
   --> crates/ethereum/primitives/src/receipt.rs:260:49
    |
260 |         let json_receipt = serde_json::to_value(receipt.into_with_bloom()).unwrap();
    |                            -------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `alloy_rpc_types_eth::Log`
    |                            |
    |                            required by a bound introduced by this call
    |
    = note: for local types consider adding `#[derive(serde::Serialize)]` to your `alloy_rpc_types_eth::Log` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `Serialize`:
              &'a T
              &'a mut T
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
            and 216 others
    = note: required for `EthereumReceipt<TxType, alloy_rpc_types_eth::Log>` to implement `Serialize`
    = note: 1 redundant requirement hidden
    = note: required for `ReceiptWithBloom<EthereumReceipt<TxType, alloy_rpc_types_eth::Log>>` to implement `Serialize`
note: required by a bound in `to_value`
   --> /Users/abhi3700/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.149/src/value/mod.rs:997:8
    |
995 | pub fn to_value<T>(value: T) -> Result<Value, Error>
    |        -------- required by a bound in this function
996 | where
997 |     T: Serialize,
    |        ^^^^^^^^^ required by this bound in `to_value`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `reth-ethereum-primitives` (lib test) due to 4 previous errors
```

</details>


