### PR TITLE
feat(payload): add oldest active job age gauge for stall detection

### DIFF
--- a/.changelog/proud-fish-run.md
+++ b/.changelog/proud-fish-run.md
@@ -1,0 +1,5 @@
+---
+reth-payload-builder: minor
+---
+
+Added `payloads.oldest_active_job_age_seconds` gauge that tracks the age of the longest-running in-flight payload job. Enables alerting on stuck builds caused by deadlocked finalization or state root computation.

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -4,6 +4,7 @@ use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
     Metrics,
 };
+use reth_primitives_traits::FastInstant as Instant;
 
 /// Payload builder service metrics
 #[derive(Metrics, Clone)]
@@ -27,6 +28,10 @@ pub(crate) struct PayloadBuilderServiceMetrics {
     pub(crate) resolve_duration_seconds: Histogram,
     /// Histogram of new payload job creation latency in seconds
     pub(crate) new_job_duration_seconds: Histogram,
+    /// Age of the oldest in-flight payload job in seconds.
+    /// Resets to 0 when no jobs are active. A sustained high value
+    /// indicates a stuck build (e.g. deadlocked finalization or state root).
+    pub(crate) oldest_active_job_age_seconds: Gauge,
 }
 
 impl PayloadBuilderServiceMetrics {
@@ -50,5 +55,15 @@ impl PayloadBuilderServiceMetrics {
     pub(crate) fn set_resolved_revenue(&self, block: u64, value: f64) {
         self.resolved_block.set(block as f64);
         self.resolved_revenue.set(value)
+    }
+
+    /// Updates the oldest active job age gauge from the current set of in-flight jobs.
+    pub(crate) fn set_oldest_job_age<T>(
+        &self,
+        jobs: &[(T, alloy_rpc_types::engine::PayloadId, tracing::Span, Instant)],
+    ) {
+        let age =
+            jobs.iter().map(|(_, _, _, created_at)| created_at.elapsed()).max().unwrap_or_default();
+        self.oldest_active_job_age_seconds.set(age.as_secs_f64());
     }
 }

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -204,10 +204,10 @@ where
 {
     /// The type that knows how to create new payloads.
     generator: Gen,
-    /// All active payload jobs, each accompanied by its id and the caller's tracing span
+    /// All active payload jobs, each accompanied by its id, the caller's tracing span
     /// propagated across the channel so that poll and resolve work appears as children of the
-    /// original Engine API request.
-    payload_jobs: Vec<(Gen::Job, PayloadId, Span)>,
+    /// original Engine API request, and the instant the job was created.
+    payload_jobs: Vec<(Gen::Job, PayloadId, Span, Instant)>,
     /// Copy of the sender half, so new [`PayloadBuilderHandle`] can be created on demand.
     service_tx: mpsc::UnboundedSender<PayloadServiceCommand<T>>,
     /// Receiver half of the command channel.
@@ -277,7 +277,7 @@ where
 
     /// Returns true if the given payload is currently being built.
     fn contains_payload(&self, id: PayloadId) -> bool {
-        self.payload_jobs.iter().any(|(_, job_id, _)| *job_id == id)
+        self.payload_jobs.iter().any(|(_, job_id, _, _)| *job_id == id)
     }
 
     /// Returns the best payload for the given identifier that has been built so far.
@@ -285,8 +285,8 @@ where
         let res = self
             .payload_jobs
             .iter()
-            .find(|(_, job_id, _)| *job_id == id)
-            .map(|(j, _, _)| j.best_payload().map(|p| p.into()));
+            .find(|(_, job_id, _, _)| *job_id == id)
+            .map(|(j, _, _, _)| j.best_payload().map(|p| p.into()));
         if let Some(Ok(ref best)) = res {
             self.metrics.set_best_revenue(best.block().number(), f64::from(best.fees()));
         }
@@ -311,12 +311,12 @@ where
             return Some(Box::pin(core::future::ready(Ok(payload.clone()))));
         }
 
-        let job = self.payload_jobs.iter().position(|(_, job_id, _)| *job_id == id)?;
+        let job = self.payload_jobs.iter().position(|(_, job_id, _, _)| *job_id == id)?;
         let (fut, keep_alive) = self.payload_jobs[job].0.resolve_kind(kind);
         let payload_timestamp = self.payload_jobs[job].0.payload_timestamp();
 
         if keep_alive == KeepPayloadJobAlive::No {
-            let (_, id, _) = self.payload_jobs.swap_remove(job);
+            let (_, id, _, _) = self.payload_jobs.swap_remove(job);
             debug!(target: "payload_builder", %id, "terminated resolved job");
         }
 
@@ -358,8 +358,8 @@ where
         let timestamp = self
             .payload_jobs
             .iter()
-            .find(|(_, job_id, _)| *job_id == id)
-            .map(|(j, _, _)| j.payload_timestamp());
+            .find(|(_, job_id, _, _)| *job_id == id)
+            .map(|(j, _, _, _)| j.payload_timestamp());
 
         if timestamp.is_none() {
             trace!(target: "payload_builder", %id, "no matching payload job found to get timestamp for");
@@ -393,7 +393,7 @@ where
             // requests
             // we don't care about the order of the jobs, so we can just swap_remove them
             for idx in (0..this.payload_jobs.len()).rev() {
-                let (mut job, id, job_span) = this.payload_jobs.swap_remove(idx);
+                let (mut job, id, job_span, created_at) = this.payload_jobs.swap_remove(idx);
 
                 let poll_result = {
                     let _entered = job_span.enter();
@@ -411,10 +411,14 @@ where
                         this.metrics.set_active_jobs(this.payload_jobs.len());
                     }
                     Poll::Pending => {
-                        this.payload_jobs.push((job, id, job_span));
+                        this.payload_jobs.push((job, id, job_span, created_at));
                     }
                 }
             }
+
+            // Report the age of the oldest in-flight job so operators can
+            // alert on stuck builds (e.g. deadlocked finalization).
+            this.metrics.set_oldest_job_age(&this.payload_jobs);
 
             // marker for exit condition
             let mut new_job = false;
@@ -442,7 +446,7 @@ where
                                     info!(target: "payload_builder", %id, %parent, "New payload job created");
                                     this.metrics.inc_initiated_jobs();
                                     new_job = true;
-                                    this.payload_jobs.push((job, id, job_span));
+                                    this.payload_jobs.push((job, id, job_span, Instant::now()));
                                     this.payload_events.send(Events::Attributes(attr)).ok();
 
                                     // Clear stale cached payload for this id so


### PR DESCRIPTION
Adds `payloads.oldest_active_job_age_seconds` gauge — tracks how long the oldest in-flight payload job has been running. Resets to 0 when idle.

Deadlocks like #22971 produce no histogram observations and go undetected. This gauge climbs steadily when a build is stuck, making it directly alertable:

```
payloads_oldest_active_job_age_seconds > 5 and payloads_active_jobs > 0
```