### PR TITLE
refactor(payload): merge redundant impl blocks

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -84,12 +84,7 @@ where
     ) -> Option<Result<u64, PayloadBuilderError>> {
         self.inner.payload_timestamp(id).await
     }
-}
 
-impl<T> PayloadStore<T>
-where
-    T: PayloadTypes,
-{
     /// Create a new instance
     pub fn new(inner: PayloadBuilderHandle<T>) -> Self {
         Self { inner: Arc::new(inner) }
@@ -348,15 +343,7 @@ where
 
         Some(Box::pin(fut))
     }
-}
 
-impl<Gen, St, T> PayloadBuilderService<Gen, St, T>
-where
-    T: PayloadTypes,
-    Gen: PayloadJobGenerator,
-    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
-    <Gen::Job as PayloadJob>::BuiltPayload: Into<T::BuiltPayload>,
-{
     /// Returns the payload timestamp for the given payload.
     fn payload_timestamp(&self, id: PayloadId) -> Option<Result<u64, PayloadBuilderError>> {
         if let Some((cached_id, timestamp, _)) = *self.cached_payload_rx.borrow() &&

--- a/crates/payload/primitives/src/error.rs
+++ b/crates/payload/primitives/src/error.rs
@@ -139,9 +139,7 @@ impl NewPayloadError {
     pub fn other(err: impl error::Error + Send + Sync + 'static) -> Self {
         Self::Other(Box::new(err))
     }
-}
 
-impl NewPayloadError {
     /// Returns `true` if the error is caused by a block hash mismatch.
     #[inline]
     pub const fn is_block_hash_mismatch(&self) -> bool {


### PR DESCRIPTION
Merge duplicate inherent `impl` blocks with identical bounds in the payload crate:

All removals are mechanical — the merged blocks have identical generic params and bounds.

Prompted by: yk