### PR TITLE
fix(net): send disconnect on invalid inbound eth messages

### DIFF
--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -63,6 +63,28 @@ impl EthStreamError {
         }
     }
 
+    /// Returns whether this error indicates a protocol breach on the receive side.
+    ///
+    /// These are errors caused by the remote peer sending invalid or malformed data
+    /// that warrant disconnecting with [`DisconnectReason::ProtocolBreach`].
+    pub const fn is_protocol_breach(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidMessage(_) |
+                Self::MessageTooBig(_) |
+                Self::TransactionHashesInvalidLenOfFields { .. } |
+                Self::UnsupportedMessage { .. } |
+                Self::P2PStreamError(
+                    P2PStreamError::Rlp(_) |
+                        P2PStreamError::Snap(_) |
+                        P2PStreamError::MessageTooBig { .. } |
+                        P2PStreamError::UnknownReservedMessageId(_) |
+                        P2PStreamError::EmptyProtocolMessage |
+                        P2PStreamError::UnknownDisconnectReason(_)
+                )
+        )
+    }
+
     /// Returns the [`io::Error`] if it was caused by IO
     pub const fn as_io(&self) -> Option<&io::Error> {
         if let Self::P2PStreamError(P2PStreamError::Io(io)) = self {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -491,7 +491,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     }
 
     /// Returns whether a receive-side stream error should be treated as a protocol breach.
-    fn is_protocol_breach_receive_error(error: &EthStreamError) -> bool {
+    const fn is_protocol_breach_receive_error(error: &EthStreamError) -> bool {
         matches!(
             error,
             EthStreamError::InvalidMessage(_) |
@@ -991,6 +991,7 @@ mod tests {
         GetBlockBodies, HelloMessageWithProtocols, P2PStream, StatusBuilder, UnauthedEthStream,
         UnauthedP2PStream, UnifiedStatus,
     };
+    use reth_eth_wire_types::{EthMessageID, RawCapabilityMessage};
     use reth_ethereum_forks::EthereumHardfork;
     use reth_network_peers::pk2id;
     use reth_network_types::session::config::PROTOCOL_BREACH_REQUEST_TIMEOUT;
@@ -1184,6 +1185,40 @@ mod tests {
         });
 
         fut.await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_invalid_message_disconnects_with_protocol_breach() {
+        let mut builder = SessionBuilder::default();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let fut = builder.with_client_stream(local_addr, async move |mut client_stream| {
+            client_stream
+                .start_send_raw(RawCapabilityMessage::eth(
+                    EthMessageID::PooledTransactions,
+                    vec![0xc0].into(),
+                ))
+                .unwrap();
+            client_stream.flush().await.unwrap();
+
+            let msg = client_stream.next().await.unwrap().unwrap_err();
+            assert_eq!(msg.as_disconnected(), Some(DisconnectReason::ProtocolBreach));
+        });
+
+        let (tx, rx) = oneshot::channel();
+
+        tokio::task::spawn(async move {
+            let (incoming, _) = listener.accept().await.unwrap();
+            let session = builder.connect_incoming(incoming).await;
+            session.await;
+
+            tx.send(()).unwrap();
+        });
+
+        fut.await;
+        rx.await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -24,7 +24,7 @@ use alloy_primitives::Sealable;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::Gauge;
 use reth_eth_wire::{
-    errors::{EthHandshakeError, EthStreamError},
+    errors::{EthHandshakeError, EthStreamError, P2PStreamError},
     message::{EthBroadcastMessage, MessageError},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
 };
@@ -490,6 +490,25 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         self.poll_terminate_message(cx).expect("message is set")
     }
 
+    /// Returns whether a receive-side stream error should be treated as a protocol breach.
+    fn is_protocol_breach_receive_error(error: &EthStreamError) -> bool {
+        matches!(
+            error,
+            EthStreamError::InvalidMessage(_) |
+                EthStreamError::MessageTooBig(_) |
+                EthStreamError::TransactionHashesInvalidLenOfFields { .. } |
+                EthStreamError::UnsupportedMessage { .. } |
+                EthStreamError::P2PStreamError(
+                    P2PStreamError::Rlp(_) |
+                        P2PStreamError::Snap(_) |
+                        P2PStreamError::MessageTooBig { .. } |
+                        P2PStreamError::UnknownReservedMessageId(_) |
+                        P2PStreamError::EmptyProtocolMessage |
+                        P2PStreamError::UnknownDisconnectReason(_)
+                )
+        )
+    }
+
     /// Starts the disconnect process
     fn start_disconnect(&mut self, reason: DisconnectReason) -> Result<(), EthStreamError> {
         Ok(self.conn.inner_mut().start_disconnect(reason)?)
@@ -742,7 +761,9 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     }
                                     OnIncomingMessageOutcome::BadMessage { error, message } => {
                                         debug!(target: "net::session", %error, msg=?message, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
-                                        return this.close_on_error(error, cx)
+                                        this.on_bad_message();
+                                        return this
+                                            .try_disconnect(DisconnectReason::ProtocolBreach, cx)
                                     }
                                     OnIncomingMessageOutcome::NoCapacity(msg) => {
                                         // failed to send due to lack of capacity
@@ -752,6 +773,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                             }
                             Err(err) => {
                                 debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to receive message");
+                                if Self::is_protocol_breach_receive_error(&err) {
+                                    this.on_bad_message();
+                                    return this.try_disconnect(DisconnectReason::ProtocolBreach, cx)
+                                }
                                 return this.close_on_error(err, cx)
                             }
                         }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -24,7 +24,7 @@ use alloy_primitives::Sealable;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::Gauge;
 use reth_eth_wire::{
-    errors::{EthHandshakeError, EthStreamError, P2PStreamError},
+    errors::{EthHandshakeError, EthStreamError},
     message::{EthBroadcastMessage, MessageError},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
 };
@@ -490,25 +490,6 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         self.poll_terminate_message(cx).expect("message is set")
     }
 
-    /// Returns whether a receive-side stream error should be treated as a protocol breach.
-    const fn is_protocol_breach_receive_error(error: &EthStreamError) -> bool {
-        matches!(
-            error,
-            EthStreamError::InvalidMessage(_) |
-                EthStreamError::MessageTooBig(_) |
-                EthStreamError::TransactionHashesInvalidLenOfFields { .. } |
-                EthStreamError::UnsupportedMessage { .. } |
-                EthStreamError::P2PStreamError(
-                    P2PStreamError::Rlp(_) |
-                        P2PStreamError::Snap(_) |
-                        P2PStreamError::MessageTooBig { .. } |
-                        P2PStreamError::UnknownReservedMessageId(_) |
-                        P2PStreamError::EmptyProtocolMessage |
-                        P2PStreamError::UnknownDisconnectReason(_)
-                )
-        )
-    }
-
     /// Starts the disconnect process
     fn start_disconnect(&mut self, reason: DisconnectReason) -> Result<(), EthStreamError> {
         Ok(self.conn.inner_mut().start_disconnect(reason)?)
@@ -773,7 +754,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                             }
                             Err(err) => {
                                 debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to receive message");
-                                if Self::is_protocol_breach_receive_error(&err) {
+                                if err.is_protocol_breach() {
                                     this.on_bad_message();
                                     return this.try_disconnect(DisconnectReason::ProtocolBreach, cx)
                                 }


### PR DESCRIPTION
Established eth sessions currently close the connection on some invalid inbound messages without sending a discMsg, from the devp2p spec https://github.com/ethereum/devp2p/blob/master/rlpx.md#disconnect-0x01, it defined the defines Disconnect (0x01) as the control message used to terminate an established session and includes 0x02 = breach of protocol as a standard reason in the disconnect reason table.

So let's explicit disconnect for established invalid inbound messages.