### PR TITLE
fix: adapt to alloy-evm bal-devnet2 API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7925,6 +7925,7 @@ name = "reth-consensus"
 version = "1.11.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",

--- a/bin/reth-bench-compare/src/benchmark.rs
+++ b/bin/reth-bench-compare/src/benchmark.rs
@@ -280,8 +280,8 @@ impl BenchmarkRunner {
             // Print all captured output when command fails
             error!("reth-bench failed with exit code: {:?}", status.code());
 
-            if let Ok(stdout) = stdout_lines.lock() &&
-                !stdout.is_empty()
+            if let Ok(stdout) = stdout_lines.lock()
+                && !stdout.is_empty()
             {
                 error!("reth-bench stdout:");
                 for line in stdout.iter() {
@@ -289,8 +289,8 @@ impl BenchmarkRunner {
                 }
             }
 
-            if let Ok(stderr) = stderr_lines.lock() &&
-                !stderr.is_empty()
+            if let Ok(stderr) = stderr_lines.lock()
+                && !stderr.is_empty()
             {
                 error!("reth-bench stderr:");
                 for line in stderr.iter() {

--- a/bin/reth-bench-compare/src/comparison.rs
+++ b/bin/reth-bench-compare/src/comparison.rs
@@ -690,8 +690,8 @@ fn calculate_std_dev(values: &[f64], mean: f64) -> f64 {
             let diff = x - mean;
             diff * diff
         })
-        .sum::<f64>() /
-        values.len() as f64;
+        .sum::<f64>()
+        / values.len() as f64;
 
     variance.sqrt()
 }

--- a/bin/reth-bench-compare/src/git.rs
+++ b/bin/reth-bench-compare/src/git.rs
@@ -189,8 +189,8 @@ impl GitManager {
                 .current_dir(&self.repo_root)
                 .output();
 
-            let found = if let Ok(output) = ref_check &&
-                output.status.success()
+            let found = if let Ok(output) = ref_check
+                && output.status.success()
             {
                 info!("Validated reference exists: {}", git_ref);
                 true
@@ -202,8 +202,8 @@ impl GitManager {
                     .current_dir(&self.repo_root)
                     .output();
 
-                if let Ok(output) = origin_check &&
-                    output.status.success()
+                if let Ok(output) = origin_check
+                    && output.status.success()
                 {
                     info!("Validated remote reference exists: origin/{}", git_ref);
                     true
@@ -259,8 +259,8 @@ impl GitManager {
                 .current_dir(&self.repo_root)
                 .output();
 
-            if let Ok(output) = tracking_output &&
-                output.status.success()
+            if let Ok(output) = tracking_output
+                && output.status.success()
             {
                 let upstream = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 if !upstream.is_empty() && upstream != format!("{git_ref}@{{upstream}}") {

--- a/bin/reth-bench/src/bench/metrics_scraper.rs
+++ b/bin/reth-bench/src/bench/metrics_scraper.rs
@@ -113,8 +113,8 @@ fn parse_gauge(text: &str, name: &str) -> Option<f64> {
         // Format: `metric_name{labels} value [timestamp]` or `metric_name value [timestamp]`
         // Value is always the second whitespace-separated token.
         let mut parts = line.split_whitespace();
-        if let Some(value_str) = parts.nth(1) &&
-            let Ok(v) = value_str.parse::<f64>()
+        if let Some(value_str) = parts.nth(1)
+            && let Ok(v) = value_str.parse::<f64>()
         {
             result = Some(v);
         }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -309,8 +309,8 @@ impl Command {
             };
             info!(target: "reth-bench", progress, %combined_result);
 
-            if let Some(scraper) = metrics_scraper.as_mut() &&
-                let Err(err) = scraper.scrape_after_block(block_number).await
+            if let Some(scraper) = metrics_scraper.as_mut()
+                && let Err(err) = scraper.scrape_after_block(block_number).await
             {
                 warn!(target: "reth-bench", %err, block_number, "Failed to scrape metrics");
             }

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -160,8 +160,8 @@ impl Command {
                 TotalGasRow { block_number, transaction_count, gas_used, time: current_duration };
             results.push((row, new_payload_result));
 
-            if let Some(scraper) = metrics_scraper.as_mut() &&
-                let Err(err) = scraper.scrape_after_block(block_number).await
+            if let Some(scraper) = metrics_scraper.as_mut()
+                && let Err(err) = scraper.scrape_after_block(block_number).await
             {
                 tracing::warn!(target: "reth-bench", %err, block_number, "Failed to scrape metrics");
             }

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -403,8 +403,8 @@ impl Command {
             let progress = format!("{}/{}", i + 1, payloads.len());
             info!(target: "reth-bench", progress, %combined_result);
 
-            if let Some(scraper) = metrics_scraper.as_mut() &&
-                let Err(err) = scraper.scrape_after_block(block_number).await
+            if let Some(scraper) = metrics_scraper.as_mut()
+                && let Err(err) = scraper.scrape_after_block(block_number).await
             {
                 tracing::warn!(target: "reth-bench", %err, block_number, "Failed to scrape metrics");
             }
@@ -460,8 +460,8 @@ impl Command {
             .wrap_err_with(|| format!("Failed to read directory {:?}", self.payload_dir))?
             .filter_map(|e| e.ok())
             .filter(|e| {
-                e.path().extension().and_then(|s| s.to_str()) == Some("json") &&
-                    e.file_name().to_string_lossy().starts_with("payload_block_")
+                e.path().extension().and_then(|s| s.to_str()) == Some("json")
+                    && e.file_name().to_string_lossy().starts_with("payload_block_")
             })
             .collect();
 
@@ -519,8 +519,8 @@ impl Command {
             .wrap_err_with(|| format!("Failed to read directory {:?}", dir))?
             .filter_map(|e| e.ok())
             .filter(|e| {
-                e.path().extension().and_then(|s| s.to_str()) == Some("json") &&
-                    e.file_name().to_string_lossy().starts_with("payload_block_")
+                e.path().extension().and_then(|s| s.to_str()) == Some("json")
+                    && e.file_name().to_string_lossy().starts_with("payload_block_")
             })
             .collect();
 

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -81,7 +81,7 @@ where
             if status.is_syncing() {
                 return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
                     "invalid range: no canonical state found for parent of requested block",
-                ))
+                ));
             }
             status =
                 self.fork_choice_updated_v1(fork_choice_state, payload_attributes.clone()).await?;
@@ -120,7 +120,7 @@ where
             if status.is_syncing() {
                 return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
                     "invalid range: no canonical state found for parent of requested block",
-                ))
+                ));
             }
             status =
                 self.fork_choice_updated_v2(fork_choice_state, payload_attributes.clone()).await?;
@@ -387,10 +387,10 @@ pub(crate) async fn call_forkchoice_updated<N, P: EngineApiValidWaitExt<N>>(
 ) -> TransportResult<ForkchoiceUpdated> {
     // FCU V3 is used for Cancun, Prague, and Amsterdam (there is no FCU V4-V6)
     match message_version {
-        EngineApiMessageVersion::V3 |
-        EngineApiMessageVersion::V4 |
-        EngineApiMessageVersion::V5 |
-        EngineApiMessageVersion::V6 => {
+        EngineApiMessageVersion::V3
+        | EngineApiMessageVersion::V4
+        | EngineApiMessageVersion::V5
+        | EngineApiMessageVersion::V6 => {
             provider.fork_choice_updated_v3_wait(forkchoice_state, payload_attributes).await
         }
         EngineApiMessageVersion::V2 => {
@@ -428,19 +428,19 @@ pub(crate) async fn call_forkchoice_updated_with_reth<
             let resp: ForkchoiceUpdated = provider.client().request(method, &reth_params).await?;
 
             if resp.is_valid() {
-                break Ok(resp)
+                break Ok(resp);
             }
 
             if resp.is_invalid() {
                 error!(target: "reth-bench", ?resp, "Invalid {method}");
                 return Err(alloy_json_rpc::RpcError::LocalUsageError(Box::new(
                     std::io::Error::other(format!("Invalid {method}: {resp:?}")),
-                )))
+                )));
             }
             if resp.is_syncing() {
                 return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
                     "invalid range: no canonical state found for parent of requested block",
-                ))
+                ));
             }
         }
     }

--- a/crates/chain-state/src/chain_info.rs
+++ b/crates/chain-state/src/chain_info.rs
@@ -118,7 +118,7 @@ where
         self.inner.safe_block.send_if_modified(|current_header| {
             if current_header.as_ref().map(SealedHeader::hash) != Some(header.hash()) {
                 let _ = current_header.replace(header);
-                return true
+                return true;
             }
 
             false
@@ -130,7 +130,7 @@ where
         self.inner.finalized_block.send_if_modified(|current_header| {
             if current_header.as_ref().map(SealedHeader::hash) != Some(header.hash()) {
                 let _ = current_header.replace(header);
-                return true
+                return true;
             }
 
             false
@@ -142,7 +142,7 @@ where
         self.inner.persisted_block.send_if_modified(|current| {
             if current.map(|b| b.hash) != Some(num_hash.hash) {
                 let _ = current.replace(num_hash);
-                return true
+                return true;
             }
 
             false

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -328,7 +328,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
         {
             if self.inner.in_memory_state.blocks.read().get(&persisted_num_hash.hash).is_none() {
                 // do nothing
-                return
+                return;
             }
         }
 
@@ -567,7 +567,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
             if let Some(tx) =
                 block_state.block_ref().recovered_block().body().transaction_by_hash(&hash)
             {
-                return Some(tx.clone())
+                return Some(tx.clone());
             }
         }
         None
@@ -772,7 +772,6 @@ impl<N: NodePrimitives> Default for ExecutedBlock<N> {
                     requests: Default::default(),
                     gas_used: 0,
                     blob_gas_used: 0,
-                    block_access_list: Default::default(),
                 },
                 state: Default::default(),
             }),
@@ -784,8 +783,8 @@ impl<N: NodePrimitives> Default for ExecutedBlock<N> {
 impl<N: NodePrimitives> PartialEq for ExecutedBlock<N> {
     fn eq(&self, other: &Self) -> bool {
         // Trie data is computed asynchronously and doesn't define block identity.
-        self.recovered_block == other.recovered_block &&
-            self.execution_output == other.execution_output
+        self.recovered_block == other.recovered_block
+            && self.execution_output == other.execution_output
     }
 }
 

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -68,10 +68,10 @@ impl<N: NodePrimitives> Stream for CanonStateNotificationStream<N> {
                 Some(Ok(notification)) => Poll::Ready(Some(notification)),
                 Some(Err(err)) => {
                     debug!(%err, "canonical state notification stream lagging behind");
-                    continue
+                    continue;
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -155,8 +155,8 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
                 .into_trie_account(EMPTY_ROOT_HASH),
             )]),
             // use the number as the timestamp so it is monotonically increasing
-            timestamp: number +
-                EthereumHardfork::Cancun.activation_timestamp(self.chain_spec.chain).unwrap(),
+            timestamp: number
+                + EthereumHardfork::Cancun.activation_timestamp(self.chain_spec.chain).unwrap(),
             withdrawals_root: Some(calculate_withdrawals_root(&[])),
             blob_gas_used: Some(0),
             excess_blob_gas: Some(0),
@@ -212,7 +212,6 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
                     requests: Default::default(),
                     gas_used: 0,
                     blob_gas_used: 0,
-                    block_access_list: Default::default(),
                 },
                 state: BundleState::default(),
             }),

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -356,8 +356,8 @@ pub fn blob_params_to_schedule(
     let bpo_forks = EthereumHardfork::bpo_variants();
     for (timestamp, blob_params) in &params.scheduled {
         for bpo_fork in bpo_forks {
-            if let ForkCondition::Timestamp(fork_ts) = hardforks.fork(bpo_fork) &&
-                fork_ts == *timestamp
+            if let ForkCondition::Timestamp(fork_ts) = hardforks.fork(bpo_fork)
+                && fork_ts == *timestamp
             {
                 schedule.insert(bpo_fork.name().to_lowercase(), *blob_params);
                 break;
@@ -549,7 +549,7 @@ impl<H: BlockHeader> ChainSpec<H> {
                 // given timestamp.
                 for (fork, params) in bf_params.iter().rev() {
                     if self.hardforks.is_fork_active_at_timestamp(fork.clone(), timestamp) {
-                        return *params
+                        return *params;
                     }
                 }
 
@@ -642,8 +642,8 @@ impl<H: BlockHeader> ChainSpec<H> {
             // We filter out TTD-based forks w/o a pre-known block since those do not show up in
             // the fork filter.
             Some(match condition {
-                ForkCondition::Block(block) |
-                ForkCondition::TTD { fork_block: Some(block), .. } => ForkFilterKey::Block(block),
+                ForkCondition::Block(block)
+                | ForkCondition::TTD { fork_block: Some(block), .. } => ForkFilterKey::Block(block),
                 ForkCondition::Timestamp(time) => ForkFilterKey::Time(time),
                 _ => return None,
             })
@@ -677,8 +677,8 @@ impl<H: BlockHeader> ChainSpec<H> {
         for (_, cond) in self.hardforks.forks_iter() {
             // handle block based forks and the sepolia merge netsplit block edge case (TTD
             // ForkCondition with Some(block))
-            if let ForkCondition::Block(block) |
-            ForkCondition::TTD { fork_block: Some(block), .. } = cond
+            if let ForkCondition::Block(block)
+            | ForkCondition::TTD { fork_block: Some(block), .. } = cond
             {
                 if head.number >= block {
                     // skip duplicated hardforks: hardforks enabled at genesis block
@@ -689,7 +689,7 @@ impl<H: BlockHeader> ChainSpec<H> {
                 } else {
                     // we can return here because this block fork is not active, so we set the
                     // `next` value
-                    return ForkId { hash: forkhash, next: block }
+                    return ForkId { hash: forkhash, next: block };
                 }
             }
         }
@@ -711,7 +711,7 @@ impl<H: BlockHeader> ChainSpec<H> {
                 // can safely return here because we have already handled all block forks and
                 // have handled all active timestamp forks, and set the next value to the
                 // timestamp that is known but not active yet
-                return ForkId { hash: forkhash, next: timestamp }
+                return ForkId { hash: forkhash, next: timestamp };
             }
         }
 

--- a/crates/cli/cli/src/chainspec.rs
+++ b/crates/cli/cli/src/chainspec.rs
@@ -80,7 +80,7 @@ pub fn parse_genesis(s: &str) -> eyre::Result<alloy_genesis::Genesis> {
             if s.contains('{') {
                 s.to_string()
             } else {
-                return Err(io_err.into()) // assume invalid path
+                return Err(io_err.into()); // assume invalid path
             }
         }
     };

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -203,13 +203,13 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
         .with_prune_modes(prune_modes.clone());
 
         // Check for consistency between database and static files.
-        if !access.is_read_only_inconsistent() &&
-            let Some(unwind_target) =
+        if !access.is_read_only_inconsistent()
+            && let Some(unwind_target) =
                 factory.static_file_provider().check_consistency(&factory.provider()?)?
         {
             if factory.db_ref().is_read_only()? {
                 warn!(target: "reth::cli", ?unwind_target, "Inconsistent storage. Restart node to heal.");
-                return Ok(factory)
+                return Ok(factory);
             }
 
             // Highly unlikely to happen, and given its destructive nature, it's better to panic

--- a/crates/cli/commands/src/db/diff.rs
+++ b/crates/cli/commands/src/db/diff.rs
@@ -308,12 +308,12 @@ where
     ) {
         // do not bother comparing if the key is already in the discrepancies map
         if self.discrepancies.contains_key(&key) {
-            return
+            return;
         }
 
         // do not bother comparing if the key is already in the extra elements map
         if self.extra_elements.contains_key(&key) {
-            return
+            return;
         }
 
         match (first, second) {

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -163,7 +163,7 @@ impl Command {
                             .account_block_changeset(key)?;
 
                         println!("{}", serde_json::to_string_pretty(&changesets)?);
-                        return Ok(())
+                        return Ok(());
                     };
 
                     let account = tool
@@ -177,7 +177,7 @@ impl Command {
                         error!(target: "reth::cli", "No content for the given table key.");
                     }
 
-                    return Ok(())
+                    return Ok(());
                 }
 
                 let content = tool.provider_factory.static_file_provider().find_static_file(
@@ -356,8 +356,8 @@ impl<N: ProviderNodeTypes> TableViewer<()> for GetValueViewer<'_, N> {
 
                 // Seek to the starting key. If there is actually a key at the starting key then
                 // seek to the subkey within it.
-                if let Some((decoded_key, _)) = cursor.seek(key.clone())? &&
-                    decoded_key == key
+                if let Some((decoded_key, _)) = cursor.seek(key.clone())?
+                    && decoded_key == key
                 {
                     cursor.seek_by_key_subkey(key.clone(), start_subkey.clone())?;
                 }
@@ -370,8 +370,8 @@ impl<N: ProviderNodeTypes> TableViewer<()> for GetValueViewer<'_, N> {
                     let decoded_subkey = decoded_value.get_subkey();
 
                     // Check if we've reached the end (exclusive)
-                    if (&decoded_key, Some(&decoded_subkey)) >=
-                        (&end_key, end_subkey_parsed.as_ref())
+                    if (&decoded_key, Some(&decoded_subkey))
+                        >= (&end_key, end_subkey_parsed.as_ref())
                     {
                         break;
                     }

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -163,7 +163,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
                     if !input.trim().eq_ignore_ascii_case("y") {
                         println!("Database drop aborted!");
-                        return Ok(())
+                        return Ok(());
                     }
                 }
 

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -147,14 +147,14 @@ fn do_verify_only<TX: DbTx, A: TrieTableAdapter>(tx: &TX) -> eyre::Result<()> {
 
             // Record metrics based on output type
             match output {
-                Output::AccountExtra(_, _) |
-                Output::AccountWrong { .. } |
-                Output::AccountMissing(_, _) => {
+                Output::AccountExtra(_, _)
+                | Output::AccountWrong { .. }
+                | Output::AccountMissing(_, _) => {
                     metrics.account_inconsistencies.increment(1);
                 }
-                Output::StorageExtra(_, _, _) |
-                Output::StorageWrong { .. } |
-                Output::StorageMissing(_, _, _) => {
+                Output::StorageExtra(_, _, _)
+                | Output::StorageWrong { .. }
+                | Output::StorageMissing(_, _, _) => {
                     metrics.storage_inconsistencies.increment(1);
                 }
                 Output::Progress(_) => unreachable!(),
@@ -181,7 +181,7 @@ fn verify_checkpoints(provider: impl StageCheckpointReader) -> eyre::Result<()> 
             "MerkleExecute stage checkpoint ({}) != AccountHashing stage checkpoint ({}), you must first complete the pipeline sync by running `reth node`",
             merkle_checkpoint.block_number,
             account_hashing_checkpoint.block_number,
-        ))
+        ));
     }
 
     if storage_hashing_checkpoint.block_number != merkle_checkpoint.block_number {
@@ -189,7 +189,7 @@ fn verify_checkpoints(provider: impl StageCheckpointReader) -> eyre::Result<()> 
             "MerkleExecute stage checkpoint ({}) != StorageHashing stage checkpoint ({}), you must first complete the pipeline sync by running `reth node`",
             merkle_checkpoint.block_number,
             storage_hashing_checkpoint.block_number,
-        ))
+        ));
     }
 
     let merkle_checkpoint_progress =
@@ -197,7 +197,7 @@ fn verify_checkpoints(provider: impl StageCheckpointReader) -> eyre::Result<()> 
     if merkle_checkpoint_progress.is_some_and(|progress| !progress.is_empty()) {
         return Err(eyre::eyre!(
             "MerkleExecute sync stage in-progress, you must first complete the pipeline sync by running `reth node`",
-        ))
+        ));
     }
 
     Ok(())
@@ -265,14 +265,14 @@ where
 
             // Record metrics based on output type
             match &output {
-                Output::AccountExtra(_, _) |
-                Output::AccountWrong { .. } |
-                Output::AccountMissing(_, _) => {
+                Output::AccountExtra(_, _)
+                | Output::AccountWrong { .. }
+                | Output::AccountMissing(_, _) => {
                     metrics.account_inconsistencies.increment(1);
                 }
-                Output::StorageExtra(_, _, _) |
-                Output::StorageWrong { .. } |
-                Output::StorageMissing(_, _, _) => {
+                Output::StorageExtra(_, _, _)
+                | Output::StorageWrong { .. }
+                | Output::StorageMissing(_, _, _) => {
                     metrics.storage_inconsistencies.increment(1);
                 }
                 Output::Progress(_) => {}
@@ -298,14 +298,14 @@ where
                     storage_trie_cursor.delete_current()?;
                 }
             }
-            Output::AccountWrong { path, expected: node, .. } |
-            Output::AccountMissing(path, node) => {
+            Output::AccountWrong { path, expected: node, .. }
+            | Output::AccountMissing(path, node) => {
                 // Wrong/missing account node value, upsert it
                 let key: A::AccountKey = path.into();
                 account_trie_cursor.upsert(key, &node)?;
             }
-            Output::StorageWrong { account, path, expected: node, .. } |
-            Output::StorageMissing(account, path, node) => {
+            Output::StorageWrong { account, path, expected: node, .. }
+            | Output::StorageMissing(account, path, node) => {
                 // Wrong/missing storage node value, upsert it
                 // (We can't just use `upsert` method with a dup cursor, it's not properly
                 // supported)

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -371,10 +371,10 @@ impl Command {
                         .add_cell(Cell::new(human_bytes(segment_config_size as f64)));
                 }
                 row.add_cell(Cell::new(human_bytes(
-                    (segment_data_size +
-                        segment_index_size +
-                        segment_offsets_size +
-                        segment_config_size) as f64,
+                    (segment_data_size
+                        + segment_index_size
+                        + segment_offsets_size
+                        + segment_config_size) as f64,
                 )));
                 table.add_row(row);
             }

--- a/crates/cli/commands/src/db/tui.rs
+++ b/crates/cli/commands/src/db/tui.rs
@@ -293,7 +293,7 @@ where
             }
         }
 
-        return Ok(false)
+        return Ok(false);
     }
 
     match event {

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -661,10 +661,10 @@ fn inject_archive_only_components(
     let is_all =
         |ty: SnapshotComponentType| selections.get(&ty).copied() == Some(ComponentSelection::All);
 
-    let is_archive = is_all(SnapshotComponentType::Transactions) &&
-        is_all(SnapshotComponentType::Receipts) &&
-        is_all(SnapshotComponentType::AccountChangesets) &&
-        is_all(SnapshotComponentType::StorageChangesets);
+    let is_archive = is_all(SnapshotComponentType::Transactions)
+        && is_all(SnapshotComponentType::Receipts)
+        && is_all(SnapshotComponentType::AccountChangesets)
+        && is_all(SnapshotComponentType::StorageChangesets);
 
     if !is_archive {
         return;
@@ -941,8 +941,8 @@ impl<R: Read> Read for ProgressReader<R> {
             return Err(io::Error::new(io::ErrorKind::Interrupted, "download cancelled"));
         }
         let bytes = self.reader.read(buf)?;
-        if bytes > 0 &&
-            let Err(e) = self.progress.update(bytes as u64)
+        if bytes > 0
+            && let Err(e) = self.progress.update(bytes as u64)
         {
             return Err(io::Error::other(e));
         }
@@ -1144,8 +1144,8 @@ fn resumable_download(
     for attempt in 1..=MAX_DOWNLOAD_RETRIES {
         let existing_size = fs::metadata(&part_path).map(|m| m.len()).unwrap_or(0);
 
-        if let Some(total) = total_size &&
-            existing_size >= total
+        if let Some(total) = total_size
+            && existing_size >= total
         {
             return finalize_download(total);
         }
@@ -1392,15 +1392,15 @@ fn blocking_download_and_extract(
 ) -> Result<()> {
     let format = CompressionFormat::from_url(url)?;
 
-    if let Ok(parsed_url) = Url::parse(url) &&
-        parsed_url.scheme() == "file"
+    if let Ok(parsed_url) = Url::parse(url)
+        && parsed_url.scheme() == "file"
     {
         let file_path = parsed_url
             .to_file_path()
             .map_err(|_| eyre::eyre!("Invalid file:// URL path: {}", url))?;
         let result = extract_from_file(&file_path, format, target_dir);
-        if result.is_ok() &&
-            let Some(sp) = shared
+        if result.is_ok()
+            && let Some(sp) = shared
         {
             sp.archive_done();
         }
@@ -1410,8 +1410,8 @@ fn blocking_download_and_extract(
     } else {
         let result =
             streaming_download_and_extract(url, format, target_dir, shared.as_ref(), cancel_token);
-        if result.is_ok() &&
-            let Some(sp) = shared
+        if result.is_ok()
+            && let Some(sp) = shared
         {
             sp.archive_done();
         }
@@ -1619,8 +1619,8 @@ async fn fetch_manifest_from_source(source: &str) -> Result<SnapshotManifest> {
 }
 
 fn resolve_manifest_base_url(manifest: &SnapshotManifest, source: &str) -> Result<String> {
-    if let Some(base_url) = manifest.base_url.as_deref() &&
-        !base_url.is_empty()
+    if let Some(base_url) = manifest.base_url.as_deref()
+        && !base_url.is_empty()
     {
         return Ok(base_url.trim_end_matches('/').to_string());
     }

--- a/crates/cli/commands/src/download/tui.rs
+++ b/crates/cli/commands/src/download/tui.rs
@@ -309,9 +309,9 @@ fn event_loop(
         let timeout =
             tick_rate.checked_sub(last_tick.elapsed()).unwrap_or_else(|| Duration::from_secs(0));
 
-        if crossterm::event::poll(timeout)? &&
-            let Event::Key(key) = event::read()? &&
-            key.kind == event::KeyEventKind::Press
+        if crossterm::event::poll(timeout)?
+            && let Event::Key(key) = event::read()?
+            && key.kind == event::KeyEventKind::Press
         {
             match key.code {
                 KeyCode::Char('q') | KeyCode::Esc => {

--- a/crates/cli/commands/src/import_core.rs
+++ b/crates/cli/commands/src/import_core.rs
@@ -62,8 +62,8 @@ pub struct ImportResult {
 impl ImportResult {
     /// Returns true if all blocks and transactions were imported successfully.
     pub fn is_complete(&self) -> bool {
-        self.total_decoded_blocks == self.total_imported_blocks &&
-            self.total_decoded_txns == self.total_imported_txns
+        self.total_decoded_blocks == self.total_imported_blocks
+            && self.total_decoded_txns == self.total_imported_txns
     }
 
     /// Returns true if the import was successful, considering stop-on-invalid-block mode.

--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -78,8 +78,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
         let next_block = provider_factory
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::Headers)
-            .unwrap_or_default() +
-            1;
+            .unwrap_or_default()
+            + 1;
 
         if let Some(path) = self.import.path {
             let stream = read_dir(path, next_block)?;

--- a/crates/cli/commands/src/init_state/without_evm.rs
+++ b/crates/cli/commands/src/init_state/without_evm.rs
@@ -118,7 +118,7 @@ where
         StaticFileSegment::TransactionSenders,
     ] {
         if sf_provider.get_highest_static_file_block(segment).is_none() {
-            continue
+            continue;
         }
         let tx_clone = tx.clone();
         let provider = sf_provider.clone();
@@ -159,7 +159,7 @@ where
     while let Ok(append_result) = rx.recv() {
         if let Err(err) = append_result {
             tracing::error!(target: "reth::cli", "Error appending dummy chain: {err}");
-            return Err(err)
+            return Err(err);
         }
     }
 
@@ -172,7 +172,7 @@ where
         StaticFileSegment::TransactionSenders,
     ] {
         if sf_provider.get_highest_static_file_block(segment).is_none() {
-            continue
+            continue;
         }
         assert_eq!(
             sf_provider.latest_writer(segment)?.user_header().block_end(),

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -180,7 +180,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         };
 
                         if let Err(err) = consensus
-                            .validate_block_post_execution(&block, &result, None)
+                            .validate_block_post_execution(&block, &result, None, None, false)
                             .wrap_err_with(|| {
                                 format!(
                                     "Failed to validate block {} {}",

--- a/crates/cli/commands/src/stage/dump/hashing_account.rs
+++ b/crates/cli/commands/src/stage/dump/hashing_account.rs
@@ -95,7 +95,7 @@ fn dry_run<N: ProviderNodeTypes>(
             checkpoint: Some(StageCheckpoint::new(from)),
         };
         if stage.execute(&provider, input)?.done {
-            break
+            break;
         }
     }
 

--- a/crates/cli/commands/src/stage/dump/hashing_storage.rs
+++ b/crates/cli/commands/src/stage/dump/hashing_storage.rs
@@ -90,7 +90,7 @@ fn dry_run<N: ProviderNodeTypes>(
             checkpoint: Some(StageCheckpoint::new(from)),
         };
         if stage.execute(&provider, input)?.done {
-            break
+            break;
         }
     }
 

--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -177,7 +177,7 @@ where
             checkpoint: Some(StageCheckpoint::new(from)),
         };
         if stage.execute(&provider, input)?.done {
-            break
+            break;
         }
     }
 

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -184,7 +184,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         match fetch_client.get_header(BlockHashOrNumber::Number(self.to)).await {
                             Ok(header) => {
                                 if let Some(header) = header.into_data() {
-                                    break header
+                                    break header;
                                 }
                             }
                             Err(error) if error.is_retryable() => {
@@ -243,8 +243,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                 config.stages.bodies.downloader_max_buffered_blocks_size_bytes,
                             )
                             .with_concurrent_requests_range(
-                                config.stages.bodies.downloader_min_concurrent_requests..=
-                                    config.stages.bodies.downloader_max_concurrent_requests,
+                                config.stages.bodies.downloader_min_concurrent_requests
+                                    ..=config.stages.bodies.downloader_max_concurrent_requests,
                             )
                             .build(fetch_client, consensus.clone(), provider_factory.clone()),
                     );
@@ -379,7 +379,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             }
 
             if done {
-                break
+                break;
             }
         }
         info!(target: "reth::cli", stage = %self.stage, time = ?start.elapsed(), "Finished stage");

--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -214,7 +214,7 @@ where
                         tries += 1;
                         bytes.extend(std::iter::repeat_n(0u8, 256));
                     } else {
-                        return Err(err)?
+                        return Err(err)?;
                     }
                 }
             }

--- a/crates/cli/commands/src/test_vectors/tables.rs
+++ b/crates/cli/commands/src/test_vectors/tables.rs
@@ -132,7 +132,7 @@ where
         let key: T::Key = start_keys.new_tree(runner).map_err(|e| eyre::eyre!("{e}"))?.current();
 
         if !seen_keys.insert(key.clone()) {
-            continue
+            continue;
         }
 
         let mut values: Vec<T::Value> =

--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -78,15 +78,15 @@ pub enum SocketAddressParsingError {
 /// An error is returned if the value is empty.
 pub fn parse_socket_address(value: &str) -> eyre::Result<SocketAddr, SocketAddressParsingError> {
     if value.is_empty() {
-        return Err(SocketAddressParsingError::Empty)
+        return Err(SocketAddressParsingError::Empty);
     }
 
     if let Some(port) = value.strip_prefix(':').or_else(|| value.strip_prefix("localhost:")) {
         let port: u16 = port.parse()?;
-        return Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+        return Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port));
     }
     if let Ok(port) = value.parse() {
-        return Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
+        return Ok(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port));
     }
     value
         .to_socket_addrs()?
@@ -110,7 +110,7 @@ pub fn read_json_from_file<T: serde::de::DeserializeOwned>(path: &str) -> Result
 pub fn parse_ether_value(value: &str) -> eyre::Result<u128> {
     let eth = value.parse::<f64>()?;
     if eth.is_sign_negative() {
-        return Err(eyre::eyre!("Ether value cannot be negative"))
+        return Err(eyre::eyre!("Ether value cannot be negative"));
     }
     let wei = eth * 1e18;
     Ok(wei as u128)

--- a/crates/cli/util/src/sigsegv_handler.rs
+++ b/crates/cli/util/src/sigsegv_handler.rs
@@ -49,7 +49,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         // Collect return addresses
         let depth = libc::backtrace(stack_trace.as_mut_ptr(), MAX_FRAMES as i32);
         if depth == 0 {
-            return
+            return;
         }
         &stack_trace[0..depth as usize]
     };
@@ -67,7 +67,7 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
         let period = period.saturating_add(1); // avoid "what if wrapped?" branches
         let Some(offset) = stack.iter().skip(period).zip(stack).position(cycled) else {
             // impossible.
-            return
+            return;
         };
 
         // Count matching trace slices, else we could miscount "biphasic cycles"

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -24,11 +24,11 @@ pub fn validate_header_gas<H: BlockHeader>(header: &H) -> Result<(), ConsensusEr
         return Err(ConsensusError::HeaderGasUsedExceedsGasLimit {
             gas_used: header.gas_used(),
             gas_limit: header.gas_limit(),
-        })
+        });
     }
     // Check that the gas limit is below the maximum allowed gas limit
     if header.gas_limit() > MAXIMUM_GAS_LIMIT_BLOCK {
-        return Err(ConsensusError::HeaderGasLimitExceedsMax { gas_limit: header.gas_limit() })
+        return Err(ConsensusError::HeaderGasLimitExceedsMax { gas_limit: header.gas_limit() });
     }
     Ok(())
 }
@@ -41,7 +41,7 @@ pub fn validate_header_base_fee<H: BlockHeader, ChainSpec: EthereumHardforks>(
 ) -> Result<(), ConsensusError> {
     if chain_spec.is_london_active_at_block(header.number()) && header.base_fee_per_gas().is_none()
     {
-        return Err(ConsensusError::BaseFeeMissing)
+        return Err(ConsensusError::BaseFeeMissing);
     }
     Ok(())
 }
@@ -127,14 +127,14 @@ where
                 expected: header.ommers_hash(),
             }
             .into(),
-        ))
+        ));
     }
 
     let tx_root = body.calculate_tx_root();
     if header.transactions_root() != tx_root {
         return Err(ConsensusError::BodyTransactionRootDiff(
             GotExpected { got: tx_root, expected: header.transactions_root() }.into(),
-        ))
+        ));
     }
 
     match (header.withdrawals_root(), body.calculate_withdrawals_root()) {
@@ -142,7 +142,7 @@ where
             if withdrawals_root != header_withdrawals_root {
                 return Err(ConsensusError::BodyWithdrawalsRootDiff(
                     GotExpected { got: withdrawals_root, expected: header_withdrawals_root }.into(),
-                ))
+                ));
             }
         }
         (None, None) => {
@@ -198,7 +198,7 @@ where
         return Err(ConsensusError::BodyTransactionRootDiff(
             GotExpected { got: calculated_transaction_root, expected: expected_transaction_root }
                 .into(),
-        ))
+        ));
     }
 
     Ok(())
@@ -229,7 +229,7 @@ where
                 expected: block.ommers_hash(),
             }
             .into(),
-        ))
+        ));
     }
 
     // EIP-4895: Beacon chain push withdrawals as operations
@@ -241,13 +241,13 @@ where
         validate_cancun_gas(block)?;
     }
 
-    if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) &&
-        block.rlp_length() > MAX_RLP_BLOCK_SIZE
+    if chain_spec.is_osaka_active_at_timestamp(block.timestamp())
+        && block.rlp_length() > MAX_RLP_BLOCK_SIZE
     {
         return Err(ConsensusError::BlockTooLarge {
             rlp_length: block.rlp_length(),
             max_rlp_length: MAX_RLP_BLOCK_SIZE,
-        })
+        });
     }
 
     Ok(())
@@ -266,21 +266,21 @@ pub fn validate_4844_header_standalone<H: BlockHeader>(
     let blob_gas_used = header.blob_gas_used().ok_or(ConsensusError::BlobGasUsedMissing)?;
 
     if header.parent_beacon_block_root().is_none() {
-        return Err(ConsensusError::ParentBeaconBlockRootMissing)
+        return Err(ConsensusError::ParentBeaconBlockRootMissing);
     }
 
     if !blob_gas_used.is_multiple_of(DATA_GAS_PER_BLOB) {
         return Err(ConsensusError::BlobGasUsedNotMultipleOfBlobGasPerBlob {
             blob_gas_used,
             blob_gas_per_blob: DATA_GAS_PER_BLOB,
-        })
+        });
     }
 
     if blob_gas_used > blob_params.max_blob_gas_per_block() {
         return Err(ConsensusError::BlobGasUsedExceedsMaxBlobGasPerBlock {
             blob_gas_used,
             max_blob_gas_per_block: blob_params.max_blob_gas_per_block(),
-        })
+        });
     }
 
     Ok(())
@@ -315,7 +315,7 @@ pub fn validate_against_parent_hash_number<H: BlockHeader>(
     if parent.hash() != header.parent_hash() {
         return Err(ConsensusError::ParentHashMismatch(
             GotExpected { got: header.parent_hash(), expected: parent.hash() }.into(),
-        ))
+        ));
     }
 
     let Some(parent_number) = parent.number().checked_add(1) else {
@@ -323,7 +323,7 @@ pub fn validate_against_parent_hash_number<H: BlockHeader>(
         return Err(ConsensusError::ParentBlockNumberMismatch {
             parent_block_number: parent.number(),
             block_number: u64::MAX,
-        })
+        });
     };
 
     // Parent number is consistent.
@@ -331,7 +331,7 @@ pub fn validate_against_parent_hash_number<H: BlockHeader>(
         return Err(ConsensusError::ParentBlockNumberMismatch {
             parent_block_number: parent.number(),
             block_number: header.number(),
-        })
+        });
     }
 
     Ok(())
@@ -361,7 +361,7 @@ pub fn validate_against_parent_eip1559_base_fee<ChainSpec: EthChainSpec + Ethere
             return Err(ConsensusError::BaseFeeDiff(GotExpected {
                 expected: expected_base_fee,
                 got: base_fee,
-            }))
+            }));
         }
     }
 
@@ -378,7 +378,7 @@ pub fn validate_against_parent_timestamp<H: BlockHeader>(
         return Err(ConsensusError::TimestampIsInPast {
             parent_timestamp: parent.timestamp(),
             timestamp: header.timestamp(),
-        })
+        });
     }
     Ok(())
 }
@@ -397,11 +397,11 @@ pub fn validate_against_parent_gas_limit<
     chain_spec: &ChainSpec,
 ) -> Result<(), ConsensusError> {
     // Determine the parent gas limit, considering elasticity multiplier on the London fork.
-    let parent_gas_limit = if !chain_spec.is_london_active_at_block(parent.number()) &&
-        chain_spec.is_london_active_at_block(header.number())
+    let parent_gas_limit = if !chain_spec.is_london_active_at_block(parent.number())
+        && chain_spec.is_london_active_at_block(header.number())
     {
-        parent.gas_limit() *
-            chain_spec.base_fee_params_at_timestamp(header.timestamp()).elasticity_multiplier
+        parent.gas_limit()
+            * chain_spec.base_fee_params_at_timestamp(header.timestamp()).elasticity_multiplier
                 as u64
     } else {
         parent.gas_limit()
@@ -413,7 +413,7 @@ pub fn validate_against_parent_gas_limit<
             return Err(ConsensusError::GasLimitInvalidIncrease {
                 parent_gas_limit,
                 child_gas_limit: header.gas_limit(),
-            })
+            });
         }
     }
     // Check for a decrease in gas limit beyond the allowed threshold.
@@ -421,11 +421,11 @@ pub fn validate_against_parent_gas_limit<
         return Err(ConsensusError::GasLimitInvalidDecrease {
             parent_gas_limit,
             child_gas_limit: header.gas_limit(),
-        })
+        });
     }
     // Check if the self gas limit is below the minimum required limit.
     else if header.gas_limit() < MINIMUM_GAS_LIMIT {
-        return Err(ConsensusError::GasLimitInvalidMinimum { child_gas_limit: header.gas_limit() })
+        return Err(ConsensusError::GasLimitInvalidMinimum { child_gas_limit: header.gas_limit() });
     }
 
     Ok(())
@@ -450,7 +450,7 @@ pub fn validate_against_parent_4844<H: BlockHeader>(
     let parent_excess_blob_gas = parent.excess_blob_gas().unwrap_or(0);
 
     if header.blob_gas_used().is_none() {
-        return Err(ConsensusError::BlobGasUsedMissing)
+        return Err(ConsensusError::BlobGasUsedMissing);
     }
     let excess_blob_gas = header.excess_blob_gas().ok_or(ConsensusError::ExcessBlobGasMissing)?;
 
@@ -465,7 +465,7 @@ pub fn validate_against_parent_4844<H: BlockHeader>(
             diff: GotExpected { got: excess_blob_gas, expected: expected_excess_blob_gas },
             parent_excess_blob_gas,
             parent_blob_gas_used,
-        })
+        });
     }
 
     Ok(())

--- a/crates/consensus/consensus/Cargo.toml
+++ b/crates/consensus/consensus/Cargo.toml
@@ -18,6 +18,7 @@ reth-primitives-traits.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
+alloy-eip7928.workspace = true
 
 # misc
 auto_impl.workspace = true

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -13,6 +13,7 @@ extern crate alloc;
 
 use alloc::{boxed::Box, fmt::Debug, string::String, sync::Arc, vec::Vec};
 use alloy_consensus::Header;
+use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{BlockHash, BlockNumber, Bloom, B256};
 use core::error::Error;
 
@@ -54,12 +55,17 @@ pub trait FullConsensus<N: NodePrimitives>: Consensus<N::Block> {
     /// If `receipt_root_bloom` is provided, the implementation should use the pre-computed
     /// receipt root and logs bloom instead of computing them from the receipts.
     ///
+    /// If `allow_bal_check` is enabled, we calculate the bal hash and match with the header bal
+    /// hash. We don't do by default because for payload validation, we do the same bal check
+    ///
     /// Note: validating blocks does not include other validations of the Consensus
     fn validate_block_post_execution(
         &self,
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        block_access_list: Option<BlockAccessList>,
+        allow_bal_check: bool,
     ) -> Result<(), ConsensusError>;
 }
 
@@ -338,6 +344,10 @@ pub enum ConsensusError {
     /// Error when an unexpected block access list hash is encountered.
     #[error("unexpected block access list hash")]
     BlockAccessListHashUnexpected,
+
+    /// Error when an unexpected block access list cost is encountered.
+    #[error("block access list cost exceeds gas limit")]
+    BlockAccessListCostMoreThanGasLimit,
 
     /// Error when the block access list hash doesn't match the expected value.
     #[error("block access list hash mismatch: {0}")]

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -77,6 +77,8 @@ impl<N: NodePrimitives> FullConsensus<N> for NoopConsensus {
         _block: &RecoveredBlock<N::Block>,
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
+        _block_access_list: Option<alloy_eip7928::BlockAccessList>,
+        _allow_bal_check: bool,
     ) -> Result<(), ConsensusError> {
         Ok(())
     }

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -52,6 +52,8 @@ impl<N: NodePrimitives> FullConsensus<N> for TestConsensus {
         _block: &RecoveredBlock<N::Block>,
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
+        _block_access_list: Option<alloy_eip7928::BlockAccessList>,
+        _allow_bal_check: bool,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {
             Err(ConsensusError::BaseFeeMissing)

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -108,7 +108,7 @@ where
                         %err,
                         "Failed to fetch a block from Etherscan",
                     );
-                    continue
+                    continue;
                 }
             };
             let block_number = block.header().number();

--- a/crates/consensus/debug-client/src/providers/rpc.rs
+++ b/crates/consensus/debug-client/src/providers/rpc.rs
@@ -82,7 +82,7 @@ where
                     "Failed to subscribe to blocks",
                 );
             }) else {
-                return
+                return;
             };
 
             while let Some(res) = stream.next().await {

--- a/crates/e2e-test-utils/src/network.rs
+++ b/crates/e2e-test-utils/src/network.rs
@@ -43,11 +43,11 @@ where
     pub async fn next_session_established(&mut self) -> Option<PeerId> {
         while let Some(ev) = self.network_events.next().await {
             match ev {
-                NetworkEvent::ActivePeerSession { info, .. } |
-                NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
+                NetworkEvent::ActivePeerSession { info, .. }
+                | NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
                     let peer_id = info.peer_id;
                     info!("Session established with peer: {:?}", peer_id);
-                    return Some(peer_id)
+                    return Some(peer_id);
                 }
                 _ => {}
             }

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -151,11 +151,11 @@ where
         loop {
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-            if !check &&
-                wait_finish_checkpoint &&
-                let Some(checkpoint) =
-                    self.inner.provider.get_stage_checkpoint(StageId::Finish)? &&
-                checkpoint.block_number >= number
+            if !check
+                && wait_finish_checkpoint
+                && let Some(checkpoint) =
+                    self.inner.provider.get_stage_checkpoint(StageId::Finish)?
+                && checkpoint.block_number >= number
             {
                 check = true
             }
@@ -163,7 +163,7 @@ where
             if check {
                 if let Some(latest_header) = self.inner.provider.header_by_number(number)? {
                     assert_eq!(latest_header.hash_slow(), expected_block_hash);
-                    break
+                    break;
                 }
                 assert!(
                     !wait_finish_checkpoint,
@@ -178,10 +178,10 @@ where
     pub async fn wait_unwind(&self, number: BlockNumber) -> eyre::Result<()> {
         loop {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            if let Some(checkpoint) = self.inner.provider.get_stage_checkpoint(StageId::Headers)? &&
-                checkpoint.block_number == number
+            if let Some(checkpoint) = self.inner.provider.get_stage_checkpoint(StageId::Headers)?
+                && checkpoint.block_number == number
             {
-                break
+                break;
             }
         }
         Ok(())
@@ -207,13 +207,13 @@ where
             // wait for the block to commit
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             if let Some(latest_block) =
-                self.inner.provider.block_by_number_or_tag(BlockNumberOrTag::Latest)? &&
-                latest_block.header().number() == block_number
+                self.inner.provider.block_by_number_or_tag(BlockNumberOrTag::Latest)?
+                && latest_block.header().number() == block_number
             {
                 // make sure the block hash we submitted via FCU engine api is the new latest
                 // block using an RPC call
                 assert_eq!(latest_block.header().hash_slow(), block_hash);
-                break
+                break;
             }
         }
         Ok(())

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -69,7 +69,7 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
                      check that the chain spec supports all generated tx types"
                 );
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                continue
+                continue;
             }
             // Resolve payload once its built
             self.payload_builder

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -186,9 +186,9 @@ where
                 }
 
                 // Connect last node with the first if there are more than two
-                if idx + 1 == self.num_nodes &&
-                    self.num_nodes > 2 &&
-                    let Some(first) = prev.first_mut()
+                if idx + 1 == self.num_nodes
+                    && self.num_nodes > 2
+                    && let Some(first) = prev.first_mut()
                 {
                     current.connect(first).await;
                 }

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -174,8 +174,8 @@ where
                 ];
 
                 // if we're on a fork, validate it now that it's canonical
-                if let Ok(active_state) = env.active_node_state() &&
-                    let Some(fork_base) = active_state.current_fork_base
+                if let Ok(active_state) = env.active_node_state()
+                    && let Some(fork_base) = active_state.current_fork_base
                 {
                     debug!("MakeCanonical: Adding fork validation from base block {}", fork_base);
                     actions.push(Box::new(ValidateFork::new(fork_base)));

--- a/crates/e2e-test-utils/src/testsuite/actions/node_ops.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/node_ops.rs
@@ -206,8 +206,8 @@ where
                 .copied()
                 .ok_or_else(|| eyre::eyre!("Block tag '{}' not found in registry", self.tag))?;
 
-            if let Some(expected_node) = self.expected_node_idx &&
-                node_idx != expected_node
+            if let Some(expected_node) = self.expected_node_idx
+                && node_idx != expected_node
             {
                 return Err(eyre::eyre!(
                     "Block tag '{}' came from node {} but expected node {}",

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -294,8 +294,8 @@ where
                 debug!("No payload ID returned, generating fresh payload attributes for forking");
 
                 let fresh_payload_attributes = PayloadAttributes {
-                    timestamp: env.active_node_state()?.latest_header_time +
-                        env.block_timestamp_increment,
+                    timestamp: env.active_node_state()?.latest_header_time
+                        + env.block_timestamp_increment,
                     prev_randao: B256::random(),
                     suggested_fee_recipient: alloy_primitives::Address::random(),
                     withdrawals: Some(vec![]),

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -92,8 +92,8 @@ async fn test_apply_with_import() -> Result<()> {
         )
         .await;
 
-        if let Ok(Some(block)) = block_result &&
-            block.header.number == 10
+        if let Ok(Some(block)) = block_result
+            && block.header.number == 10
         {
             debug!("Pipeline finished, block 10 is fully available");
             break;

--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -731,8 +731,8 @@ mod tests {
 
         // Modify the state to create a mismatch
         let addr = Address::from([1u8; 20]);
-        if let Some(account) = modified_state.state.get_mut(&addr) &&
-            let Some(ref mut info) = account.info
+        if let Some(account) = modified_state.state.get_mut(&addr)
+            && let Some(ref mut info) = account.info
         {
             info.balance = U256::from(999);
         }
@@ -840,7 +840,6 @@ mod tests {
                 requests: Requests::default(),
                 gas_used: 0,
                 blob_gas_used: 0,
-                block_access_list: Default::default(),
             },
         };
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -114,13 +114,13 @@ impl<Pool: TransactionPool + Unpin> Future for MiningMode<Pool> {
             }
             Self::Interval(interval) => {
                 if interval.poll_tick(cx).is_ready() {
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
                 Poll::Pending
             }
             Self::Trigger(trigger) => {
                 if trigger.poll_next_unpin(cx).is_ready() {
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
                 Poll::Pending
             }

--- a/crates/engine/tree/src/backfill.rs
+++ b/crates/engine/tree/src/backfill.rs
@@ -124,7 +124,7 @@ impl<N: ProviderNodeTypes> PipelineSync<N> {
                 "Pipeline target cannot be zero hash."
             );
             // precaution to never sync to the zero hash
-            return
+            return;
         }
         self.pending_pipeline_target = Some(target);
     }
@@ -187,14 +187,14 @@ impl<N: ProviderNodeTypes> BackfillSync for PipelineSync<N> {
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<BackfillEvent> {
         // try to spawn a pipeline if a target is set
         if let Some(event) = self.try_spawn_pipeline() {
-            return Poll::Ready(event)
+            return Poll::Ready(event);
         }
 
         // make sure we poll the pipeline if it's active, and return any ready pipeline events
         if self.is_pipeline_active() {
             // advance the pipeline
             if let Poll::Ready(event) = self.poll_pipeline(cx) {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
         }
 

--- a/crates/engine/tree/src/chain.rs
+++ b/crates/engine/tree/src/chain.rs
@@ -100,7 +100,7 @@ where
                                 tracing::error!( %err, "backfill sync failed");
                                 Poll::Ready(ChainEvent::FatalError)
                             }
-                        }
+                        };
                     }
                     BackfillEvent::TaskDropped(err) => {
                         tracing::error!( %err, "backfill sync task dropped");
@@ -124,13 +124,13 @@ where
                         }
                         HandlerEvent::FatalError => {
                             error!(target: "engine::tree", "Fatal error");
-                            return Poll::Ready(ChainEvent::FatalError)
+                            return Poll::Ready(ChainEvent::FatalError);
                         }
                     }
                 }
                 Poll::Pending => {
                     // no more events to process
-                    break 'outer
+                    break 'outer;
                 }
             }
         }

--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -144,7 +144,7 @@ where
     /// given hash.
     fn download_full_block(&mut self, hash: B256) -> bool {
         if self.is_inflight_request(hash) {
-            return false
+            return false;
         }
         self.push_pending_event(DownloadOutcome::NewDownloadStarted {
             remaining_blocks: 1,
@@ -172,8 +172,8 @@ where
 
     /// Sets the metrics for the active downloads
     fn update_block_download_metrics(&self) {
-        let blocks = self.inflight_full_block_requests.len() +
-            self.inflight_block_range_requests.iter().map(|r| r.count() as usize).sum::<usize>();
+        let blocks = self.inflight_full_block_requests.len()
+            + self.inflight_block_range_requests.iter().map(|r| r.count() as usize).sum::<usize>();
         self.metrics.active_block_downloads.set(blocks as f64);
     }
 
@@ -248,7 +248,7 @@ where
                 if peek.0 .0.hash() == block.0 .0.hash() {
                     PeekMut::pop(peek);
                 } else {
-                    break
+                    break;
                 }
             }
             downloaded_blocks.push(block.0.into());

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -95,7 +95,7 @@ where
                                 Poll::Ready(HandlerEvent::Event(ev))
                             }
                             HandlerEvent::FatalError => Poll::Ready(HandlerEvent::FatalError),
-                        }
+                        };
                     }
                     RequestHandlerEvent::Download(req) => {
                         // delegate download request to the downloader
@@ -109,7 +109,7 @@ where
                 // and delegate the request to the handler
                 self.handler.on_event(FromEngine::Request(req.into()));
                 // skip downloading in this iteration to allow the handler to process the request
-                continue
+                continue;
             }
 
             // advance the downloader
@@ -118,10 +118,10 @@ where
                     // delegate the downloaded blocks to the handler
                     self.handler.on_event(FromEngine::DownloadedBlocks(blocks));
                 }
-                continue
+                continue;
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }
@@ -201,7 +201,7 @@ where
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {
         let Some(ev) = ready!(self.from_tree.poll_recv(cx)) else {
-            return Poll::Ready(RequestHandlerEvent::HandlerEvent(HandlerEvent::FatalError))
+            return Poll::Ready(RequestHandlerEvent::HandlerEvent(HandlerEvent::FatalError));
         };
 
         let ev = match ev {

--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -109,7 +109,7 @@ impl<B: Block> BlockBuffer<B> {
         // discard all blocks that are before the finalized number.
         while let Some(entry) = self.earliest_blocks.first_entry() {
             if *entry.key() > block_number {
-                break
+                break;
             }
             let block_hashes = entry.remove();
             block_hashes_to_remove.extend(block_hashes);

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -805,7 +805,7 @@ impl ExecutionCache {
             // If the account was not modified, as in not changed and not destroyed, then we have
             // nothing to do w.r.t. this particular account and can move on
             if account.status.is_not_modified() {
-                continue
+                continue;
             }
 
             // If the original account had code (was a contract), we must clear the entire cache
@@ -828,7 +828,7 @@ impl ExecutionCache {
                         );
                     });
                     self.clear();
-                    return Ok(())
+                    return Ok(());
                 }
 
                 self.0.account_cache.remove(addr);
@@ -841,7 +841,7 @@ impl ExecutionCache {
             // `None` current info, should be destroyed.
             let Some(ref account_info) = account.info else {
                 trace!(target: "engine::caching", ?account, "Account with None account info found in state updates");
-                return Err(())
+                return Err(());
             };
 
             // Now we iterate over all storage and make updates to the cached storage values
@@ -958,7 +958,7 @@ impl SavedCache {
     /// `with_disable_cache_metrics(true)` to skip.
     pub(crate) fn update_metrics(&self) {
         if self.disable_cache_metrics {
-            return
+            return;
         }
         self.caches.update_metrics(&self.metrics);
     }

--- a/crates/engine/tree/src/tree/invalid_headers.rs
+++ b/crates/engine/tree/src/tree/invalid_headers.rs
@@ -42,7 +42,7 @@ impl InvalidHeaderCache {
             let entry = self.headers.get(hash)?;
             entry.hit_count += 1;
             if entry.hit_count < INVALID_HEADER_HIT_EVICTION_THRESHOLD {
-                return Some(entry.header)
+                return Some(entry.header);
             }
         }
         // if we get here, the entry has been hit too many times, so we evict it

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -594,7 +594,6 @@ mod tests {
                 requests: Requests::default(),
                 gas_used: 21000,
                 blob_gas_used: 0,
-                block_access_list: Default::default(),
             },
         };
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -466,19 +466,19 @@ where
                         Ok(ops::ControlFlow::Continue(())) => {}
                         Err(fatal) => {
                             error!(target: "engine::tree", %fatal, "insert block fatal error");
-                            return
+                            return;
                         }
                     }
                 }
                 LoopEvent::PersistenceComplete { result, start_time } => {
                     if let Err(err) = self.on_persistence_complete(result, start_time) {
                         error!(target: "engine::tree", %err, "Persistence complete handling failed");
-                        return
+                        return;
                     }
                 }
                 LoopEvent::Disconnected => {
                     error!(target: "engine::tree", "Channel disconnected");
-                    return
+                    return;
                 }
             }
 
@@ -488,7 +488,7 @@ where
             // - After persistence completion: we can now persist more blocks if needed
             if let Err(err) = self.advance_persistence() {
                 error!(target: "engine::tree", %err, "Advancing persistence failed");
-                return
+                return;
             }
         }
     }
@@ -545,7 +545,7 @@ where
     ) -> Result<Option<TreeEvent>, InsertBlockFatalError> {
         if blocks.is_empty() {
             // nothing to execute
-            return Ok(None)
+            return Ok(None);
         }
 
         trace!(target: "engine::tree", block_count = %blocks.len(), "received downloaded blocks");
@@ -556,7 +556,7 @@ where
                 self.on_tree_event(event)?;
                 if needs_backfill {
                     // can exit early if backfill is needed
-                    return Ok(None)
+                    return Ok(None);
                 }
             }
         }
@@ -690,8 +690,8 @@ where
                         latest_valid_hash = Some(block_hash);
                         PayloadStatusEnum::Valid
                     }
-                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) |
-                    InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
+                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. })
+                    | InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
                         // not known to be invalid, but we don't know anything else
                         PayloadStatusEnum::Syncing
                     }
@@ -747,7 +747,7 @@ where
         let Some(new_head_block) = self.state.tree_state.blocks_by_hash.get(&new_head) else {
             debug!(target: "engine::tree", new_head=?new_head, "New head block not found in inmemory tree state");
             self.metrics.engine.executed_new_block_cache_miss.increment(1);
-            return Ok(None)
+            return Ok(None);
         };
 
         let new_head_number = new_head_block.recovered_block().number();
@@ -771,7 +771,7 @@ where
                 warn!(target: "engine::tree", current_hash=?current_hash, "Sidechain block not found in TreeState");
                 // This should never happen as we're walking back a chain that should connect to
                 // the canonical chain
-                return Ok(None)
+                return Ok(None);
             }
         }
 
@@ -781,7 +781,7 @@ where
             new_chain.reverse();
 
             // Simple extension of the current chain
-            return Ok(Some(NewCanonicalChain::Commit { new: new_chain }))
+            return Ok(Some(NewCanonicalChain::Commit { new: new_chain }));
         }
 
         // We have a reorg. Walk back both chains to find the fork point.
@@ -798,7 +798,7 @@ where
             } else {
                 // This shouldn't happen as we're walking back the canonical chain
                 warn!(target: "engine::tree", current_hash=?old_hash, "Canonical block not found in TreeState");
-                return Ok(None)
+                return Ok(None);
             }
         }
 
@@ -814,7 +814,7 @@ where
             } else {
                 // This shouldn't happen as we're walking back the canonical chain
                 warn!(target: "engine::tree", current_hash=?old_hash, "Canonical block not found in TreeState");
-                return Ok(None)
+                return Ok(None);
             }
 
             if let Some(block) = self.state.tree_state.executed_block_by_hash(current_hash).cloned()
@@ -824,7 +824,7 @@ where
             } else {
                 // This shouldn't happen as we've already walked this path
                 warn!(target: "engine::tree", invalid_hash=?current_hash, "New chain block not found in TreeState");
-                return Ok(None)
+                return Ok(None);
             }
         }
         new_chain.reverse();
@@ -1165,8 +1165,8 @@ where
 
             // For OpStack, or if explicitly configured, the proposers are allowed to reorg their
             // own chain at will, so we need to always trigger a new payload job if requested.
-            if self.engine_kind.is_opstack() ||
-                self.config.always_process_payload_attributes_on_canonical_head()
+            if self.engine_kind.is_opstack()
+                || self.config.always_process_payload_attributes_on_canonical_head()
             {
                 // We need to effectively unwind the _canonical_ chain to the FCU's head, which is
                 // part of the canonical chain. We need to update the latest block state to reflect
@@ -1277,7 +1277,7 @@ where
     fn persist_blocks(&mut self, blocks_to_persist: Vec<ExecutedBlock<N>>) {
         if blocks_to_persist.is_empty() {
             debug!(target: "engine::tree", "Returned empty set of blocks to persist");
-            return
+            return;
         }
 
         // NOTE: checked non-empty above
@@ -1339,7 +1339,7 @@ where
 
             if blocks_to_persist.is_empty() {
                 debug!(target: "engine::tree", "persistence complete, signaling termination");
-                return Ok(())
+                return Ok(());
             }
 
             debug!(target: "engine::tree", count = blocks_to_persist.len(), "persisting remaining blocks before shutdown");
@@ -1388,7 +1388,7 @@ where
         else {
             // if this happened, then we persisted no blocks because we sent an empty vec of blocks
             warn!(target: "engine::tree", "Persistence task completed but did not persist any blocks");
-            return Ok(())
+            return Ok(());
         };
 
         debug!(target: "engine::tree", ?last_persisted_block_hash, ?last_persisted_block_number, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
@@ -1456,7 +1456,7 @@ where
                     if let Err(err) = self.finish_termination(tx) {
                         error!(target: "engine::tree", %err, "Termination failed");
                     }
-                    return Ok(ops::ControlFlow::Break(()))
+                    return Ok(ops::ControlFlow::Break(()));
                 }
             },
             FromEngine::Request(request) => {
@@ -1465,7 +1465,7 @@ where
                         let block_num_hash = block.recovered_block().num_hash();
                         if block_num_hash.number <= self.state.tree_state.canonical_block_number() {
                             // outdated block that can be skipped
-                            return Ok(ops::ControlFlow::Continue(()))
+                            return Ok(ops::ControlFlow::Continue(()));
                         }
 
                         debug!(target: "engine::tree", block=?block_num_hash, "inserting already executed block");
@@ -1473,8 +1473,8 @@ where
 
                         // if the parent is the canonical head, we can insert the block as the
                         // pending block
-                        if self.state.tree_state.canonical_block_hash() ==
-                            block.recovered_block().parent_hash()
+                        if self.state.tree_state.canonical_block_hash()
+                            == block.recovered_block().parent_hash()
                         {
                             debug!(target: "engine::tree", pending=?block_num_hash, "updating pending block");
                             self.canonical_in_memory_state.set_pending_block(block.clone());
@@ -1717,7 +1717,7 @@ where
             .map(|hash| BlockNumHash { hash, number: backfill_height })
         else {
             debug!(target: "engine::tree", ?ctrl, "Backfill block not found");
-            return Ok(())
+            return Ok(());
         };
 
         if ctrl.is_unwind() {
@@ -1756,11 +1756,11 @@ where
         // the backfill height
         let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()
         else {
-            return Ok(())
+            return Ok(());
         };
         if sync_target_state.finalized_block_hash.is_zero() {
             // no finalized block, can't check distance
-            return Ok(())
+            return Ok(());
         }
         // get the block number of the finalized block, if we have it
         let newest_finalized = self
@@ -1785,7 +1785,7 @@ where
             self.emit_event(EngineApiEvent::BackfillAction(BackfillAction::Start(
                 backfill_target.into(),
             )));
-            return Ok(())
+            return Ok(());
         };
 
         // Check if there are more blocks to sync between current head and FCU target
@@ -1923,7 +1923,7 @@ where
                 // backfill sync and persisting data are mutually exclusive, so we can't start
                 // backfill while we're still persisting
                 debug!(target: "engine::tree", "skipping backfill file while persistence task is active");
-                return
+                return;
             }
 
             self.backfill_sync_state = BackfillSyncState::Pending;
@@ -1942,12 +1942,12 @@ where
     pub const fn should_persist(&self) -> bool {
         if !self.backfill_sync_state.is_idle() {
             // can't persist if backfill is running
-            return false
+            return false;
         }
 
         let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
-            self.config.persistence_threshold()
+        self.state.tree_state.canonical_block_number().saturating_sub(min_block)
+            > self.config.persistence_threshold()
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range
@@ -2010,7 +2010,7 @@ where
         // state.
         if let Some(remove_above) = self.find_disk_reorg()? {
             self.remove_blocks(remove_above);
-            return Ok(())
+            return Ok(());
         }
 
         let finalized = self.state.forkchoice_state_tracker.last_valid_finalized();
@@ -2033,7 +2033,7 @@ where
         trace!(target: "engine::tree", ?hash, "Fetching executed block by hash");
         // check memory first
         if let Some(block) = self.state.tree_state.executed_block_by_hash(hash) {
-            return Ok(Some(block.clone()))
+            return Ok(Some(block.clone()));
         }
 
         let (block, senders) = self
@@ -2072,7 +2072,6 @@ where
                 requests: execution_output.requests.pop().unwrap_or_default(),
                 gas_used: block.gas_used(),
                 blob_gas_used: block.blob_gas_used().unwrap_or_default(),
-                block_access_list: Default::default(),
             },
         });
 
@@ -2128,7 +2127,7 @@ where
     ) -> ProviderResult<Option<B256>> {
         // Check if parent exists in side chain or in canonical chain.
         if self.sealed_header_by_hash(parent_hash)?.is_some() {
-            return Ok(Some(parent_hash))
+            return Ok(Some(parent_hash));
         }
 
         // iterate over ancestors in the invalid cache
@@ -2142,7 +2141,7 @@ where
             // If current_header is None, then the current_hash does not have an invalid
             // ancestor in the cache, check its presence in blockchain tree
             if current_block.is_none() && self.sealed_header_by_hash(current_hash)?.is_some() {
-                return Ok(Some(current_hash))
+                return Ok(Some(current_hash));
             }
         }
         Ok(None)
@@ -2172,7 +2171,7 @@ where
     /// See [`ForkchoiceStateTracker::sync_target_state`]
     fn is_sync_target_head(&self, block_hash: B256) -> bool {
         if let Some(target) = self.state.forkchoice_state_tracker.sync_target_state() {
-            return target.head_block_hash == block_hash
+            return target.head_block_hash == block_hash;
         }
         false
     }
@@ -2182,7 +2181,7 @@ where
     /// See [`ForkchoiceStateTracker::sync_target_state`]
     fn is_any_sync_target(&self, block_hash: B256) -> bool {
         if let Some(target) = self.state.forkchoice_state_tracker.sync_target_state() {
-            return target.contains(block_hash)
+            return target.contains(block_hash);
         }
         false
     }
@@ -2303,12 +2302,12 @@ where
     fn validate_block(&self, block: &SealedBlock<N::Block>) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
             error!(target: "engine::tree", ?block, "Failed to validate header {}: {e}", block.hash());
-            return Err(e)
+            return Err(e);
         }
 
         if let Err(e) = self.consensus.validate_block_pre_execution(block) {
             error!(target: "engine::tree", ?block, "Failed to validate block {}: {e}", block.hash());
-            return Err(e)
+            return Err(e);
         }
 
         Ok(())
@@ -2324,7 +2323,7 @@ where
 
         if blocks.is_empty() {
             // nothing to append
-            return Ok(())
+            return Ok(());
         }
 
         let now = Instant::now();
@@ -2334,8 +2333,8 @@ where
             match self.insert_block(child) {
                 Ok(res) => {
                     debug!(target: "engine::tree", child =?child_num_hash, ?res, "connected buffered block");
-                    if self.is_any_sync_target(child_num_hash.hash) &&
-                        matches!(res, InsertPayloadOk::Inserted(BlockStatus::Valid))
+                    if self.is_any_sync_target(child_num_hash.hash)
+                        && matches!(res, InsertPayloadOk::Inserted(BlockStatus::Valid))
                     {
                         debug!(target: "engine::tree", child =?child_num_hash, "connected sync target block");
                         // we just inserted a block that we know is part of the canonical chain, so
@@ -2348,7 +2347,7 @@ where
                         debug!(target: "engine::tree", ?err, "failed to connect buffered block to tree");
                         if let Err(fatal) = self.on_insert_block_error(err) {
                             warn!(target: "engine::tree", %fatal, "fatal error occurred while connecting buffered blocks");
-                            return Err(fatal)
+                            return Err(fatal);
                         }
                     }
                 }
@@ -2365,7 +2364,7 @@ where
         block: SealedBlock<N::Block>,
     ) -> Result<(), InsertBlockError<N::Block>> {
         if let Err(err) = self.validate_block(&block) {
-            return Err(InsertBlockError::consensus_error(err, block))
+            return Err(InsertBlockError::consensus_error(err, block));
         }
         self.state.buffer.insert_block(block);
         Ok(())
@@ -2445,7 +2444,7 @@ where
                     if !state.finalized_block_hash.is_zero() {
                         // we don't have the block yet and the distance exceeds the allowed
                         // threshold
-                        return Some(state.finalized_block_hash)
+                        return Some(state.finalized_block_hash);
                     }
 
                     // OPTIMISTIC SYNCING
@@ -2461,7 +2460,7 @@ where
                     // However, optimism chains will do this. The risk of a reorg is however
                     // low.
                     debug!(target: "engine::tree", hash=?state.head_block_hash, "Setting head hash as an optimistic backfill target.");
-                    return Some(state.head_block_hash)
+                    return Some(state.head_block_hash);
                 }
                 Ok(Some(_)) => {
                     // we're fully synced to the finalized block
@@ -2567,12 +2566,12 @@ where
     /// This updates metrics based on the given reorg length and first reorged block number.
     fn update_reorg_metrics(&self, old_chain_length: usize, first_reorged_block: Option<NumHash>) {
         if let Some(first_reorged_block) = first_reorged_block.map(|block| block.number) {
-            if let Some(finalized) = self.canonical_in_memory_state.get_finalized_num_hash() &&
-                first_reorged_block <= finalized.number
+            if let Some(finalized) = self.canonical_in_memory_state.get_finalized_num_hash()
+                && first_reorged_block <= finalized.number
             {
                 self.metrics.tree.reorgs.finalized.increment(1);
-            } else if let Some(safe) = self.canonical_in_memory_state.get_safe_num_hash() &&
-                first_reorged_block <= safe.number
+            } else if let Some(safe) = self.canonical_in_memory_state.get_safe_num_hash()
+                && first_reorged_block <= safe.number
             {
                 self.metrics.tree.reorgs.safe.increment(1);
             } else {
@@ -2653,8 +2652,8 @@ where
     ) -> Result<Option<TreeEvent>, InsertBlockFatalError> {
         // check if we just inserted a block that's part of sync targets,
         // i.e. head, safe, or finalized
-        if let Some(sync_target) = self.state.forkchoice_state_tracker.sync_target_state() &&
-            sync_target.contains(block_num_hash.hash)
+        if let Some(sync_target) = self.state.forkchoice_state_tracker.sync_target_state()
+            && sync_target.contains(block_num_hash.hash)
         {
             debug!(target: "engine::tree", ?sync_target, "appended downloaded sync target block");
 
@@ -2662,7 +2661,7 @@ where
                 // we just inserted the sync target head block, make it canonical
                 return Ok(Some(TreeEvent::TreeAction(TreeAction::MakeCanonical {
                     sync_target_head: block_num_hash.hash,
-                })))
+                })));
             }
 
             // This block is part of the sync target (safe or finalized) but not the
@@ -2676,10 +2675,10 @@ where
             if self.state.tree_state.canonical_block_hash() != sync_target.head_block_hash {
                 let target = self.lowest_buffered_ancestor_or(sync_target.head_block_hash);
                 trace!(target: "engine::tree", %target, "sync target head not yet reached, downloading head block");
-                return Ok(Some(TreeEvent::Download(DownloadRequest::single_block(target))))
+                return Ok(Some(TreeEvent::Download(DownloadRequest::single_block(target))));
             }
 
-            return Ok(None)
+            return Ok(None);
         }
         trace!(target: "engine::tree", "appended downloaded block");
         self.try_connect_buffered_blocks(block_num_hash)?;
@@ -2699,18 +2698,18 @@ where
         let block_num_hash = block.num_hash();
         let lowest_buffered_ancestor = self.lowest_buffered_ancestor_or(block_num_hash.hash);
         if self.check_invalid_ancestor_with_head(lowest_buffered_ancestor, &block)?.is_some() {
-            return Ok(None)
+            return Ok(None);
         }
 
         if !self.backfill_sync_state.is_idle() {
-            return Ok(None)
+            return Ok(None);
         }
 
         // try to append the block
         match self.insert_block(block) {
             Ok(
-                InsertPayloadOk::Inserted(BlockStatus::Valid) |
-                InsertPayloadOk::AlreadySeen(BlockStatus::Valid),
+                InsertPayloadOk::Inserted(BlockStatus::Valid)
+                | InsertPayloadOk::AlreadySeen(BlockStatus::Valid),
             ) => {
                 return self.on_valid_downloaded_block(block_num_hash);
             }
@@ -2721,7 +2720,7 @@ where
                     block_num_hash,
                     missing_ancestor,
                     head,
-                ))
+                ));
             }
             Ok(InsertPayloadOk::AlreadySeen(_)) => {
                 trace!(target: "engine::tree", "downloaded block already executed");
@@ -2731,7 +2730,7 @@ where
                     debug!(target: "engine::tree", err=%err.kind(), "failed to insert downloaded block");
                     if let Err(fatal) = self.on_insert_block_error(err) {
                         warn!(target: "engine::tree", %fatal, "fatal error occurred while inserting downloaded block");
-                        return Err(fatal)
+                        return Err(fatal);
                     }
                 }
             }
@@ -2852,7 +2851,7 @@ where
                 return Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected {
                     head: self.state.tree_state.current_canonical_head,
                     missing_ancestor,
-                }))
+                }));
             }
             Ok(Some(_)) => {}
         }
@@ -2984,18 +2983,18 @@ where
         finalized_block_hash: B256,
     ) -> Result<(), OnForkChoiceUpdated> {
         if finalized_block_hash.is_zero() {
-            return Ok(())
+            return Ok(());
         }
 
         match self.find_canonical_header(finalized_block_hash) {
             Ok(None) => {
                 debug!(target: "engine::tree", "Finalized block not found in canonical chain");
                 // if the finalized block is not known, we can't update the finalized block
-                return Err(OnForkChoiceUpdated::invalid_state())
+                return Err(OnForkChoiceUpdated::invalid_state());
             }
             Ok(Some(finalized)) => {
-                if Some(finalized.num_hash()) !=
-                    self.canonical_in_memory_state.get_finalized_num_hash()
+                if Some(finalized.num_hash())
+                    != self.canonical_in_memory_state.get_finalized_num_hash()
                 {
                     // we're also persisting the finalized block on disk so we can reload it on
                     // restart this is required by optimism which queries the finalized block: <https://github.com/ethereum-optimism/optimism/blob/c383eb880f307caa3ca41010ec10f30f08396b2e/op-node/rollup/sync/start.go#L65-L65>
@@ -3016,14 +3015,14 @@ where
     /// Updates the tracked safe block if we have it
     fn update_safe_block(&self, safe_block_hash: B256) -> Result<(), OnForkChoiceUpdated> {
         if safe_block_hash.is_zero() {
-            return Ok(())
+            return Ok(());
         }
 
         match self.find_canonical_header(safe_block_hash) {
             Ok(None) => {
                 debug!(target: "engine::tree", "Safe block not found in canonical chain");
                 // if the safe block is not known, we can't update the safe block
-                return Err(OnForkChoiceUpdated::invalid_state())
+                return Err(OnForkChoiceUpdated::invalid_state());
             }
             Ok(Some(safe)) => {
                 if Some(safe.num_hash()) != self.canonical_in_memory_state.get_safe_num_hash() {
@@ -3085,7 +3084,7 @@ where
             self.payload_validator.validate_payload_attributes_against_header(&attrs, head)
         {
             warn!(target: "engine::tree", %err, ?head, "Invalid payload attributes");
-            return OnForkChoiceUpdated::invalid_payload_attributes()
+            return OnForkChoiceUpdated::invalid_payload_attributes();
         }
 
         // 8. Client software MUST begin a payload build process building on top of
@@ -3167,7 +3166,7 @@ where
                 self.provider.clone(),
                 historical,
                 Some(blocks),
-            )))
+            )));
         }
 
         // Check if the block is persisted
@@ -3175,7 +3174,7 @@ where
             debug!(target: "engine::tree", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)));
         }
 
         debug!(target: "engine::tree", %hash, "no canonical state found for block");

--- a/crates/engine/tree/src/tree/payload_processor/bal.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal.rs
@@ -149,12 +149,12 @@ where
         };
 
         // If the account was only read then don't add it to the HashedPostState
-        if balance.is_none() &&
-            nonce.is_none() &&
-            code_hash.is_none() &&
-            account_changes.storage_changes.is_empty()
+        if balance.is_none()
+            && nonce.is_none()
+            && code_hash.is_none()
+            && account_changes.storage_changes.is_empty()
         {
-            continue
+            continue;
         }
 
         // Build the final account state

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1056,7 +1056,7 @@ impl PayloadExecutionCache {
                 if !hash_matches {
                     c.clear();
                 }
-                return Some(c.clone())
+                return Some(c.clone());
             } else if hash_matches {
                 self.metrics.execution_cache_in_use.increment(1);
             }

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -222,9 +222,9 @@ pub(crate) fn dispatch_with_chunking<T, I>(
 where
     I: IntoIterator<Item = T>,
 {
-    let should_chunk = chunking_len > max_targets_for_chunking ||
-        available_account_workers > 1 ||
-        available_storage_workers > 1;
+    let should_chunk = chunking_len > max_targets_for_chunking
+        || available_account_workers > 1
+        || available_storage_workers > 1;
 
     if should_chunk && chunking_len > chunk_size {
         let mut num_chunks = 0usize;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -181,9 +181,9 @@ where
                 }
 
                 // Send withdrawal prefetch targets after all transactions dispatched
-                if let Some(to_multi_proof) = to_multi_proof &&
-                    let Some(withdrawals) = &ctx.env.withdrawals &&
-                    !withdrawals.is_empty()
+                if let Some(to_multi_proof) = to_multi_proof
+                    && let Some(withdrawals) = &ctx.env.withdrawals
+                    && !withdrawals.is_empty()
                 {
                     let targets = multiproof_targets_from_withdrawals(withdrawals);
                     let _ = to_multi_proof.send(MultiProofMessage::PrefetchProofs(targets));
@@ -463,7 +463,7 @@ where
 
                     if finished_execution {
                         // all tasks are done, we can exit, which will save caches and exit
-                        break
+                        break;
                     }
                 }
                 PrewarmTaskEvent::FinishedTxExecution { executed_transactions } => {
@@ -475,7 +475,7 @@ where
 
                     if final_execution_outcome.is_some() {
                         // all tasks are done, we can exit, which will save caches and exit
-                        break
+                        break;
                     }
                 }
             }
@@ -541,7 +541,7 @@ where
                     %err,
                     "Failed to build state provider in prewarm thread"
                 );
-                return None
+                return None;
             }
         };
 
@@ -571,7 +571,7 @@ where
 
         if !self.precompile_cache_disabled {
             // Only cache pure precompiles to avoid issues with stateful precompiles
-            evm.precompiles_mut().map_pure_precompiles(|address, precompile| {
+            evm.precompiles_mut().map_cacheable_precompiles(|address, precompile| {
                 CachedPrecompile::wrap(
                     precompile,
                     self.precompile_cache_map.cache_for_address(*address),
@@ -656,7 +656,7 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         //
         // See: https://eips.ethereum.org/EIPS/eip-6780
         if !account.is_touched() || account.is_selfdestructed() {
-            continue
+            continue;
         }
 
         let hashed_address = keccak256(addr);
@@ -666,7 +666,7 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         for (key, slot) in account.storage {
             // do nothing if unchanged
             if !slot.is_changed() {
-                continue
+                continue;
             }
 
             let hashed_slot = keccak256(B256::new(key.to_be_bytes()));

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -308,9 +308,9 @@ where
                 self.promote_pending_account_updates()?;
                 self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
 
-                if self.finished_state_updates &&
-                    self.account_updates.is_empty() &&
-                    self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
+                if self.finished_state_updates
+                    && self.account_updates.is_empty()
+                    && self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
                 {
                     break;
                 }
@@ -626,8 +626,8 @@ where
         let mut tries_to_compute_roots: Vec<(B256, SendStorageTriePtr<S>)> =
             Vec::with_capacity(addresses_to_compute_roots.len());
         for address in addresses_to_compute_roots {
-            if let Some(trie) = self.trie.storage_tries_mut().get_mut(&address) &&
-                !trie.is_root_cached()
+            if let Some(trie) = self.trie.storage_tries_mut().get_mut(&address)
+                && !trie.is_root_cached()
             {
                 tries_to_compute_roots.push((address, SendStorageTriePtr(trie)));
             }
@@ -726,7 +726,7 @@ where
             // We need to keep iterating if any updates are being drained because that might
             // indicate that more pending account updates can be promoted.
             if num_promoted == 0 || !self.process_account_leaf_updates(false)? {
-                break
+                break;
             }
         }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -11,7 +11,7 @@ use crate::tree::{
     StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::BlockAccessList;
+use alloy_eip7928::{total_bal_items, BlockAccessList, ITEM_COST};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -314,7 +314,7 @@ where
         // Validate block consensus rules which includes header validation
         if let Err(consensus_err) = self.validate_block_inner(&block, None) {
             // Header validation error takes precedence over execution error
-            return Err(InsertBlockError::new(block, consensus_err.into()).into())
+            return Err(InsertBlockError::new(block, consensus_err.into()).into());
         }
 
         // Also validate against the parent
@@ -322,7 +322,7 @@ where
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
             // Parent validation error takes precedence over execution error
-            return Err(InsertBlockError::new(block, consensus_err.into()).into())
+            return Err(InsertBlockError::new(block, consensus_err.into()).into());
         }
 
         // No header validation errors, return the original execution error
@@ -397,7 +397,7 @@ where
                     Ok(val) => val,
                     Err(e) => {
                         let block = convert_to_block(input)?;
-                        return Err(InsertBlockError::new(block, e.into()).into())
+                        return Err(InsertBlockError::new(block, e.into()).into());
                     }
                 }
             };
@@ -430,7 +430,7 @@ where
                 convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
-            .into())
+            .into());
         };
         let mut state_provider = ensure_ok!(provider_builder.build());
         drop(_enter);
@@ -443,7 +443,7 @@ where
                 convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
-            .into())
+            .into());
         };
 
         let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm_env")
@@ -763,7 +763,7 @@ where
                 )
                 .into(),
             )
-            .into())
+            .into());
         }
 
         let timing_stats = state_provider_stats.map(|stats| {
@@ -825,14 +825,14 @@ where
     ) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
-            return Err(e)
+            return Err(e);
         }
 
         if let Err(e) =
             self.consensus.validate_block_pre_execution_with_tx_root(block, transaction_root)
         {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate block {}: {e}", block.hash());
-            return Err(e)
+            return Err(e);
         }
 
         Ok(())
@@ -874,11 +874,27 @@ where
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
         let has_bal = input.block_access_list().is_some();
+        if has_bal {
+            let bal = input
+                .block_access_list()
+                .transpose()
+                .map_err(BlockExecutionError::other)?
+                .unwrap_or_default();
+
+            let bal_items = total_bal_items(&bal);
+
+            if bal_items > input.gas_limit() / ITEM_COST as u64 {
+                debug!(target: "engine::tree::payload_validator", bal_items, "{} {}", input.gas_limit(), "BAL is invalid since it contains more items than the gas limit allows");
+                return Err(InsertBlockErrorKind::Consensus(
+                    ConsensusError::BlockAccessListCostMoreThanGasLimit,
+                ));
+            }
+        }
+
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
                 .with_bundle_update()
-                .without_state_clear()
                 .with_bal_builder_if(has_bal)
                 .build()
         });
@@ -896,19 +912,21 @@ where
 
         if !self.config.precompile_cache_disabled() {
             let _span = debug_span!(target: "engine::tree", "setup_precompile_cache").entered();
-            executor.evm_mut().precompiles_mut().map_pure_precompiles(|address, precompile| {
-                let metrics = self
-                    .precompile_cache_metrics
-                    .entry(*address)
-                    .or_insert_with(|| CachedPrecompileMetrics::new_with_address(*address))
-                    .clone();
-                CachedPrecompile::wrap(
-                    precompile,
-                    self.precompile_cache_map.cache_for_address(*address),
-                    spec_id,
-                    Some(metrics),
-                )
-            });
+            executor.evm_mut().precompiles_mut().map_cacheable_precompiles(
+                |address, precompile| {
+                    let metrics = self
+                        .precompile_cache_metrics
+                        .entry(*address)
+                        .or_insert_with(|| CachedPrecompileMetrics::new_with_address(*address))
+                        .clone();
+                    CachedPrecompile::wrap(
+                        precompile,
+                        self.precompile_cache_map.cache_for_address(*address),
+                        spec_id,
+                        Some(metrics),
+                    )
+                },
+            );
         }
 
         // Spawn background task to compute receipt root and logs bloom incrementally.
@@ -936,6 +954,7 @@ where
             handle.iter_transactions(),
             &receipt_tx,
             &executed_tx_index,
+            has_bal,
         )?;
         drop(receipt_tx);
 
@@ -956,7 +975,7 @@ where
             let expected_bal =
                 input.block_access_list().transpose().map_err(BlockExecutionError::other)?;
 
-            let built_bal = &result.block_access_list;
+            let built_bal = db.take_built_alloy_bal();
 
             // Compute hashes and compare
             let expected_hash = expected_bal
@@ -967,8 +986,8 @@ where
                 .as_ref()
                 .map(|bal| alloy_eips::eip7928::compute_block_access_list_hash(bal));
 
-            if let (Some(expected), Some(got)) = (expected_hash, built_hash) &&
-                expected != got
+            if let (Some(expected), Some(got)) = (expected_hash, built_hash)
+                && expected != got
             {
                 return Err(InsertBlockErrorKind::Consensus(
                     ConsensusError::BlockAccessListHashMismatch((got, expected).into()),
@@ -1003,6 +1022,7 @@ where
         transactions: impl Iterator<Item = Result<Tx, Err>>,
         receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
         executed_tx_index: &AtomicUsize,
+        has_bal: bool,
     ) -> Result<(E, Vec<Address>), BlockExecutionError>
     where
         E: BlockExecutor<Receipt = N::Receipt, Evm: alloy_evm::Evm<DB = &'a mut State<DB>>>,
@@ -1018,6 +1038,11 @@ where
         debug_span!(target: "engine::tree", "pre_execution")
             .in_scope(|| executor.apply_pre_execution_changes())?;
         self.metrics.record_pre_execution(pre_exec_start.elapsed());
+
+        // Bump BAL index after pre-execution changes (EIP-7928: index 0 is pre-execution)
+        if has_bal {
+            executor.evm_mut().db_mut().bump_bal_index();
+        }
 
         // Execute transactions
         let exec_span = debug_span!(target: "engine::tree", "execution").entered();
@@ -1061,6 +1086,10 @@ where
                     let tx_index = current_len - 1;
                     let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
                 }
+            }
+            // Bump BAL index after each transaction (EIP-7928)
+            if has_bal {
+                executor.evm_mut().db_mut().bump_bal_index();
             }
         }
         drop(exec_span);
@@ -1355,7 +1384,7 @@ where
         trace!(target: "engine::tree::payload_validator", block=?block.num_hash(), "Validating block consensus");
         // validate block consensus rules
         if let Err(e) = self.validate_block_inner(block, transaction_root) {
-            return Err(e.into())
+            return Err(e.into());
         }
 
         // now validate against the parent
@@ -1364,7 +1393,7 @@ where
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
             warn!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {} against parent: {e}", block.hash());
-            return Err(e.into())
+            return Err(e.into());
         }
         drop(_enter);
 
@@ -1372,12 +1401,16 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
-        if let Err(err) =
-            self.consensus.validate_block_post_execution(block, output, receipt_root_bloom)
-        {
+        if let Err(err) = self.consensus.validate_block_post_execution(
+            block,
+            output,
+            receipt_root_bloom,
+            None,
+            false,
+        ) {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into())
+            return Err(err.into());
         }
         drop(_enter);
 
@@ -1393,7 +1426,7 @@ where
         {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into())
+            return Err(err.into());
         }
 
         // record post-execution validation duration
@@ -1501,7 +1534,7 @@ where
                 self.provider.clone(),
                 historical,
                 Some(blocks),
-            )))
+            )));
         }
 
         // Check if the block is persisted
@@ -1509,7 +1542,7 @@ where
             debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)));
         }
 
         debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");
@@ -1541,7 +1574,7 @@ where
     ) {
         if state.invalid_headers.get(&block.hash()).is_some() {
             // we already marked this block as invalid
-            return
+            return;
         }
         self.invalid_block_hook.on_invalid_block(parent_header, block, output, trie_updates);
     }
@@ -1793,9 +1826,9 @@ where
             .sum();
 
         // Total time spent fetching state during execution
-        let state_read_duration = provider_stats.total_account_fetch_latency() +
-            provider_stats.total_storage_fetch_latency() +
-            provider_stats.total_code_fetch_latency();
+        let state_read_duration = provider_stats.total_account_fetch_latency()
+            + provider_stats.total_storage_fetch_latency()
+            + provider_stats.total_code_fetch_latency();
 
         // EIP-7702 delegation tracking from bytecode changes
         // Count new EIP-7702 bytecodes as delegations set
@@ -2102,6 +2135,17 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(payload) => payload.gas_used(),
             Self::Block(block) => block.gas_used(),
+        }
+    }
+
+    /// Returns the gas limit used by the block.
+    pub fn gas_limit(&self) -> u64
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.gas_limit(),
+            Self::Block(block) => block.gas_limit(),
         }
     }
 }

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -172,7 +172,7 @@ where
         if let Some(entry) = &self.cache.get(input.data, self.spec_id.clone()) {
             self.increment_by_one_precompile_cache_hits();
             if input.gas >= entry.gas_used() {
-                return entry.to_precompile_result()
+                return entry.to_precompile_result();
             }
         }
 

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -216,13 +216,13 @@ impl<N: NodePrimitives> TreeState<N> {
     pub fn is_canonical(&self, hash: B256) -> bool {
         let mut current_block = self.current_canonical_head.hash;
         if current_block == hash {
-            return true
+            return true;
         }
 
         while let Some(executed) = self.blocks_by_hash.get(&current_block) {
             current_block = executed.recovered_block().parent_hash();
             if current_block == hash {
-                return true
+                return true;
             }
         }
 
@@ -237,7 +237,7 @@ impl<N: NodePrimitives> TreeState<N> {
         // If the last persisted hash is not canonical, then we don't want to remove any canonical
         // blocks yet.
         if !self.is_canonical(last_persisted_hash) {
-            return
+            return;
         }
 
         // First, let's walk back the canonical chain and remove canonical blocks lower than the
@@ -387,19 +387,19 @@ impl<N: NodePrimitives> TreeState<N> {
         // If the second block's parent is the first block's hash, then it is a direct child
         // and we can return early.
         if second.parent == first.hash {
-            return true
+            return true;
         }
 
         // If the second block is lower than, or has the same block number, they are not
         // descendants.
         if second.block.number <= first.number {
-            return false
+            return false;
         }
 
         // iterate through parents of the second until we reach the number
         let Some(mut current_block) = self.blocks_by_hash.get(&second.parent) else {
             // If we can't find its parent in the tree, we can't continue, so return false
-            return false
+            return false;
         };
 
         while current_block.recovered_block().number() > first.number + 1 {
@@ -407,7 +407,7 @@ impl<N: NodePrimitives> TreeState<N> {
                 self.blocks_by_hash.get(&current_block.recovered_block().parent_hash())
             else {
                 // If we can't find its parent in the tree, we can't continue, so return false
-                return false
+                return false;
             };
 
             current_block = block;

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -934,8 +934,8 @@ async fn test_get_canonical_blocks_to_persist() {
     assert!(!blocks_to_persist.iter().any(|b| b.recovered_block().hash() == fork_block_hash));
 
     // check that the original block 4 is still included
-    assert!(blocks_to_persist.iter().any(|b| b.recovered_block().number == 4 &&
-        b.recovered_block().hash() == blocks[4].recovered_block().hash()));
+    assert!(blocks_to_persist.iter().any(|b| b.recovered_block().number == 4
+        && b.recovered_block().hash() == blocks[4].recovered_block().hash()));
 
     // check that if we advance persistence, the persistence action is the correct value
     test_harness.tree.advance_persistence().expect("advancing persistence should succeed");

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -27,9 +27,9 @@ struct TrieUpdatesDiff {
 
 impl TrieUpdatesDiff {
     fn has_differences(&self) -> bool {
-        !self.account_nodes.is_empty() ||
-            !self.removed_nodes.is_empty() ||
-            !self.storage_tries.is_empty()
+        !self.account_nodes.is_empty()
+            || !self.removed_nodes.is_empty()
+            || !self.storage_tries.is_empty()
     }
 
     pub(super) fn log_differences(mut self) {
@@ -66,9 +66,9 @@ struct StorageTrieUpdatesDiff {
 
 impl StorageTrieUpdatesDiff {
     fn has_differences(&self) -> bool {
-        self.is_deleted.is_some() ||
-            !self.storage_nodes.is_empty() ||
-            !self.removed_nodes.is_empty()
+        self.is_deleted.is_some()
+            || !self.storage_nodes.is_empty()
+            || !self.removed_nodes.is_empty()
     }
 
     fn log_differences(&self, address: B256) {
@@ -294,11 +294,11 @@ fn branch_nodes_equal(
 ) -> Result<bool, DatabaseError> {
     Ok(match (task, regular) {
         (Some(task), Some(regular)) => {
-            task.state_mask == regular.state_mask &&
-                task.tree_mask == regular.tree_mask &&
-                task.hash_mask == regular.hash_mask &&
-                task.hashes == regular.hashes &&
-                task.root_hash == regular.root_hash
+            task.state_mask == regular.state_mask
+                && task.tree_mask == regular.tree_mask
+                && task.hash_mask == regular.hash_mask
+                && task.hashes == regular.hashes
+                && task.root_hash == regular.root_hash
         }
         (None, None) => true,
         _ => {

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -77,8 +77,8 @@ impl EngineMessageStore {
                     })?,
                 )?;
             }
-            BeaconEngineMessage::NewPayload { payload, .. } |
-            BeaconEngineMessage::RethNewPayload { payload, .. } => {
+            BeaconEngineMessage::NewPayload { payload, .. }
+            | BeaconEngineMessage::RethNewPayload { payload, .. } => {
                 let filename = format!("{}-new_payload-{}.json", timestamp, payload.block_hash());
                 fs::write(
                     self.path.join(filename),
@@ -141,8 +141,8 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
         let next = ready!(this.stream.poll_next_unpin(cx));
-        if let Some(msg) = &next &&
-            let Err(error) = this.store.on_message(msg, SystemTime::now())
+        if let Some(msg) = &next
+            && let Err(error) = this.store.on_message(msg, SystemTime::now())
         {
             error!(target: "engine::stream::store", ?msg, %error, "Error handling Engine API message");
         }

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -127,7 +127,7 @@ where
                     }
                     Err(_) => {}
                 };
-                continue
+                continue;
             }
 
             if let EngineReorgState::Reorg { queue } = &mut this.state {
@@ -173,7 +173,7 @@ where
                             return Poll::Ready(Some(BeaconEngineMessage::NewPayload {
                                 payload,
                                 tx,
-                            }))
+                            }));
                         }
                     };
                     let reorg_forkchoice_state = ForkchoiceState {
@@ -206,7 +206,7 @@ where
                         },
                     ]);
                     *this.state = EngineReorgState::Reorg { queue };
-                    continue
+                    continue;
                 }
                 (
                     Some(BeaconEngineMessage::ForkchoiceUpdated {
@@ -231,7 +231,7 @@ where
                 }
                 (item, _) => item,
             };
-            return Poll::Ready(item)
+            return Poll::Ready(item);
         }
     }
 }
@@ -264,7 +264,7 @@ where
                 .block_by_hash(previous_hash)?
                 .ok_or_else(|| ProviderError::HeaderNotFound(previous_hash.into()))?;
             if depth == 0 {
-                break 'target reorg_target.seal_slow()
+                break 'target reorg_target.seal_slow();
             }
 
             depth -= 1;
@@ -295,7 +295,7 @@ where
     for tx in candidate_transactions {
         // ensure we still have capacity for this transaction
         if cumulative_gas_used + tx.gas_limit() > reorg_target.gas_limit() {
-            continue
+            continue;
         }
 
         let tx_recovered =
@@ -307,7 +307,7 @@ where
                 error,
             })) => {
                 trace!(target: "engine::stream::reorg", hash = %hash, ?error, "Error executing transaction from next block");
-                continue
+                continue;
             }
             // Treat error as fatal
             Err(error) => return Err(RethError::Execution(error)),

--- a/crates/engine/util/src/skip_fcu.rs
+++ b/crates/engine/util/src/skip_fcu.rs
@@ -55,7 +55,7 @@ where
                         *this.skipped += 1;
                         tracing::warn!(target: "engine::stream::skip_fcu", ?state, ?payload_attrs, threshold=this.threshold, skipped=this.skipped, "Skipping FCU");
                         let _ = tx.send(Ok(OnForkChoiceUpdated::syncing()));
-                        continue
+                        continue;
                     }
                     *this.skipped = 0;
                     Some(BeaconEngineMessage::ForkchoiceUpdated {
@@ -67,7 +67,7 @@ where
                 }
                 next => next,
             };
-            return Poll::Ready(item)
+            return Poll::Ready(item);
         }
     }
 }

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -53,14 +53,14 @@ where
                             skipped=this.skipped, "Skipping new payload"
                         );
                         let _ = tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing)));
-                        continue
+                        continue;
                     }
                     *this.skipped = 0;
                     Some(BeaconEngineMessage::NewPayload { payload, tx })
                 }
                 next => next,
             };
-            return Poll::Ready(item)
+            return Poll::Ready(item);
         }
     }
 }

--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -114,9 +114,9 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
 
         if let Ok(mut dir) = fs::read_dir(&self.folder).await {
             while let Ok(Some(entry)) = dir.next_entry().await {
-                if let Some(name) = entry.file_name().to_str() &&
-                    let Some(number) = self.file_name_to_number(name) &&
-                    (max.is_none() || matches!(max, Some(max) if number > max))
+                if let Some(name) = entry.file_name().to_str()
+                    && let Some(number) = self.file_name_to_number(name)
+                    && (max.is_none() || matches!(max, Some(max) if number > max))
                 {
                     max.replace(number + 1);
                 }
@@ -132,9 +132,9 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
 
         if let Ok(mut dir) = fs::read_dir(&self.folder).await {
             while let Ok(Some(entry)) = dir.next_entry().await {
-                if let Some(name) = entry.file_name().to_str() &&
-                    let Some(number) = self.file_name_to_number(name) &&
-                    (number < index || number >= last)
+                if let Some(name) = entry.file_name().to_str()
+                    && let Some(number) = self.file_name_to_number(name)
+                    && (number < index || number >= last)
                 {
                     reth_fs_util::remove_file(entry.path())?;
                 }
@@ -206,8 +206,8 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
         let ext_len = ext.len();
 
         while let Some(line) = lines.next_line().await? {
-            if let Some(j) = line.find(ext) &&
-                let Some(i) = line[..j].rfind(|c: char| !c.is_alphanumeric() && c != '-')
+            if let Some(j) = line.find(ext)
+                && let Some(i) = line[..j].rfind(|c: char| !c.is_alphanumeric() && c != '-')
             {
                 let era = &line[i + 1..j + ext_len];
                 writer.write_all(era.as_bytes()).await?;

--- a/crates/era-downloader/src/fs.rs
+++ b/crates/era-downloader/src/fs.rs
@@ -19,8 +19,8 @@ pub fn read_dir(
             (|| {
                 let path = entry?.path();
 
-                if path.extension() == Some("era1".as_ref()) &&
-                    let Some(last) = path.components().next_back()
+                if path.extension() == Some("era1".as_ref())
+                    && let Some(last) = path.components().next_back()
                 {
                     let str = last.as_os_str().to_string_lossy().to_string();
                     let parts = str.split('-').collect::<Vec<_>>();

--- a/crates/era-downloader/src/stream.rs
+++ b/crates/era-downloader/src/stream.rs
@@ -262,8 +262,8 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for Starti
             self.fetch_file_list();
         }
 
-        if self.state == State::FetchFileList &&
-            let Poll::Ready(result) = self.fetch_file_list.poll_unpin(cx)
+        if self.state == State::FetchFileList
+            && let Poll::Ready(result) = self.fetch_file_list.poll_unpin(cx)
         {
             match result {
                 Ok(_) => self.delete_outside_range(),
@@ -275,8 +275,8 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for Starti
             }
         }
 
-        if self.state == State::DeleteOutsideRange &&
-            let Poll::Ready(result) = self.delete_outside_range.poll_unpin(cx)
+        if self.state == State::DeleteOutsideRange
+            && let Poll::Ready(result) = self.delete_outside_range.poll_unpin(cx)
         {
             match result {
                 Ok(_) => self.recover_index(),
@@ -288,15 +288,15 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for Starti
             }
         }
 
-        if self.state == State::RecoverIndex &&
-            let Poll::Ready(last) = self.recover_index.poll_unpin(cx)
+        if self.state == State::RecoverIndex
+            && let Poll::Ready(last) = self.recover_index.poll_unpin(cx)
         {
             self.last = last;
             self.count_files();
         }
 
-        if self.state == State::CountFiles &&
-            let Poll::Ready(downloaded) = self.files_count.poll_unpin(cx)
+        if self.state == State::CountFiles
+            && let Poll::Ready(downloaded) = self.files_count.poll_unpin(cx)
         {
             let max_missing = self
                 .max_files
@@ -316,8 +316,8 @@ impl<Http: HttpClient + Clone + Send + Sync + 'static + Unpin> Stream for Starti
             }
         }
 
-        if let State::NextUrl(max_missing) = self.state &&
-            let Poll::Ready(url) = self.next_url.poll_unpin(cx)
+        if let State::NextUrl(max_missing) = self.state
+            && let Poll::Ready(url) = self.next_url.poll_unpin(cx)
         {
             self.state = State::Missing(max_missing - 1);
 

--- a/crates/era-downloader/tests/it/checksums.rs
+++ b/crates/era-downloader/tests/it/checksums.rs
@@ -64,17 +64,17 @@ impl HttpClient for FailingClient {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(crate::ERA1_NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(crate::ERA1_ETH_PORTAL),
             "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(crate::ERA1_ITHACA),
-            "https://mainnet.era1.nimbus.team/checksums.txt" |
-            "https://era1.ethportal.net/checksums.txt" |
-            "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(CHECKSUMS),
-            "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" |
-            "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
+            "https://mainnet.era1.nimbus.team/checksums.txt"
+            | "https://era1.ethportal.net/checksums.txt"
+            | "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(CHECKSUMS),
+            "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1"
+            | "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1"
+            | "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
                 Bytes::from_static(crate::ERA1_MAINNET_0)
             }
-            "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" |
-            "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
+            "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1"
+            | "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1"
+            | "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
                 Bytes::from_static(crate::ERA1_MAINNET_1)
             }
             v => unimplemented!("Unexpected URL \"{v}\""),

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -45,17 +45,17 @@ impl HttpClient for StubClient {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(ERA1_NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(ERA1_ETH_PORTAL),
             "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(ERA1_ITHACA),
-            "https://mainnet.era1.nimbus.team/checksums.txt" |
-            "https://era1.ethportal.net/checksums.txt" |
-            "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(ERA1_CHECKSUMS),
-            "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" |
-            "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
+            "https://mainnet.era1.nimbus.team/checksums.txt"
+            | "https://era1.ethportal.net/checksums.txt"
+            | "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(ERA1_CHECKSUMS),
+            "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1"
+            | "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1"
+            | "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
                 Bytes::from_static(ERA1_MAINNET_0)
             }
-            "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" |
-            "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
+            "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1"
+            | "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1"
+            | "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
                 Bytes::from_static(ERA1_MAINNET_1)
             }
             // Era urls

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -292,8 +292,8 @@ where
         if number <= last_header_number {
             continue;
         }
-        if let Some(target) = target &&
-            number > target
+        if let Some(target) = target
+            && number > target
         {
             break;
         }
@@ -336,9 +336,9 @@ where
         provider.tx_ref().cursor_write::<RawTable<tables::HeaderNumbers>>()?;
     // If we only have the genesis block hash, then we are at first sync, and we can remove it,
     // add it to the collector and use tx.append on all hashes.
-    let first_sync = if provider.tx_ref().entries::<RawTable<tables::HeaderNumbers>>()? == 1 &&
-        let Some((hash, block_number)) = cursor_header_numbers.last()? &&
-        block_number.value()? == 0
+    let first_sync = if provider.tx_ref().entries::<RawTable<tables::HeaderNumbers>>()? == 1
+        && let Some((hash, block_number)) = cursor_header_numbers.last()?
+        && block_number.value()? == 0
     {
         hash_collector.insert(hash.key()?, 0)?;
         cursor_header_numbers.delete_current()?;

--- a/crates/era/src/era/file.rs
+++ b/crates/era/src/era/file.rs
@@ -276,9 +276,9 @@ impl<W: Write> EraWriter<W> {
         self.ensure_version_written()?;
 
         // Ensure blocks are written before state/indices
-        if self.has_written_state ||
-            self.has_written_block_slot_index ||
-            self.has_written_state_slot_index
+        if self.has_written_state
+            || self.has_written_block_slot_index
+            || self.has_written_state_slot_index
         {
             return Err(E2sError::Ssz("Cannot write blocks after state or indices".to_string()));
         }

--- a/crates/era/src/era1/file.rs
+++ b/crates/era/src/era1/file.rs
@@ -147,13 +147,17 @@ impl<R: Read + Seek> BlockTupleIterator<R> {
                 }
                 ACCUMULATOR => {
                     if self.accumulator.is_some() {
-                        return Err(E2sError::Ssz("Multiple accumulator entries found".to_string()));
+                        return Err(E2sError::Ssz(
+                            "Multiple accumulator entries found".to_string(),
+                        ));
                     }
                     self.accumulator = Some(Accumulator::from_entry(&entry)?);
                 }
                 BLOCK_INDEX => {
                     if self.block_index.is_some() {
-                        return Err(E2sError::Ssz("Multiple block index entries found".to_string()));
+                        return Err(E2sError::Ssz(
+                            "Multiple block index entries found".to_string(),
+                        ));
                     }
                     self.block_index = Some(BlockIndex::from_entry(&entry)?);
                 }
@@ -162,10 +166,10 @@ impl<R: Read + Seek> BlockTupleIterator<R> {
                 }
             }
 
-            if !self.headers.is_empty() &&
-                !self.bodies.is_empty() &&
-                !self.receipts.is_empty() &&
-                !self.difficulties.is_empty()
+            if !self.headers.is_empty()
+                && !self.bodies.is_empty()
+                && !self.receipts.is_empty()
+                && !self.difficulties.is_empty()
             {
                 let header = self.headers.pop_front().unwrap();
                 let body = self.bodies.pop_front().unwrap();
@@ -223,9 +227,9 @@ impl<R: Read + Seek> Era1Reader<R> {
         } = iter;
 
         // Ensure we have matching counts for block components
-        if headers.len() != bodies.len() ||
-            headers.len() != receipts.len() ||
-            headers.len() != difficulties.len()
+        if headers.len() != bodies.len()
+            || headers.len() != receipts.len()
+            || headers.len() != difficulties.len()
         {
             return Err(E2sError::Ssz(format!(
                 "Mismatched block component counts: headers={}, bodies={}, receipts={}, difficulties={}",
@@ -300,7 +304,9 @@ impl<W: Write> StreamWriter<W> for Era1Writer<W> {
 
         // Ensure blocks are written before other entries
         if era1_file.group.blocks.len() > MAX_BLOCKS_PER_ERA1 {
-            return Err(E2sError::Ssz("Era1 file cannot contain more than 8192 blocks".to_string()));
+            return Err(E2sError::Ssz(
+                "Era1 file cannot contain more than 8192 blocks".to_string(),
+            ));
         }
 
         // Write all blocks

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 
 use alloc::{fmt::Debug, sync::Arc};
 use alloy_consensus::{constants::MAXIMUM_EXTRA_DATA_SIZE, EMPTY_OMMER_ROOT_HASH};
-use alloy_eips::eip7840::BlobParams;
+use alloy_eips::{eip7840::BlobParams, eip7928::BlockAccessList};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::{
     Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom, TransactionRoot,
@@ -78,6 +78,8 @@ where
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        block_access_list: Option<BlockAccessList>,
+        allow_bal_check: bool,
     ) -> Result<(), ConsensusError> {
         validate_block_post_execution(
             block,
@@ -85,7 +87,8 @@ where
             &result.receipts,
             &result.requests,
             receipt_root_bloom,
-            &result.block_access_list,
+            &block_access_list,
+            allow_bal_check,
             Some(result.gas_used),
         )
     }
@@ -146,8 +149,8 @@ where
                     .unwrap()
                     .as_secs();
 
-                if header.timestamp() >
-                    present_timestamp + alloy_eips::merge::ALLOWED_FUTURE_BLOCK_TIME_SECONDS
+                if header.timestamp()
+                    > present_timestamp + alloy_eips::merge::ALLOWED_FUTURE_BLOCK_TIME_SECONDS
                 {
                     return Err(ConsensusError::TimestampIsInFuture {
                         timestamp: header.timestamp(),
@@ -161,14 +164,14 @@ where
         validate_header_base_fee(header, &self.chain_spec)?;
 
         // EIP-4895: Beacon chain push withdrawals as operations
-        if self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) &&
-            header.withdrawals_root().is_none()
+        if self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp())
+            && header.withdrawals_root().is_none()
         {
-            return Err(ConsensusError::WithdrawalsRootMissing)
-        } else if !self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) &&
-            header.withdrawals_root().is_some()
+            return Err(ConsensusError::WithdrawalsRootMissing);
+        } else if !self.chain_spec.is_shanghai_active_at_timestamp(header.timestamp())
+            && header.withdrawals_root().is_some()
         {
-            return Err(ConsensusError::WithdrawalsRootUnexpected)
+            return Err(ConsensusError::WithdrawalsRootUnexpected);
         }
 
         // Ensures that EIP-4844 fields are valid once cancun is active.
@@ -180,19 +183,19 @@ where
                     .unwrap_or_else(BlobParams::cancun),
             )?;
         } else if header.blob_gas_used().is_some() {
-            return Err(ConsensusError::BlobGasUsedUnexpected)
+            return Err(ConsensusError::BlobGasUsedUnexpected);
         } else if header.excess_blob_gas().is_some() {
-            return Err(ConsensusError::ExcessBlobGasUnexpected)
+            return Err(ConsensusError::ExcessBlobGasUnexpected);
         } else if header.parent_beacon_block_root().is_some() {
-            return Err(ConsensusError::ParentBeaconBlockRootUnexpected)
+            return Err(ConsensusError::ParentBeaconBlockRootUnexpected);
         }
 
         if self.chain_spec.is_prague_active_at_timestamp(header.timestamp()) {
             if header.requests_hash().is_none() {
-                return Err(ConsensusError::RequestsHashMissing)
+                return Err(ConsensusError::RequestsHashMissing);
             }
         } else if header.requests_hash().is_some() {
-            return Err(ConsensusError::RequestsHashUnexpected)
+            return Err(ConsensusError::RequestsHashUnexpected);
         }
 
         Ok(())

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -24,6 +24,7 @@ use reth_primitives_traits::{
 /// (Amsterdam) is active, block header `gas_used` tracks gas before refunds while receipt
 /// `cumulative_gas_used` tracks gas after refunds. In that case, the header must be validated
 /// against the execution result's `gas_used` rather than the receipt value.
+#[allow(clippy::too_many_arguments)]
 pub fn validate_block_post_execution<B, R, ChainSpec>(
     block: &RecoveredBlock<B>,
     chain_spec: &ChainSpec,
@@ -31,6 +32,7 @@ pub fn validate_block_post_execution<B, R, ChainSpec>(
     requests: &Requests,
     receipt_root_bloom: Option<(B256, Bloom)>,
     block_access_list: &Option<BlockAccessList>,
+    allow_bal_check: bool,
     gas_spent: Option<u64>,
 ) -> Result<(), ConsensusError>
 where
@@ -51,10 +53,10 @@ where
         return Err(ConsensusError::BlockGasUsed {
             gas: GotExpected { got: cumulative_gas_used, expected: block.header().gas_used() },
             gas_spent_by_tx: gas_spent_by_transactions(receipts),
-        })
+        });
     }
     // Validate that the block access list hash matches the calculated block access list hash
-    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) {
+    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) && allow_bal_check {
         let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
         let default_bal = BlockAccessList::default();
         let block_access_list_hash =
@@ -62,7 +64,7 @@ where
         if block_access_list_hash != block_bal_hash {
             return Err(ConsensusError::BlockAccessListHashMismatch(
                 (block_access_list_hash, block_bal_hash).into(),
-            ))
+            ));
         }
     }
 
@@ -88,20 +90,20 @@ where
                 .map(|r| Bytes::from(r.with_bloom_ref().encoded_2718()))
                 .collect::<Vec<_>>();
             tracing::debug!(%error, ?receipts, "receipts verification failed");
-            return Err(error)
+            return Err(error);
         }
     }
 
     // Validate that the header requests hash matches the calculated requests hash
     if chain_spec.is_prague_active_at_timestamp(block.header().timestamp()) {
         let Some(header_requests_hash) = block.header().requests_hash() else {
-            return Err(ConsensusError::RequestsHashMissing)
+            return Err(ConsensusError::RequestsHashMissing);
         };
         let requests_hash = requests.requests_hash();
         if requests_hash != header_requests_hash {
             return Err(ConsensusError::BodyRequestsHashDiff(
                 GotExpected::new(requests_hash, header_requests_hash).into(),
-            ))
+            ));
         }
     }
 
@@ -141,13 +143,13 @@ fn compare_receipts_root_and_logs_bloom(
     if calculated_receipts_root != expected_receipts_root {
         return Err(ConsensusError::BodyReceiptRootDiff(
             GotExpected { got: calculated_receipts_root, expected: expected_receipts_root }.into(),
-        ))
+        ));
     }
 
     if calculated_logs_bloom != expected_logs_bloom {
         return Err(ConsensusError::BodyBloomLogDiff(
             GotExpected { got: calculated_logs_bloom, expected: expected_logs_bloom }.into(),
-        ))
+        ));
     }
 
     Ok(())

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -3,7 +3,7 @@ use alloy_consensus::{
     proofs::{self, calculate_receipt_root},
     Block, BlockBody, BlockHeader, Header, TxReceipt, EMPTY_OMMER_ROOT_HASH,
 };
-use alloy_eips::merge::BEACON_NONCE;
+use alloy_eips::{eip4895::Withdrawals, merge::BEACON_NONCE};
 use alloy_evm::{block::BlockExecutorFactory, eth::EthBlockExecutionCtx};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput, BlockExecutionError};
@@ -61,7 +61,7 @@ where
         let withdrawals = self
             .chain_spec
             .is_shanghai_active_at_timestamp(timestamp)
-            .then(|| ctx.withdrawals.map(|w| w.into_owned()).unwrap_or_default());
+            .then(|| Withdrawals::new(ctx.withdrawals.map(|w| w.into_owned()).unwrap_or_default()));
 
         let withdrawals_root =
             withdrawals.as_deref().map(|w| proofs::calculate_withdrawals_root(w));

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -193,7 +193,7 @@ where
             parent_hash: block.header().parent_hash,
             parent_beacon_block_root: block.header().parent_beacon_block_root,
             ommers: &block.body().ommers,
-            withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
+            withdrawals: block.body().withdrawals.as_ref().map(|w| Cow::Borrowed(w.as_slice())),
             extra_data: block.header().extra_data.clone(),
             slot_number: block.header().slot_number,
         })
@@ -209,7 +209,7 @@ where
             parent_hash: parent.hash(),
             parent_beacon_block_root: attributes.parent_beacon_block_root,
             ommers: &[],
-            withdrawals: attributes.withdrawals.map(Cow::Owned),
+            withdrawals: attributes.withdrawals.map(|w| Cow::Owned(w.into_inner())),
             extra_data: attributes.extra_data,
             slot_number: attributes.slot_number,
         })
@@ -295,7 +295,7 @@ where
             parent_hash: payload.parent_hash(),
             parent_beacon_block_root: payload.sidecar.parent_beacon_block_root(),
             ommers: &[],
-            withdrawals: payload.payload.withdrawals().map(|w| Cow::Owned(w.clone().into())),
+            withdrawals: payload.payload.withdrawals().map(|w| Cow::Owned(w.clone())),
             extra_data: payload.payload.as_v1().extra_data.clone(),
             slot_number: payload.payload.as_v4().map(|v4| v4.slot_number),
         })

--- a/crates/ethereum/evm/src/test_utils.rs
+++ b/crates/ethereum/evm/src/test_utils.rs
@@ -136,7 +136,6 @@ impl<'a, DB: Database, I: Inspector<EthEvmContext<&'a mut State<DB>>>> BlockExec
             }),
             gas_used: 0,
             blob_gas_used: 0,
-            block_access_list: Default::default(),
         };
 
         evm.db_mut().bundle_state = bundle;

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -463,8 +463,8 @@ where
     ) -> eyre::Result<Self::Pool> {
         let pool_config = ctx.pool_config();
 
-        let blobs_disabled = ctx.config().txpool.disable_blobs_support ||
-            ctx.config().txpool.blobpool_max_count == 0;
+        let blobs_disabled = ctx.config().txpool.disable_blobs_support
+            || ctx.config().txpool.blobpool_max_count == 0;
 
         let blob_cache_size = if let Some(blob_cache_size) = pool_config.blob_cache_size {
             Some(blob_cache_size)

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -68,8 +68,8 @@ async fn can_run_dev_node_custom_attributes() -> eyre::Result<()> {
             .unwrap()
             .unwrap()
             .header
-            .beneficiary ==
-            fee_recipient
+            .beneficiary
+            == fee_recipient
     );
 
     Ok(())

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -73,9 +73,9 @@ async fn test_fee_history() -> eyre::Result<()> {
     let fee_history = provider.get_fee_history(10, 0_u64.into(), &[]).await?;
 
     let genesis_base_fee = chain_spec.initial_base_fee().unwrap() as u128;
-    let expected_first_base_fee = genesis_base_fee -
-        genesis_base_fee /
-            chain_spec
+    let expected_first_base_fee = genesis_base_fee
+        - genesis_base_fee
+            / chain_spec
                 .base_fee_params_at_timestamp(chain_spec.genesis_timestamp())
                 .max_change_denominator;
     assert_eq!(fee_history.base_fee_per_gas[0], genesis_base_fee);

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -230,12 +230,12 @@ where
                 &pool_tx,
                 &InvalidPoolTransactionError::ExceedsGasLimit(pool_tx.gas_limit(), block_gas_limit),
             );
-            continue
+            continue;
         }
 
         // check if the job was cancelled, if so we can exit early
         if cancel.is_cancelled() {
-            return Ok(BuildOutcome::Cancelled)
+            return Ok(BuildOutcome::Cancelled);
         }
 
         // convert tx to a signed transaction
@@ -254,7 +254,7 @@ where
                     limit: MAX_RLP_BLOCK_SIZE,
                 },
             );
-            continue
+            continue;
         }
 
         // There's only limited amount of blob space available per block, so we need to check if
@@ -278,14 +278,14 @@ where
                         },
                     ),
                 );
-                continue
+                continue;
             }
 
             let blob_sidecar_result = 'sidecar: {
                 let Some(sidecar) =
                     pool.get_blob(*tx.hash()).map_err(PayloadBuilderError::other)?
                 else {
-                    break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar)
+                    break 'sidecar Err(Eip4844PoolTransactionError::MissingEip4844BlobSidecar);
                 };
 
                 if is_osaka {
@@ -305,7 +305,7 @@ where
                 Ok(sidecar) => Some(sidecar),
                 Err(error) => {
                     best_txs.mark_invalid(&pool_tx, &InvalidPoolTransactionError::Eip4844(error));
-                    continue
+                    continue;
                 }
             };
         }
@@ -329,7 +329,7 @@ where
                         ),
                     );
                 }
-                continue
+                continue;
             }
             // EIP-7778: the executor tracks gas_before_refund while the payload builder's
             // pre-check uses gas_after_refund. Near-full blocks can pass the pre-check but
@@ -348,7 +348,7 @@ where
                         block_available_gas,
                     ),
                 );
-                continue
+                continue;
             }
             // this is an error that we should treat as fatal for this attempt
             Err(err) => return Err(PayloadBuilderError::evm(err)),
@@ -383,7 +383,7 @@ where
         // Release db
         drop(builder);
         // can skip building the block
-        return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
+        return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads });
     }
 
     let BlockBuilderOutcome { execution_result, block, block_access_list, .. } =

--- a/crates/ethereum/payload/src/validator.rs
+++ b/crates/ethereum/payload/src/validator.rs
@@ -83,7 +83,7 @@ where
         return Err(PayloadError::BlockHash {
             execution: sealed_block.hash(),
             consensus: expected_hash,
-        })
+        });
     }
 
     shanghai::ensure_well_formed_fields(

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -256,7 +256,7 @@ impl EtlFile {
     /// Can return error if it reaches EOF before filling the internal buffers.
     pub(crate) fn read_next(&mut self) -> std::io::Result<Option<(Vec<u8>, Vec<u8>)>> {
         if self.len == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
         let mut buffer_key_length = [0; KV_LEN];

--- a/crates/evm/evm/src/either.rs
+++ b/crates/evm/evm/src/either.rs
@@ -73,6 +73,13 @@ where
         }
     }
 
+    fn take_bal(&mut self) -> Option<alloy_eips::eip7928::BlockAccessList> {
+        match self {
+            Self::Left(a) => a.take_bal(),
+            Self::Right(b) => b.take_bal(),
+        }
+    }
+
     fn size_hint(&self) -> usize {
         match self {
             Self::Left(a) => a.size_hint(),

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -147,6 +147,9 @@ pub trait Executor<DB: Database>: Sized {
     /// Consumes the executor and returns the [`State`] containing all state changes.
     fn into_state(self) -> State<DB>;
 
+    /// Take built [`BlockAccessList`] from executor
+    fn take_bal(&mut self) -> Option<BlockAccessList>;
+
     /// The size hint of the batch's tracked state size.
     ///
     /// This is used to optimize DB commits depending on the size of the state.
@@ -464,6 +467,8 @@ where
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
         self.executor.apply_pre_execution_changes()?;
+        // Bump BAL index after pre-execution changes (EIP-7928: index 0 is pre-execution)
+        self.executor.evm_mut().db_mut().bump_bal_index();
 
         Ok(())
     }
@@ -480,6 +485,8 @@ where
             self.executor.execute_transaction_with_commit_condition((tx_env, &tx), f)?
         {
             self.transactions.push(tx);
+            // Bump BAL index after each committed transaction (EIP-7928)
+            self.executor.evm_mut().db_mut().bump_bal_index();
 
             Ok(Some(gas_used))
         } else {
@@ -498,7 +505,7 @@ where
         db.merge_transitions(BundleRetention::Reverts);
 
         // extract the built block access list (EIP-7928, Amsterdam) and compute its hash
-        let block_access_list = result.block_access_list.clone();
+        let block_access_list = db.take_built_alloy_bal();
         let block_access_list_hash =
             block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal));
 
@@ -563,7 +570,6 @@ impl<F, DB: Database> BasicBlockExecutor<F, DB> {
         let db = State::builder()
             .with_database(db)
             .with_bundle_update()
-            .without_state_clear()
             .with_bal_builder_if(true)
             .build();
         Self { strategy_factory, db }
@@ -616,6 +622,10 @@ where
 
     fn into_state(self) -> State<DB> {
         self.db
+    }
+
+    fn take_bal(&mut self) -> Option<BlockAccessList> {
+        self.db.take_built_alloy_bal()
     }
 
     fn size_hint(&self) -> usize {
@@ -721,6 +731,10 @@ mod tests {
 
         fn into_state(self) -> State<DB> {
             unreachable!()
+        }
+
+        fn take_bal(&mut self) -> Option<BlockAccessList> {
+            None
         }
 
         fn size_hint(&self) -> usize {

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -316,7 +316,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         &'a self,
         evm: EvmFor<Self, &'a mut State<DB>, I>,
         ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, DB, I>
+    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>, I>
     where
         DB: Database,
         I: InspectorFor<Self, &'a mut State<DB>> + 'a,
@@ -329,7 +329,8 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         &'a self,
         db: &'a mut State<DB>,
         block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
-    ) -> Result<impl BlockExecutorFor<'a, Self::BlockExecutorFactory, DB>, Self::Error> {
+    ) -> Result<impl BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>>, Self::Error>
+    {
         let evm = self.evm_for_block(db, block.header())?;
         let ctx = self.context_for_block(block)?;
         Ok(self.create_executor(evm, ctx))
@@ -357,7 +358,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
     ) -> impl BlockBuilder<
         Primitives = Self::Primitives,
-        Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, DB, I>,
+        Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>, I>,
     >
     where
         DB: Database,
@@ -409,7 +410,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
-            Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, DB>,
+            Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>>,
         >,
         Self::Error,
     > {

--- a/crates/evm/execution-errors/src/trie.rs
+++ b/crates/evm/execution-errors/src/trie.rs
@@ -23,8 +23,8 @@ pub enum StateRootError {
 impl From<StateRootError> for ProviderError {
     fn from(value: StateRootError) -> Self {
         match value {
-            StateRootError::Database(err) |
-            StateRootError::StorageRootError(StorageRootError::Database(err)) => {
+            StateRootError::Database(err)
+            | StateRootError::StorageRootError(StorageRootError::Database(err)) => {
                 Self::Database(err)
             }
             StateRootError::PrefixSetLoadError(err) => err,

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -146,13 +146,13 @@ impl<N: NodePrimitives> Chain<N> {
         block_number: BlockNumber,
     ) -> Option<ExecutionOutcome<N::Receipt>> {
         if self.tip().number() == block_number {
-            return Some(self.execution_outcome.clone())
+            return Some(self.execution_outcome.clone());
         }
 
         if self.blocks.contains_key(&block_number) {
             let mut execution_outcome = self.execution_outcome.clone();
             execution_outcome.revert_to(block_number);
-            return Some(execution_outcome)
+            return Some(execution_outcome);
         }
         None
     }
@@ -342,7 +342,7 @@ impl<N: NodePrimitives> Chain<N> {
         let chain_tip = self.tip();
         let other_fork_block = other.fork_block();
         if chain_tip.hash() != other_fork_block.hash {
-            return Err(other)
+            return Err(other);
         }
 
         // Insert blocks from other chain

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -58,7 +58,6 @@ impl<T> Default for BlockExecutionOutput<T> {
                 requests: Default::default(),
                 gas_used: 0,
                 blob_gas_used: 0,
-                block_access_list: Default::default(),
             },
             state: Default::default(),
         }

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -216,11 +216,11 @@ impl<T> ExecutionOutcome<T> {
     /// Transform block number to the index of block.
     pub const fn block_number_to_index(&self, block_number: BlockNumber) -> Option<usize> {
         if self.first_block > block_number {
-            return None
+            return None;
         }
         let index = block_number - self.first_block;
         if index >= self.receipts.len() as u64 {
-            return None
+            return None;
         }
         Some(index as usize)
     }
@@ -317,7 +317,7 @@ impl<T> ExecutionOutcome<T> {
         T: Clone,
     {
         if at == self.first_block {
-            return (None, self)
+            return (None, self);
         }
 
         let (mut lower_state, mut higher_state) = (self.clone(), self);

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -47,7 +47,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.range.is_empty() {
-            return None
+            return None;
         }
 
         Some(self.execute_range())
@@ -128,7 +128,7 @@ where
                 cumulative_gas,
                 batch_start.elapsed(),
             ) {
-                break
+                break;
             }
         }
 

--- a/crates/exex/exex/src/backfill/stream.rs
+++ b/crates/exex/exex/src/backfill/stream.rs
@@ -108,7 +108,7 @@ where
                 // next.
                 self.push_front(job);
 
-                return Poll::Ready(Some(job_result))
+                return Poll::Ready(Some(job_result));
             };
         }
 

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -149,7 +149,7 @@ impl<N: NodePrimitives> ExExHandle<N> {
                         );
 
                         self.next_notification_id = notification_id + 1;
-                        return Poll::Ready(Ok(()))
+                        return Poll::Ready(Ok(()));
                     }
                 }
                 // Do not handle [ExExNotification::ChainReorged] and
@@ -499,9 +499,9 @@ where
                 }
 
                 this.push_notification(notification);
-                continue
+                continue;
             }
-            break
+            break;
         }
         let buffer_full = this.buffer.len() >= this.max_capacity;
 
@@ -516,11 +516,11 @@ where
                 .next_notification_id
                 .checked_sub(this.min_id)
                 .expect("exex expected notification ID outside the manager's range");
-            if let Some(notification) = this.buffer.get(notification_index) &&
-                let Poll::Ready(Err(err)) = exex.send(cx, notification)
+            if let Some(notification) = this.buffer.get(notification_index)
+                && let Poll::Ready(Err(err)) = exex.send(cx, notification)
             {
                 // The channel was closed, which is irrecoverable for the manager
-                return Poll::Ready(Err(err.into()))
+                return Poll::Ready(Err(err.into()));
             }
             min_id = min_id.min(exex.next_notification_id);
             this.exex_handles.push(exex);

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -345,12 +345,12 @@ where
     /// we're not on the canonical chain and we need to revert the notification with the ExEx
     /// head block.
     fn check_canonical(&mut self) -> eyre::Result<Option<ExExNotification<E::Primitives>>> {
-        if self.provider.is_known(self.initial_exex_head.block.hash)? &&
-            self.initial_exex_head.block.number <= self.initial_local_head.number
+        if self.provider.is_known(self.initial_exex_head.block.hash)?
+            && self.initial_exex_head.block.number <= self.initial_local_head.number
         {
             // we have the targeted block and that block is below the current head
             debug!(target: "exex::notifications", "ExEx head is on the canonical chain");
-            return Ok(None)
+            return Ok(None);
         }
 
         // If the head block is not found in the database, it means we're not on the canonical
@@ -370,7 +370,7 @@ where
             return Err(eyre::eyre!(
                 "Could not find notification for block hash {:?} in the WAL",
                 self.initial_exex_head.block.hash
-            ))
+            ));
         };
 
         // Update the head block hash to the parent hash of the first committed block.
@@ -437,7 +437,7 @@ where
         // 1. Check once whether we need to retrieve a notification gap from the WAL.
         if this.pending_check_canonical {
             if let Some(canonical_notification) = this.check_canonical()? {
-                return Poll::Ready(Some(Ok(canonical_notification)))
+                return Poll::Ready(Some(Ok(canonical_notification)));
             }
 
             // ExEx head is on the canonical chain, we no longer need to check it
@@ -471,8 +471,8 @@ where
                     this.pending_notifications.push_back(notification);
                     continue;
                 }
-                if let Some(committed) = notification.committed_chain() &&
-                    committed.tip().number() <= this.initial_local_head.number
+                if let Some(committed) = notification.committed_chain()
+                    && committed.tip().number() <= this.initial_local_head.number
                 {
                     // Covered by backfill range, safe to discard
                     continue;
@@ -485,7 +485,7 @@ where
                 debug!(target: "exex::notifications", range = ?chain.range(), "Backfill job returned a chain");
                 return Poll::Ready(Some(Ok(ExExNotification::ChainCommitted {
                     new: Arc::new(chain),
-                })))
+                })));
             }
 
             // Backfill job is done, remove it
@@ -494,24 +494,24 @@ where
 
         // 4. Deliver any notifications that were buffered during backfill
         if let Some(notification) = this.pending_notifications.pop_front() {
-            return Poll::Ready(Some(Ok(notification)))
+            return Poll::Ready(Some(Ok(notification)));
         }
 
         // 5. Otherwise advance the regular event stream
         loop {
             let Some(notification) = ready!(this.notifications.poll_recv(cx)) else {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             };
 
             // 6. In case the exex is ahead of the new tip, we must skip it
             if let Some(committed) = notification.committed_chain() {
                 // inclusive check because we should start with `exex.head + 1`
                 if this.initial_exex_head.block.number >= committed.tip().number() {
-                    continue
+                    continue;
                 }
             }
 
-            return Poll::Ready(Some(Ok(notification)))
+            return Poll::Ready(Some(Ok(notification)));
         }
     }
 }

--- a/crates/exex/exex/src/wal/cache.rs
+++ b/crates/exex/exex/src/wal/cache.rs
@@ -59,7 +59,7 @@ impl BlockCache {
                 debug_assert_eq!(popped_block, block);
                 file_ids.insert(file_id);
             } else {
-                break
+                break;
             }
         }
 

--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -169,7 +169,7 @@ where
         // Remove notifications from the storage.
         if file_ids.is_empty() {
             debug!(target: "exex::wal", "No notifications were finalized from the storage");
-            return Ok(())
+            return Ok(());
         }
 
         let (removed_notifications, removed_size) = self.storage.remove_notifications(file_ids)?;
@@ -199,7 +199,7 @@ where
         &self,
     ) -> WalResult<Box<dyn Iterator<Item = WalResult<ExExNotification<N>>> + '_>> {
         let Some(range) = self.storage.files_range()? else {
-            return Ok(Box::new(std::iter::empty()))
+            return Ok(Box::new(std::iter::empty()));
         };
 
         Ok(Box::new(self.storage.iter_notifications(range).map(|entry| Ok(entry?.2))))
@@ -223,7 +223,7 @@ where
     ) -> WalResult<Option<ExExNotification<N>>> {
         let Some(file_id) = self.wal.block_cache().get_file_id_by_committed_block_hash(block_hash)
         else {
-            return Ok(None)
+            return Ok(None);
         };
 
         self.wal

--- a/crates/net/banlist/src/lib.rs
+++ b/crates/net/banlist/src/lib.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Instant};
 /// Should be replaced with [`IpAddr::is_global`](std::net::IpAddr::is_global) once it is stable.
 pub const fn is_global(ip: &IpAddr) -> bool {
     if ip.is_unspecified() || ip.is_loopback() {
-        return false
+        return false;
     }
 
     match ip {
@@ -59,11 +59,11 @@ impl BanList {
     pub fn evict_peers(&mut self, now: Instant) -> Vec<PeerId> {
         let mut evicted = Vec::new();
         self.banned_peers.retain(|peer, until| {
-            if let Some(until) = until &&
-                now > *until
+            if let Some(until) = until
+                && now > *until
             {
                 evicted.push(*peer);
-                return false
+                return false;
             }
             true
         });
@@ -74,11 +74,11 @@ impl BanList {
     pub fn evict_ips(&mut self, now: Instant) -> Vec<IpAddr> {
         let mut evicted = Vec::new();
         self.banned_ips.retain(|peer, until| {
-            if let Some(until) = until &&
-                now > *until
+            if let Some(until) = until
+                && now > *until
             {
                 evicted.push(*peer);
-                return false
+                return false;
             }
             true
         });
@@ -239,7 +239,7 @@ impl IpFilter {
     /// Returns an error if any of the CIDR strings cannot be parsed.
     pub fn from_cidr_string(cidrs: &str) -> Result<Self, ipnet::AddrParseError> {
         if cidrs.is_empty() {
-            return Ok(Self::allow_all())
+            return Ok(Self::allow_all());
         }
 
         let networks = cidrs
@@ -264,7 +264,7 @@ impl IpFilter {
     pub fn is_allowed(&self, ip: &IpAddr) -> bool {
         // If no restrictions are set, allow all IPs
         if self.allowed_networks.is_empty() {
-            return true
+            return true;
         }
 
         // Check if the IP is within any of the allowed networks

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -635,8 +635,8 @@ impl Discv4Service {
     /// [`NatResolver::ExternalAddr`]. In the case of [`NatResolver::ExternalAddr`], it will return
     /// the first IP address found for the domain associated with the discv4 UDP port.
     fn resolve_external_ip(&mut self) {
-        if let Some(r) = &self.resolve_external_ip_interval &&
-            let Some(external_ip) =
+        if let Some(r) = &self.resolve_external_ip_interval
+            && let Some(external_ip) =
                 r.resolver().clone().as_external_ip(self.local_node_record.udp_port)
         {
             self.set_external_ip_addr(external_ip);
@@ -778,8 +778,8 @@ impl Discv4Service {
             self.kbuckets
                 .closest_values(&target_key)
                 .filter(|node| {
-                    node.value.has_endpoint_proof &&
-                        !self.pending_find_nodes.contains_key(&node.key.preimage().0)
+                    node.value.has_endpoint_proof
+                        && !self.pending_find_nodes.contains_key(&node.key.preimage().0)
                 })
                 .take(MAX_NODES_PER_BUCKET)
                 .map(|n| (target_key.distance(&n.key), n.value.record)),
@@ -795,7 +795,7 @@ impl Discv4Service {
             // (e.g. connectivity problems over a long period of time, or issues during initial
             // bootstrapping) so we attempt to bootstrap again
             self.bootstrap();
-            return
+            return;
         }
 
         trace!(target: "discv4", ?target, num = closest.len(), "Start lookup closest nodes");
@@ -892,7 +892,7 @@ impl Discv4Service {
         let Some(bucket) = self.kbuckets.get_bucket(&key) else { return false };
         if bucket.num_entries() < MAX_NODES_PER_BUCKET / 2 {
             // skip half empty bucket
-            return false
+            return false;
         }
         self.remove_key(node_id, key)
     }
@@ -913,10 +913,10 @@ impl Discv4Service {
 
     /// Check if the peer has an active bond.
     fn has_bond(&self, remote_id: PeerId, remote_ip: IpAddr) -> bool {
-        if let Some(timestamp) = self.received_pongs.last_pong(remote_id, remote_ip) &&
-            timestamp.elapsed() < self.config.bond_expiration
+        if let Some(timestamp) = self.received_pongs.last_pong(remote_id, remote_ip)
+            && timestamp.elapsed() < self.config.bond_expiration
         {
-            return true
+            return true;
         }
         false
     }
@@ -942,7 +942,7 @@ impl Discv4Service {
     /// a followup request to retrieve the updated ENR
     fn update_on_reping(&mut self, record: NodeRecord, mut last_enr_seq: Option<u64>) {
         if record.id == self.local_node_record.id {
-            return
+            return;
         }
 
         // If EIP868 extension is disabled then we want to ignore this
@@ -975,7 +975,7 @@ impl Discv4Service {
     /// Callback invoked when we receive a pong from the peer.
     fn update_on_pong(&mut self, record: NodeRecord, mut last_enr_seq: Option<u64>) {
         if record.id == *self.local_peer_id() {
-            return
+            return;
         }
 
         // If EIP868 extension is disabled then we want to ignore this
@@ -1097,7 +1097,7 @@ impl Discv4Service {
     fn on_ping(&mut self, ping: Ping, remote_addr: SocketAddr, remote_id: PeerId, hash: B256) {
         if self.is_expired(ping.expire) {
             // ping's expiration timestamp is in the past
-            return
+            return;
         }
 
         // create the record
@@ -1227,17 +1227,17 @@ impl Discv4Service {
     fn try_ping(&mut self, node: NodeRecord, reason: PingReason) {
         if node.id == *self.local_peer_id() {
             // don't ping ourselves
-            return
+            return;
         }
 
-        if self.pending_pings.contains_key(&node.id) ||
-            self.pending_find_nodes.contains_key(&node.id)
+        if self.pending_pings.contains_key(&node.id)
+            || self.pending_find_nodes.contains_key(&node.id)
         {
-            return
+            return;
         }
 
         if self.queued_pings.iter().any(|(n, _)| n.id == node.id) {
-            return
+            return;
         }
 
         if self.pending_pings.len() < MAX_NODES_PING {
@@ -1272,7 +1272,7 @@ impl Discv4Service {
     /// Returns the echo hash of the ping message.
     pub(crate) fn send_enr_request(&mut self, node: NodeRecord) {
         if !self.config.enable_eip868 {
-            return
+            return;
         }
         let remote_addr = node.udp_addr();
         let enr_request = EnrRequest { expire: self.enr_request_expiration() };
@@ -1287,7 +1287,7 @@ impl Discv4Service {
     /// Message handler for an incoming `Pong`.
     fn on_pong(&mut self, pong: Pong, remote_addr: SocketAddr, remote_id: PeerId) {
         if self.is_expired(pong.expire) {
-            return
+            return;
         }
 
         let PingRequest { node, reason, .. } = match self.pending_pings.entry(remote_id) {
@@ -1296,7 +1296,7 @@ impl Discv4Service {
                     let request = entry.get();
                     if request.echo_hash != pong.echo {
                         trace!(target: "discv4", from=?remote_addr, expected=?request.echo_hash, echo_hash=?pong.echo,"Got unexpected Pong");
-                        return
+                        return;
                     }
                 }
                 entry.remove()
@@ -1339,11 +1339,11 @@ impl Discv4Service {
     fn on_find_node(&mut self, msg: FindNode, remote_addr: SocketAddr, node_id: PeerId) {
         if self.is_expired(msg.expire) {
             // expiration timestamp is in the past
-            return
+            return;
         }
         if node_id == *self.local_peer_id() {
             // ignore find node requests to ourselves
-            return
+            return;
         }
 
         if self.has_bond(node_id, remote_addr.ip()) {
@@ -1358,7 +1358,7 @@ impl Discv4Service {
             // ensure the ENR's public key matches the expected node id
             let enr_id = pk2id(&msg.enr.public_key());
             if id != enr_id {
-                return
+                return;
             }
 
             if resp.echo_hash == msg.request_hash {
@@ -1395,7 +1395,7 @@ impl Discv4Service {
         request_hash: B256,
     ) {
         if !self.config.enable_eip868 || self.is_expired(msg.expire) {
-            return
+            return;
         }
 
         if self.has_bond(id, remote_addr.ip()) {
@@ -1414,7 +1414,7 @@ impl Discv4Service {
     fn on_neighbours(&mut self, msg: Neighbours, remote_addr: SocketAddr, node_id: PeerId) {
         if self.is_expired(msg.expire) {
             // response is expired
-            return
+            return;
         }
         // check if this request was expected
         let ctx = match self.pending_find_nodes.entry(node_id) {
@@ -1430,7 +1430,7 @@ impl Discv4Service {
                         request.response_count = total;
                     } else {
                         trace!(target: "discv4", total, from=?remote_addr, "Received neighbors packet entries exceeds max nodes per bucket");
-                        return
+                        return;
                     }
                 };
 
@@ -1446,7 +1446,7 @@ impl Discv4Service {
             Entry::Vacant(_) => {
                 // received neighbours response without requesting it
                 trace!(target: "discv4", from=?remote_addr, "Received unsolicited Neighbours");
-                return
+                return;
             }
         };
 
@@ -1466,7 +1466,7 @@ impl Discv4Service {
             // prevent banned peers from being added to the context
             if self.config.ban_list.is_banned(&node.id, &node.address) {
                 trace!(target: "discv4", peer_id=?node.id, ip=?node.address, "ignoring banned record");
-                continue
+                continue;
             }
 
             ctx.add_node(node);
@@ -1562,7 +1562,7 @@ impl Discv4Service {
         self.pending_pings.retain(|node_id, ping_request| {
             if now.duration_since(ping_request.sent_at) > self.config.ping_expiration {
                 failed_pings.push(*node_id);
-                return false
+                return false;
             }
             true
         });
@@ -1579,7 +1579,7 @@ impl Discv4Service {
         self.pending_lookup.retain(|node_id, (lookup_sent_at, _)| {
             if now.duration_since(*lookup_sent_at) > self.config.request_timeout {
                 failed_lookups.push(*node_id);
-                return false
+                return false;
             }
             true
         });
@@ -1605,13 +1605,13 @@ impl Discv4Service {
                     // treat this as an hard error since it responded.
                     failed_find_nodes.push(*node_id);
                 }
-                return false
+                return false;
             }
             true
         });
 
         if failed_find_nodes.is_empty() {
-            return
+            return;
         }
 
         trace!(target: "discv4", num=%failed_find_nodes.len(), "processing failed find nodes");
@@ -1678,7 +1678,7 @@ impl Discv4Service {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
         if self.config.enforce_expiration_timestamps && timestamp < now {
             trace!(target: "discv4", "Expired packet");
-            return Err(())
+            return Err(());
         }
         Ok(())
     }
@@ -1722,7 +1722,7 @@ impl Discv4Service {
         loop {
             // drain buffered events first
             if let Some(event) = self.queued_events.pop_front() {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // trigger self lookup
@@ -1847,7 +1847,7 @@ impl Discv4Service {
                         // this will make sure we're woken up again
                         cx.waker().wake_by_ref();
                     }
-                    break
+                    break;
                 }
             }
 
@@ -1865,7 +1865,7 @@ impl Discv4Service {
             }
 
             if self.queued_events.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -1972,7 +1972,7 @@ pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_i
                 // rate limit incoming packets by IP
                 if cache.inc_ip(remote_addr.ip()) > MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP {
                     trace!(target: "discv4", ?remote_addr, "Too many incoming packets from IP.");
-                    continue
+                    continue;
                 }
 
                 let packet = &buf[..read];
@@ -1981,13 +1981,13 @@ pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_i
                         if packet.node_id == local_id {
                             // received our own message
                             debug!(target: "discv4", ?remote_addr, "Received own packet.");
-                            continue
+                            continue;
                         }
 
                         // skip if we've already received the same packet
                         if cache.contains_packet(packet.hash) {
                             debug!(target: "discv4", ?remote_addr, "Received duplicate packet.");
-                            continue
+                            continue;
                         }
 
                         send(IngressEvent::Packet(remote_addr, packet)).await;
@@ -2136,7 +2136,7 @@ impl LookupTargetRotator {
         self.counter += 1;
         self.counter %= self.interval;
         if self.counter == 0 {
-            return *local
+            return *local;
         }
         PeerId::random()
     }
@@ -2326,9 +2326,9 @@ impl CachedFindNode {
         secret_key: &secp256k1::SecretKey,
         expire: u64,
     ) -> (Bytes, B256) {
-        if let Some(c) = cache.as_ref() &&
-            c.target == target &&
-            c.cached_at.elapsed() < ttl
+        if let Some(c) = cache.as_ref()
+            && c.target == target
+            && c.cached_at.elapsed() < ttl
         {
             return (c.payload.clone(), c.hash);
         }
@@ -2545,7 +2545,7 @@ mod tests {
                 assert!(service.pending_pings.contains_key(&node.id));
                 assert_eq!(service.pending_pings.len(), num_inserted);
                 if num_inserted == MAX_NODES_PING {
-                    break
+                    break;
                 }
             }
         }
@@ -2725,8 +2725,8 @@ mod tests {
         })
         .await;
 
-        let expiry = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() +
-            10000000000000;
+        let expiry = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+            + 10000000000000;
         let msg = Neighbours { nodes: vec![service2.local_node_record], expire: expiry };
         service.on_neighbours(msg, record.tcp_addr(), id);
         // wait for the processed ping

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -141,7 +141,7 @@ impl Message {
     /// Returns the decoded message and the public key of the sender.
     pub fn decode(packet: &[u8]) -> Result<Packet, DecodePacketError> {
         if packet.len() < MIN_PACKET_SIZE {
-            return Err(DecodePacketError::PacketTooShort)
+            return Err(DecodePacketError::PacketTooShort);
         }
 
         // parses the wire-protocol, every packet starts with a header:
@@ -152,7 +152,7 @@ impl Message {
         let header_hash = keccak256(&packet[32..]);
         let data_hash = B256::from_slice(&packet[..32]);
         if data_hash != header_hash {
-            return Err(DecodePacketError::HashMismatch)
+            return Err(DecodePacketError::HashMismatch);
         }
 
         let signature = &packet[32..96];
@@ -282,7 +282,7 @@ impl Decodable for FindNode {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -296,7 +296,7 @@ impl Decodable for FindNode {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;
@@ -324,7 +324,7 @@ impl Decodable for Neighbours {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -338,7 +338,7 @@ impl Decodable for Neighbours {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;
@@ -367,7 +367,7 @@ impl Decodable for EnrRequest {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -381,7 +381,7 @@ impl Decodable for EnrRequest {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
 
         let rem = rlp_head.payload_length - consumed;
@@ -475,7 +475,7 @@ impl Decodable for Ping {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
 
@@ -499,7 +499,7 @@ impl Decodable for Ping {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
         let rem = rlp_head.payload_length - consumed;
         b.advance(rem);
@@ -554,7 +554,7 @@ impl Decodable for Pong {
         let b = &mut &**buf;
         let rlp_head = Header::decode(b)?;
         if !rlp_head.list {
-            return Err(RlpError::UnexpectedString)
+            return Err(RlpError::UnexpectedString);
         }
         let started_len = b.len();
         let mut this = Self {
@@ -574,7 +574,7 @@ impl Decodable for Pong {
             return Err(RlpError::ListLengthMismatch {
                 expected: rlp_head.payload_length,
                 got: consumed,
-            })
+            });
         }
         let rem = rlp_head.payload_length - consumed;
         b.advance(rem);

--- a/crates/net/discv4/src/test_utils.rs
+++ b/crates/net/discv4/src/test_utils.rs
@@ -167,7 +167,7 @@ impl Stream for MockDiscovery {
                                 ping,
                                 pong,
                                 to: remote_addr,
-                            }))
+                            }));
                         }
                     }
                     Message::Pong(_) | Message::Neighbours(_) => {}
@@ -181,7 +181,7 @@ impl Stream for MockDiscovery {
                             return Poll::Ready(Some(MockEvent::Neighbours {
                                 nodes,
                                 to: remote_addr,
-                            }))
+                            }));
                         }
                     }
                     Message::EnrRequest(_) | Message::EnrResponse(_) => todo!(),

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -152,8 +152,8 @@ impl ConfigBuilder {
     /// Adds a comma-separated list of enodes, serialized unsigned node records, to boot nodes.
     pub fn add_serialized_unsigned_boot_nodes(mut self, enodes: &[&str]) -> Self {
         for node in enodes {
-            if let Ok(node) = node.parse() &&
-                let Ok(node) = BootNode::from_unsigned(node)
+            if let Ok(node) = node.parse()
+                && let Ok(node) = BootNode::from_unsigned(node)
             {
                 self.bootstrap_nodes.insert(node);
             }
@@ -350,8 +350,8 @@ impl Config {
 /// Returns the IPv4 discovery socket if one is configured.
 pub const fn ipv4(listen_config: &ListenConfig) -> Option<SocketAddrV4> {
     match listen_config {
-        ListenConfig::Ipv4 { ip, port } |
-        ListenConfig::DualStack { ipv4: ip, ipv4_port: port, .. } => {
+        ListenConfig::Ipv4 { ip, port }
+        | ListenConfig::DualStack { ipv4: ip, ipv4_port: port, .. } => {
             Some(SocketAddrV4::new(*ip, *port))
         }
         ListenConfig::Ipv6 { .. } => None,
@@ -362,8 +362,8 @@ pub const fn ipv4(listen_config: &ListenConfig) -> Option<SocketAddrV4> {
 pub const fn ipv6(listen_config: &ListenConfig) -> Option<SocketAddrV6> {
     match listen_config {
         ListenConfig::Ipv4 { .. } => None,
-        ListenConfig::Ipv6 { ip, port } |
-        ListenConfig::DualStack { ipv6: ip, ipv6_port: port, .. } => {
+        ListenConfig::Ipv6 { ip, port }
+        | ListenConfig::DualStack { ipv6: ip, ipv6_port: port, .. } => {
             Some(SocketAddrV6::new(*ip, *port, 0, 0))
         }
     }
@@ -411,8 +411,8 @@ pub fn discv5_sockets_wrt_rlpx_addr(
             let discv5_socket_ipv6 =
                 discv5_addr_ipv6.map(|ip| SocketAddrV6::new(ip, discv5_port_ipv6, 0, 0));
 
-            if let Some(discv5_addr) = discv5_addr_ipv4 &&
-                discv5_addr != rlpx_addr
+            if let Some(discv5_addr) = discv5_addr_ipv4
+                && discv5_addr != rlpx_addr
             {
                 debug!(target: "net::discv5",
                     %discv5_addr,
@@ -430,8 +430,8 @@ pub fn discv5_sockets_wrt_rlpx_addr(
             let discv5_socket_ipv4 =
                 discv5_addr_ipv4.map(|ip| SocketAddrV4::new(ip, discv5_port_ipv4));
 
-            if let Some(discv5_addr) = discv5_addr_ipv6 &&
-                discv5_addr != rlpx_addr
+            if let Some(discv5_addr) = discv5_addr_ipv6
+                && discv5_addr != rlpx_addr
             {
                 debug!(target: "net::discv5",
                     %discv5_addr,
@@ -511,9 +511,9 @@ mod test {
         for node in config.bootstrap_nodes {
             let BootNode::Enr(node) = node else { panic!() };
             assert!(
-                socket_1 == node.udp4_socket().unwrap() && socket_1 == node.tcp4_socket().unwrap() ||
-                    socket_2 == node.udp4_socket().unwrap() &&
-                        socket_2 == node.tcp4_socket().unwrap()
+                socket_1 == node.udp4_socket().unwrap() && socket_1 == node.tcp4_socket().unwrap()
+                    || socket_2 == node.udp4_socket().unwrap()
+                        && socket_2 == node.tcp4_socket().unwrap()
             );
             assert_eq!("84b4940500", hex::encode(node.get_raw_rlp("opstack").unwrap()));
         }

--- a/crates/net/discv5/src/enr.rs
+++ b/crates/net/discv5/src/enr.rs
@@ -11,7 +11,7 @@ use secp256k1::{PublicKey, SecretKey};
 pub fn enr_to_discv4_id(enr: &discv5::Enr) -> Option<PeerId> {
     let pk = enr.public_key();
     if !matches!(pk, CombinedPublicKey::Secp256k1(_)) {
-        return None
+        return None;
     }
 
     let pk = PublicKey::from_slice(&pk.encode()).unwrap();

--- a/crates/net/discv5/src/filter.rs
+++ b/crates/net/discv5/src/filter.rs
@@ -37,7 +37,7 @@ impl MustIncludeKey {
         if enr.get_raw_rlp(self.key).is_none() {
             return FilterOutcome::Ignore {
                 reason: format!("{} fork required", String::from_utf8_lossy(self.key)),
-            }
+            };
         }
         FilterOutcome::Ok
     }
@@ -72,7 +72,7 @@ impl MustNotIncludeKeys {
                         "{} forks not allowed",
                         self.keys.iter().map(|key| String::from_utf8_lossy(key.key)).format(",")
                     ),
-                }
+                };
             }
         }
 

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -104,7 +104,7 @@ impl Discv5 {
                 err="key not utf-8",
                 "failed to update local enr"
             );
-            return
+            return;
         };
         if let Err(err) = self.discv5.enr_insert(key_str, &rlp) {
             error!(target: "net::discv5",
@@ -322,7 +322,7 @@ impl Discv5 {
 
                 self.metrics.discovered_peers.increment_established_sessions_unreachable_enr(1);
 
-                return None
+                return None;
             }
         };
         if let FilterOutcome::Ignore { reason } = self.filter_discovered_peer(enr) {
@@ -334,7 +334,7 @@ impl Discv5 {
 
             self.metrics.discovered_peers.increment_established_sessions_filtered(1);
 
-            return None
+            return None;
         }
 
         let fork_id = self.get_fork_id(enr).ok();
@@ -545,7 +545,7 @@ pub async fn bootstrap(
         match node {
             BootNode::Enr(node) => {
                 if let Err(err) = discv5.add_enr(node) {
-                    return Err(Error::AddNodeFailed(err))
+                    return Err(Error::AddNodeFailed(err));
                 }
             }
             BootNode::Enode(enode) => {

--- a/crates/net/discv5/src/network_stack_id.rs
+++ b/crates/net/discv5/src/network_stack_id.rs
@@ -23,9 +23,9 @@ impl NetworkStackId {
     /// Returns the [`NetworkStackId`] that matches the given chain spec.
     pub fn id(chain: impl EthChainSpec) -> Option<&'static [u8]> {
         if chain.is_optimism() {
-            return Some(Self::OPEL)
+            return Some(Self::OPEL);
         } else if chain.is_ethereum() {
-            return Some(Self::ETH)
+            return Some(Self::ETH);
         }
 
         None

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -220,7 +220,7 @@ impl<R: Resolver> DnsDiscoveryService<R> {
             // already resolved
             let cached = ResolveEntryResult { entry: Some(Ok(entry)), link, hash, kind };
             self.on_resolved_entry(cached);
-            return
+            return;
         }
         self.queries.resolve_entry(link, hash, kind)
     }
@@ -295,7 +295,7 @@ impl<R: Resolver> DnsDiscoveryService<R> {
         loop {
             // drain buffered events first
             if let Some(event) = self.queued_events.pop_front() {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // process all incoming commands
@@ -348,7 +348,7 @@ impl<R: Resolver> DnsDiscoveryService<R> {
             }
 
             if !progress && self.queued_events.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/dns/src/query.rs
+++ b/crates/net/dns/src/query.rs
@@ -75,19 +75,19 @@ impl<R: Resolver, K: EnrKeyUnambiguous> QueryPool<R, K> {
         loop {
             // drain buffered events first
             if let Some(event) = self.queued_outcomes.pop_front() {
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // queue in new queries if we have capacity
             'queries: while self.active_queries.len() < self.rate_limit.limit() as usize {
-                if self.rate_limit.poll_ready(cx).is_ready() &&
-                    let Some(query) = self.queued_queries.pop_front()
+                if self.rate_limit.poll_ready(cx).is_ready()
+                    && let Some(query) = self.queued_queries.pop_front()
                 {
                     self.rate_limit.tick();
                     self.active_queries.push(query);
-                    continue 'queries
+                    continue 'queries;
                 }
-                break
+                break;
             }
 
             // advance all queries
@@ -102,7 +102,7 @@ impl<R: Resolver, K: EnrKeyUnambiguous> QueryPool<R, K> {
             }
 
             if self.queued_outcomes.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/dns/src/sync.rs
+++ b/crates/net/dns/src/sync.rs
@@ -63,27 +63,27 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
         match self.sync_state {
             SyncState::Pending => {
                 self.sync_state = SyncState::Enr;
-                return Some(SyncAction::Link(self.root.link_root.clone()))
+                return Some(SyncAction::Link(self.root.link_root.clone()));
             }
             SyncState::Enr => {
                 self.sync_state = SyncState::Active;
-                return Some(SyncAction::Enr(self.root.enr_root.clone()))
+                return Some(SyncAction::Enr(self.root.enr_root.clone()));
             }
             SyncState::Link => {
                 self.sync_state = SyncState::Active;
-                return Some(SyncAction::Link(self.root.link_root.clone()))
+                return Some(SyncAction::Link(self.root.link_root.clone()));
             }
             SyncState::Active => {
                 if now > self.root_updated + update_timeout {
                     self.sync_state = SyncState::RootUpdate;
-                    return Some(SyncAction::UpdateRoot)
+                    return Some(SyncAction::UpdateRoot);
                 }
             }
             SyncState::RootUpdate => return None,
         }
 
         if let Some(link) = self.unresolved_links.pop_front() {
-            return Some(SyncAction::Link(link))
+            return Some(SyncAction::Link(link));
         }
 
         let enr = self.unresolved_nodes.pop_front()?;

--- a/crates/net/dns/src/tree.rs
+++ b/crates/net/dns/src/tree.rs
@@ -205,7 +205,7 @@ impl BranchEntry {
 
             let decoded_len = base32_no_padding_decoded_len(hash.len());
             if !(12..=32).contains(&decoded_len) || hash.chars().any(|c| c.is_whitespace()) {
-                return Err(ParseDnsEntryError::InvalidChildHash(hash.to_string()))
+                return Err(ParseDnsEntryError::InvalidChildHash(hash.to_string()));
             }
             Ok(hash.to_string())
         }

--- a/crates/net/downloaders/src/bodies/bodies.rs
+++ b/crates/net/downloaders/src/bodies/bodies.rs
@@ -102,7 +102,7 @@ where
         max_non_empty: u64,
     ) -> DownloadResult<Option<Vec<SealedHeader<B::Header>>>> {
         if range.is_empty() || max_non_empty == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
         // Collect headers while
@@ -113,9 +113,9 @@ where
         let mut collected = 0;
         let mut non_empty_headers = 0;
         let headers = self.provider.sealed_headers_while(range.clone(), |header| {
-            let should_take = range.contains(&header.number()) &&
-                non_empty_headers < max_non_empty &&
-                collected < self.stream_batch_size;
+            let should_take = range.contains(&header.number())
+                && non_empty_headers < max_non_empty
+                && collected < self.stream_batch_size;
 
             if should_take {
                 collected += 1;
@@ -151,7 +151,7 @@ where
 
         // if we're only connected to a few peers, we keep it low
         if num_peers < *self.concurrent_requests_range.start() {
-            return max_requests
+            return max_requests;
         }
 
         max_requests.min(*self.concurrent_requests_range.end())
@@ -170,10 +170,10 @@ where
             self.in_progress_queue
                 .last_requested_block_number.is_some_and(|last| last == *self.download_range.end());
 
-        nothing_to_request &&
-            self.in_progress_queue.is_empty() &&
-            self.buffered_responses.is_empty() &&
-            self.queued_bodies.is_empty()
+        nothing_to_request
+            && self.in_progress_queue.is_empty()
+            && self.buffered_responses.is_empty()
+            && self.queued_bodies.is_empty()
     }
 
     /// Clear all download related data.
@@ -241,7 +241,7 @@ where
                         .skip_while(|b| b.block_number() < expected)
                         .take_while(|b| self.download_range.contains(&b.block_number()))
                         .collect()
-                })
+                });
             }
 
             // Drop buffered response since we passed that range
@@ -260,7 +260,7 @@ where
             self.queued_bodies.shrink_to_fit();
             self.metrics.total_flushed.increment(next_batch.len() as u64);
             self.metrics.queued_blocks.set(self.queued_bodies.len() as f64);
-            return Some(next_batch)
+            return Some(next_batch);
         }
         None
     }
@@ -273,9 +273,9 @@ where
         // requests are issued in order but not necessarily finished in order, so the queued bodies
         // can grow large if a certain request is slow, so we limit the followup requests if the
         // queued bodies grew too large
-        self.queued_bodies.len() < 4 * self.stream_batch_size &&
-            self.has_buffer_capacity() &&
-            self.in_progress_queue.len() < self.concurrent_request_limit()
+        self.queued_bodies.len() < 4 * self.stream_batch_size
+            && self.has_buffer_capacity()
+            && self.in_progress_queue.len() < self.concurrent_request_limit()
     }
 }
 
@@ -311,16 +311,16 @@ where
         // Check if the range is valid.
         if range.is_empty() {
             tracing::error!(target: "downloaders::bodies", ?range, "Bodies download range is invalid (empty)");
-            return Err(DownloadError::InvalidBodyRange { range })
+            return Err(DownloadError::InvalidBodyRange { range });
         }
 
         // Check if the provided range is the subset of the existing range.
-        let is_current_range_subset = self.download_range.contains(range.start()) &&
-            *range.end() == *self.download_range.end();
+        let is_current_range_subset = self.download_range.contains(range.start())
+            && *range.end() == *self.download_range.end();
         if is_current_range_subset {
             tracing::trace!(target: "downloaders::bodies", ?range, "Download range already in progress");
             // The current range already includes requested.
-            return Ok(())
+            return Ok(());
         }
 
         // Check if the provided range is the next expected range.
@@ -331,7 +331,7 @@ where
             tracing::trace!(target: "downloaders::bodies", ?range, "New download range set");
             info!(target: "downloaders::bodies", count, ?range, "Downloading bodies");
             self.download_range = range;
-            return Ok(())
+            return Ok(());
         }
 
         // The block range is reset. This can happen either after unwind or after the bodies were
@@ -339,8 +339,8 @@ where
         tracing::trace!(target: "downloaders::bodies", ?range, prev_range = ?self.download_range, "Download range reset");
         info!(target: "downloaders::bodies", count, ?range, "Downloading bodies");
         // Increment out-of-order requests metric if the new start is below the last returned block
-        if let Some(last_returned) = self.latest_queued_block_number &&
-            *range.start() < last_returned
+        if let Some(last_returned) = self.latest_queued_block_number
+            && *range.start() < last_returned
         {
             self.metrics.out_of_order_requests.increment(1);
         }
@@ -361,13 +361,13 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         if this.is_terminated() {
-            return Poll::Ready(None)
+            return Poll::Ready(None);
         }
         // Submit new requests and poll any in progress
         loop {
             // Yield next batch if ready
             if let Some(next_batch) = this.try_split_next_batch() {
-                return Poll::Ready(Some(Ok(next_batch)))
+                return Poll::Ready(Some(Ok(next_batch)));
             }
 
             // Poll requests
@@ -380,7 +380,7 @@ where
                     Err(error) => {
                         tracing::debug!(target: "downloaders::bodies", %error, "Request failed");
                         this.clear();
-                        return Poll::Ready(Some(Err(error)))
+                        return Poll::Ready(Some(Err(error)));
                     }
                 };
             }
@@ -403,7 +403,7 @@ where
                     Err(error) => {
                         tracing::error!(target: "downloaders::bodies", %error, "Failed to download from next request");
                         this.clear();
-                        return Poll::Ready(Some(Err(error)))
+                        return Poll::Ready(Some(Err(error)));
                     }
                 };
             }
@@ -416,21 +416,21 @@ where
             this.buffered_responses.shrink_to_fit();
 
             if !new_request_submitted {
-                break
+                break;
             }
         }
 
         // All requests are handled, stream is finished
         if this.in_progress_queue.is_empty() {
             if this.queued_bodies.is_empty() {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
             let batch_size = this.stream_batch_size.min(this.queued_bodies.len());
             let next_batch = this.queued_bodies.drain(..batch_size).collect::<Vec<_>>();
             this.queued_bodies.shrink_to_fit();
             this.metrics.total_flushed.increment(next_batch.len() as u64);
             this.metrics.queued_blocks.set(this.queued_bodies.len() as f64);
-            return Poll::Ready(Some(Ok(next_batch)))
+            return Poll::Ready(Some(Ok(next_batch)));
         }
 
         Poll::Pending
@@ -519,8 +519,8 @@ impl BodiesDownloaderBuilder {
             .with_request_limit(config.downloader_request_limit)
             .with_max_buffered_blocks_size_bytes(config.downloader_max_buffered_blocks_size_bytes)
             .with_concurrent_requests_range(
-                config.downloader_min_concurrent_requests..=
-                    config.downloader_max_concurrent_requests,
+                config.downloader_min_concurrent_requests
+                    ..=config.downloader_max_concurrent_requests,
             )
     }
 }

--- a/crates/net/downloaders/src/bodies/request.rs
+++ b/crates/net/downloaders/src/bodies/request.rs
@@ -133,14 +133,14 @@ where
         // next one exceed the soft response limit, if not then peer either does not have the next
         // block or deliberately sent a single block.
         if bodies.is_empty() {
-            return Err(DownloadError::EmptyResponse)
+            return Err(DownloadError::EmptyResponse);
         }
 
         if response_len > request_len {
             return Err(DownloadError::TooManyBodies(GotExpected {
                 got: response_len,
                 expected: request_len,
-            }))
+            }));
         }
 
         // Buffer block responses
@@ -194,7 +194,7 @@ where
                         hash,
                         number,
                         error: Box::new(error),
-                    })
+                    });
                 }
 
                 self.buffer.push(BlockResponse::Full(block));
@@ -221,7 +221,7 @@ where
 
         loop {
             if this.pending_headers.is_empty() {
-                return Poll::Ready(Ok(std::mem::take(&mut this.buffer)))
+                return Poll::Ready(Ok(std::mem::take(&mut this.buffer)));
             }
 
             // Check if there is a pending requests. It might not exist if all
@@ -236,7 +236,7 @@ where
                     }
                     Err(error) => {
                         if error.is_channel_closed() {
-                            return Poll::Ready(Err(error.into()))
+                            return Poll::Ready(Err(error.into()));
                         }
 
                         this.on_error(error.into(), None);

--- a/crates/net/downloaders/src/bodies/task.rs
+++ b/crates/net/downloaders/src/bodies/task.rs
@@ -97,13 +97,13 @@ impl<T: BodyDownloader> Future for SpawnedDownloader<T> {
                         if forward_error_result.is_err() {
                             // channel closed, this means [TaskDownloader] was dropped,
                             // so we can also exit
-                            return Poll::Ready(())
+                            return Poll::Ready(());
                         }
                     }
                 } else {
                     // channel closed, this means [TaskDownloader] was dropped, so we can also
                     // exit
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
             }
 
@@ -113,7 +113,7 @@ impl<T: BodyDownloader> Future for SpawnedDownloader<T> {
                         if this.bodies_tx.send_item(bodies).is_err() {
                             // channel closed, this means [TaskDownloader] was dropped, so we can
                             // also exit
-                            return Poll::Ready(())
+                            return Poll::Ready(());
                         }
                     }
                     None => return Poll::Pending,
@@ -121,7 +121,7 @@ impl<T: BodyDownloader> Future for SpawnedDownloader<T> {
                 Err(_) => {
                     // channel closed, this means [TaskDownloader] was dropped, so we can also
                     // exit
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
             }
         }

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -161,7 +161,7 @@ impl<B: FullBlock> FileClient<B> {
     /// Returns true if all blocks are canonical (no gaps)
     pub fn has_canonical_blocks(&self) -> bool {
         if self.headers.is_empty() {
-            return true
+            return true;
         }
         let mut nums = self.headers.keys().copied().collect::<Vec<_>>();
         nums.sort_unstable();
@@ -169,7 +169,7 @@ impl<B: FullBlock> FileClient<B> {
         let mut lowest = iter.next().expect("not empty");
         for next in iter {
             if next != lowest + 1 {
-                return false
+                return false;
             }
             lowest = next;
         }
@@ -273,7 +273,7 @@ impl<B: FullBlock<Header: reth_primitives_traits::BlockHeader>> FromReader
                             "partial block returned from decoding chunk"
                         );
                         remaining_bytes = bytes;
-                        break
+                        break;
                     }
                     Err(err) => return Err(err),
                 };
@@ -343,7 +343,7 @@ impl<B: FullBlock> HeadersClient for FileClient<B> {
                 Some(num) => *num,
                 None => {
                     warn!(%hash, "Could not find starting block number for requested header hash");
-                    return Box::pin(async move { Err(RequestError::BadResponse) })
+                    return Box::pin(async move { Err(RequestError::BadResponse) });
                 }
             },
             BlockHashOrNumber::Number(num) => num,
@@ -367,7 +367,7 @@ impl<B: FullBlock> HeadersClient for FileClient<B> {
                 Some(header) => headers.push(header),
                 None => {
                     warn!(number=%block_number, "Could not find header");
-                    return Box::pin(async move { Err(RequestError::BadResponse) })
+                    return Box::pin(async move { Err(RequestError::BadResponse) });
                 }
             }
         }
@@ -463,7 +463,7 @@ impl FileReader {
 
         if *remaining_bytes == 0 && chunk.is_empty() {
             // eof
-            return Ok(None)
+            return Ok(None);
         }
 
         let chunk_target_len = chunk_byte_len.min(*remaining_bytes + chunk.len() as u64);
@@ -506,7 +506,7 @@ impl FileReader {
         let mut buffer = vec![0u8; 64 * 1024];
         loop {
             if chunk.len() >= chunk_byte_len as usize {
-                return Ok(true)
+                return Ok(true);
             }
 
             match self.read(&mut buffer).await {
@@ -613,7 +613,7 @@ impl ChunkedFileReader {
             })
         })?
         else {
-            return Ok(None)
+            return Ok(None);
         };
 
         // make new file client from chunk

--- a/crates/net/downloaders/src/file_codec.rs
+++ b/crates/net/downloaders/src/file_codec.rs
@@ -32,7 +32,7 @@ impl<B: Decodable> Decoder for BlockFileCodec<B> {
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if src.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
 
         let buf_slice = &mut src.as_ref();

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -160,7 +160,7 @@ where
 
         // If only a few peers are connected we keep it low
         if num_peers < self.min_concurrent_requests {
-            return max_dynamic
+            return max_dynamic;
         }
 
         max_dynamic.min(self.max_concurrent_requests)
@@ -172,8 +172,8 @@ where
     ///
     /// Returns `None` if no more requests are required.
     fn next_request(&mut self) -> Option<HeadersRequest> {
-        if let Some(local_head) = self.local_block_number() &&
-            self.next_request_block_number > local_head
+        if let Some(local_head) = self.local_block_number()
+            && self.next_request_block_number > local_head
         {
             let request =
                 calc_next_request(local_head, self.next_request_block_number, self.request_limit);
@@ -181,7 +181,7 @@ where
             // headers so follow-up requests will use that as start.
             self.next_request_block_number -= request.limit;
 
-            return Some(request)
+            return Some(request);
         }
 
         None
@@ -269,7 +269,7 @@ where
                     trace!(target: "downloaders::headers", %error ,"Failed to validate header");
                     return Err(
                         HeadersResponseError { request, peer_id: Some(peer_id), error }.into()
-                    )
+                    );
                 }
             } else {
                 self.validate_sync_target(&parent, request.clone(), peer_id)?;
@@ -296,7 +296,7 @@ where
                         error: Box::new(error),
                     },
                 }
-                .into())
+                .into());
             }
 
             // If the header is valid on its own, but not against its parent, we return it as
@@ -321,7 +321,7 @@ where
                     header: Box::new(last_header.clone()),
                     error: Box::new(error),
                 }
-                .into())
+                .into());
             }
         }
 
@@ -394,7 +394,7 @@ where
                         peer_id: Some(peer_id),
                         error: DownloadError::EmptyResponse,
                     }
-                    .into())
+                    .into());
                 }
 
                 let header = headers.swap_remove(0);
@@ -410,7 +410,7 @@ where
                                     GotExpected { got: target.hash(), expected: hash }.into(),
                                 ),
                             }
-                            .into())
+                            .into());
                         }
                     }
                     SyncTargetBlock::Number(number) => {
@@ -423,7 +423,7 @@ where
                                     expected: number,
                                 }),
                             }
-                            .into())
+                            .into());
                         }
                     }
                 }
@@ -472,7 +472,7 @@ where
                         peer_id: Some(peer_id),
                         error: DownloadError::EmptyResponse,
                     }
-                    .into())
+                    .into());
                 }
 
                 if (headers.len() as u64) != request.limit {
@@ -484,7 +484,7 @@ where
                         }),
                         request,
                     }
-                    .into())
+                    .into());
                 }
 
                 // sort headers from highest to lowest block number
@@ -504,7 +504,7 @@ where
                             expected: requested_block_number,
                         }),
                     }
-                    .into())
+                    .into());
                 }
 
                 // check if the response is the next expected
@@ -575,7 +575,7 @@ where
                     self.metrics.buffered_responses.decrement(1.);
 
                     if let Err(err) = self.process_next_headers(request, headers, peer_id) {
-                        return Some(err)
+                        return Some(err);
                     }
                 }
                 Ordering::Greater => {
@@ -718,7 +718,7 @@ where
                         .map(|h| h.number())
                     {
                         self.sync_target = Some(new_sync_target.with_number(target_number));
-                        return
+                        return;
                     }
 
                     trace!(target: "downloaders::headers", new=?target, "Request new sync target");
@@ -785,7 +785,7 @@ where
                 sync_target=?this.sync_target,
                 "The downloader sync boundaries have not been set"
             );
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         // If we have a new tip request we need to complete that first before we send batched
@@ -799,7 +799,7 @@ where
                             trace!(target: "downloaders::headers", %error, "invalid sync target response");
                             if error.is_channel_closed() {
                                 // download channel closed which means the network was dropped
-                                return Poll::Ready(None)
+                                return Poll::Ready(None);
                             }
 
                             this.penalize_peer(error.peer_id, &error.error);
@@ -809,13 +809,13 @@ where
                         }
                         Err(ReverseHeadersDownloaderError::Downloader(error)) => {
                             this.clear();
-                            return Poll::Ready(Some(Err(error)))
+                            return Poll::Ready(Some(Err(error)));
                         }
                     };
                 }
                 Poll::Pending => {
                     this.sync_target_request = Some(req);
-                    return Poll::Pending
+                    return Poll::Pending;
                 }
             }
         }
@@ -841,13 +841,13 @@ where
                     Err(ReverseHeadersDownloaderError::Response(error)) => {
                         if error.is_channel_closed() {
                             // download channel closed which means the network was dropped
-                            return Poll::Ready(None)
+                            return Poll::Ready(None);
                         }
                         this.on_headers_error(error);
                     }
                     Err(ReverseHeadersDownloaderError::Downloader(error)) => {
                         this.clear();
-                        return Poll::Ready(Some(Err(error)))
+                        return Poll::Ready(Some(Err(error)));
                     }
                 };
             }
@@ -860,8 +860,8 @@ where
 
             let concurrent_request_limit = this.concurrent_request_limit();
             // populate requests
-            while this.in_progress_queue.len() < concurrent_request_limit &&
-                this.buffered_responses.len() < this.max_buffered_responses
+            while this.in_progress_queue.len() < concurrent_request_limit
+                && this.buffered_responses.len() < this.max_buffered_responses
             {
                 if let Some(request) = this.next_request() {
                     trace!(
@@ -872,7 +872,7 @@ where
                     this.submit_request(request, Priority::Normal);
                 } else {
                     // no more requests
-                    break
+                    break;
                 }
             }
 
@@ -889,11 +889,11 @@ where
                 trace!(target: "downloaders::headers", batch=%next_batch.len(), "Returning validated batch");
 
                 this.metrics.total_flushed.increment(next_batch.len() as u64);
-                return Poll::Ready(Some(Ok(next_batch)))
+                return Poll::Ready(Some(Ok(next_batch)));
             }
 
             if !progress {
-                break
+                break;
             }
         }
 
@@ -902,10 +902,10 @@ where
             let next_batch = this.split_next_batch();
             if next_batch.is_empty() {
                 this.clear();
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
             this.metrics.total_flushed.increment(next_batch.len() as u64);
-            return Poll::Ready(Some(Ok(next_batch)))
+            return Poll::Ready(Some(Ok(next_batch)));
         }
 
         Poll::Pending
@@ -998,7 +998,7 @@ impl HeadersResponseError {
     /// Returns true if the error was caused by a closed channel to the network.
     const fn is_channel_closed(&self) -> bool {
         if let DownloadError::RequestError(ref err) = self.error {
-            return err.is_channel_closed()
+            return err.is_channel_closed();
         }
         false
     }

--- a/crates/net/downloaders/src/headers/task.rs
+++ b/crates/net/downloaders/src/headers/task.rs
@@ -102,7 +102,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
                     Poll::Ready(None) => {
                         // channel closed, this means [TaskDownloader] was dropped, so we can also
                         // exit
-                        return Poll::Ready(())
+                        return Poll::Ready(());
                     }
                     Poll::Ready(Some(update)) => match update {
                         DownloaderUpdates::UpdateSyncGap(head, target) => {
@@ -128,7 +128,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
                             if this.headers_tx.send_item(headers).is_err() {
                                 // channel closed, this means [TaskDownloader] was dropped, so we
                                 // can also exit
-                                return Poll::Ready(())
+                                return Poll::Ready(());
                             }
                         }
                         None => return Poll::Pending,
@@ -137,7 +137,7 @@ impl<T: HeaderDownloader> Future for SpawnedDownloader<T> {
                 Err(_) => {
                     // channel closed, this means [TaskDownloader] was dropped, so
                     // we can also exit
-                    return Poll::Ready(())
+                    return Poll::Ready(());
                 }
             }
         }

--- a/crates/net/downloaders/src/receipt_file_client.rs
+++ b/crates/net/downloaders/src/receipt_file_client.rs
@@ -100,7 +100,7 @@ where
 
                         remaining_bytes = bytes;
 
-                        break
+                        break;
                     }
                     Err(err) => return Err(err),
                 };
@@ -109,7 +109,7 @@ where
                     Some(ReceiptWithBlockNumber { receipt, number }) => {
                         if block_number > number {
                             warn!(target: "downloaders::file", previous_block_number = block_number, "skipping receipt from a lower block: {number}");
-                            continue
+                            continue;
                         }
 
                         total_receipts += 1;
@@ -266,7 +266,7 @@ mod test {
 
         fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
             if src.is_empty() {
-                return Ok(None)
+                return Ok(None);
             }
 
             let buf_slice = &mut src.as_ref();

--- a/crates/net/downloaders/src/test_utils/bodies_client.rs
+++ b/crates/net/downloaders/src/test_utils/bodies_client.rs
@@ -96,7 +96,7 @@ impl BodiesClient for TestBodiesClient {
 
         Box::pin(async move {
             if should_respond_empty {
-                return Ok((PeerId::default(), vec![]).into())
+                return Ok((PeerId::default(), vec![]).into());
             }
 
             if should_delay {

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -98,7 +98,7 @@ impl core::fmt::Debug for ECIES {
 
 fn split_at_mut<T>(arr: &mut [T], idx: usize) -> Result<(&mut [T], &mut [T]), ECIESError> {
     if idx > arr.len() {
-        return Err(ECIESErrorImpl::OutOfBounds { idx, len: arr.len() }.into())
+        return Err(ECIESErrorImpl::OutOfBounds { idx, len: arr.len() }.into());
     }
     Ok(arr.split_at_mut(idx))
 }
@@ -137,7 +137,7 @@ impl<'a> EncryptedMessage<'a> {
     pub fn parse(data: &mut [u8]) -> Result<EncryptedMessage<'_>, ECIESError> {
         // Auth data is 2 bytes, public key is 65 bytes
         if data.len() < 65 + 2 {
-            return Err(ECIESErrorImpl::EncryptedDataTooSmall.into())
+            return Err(ECIESErrorImpl::EncryptedDataTooSmall.into());
         }
         let (auth_data, encrypted) = data.split_at_mut(2);
 
@@ -163,7 +163,7 @@ impl<'a> EncryptedMessage<'a> {
 
         // now we can check if the encrypted data is long enough to contain the IV
         if data_iv.len() < 16 {
-            return Err(ECIESErrorImpl::EncryptedDataTooSmall.into())
+            return Err(ECIESErrorImpl::EncryptedDataTooSmall.into());
         }
         let (iv, encrypted_data) = data_iv.split_at_mut(16);
 
@@ -233,7 +233,7 @@ impl<'a> EncryptedMessage<'a> {
             &self.auth_data,
         );
         if check_tag != self.tag {
-            return Err(ECIESErrorImpl::TagCheckDecryptFailed.into())
+            return Err(ECIESErrorImpl::TagCheckDecryptFailed.into());
         }
 
         Ok(())
@@ -653,7 +653,7 @@ impl ECIES {
         //
         // The header is 16 bytes, and the mac is 16 bytes, so the data must be at least 32 bytes
         if data.len() < 32 {
-            return Err(ECIESErrorImpl::InvalidHeader.into())
+            return Err(ECIESErrorImpl::InvalidHeader.into());
         }
 
         let (header_bytes, mac_bytes) = split_at_mut(data, 16)?;
@@ -663,12 +663,12 @@ impl ECIES {
         self.ingress_mac.as_mut().unwrap().update_header(header);
         let check_mac = self.ingress_mac.as_mut().unwrap().digest();
         if check_mac != mac {
-            return Err(ECIESErrorImpl::TagCheckHeaderFailed.into())
+            return Err(ECIESErrorImpl::TagCheckHeaderFailed.into());
         }
 
         self.ingress_aes.as_mut().unwrap().apply_keystream(header);
         if header.len() < 3 {
-            return Err(ECIESErrorImpl::InvalidHeader.into())
+            return Err(ECIESErrorImpl::InvalidHeader.into());
         }
 
         let body_size = usize::try_from((&header[..]).read_uint::<BigEndian>(3)?)?;
@@ -719,7 +719,7 @@ impl ECIES {
         self.ingress_mac.as_mut().unwrap().update_body(body);
         let check_mac = self.ingress_mac.as_mut().unwrap().digest();
         if check_mac != mac {
-            return Err(ECIESErrorImpl::TagCheckBodyFailed.into())
+            return Err(ECIESErrorImpl::TagCheckBodyFailed.into());
         }
 
         let size = self.body_size.unwrap();

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -65,7 +65,7 @@ impl Decoder for ECIESCodec {
                 ECIESState::Auth => {
                     trace!("parsing auth");
                     if buf.len() < 2 {
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let payload_size = u16::from_be_bytes([buf[0], buf[1]]) as usize;
@@ -73,18 +73,18 @@ impl Decoder for ECIESCodec {
 
                     if buf.len() < total_size {
                         trace!("current len {}, need {}", buf.len(), total_size);
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     self.ecies.read_auth(&mut buf.split_to(total_size))?;
 
                     self.state = ECIESState::InitialHeader;
-                    return Ok(Some(IngressECIESValue::AuthReceive(self.ecies.remote_id())))
+                    return Ok(Some(IngressECIESValue::AuthReceive(self.ecies.remote_id())));
                 }
                 ECIESState::Ack => {
                     trace!("parsing ack with len {}", buf.len());
                     if buf.len() < 2 {
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let payload_size = u16::from_be_bytes([buf[0], buf[1]]) as usize;
@@ -92,18 +92,18 @@ impl Decoder for ECIESCodec {
 
                     if buf.len() < total_size {
                         trace!("current len {}, need {}", buf.len(), total_size);
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     self.ecies.read_ack(&mut buf.split_to(total_size))?;
 
                     self.state = ECIESState::InitialHeader;
-                    return Ok(Some(IngressECIESValue::Ack))
+                    return Ok(Some(IngressECIESValue::Ack));
                 }
                 ECIESState::InitialHeader => {
                     if buf.len() < ECIES::header_len() {
                         trace!("current len {}, need {}", buf.len(), ECIES::header_len());
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let body_size =
@@ -115,7 +115,7 @@ impl Decoder for ECIESCodec {
                             body_size,
                             max_body_size: MAX_INITIAL_HANDSHAKE_SIZE,
                         }
-                        .into())
+                        .into());
                     }
 
                     self.state = ECIESState::Body;
@@ -123,7 +123,7 @@ impl Decoder for ECIESCodec {
                 ECIESState::Header => {
                     if buf.len() < ECIES::header_len() {
                         trace!("current len {}, need {}", buf.len(), ECIES::header_len());
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     self.ecies.read_header(&mut buf.split_to(ECIES::header_len()))?;
@@ -132,7 +132,7 @@ impl Decoder for ECIESCodec {
                 }
                 ECIESState::Body => {
                     if buf.len() < self.ecies.body_len() {
-                        return Ok(None)
+                        return Ok(None);
                     }
 
                     let mut data = buf.split_to(self.ecies.body_len());
@@ -140,7 +140,7 @@ impl Decoder for ECIESCodec {
                     ret.extend_from_slice(self.ecies.read_body(&mut data)?);
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::Message(ret)))
+                    return Ok(Some(IngressECIESValue::Message(ret)));
                 }
             }
         }

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -519,13 +519,13 @@ impl Decodable for NewPooledTransactionHashes68 {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: msg.hashes.len(),
                 got: msg.types.len(),
-            })
+            });
         }
         if msg.hashes.len() != msg.sizes.len() {
             return Err(alloy_rlp::Error::ListLengthMismatch {
                 expected: msg.hashes.len(),
                 got: msg.sizes.len(),
-            })
+            });
         }
 
         Ok(msg)
@@ -798,7 +798,7 @@ impl RequestTxHashes {
     pub fn retain_count(&mut self, count: usize) -> Self {
         let rest_capacity = self.hashes.len().saturating_sub(count);
         if rest_capacity == 0 {
-            return Self::empty()
+            return Self::empty();
         }
         let mut rest = Self::with_capacity(rest_capacity);
 
@@ -806,7 +806,7 @@ impl RequestTxHashes {
         self.hashes.retain(|hash| {
             if i >= count {
                 rest.insert(*hash);
-                return false
+                return false;
             }
             i += 1;
 

--- a/crates/net/eth-wire-types/src/capability.rs
+++ b/crates/net/eth-wire-types/src/capability.rs
@@ -154,12 +154,12 @@ impl Capability {
     /// Whether this is any eth version.
     #[inline]
     pub fn is_eth(&self) -> bool {
-        self.is_eth_v66() ||
-            self.is_eth_v67() ||
-            self.is_eth_v68() ||
-            self.is_eth_v69() ||
-            self.is_eth_v70() ||
-            self.is_eth_v71()
+        self.is_eth_v66()
+            || self.is_eth_v67()
+            || self.is_eth_v68()
+            || self.is_eth_v69()
+            || self.is_eth_v70()
+            || self.is_eth_v71()
     }
 }
 

--- a/crates/net/eth-wire-types/src/disconnect_reason.rs
+++ b/crates/net/eth-wire-types/src/disconnect_reason.rs
@@ -96,9 +96,9 @@ impl Decodable for DisconnectReason {
     /// reason encoded a single byte or a RLP list containing the disconnect reason.
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         if buf.is_empty() {
-            return Err(alloy_rlp::Error::InputTooShort)
+            return Err(alloy_rlp::Error::InputTooShort);
         } else if buf.len() > 2 {
-            return Err(alloy_rlp::Error::Overflow)
+            return Err(alloy_rlp::Error::Overflow);
         }
 
         if buf.len() > 1 {
@@ -107,14 +107,14 @@ impl Decodable for DisconnectReason {
             let header = Header::decode(buf)?;
 
             if !header.list {
-                return Err(alloy_rlp::Error::UnexpectedString)
+                return Err(alloy_rlp::Error::UnexpectedString);
             }
 
             if header.payload_length != 1 {
                 return Err(alloy_rlp::Error::ListLengthMismatch {
                     expected: 1,
                     got: header.payload_length,
-                })
+                });
             }
         }
 

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -71,7 +71,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         let message_type = EthMessageID::decode(buf)?;
 
         if message_type != EthMessageID::Status {
-            return Err(MessageError::ExpectedStatusMessage(message_type))
+            return Err(MessageError::ExpectedStatusMessage(message_type));
         }
 
         let status = if version < EthVersion::Eth69 {
@@ -127,13 +127,13 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
             }
             EthMessageID::GetNodeData => {
                 if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData))
+                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData));
                 }
                 EthMessage::GetNodeData(RequestPair::decode(buf)?)
             }
             EthMessageID::NodeData => {
                 if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::NodeData))
+                    return Err(MessageError::Invalid(version, EthMessageID::NodeData));
                 }
                 EthMessage::NodeData(RequestPair::decode(buf)?)
             }
@@ -164,19 +164,19 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
             }
             EthMessageID::BlockRangeUpdate => {
                 if version < EthVersion::Eth69 {
-                    return Err(MessageError::Invalid(version, EthMessageID::BlockRangeUpdate))
+                    return Err(MessageError::Invalid(version, EthMessageID::BlockRangeUpdate));
                 }
                 EthMessage::BlockRangeUpdate(BlockRangeUpdate::decode(buf)?)
             }
             EthMessageID::GetBlockAccessLists => {
                 if version < EthVersion::Eth71 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetBlockAccessLists))
+                    return Err(MessageError::Invalid(version, EthMessageID::GetBlockAccessLists));
                 }
                 EthMessage::GetBlockAccessLists(RequestPair::decode(buf)?)
             }
             EthMessageID::BlockAccessLists => {
                 if version < EthVersion::Eth71 {
-                    return Err(MessageError::Invalid(version, EthMessageID::BlockAccessLists))
+                    return Err(MessageError::Invalid(version, EthMessageID::BlockAccessLists));
                 }
                 EthMessage::BlockAccessLists(RequestPair::decode(buf)?)
             }
@@ -392,13 +392,13 @@ impl<N: NetworkPrimitives> EthMessage<N> {
     pub const fn is_request(&self) -> bool {
         matches!(
             self,
-            Self::GetBlockBodies(_) |
-                Self::GetBlockHeaders(_) |
-                Self::GetReceipts(_) |
-                Self::GetReceipts70(_) |
-                Self::GetBlockAccessLists(_) |
-                Self::GetPooledTransactions(_) |
-                Self::GetNodeData(_)
+            Self::GetBlockBodies(_)
+                | Self::GetBlockHeaders(_)
+                | Self::GetReceipts(_)
+                | Self::GetReceipts70(_)
+                | Self::GetBlockAccessLists(_)
+                | Self::GetPooledTransactions(_)
+                | Self::GetNodeData(_)
         )
     }
 
@@ -406,14 +406,14 @@ impl<N: NetworkPrimitives> EthMessage<N> {
     pub const fn is_response(&self) -> bool {
         matches!(
             self,
-            Self::PooledTransactions(_) |
-                Self::Receipts(_) |
-                Self::Receipts69(_) |
-                Self::Receipts70(_) |
-                Self::BlockAccessLists(_) |
-                Self::BlockHeaders(_) |
-                Self::BlockBodies(_) |
-                Self::NodeData(_)
+            Self::PooledTransactions(_)
+                | Self::Receipts(_)
+                | Self::Receipts69(_)
+                | Self::Receipts70(_)
+                | Self::BlockAccessLists(_)
+                | Self::BlockHeaders(_)
+                | Self::BlockBodies(_)
+                | Self::NodeData(_)
         )
     }
 
@@ -439,7 +439,7 @@ impl<N: NetworkPrimitives> EthMessage<N> {
                     Self::GetReceipts70(req)
                 }
                 other => other,
-            }
+            };
         }
 
         self
@@ -773,7 +773,7 @@ where
         // RequestPair
         let consumed_len = initial_length - buf.len();
         if consumed_len != header.payload_length {
-            return Err(alloy_rlp::Error::UnexpectedLength)
+            return Err(alloy_rlp::Error::UnexpectedLength);
         }
 
         Ok(Self { request_id, message })

--- a/crates/net/eth-wire/src/capability.rs
+++ b/crates/net/eth-wire/src/capability.rs
@@ -58,7 +58,7 @@ impl SharedCapability {
         messages: u8,
     ) -> Result<Self, SharedCapabilityError> {
         if offset <= MAX_RESERVED_MESSAGE_ID {
-            return Err(SharedCapabilityError::ReservedMessageIdOffset(offset))
+            return Err(SharedCapabilityError::ReservedMessageIdOffset(offset));
         }
 
         match name {
@@ -214,12 +214,12 @@ impl SharedCapabilities {
         let mut cap = iter.next()?;
         if offset < cap.message_id_offset() {
             // reserved message id space
-            return None
+            return None;
         }
 
         for next in iter {
             if offset < next.message_id_offset() {
-                return Some(cap)
+                return Some(cap);
             }
             cap = next
         }
@@ -303,7 +303,7 @@ pub fn shared_capability_offsets(
 
     // disconnect if we don't share any capabilities
     if shared_capabilities.is_empty() {
-        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities))
+        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities));
     }
 
     // order versions based on capability name (alphabetical) and select offsets based on
@@ -327,7 +327,7 @@ pub fn shared_capability_offsets(
     }
 
     if shared_with_offsets.is_empty() {
-        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities))
+        return Err(P2PStreamError::HandshakeError(P2PHandshakeError::NoSharedCapabilities));
     }
 
     Ok(shared_with_offsets)

--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -66,7 +66,7 @@ impl EthStreamError {
     /// Returns the [`io::Error`] if it was caused by IO
     pub const fn as_io(&self) -> Option<&io::Error> {
         if let Self::P2PStreamError(P2PStreamError::Io(io)) = self {
-            return Some(io)
+            return Some(io);
         }
         None
     }

--- a/crates/net/eth-wire/src/errors/p2p.rs
+++ b/crates/net/eth-wire/src/errors/p2p.rs
@@ -82,8 +82,8 @@ impl P2PStreamError {
     /// Returns the [`DisconnectReason`] if it is the `Disconnected` variant.
     pub const fn as_disconnected(&self) -> Option<DisconnectReason> {
         let reason = match self {
-            Self::HandshakeError(P2PHandshakeError::Disconnected(reason)) |
-            Self::Disconnected(reason) => reason,
+            Self::HandshakeError(P2PHandshakeError::Disconnected(reason))
+            | Self::Disconnected(reason) => reason,
             _ => return None,
         };
 

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -236,9 +236,9 @@ where
                     Err(EthSnapStreamError::InvalidMessage(self.eth_version, err.to_string()))
                 }
             }
-        } else if message_id > EthMessageID::max(self.eth_version) &&
-            message_id <=
-                EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
+        } else if message_id > EthMessageID::max(self.eth_version)
+            && message_id
+                <= EthMessageID::message_count(self.eth_version) + SnapMessageId::TrieNodes as u8
         {
             // Checks for multiplexed snap message IDs :
             // - message_id > EthMessageID::max() : ensures it's not an eth message
@@ -406,8 +406,8 @@ mod tests {
         // This should be decoded as eth message
         let eth_boundary_result = inner.decode_message(eth_boundary_bytes);
         assert!(
-            eth_boundary_result.is_err() ||
-                matches!(eth_boundary_result, Ok(EthSnapMessage::Eth(_)))
+            eth_boundary_result.is_err()
+                || matches!(eth_boundary_result, Ok(EthSnapMessage::Eth(_)))
         );
 
         // Create a bytes buffer with message ID just above eth max, it should be snap min

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -284,7 +284,7 @@ where
             // but we can start the disconnect process. The actual disconnect will be handled
             // asynchronously by the caller or the stream's poll methods.
             let _disconnect_future = this.inner.disconnect(DisconnectReason::ProtocolBreach);
-            return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
+            return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake));
         }
 
         self.project()

--- a/crates/net/eth-wire/src/handshake.rs
+++ b/crates/net/eth-wire/src/handshake.rs
@@ -173,8 +173,8 @@ where
         }
 
         // Ensure peer's total difficulty is reasonable
-        if let StatusMessage::Legacy(s) = &their_status_message &&
-            s.total_difficulty.bit_len() > 160
+        if let StatusMessage::Legacy(s) = &their_status_message
+            && s.total_difficulty.bit_len() > 160
         {
             unauth
                 .disconnect(DisconnectReason::ProtocolBreach)

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -83,7 +83,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
     {
         let Ok(shared_cap) = self.shared_capabilities().ensure_matching_capability(cap).cloned()
         else {
-            return Err(P2PStreamError::CapabilityNotShared)
+            return Err(P2PStreamError::CapabilityNotShared);
         };
 
         let (to_primary, from_wire) = mpsc::unbounded_channel();
@@ -151,7 +151,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
     {
         let Ok(shared_cap) = self.shared_capabilities().ensure_matching_capability(cap).cloned()
         else {
-            return Err(P2PStreamError::CapabilityNotShared.into())
+            return Err(P2PStreamError::CapabilityNotShared.into());
         };
 
         let (to_primary, from_wire) = mpsc::unbounded_channel();
@@ -259,7 +259,7 @@ impl<St> MultiplexInner<St> {
         for proto in &self.protocols {
             if proto.shared_cap == *cap {
                 proto.send_raw(msg);
-                return true
+                return true;
             }
         }
         false
@@ -315,7 +315,7 @@ impl ProtocolProxy {
     fn try_send(&self, msg: Bytes) -> Result<(), io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         self.to_wire.send(self.mask_msg_id(msg)?).map_err(|_| io::ErrorKind::BrokenPipe.into())
     }
@@ -325,7 +325,7 @@ impl ProtocolProxy {
     fn mask_msg_id(&self, msg: Bytes) -> Result<Bytes, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
 
         let offset = self.shared_cap.relative_message_id_offset();
@@ -343,7 +343,7 @@ impl ProtocolProxy {
     fn unmask_id(&self, mut msg: BytesMut) -> Result<BytesMut, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         msg[0] = msg[0]
             .checked_sub(self.shared_cap.relative_message_id_offset())
@@ -527,7 +527,7 @@ where
         loop {
             // first drain the primary stream
             if let Poll::Ready(Some(msg)) = this.primary.st.try_poll_next_unpin(cx) {
-                return Poll::Ready(Some(msg))
+                return Poll::Ready(Some(msg));
             }
 
             let mut conn_ready = true;
@@ -536,23 +536,23 @@ where
                     Poll::Ready(Ok(())) => {
                         if let Some(msg) = this.inner.out_buffer.pop_front() {
                             if let Err(err) = this.inner.conn.start_send_unpin(msg) {
-                                return Poll::Ready(Some(Err(err.into())))
+                                return Poll::Ready(Some(Err(err.into())));
                             }
                         } else {
-                            break
+                            break;
                         }
                     }
                     Poll::Ready(Err(err)) => {
                         if let Err(disconnect_err) =
                             this.inner.conn.start_disconnect(DisconnectReason::DisconnectRequested)
                         {
-                            return Poll::Ready(Some(Err(disconnect_err.into())))
+                            return Poll::Ready(Some(Err(disconnect_err.into())));
                         }
-                        return Poll::Ready(Some(Err(err.into())))
+                        return Poll::Ready(Some(Err(err.into())));
                     }
                     Poll::Pending => {
                         conn_ready = false;
-                        break
+                        break;
                     }
                 }
             }
@@ -565,7 +565,7 @@ where
                     }
                     Poll::Ready(None) => {
                         // primary closed
-                        return Poll::Ready(None)
+                        return Poll::Ready(None);
                     }
                     Poll::Pending => break,
                 }
@@ -585,7 +585,7 @@ where
                         Poll::Ready(None) => return Poll::Ready(None),
                         Poll::Pending => {
                             this.inner.protocols.push(proto);
-                            break
+                            break;
                         }
                     }
                 }
@@ -600,7 +600,7 @@ where
                         let Some(offset) = msg.first().copied() else {
                             return Poll::Ready(Some(Err(
                                 P2PStreamError::EmptyProtocolMessage.into()
-                            )))
+                            )));
                         };
                         // delegate the multiplexed message to the correct protocol
                         if let Some(cap) =
@@ -614,28 +614,27 @@ where
                                 for proto in &this.inner.protocols {
                                     if proto.shared_cap == *cap {
                                         proto.send_raw(msg);
-                                        break
+                                        break;
                                     }
                                 }
                             }
                         } else {
-                            return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(
-                                offset,
-                            )
-                            .into())))
+                            return Poll::Ready(Some(Err(
+                                P2PStreamError::UnknownReservedMessageId(offset).into(),
+                            )));
                         }
                     }
                     Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err.into()))),
                     Poll::Ready(None) => {
                         // connection closed
-                        return Poll::Ready(None)
+                        return Poll::Ready(None);
                     }
                     Poll::Pending => break,
                 }
             }
 
             if !conn_ready || (!delegated && this.inner.out_buffer.is_empty()) {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -652,10 +651,10 @@ where
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
         if let Err(err) = ready!(this.inner.conn.poll_ready_unpin(cx)) {
-            return Poll::Ready(Err(err.into()))
+            return Poll::Ready(Err(err.into()));
         }
         if let Err(err) = ready!(this.primary.st.poll_ready_unpin(cx)) {
-            return Poll::Ready(Err(err))
+            return Poll::Ready(Err(err));
         }
         Poll::Ready(Ok(()))
     }
@@ -687,7 +686,7 @@ impl ProtocolStream {
     fn mask_msg_id(&self, mut msg: BytesMut) -> Result<Bytes, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         msg[0] = msg[0]
             .checked_add(self.shared_cap.relative_message_id_offset())
@@ -700,7 +699,7 @@ impl ProtocolStream {
     fn unmask_id(&self, mut msg: BytesMut) -> Result<BytesMut, io::Error> {
         if msg.is_empty() {
             // message must not be empty
-            return Err(io::ErrorKind::InvalidInput.into())
+            return Err(io::ErrorKind::InvalidInput.into());
         }
         msg[0] = msg[0]
             .checked_sub(self.shared_cap.relative_message_id_offset())
@@ -751,7 +750,7 @@ impl<'a> Future for ProtocolsPoller<'a> {
             match proto.poll_next_unpin(cx) {
                 Poll::Ready(Some(Err(err))) => {
                     self.protocols.push(proto);
-                    return Poll::Ready(Err(P2PStreamError::from(err)))
+                    return Poll::Ready(Err(P2PStreamError::from(err)));
                 }
                 Poll::Ready(Some(Ok(msg))) => {
                     // Got a message, put protocol back and return the message

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -108,7 +108,7 @@ where
             return Err(P2PStreamError::MessageTooBig {
                 message_size: first_message_bytes.len(),
                 max_size: MAX_PAYLOAD_SIZE,
-            })
+            });
         }
 
         // The first message sent MUST be a hello OR disconnect message
@@ -150,7 +150,7 @@ where
             return Err(P2PStreamError::MismatchedProtocolVersion(GotExpected {
                 got: their_hello.protocol_version,
                 expected: hello.protocol_version,
-            }))
+            }));
         }
 
         // determine shared capabilities (currently returns only one capability)
@@ -395,7 +395,7 @@ where
 
         if this.disconnecting {
             // if disconnecting, stop reading messages
-            return Poll::Ready(None)
+            return Poll::Ready(None);
         }
 
         // we should loop here to ensure we don't return Poll::Pending if we have a message to
@@ -409,7 +409,7 @@ where
 
             if bytes.is_empty() {
                 // empty messages are not allowed
-                return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage)))
+                return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage)));
             }
 
             // first decode disconnect reasons, because they can be encoded in a variety of forms
@@ -430,7 +430,7 @@ where
                 // message is snappy compressed. Failure handling in that step is the primary point
                 // where an error is returned if the disconnect reason is malformed.
                 if let Ok(reason) = DisconnectReason::decode(&mut &bytes[1..]) {
-                    return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))))
+                    return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))));
                 }
             }
 
@@ -441,7 +441,7 @@ where
                 return Poll::Ready(Some(Err(P2PStreamError::MessageTooBig {
                     message_size: decompressed_len,
                     max_size: MAX_PAYLOAD_SIZE,
-                })))
+                })));
             }
 
             // create a buffer to hold the decompressed message, adding a byte to the length for
@@ -472,7 +472,7 @@ where
                     // an error
                     return Poll::Ready(Some(Err(P2PStreamError::HandshakeError(
                         P2PHandshakeError::HelloNotInHandshake,
-                    ))))
+                    ))));
                 }
                 _ if id == P2PMessageID::Pong as u8 => {
                     // if we were waiting for a pong, this will reset the pinger state
@@ -489,11 +489,11 @@ where
                             %err, msg=%hex::encode(&decompress_buf[1..]), "Failed to decode disconnect message from peer"
                         );
                     })?;
-                    return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))))
+                    return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))));
                 }
                 _ if id > MAX_P2P_MESSAGE_ID && id <= MAX_RESERVED_MESSAGE_ID => {
                     // we have received an unknown reserved message
-                    return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(id))))
+                    return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(id))));
                 }
                 _ => {
                     // we have received a message that is outside the `p2p` reserved message space,
@@ -521,7 +521,7 @@ where
                     //
                     decompress_buf[0] = bytes[0] - MAX_RESERVED_MESSAGE_ID - 1;
 
-                    return Poll::Ready(Some(Ok(decompress_buf)))
+                    return Poll::Ready(Some(Ok(decompress_buf)));
                 }
             }
         }
@@ -550,7 +550,7 @@ where
                 this.start_disconnect(DisconnectReason::PingTimeout)?;
 
                 // End the stream after ping related error
-                return Poll::Ready(Ok(()))
+                return Poll::Ready(Ok(()));
             }
         }
 
@@ -560,7 +560,7 @@ where
             Poll::Ready(Ok(())) => {
                 let flushed = this.poll_flush(cx);
                 if flushed.is_ready() {
-                    return flushed
+                    return flushed;
                 }
             }
         }
@@ -578,17 +578,17 @@ where
             return Err(P2PStreamError::MessageTooBig {
                 message_size: item.len(),
                 max_size: MAX_PAYLOAD_SIZE,
-            })
+            });
         }
 
         if item.is_empty() {
             // empty messages are not allowed
-            return Err(P2PStreamError::EmptyProtocolMessage)
+            return Err(P2PStreamError::EmptyProtocolMessage);
         }
 
         // ensure we have free capacity
         if !self.has_outgoing_capacity() {
-            return Err(P2PStreamError::SendBufferFull)
+            return Err(P2PStreamError::SendBufferFull);
         }
 
         let this = self.project();
@@ -625,10 +625,10 @@ where
                 Poll::Ready(Err(err)) => break Poll::Ready(Err(err.into())),
                 Poll::Ready(Ok(())) => {
                     let Some(message) = this.outgoing_messages.pop_front() else {
-                        break Poll::Ready(Ok(()))
+                        break Poll::Ready(Ok(()));
                     };
                     if let Err(err) = this.inner.as_mut().start_send(message) {
-                        break Poll::Ready(Err(err.into()))
+                        break Poll::Ready(Err(err.into()));
                     }
                 }
             }
@@ -726,10 +726,10 @@ impl Decodable for P2PMessage {
         /// Removes the snappy prefix from the Ping/Pong buffer
         fn advance_snappy_ping_pong_payload(buf: &mut &[u8]) -> alloy_rlp::Result<()> {
             if buf.len() < 3 {
-                return Err(RlpError::InputTooShort)
+                return Err(RlpError::InputTooShort);
             }
             if buf[..3] != [0x01, 0x00, EMPTY_LIST_CODE] {
-                return Err(RlpError::Custom("expected snappy payload"))
+                return Err(RlpError::Custom("expected snappy payload"));
             }
             buf.advance(3);
             Ok(())

--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -74,19 +74,19 @@ impl Pinger {
                 if self.ping_interval.poll_tick(cx).is_ready() {
                     self.timeout_timer.as_mut().reset(Instant::now() + self.timeout);
                     self.state = PingState::WaitingForPong;
-                    return Poll::Ready(Ok(PingerEvent::Ping))
+                    return Poll::Ready(Ok(PingerEvent::Ping));
                 }
             }
             PingState::WaitingForPong => {
                 if self.timeout_timer.as_mut().poll(cx).is_ready() {
                     self.state = PingState::TimedOut;
-                    return Poll::Ready(Ok(PingerEvent::Timeout))
+                    return Poll::Ready(Ok(PingerEvent::Timeout));
                 }
             }
             PingState::TimedOut => {
                 // we treat continuous calls while in timeout as pending, since the connection is
                 // not yet terminated
-                return Poll::Pending
+                return Poll::Pending;
             }
         };
         Poll::Pending

--- a/crates/net/eth-wire/src/test_utils.rs
+++ b/crates/net/eth-wire/src/test_utils.rs
@@ -142,7 +142,7 @@ pub mod proto {
         /// Decodes a `TestProtoMessage` from the given message buffer.
         pub fn decode_message(buf: &mut &[u8]) -> Option<Self> {
             if buf.is_empty() {
-                return None
+                return None;
             }
             let id = buf[0];
             buf.advance(1);

--- a/crates/net/network-types/src/peers/mod.rs
+++ b/crates/net/network-types/src/peers/mod.rs
@@ -97,15 +97,15 @@ impl Peer {
 
         if self.state.is_connected() && self.is_banned() {
             self.state.disconnect();
-            return ReputationChangeOutcome::DisconnectAndBan
+            return ReputationChangeOutcome::DisconnectAndBan;
         }
 
         if self.is_banned() && !is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Ban
+            return ReputationChangeOutcome::Ban;
         }
 
         if !self.is_banned() && is_banned_reputation(previous) {
-            return ReputationChangeOutcome::Unban
+            return ReputationChangeOutcome::Unban;
         }
 
         ReputationChangeOutcome::None

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -660,9 +660,9 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
 
         // If default DNS config is used then we add the known dns network to bootstrap from
         if let Some(dns_networks) =
-            dns_discovery_config.as_mut().and_then(|c| c.bootstrap_dns_networks.as_mut()) &&
-            dns_networks.is_empty() &&
-            let Some(link) = chain_spec.chain().public_dns_network_protocol()
+            dns_discovery_config.as_mut().and_then(|c| c.bootstrap_dns_networks.as_mut())
+            && dns_networks.is_empty()
+            && let Some(link) = chain_spec.chain().public_dns_network_protocol()
         {
             dns_networks.insert(link.parse().expect("is valid DNS link entry"));
         }

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -220,7 +220,7 @@ impl Discovery {
         let tcp_addr = record.tcp_addr();
         if tcp_addr.port() == 0 {
             // useless peer for p2p
-            return
+            return;
         }
         let udp_addr = record.udp_addr();
         let addr = PeerAddr::new(tcp_addr, Some(udp_addr));
@@ -258,7 +258,7 @@ impl Discovery {
             // Drain all buffered events first
             if let Some(event) = self.queued_events.pop_front() {
                 self.notify_listeners(&event);
-                return Poll::Ready(event)
+                return Poll::Ready(event);
             }
 
             // drain the discv4 update stream
@@ -272,8 +272,8 @@ impl Discovery {
             while let Some(Poll::Ready(Some(update))) =
                 self.discv5_updates.as_mut().map(|updates| updates.poll_next_unpin(cx))
             {
-                if let Some(discv5) = self.discv5.as_mut() &&
-                    let Some(DiscoveredPeer { node_record, fork_id }) =
+                if let Some(discv5) = self.discv5.as_mut()
+                    && let Some(DiscoveredPeer { node_record, fork_id }) =
                         discv5.on_discv5_update(update)
                 {
                     self.on_node_record_update(node_record, fork_id);
@@ -295,7 +295,7 @@ impl Discovery {
             }
 
             if self.queued_events.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -72,7 +72,7 @@ impl NetworkError {
             ErrorKind::AddrInUse => Self::AddressAlreadyInUse { kind, error: err },
             _ => {
                 if let ServiceKind::Discovery(address) = kind {
-                    return Self::Discovery(address, err)
+                    return Self::Discovery(address, err);
                 }
                 Self::Io(err)
             }
@@ -110,8 +110,8 @@ impl SessionError for EthStreamError {
     fn merits_discovery_ban(&self) -> bool {
         match self {
             Self::P2PStreamError(P2PStreamError::HandshakeError(
-                P2PHandshakeError::HelloNotInHandshake |
-                P2PHandshakeError::NonHelloMessageInHandshake,
+                P2PHandshakeError::HelloNotInHandshake
+                | P2PHandshakeError::NonHelloMessageInHandshake,
             )) => true,
             Self::EthHandshakeError(err) => {
                 #[allow(clippy::match_same_arms)]
@@ -139,24 +139,24 @@ impl SessionError for EthStreamError {
                 matches!(
                     err,
                     P2PStreamError::HandshakeError(
-                        P2PHandshakeError::NoSharedCapabilities |
-                            P2PHandshakeError::HelloNotInHandshake |
-                            P2PHandshakeError::NonHelloMessageInHandshake |
-                            P2PHandshakeError::Disconnected(
-                                DisconnectReason::UselessPeer |
-                                    DisconnectReason::IncompatibleP2PProtocolVersion |
-                                    DisconnectReason::ProtocolBreach
+                        P2PHandshakeError::NoSharedCapabilities
+                            | P2PHandshakeError::HelloNotInHandshake
+                            | P2PHandshakeError::NonHelloMessageInHandshake
+                            | P2PHandshakeError::Disconnected(
+                                DisconnectReason::UselessPeer
+                                    | DisconnectReason::IncompatibleP2PProtocolVersion
+                                    | DisconnectReason::ProtocolBreach
                             )
-                    ) | P2PStreamError::UnknownReservedMessageId(_) |
-                        P2PStreamError::EmptyProtocolMessage |
-                        P2PStreamError::ParseSharedCapability(_) |
-                        P2PStreamError::CapabilityNotShared |
-                        P2PStreamError::Disconnected(
-                            DisconnectReason::UselessPeer |
-                                DisconnectReason::IncompatibleP2PProtocolVersion |
-                                DisconnectReason::ProtocolBreach
-                        ) |
-                        P2PStreamError::MismatchedProtocolVersion { .. }
+                    ) | P2PStreamError::UnknownReservedMessageId(_)
+                        | P2PStreamError::EmptyProtocolMessage
+                        | P2PStreamError::ParseSharedCapability(_)
+                        | P2PStreamError::CapabilityNotShared
+                        | P2PStreamError::Disconnected(
+                            DisconnectReason::UselessPeer
+                                | DisconnectReason::IncompatibleP2PProtocolVersion
+                                | DisconnectReason::ProtocolBreach
+                        )
+                        | P2PStreamError::MismatchedProtocolVersion { .. }
                 )
             }
             Self::EthHandshakeError(err) => {
@@ -181,50 +181,50 @@ impl SessionError for EthStreamError {
 
     fn should_backoff(&self) -> Option<BackoffKind> {
         if let Some(err) = self.as_io() {
-            return err.should_backoff()
+            return err.should_backoff();
         }
 
         if let Some(err) = self.as_disconnected() {
             return match err {
-                DisconnectReason::TooManyPeers |
-                DisconnectReason::AlreadyConnected |
-                DisconnectReason::PingTimeout |
-                DisconnectReason::DisconnectRequested |
-                DisconnectReason::TcpSubsystemError => Some(BackoffKind::Low),
+                DisconnectReason::TooManyPeers
+                | DisconnectReason::AlreadyConnected
+                | DisconnectReason::PingTimeout
+                | DisconnectReason::DisconnectRequested
+                | DisconnectReason::TcpSubsystemError => Some(BackoffKind::Low),
 
-                DisconnectReason::ProtocolBreach |
-                DisconnectReason::UselessPeer |
-                DisconnectReason::IncompatibleP2PProtocolVersion |
-                DisconnectReason::NullNodeIdentity |
-                DisconnectReason::ClientQuitting |
-                DisconnectReason::UnexpectedHandshakeIdentity |
-                DisconnectReason::ConnectedToSelf |
-                DisconnectReason::SubprotocolSpecific => {
+                DisconnectReason::ProtocolBreach
+                | DisconnectReason::UselessPeer
+                | DisconnectReason::IncompatibleP2PProtocolVersion
+                | DisconnectReason::NullNodeIdentity
+                | DisconnectReason::ClientQuitting
+                | DisconnectReason::UnexpectedHandshakeIdentity
+                | DisconnectReason::ConnectedToSelf
+                | DisconnectReason::SubprotocolSpecific => {
                     // These are considered fatal, and are handled by the
                     // [`SessionError::is_fatal_protocol_error`]
                     Some(BackoffKind::High)
                 }
-            }
+            };
         }
 
         // This only checks for a subset of error variants, the counterpart of
         // [`SessionError::is_fatal_protocol_error`]
         match self {
             // timeouts
-            Self::EthHandshakeError(EthHandshakeError::NoResponse) |
-            Self::P2PStreamError(
-                P2PStreamError::HandshakeError(P2PHandshakeError::NoResponse) |
-                P2PStreamError::PingTimeout,
+            Self::EthHandshakeError(EthHandshakeError::NoResponse)
+            | Self::P2PStreamError(
+                P2PStreamError::HandshakeError(P2PHandshakeError::NoResponse)
+                | P2PStreamError::PingTimeout,
             ) => Some(BackoffKind::Low),
             // malformed messages
             Self::P2PStreamError(
-                P2PStreamError::Rlp(_) |
-                P2PStreamError::UnknownReservedMessageId(_) |
-                P2PStreamError::UnknownDisconnectReason(_) |
-                P2PStreamError::MessageTooBig { .. } |
-                P2PStreamError::EmptyProtocolMessage |
-                P2PStreamError::PingerError(_) |
-                P2PStreamError::Snap(_),
+                P2PStreamError::Rlp(_)
+                | P2PStreamError::UnknownReservedMessageId(_)
+                | P2PStreamError::UnknownDisconnectReason(_)
+                | P2PStreamError::MessageTooBig { .. }
+                | P2PStreamError::EmptyProtocolMessage
+                | P2PStreamError::PingerError(_)
+                | P2PStreamError::Snap(_),
             ) => Some(BackoffKind::Medium),
             Self::EthHandshakeError(EthHandshakeError::InvalidFork(_)) => {
                 // the remote can come back online after updating client version, so we can back off
@@ -242,14 +242,14 @@ impl SessionError for PendingSessionHandshakeError {
             Self::Eth(eth) => eth.merits_discovery_ban(),
             Self::Ecies(err) => matches!(
                 err.inner(),
-                ECIESErrorImpl::TagCheckDecryptFailed |
-                    ECIESErrorImpl::TagCheckHeaderFailed |
-                    ECIESErrorImpl::TagCheckBodyFailed |
-                    ECIESErrorImpl::InvalidAuthData |
-                    ECIESErrorImpl::InvalidAckData |
-                    ECIESErrorImpl::InvalidHeader |
-                    ECIESErrorImpl::Secp256k1(_) |
-                    ECIESErrorImpl::InvalidHandshake { .. }
+                ECIESErrorImpl::TagCheckDecryptFailed
+                    | ECIESErrorImpl::TagCheckHeaderFailed
+                    | ECIESErrorImpl::TagCheckBodyFailed
+                    | ECIESErrorImpl::InvalidAuthData
+                    | ECIESErrorImpl::InvalidAckData
+                    | ECIESErrorImpl::InvalidHeader
+                    | ECIESErrorImpl::Secp256k1(_)
+                    | ECIESErrorImpl::InvalidHandshake { .. }
             ),
             Self::Timeout | Self::UnsupportedExtraCapability => false,
         }
@@ -260,14 +260,14 @@ impl SessionError for PendingSessionHandshakeError {
             Self::Eth(eth) => eth.is_fatal_protocol_error(),
             Self::Ecies(err) => matches!(
                 err.inner(),
-                ECIESErrorImpl::TagCheckDecryptFailed |
-                    ECIESErrorImpl::TagCheckHeaderFailed |
-                    ECIESErrorImpl::TagCheckBodyFailed |
-                    ECIESErrorImpl::InvalidAuthData |
-                    ECIESErrorImpl::InvalidAckData |
-                    ECIESErrorImpl::InvalidHeader |
-                    ECIESErrorImpl::Secp256k1(_) |
-                    ECIESErrorImpl::InvalidHandshake { .. }
+                ECIESErrorImpl::TagCheckDecryptFailed
+                    | ECIESErrorImpl::TagCheckHeaderFailed
+                    | ECIESErrorImpl::TagCheckBodyFailed
+                    | ECIESErrorImpl::InvalidAuthData
+                    | ECIESErrorImpl::InvalidAckData
+                    | ECIESErrorImpl::InvalidHeader
+                    | ECIESErrorImpl::Secp256k1(_)
+                    | ECIESErrorImpl::InvalidHandshake { .. }
             ),
             Self::Timeout => false,
             Self::UnsupportedExtraCapability => true,

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -95,7 +95,7 @@ where
             BlockHashOrNumber::Hash(start) => start.into(),
             BlockHashOrNumber::Number(num) => {
                 let Some(hash) = self.client.block_hash(num).unwrap_or_default() else {
-                    return headers
+                    return headers;
                 };
                 hash.into()
             }
@@ -113,7 +113,7 @@ where
                 headers.push(header);
 
                 if headers.len() >= MAX_HEADERS_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
+                    break;
                 }
 
                 match direction {
@@ -122,7 +122,7 @@ where
                         {
                             block = next.into()
                         } else {
-                            break
+                            break;
                         }
                     }
                     HeadersDirection::Falling => {
@@ -134,7 +134,7 @@ where
                             {
                                 block = next.into()
                             } else {
-                                break
+                                break;
                             }
                         } else {
                             block = parent_hash.into()
@@ -142,7 +142,7 @@ where
                     }
                 }
             } else {
-                break
+                break;
             }
         }
 
@@ -178,10 +178,10 @@ where
                 bodies.push(body);
 
                 if bodies.len() >= MAX_BODIES_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
+                    break;
                 }
             } else {
-                break
+                break;
             }
         }
 
@@ -238,13 +238,13 @@ where
 
         for (idx, hash) in block_hashes.into_iter().enumerate() {
             if idx >= MAX_RECEIPTS_SERVE {
-                break
+                break;
             }
 
             let Some(mut block_receipts) =
                 self.client.receipts_by_block(BlockHashOrNumber::Hash(hash)).unwrap_or_default()
             else {
-                break
+                break;
             };
 
             if idx == 0 && first_block_receipt_index > 0 {
@@ -313,10 +313,10 @@ where
                 receipts.push(transformed_receipts);
 
                 if receipts.len() >= MAX_RECEIPTS_SERVE || total_bytes > SOFT_RESPONSE_LIMIT {
-                    break
+                    break;
                 }
             } else {
-                break
+                break;
             }
         }
 

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -129,12 +129,12 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     ///
     /// Returns `true` if this a newer block
     pub(crate) fn update_peer_block(&mut self, peer_id: &PeerId, hash: B256, number: u64) -> bool {
-        if let Some(peer) = self.peers.get_mut(peer_id) &&
-            number > peer.best_number
+        if let Some(peer) = self.peers.get_mut(peer_id)
+            && number > peer.best_number
         {
             peer.best_hash = hash;
             peer.best_number = number;
-            return true
+            return true;
         }
         false
     }
@@ -159,18 +159,18 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             // replace best peer if our current best peer sent us a bad response last time
             if best_peer.1.last_response_likely_bad && !maybe_better.1.last_response_likely_bad {
                 best_peer = maybe_better;
-                continue
+                continue;
             }
 
             // replace best peer if this peer meets the requirements better
             if maybe_better.1.is_better(best_peer.1, &requirement) {
                 best_peer = maybe_better;
-                continue
+                continue;
             }
 
             // replace best peer if this peer has better rtt and both have same range quality
-            if maybe_better.1.timeout() < best_peer.1.timeout() &&
-                !maybe_better.1.last_response_likely_bad
+            if maybe_better.1.timeout() < best_peer.1.timeout()
+                && !maybe_better.1.last_response_likely_bad
             {
                 best_peer = maybe_better;
             }
@@ -183,14 +183,14 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     fn poll_action(&mut self) -> PollAction {
         // we only check and not pop here since we don't know yet whether a peer is available.
         if self.queued_requests.is_empty() {
-            return PollAction::NoRequests
+            return PollAction::NoRequests;
         }
 
         let request = self.queued_requests.pop_front().expect("not empty");
         let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
             // need to put back the request
             self.queued_requests.push_front(request);
-            return PollAction::NoPeersAvailable
+            return PollAction::NoPeersAvailable;
         };
 
         let request = self.prepare_block_request(peer_id, request);
@@ -234,7 +234,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             }
 
             if self.queued_requests.is_empty() || no_peers_available {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -312,7 +312,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             // If the peer is still ready to accept new requests, we try to send a followup
             // request immediately.
             if peer.state.on_request_finished() && !is_error && !is_likely_bad_response {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
 
@@ -338,7 +338,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             peer.last_response_likely_bad = is_likely_bad_response;
 
             if peer.state.on_request_finished() && !is_likely_bad_response {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
         None
@@ -362,7 +362,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             peer.last_response_likely_bad = is_likely_bad_response;
 
             if peer.state.on_request_finished() && !is_likely_bad_response {
-                return self.followup_request(peer_id)
+                return self.followup_request(peer_id);
             }
         }
         None
@@ -513,7 +513,7 @@ impl PeerState {
     const fn on_request_finished(&mut self) -> bool {
         if !matches!(self, Self::Closing) {
             *self = Self::Idle;
-            return true
+            return true;
         }
         false
     }
@@ -569,9 +569,9 @@ impl<N: NetworkPrimitives> DownloadRequest<N> {
     /// Returns the requested priority of this request
     const fn get_priority(&self) -> &Priority {
         match self {
-            Self::GetBlockHeaders { priority, .. } |
-            Self::GetBlockBodies { priority, .. } |
-            Self::GetReceipts { priority, .. } => priority,
+            Self::GetBlockHeaders { priority, .. }
+            | Self::GetBlockBodies { priority, .. }
+            | Self::GetReceipts { priority, .. } => priority,
         }
     }
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -684,7 +684,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 if self.handle.mode().is_stake() {
                     // See [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#devp2p)
                     warn!(target: "net", "Peer performed block propagation, but it is not supported in proof of stake (EIP-3675)");
-                    return
+                    return;
                 }
                 let msg = NewBlockMessage { hash, block: Arc::new(block) };
                 self.swarm.state_mut().announce_new_block(msg);
@@ -1159,7 +1159,7 @@ impl<N: NetworkPrimitives> Future for NetworkManager<N> {
         if maybe_more_handle_messages || maybe_more_swarm_events {
             // make sure we're woken up again
             cx.waker().wake_by_ref();
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         this.update_poll_metrics(start, poll_durations);

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -87,10 +87,10 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
             Self::ReceivedTransaction(msg) => msg.len(),
             Self::SendTransactions(msg) => msg.len(),
             Self::PooledTransactions(msg) => msg.len(),
-            Self::NewBlock(_) |
-            Self::EthRequest(_) |
-            Self::BlockRangeUpdated(_) |
-            Self::Other(_) => 1,
+            Self::NewBlock(_)
+            | Self::EthRequest(_)
+            | Self::BlockRangeUpdated(_)
+            | Self::Other(_) => 1,
         }
     }
 }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -418,7 +418,7 @@ impl<N: NetworkPrimitives> SyncStateProvider for NetworkHandle<N> {
     // used to guard the txpool
     fn is_initially_syncing(&self) -> bool {
         if self.inner.initial_sync_done.load(Ordering::Relaxed) {
-            return false
+            return false;
         }
         self.inner.is_syncing.load(Ordering::Relaxed)
     }

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -146,7 +146,7 @@ impl PeersManager {
             // confirmed fork ID. These were likely accumulated from a different network during
             // a prior run without the flag.
             if enforce_enr_fork_id && fork_id.is_none() {
-                continue
+                continue;
             }
             let NodeRecord { address, tcp_port, udp_port, id } = record;
             peers.entry(id).or_insert_with(|| {
@@ -310,11 +310,11 @@ impl PeersManager {
         // Check if the IP is in the allowed ranges (netrestrict)
         if !self.ip_filter.is_allowed(&addr) {
             trace!(target: "net", ?addr, "Rejecting connection from IP not in allowed ranges");
-            return Err(InboundConnectionError::IpBanned)
+            return Err(InboundConnectionError::IpBanned);
         }
 
         if self.ban_list.is_banned_ip(&addr) {
-            return Err(InboundConnectionError::IpBanned)
+            return Err(InboundConnectionError::IpBanned);
         }
 
         // check if we even have slots for a new incoming connection
@@ -322,7 +322,7 @@ impl PeersManager {
             if self.trusted_peer_ids.is_empty() {
                 // if we don't have any incoming slots and no trusted peers, we don't accept any new
                 // connections
-                return Err(InboundConnectionError::ExceedsCapacity)
+                return Err(InboundConnectionError::ExceedsCapacity);
             }
 
             // there's an edge case here where no incoming connections besides from trusted peers
@@ -335,17 +335,17 @@ impl PeersManager {
                     self.trusted_peer_ids.len().max(self.connection_info.config.max_inbound);
                 if self.connection_info.num_pending_in < max_inbound {
                     self.connection_info.inc_pending_in();
-                    return Ok(())
+                    return Ok(());
                 }
             }
 
             // all trusted peers are either connected or connecting
-            return Err(InboundConnectionError::ExceedsCapacity)
+            return Err(InboundConnectionError::ExceedsCapacity);
         }
 
         // also cap the incoming connections we can process at once
         if !self.connection_info.has_in_pending_capacity() {
-            return Err(InboundConnectionError::ExceedsCapacity)
+            return Err(InboundConnectionError::ExceedsCapacity);
         }
 
         // apply the rate limit
@@ -397,14 +397,14 @@ impl PeersManager {
         // on_incoming_pending_session. We also check if the peer is in the backoff list here.
         if self.ban_list.is_banned_peer(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-            return
+            return;
         }
 
         // check if the peer is trustable or not
         let mut is_trusted = self.trusted_peer_ids.contains(&peer_id);
         if self.trusted_nodes_only && !is_trusted {
             self.queued_actions.push_back(PeerAction::DisconnectUntrustedIncoming { peer_id });
-            return
+            return;
         }
 
         // start a new tick, so the peer is not immediately rewarded for the time since last tick
@@ -415,7 +415,7 @@ impl PeersManager {
                 let peer = entry.get_mut();
                 if peer.is_banned() {
                     self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-                    return
+                    return;
                 }
                 // it might be the case that we're also trying to connect to this peer at the same
                 // time, so we need to adjust the state here
@@ -452,8 +452,8 @@ impl PeersManager {
 
     /// Bans the peer temporarily with the configured ban timeout
     fn ban_peer(&mut self, peer_id: PeerId) {
-        let ban_duration = if let Some(peer) = self.peers.get(&peer_id) &&
-            (peer.is_trusted() || peer.is_static())
+        let ban_duration = if let Some(peer) = self.peers.get(&peer_id)
+            && (peer.is_trusted() || peer.is_static())
         {
             // For misbehaving trusted or static peers, we provide a bit more leeway when
             // penalizing them.
@@ -539,12 +539,12 @@ impl PeersManager {
                     // exempt trusted and static peers from reputation slashing for
                     if matches!(
                         rep,
-                        ReputationChangeKind::Dropped |
-                            ReputationChangeKind::BadAnnouncement |
-                            ReputationChangeKind::Timeout |
-                            ReputationChangeKind::AlreadySeenTransaction
+                        ReputationChangeKind::Dropped
+                            | ReputationChangeKind::BadAnnouncement
+                            | ReputationChangeKind::Timeout
+                            | ReputationChangeKind::AlreadySeenTransaction
                     ) {
-                        return
+                        return;
                     }
 
                     // also be less strict with the reputation slashing for trusted peers
@@ -556,7 +556,7 @@ impl PeersManager {
                 peer.apply_reputation(reputation_change, rep)
             }
         } else {
-            return
+            return;
         };
 
         match outcome {
@@ -668,7 +668,7 @@ impl PeersManager {
         if let Some(peer) = self.peers.get(peer_id) {
             if peer.state.is_incoming() {
                 // we already have an active connection to the peer, so we can ignore this error
-                return
+                return;
             }
 
             if peer.is_trusted() && is_connection_failed_reputation(peer.reputation) {
@@ -754,9 +754,9 @@ impl PeersManager {
                 self.connection_info.decr_state(peer.state);
                 peer.state = PeerConnectionState::Idle;
 
-                if peer.severe_backoff_counter > self.max_backoff_count &&
-                    !peer.is_trusted() &&
-                    !peer.is_static()
+                if peer.severe_backoff_counter > self.max_backoff_count
+                    && !peer.is_trusted()
+                    && !peer.is_static()
                 {
                     // mark peer for removal if it has been backoff too many times and is _not_
                     // trusted or static
@@ -835,11 +835,11 @@ impl PeersManager {
         // Check if the IP is in the allowed ranges (netrestrict)
         if !self.ip_filter.is_allowed(&ip_addr) {
             trace!(target: "net", ?peer_id, ?ip_addr, "Skipping peer from IP not in allowed ranges");
-            return
+            return;
         }
 
         if self.ban_list.is_banned(&peer_id, &ip_addr) {
-            return
+            return;
         }
 
         match self.peers.entry(peer_id) {
@@ -878,7 +878,7 @@ impl PeersManager {
     pub(crate) fn remove_peer(&mut self, peer_id: PeerId) {
         let Entry::Occupied(entry) = self.peers.entry(peer_id) else { return };
         if entry.get().is_trusted() {
-            return
+            return;
         }
         let mut peer = entry.remove();
 
@@ -928,11 +928,11 @@ impl PeersManager {
         // Check if the IP is in the allowed ranges (netrestrict)
         if !self.ip_filter.is_allowed(&ip_addr) {
             trace!(target: "net", ?peer_id, ?ip_addr, "Skipping outbound connection to IP not in allowed ranges");
-            return
+            return;
         }
 
         if self.ban_list.is_banned(&peer_id, &ip_addr) {
-            return
+            return;
         }
 
         match self.peers.entry(peer_id) {
@@ -971,7 +971,7 @@ impl PeersManager {
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
         if !entry.get().is_trusted() {
-            return
+            return;
         }
 
         let peer = entry.get_mut();
@@ -994,23 +994,23 @@ impl PeersManager {
     /// Returns `None` if no peer is available.
     fn best_unconnected(&mut self) -> Option<(PeerId, &mut Peer)> {
         let mut unconnected = self.peers.iter_mut().filter(|(_, peer)| {
-            !peer.is_backed_off() &&
-                !peer.is_banned() &&
-                peer.state.is_unconnected() &&
-                (!self.trusted_nodes_only || peer.is_trusted())
+            !peer.is_backed_off()
+                && !peer.is_banned()
+                && peer.state.is_unconnected()
+                && (!self.trusted_nodes_only || peer.is_trusted())
         });
 
         // keep track of the best peer, if there's one
         let mut best_peer = unconnected.next()?;
 
         if best_peer.1.is_trusted() || best_peer.1.is_static() {
-            return Some((*best_peer.0, best_peer.1))
+            return Some((*best_peer.0, best_peer.1));
         }
 
         for maybe_better in unconnected {
             // if the peer is trusted or static, return it immediately
             if maybe_better.1.is_trusted() || maybe_better.1.is_static() {
-                return Some((*maybe_better.0, maybe_better.1))
+                return Some((*maybe_better.0, maybe_better.1));
             }
 
             // prefer higher reputation, break ties by fork_id presence
@@ -1037,7 +1037,7 @@ impl PeersManager {
 
         if !self.net_connection_state.is_active() {
             // nothing to fill
-            return
+            return;
         }
 
         // as long as there are slots available fill them with the best peers
@@ -1098,7 +1098,7 @@ impl PeersManager {
         loop {
             // drain buffered actions
             if let Some(action) = self.queued_actions.pop_front() {
-                return Poll::Ready(action)
+                return Poll::Ready(action);
             }
 
             while let Poll::Ready(Some(cmd)) = self.handle_rx.poll_next_unpin(cx) {
@@ -1137,7 +1137,7 @@ impl PeersManager {
                         if let Some(peer) = self.peers.get_mut(peer_id) {
                             peer.backed_off = false;
                         }
-                        return false
+                        return false;
                     }
                     true
                 })
@@ -1152,7 +1152,7 @@ impl PeersManager {
             }
 
             if self.queued_actions.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -1189,8 +1189,8 @@ impl ConnectionInfo {
 
     ///  Returns `true` if there's still capacity to perform an outgoing connection.
     const fn has_out_capacity(&self) -> bool {
-        self.num_pending_out < self.config.max_concurrent_outbound_dials &&
-            self.num_outbound < self.config.max_outbound
+        self.num_pending_out < self.config.max_concurrent_outbound_dials
+            && self.num_outbound < self.config.max_outbound
     }
 
     ///  Returns `true` if there's still capacity to accept a new incoming connection.
@@ -2190,7 +2190,7 @@ mod tests {
 
             let p = peers.peers.get(&peer).unwrap();
             if p.is_banned() {
-                break
+                break;
             }
         }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -388,8 +388,8 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
     /// Returns the deadline timestamp at which the request times out
     fn request_deadline(&self) -> Instant {
-        Instant::now() +
-            Duration::from_millis(self.internal_request_timeout.load(Ordering::Relaxed))
+        Instant::now()
+            + Duration::from_millis(self.internal_request_timeout.load(Ordering::Relaxed))
     }
 
     /// Handle a Response to the peer
@@ -534,7 +534,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                     debug!(target: "net::session", ?id, remote_peer_id=?self.remote_peer_id, "timed out outgoing request");
                     req.timeout();
                 } else if now - req.timestamp > self.protocol_breach_request_timeout {
-                    return true
+                    return true;
                 }
             }
         }
@@ -558,7 +558,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         match tx.poll_reserve(cx) {
             Poll::Pending => {
                 self.terminate_message = Some((tx, msg));
-                return Some(Poll::Pending)
+                return Some(Poll::Pending);
             }
             Poll::Ready(Ok(())) => {
                 let _ = tx.send_item(msg);
@@ -580,11 +580,11 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
 
         // if the session is terminate we have to send the termination message before we can close
         if let Some(terminate) = this.poll_terminate_message(cx) {
-            return terminate
+            return terminate;
         }
 
         if this.is_disconnecting() {
-            return this.poll_disconnect(cx)
+            return this.poll_disconnect(cx);
         }
 
         // The receive loop can be CPU intensive since it involves message decoding which could take
@@ -605,7 +605,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     Poll::Ready(None) => {
                         // this is only possible when the manager was dropped, in which case we also
                         // terminate this session
-                        return Poll::Ready(())
+                        return Poll::Ready(());
                     }
                     Poll::Ready(Some(cmd)) => {
                         progress = true;
@@ -620,7 +620,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                 let reason =
                                     reason.unwrap_or(DisconnectReason::DisconnectRequested);
 
-                                return this.try_disconnect(reason, cx)
+                                return this.try_disconnect(reason, cx);
                             }
                             SessionCommand::Message(msg) => {
                                 this.on_internal_peer_message(msg);
@@ -664,11 +664,11 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     if let Err(err) = res {
                         debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
                         // notify the manager
-                        return this.close_on_error(err, cx)
+                        return this.close_on_error(err, cx);
                     }
                 } else {
                     // no more messages to send over the wire
-                    break
+                    break;
                 }
             }
 
@@ -679,7 +679,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 if budget == 0 {
                     // make sure we're woken up again
                     cx.waker().wake_by_ref();
-                    break 'main
+                    break 'main;
                 }
 
                 // try to resend the pending message that we could not send because the channel was
@@ -693,7 +693,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         Poll::Ready(Err(_)) => return Poll::Ready(()),
                         Poll::Pending => {
                             this.pending_message_to_session = Some(msg);
-                            break 'receive
+                            break 'receive;
                         }
                     };
                 }
@@ -705,12 +705,12 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     //
                     // Note: we don't need to register the waker here because we polled the requests
                     // above
-                    break 'receive
+                    break 'receive;
                 }
 
                 // we also need to check if we have multiple responses queued up
-                if this.queued_outgoing.messages.len() > MAX_QUEUED_OUTGOING_RESPONSES &&
-                    this.queued_response_count() > MAX_QUEUED_OUTGOING_RESPONSES
+                if this.queued_outgoing.messages.len() > MAX_QUEUED_OUTGOING_RESPONSES
+                    && this.queued_response_count() > MAX_QUEUED_OUTGOING_RESPONSES
                 {
                     // if we've queued up more responses than allowed, we don't poll for new
                     // messages and break the receive loop early
@@ -718,17 +718,17 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     // Note: we don't need to register the waker here because we still have
                     // queued messages and the sink impl registered the waker because we've
                     // already advanced it to `Pending` earlier
-                    break 'receive
+                    break 'receive;
                 }
 
                 match this.conn.poll_next_unpin(cx) {
                     Poll::Pending => break,
                     Poll::Ready(None) => {
                         if this.is_disconnecting() {
-                            break
+                            break;
                         }
                         debug!(target: "net::session", remote_peer_id=?this.remote_peer_id, "eth stream completed");
-                        return this.emit_disconnect(cx)
+                        return this.emit_disconnect(cx);
                     }
                     Poll::Ready(Some(res)) => {
                         match res {
@@ -742,7 +742,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     }
                                     OnIncomingMessageOutcome::BadMessage { error, message } => {
                                         debug!(target: "net::session", %error, msg=?message, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
-                                        return this.close_on_error(error, cx)
+                                        return this.close_on_error(error, cx);
                                     }
                                     OnIncomingMessageOutcome::NoCapacity(msg) => {
                                         // failed to send due to lack of capacity
@@ -752,7 +752,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                             }
                             Err(err) => {
                                 debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to receive message");
-                                return this.close_on_error(err, cx)
+                                return this.close_on_error(err, cx);
                             }
                         }
                     }
@@ -760,7 +760,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             }
 
             if !progress {
-                break 'main
+                break 'main;
             }
         }
 
@@ -786,8 +786,8 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
 
         while this.internal_request_timeout_interval.poll_tick(cx).is_ready() {
             // check for timed out requests
-            if this.check_timed_out_requests(Instant::now()) &&
-                let Poll::Ready(Ok(_)) = this.to_session_manager.poll_reserve(cx)
+            if this.check_timed_out_requests(Instant::now())
+                && let Poll::Ready(Ok(_)) = this.to_session_manager.poll_reserve(cx)
             {
                 let msg = ActiveSessionMessage::ProtocolBreach { peer_id: this.remote_peer_id };
                 this.pending_message_to_session = Some(msg);
@@ -1335,7 +1335,7 @@ mod tests {
                 .try_send(ActiveSessionMessage::ProtocolBreach { peer_id: PeerId::random() })
                 .is_err()
             {
-                break
+                break;
             }
             num_fill_messages += 1;
         }

--- a/crates/net/network/src/session/counter.rs
+++ b/crates/net/network/src/session/counter.rs
@@ -80,10 +80,10 @@ impl SessionCounter {
     }
 
     const fn ensure(current: u32, limit: Option<u32>) -> Result<(), ExceedsSessionLimit> {
-        if let Some(limit) = limit &&
-            current >= limit
+        if let Some(limit) = limit
+            && current >= limit
         {
-            return Err(ExceedsSessionLimit(limit))
+            return Err(ExceedsSessionLimit(limit));
         }
         Ok(())
     }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -416,7 +416,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
     ) {
         if !self.disconnections_counter.has_capacity() {
             // drop the connection if we don't have capacity for gracefully disconnecting
-            return
+            return;
         }
 
         let guard = self.disconnections_counter.clone();
@@ -524,7 +524,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                         peer_id,
                         remote_addr,
                         direction,
-                    })
+                    });
                 }
 
                 let (commands_to_session, commands_rx) = mpsc::channel(self.session_command_buffer);
@@ -941,7 +941,7 @@ async fn start_pending_outbound_session<N: NetworkPrimitives>(
                     error,
                 })
                 .await;
-            return
+            return;
         }
     };
     authenticate(
@@ -989,7 +989,7 @@ async fn authenticate<N: NetworkPrimitives>(
                     direction,
                 })
                 .await;
-            return
+            return;
         }
     };
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -210,7 +210,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         for (peer_id, peer) in peers {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             // Queue a `NewBlock` message for the peer
@@ -230,7 +230,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
             }
 
             if count >= num_propagate {
-                break
+                break;
             }
         }
     }
@@ -243,7 +243,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         for (peer_id, peer) in &mut self.active_peers {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             if self.state_fetcher.update_peer_block(peer_id, msg.hash, number) {
@@ -337,7 +337,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 let peer_id = record.id;
                 let tcp_addr = record.tcp_addr();
                 if tcp_addr.port() == 0 {
-                    return
+                    return;
                 }
                 let udp_addr = record.udp_addr();
                 let addr = PeerAddr::new(tcp_addr, Some(udp_addr));
@@ -360,8 +360,8 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 self.state_fetcher.on_pending_disconnect(&peer_id);
                 self.queued_messages.push_back(StateAction::Disconnect { peer_id, reason });
             }
-            PeerAction::DisconnectBannedIncoming { peer_id } |
-            PeerAction::DisconnectUntrustedIncoming { peer_id } => {
+            PeerAction::DisconnectBannedIncoming { peer_id }
+            | PeerAction::DisconnectUntrustedIncoming { peer_id } => {
                 self.state_fetcher.on_pending_disconnect(&peer_id);
                 self.queued_messages.push_back(StateAction::Disconnect { peer_id, reason: None });
             }
@@ -487,7 +487,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         loop {
             // drain buffered messages
             if let Some(message) = self.queued_messages.pop_front() {
-                return Poll::Ready(message)
+                return Poll::Ready(message);
             }
 
             while let Poll::Ready(discovery) = self.discovery.poll(cx) {
@@ -557,7 +557,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
             // We need to poll again in case we have received any responses because they may have
             // triggered follow-up requests.
             if self.queued_messages.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/net/network/src/swarm.rs
+++ b/crates/net/network/src/swarm.rs
@@ -197,7 +197,7 @@ impl<N: NetworkPrimitives> Swarm<N> {
             ListenerEvent::Incoming { stream, remote_addr } => {
                 // Reject incoming connection if node is shutting down.
                 if self.is_shutting_down() {
-                    return None
+                    return None;
                 }
                 // ensure we can handle an incoming connection from this address
                 if let Err(err) = self.peers_mut().on_incoming_pending_session(remote_addr.ip()) {
@@ -213,13 +213,13 @@ impl<N: NetworkPrimitives> Swarm<N> {
                             );
                         }
                     }
-                    return None
+                    return None;
                 }
 
                 match self.sessions.on_incoming(stream, remote_addr) {
                     Ok(session_id) => {
                         trace!(target: "net", ?remote_addr, "Incoming connection");
-                        return Some(SwarmEvent::IncomingTcpConnection { session_id, remote_addr })
+                        return Some(SwarmEvent::IncomingTcpConnection { session_id, remote_addr });
                     }
                     Err(err) => {
                         trace!(target: "net", %err, "Incoming connection rejected, capacity already reached.");
@@ -238,7 +238,7 @@ impl<N: NetworkPrimitives> Swarm<N> {
         match event {
             StateAction::Connect { remote_addr, peer_id } => {
                 self.dial_outbound(remote_addr, peer_id);
-                return Some(SwarmEvent::OutgoingTcpConnection { remote_addr, peer_id })
+                return Some(SwarmEvent::OutgoingTcpConnection { remote_addr, peer_id });
             }
             StateAction::Disconnect { peer_id, reason } => {
                 self.sessions.disconnect(peer_id, reason);
@@ -255,7 +255,7 @@ impl<N: NetworkPrimitives> Swarm<N> {
             StateAction::PeerRemoved(peer_id) => return Some(SwarmEvent::PeerRemoved(peer_id)),
             StateAction::DiscoveredNode { peer_id, addr, fork_id } => {
                 if self.is_shutting_down() {
-                    return None
+                    return None;
                 }
 
                 // When `enforce_enr_fork_id` is enabled, peers discovered without a confirmed
@@ -321,7 +321,7 @@ impl<N: NetworkPrimitives> Stream for Swarm<N> {
         loop {
             while let Poll::Ready(action) = this.state.poll(cx) {
                 if let Some(event) = this.on_state_action(action) {
-                    return Poll::Ready(Some(event))
+                    return Poll::Ready(Some(event));
                 }
             }
 
@@ -330,9 +330,9 @@ impl<N: NetworkPrimitives> Stream for Swarm<N> {
                 Poll::Pending => {}
                 Poll::Ready(event) => {
                     if let Some(event) = this.on_session_event(event) {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
-                    continue
+                    continue;
                 }
             }
 
@@ -341,13 +341,13 @@ impl<N: NetworkPrimitives> Stream for Swarm<N> {
                 Poll::Pending => {}
                 Poll::Ready(event) => {
                     if let Some(event) = this.on_connection(event) {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
-                    continue
+                    continue;
                 }
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }

--- a/crates/net/network/src/test_utils/init.rs
+++ b/crates/net/network/src/test_utils/init.rs
@@ -42,7 +42,7 @@ pub fn unused_tcp_and_udp_port() -> u16 {
     loop {
         let port = unused_port();
         if std::net::UdpSocket::bind(format!("127.0.0.1:{port}")).is_ok() {
-            return port
+            return port;
         }
     }
 }

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -370,7 +370,7 @@ impl<C, Pool> TestnetHandle<C, Pool> {
     /// Returns once all sessions are established.
     pub async fn connect_peers(&self) {
         if self.peers.len() < 2 {
-            return
+            return;
         }
 
         // add an event stream for _each_ peer
@@ -748,7 +748,7 @@ impl NetworkEventStream {
     pub async fn next_session_closed(&mut self) -> Option<(PeerId, Option<DisconnectReason>)> {
         while let Some(ev) = self.inner.next().await {
             if let NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, reason }) = ev {
-                return Some((peer_id, reason))
+                return Some((peer_id, reason));
             }
         }
         None
@@ -758,8 +758,8 @@ impl NetworkEventStream {
     pub async fn next_session_established(&mut self) -> Option<PeerId> {
         while let Some(ev) = self.inner.next().await {
             match ev {
-                NetworkEvent::ActivePeerSession { info, .. } |
-                NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
+                NetworkEvent::ActivePeerSession { info, .. }
+                | NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
                     return Some(info.peer_id)
                 }
                 _ => {}

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -137,8 +137,8 @@ pub mod tx_fetcher {
     /// [`DEFAULT_MAX_COUNT_INFLIGHT_REQUESTS_ON_FETCH_PENDING_HASHES`], which is 25600 hashes and
     /// 65 requests, so it is 25665 hashes.
     pub const DEFAULT_MAX_CAPACITY_CACHE_INFLIGHT_AND_PENDING_FETCH: u32 =
-        DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH +
-            DEFAULT_MAX_COUNT_INFLIGHT_REQUESTS_ON_FETCH_PENDING_HASHES as u32;
+        DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH
+            + DEFAULT_MAX_COUNT_INFLIGHT_REQUESTS_ON_FETCH_PENDING_HASHES as u32;
 
     /// Default maximum number of hashes pending fetch to tolerate at any time.
     ///
@@ -189,8 +189,8 @@ pub mod tx_fetcher {
     /// which defaults to 128 KiB, so 64 KiB.
     pub const DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES:
         usize =
-        DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ /
-            2;
+        DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ
+            / 2;
 
     /// Default max inflight request when fetching pending hashes.
     ///
@@ -239,8 +239,8 @@ pub mod tx_fetcher {
     /// divided by [`SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE`], which
     /// is spec'd at 4096 hashes, so 521 bytes.
     pub const AVERAGE_BYTE_SIZE_TX_ENCODED: usize =
-        SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE /
-            SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
+        SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE
+            / SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 
     /// Median observed size in bytes of a small encoded legacy transaction.
     ///

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -162,7 +162,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let Some(inflight_count) = self.active_peers.get(peer_id) {
                 *inflight_count = inflight_count.saturating_sub(1);
                 if *inflight_count == 0 {
-                    return true
+                    return true;
                 }
             }
             false
@@ -178,7 +178,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     pub fn is_idle(&self, peer_id: &PeerId) -> bool {
         let Some(inflight_count) = self.active_peers.peek(peer_id) else { return true };
         if *inflight_count < self.info.max_inflight_requests_per_peer {
-            return true
+            return true;
         }
         false
     }
@@ -210,13 +210,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             if idle_peer.is_some() {
                 hashes_to_request.insert(hash);
-                break idle_peer.copied()
+                break idle_peer.copied();
             }
 
             if let Some(ref mut bud) = budget {
                 *bud = bud.saturating_sub(1);
                 if *bud == 0 {
-                    return None
+                    return None;
                 }
             }
         };
@@ -239,7 +239,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes_from_announcement: ValidAnnouncementData,
     ) -> RequestTxHashes {
         if hashes_from_announcement.msg_version().is_eth68() {
-            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement)
+            return self.pack_request_eth68(hashes_to_request, hashes_from_announcement);
         }
         self.pack_request_eth66(hashes_to_request, hashes_from_announcement)
     }
@@ -269,7 +269,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             // tx is really big, pack request with single tx
             if size >= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request {
-                return hashes_from_announcement_iter.collect()
+                return hashes_from_announcement_iter.collect();
             }
             acc_size_response = size;
         }
@@ -285,8 +285,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             let next_acc_size = acc_size_response + size;
 
-            if next_acc_size <=
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+            if next_acc_size
+                <= self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
             {
                 // only update accumulated size of tx response if tx will fit in without exceeding
                 // soft limit
@@ -297,11 +297,11 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             }
 
             let free_space =
-                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request -
-                    acc_size_response;
+                self.info.soft_limit_byte_size_pooled_transactions_response_on_pack_request
+                    - acc_size_response;
 
             if free_space < MEDIAN_BYTE_SIZE_SMALL_LEGACY_TX_ENCODED {
-                break
+                break;
             }
         }
 
@@ -348,7 +348,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes.retain(|hash| {
             if let Some(entry) = self.hashes_fetch_inflight_and_pending_fetch.get(hash) {
                 entry.fallback_peers_mut().remove(peer_failed_to_serve);
-                return true
+                return true;
             }
             // tx has been seen over broadcast in the time it took for the request to resolve
             false
@@ -375,13 +375,13 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         for hash in hashes {
             // hash could have been evicted from bounded lru map
             if self.hashes_fetch_inflight_and_pending_fetch.peek(&hash).is_none() {
-                continue
+                continue;
             }
 
             let Some(TxFetchMetadata { retries, fallback_peers, .. }) =
                 self.hashes_fetch_inflight_and_pending_fetch.get(&hash)
             else {
-                continue
+                continue;
             };
 
             if let Some(peer_id) = fallback_peer {
@@ -397,7 +397,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
                     self.hashes_fetch_inflight_and_pending_fetch.remove(&hash);
                     self.hashes_pending_fetch.remove(&hash);
-                    continue
+                    continue;
                 }
                 *retries += 1;
             }
@@ -434,7 +434,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     budget_find_idle_fallback_peer,
                 ) else {
                     // no peers are idle or budget is depleted
-                    return false
+                    return false;
                 };
 
                 peer_id
@@ -487,7 +487,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             );
 
             self.buffer_hashes(failed_to_request_hashes, Some(peer_id));
-            return false
+            return false;
         }
 
         true
@@ -595,7 +595,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 max_inflight_transaction_requests=self.info.max_inflight_requests,
                 "limit for concurrent `GetPooledTransactions` requests reached, dropping request for hashes to peer"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         }
 
         let Some(inflight_count) = self.active_peers.get_or_insert(peer_id, || 0) else {
@@ -605,7 +605,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 conn_eth_version=%conn_eth_version,
                 "failed to cache active peer in schnellru::LruMap, dropping request to peer"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         };
 
         if *inflight_count >= self.info.max_inflight_requests_per_peer {
@@ -616,7 +616,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                 max_concurrent_tx_reqs_per_peer=self.info.max_inflight_requests_per_peer,
                 "limit for concurrent `GetPooledTransactions` requests per peer reached"
             );
-            return Some(new_announced_hashes)
+            return Some(new_announced_hashes);
         }
 
         #[cfg(debug_assertions)]
@@ -649,7 +649,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     self.metrics.egress_peer_channel_full.increment(1);
                     Some(new_announced_hashes)
                 }
-            }
+            };
         }
 
         *inflight_count += 1;
@@ -693,10 +693,10 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             .unwrap_or(AVERAGE_BYTE_SIZE_TX_ENCODED);
 
         // if request full enough already, we're satisfied, send request for single tx
-        if acc_size_response >=
-            DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
+        if acc_size_response
+            >= DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE_ON_FETCH_PENDING_HASHES
         {
-            return
+            return;
         }
 
         // try to fill request by checking if any other hashes pending fetch (in lru order) are
@@ -704,7 +704,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         for hash in self.hashes_pending_fetch.iter() {
             // 1. Check if a hash pending fetch is seen by peer.
             if !seen_hashes.contains(hash) {
-                continue
+                continue;
             };
 
             // 2. Optimistically include the hash in the request.
@@ -733,7 +733,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             if let Some(ref mut bud) = budget_fill_request {
                 *bud -= 1;
                 if *bud == 0 {
-                    break
+                    break;
                 }
             }
         }
@@ -769,8 +769,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests /
-                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
+            info.max_inflight_requests
+                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_IDLE_PEER,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_IDLE_PEER,
@@ -808,8 +808,8 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         let info = &self.info;
 
         let tx_fetcher_has_capacity = self.has_capacity(
-            info.max_inflight_requests /
-                DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
+            info.max_inflight_requests
+                / DEFAULT_DIVISOR_MAX_COUNT_INFLIGHT_REQUESTS_ON_FIND_INTERSECTION,
         );
         let tx_pool_has_capacity = has_capacity_wrt_pending_pool_imports(
             DEFAULT_DIVISOR_MAX_COUNT_PENDING_POOL_IMPORTS_ON_FIND_INTERSECTION,
@@ -860,7 +860,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                         "received empty `PooledTransactions` response from peer, peer failed to serve hashes it announced"
                     );
 
-                    return FetchEvent::EmptyResponse { peer_id }
+                    return FetchEvent::EmptyResponse { peer_id };
                 }
 
                 //
@@ -891,7 +891,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
                 // peer has only sent hashes that we didn't request
                 if verified_payload.is_empty() {
-                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse }
+                    return FetchEvent::FetchError { peer_id, error: RequestError::BadResponse };
                 }
 
                 //
@@ -927,7 +927,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
                     if valid_payload.contains_key(requested_hash) {
                         // hash is now known, stop tracking
                         fetched.push(*requested_hash);
-                        return false
+                        return false;
                     }
                     true
                 });
@@ -973,11 +973,11 @@ impl<N: NetworkPrimitives> Stream for TransactionFetcher<N> {
         // `FuturesUnordered` doesn't close when `None` is returned. so just return pending.
         // <https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=815be2b6c8003303757c3ced135f363e>
         if self.inflight_requests.is_empty() {
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         if let Some(resp) = ready!(self.inflight_requests.poll_next_unpin(cx)) {
-            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)))
+            return Poll::Ready(Some(self.on_resolved_get_pooled_transactions_request_fut(resp)));
         }
 
         Poll::Pending
@@ -1184,7 +1184,7 @@ impl<T: SignedTransaction> VerifyPooledTransactionsResponse for UnverifiedPooled
                     tx_hashes_not_requested_count += 1;
                 }
 
-                return false
+                return false;
             }
             true
         });

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -133,7 +133,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
     pub fn propagate_hashes_to(&self, hash: impl IntoIterator<Item = TxHash>, peer: PeerId) {
         let hashes = hash.into_iter().collect::<Vec<_>>();
         if hashes.is_empty() {
-            return
+            return;
         }
         self.send(TransactionsCommand::PropagateHashesTo(hashes, peer))
     }
@@ -150,7 +150,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
     /// Do nothing if transactions are empty.
     pub fn propagate_transactions_to(&self, transactions: Vec<TxHash>, peer: PeerId) {
         if transactions.is_empty() {
-            return
+            return;
         }
         self.send(TransactionsCommand::PropagateTransactionsTo(transactions, peer))
     }
@@ -161,7 +161,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
     /// full.
     pub fn propagate_transactions(&self, transactions: Vec<TxHash>) {
         if transactions.is_empty() {
-            return
+            return;
         }
         self.send(TransactionsCommand::PropagateTransactions(transactions))
     }
@@ -177,7 +177,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
         let transactions =
             transactions.into_iter().map(PropagateTransaction::new).collect::<Vec<_>>();
         if transactions.is_empty() {
-            return
+            return;
         }
         self.send(TransactionsCommand::BroadcastTransactions(transactions))
     }
@@ -188,7 +188,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
         peers: Vec<PeerId>,
     ) -> Result<HashMap<PeerId, HashSet<TxHash>>, RecvError> {
         if peers.is_empty() {
-            return Ok(Default::default())
+            return Ok(Default::default());
         }
         let (tx, rx) = oneshot::channel();
         self.send(TransactionsCommand::GetTransactionHashes { peers, tx });
@@ -428,8 +428,8 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     /// Returns `true` if [`TransactionsManager`] has capacity to request pending hashes. Returns
     /// `false` if [`TransactionsManager`] is operating close to full capacity.
     fn has_capacity_for_fetching_pending_hashes(&self) -> bool {
-        self.has_capacity_for_pending_pool_imports() &&
-            self.transaction_fetcher.has_capacity_for_fetching_pending_hashes()
+        self.has_capacity_for_pending_pool_imports()
+            && self.transaction_fetcher.has_capacity_for_fetching_pending_hashes()
     }
 
     /// Returns `true` if [`TransactionsManager`] has capacity for more pending pool imports.
@@ -492,7 +492,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
 
         // if we're _currently_ syncing, we ignore a bad transaction
         if !err.is_bad_transaction() || self.network.is_syncing() {
-            return
+            return;
         }
         // otherwise we penalize the peer that sent the bad transaction, with the assumption that
         // the peer should have known that this transaction is bad (e.g. violating consensus rules)
@@ -525,7 +525,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             RequestError::Timeout => ReputationChangeKind::Timeout,
             RequestError::ChannelClosed | RequestError::ConnectionDropped => {
                 // peer is already disconnected
-                return
+                return;
             }
             RequestError::BadResponse => return self.report_peer_bad_transactions(peer_id),
         };
@@ -582,10 +582,10 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     ) {
         // If the node is initially syncing, ignore transactions
         if self.network.is_initially_syncing() {
-            return
+            return;
         }
         if self.network.tx_gossip_disabled() {
-            return
+            return;
         }
 
         // get handle to peer's session, if the session is still active
@@ -596,7 +596,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
                 "discarding announcement from inactive peer"
             );
 
-            return
+            return;
         };
         let client = peer.client_version.clone();
 
@@ -674,9 +674,9 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
                 }
             };
 
-            if is_eth68_message &&
-                let Some((actual_ty_byte, _)) = *metadata_ref_mut &&
-                let Ok(parsed_tx_type) = TxType::try_from(actual_ty_byte)
+            if is_eth68_message
+                && let Some((actual_ty_byte, _)) = *metadata_ref_mut
+                && let Ok(parsed_tx_type) = TxType::try_from(actual_ty_byte)
             {
                 tx_types_counter.increase_by_tx_type(parsed_tx_type);
             }
@@ -725,7 +725,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
 
         if partially_valid_msg.is_empty() {
             // nothing to request
-            return
+            return;
         }
 
         let mut valid_announcement_data =
@@ -733,7 +733,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
 
         if valid_announcement_data.is_empty() {
             // no valid announcement data
-            return
+            return;
         }
 
         // 5. filter out already seen unknown hashes
@@ -752,7 +752,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
 
         if valid_announcement_data.is_empty() {
             // nothing to request
-            return
+            return;
         }
 
         trace!(target: "net::tx::propagation",
@@ -781,7 +781,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
 
             self.transaction_fetcher.buffer_hashes(hashes, Some(peer_id));
 
-            return
+            return;
         }
 
         let mut hashes_to_request =
@@ -854,7 +854,7 @@ where
         // During initial sync we skip importing tx announcements from peers in
         // `on_new_pooled_transaction_hashes`, so transactions reaching this path are local.
         if self.network.tx_gossip_disabled() {
-            return
+            return;
         }
 
         trace!(target: "net::tx", num_hashes=?hashes.len(), "Start propagating transactions");
@@ -896,7 +896,7 @@ where
 
         if full_transactions.is_empty() {
             // nothing to propagate
-            return None
+            return None;
         }
 
         let PropagateTransactions { pooled, full } = full_transactions.build();
@@ -947,7 +947,7 @@ where
         let propagated = {
             let Some(peer) = self.peers.get_mut(&peer_id) else {
                 // no such peer
-                return
+                return;
             };
 
             let to_propagate =
@@ -973,7 +973,7 @@ where
 
             if new_pooled_hashes.is_empty() {
                 // nothing to propagate
-                return
+                return;
             }
 
             if let Some(peer) = self.peers.get_mut(&peer_id) {
@@ -1011,7 +1011,7 @@ where
     ) -> PropagatedTransactions {
         let mut propagated = PropagatedTransactions::default();
         if self.network.tx_gossip_disabled() {
-            return propagated
+            return propagated;
         }
 
         // send full transactions to a set of the connected peers based on the configured mode
@@ -1021,7 +1021,7 @@ where
         for (peer_idx, (peer_id, peer)) in self.peers.iter_mut().enumerate() {
             if !self.policies.propagation_policy().can_propagate(peer) {
                 // skip peers we should not propagate to
-                continue
+                continue;
             }
             // determine whether to send full tx objects or hashes.
             let mut builder = if peer_idx > max_num_full {
@@ -1047,7 +1047,7 @@ where
 
             if builder.is_empty() {
                 trace!(target: "net::tx", ?peer_id, "Nothing to propagate to peer; has seen all transactions");
-                continue
+                continue;
             }
 
             let PropagateTransactions { pooled, full } = builder.build();
@@ -1099,7 +1099,7 @@ where
     fn propagate_all(&mut self, hashes: Vec<TxHash>) {
         if self.peers.is_empty() {
             // nothing to propagate
-            return
+            return;
         }
         let propagated = self.propagate_transactions(
             self.pool.get_all(hashes).into_iter().map(PropagateTransaction::pool_tx).collect(),
@@ -1120,7 +1120,7 @@ where
         // fast exit if gossip is disabled
         if self.network.tx_gossip_disabled() {
             let _ = response.send(Ok(PooledTransactions::default()));
-            return
+            return;
         }
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             let transactions = self.pool.get_pooled_transaction_elements(
@@ -1217,7 +1217,7 @@ where
         // transactions in the pool.
         if self.network.is_initially_syncing() || self.network.tx_gossip_disabled() {
             trace!(target: "net::tx", ?peer_id, "Skipping transaction broadcast: node syncing or gossip disabled");
-            return
+            return;
         }
 
         // Get transactions to broadcast
@@ -1336,15 +1336,15 @@ where
     ) {
         // If the node is pipeline syncing, ignore transactions
         if self.network.is_initially_syncing() {
-            return
+            return;
         }
         if self.network.tx_gossip_disabled() {
-            return
+            return;
         }
 
         // Early return if we don't have capacity for any imports
         if !self.has_capacity_for_pending_pool_imports() {
-            return
+            return;
         }
 
         let mut transactions = transactions.0;
@@ -1390,7 +1390,7 @@ where
         transactions.retain(|tx| {
             if let Entry::Occupied(mut entry) = self.transactions_by_peers.entry(*tx.tx_hash()) {
                 entry.get_mut().insert(peer_id);
-                return false
+                return false;
             }
             if self.bad_imports.contains(tx.tx_hash()) {
                 trace!(target: "net::tx",
@@ -1574,9 +1574,8 @@ where
                     // try once more, because mostlikely the channel is now empty and the waker is
                     // registered if this is pending, if we filled additional hashes, we poll again
                     // on the next iteration
-                    let limit =
-                        SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE -
-                            new_txs.len();
+                    let limit = SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE
+                        - new_txs.len();
                     this.pending_transactions.poll_recv_many(cx, &mut new_txs, limit).is_ready()
                 }
             }
@@ -1657,8 +1656,8 @@ where
         // Sends at most one request.
         duration_metered_exec!(
             {
-                if this.has_capacity_for_fetching_pending_hashes() &&
-                    this.on_fetch_hashes_pending_fetch()
+                if this.has_capacity_for_fetching_pending_hashes()
+                    && this.on_fetch_hashes_pending_fetch()
                 {
                     maybe_more_tx_fetch_events = true;
                 }
@@ -1679,16 +1678,16 @@ where
         this.transaction_fetcher.update_metrics();
 
         // all channels are fully drained and import futures pending
-        if maybe_more_network_events ||
-            maybe_more_commands ||
-            maybe_more_tx_events ||
-            maybe_more_tx_fetch_events ||
-            maybe_more_pool_imports ||
-            maybe_more_pending_txns
+        if maybe_more_network_events
+            || maybe_more_commands
+            || maybe_more_tx_events
+            || maybe_more_tx_fetch_events
+            || maybe_more_pool_imports
+            || maybe_more_pending_txns
         {
             // make sure we're woken up again
             cx.waker().wake_by_ref();
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         this.update_poll_metrics(start, poll_durations);
@@ -1878,16 +1877,16 @@ impl<T: SignedTransaction> FullTransactionsBuilder<T> {
         // From: <https://eips.ethereum.org/EIPS/eip-4844#networking>
         if !transaction.transaction.is_broadcastable_in_full() {
             self.pooled.push(transaction);
-            return
+            return;
         }
 
         let new_size = self.total_size + transaction.size;
-        if new_size > DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE &&
-            self.total_size > 0
+        if new_size > DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
+            && self.total_size > 0
         {
             // transaction does not fit into the message
             self.pooled.push(transaction);
-            return
+            return;
         }
 
         self.total_size = new_size;
@@ -2303,8 +2302,8 @@ mod tests {
         let mut established = listener0.take(2);
         while let Some(ev) = established.next().await {
             match ev {
-                NetworkEvent::ActivePeerSession { .. } |
-                NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
+                NetworkEvent::ActivePeerSession { .. }
+                | NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
                     // to insert a new peer in transactions peerset
                     transactions.on_network_event(ev);
                 }
@@ -2472,8 +2471,8 @@ mod tests {
         let mut established = listener0.take(2);
         while let Some(ev) = established.next().await {
             match ev {
-                NetworkEvent::ActivePeerSession { .. } |
-                NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
+                NetworkEvent::ActivePeerSession { .. }
+                | NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
                     // to insert a new peer in transactions peerset
                     transactions.on_network_event(ev);
                 }
@@ -2550,8 +2549,8 @@ mod tests {
         let mut established = listener0.take(2);
         while let Some(ev) = established.next().await {
             match ev {
-                NetworkEvent::ActivePeerSession { .. } |
-                NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
+                NetworkEvent::ActivePeerSession { .. }
+                | NetworkEvent::Peer(PeerEvent::SessionEstablished(_)) => {
                     transactions.on_network_event(ev);
                 }
                 NetworkEvent::Peer(PeerEvent::PeerAdded(_peer_id)) => {}

--- a/crates/net/network/tests/it/connect.rs
+++ b/crates/net/network/tests/it/connect.rs
@@ -64,8 +64,8 @@ async fn test_establish_connections() {
                 NetworkEvent::Peer(PeerEvent::SessionClosed { .. } | PeerEvent::PeerRemoved(_)) => {
                     panic!("unexpected event")
                 }
-                NetworkEvent::ActivePeerSession { info, .. } |
-                NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
+                NetworkEvent::ActivePeerSession { info, .. }
+                | NetworkEvent::Peer(PeerEvent::SessionEstablished(info)) => {
                     let SessionInfo { peer_id, .. } = info;
                     assert!(expected_connections.remove(&peer_id));
                 }

--- a/crates/net/network/tests/it/multiplex.rs
+++ b/crates/net/network/tests/it/multiplex.rs
@@ -104,8 +104,8 @@ mod proto {
             buf.put_u8(self.message_type as u8);
             match &self.message {
                 PingPongProtoMessageKind::Ping | PingPongProtoMessageKind::Pong => {}
-                PingPongProtoMessageKind::PingMessage(msg) |
-                PingPongProtoMessageKind::PongMessage(msg) => {
+                PingPongProtoMessageKind::PingMessage(msg)
+                | PingPongProtoMessageKind::PongMessage(msg) => {
                     buf.put(msg.as_bytes());
                 }
             }
@@ -115,7 +115,7 @@ mod proto {
         /// Decodes a `TestProtoMessage` from the given message buffer.
         pub fn decode_message(buf: &mut &[u8]) -> Option<Self> {
             if buf.is_empty() {
-                return None
+                return None;
             }
             let id = buf[0];
             buf.advance(1);
@@ -239,7 +239,7 @@ impl Stream for PingPongProtoConnection {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         if let Some(initial_ping) = this.initial_ping.take() {
-            return Poll::Ready(Some(initial_ping.encoded()))
+            return Poll::Ready(Some(initial_ping.encoded()));
         }
 
         loop {
@@ -249,12 +249,12 @@ impl Stream for PingPongProtoConnection {
                         this.pending_pong = Some(response);
                         Poll::Ready(Some(PingPongProtoMessage::ping_message(msg).encoded()))
                     }
-                }
+                };
             }
             let Some(msg) = ready!(this.conn.poll_next_unpin(cx)) else { return Poll::Ready(None) };
 
             let Some(msg) = PingPongProtoMessage::decode_message(&mut &msg[..]) else {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             };
 
             match msg.message {
@@ -269,11 +269,11 @@ impl Stream for PingPongProtoConnection {
                     if let Some(sender) = this.pending_pong.take() {
                         sender.send(msg).ok();
                     }
-                    continue
+                    continue;
                 }
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -284,8 +284,8 @@ async fn test_sending_invalid_transactions() {
             NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, .. }) => {
                 assert_eq!(peer_id, *peer0.peer_id());
             }
-            NetworkEvent::ActivePeerSession { .. } |
-            NetworkEvent::Peer(PeerEvent::SessionEstablished { .. }) => {
+            NetworkEvent::ActivePeerSession { .. }
+            | NetworkEvent::Peer(PeerEvent::SessionEstablished { .. }) => {
                 panic!("unexpected SessionEstablished event")
             }
             NetworkEvent::Peer(PeerEvent::PeerAdded(_)) => {

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -34,7 +34,7 @@ impl<H: BlockHeader> EthResponseValidator for RequestResult<Vec<H>> {
                 let request_length = headers.len() as u64;
 
                 if request_length <= 1 && request.limit != request_length {
-                    return true
+                    return true;
                 }
 
                 match request.start {
@@ -62,10 +62,10 @@ impl<H: BlockHeader> EthResponseValidator for RequestResult<Vec<H>> {
     fn reputation_change_err(&self) -> Option<ReputationChangeKind> {
         if let Err(err) = self {
             match err {
-                RequestError::ChannelClosed |
-                RequestError::ConnectionDropped |
-                RequestError::UnsupportedCapability |
-                RequestError::BadResponse => None,
+                RequestError::ChannelClosed
+                | RequestError::ConnectionDropped
+                | RequestError::UnsupportedCapability
+                | RequestError::BadResponse => None,
                 RequestError::Timeout => Some(ReputationChangeKind::Timeout),
             }
         } else {

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -143,7 +143,7 @@ where
     /// Returns the [`SealedBlock`] if the request is complete and valid.
     fn take_block(&mut self) -> Option<SealedBlock<Client::Block>> {
         if self.header.is_none() || self.body.is_none() {
-            return None
+            return None;
         }
 
         let header = self.header.take().unwrap();
@@ -158,7 +158,7 @@ where
                     self.client.report_bad_message(resp.peer_id());
                     self.header = Some(header);
                     self.request.body = Some(self.client.get_block_body(self.hash));
-                    return None
+                    return None;
                 }
                 Some(SealedBlock::from_sealed_parts(header, resp.into_data()))
             }
@@ -170,10 +170,10 @@ where
             if let Err(err) = self.consensus.validate_body_against_header(resp.data(), header) {
                 debug!(target: "downloaders", %err, hash=?header.hash(), "Received wrong body");
                 self.client.report_bad_message(resp.peer_id());
-                return
+                return;
             }
             self.body = Some(BodyResponse::Validated(resp.into_data()));
-            return
+            return;
         }
         self.body = Some(BodyResponse::PendingValidation(resp));
     }
@@ -237,7 +237,7 @@ where
             }
 
             if let Some(res) = this.take_block() {
-                return Poll::Ready(res)
+                return Poll::Ready(res);
             }
 
             // ensure we still have enough budget for another iteration
@@ -245,7 +245,7 @@ where
             if budget == 0 {
                 // make sure we're woken up again
                 cx.waker().wake_by_ref();
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -277,18 +277,18 @@ where
     Client: BlockClient,
 {
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<ResponseResult<Client::Header, Client::Body>> {
-        if let Some(fut) = Pin::new(&mut self.header).as_pin_mut() &&
-            let Poll::Ready(res) = fut.poll(cx)
+        if let Some(fut) = Pin::new(&mut self.header).as_pin_mut()
+            && let Poll::Ready(res) = fut.poll(cx)
         {
             self.header = None;
-            return Poll::Ready(ResponseResult::Header(res))
+            return Poll::Ready(ResponseResult::Header(res));
         }
 
-        if let Some(fut) = Pin::new(&mut self.body).as_pin_mut() &&
-            let Poll::Ready(res) = fut.poll(cx)
+        if let Some(fut) = Pin::new(&mut self.body).as_pin_mut()
+            && let Poll::Ready(res) = fut.poll(cx)
         {
             self.body = None;
-            return Poll::Ready(ResponseResult::Body(res))
+            return Poll::Ready(ResponseResult::Body(res));
         }
 
         Poll::Pending
@@ -392,7 +392,7 @@ where
     fn take_blocks(&mut self) -> Option<Vec<SealedBlock<Client::Block>>> {
         if !self.is_bodies_complete() {
             // not done with bodies yet
-            return None
+            return None;
         }
 
         let headers = self.headers.take()?;
@@ -415,7 +415,7 @@ where
                             // get body that doesn't match, put back into vecdeque, and retry it
                             self.pending_headers.push_back(header.clone());
                             needs_retry = true;
-                            continue
+                            continue;
                         }
 
                         resp.into_data()
@@ -441,7 +441,7 @@ where
             // create response for failing bodies
             let hashes = self.remaining_bodies_hashes();
             self.request.bodies = Some(self.client.get_block_bodies(hashes));
-            return None
+            return None;
         }
 
         Some(valid_responses)
@@ -593,7 +593,7 @@ where
             }
 
             if let Some(res) = this.take_blocks() {
-                return Poll::Ready(res)
+                return Poll::Ready(res);
             }
         }
     }
@@ -618,18 +618,18 @@ where
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<RangeResponseResult<Client::Header, Client::Body>> {
-        if let Some(fut) = Pin::new(&mut self.headers).as_pin_mut() &&
-            let Poll::Ready(res) = fut.poll(cx)
+        if let Some(fut) = Pin::new(&mut self.headers).as_pin_mut()
+            && let Poll::Ready(res) = fut.poll(cx)
         {
             self.headers = None;
-            return Poll::Ready(RangeResponseResult::Header(res))
+            return Poll::Ready(RangeResponseResult::Header(res));
         }
 
-        if let Some(fut) = Pin::new(&mut self.bodies).as_pin_mut() &&
-            let Poll::Ready(res) = fut.poll(cx)
+        if let Some(fut) = Pin::new(&mut self.bodies).as_pin_mut()
+            && let Poll::Ready(res) = fut.poll(cx)
         {
             self.bodies = None;
-            return Poll::Ready(RangeResponseResult::Body(res))
+            return Poll::Ready(RangeResponseResult::Body(res));
         }
 
         Poll::Pending
@@ -852,7 +852,7 @@ mod tests {
         ) -> Self::Output {
             let attempt = self.body_requests.fetch_add(1, Ordering::SeqCst);
             if attempt == self.fail_on {
-                return futures::future::ready(Err(RequestError::Timeout))
+                return futures::future::ready(Err(RequestError::Timeout));
             }
 
             self.inner.get_block_bodies_with_priority_and_range_hint(hashes, priority, range_hint)

--- a/crates/net/p2p/src/test_utils/headers.rs
+++ b/crates/net/p2p/src/test_utils/headers.rs
@@ -72,7 +72,7 @@ impl Stream for TestHeaderDownloader {
         let this = self.get_mut();
         loop {
             if this.queued_headers.len() == this.batch_size {
-                return Poll::Ready(Some(Ok(std::mem::take(&mut this.queued_headers))))
+                return Poll::Ready(Some(Ok(std::mem::take(&mut this.queued_headers))));
             }
             if this.download.is_none() {
                 this.download = Some(this.create_download());
@@ -130,9 +130,9 @@ impl Stream for TestDownload {
 
         loop {
             if let Some(header) = this.buffer.pop() {
-                return Poll::Ready(Some(Ok(header)))
+                return Poll::Ready(Some(Ok(header)));
             } else if this.done {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
 
             match ready!(this.get_or_init_fut().poll_unpin(cx)) {
@@ -151,7 +151,7 @@ impl Stream for TestDownload {
                     return Poll::Ready(Some(Err(match err {
                         RequestError::Timeout => DownloadError::Timeout,
                         _ => DownloadError::RequestError(err),
-                    })))
+                    })));
                 }
             }
         }
@@ -217,7 +217,7 @@ impl HeadersClient for TestHeadersClient {
 
         Box::pin(async move {
             if let Some(err) = &mut *error.lock().await {
-                return Err(err.clone())
+                return Err(err.clone());
             }
 
             let mut lock = responses.lock().await;

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -178,17 +178,17 @@ impl FromStr for AnyNode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(rem) = s.strip_prefix("enode://") {
             if let Ok(record) = NodeRecord::from_str(s) {
-                return Ok(Self::NodeRecord(record))
+                return Ok(Self::NodeRecord(record));
             }
             // incomplete enode
             if let Ok(peer_id) = PeerId::from_str(rem) {
-                return Ok(Self::PeerId(peer_id))
+                return Ok(Self::PeerId(peer_id));
             }
-            return Err(format!("invalid public key: {rem}"))
+            return Err(format!("invalid public key: {rem}"));
         }
         #[cfg(feature = "secp256k1")]
         if s.starts_with("enr:") {
-            return Enr::from_str(s).map(AnyNode::Enr)
+            return Enr::from_str(s).map(AnyNode::Enr);
         }
         Err("missing 'enr:' prefix for base64-encoded record".to_string())
     }

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -63,11 +63,11 @@ impl NodeRecord {
     /// See also [`std::net::Ipv6Addr::to_ipv4_mapped`]
     pub fn convert_ipv4_mapped(&mut self) -> bool {
         // convert IPv4 mapped IPv6 address
-        if let IpAddr::V6(v6) = self.address &&
-            let Some(v4) = v6.to_ipv4_mapped()
+        if let IpAddr::V6(v6) = self.address
+            && let Some(v4) = v6.to_ipv4_mapped()
         {
             self.address = v4.into();
-            return true
+            return true;
         }
         false
     }
@@ -215,15 +215,15 @@ impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
     fn try_from(enr: &Enr<secp256k1::SecretKey>) -> Result<Self, Self::Error> {
         let Some(address) = enr.ip4().map(IpAddr::from).or_else(|| enr.ip6().map(IpAddr::from))
         else {
-            return Err(NodeRecordParseError::InvalidUrl("ip missing".to_string()))
+            return Err(NodeRecordParseError::InvalidUrl("ip missing".to_string()));
         };
 
         let Some(udp_port) = enr.udp4().or_else(|| enr.udp6()) else {
-            return Err(NodeRecordParseError::InvalidUrl("udp port missing".to_string()))
+            return Err(NodeRecordParseError::InvalidUrl("udp port missing".to_string()));
         };
 
         let Some(tcp_port) = enr.tcp4().or_else(|| enr.tcp6()) else {
-            return Err(NodeRecordParseError::InvalidUrl("tcp port missing".to_string()))
+            return Err(NodeRecordParseError::InvalidUrl("tcp port missing".to_string()));
         };
 
         let id = crate::pk2id(&enr.public_key());

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -911,9 +911,9 @@ where
     /// This checks for OP-Mainnet and ensures we have all the necessary data to progress (past
     /// bedrock height)
     fn ensure_chain_specific_db_checks(&self) -> ProviderResult<()> {
-        if self.chain_spec().is_optimism() &&
-            !self.is_dev() &&
-            self.chain_id() == Chain::optimism_mainnet()
+        if self.chain_spec().is_optimism()
+            && !self.is_dev()
+            && self.chain_id() == Chain::optimism_mainnet()
         {
             let latest = self.blockchain_db().last_block_number()?;
             // bedrock height
@@ -1106,8 +1106,8 @@ where
             while let Some(event) = engine_events.next().await {
                 use reth_engine_primitives::ConsensusEngineEvent;
                 match event {
-                    ConsensusEngineEvent::ForkBlockAdded(executed, duration) |
-                    ConsensusEngineEvent::CanonicalBlockAdded(executed, duration) => {
+                    ConsensusEngineEvent::ForkBlockAdded(executed, duration)
+                    | ConsensusEngineEvent::CanonicalBlockAdded(executed, duration) => {
                         let block_hash = executed.recovered_block.num_hash().hash;
                         let block_number = executed.recovered_block.num_hash().number;
                         if let Err(e) = ethstats_for_events

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -75,7 +75,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
 
         if extensions.is_empty() {
             // nothing to launch
-            return Ok(None)
+            return Ok(None);
         }
 
         info!(target: "reth::cli", "Loading ExEx Write-Ahead Log...");

--- a/crates/node/builder/src/launch/invalid_block_hook.rs
+++ b/crates/node/builder/src/launch/invalid_block_hook.rs
@@ -84,7 +84,7 @@ where
     use reth_invalid_block_hooks::InvalidBlockWitnessHook;
 
     let Some(ref hook) = config.debug.invalid_block_hook else {
-        return Ok(Box::new(NoopInvalidBlockHook::default()))
+        return Ok(Box::new(NoopInvalidBlockHook::default()));
     };
 
     let healthy_node_rpc_client = get_healthy_node_client(config, chain_id).await?;

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -236,7 +236,7 @@ impl FromStr for InvalidBlockSelection {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Ok(Self(Default::default()))
+            return Ok(Self(Default::default()));
         }
         let hooks = s.split(',').map(str::trim).peekable();
         Self::try_from_selection(hooks)

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -835,9 +835,9 @@ impl DiscoveryArgs {
             return false;
         }
 
-        self.enable_discv5_discovery ||
-            self.discv5_addr.is_some() ||
-            self.discv5_addr_ipv6.is_some()
+        self.enable_discv5_discovery
+            || self.discv5_addr.is_some()
+            || self.discv5_addr_ipv6.is_some()
     }
 
     /// Set the discovery port to zero, to allow the OS to assign a random unused port when

--- a/crates/node/core/src/args/payload_builder.rs
+++ b/crates/node/core/src/args/payload_builder.rs
@@ -203,7 +203,7 @@ impl TypedValueParser for ExtraDataValueParser {
                 format!(
                     "Payload builder extradata size exceeds {MAXIMUM_EXTRA_DATA_SIZE}-byte limit"
                 ),
-            ))
+            ));
         }
 
         Ok(bytes.into())

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -455,7 +455,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         // try to look up the header in the database
         if let Some(header) = header {
             info!(target: "reth::cli", ?tip, "Successfully looked up tip block in the database");
-            return Ok(header.number())
+            return Ok(header.number());
         }
 
         Ok(self.fetch_tip_from_network(client, tip.into()).await.number())
@@ -478,7 +478,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             match get_single_header(&client, tip).await {
                 Ok(tip_header) => {
                     info!(target: "reth::cli", ?tip, "Successfully fetched tip");
-                    return tip_header
+                    return tip_header;
                 }
                 Err(error) => {
                     fetch_failures += 1;

--- a/crates/node/ethstats/src/ethstats.rs
+++ b/crates/node/ethstats/src/ethstats.rs
@@ -182,8 +182,8 @@ where
         let response =
             timeout(READ_TIMEOUT, conn.read_json()).await.map_err(|_| EthStatsError::Timeout)??;
 
-        if let Some(ack) = response.get("emit") &&
-            ack.get(0) == Some(&Value::String("ready".to_string()))
+        if let Some(ack) = response.get("emit")
+            && ack.get(0) == Some(&Value::String("ready".to_string()))
         {
             info!(
                 target: "ethstats",
@@ -735,8 +735,8 @@ where
     /// Attempts to close the connection cleanly and logs any errors
     /// that occur during the process.
     async fn disconnect(&self) {
-        if let Some(conn) = self.conn.write().await.take() &&
-            let Err(e) = conn.close().await
+        if let Some(conn) = self.conn.write().await.take()
+            && let Err(e) = conn.close().await
         {
             debug!(target: "ethstats", "Error closing connection: {}", e);
         }
@@ -787,8 +787,8 @@ mod tests {
 
             // Handle ping
             while let Some(Ok(msg)) = ws_stream.next().await {
-                if let Message::Text(text) = msg &&
-                    text.contains("node-ping")
+                if let Message::Text(text) = msg
+                    && text.contains("node-ping")
                 {
                     let pong = json!({
                         "emit": ["node-pong", {"id": "test-node"}]

--- a/crates/node/events/src/cl.rs
+++ b/crates/node/events/src/cl.rs
@@ -51,18 +51,18 @@ impl<H: Send + Sync> Stream for ConsensusLayerHealthEvents<H> {
             if let Some(fork_choice) = this.canon_chain.last_received_update_timestamp() {
                 if fork_choice.elapsed() <= NO_FORKCHOICE_UPDATE_RECEIVED_PERIOD {
                     // We had an FCU, and it's recent. CL is healthy.
-                    continue
+                    continue;
                 }
                 // We had an FCU, but it's too old.
                 return Poll::Ready(Some(
                     ConsensusLayerHealthEvent::HaveNotReceivedUpdatesForAWhile(
                         fork_choice.elapsed(),
                     ),
-                ))
+                ));
             }
 
             // We never received any forkchoice updates.
-            return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen))
+            return Poll::Ready(Some(ConsensusLayerHealthEvent::NeverSeen));
         }
     }
 }

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -222,8 +222,8 @@ impl NodeState {
             ConsensusEngineEvent::ForkchoiceUpdated(state, status) => {
                 let ForkchoiceState { head_block_hash, safe_block_hash, finalized_block_hash } =
                     state;
-                if self.safe_block_hash != Some(safe_block_hash) &&
-                    self.finalized_block_hash != Some(finalized_block_hash)
+                if self.safe_block_hash != Some(safe_block_hash)
+                    && self.finalized_block_hash != Some(finalized_block_hash)
                 {
                     let msg = match status {
                         ForkchoiceStatus::Valid => "Forkchoice updated",
@@ -597,7 +597,7 @@ impl Eta {
             else {
                 self.eta = None;
                 debug!(target: "reth::cli", %stage, ?current, ?self.last_checkpoint, "Failed to calculate the ETA: processed entities is less than the last checkpoint");
-                return
+                return;
             };
             let elapsed = last_checkpoint_time.elapsed();
             let per_second = processed_since_last as f64 / elapsed.as_secs_f64();
@@ -605,7 +605,7 @@ impl Eta {
             let Some(remaining) = current.total.checked_sub(current.processed) else {
                 self.eta = None;
                 debug!(target: "reth::cli", %stage, ?current, "Failed to calculate the ETA: total entities is less than processed entities");
-                return
+                return;
             };
 
             self.eta = Duration::try_from_secs_f64(remaining as f64 / per_second).ok();
@@ -626,8 +626,8 @@ impl Eta {
     /// It's not the case for network-dependent ([`StageId::Headers`] and [`StageId::Bodies`]) and
     /// [`StageId::Execution`] stages.
     fn fmt_for_stage(&self, stage: StageId) -> Option<String> {
-        if !self.is_available() ||
-            matches!(stage, StageId::Headers | StageId::Bodies | StageId::Execution)
+        if !self.is_available()
+            || matches!(stage, StageId::Headers | StageId::Bodies | StageId::Execution)
         {
             None
         } else {
@@ -648,7 +648,7 @@ impl Display for Eta {
                     humantime::format_duration(Duration::from_secs(remaining.as_secs()))
                         .to_string()
                         .replace(' ', "")
-                )
+                );
             }
         }
 

--- a/crates/node/metrics/src/hooks.rs
+++ b/crates/node/metrics/src/hooks.rs
@@ -93,7 +93,7 @@ fn collect_memory_stats() {
 
     if epoch::advance().map_err(|error| error!(%error, "Failed to advance jemalloc epoch")).is_err()
     {
-        return
+        return;
     }
 
     if let Ok(value) = stats::active::read()
@@ -144,13 +144,13 @@ fn collect_io_stats() {
     let Ok(process) = procfs::process::Process::myself()
         .map_err(|error| error!(%error, "Failed to get currently running process"))
     else {
-        return
+        return;
     };
 
     let Ok(io) = process.io().map_err(
         |error| error!(%error, "Failed to get IO stats for the currently running process"),
     ) else {
-        return
+        return;
     };
 
     counter!("io.rchar").absolute(io.rchar);

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -373,7 +373,7 @@ where
         // check if the deadline is reached
         if this.deadline.as_mut().poll(cx).is_ready() {
             trace!(target: "payload_builder", "payload building deadline reached");
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         loop {
@@ -409,13 +409,13 @@ where
                     }
                     Poll::Pending => {
                         this.pending_block = Some(fut);
-                        return Poll::Pending
+                        return Poll::Pending;
                     }
                 }
             }
 
             if this.best_payload.is_frozen() {
-                return Poll::Pending
+                return Poll::Pending;
             }
 
             // Wait for the next build interval tick.
@@ -590,25 +590,25 @@ where
         let this = self.get_mut();
 
         // check if there is a better payload before returning the best payload
-        if let Some(fut) = Pin::new(&mut this.maybe_better).as_pin_mut() &&
-            let Poll::Ready(res) = fut.poll(cx)
+        if let Some(fut) = Pin::new(&mut this.maybe_better).as_pin_mut()
+            && let Poll::Ready(res) = fut.poll(cx)
         {
             this.maybe_better = None;
             if let Ok(Some(payload)) = res.map(|out| out.into_payload()).inspect_err(
                 |err| warn!(target: "payload_builder", %err, "failed to resolve pending payload"),
             ) {
                 debug!(target: "payload_builder", "resolving better payload");
-                return Poll::Ready(Ok(payload))
+                return Poll::Ready(Ok(payload));
             }
         }
 
         if let Some(best) = this.best_payload.take() {
             debug!(target: "payload_builder", "resolving best payload");
-            return Poll::Ready(Ok(best))
+            return Poll::Ready(Ok(best));
         }
 
-        if let Some(fut) = Pin::new(&mut this.empty_payload).as_pin_mut() &&
-            let Poll::Ready(res) = fut.poll(cx)
+        if let Some(fut) = Pin::new(&mut this.empty_payload).as_pin_mut()
+            && let Poll::Ready(res) = fut.poll(cx)
         {
             this.empty_payload = None;
             return match res {
@@ -621,11 +621,11 @@ where
                     Poll::Ready(res)
                 }
                 Err(err) => Poll::Ready(Err(err.into())),
-            }
+            };
         }
 
         if this.is_empty() {
-            return Poll::Ready(Err(PayloadBuilderError::MissingPayload))
+            return Poll::Ready(Err(PayloadBuilderError::MissingPayload));
         }
 
         Poll::Pending

--- a/crates/payload/builder-primitives/src/events.rs
+++ b/crates/payload/builder-primitives/src/events.rs
@@ -69,14 +69,14 @@ impl<T: PayloadTypes> Stream for BuiltPayloadStream<T> {
                 Some(Ok(Events::BuiltPayload(payload))) => Poll::Ready(Some(payload)),
                 Some(Ok(Events::Attributes(_))) => {
                     // ignoring attributes
-                    continue
+                    continue;
                 }
                 Some(Err(err)) => {
                     debug!(%err, "payload event stream lagging behind");
-                    continue
+                    continue;
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }
@@ -99,14 +99,14 @@ impl<T: PayloadTypes> Stream for PayloadAttributeStream<T> {
                 Some(Ok(Events::Attributes(attr))) => Poll::Ready(Some(attr)),
                 Some(Ok(Events::BuiltPayload(_))) => {
                     // ignoring payloads
-                    continue
+                    continue;
                 }
                 Some(Err(err)) => {
                     debug!(%err, "payload event stream lagging behind");
-                    continue
+                    continue;
                 }
                 None => Poll::Ready(None),
-            }
+            };
         }
     }
 }

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -42,7 +42,7 @@ where
         let this = self.get_mut();
         loop {
             let Some(cmd) = ready!(this.command_rx.poll_next_unpin(cx)) else {
-                return Poll::Ready(())
+                return Poll::Ready(());
             };
             match cmd {
                 PayloadServiceCommand::BuildNewPayload(attr, _, tx) => {

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -308,8 +308,8 @@ where
     ) -> Option<PayloadFuture<T::BuiltPayload>> {
         debug!(target: "payload_builder", %id, "resolving payload job");
 
-        if let Some((cached, _, payload)) = &*self.cached_payload_rx.borrow() &&
-            *cached == id
+        if let Some((cached, _, payload)) = &*self.cached_payload_rx.borrow()
+            && *cached == id
         {
             return Some(Box::pin(core::future::ready(Ok(payload.clone()))));
         }
@@ -359,8 +359,8 @@ where
 {
     /// Returns the payload timestamp for the given payload.
     fn payload_timestamp(&self, id: PayloadId) -> Option<Result<u64, PayloadBuilderError>> {
-        if let Some((cached_id, timestamp, _)) = *self.cached_payload_rx.borrow() &&
-            cached_id == id
+        if let Some((cached_id, timestamp, _)) = *self.cached_payload_rx.borrow()
+            && cached_id == id
         {
             return Some(Ok(timestamp));
         }
@@ -457,8 +457,8 @@ where
                                     // resolve() never returns an outdated result
                                     // from a previous job with the same id.
                                     if let Some((cached_id, _, _)) =
-                                        &*this.cached_payload_rx.borrow() &&
-                                        *cached_id == id
+                                        &*this.cached_payload_rx.borrow()
+                                        && *cached_id == id
                                     {
                                         trace!(target: "payload_builder", %id, "clearing stale cached payload for reused payload id");
                                         let _ = this.cached_payload_tx.send(None);
@@ -492,7 +492,7 @@ where
             }
 
             if !new_job {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -100,7 +100,7 @@ pub fn validate_payload_timestamp(
         //
         // 1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of
         //    payload or payloadAttributes is greater or equal to the Cancun activation timestamp.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     if version.is_v3() && !is_cancun {
@@ -122,7 +122,7 @@ pub fn validate_payload_timestamp(
         //
         // 2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of
         //    the payload does not fall within the time frame of the Cancun fork.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     let is_prague = chain_spec.is_prague_active_at_timestamp(timestamp);
@@ -145,7 +145,7 @@ pub fn validate_payload_timestamp(
         //
         // 2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of
         //    the payload does not fall within the time frame of the Prague fork.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     let is_osaka = chain_spec.is_osaka_active_at_timestamp(timestamp);
@@ -157,10 +157,10 @@ pub fn validate_payload_timestamp(
         //
         // 1. Client software MUST return -38005: Unsupported fork error if the timestamp of the
         //    built payload does not fall within the time frame of the Osaka fork.
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
     if version.is_v4() && kind == MessageValidationKind::GetPayload && is_osaka {
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     let is_amsterdam = chain_spec.is_amsterdam_active_at_timestamp(timestamp);
@@ -173,7 +173,7 @@ pub fn validate_payload_timestamp(
         // 1. Client software MUST return -38005: Unsupported fork error if the timestamp of the
         //    built payload does not fall within the time frame of the Amsterdam fork.
 
-        return Err(EngineObjectValidationError::UnsupportedFork)
+        return Err(EngineObjectValidationError::UnsupportedFork);
     }
 
     Ok(())
@@ -195,21 +195,21 @@ pub fn validate_withdrawals_presence<T: EthereumHardforks>(
         EngineApiMessageVersion::V1 => {
             if has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1))
+                    .to_error(VersionSpecificValidationError::WithdrawalsNotSupportedInV1));
             }
         }
-        EngineApiMessageVersion::V2 |
-        EngineApiMessageVersion::V3 |
-        EngineApiMessageVersion::V4 |
-        EngineApiMessageVersion::V5 |
-        EngineApiMessageVersion::V6 => {
+        EngineApiMessageVersion::V2
+        | EngineApiMessageVersion::V3
+        | EngineApiMessageVersion::V4
+        | EngineApiMessageVersion::V5
+        | EngineApiMessageVersion::V6 => {
             if is_shanghai_active && !has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai))
+                    .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai));
             }
             if !is_shanghai_active && has_withdrawals {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::HasWithdrawalsPreShanghai))
+                    .to_error(VersionSpecificValidationError::HasWithdrawalsPreShanghai));
             }
         }
     };
@@ -230,25 +230,25 @@ pub fn validate_block_access_list_presence<T: EthereumHardforks>(
     let is_amsterdam_active = chain_spec.is_amsterdam_active_at_timestamp(timestamp);
 
     match version {
-        EngineApiMessageVersion::V1 |
-        EngineApiMessageVersion::V2 |
-        EngineApiMessageVersion::V3 |
-        EngineApiMessageVersion::V4 |
-        EngineApiMessageVersion::V5 => {
+        EngineApiMessageVersion::V1
+        | EngineApiMessageVersion::V2
+        | EngineApiMessageVersion::V3
+        | EngineApiMessageVersion::V4
+        | EngineApiMessageVersion::V5 => {
             if has_block_access_list {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::BlockAccessListNotSupportedBeforeV6))
+                    .to_error(VersionSpecificValidationError::BlockAccessListNotSupportedBeforeV6));
             }
         }
 
         EngineApiMessageVersion::V6 => {
             if is_amsterdam_active && !has_block_access_list {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::NoBlockAccessListPostAmsterdam))
+                    .to_error(VersionSpecificValidationError::NoBlockAccessListPostAmsterdam));
             }
             if !is_amsterdam_active && has_block_access_list {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::HasBlockAccessListPreAmsterdam))
+                    .to_error(VersionSpecificValidationError::HasBlockAccessListPreAmsterdam));
             }
         }
     };
@@ -269,25 +269,25 @@ pub fn validate_slot_number_presence<T: EthereumHardforks>(
     let is_amsterdam_active = chain_spec.is_amsterdam_active_at_timestamp(timestamp);
 
     match version {
-        EngineApiMessageVersion::V1 |
-        EngineApiMessageVersion::V2 |
-        EngineApiMessageVersion::V3 |
-        EngineApiMessageVersion::V4 |
-        EngineApiMessageVersion::V5 => {
+        EngineApiMessageVersion::V1
+        | EngineApiMessageVersion::V2
+        | EngineApiMessageVersion::V3
+        | EngineApiMessageVersion::V4
+        | EngineApiMessageVersion::V5 => {
             if has_slot_number {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::SlotNumberNotSupportedBeforeV6))
+                    .to_error(VersionSpecificValidationError::SlotNumberNotSupportedBeforeV6));
             }
         }
 
         EngineApiMessageVersion::V6 => {
             if is_amsterdam_active && !has_slot_number {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::NoSlotNumberPostAmsterdam))
+                    .to_error(VersionSpecificValidationError::NoSlotNumberPostAmsterdam));
             }
             if !is_amsterdam_active && has_slot_number {
                 return Err(message_validation_kind
-                    .to_error(VersionSpecificValidationError::HasSlotNumberPreAmsterdam))
+                    .to_error(VersionSpecificValidationError::HasSlotNumberPreAmsterdam));
             }
         }
     };
@@ -378,16 +378,16 @@ pub fn validate_parent_beacon_block_root_presence<T: EthereumHardforks>(
             if has_parent_beacon_block_root {
                 return Err(validation_kind.to_error(
                     VersionSpecificValidationError::ParentBeaconBlockRootNotSupportedBeforeV3,
-                ))
+                ));
             }
         }
-        EngineApiMessageVersion::V3 |
-        EngineApiMessageVersion::V4 |
-        EngineApiMessageVersion::V5 |
-        EngineApiMessageVersion::V6 => {
+        EngineApiMessageVersion::V3
+        | EngineApiMessageVersion::V4
+        | EngineApiMessageVersion::V5
+        | EngineApiMessageVersion::V6 => {
             if !has_parent_beacon_block_root {
                 return Err(validation_kind
-                    .to_error(VersionSpecificValidationError::NoParentBeaconBlockRootPostCancun))
+                    .to_error(VersionSpecificValidationError::NoParentBeaconBlockRootPostCancun));
             }
         }
     };
@@ -598,20 +598,20 @@ pub fn validate_execution_requests(requests: &[Bytes]) -> Result<(), EngineObjec
     let mut last_request_type = None;
     for request in requests {
         if request.len() <= 1 {
-            return Err(EngineObjectValidationError::InvalidParams("EmptyExecutionRequest".into()))
+            return Err(EngineObjectValidationError::InvalidParams("EmptyExecutionRequest".into()));
         }
 
         let request_type = request[0];
         if Some(request_type) < last_request_type {
             return Err(EngineObjectValidationError::InvalidParams(
                 "OutOfOrderExecutionRequest".into(),
-            ))
+            ));
         }
 
         if Some(request_type) == last_request_type {
             return Err(EngineObjectValidationError::InvalidParams(
                 "DuplicatedExecutionRequestType".into(),
-            ))
+            ));
         }
 
         last_request_type = Some(request_type);

--- a/crates/payload/primitives/src/payload.rs
+++ b/crates/payload/primitives/src/payload.rs
@@ -61,6 +61,9 @@ pub trait ExecutionPayload:
     /// Returns the total gas consumed by all transactions in this block.
     fn gas_used(&self) -> u64;
 
+    /// Returns the gas limit of this block.
+    fn gas_limit(&self) -> u64;
+
     /// Returns the number of transactions in the payload.
     fn transaction_count(&self) -> usize;
 }
@@ -100,6 +103,10 @@ impl ExecutionPayload for ExecutionData {
 
     fn gas_used(&self) -> u64 {
         self.payload.as_v1().gas_used
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.payload.as_v1().gas_limit
     }
 
     fn transaction_count(&self) -> usize {
@@ -231,6 +238,10 @@ impl ExecutionPayload for op_alloy_rpc_types_engine::OpExecutionData {
 
     fn gas_used(&self) -> u64 {
         self.payload.as_v1().gas_used
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.payload.as_v1().gas_limit
     }
 
     fn transaction_count(&self) -> usize {

--- a/crates/payload/util/src/traits.rs
+++ b/crates/payload/util/src/traits.rs
@@ -84,9 +84,9 @@ where
         loop {
             let tx = self.best.next()?;
             if self.invalid.contains(tx.sender_ref()) {
-                continue
+                continue;
             }
-            return Some(tx.transaction.clone())
+            return Some(tx.transaction.clone());
         }
     }
 

--- a/crates/payload/validator/src/cancun.rs
+++ b/crates/payload/validator/src/cancun.rs
@@ -39,28 +39,28 @@ pub fn ensure_well_formed_header_and_sidecar_fields<T: Block>(
     if is_cancun_active {
         if block.blob_gas_used().is_none() {
             // cancun active but blob gas used not present
-            return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed)
+            return Err(PayloadError::PostCancunBlockWithoutBlobGasUsed);
         }
         if block.excess_blob_gas().is_none() {
             // cancun active but excess blob gas not present
-            return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas)
+            return Err(PayloadError::PostCancunBlockWithoutExcessBlobGas);
         }
         if cancun_sidecar_fields.is_none() {
             // cancun active but cancun fields not present
-            return Err(PayloadError::PostCancunWithoutCancunFields)
+            return Err(PayloadError::PostCancunWithoutCancunFields);
         }
     } else {
         if block.blob_gas_used().is_some() {
             // cancun not active but blob gas used present
-            return Err(PayloadError::PreCancunBlockWithBlobGasUsed)
+            return Err(PayloadError::PreCancunBlockWithBlobGasUsed);
         }
         if block.excess_blob_gas().is_some() {
             // cancun not active but excess blob gas present
-            return Err(PayloadError::PreCancunBlockWithExcessBlobGas)
+            return Err(PayloadError::PreCancunBlockWithExcessBlobGas);
         }
         if cancun_sidecar_fields.is_some() {
             // cancun not active but cancun fields present
-            return Err(PayloadError::PreCancunWithCancunFields)
+            return Err(PayloadError::PreCancunWithCancunFields);
         }
     }
 
@@ -81,7 +81,7 @@ pub fn ensure_well_formed_transactions_field_with_sidecar<T: Transaction + Typed
     if is_cancun_active {
         ensure_matching_blob_versioned_hashes(block_body, cancun_sidecar_fields)?
     } else if block_body.has_eip4844_transactions() {
-        return Err(PayloadError::PreCancunBlockWithBlobTransactions)
+        return Err(PayloadError::PreCancunBlockWithBlobTransactions);
     }
 
     Ok(())
@@ -99,20 +99,20 @@ pub fn ensure_matching_blob_versioned_hashes<T: Transaction + Typed2718, H>(
     if let Some(versioned_hashes) = cancun_sidecar_fields.map(|fields| &fields.versioned_hashes) {
         if num_blob_versioned_hashes != versioned_hashes.len() {
             // Number of blob versioned hashes does not match
-            return Err(PayloadError::InvalidVersionedHashes)
+            return Err(PayloadError::InvalidVersionedHashes);
         }
         // we can use `zip` safely here because we already compared their length
         for (payload_versioned_hash, block_versioned_hash) in
             versioned_hashes.iter().zip(block_body.blob_versioned_hashes_iter())
         {
             if payload_versioned_hash != block_versioned_hash {
-                return Err(PayloadError::InvalidVersionedHashes)
+                return Err(PayloadError::InvalidVersionedHashes);
             }
         }
     } else {
         // No Cancun fields, if block includes any blobs, this is an error
         if num_blob_versioned_hashes > 0 {
-            return Err(PayloadError::InvalidVersionedHashes)
+            return Err(PayloadError::InvalidVersionedHashes);
         }
     }
 

--- a/crates/payload/validator/src/prague.rs
+++ b/crates/payload/validator/src/prague.rs
@@ -27,7 +27,7 @@ pub const fn ensure_well_formed_sidecar_fields(
 ) -> Result<(), PayloadError> {
     if !is_prague_active && prague_fields.is_some() {
         // prague _not_ active but prague fields present
-        return Err(PayloadError::PrePragueBlockRequests)
+        return Err(PayloadError::PrePragueBlockRequests);
     }
 
     Ok(())
@@ -41,7 +41,7 @@ pub fn ensure_well_formed_transactions_field<T: Typed2718, H>(
     is_prague_active: bool,
 ) -> Result<(), PayloadError> {
     if !is_prague_active && block_body.has_eip7702_transactions() {
-        return Err(PayloadError::PrePragueBlockWithEip7702Transactions)
+        return Err(PayloadError::PrePragueBlockWithEip7702Transactions);
     }
 
     Ok(())

--- a/crates/payload/validator/src/shanghai.rs
+++ b/crates/payload/validator/src/shanghai.rs
@@ -12,11 +12,11 @@ pub fn ensure_well_formed_fields<T: BlockBody>(
     if is_shanghai_active {
         if block_body.withdrawals().is_none() {
             // shanghai active but no withdrawals present
-            return Err(PayloadError::PostShanghaiBlockWithoutWithdrawals)
+            return Err(PayloadError::PostShanghaiBlockWithoutWithdrawals);
         }
     } else if block_body.withdrawals().is_some() {
         // shanghai not active but withdrawals present
-        return Err(PayloadError::PreShanghaiBlockWithWithdrawals)
+        return Err(PayloadError::PreShanghaiBlockWithWithdrawals);
     }
 
     Ok(())

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -47,9 +47,9 @@ impl Account {
     /// After `SpuriousDragon` empty account is defined as account with nonce == 0 && balance == 0
     /// && bytecode = None (or hash is [`KECCAK_EMPTY`]).
     pub fn is_empty(&self) -> bool {
-        self.nonce == 0 &&
-            self.balance.is_zero() &&
-            self.bytecode_hash.is_none_or(|hash| hash == KECCAK_EMPTY)
+        self.nonce == 0
+            && self.balance.is_zero()
+            && self.bytecode_hash.is_none_or(|hash| hash == KECCAK_EMPTY)
     }
 
     /// Returns an account bytecode's hash.

--- a/crates/primitives-traits/src/block/mod.rs
+++ b/crates/primitives-traits/src/block/mod.rs
@@ -161,7 +161,7 @@ pub trait Block:
         } else {
             // Fall back to recovery if lengths don't match
             let Ok(senders) = self.body().recover_signers_unchecked() else {
-                return Err(BlockRecoveryError::new(self))
+                return Err(BlockRecoveryError::new(self));
             };
             senders
         };
@@ -184,7 +184,7 @@ pub trait Block:
     /// Returns the block as error if a signature is invalid.
     fn try_into_recovered(self) -> Result<RecoveredBlock<Self>, BlockRecoveryError<Self>> {
         let Ok(signers) = self.body().recover_signers() else {
-            return Err(BlockRecoveryError::new(self))
+            return Err(BlockRecoveryError::new(self));
         };
         Ok(RecoveredBlock::new_unhashed(self, signers))
     }

--- a/crates/primitives-traits/src/block/sealed.rs
+++ b/crates/primitives-traits/src/block/sealed.rs
@@ -266,7 +266,7 @@ impl<B: Block> SealedBlock<B> {
             return Err(GotExpected {
                 got: calculated_root,
                 expected: self.header().transactions_root(),
-            })
+            });
         }
 
         Ok(())

--- a/crates/primitives-traits/src/size.rs
+++ b/crates/primitives-traits/src/size.rs
@@ -72,9 +72,9 @@ impl_in_mem_size_size_of!(op_alloy_consensus::OpTxType);
 impl InMemorySize for alloy_consensus::Receipt {
     fn size(&self) -> usize {
         let Self { status, cumulative_gas_used, logs } = self;
-        core::mem::size_of_val(status) +
-            core::mem::size_of_val(cumulative_gas_used) +
-            logs.iter().map(|log| log.size()).sum::<usize>()
+        core::mem::size_of_val(status)
+            + core::mem::size_of_val(cumulative_gas_used)
+            + logs.iter().map(|log| log.size()).sum::<usize>()
     }
 }
 
@@ -112,9 +112,10 @@ impl<T: InMemorySize, H: InMemorySize> InMemorySize for alloy_consensus::BlockBo
     /// Calculates a heuristic for the in-memory size of the block body
     #[inline]
     fn size(&self) -> usize {
-        self.transactions.iter().map(T::size).sum::<usize>() +
-            self.ommers.iter().map(H::size).sum::<usize>() +
-            self.withdrawals
+        self.transactions.iter().map(T::size).sum::<usize>()
+            + self.ommers.iter().map(H::size).sum::<usize>()
+            + self
+                .withdrawals
                 .as_ref()
                 .map_or(core::mem::size_of::<Option<Withdrawals>>(), Withdrawals::total_size)
     }
@@ -148,19 +149,19 @@ mod op {
     impl InMemorySize for op_alloy_consensus::OpDepositReceipt {
         fn size(&self) -> usize {
             let Self { inner, deposit_nonce, deposit_receipt_version } = self;
-            inner.size() +
-                core::mem::size_of_val(deposit_nonce) +
-                core::mem::size_of_val(deposit_receipt_version)
+            inner.size()
+                + core::mem::size_of_val(deposit_nonce)
+                + core::mem::size_of_val(deposit_receipt_version)
         }
     }
 
     impl InMemorySize for op_alloy_consensus::OpReceipt {
         fn size(&self) -> usize {
             match self {
-                Self::Legacy(receipt) |
-                Self::Eip2930(receipt) |
-                Self::Eip1559(receipt) |
-                Self::Eip7702(receipt) => receipt.size(),
+                Self::Legacy(receipt)
+                | Self::Eip2930(receipt)
+                | Self::Eip1559(receipt)
+                | Self::Eip7702(receipt) => receipt.size(),
                 Self::Deposit(receipt) => receipt.size(),
             }
         }

--- a/crates/primitives-traits/src/withdrawal.rs
+++ b/crates/primitives-traits/src/withdrawal.rs
@@ -40,10 +40,10 @@ mod tests {
 
     impl PartialEq<Withdrawal> for RethWithdrawal {
         fn eq(&self, other: &Withdrawal) -> bool {
-            self.index == other.index &&
-                self.validator_index == other.validator_index &&
-                self.address == other.address &&
-                self.amount == other.amount
+            self.index == other.index
+                && self.validator_index == other.validator_index
+                && self.address == other.address
+                && self.amount == other.amount
         }
     }
 

--- a/crates/prune/prune/src/db_ext.rs
+++ b/crates/prune/prune/src/db_ext.rs
@@ -54,7 +54,7 @@ pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
                     "Pruning limit reached"
                 );
                 done = false;
-                break
+                break;
             }
 
             let key = keys.next().expect("peek() said Some");
@@ -97,7 +97,7 @@ pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
                     table = %T::NAME,
                     "Pruning limit reached"
                 );
-                break false
+                break false;
             }
 
             let result = self.prune_table_with_range_step(
@@ -112,7 +112,7 @@ pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
             }
 
             if result.done {
-                break true
+                break true;
             }
         };
 
@@ -132,7 +132,7 @@ pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
         delete_callback: &mut impl FnMut(TableRow<T>),
     ) -> Result<PruneStepResult, DatabaseError> {
         let Some(res) = walker.next() else {
-            return Ok(PruneStepResult { done: true, deleted: false })
+            return Ok(PruneStepResult { done: true, deleted: false });
         };
 
         let row = res?;
@@ -171,7 +171,7 @@ pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
                     table = %T::NAME,
                     "Pruning limit reached"
                 );
-                break false
+                break false;
             }
 
             let Some(res) = walker.next() else { break true };

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -129,13 +129,13 @@ where
         let Some(tip_block_number) =
             self.adjust_tip_block_number_to_finished_exex_height(tip_block_number)
         else {
-            return Ok(PruneProgress::Finished.into())
+            return Ok(PruneProgress::Finished.into());
         };
         if tip_block_number == 0 {
             self.previous_tip_block_number = Some(tip_block_number);
 
             debug!(target: "pruner", %tip_block_number, "Nothing to prune yet");
-            return Ok(PruneProgress::Finished.into())
+            return Ok(PruneProgress::Finished.into());
         }
 
         self.event_sender.notify(PrunerEvent::Started { tip_block_number });
@@ -187,7 +187,7 @@ where
             if limiter.is_limit_reached() {
                 output.progress =
                     output.progress.combine(PruneProgress::HasMoreData(limiter.interrupt_reason()));
-                break
+                break;
             }
 
             if let Some((to_block, prune_mode)) = segment
@@ -199,8 +199,8 @@ where
                 .flatten()
             {
                 // Check if segment has a required stage that must be finished first
-                if let Some(required_stage) = segment.required_stage() &&
-                    !is_stage_finished(provider, required_stage)?
+                if let Some(required_stage) = segment.required_stage()
+                    && !is_stage_finished(provider, required_stage)?
                 {
                     debug!(
                         target: "pruner",
@@ -208,7 +208,7 @@ where
                         ?required_stage,
                         "Segment's required stage not finished, skipping"
                     );
-                    continue
+                    continue;
                 }
 
                 debug!(
@@ -281,14 +281,14 @@ where
         let Some(tip_block_number) =
             self.adjust_tip_block_number_to_finished_exex_height(tip_block_number)
         else {
-            return false
+            return false;
         };
 
         // Saturating subtraction is needed for the case when the chain was reverted, meaning
         // current block number might be less than the previous tip block number.
         // If that's the case, no pruning is needed as outdated data is also reverted.
-        if tip_block_number.saturating_sub(self.previous_tip_block_number.unwrap_or_default()) >=
-            self.min_block_interval as u64
+        if tip_block_number.saturating_sub(self.previous_tip_block_number.unwrap_or_default())
+            >= self.min_block_interval as u64
         {
             debug!(
                 target: "pruner",

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -47,7 +47,7 @@ where
             checkpoint: input
                 .previous_checkpoint
                 .map(SegmentOutputCheckpoint::from_prune_checkpoint),
-        })
+        });
     }
 
     let tx_ranges = deleted_headers.iter().filter_map(|header| header.tx_range());
@@ -86,7 +86,7 @@ where
     let deleted_headers = provider.static_file_provider().delete_segment(segment)?;
 
     if deleted_headers.is_empty() {
-        return Ok(SegmentOutput::done())
+        return Ok(SegmentOutput::done());
     }
 
     let tx_ranges = deleted_headers.iter().filter_map(|header| header.tx_range());
@@ -187,7 +187,7 @@ impl PruneInput {
                     // Prevents a scenario where the pruner correctly starts at a finalized block,
                     // but the first transaction (tx_num = 0) only appears on a non-finalized one.
                     // Should only happen on a test/hive scenario.
-                    return Ok(None)
+                    return Ok(None);
                 }
                 last_tx
             }
@@ -196,7 +196,7 @@ impl PruneInput {
 
         let range = from_tx_number..=to_tx_number;
         if range.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
 
         Ok(Some(range))
@@ -214,7 +214,7 @@ impl PruneInput {
         let from_block = self.get_start_next_block_range();
         let range = from_block..=self.to_block;
         if range.is_empty() {
-            return None
+            return None;
         }
 
         Some(range)

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -33,7 +33,7 @@ where
 {
     if EitherWriter::receipts_destination(provider).is_static_file() {
         debug!(target: "pruner", "Pruning receipts from static files.");
-        return segments::prune_static_files(provider, input, StaticFileSegment::Receipts)
+        return segments::prune_static_files(provider, input, StaticFileSegment::Receipts);
     }
     debug!(target: "pruner", "Pruning receipts from database.");
 
@@ -42,7 +42,7 @@ where
         Some(range) => range,
         None => {
             trace!(target: "pruner", "No receipts to prune");
-            return Ok(SegmentOutput::done())
+            return Ok(SegmentOutput::done());
         }
     };
     let tx_range_end = *tx_range.end();
@@ -182,8 +182,8 @@ mod tests {
                 .map(|block| block.transaction_count())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -34,7 +34,7 @@ impl<Provider> SegmentSet<Provider> {
     /// Adds new [Segment] to collection if it's [Some].
     pub fn segment_opt<S: Segment<Provider> + 'static>(self, segment: Option<S>) -> Self {
         if let Some(segment) = segment {
-            return self.segment(segment)
+            return self.segment(segment);
         }
         self
     }

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -68,7 +68,7 @@ where
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No account history to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
         let range_end = *range.end();
@@ -112,7 +112,7 @@ impl AccountHistory {
             return Ok(SegmentOutput::not_done(
                 limiter.interrupt_reason(),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         // Deleted account changeset keys (account addresses) with the highest block number deleted
@@ -186,7 +186,7 @@ impl AccountHistory {
             return Ok(SegmentOutput::not_done(
                 limiter.interrupt_reason(),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         // Deleted account changeset keys (account addresses) with the highest block number deleted
@@ -252,7 +252,7 @@ impl AccountHistory {
             return Ok(SegmentOutput::not_done(
                 limiter.interrupt_reason(),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         let mut highest_deleted_accounts = FxHashMap::default();
@@ -436,8 +436,8 @@ mod tests {
                     .iter()
                     .enumerate()
                     .skip_while(|(i, (block_number, _))| {
-                        *i < deleted_entries_limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE * run &&
-                            *block_number <= to_block as usize
+                        *i < deleted_entries_limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE * run
+                            && *block_number <= to_block as usize
                     })
                     .next()
                     .map(|(i, _)| i)
@@ -597,8 +597,8 @@ mod tests {
                     .iter()
                     .enumerate()
                     .skip_while(|(i, (block_number, _))| {
-                        *i < deleted_entries_limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE * run &&
-                            *block_number <= to_block as usize
+                        *i < deleted_entries_limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE * run
+                            && *block_number <= to_block as usize
                     })
                     .next()
                     .map(|(i, _)| i)

--- a/crates/prune/prune/src/segments/user/bodies.rs
+++ b/crates/prune/prune/src/segments/user/bodies.rs
@@ -70,7 +70,7 @@ impl Bodies {
                 if input.previous_checkpoint.is_some_and(|cp| cp.block_number.unwrap_or(0) >= safe)
                 {
                     // we have pruned what we can
-                    return Ok(None)
+                    return Ok(None);
                 }
 
                 debug!(

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -112,7 +112,7 @@ where
             let Some((key, block_nums)) =
                 shard.map(|(k, v)| Result::<_, DatabaseError>::Ok((k.key()?, v))).transpose()?
             else {
-                break
+                break;
             };
 
             if key_matches(&key, &sharded_key) {
@@ -123,7 +123,7 @@ where
                 }
             } else {
                 // If such shard doesn't exist, skip to the next sharded key
-                break 'shard
+                break 'shard;
             }
 
             shard = cursor.next()?;

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -146,7 +146,7 @@ where
                         ?block_range,
                         "No receipts to prune."
                     );
-                    continue
+                    continue;
                 }
             };
             let tx_range = from_tx_number..=tx_range_end;
@@ -160,10 +160,11 @@ where
                 tx_range,
                 &mut limiter,
                 |(tx_num, receipt)| {
-                    let skip = num_addresses > 0 &&
-                        receipt.logs().iter().any(|log| {
-                            filtered_addresses[..num_addresses].contains(&&log.address)
-                        });
+                    let skip = num_addresses > 0
+                        && receipt
+                            .logs()
+                            .iter()
+                            .any(|log| filtered_addresses[..num_addresses].contains(&&log.address));
 
                     if skip {
                         last_skipped_transaction = *tx_num;
@@ -195,7 +196,7 @@ where
 
             if limiter.is_limit_reached() {
                 done &= end_block == to_block;
-                break
+                break;
             }
 
             from_tx_number = last_pruned_transaction + 1;
@@ -341,8 +342,8 @@ mod tests {
 
             assert_eq!(
                 db.table::<tables::Receipts>().unwrap().len(),
-                blocks.iter().map(|block| block.transaction_count()).sum::<usize>() -
-                    ((pruned_tx + 1) - unprunable) as usize
+                blocks.iter().map(|block| block.transaction_count()).sum::<usize>()
+                    - ((pruned_tx + 1) - unprunable) as usize
             );
 
             output.progress.is_finished()
@@ -359,8 +360,8 @@ mod tests {
             // Either we only find our contract, or the receipt is part of the unprunable receipts
             // set by tip - 128
             assert!(
-                receipt.logs.iter().any(|l| l.address == deposit_contract_addr) ||
-                    provider.block_by_transaction_id(tx_num).unwrap().unwrap() > tip - 128,
+                receipt.logs.iter().any(|l| l.address == deposit_contract_addr)
+                    || provider.block_by_transaction_id(tx_num).unwrap().unwrap() > tip - 128,
             );
         }
     }

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -61,14 +61,14 @@ where
                     provider,
                     input,
                     StaticFileSegment::TransactionSenders,
-                )
+                );
             }
 
             return segments::prune_static_files(
                 provider,
                 input,
                 StaticFileSegment::TransactionSenders,
-            )
+            );
         }
         debug!(target: "pruner", "Pruning transaction senders from database.");
 
@@ -76,7 +76,7 @@ where
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No transaction senders to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
         let tx_range_end = *tx_range.end();
@@ -214,8 +214,8 @@ mod tests {
                 .map(|block| block.transaction_count())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -69,7 +69,7 @@ where
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No storage history to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         };
         let range_end = *range.end();
@@ -113,7 +113,7 @@ impl StorageHistory {
             return Ok(SegmentOutput::not_done(
                 limiter.interrupt_reason(),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         // The size of this map is limited by `prune_delete_limit * blocks_since_last_run /
@@ -188,7 +188,7 @@ impl StorageHistory {
             return Ok(SegmentOutput::not_done(
                 limiter.interrupt_reason(),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         // Deleted storage changeset keys (account addresses and storage slots) with the highest
@@ -253,7 +253,7 @@ impl StorageHistory {
             return Ok(SegmentOutput::not_done(
                 limiter.interrupt_reason(),
                 input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
-            ))
+            ));
         }
 
         let mut highest_deleted_storages: FxHashMap<_, _> = FxHashMap::default();
@@ -446,8 +446,8 @@ mod tests {
                 .iter()
                 .enumerate()
                 .skip_while(|(i, (block_number, _, _))| {
-                    *i < deleted_entries_limit / STORAGE_HISTORY_TABLES_TO_PRUNE * run &&
-                        *block_number <= to_block as usize
+                    *i < deleted_entries_limit / STORAGE_HISTORY_TABLES_TO_PRUNE * run
+                        && *block_number <= to_block as usize
                 })
                 .next()
                 .map(|(i, _)| i)
@@ -612,8 +612,8 @@ mod tests {
                 .iter()
                 .enumerate()
                 .skip_while(|(i, (block_number, _, _))| {
-                    *i < deleted_entries_limit / STORAGE_HISTORY_TABLES_TO_PRUNE * run &&
-                        *block_number <= to_block as usize
+                    *i < deleted_entries_limit / STORAGE_HISTORY_TABLES_TO_PRUNE * run
+                        && *block_number <= to_block as usize
                 })
                 .next()
                 .map(|(i, _)| i)

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -65,8 +65,8 @@ where
         // pre-merge history is dropped and then later tx lookup pruning is enabled) then we can
         // only prune from the lowest static file.
         if let Some(lowest_range) =
-            provider.static_file_provider().get_lowest_range(StaticFileSegment::Transactions) &&
-            input
+            provider.static_file_provider().get_lowest_range(StaticFileSegment::Transactions)
+            && input
                 .previous_checkpoint
                 .is_none_or(|checkpoint| checkpoint.block_number < Some(lowest_range.start()))
         {
@@ -89,7 +89,7 @@ where
             Some(range) => range,
             None => {
                 trace!(target: "pruner", "No transaction lookup entries to prune");
-                return Ok(SegmentOutput::done())
+                return Ok(SegmentOutput::done());
             }
         }
         .into_inner();
@@ -119,8 +119,8 @@ where
             });
         }
 
-        let tx_range = start..=
-            Some(end)
+        let tx_range = start
+            ..=Some(end)
                 .min(
                     input
                         .limiter
@@ -149,7 +149,7 @@ where
         if hashes.len() != tx_count {
             return Err(PrunerError::InconsistentData(
                 "Unexpected number of transaction hashes retrieved by transaction number range",
-            ))
+            ));
         }
 
         let mut limiter = input.limiter;
@@ -249,7 +249,7 @@ impl TransactionLookup {
         if hashes.len() != tx_count {
             return Err(PrunerError::InconsistentData(
                 "Unexpected number of transaction hashes retrieved by transaction number range",
-            ))
+            ));
         }
 
         let mut limiter = input.limiter;
@@ -372,8 +372,8 @@ mod tests {
                 .map(|block| block.transaction_count())
                 .sum::<usize>()
                 .min(
-                    next_tx_number_to_prune as usize +
-                        input.limiter.deleted_entries_limit().unwrap(),
+                    next_tx_number_to_prune as usize
+                        + input.limiter.deleted_entries_limit().unwrap(),
                 )
                 .sub(1);
 

--- a/crates/prune/types/src/lib.rs
+++ b/crates/prune/types/src/lib.rs
@@ -79,8 +79,8 @@ impl ReceiptsLogPruneConfig {
             let block = base_block.max(
                 mode.prune_target_block(tip, PruneSegment::ContractLogs, PrunePurpose::User)?
                     .map(|(block, _)| block)
-                    .unwrap_or_default() +
-                    1,
+                    .unwrap_or_default()
+                    + 1,
             );
 
             map.entry(block).or_insert_with(Vec::new).push(address)
@@ -98,8 +98,8 @@ impl ReceiptsLogPruneConfig {
         let mut lowest = None;
 
         for mode in self.values() {
-            if mode.is_distance() &&
-                let Some((block, _)) =
+            if mode.is_distance()
+                && let Some((block, _)) =
                     mode.prune_target_block(tip, PruneSegment::ContractLogs, PrunePurpose::User)?
             {
                 lowest = Some(lowest.unwrap_or(u64::MAX).min(block));

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -67,7 +67,7 @@ impl PruneMode {
             Self::Full => true,
             Self::Distance(distance) => {
                 if *distance > tip {
-                    return false
+                    return false;
                 }
                 block < tip - *distance
             }

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -161,7 +161,7 @@ impl PruneModes {
                             target_block,
                             history_type: history_type.clone(),
                             limit: *limit,
-                        })
+                        });
                     }
                 }
             }

--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -240,20 +240,20 @@ mod tests {
 
         // Verify the combined state
         assert!(
-            primary.accounts.len() == 2 &&
-                primary.contracts.len() == 2 &&
-                primary.block_hashes.len() == 2,
+            primary.accounts.len() == 2
+                && primary.contracts.len() == 2
+                && primary.block_hashes.len() == 2,
             "All maps should contain 2 entries"
         );
 
         // Verify specific entries
         assert!(
-            primary.accounts.contains_key(&address1) &&
-                primary.accounts.contains_key(&address2) &&
-                primary.contracts.contains_key(&hash1) &&
-                primary.contracts.contains_key(&hash2) &&
-                primary.block_hashes.get(&1) == Some(&hash1) &&
-                primary.block_hashes.get(&2) == Some(&hash2),
+            primary.accounts.contains_key(&address1)
+                && primary.accounts.contains_key(&address2)
+                && primary.contracts.contains_key(&hash1)
+                && primary.contracts.contains_key(&hash2)
+                && primary.block_hashes.get(&1) == Some(&hash1)
+                && primary.block_hashes.get(&2) == Some(&hash2),
             "All expected entries should be present"
         );
     }

--- a/crates/rpc/ipc/src/server/connection.rs
+++ b/crates/rpc/ipc/src/server/connection.rs
@@ -102,7 +102,7 @@ where
             if budget == 0 {
                 // make sure we're woken up again
                 cx.waker().wake_by_ref();
-                return Poll::Pending
+                return Poll::Pending;
             }
 
             // write all responses to the sink
@@ -110,10 +110,10 @@ where
                 if let Some(item) = this.items.pop_front() {
                     if let Err(err) = this.conn.as_mut().start_send(item) {
                         tracing::warn!("IPC response failed: {:?}", err);
-                        return Poll::Ready(())
+                        return Poll::Ready(());
                     }
                 } else {
-                    break
+                    break;
                 }
             }
 
@@ -147,7 +147,7 @@ where
                                         Err(err) => err.into().to_string(),
                                     };
                                     this.items.push_back(item);
-                                    continue 'outer
+                                    continue 'outer;
                                 }
                                 Poll::Pending => {
                                     this.pending_calls.push(call);
@@ -157,14 +157,14 @@ where
                         Some(Err(err)) => {
                             // this can happen if the client closes the connection
                             tracing::debug!("IPC request failed: {:?}", err);
-                            return Poll::Ready(())
+                            return Poll::Ready(());
                         }
                         None => return Poll::Ready(()),
                     },
                     Poll::Pending => {
                         if drained || this.pending_calls.is_empty() {
                             // at this point all things are pending
-                            return Poll::Pending
+                            return Poll::Pending;
                         }
                     }
                 }

--- a/crates/rpc/ipc/src/server/ipc.rs
+++ b/crates/rpc/ipc/src/server/ipc.rs
@@ -66,7 +66,7 @@ where
 
         while let Some(response) = pending_calls.next().await {
             if let Err(too_large) = batch_response.append(response) {
-                return Some(too_large.to_json().to_string())
+                return Some(too_large.to_json().to_string());
             }
         }
 
@@ -138,7 +138,7 @@ where
         return Some(
             batch_response_error(Id::Null, reject_too_big_request(max_request_body_size as u32))
                 .to_string(),
-        )
+        );
     }
 
     // Single request or notification

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -144,8 +144,8 @@ where
                 {
                     // set permissions only on unix
                     use std::os::unix::fs::PermissionsExt;
-                    if let Some(perms_str) = &self.cfg.ipc_socket_permissions &&
-                        let Ok(mode) = u32::from_str_radix(&perms_str.replace("0o", ""), 8)
+                    if let Some(perms_str) = &self.cfg.ipc_socket_permissions
+                        && let Ok(mode) = u32::from_str_radix(&perms_str.replace("0o", ""), 8)
                     {
                         let perms = std::fs::Permissions::from_mode(mode);
                         let _ = std::fs::set_permissions(&self.endpoint, perms);

--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -117,7 +117,7 @@ impl tokio_util::codec::Decoder for StreamCodec {
                         buf.advance(start_idx);
                     }
                     let bts = buf.split_to(idx + 1 - start_idx);
-                    return Ok(String::from_utf8(bts.into()).ok())
+                    return Ok(String::from_utf8(bts.into()).ok());
                 }
             }
             Ok(None)

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -397,7 +397,7 @@ impl AuthServerHandle {
                     .build(ipc_endpoint)
                     .await
                     .expect("Failed to create ipc client"),
-            )
+            );
         }
         None
     }

--- a/crates/rpc/rpc-builder/src/cors.rs
+++ b/crates/rpc/rpc-builder/src/cors.rs
@@ -31,7 +31,7 @@ pub(crate) fn create_cors_layer(http_cors_domains: &str) -> Result<CorsLayer, Co
             if iter.clone().any(|o| o == "*") {
                 return Err(CorsDomainError::WildCardNotAllowed {
                     input: http_cors_domains.to_string(),
-                })
+                });
             }
 
             let origins = iter

--- a/crates/rpc/rpc-builder/src/error.rs
+++ b/crates/rpc/rpc-builder/src/error.rs
@@ -79,7 +79,7 @@ impl RpcError {
     /// Converts an [`io::Error`] to a more descriptive `RpcError`.
     pub fn server_error(io_error: io::Error, kind: ServerKind) -> Self {
         if io_error.kind() == ErrorKind::AddrInUse {
-            return Self::AddressAlreadyInUse { kind, error: io_error }
+            return Self::AddressAlreadyInUse { kind, error: io_error };
         }
         Self::ServerError { kind, error: io_error }
     }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1024,9 +1024,9 @@ where
                         // these are implementation specific and need to be handled during
                         // initialization and should be registered via extend_rpc_modules in the
                         // nodebuilder rpc addon stack
-                        RethRpcModule::Flashbots |
-                        RethRpcModule::Testing |
-                        RethRpcModule::Other(_) => Default::default(),
+                        RethRpcModule::Flashbots
+                        | RethRpcModule::Testing
+                        | RethRpcModule::Other(_) => Default::default(),
                     })
                     .clone()
             })
@@ -1278,9 +1278,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
     ///
     /// If no server is configured, no server will be launched on [`RpcServerConfig::start`].
     pub const fn has_server(&self) -> bool {
-        self.http_server_config.is_some() ||
-            self.ws_server_config.is_some() ||
-            self.ipc_server_config.is_some()
+        self.http_server_config.is_some()
+            || self.ws_server_config.is_some()
+            || self.ipc_server_config.is_some()
     }
 
     /// Returns the [`SocketAddr`] of the http server
@@ -1353,9 +1353,9 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
         }
 
         // If both are configured on the same port, we combine them into one server.
-        if self.http_addr == self.ws_addr &&
-            self.http_server_config.is_some() &&
-            self.ws_server_config.is_some()
+        if self.http_addr == self.ws_addr
+            && self.http_server_config.is_some()
+            && self.ws_server_config.is_some()
         {
             let cors = match (self.ws_cors_domains.as_ref(), self.http_cors_domains.as_ref()) {
                 (Some(ws_cors), Some(http_cors)) => {
@@ -1749,7 +1749,7 @@ impl TransportRpcModules {
     /// Returns [Ok(false)] if no http transport is configured.
     pub fn merge_http(&mut self, other: impl Into<Methods>) -> Result<bool, RegisterMethodError> {
         if let Some(ref mut http) = self.http {
-            return http.merge(other.into()).map(|_| true)
+            return http.merge(other.into()).map(|_| true);
         }
         Ok(false)
     }
@@ -1761,7 +1761,7 @@ impl TransportRpcModules {
     /// Returns [Ok(false)] if no ws transport is configured.
     pub fn merge_ws(&mut self, other: impl Into<Methods>) -> Result<bool, RegisterMethodError> {
         if let Some(ref mut ws) = self.ws {
-            return ws.merge(other.into()).map(|_| true)
+            return ws.merge(other.into()).map(|_| true);
         }
         Ok(false)
     }
@@ -1773,7 +1773,7 @@ impl TransportRpcModules {
     /// Returns [Ok(false)] if no ipc transport is configured.
     pub fn merge_ipc(&mut self, other: impl Into<Methods>) -> Result<bool, RegisterMethodError> {
         if let Some(ref mut ipc) = self.ipc {
-            return ipc.merge(other.into()).map(|_| true)
+            return ipc.merge(other.into()).map(|_| true);
         }
         Ok(false)
     }
@@ -2108,8 +2108,8 @@ impl RpcServerHandle {
                 "Bearer {}",
                 secret
                     .encode(&Claims {
-                        iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
-                            Duration::from_secs(60))
+                        iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+                            + Duration::from_secs(60))
                         .as_secs(),
                         exp: None,
                     })

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -33,8 +33,8 @@ use std::collections::HashSet;
 fn is_unimplemented(err: jsonrpsee::core::client::Error) -> bool {
     match err {
         jsonrpsee::core::client::Error::Call(error_obj) => {
-            error_obj.code() == ErrorCode::InternalError.code() &&
-                error_obj.message() == "unimplemented"
+            error_obj.code() == ErrorCode::InternalError.code()
+                && error_obj.message() == "unimplemented"
         }
         _ => false,
     }
@@ -1727,8 +1727,8 @@ async fn test_debug_db_get() {
     let match_error_msg = |err: jsonrpsee::core::client::Error, expected: String| -> bool {
         match err {
             jsonrpsee::core::client::Error::Call(error_obj) => {
-                error_obj.code() == ErrorCode::InvalidParams.code() &&
-                    error_obj.message() == expected
+                error_obj.code() == ErrorCode::InvalidParams.code()
+                    && error_obj.message() == expected
             }
             _ => false,
         }

--- a/crates/rpc/rpc-e2e-tests/src/rpc_compat.rs
+++ b/crates/rpc/rpc-e2e-tests/src/rpc_compat.rs
@@ -142,7 +142,12 @@ impl RunRpcCompatTests {
                 // Direct value comparison
                 (a, b) => {
                     if a != b {
-                        return Err(eyre!("Value mismatch at {}: {:?} != {:?}", current_path, a, b));
+                        return Err(eyre!(
+                            "Value mismatch at {}: {:?} != {:?}",
+                            current_path,
+                            a,
+                            b
+                        ));
                     }
                 }
             }
@@ -226,7 +231,9 @@ impl RunRpcCompatTests {
                 } else if let Some(error) = actual_error {
                     return Err(eyre!("Expected success response but got error: {}", error));
                 } else {
-                    return Err(eyre!("Expected success response but got neither result nor error"));
+                    return Err(eyre!(
+                        "Expected success response but got neither result nor error"
+                    ));
                 }
             }
             (None, Some(_)) => {

--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -123,8 +123,8 @@ impl EngineCapabilities {
 /// Returns `true` if the method is critical for block production and chain synchronization.
 fn is_critical_method(method: &str) -> bool {
     CRITICAL_METHOD_PREFIXES.iter().any(|prefix| {
-        method.starts_with(prefix) &&
-            method[prefix.len()..]
+        method.starts_with(prefix)
+            && method[prefix.len()..]
                 .strip_prefix('V')
                 .is_some_and(|s| s.chars().next().is_some_and(|c| c.is_ascii_digit()))
     })

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -665,9 +665,10 @@ where
             // > Client software MUST NOT return trailing null values if the request extends past the current latest known block.
             // truncate the end if it's greater than the last block
             if let Ok(best_block) = inner.provider.best_block_number()
-                && end > best_block {
-                    end = best_block;
-                }
+                && end > best_block
+            {
+                end = best_block;
+            }
 
             // Check if the requested range starts before the earliest available block due to pruning/expiry
             let earliest_block = inner.provider.earliest_block_number().unwrap_or(0);
@@ -878,9 +879,9 @@ where
                 let fcu_res =
                     self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?;
                 if fcu_res.is_invalid() || fcu_res.payload_status.is_syncing() {
-                    return Ok(fcu_res)
+                    return Ok(fcu_res);
                 }
-                return Err(err.into())
+                return Err(err.into());
             }
         }
 
@@ -906,7 +907,7 @@ where
         }
 
         if versioned_hashes.len() > MAX_BLOB_LIMIT {
-            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() })
+            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() });
         }
 
         self.inner
@@ -950,7 +951,7 @@ where
         }
 
         if versioned_hashes.len() > MAX_BLOB_LIMIT {
-            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() })
+            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() });
         }
 
         self.inner
@@ -973,12 +974,12 @@ where
         }
 
         if versioned_hashes.len() > MAX_BLOB_LIMIT {
-            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() })
+            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() });
         }
 
         // Spec requires returning `null` if syncing.
         if (*self.inner.is_syncing)() {
-            return Ok(None)
+            return Ok(None);
         }
 
         self.inner
@@ -1877,8 +1878,8 @@ mod tests {
                 blocks
                     .iter()
                     .filter(|b| {
-                        !first_missing_range.contains(&b.number) &&
-                            !second_missing_range.contains(&b.number)
+                        !first_missing_range.contains(&b.number)
+                            && !second_missing_range.contains(&b.number)
                     })
                     .map(|b| (b.hash(), b.clone().into_block())),
             );
@@ -1907,8 +1908,8 @@ mod tests {
                 // ensure we still return trailing `None`s here because by-hash will not be aware
                 // of the missing block's number, and cannot compare it to the current best block
                 .map(|b| {
-                    if first_missing_range.contains(&b.number) ||
-                        second_missing_range.contains(&b.number)
+                    if first_missing_range.contains(&b.number)
+                        || second_missing_range.contains(&b.number)
                     {
                         None
                     } else {

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -170,7 +170,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
                 return Ok(self
                     .converter()
                     .convert_receipts_with_block(inputs, block.sealed_block())
-                    .map(Some)?)
+                    .map(Some)?);
             }
 
             Ok(None)
@@ -210,8 +210,8 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
             }
 
             if let Some(block_hash) =
-                self.provider().block_hash_for_id(block_id).map_err(Self::Error::from_eth_err)? &&
-                let Some((block, receipts)) = self
+                self.provider().block_hash_for_id(block_id).map_err(Self::Error::from_eth_err)?
+                && let Some((block, receipts)) = self
                     .cache()
                     .get_block_and_receipts(block_hash)
                     .await

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -73,7 +73,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
         async move {
             if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {
-                return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into())
+                return Err(EthApiError::InvalidParams("too many blocks.".to_string()).into());
             }
 
             let block = block.unwrap_or_default();
@@ -86,7 +86,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             } = payload;
 
             if block_state_calls.is_empty() {
-                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into())
+                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into());
             }
 
             let base_block =
@@ -329,7 +329,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     .block_hash_for_id(target_block)
                     .map_err(Self::Error::from_eth_err::<ProviderError>)?
                 else {
-                    return Err(EthApiError::HeaderNotFound(target_block).into())
+                    return Err(EthApiError::HeaderNotFound(target_block).into());
                 };
                 target_block = block_hash.into();
             }
@@ -631,7 +631,7 @@ pub trait Call:
                 .spawn_with_call_at(request, at, overrides, move |db, evm_env, tx_env| {
                     if cancel.is_cancelled() {
                         // callsite dropped the guard
-                        return Err(EthApiError::InternalEthError.into())
+                        return Err(EthApiError::InternalEthError.into());
                     }
                     this.transact(db, evm_env, tx_env)
                 })
@@ -793,7 +793,7 @@ pub trait Call:
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {
                 // reached the target transaction
-                break
+                break;
             }
 
             let tx_env = self.evm_config().tx_env(tx);

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -97,8 +97,8 @@ pub trait EstimateCall: Call {
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
 
         // Check if this is a basic transfer (no input data to account with no code)
-        let is_basic_transfer = if tx_env.input().is_empty() &&
-            let TxKind::Call(to) = tx_env.kind()
+        let is_basic_transfer = if tx_env.input().is_empty()
+            && let TxKind::Call(to) = tx_env.kind()
         {
             match db.database.basic_account(&to) {
                 Ok(Some(account)) => {
@@ -136,10 +136,10 @@ pub trait EstimateCall: Call {
             min_tx_env.set_gas_limit(MIN_TRANSACTION_GAS);
 
             // Reuse the same EVM instance
-            if let Ok(res) = evm.transact(min_tx_env).map_err(Self::Error::from_evm_err) &&
-                res.result.is_success()
+            if let Ok(res) = evm.transact(min_tx_env).map_err(Self::Error::from_evm_err)
+                && res.result.is_success()
             {
-                return Ok(U256::from(MIN_TRANSACTION_GAS))
+                return Ok(U256::from(MIN_TRANSACTION_GAS));
             }
         }
 
@@ -152,8 +152,8 @@ pub trait EstimateCall: Call {
             // retry the transaction with the block's gas limit to determine if
             // the failure was due to insufficient gas.
             Err(err)
-                if err.is_gas_too_high() &&
-                    (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
+                if err.is_gas_too_high()
+                    && (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
             {
                 return Self::map_out_of_gas_err(&mut evm, tx_env, max_gas_limit);
             }
@@ -176,7 +176,7 @@ pub trait EstimateCall: Call {
             ExecutionResult::Halt { reason, .. } => {
                 // here we don't check for invalid opcode because already executed with highest gas
                 // limit
-                return Err(Self::Error::from_evm_halt(reason, tx_env.gas_limit()))
+                return Err(Self::Error::from_evm_halt(reason, tx_env.gas_limit()));
             }
             ExecutionResult::Revert { output, .. } => {
                 // if price or limit was included in the request then we can execute the request
@@ -246,7 +246,7 @@ pub trait EstimateCall: Call {
             // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152
             let ratio = (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64);
             if ratio < ESTIMATE_GAS_ERROR_RATIO {
-                break
+                break;
             };
 
             let mut mid_tx_env = tx_env.clone();

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -63,25 +63,25 @@ pub trait EthFees:
     ) -> impl Future<Output = Result<FeeHistory, Self::Error>> + Send {
         async move {
             if block_count == 0 {
-                return Ok(FeeHistory::default())
+                return Ok(FeeHistory::default());
             }
 
             // ensure the given reward percentiles aren't excessive
-            if reward_percentiles.as_ref().map(|perc| perc.len() as u64) >
-                Some(self.gas_oracle().config().max_reward_percentile_count)
+            if reward_percentiles.as_ref().map(|perc| perc.len() as u64)
+                > Some(self.gas_oracle().config().max_reward_percentile_count)
             {
-                return Err(EthApiError::InvalidRewardPercentiles.into())
+                return Err(EthApiError::InvalidRewardPercentiles.into());
             }
 
             // If reward percentiles were specified, we
             // need to validate that they are monotonically
             // increasing and 0 <= p <= 100
             // Note: The types used ensure that the percentiles are never < 0
-            if let Some(percentiles) = &reward_percentiles &&
-                (percentiles.iter().any(|p| *p < 0.0 || *p > 100.0) ||
-                    percentiles.windows(2).any(|w| w[0] > w[1]))
+            if let Some(percentiles) = &reward_percentiles
+                && (percentiles.iter().any(|p| *p < 0.0 || *p > 100.0)
+                    || percentiles.windows(2).any(|w| w[0] > w[1]))
             {
-                return Err(EthApiError::InvalidRewardPercentiles.into())
+                return Err(EthApiError::InvalidRewardPercentiles.into());
             }
 
             // See https://github.com/ethereum/go-ethereum/blob/2754b197c935ee63101cbbca2752338246384fec/eth/gasprice/feehistory.go#L218C8-L225
@@ -112,7 +112,7 @@ pub trait EthFees:
                 if requested > latest_block {
                     return Err(
                         EthApiError::RequestBeyondHead { requested, head: latest_block }.into()
-                    )
+                    );
                 }
             }
 
@@ -150,7 +150,7 @@ pub trait EthFees:
 
             if let Some(fee_entries) = fee_entries {
                 if fee_entries.len() != block_count as usize {
-                    return Err(EthApiError::InvalidBlockRange.into())
+                    return Err(EthApiError::InvalidBlockRange.into());
                 }
 
                 for entry in &fee_entries {
@@ -182,11 +182,12 @@ pub trait EthFees:
                 base_fee_per_blob_gas.push(last_entry.next_block_blob_fee().unwrap_or_default());
             } else {
                 // read the requested header range
-                let headers = self.provider()
+                let headers = self
+                    .provider()
                     .sealed_headers_range(start_block..=end_block)
                     .map_err(Self::Error::from_eth_err)?;
                 if headers.len() != block_count as usize {
-                    return Err(EthApiError::InvalidBlockRange.into())
+                    return Err(EthApiError::InvalidBlockRange.into());
                 }
 
                 let chain_spec = self.provider().chain_spec();
@@ -207,10 +208,9 @@ pub trait EthFees:
 
                 if let Some(percentiles) = reward_percentiles.as_ref().filter(|p| !p.is_empty()) {
                     let hashes: Vec<_> = headers.iter().map(|h| h.hash()).collect();
-                    let mut stream =
-                        futures::stream::iter(hashes)
-                            .map(|hash| self.cache().get_block_and_receipts(hash))
-                            .buffered(4);
+                    let mut stream = futures::stream::iter(hashes)
+                        .map(|hash| self.cache().get_block_and_receipts(hash))
+                        .buffered(4);
                     let mut header_idx = 0;
                     while let Some(result) = stream.next().await {
                         let header = &headers[header_idx];
@@ -246,9 +246,10 @@ pub trait EthFees:
                 // > "[..] includes the next block after the newest of the returned range, because this value can be derived from the newest block.
                 base_fee_per_blob_gas.push(
                     last_header
-                    .maybe_next_block_blob_fee(
-                        chain_spec.blob_params_at_timestamp(last_header.timestamp())
-                    ).unwrap_or_default()
+                        .maybe_next_block_blob_fee(
+                            chain_spec.blob_params_at_timestamp(last_header.timestamp()),
+                        )
+                        .unwrap_or_default(),
                 );
             };
 

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -170,9 +170,9 @@ pub trait LoadPendingBlock:
             // Is the pending block cached?
             if let Some(pending_block) = lock.as_ref() {
                 // Is the cached block not expired and latest is its parent?
-                if evm_env.block_env.number() == U256::from(pending_block.block().number()) &&
-                    parent.hash() == pending_block.block().parent_hash() &&
-                    now <= pending_block.expires_at
+                if evm_env.block_env.number() == U256::from(pending_block.block().number())
+                    && parent.hash() == pending_block.block().parent_hash()
+                    && now <= pending_block.expires_at
                 {
                     return Ok(Some(pending_block.clone()));
                 }
@@ -188,7 +188,7 @@ pub trait LoadPendingBlock:
                 Ok(block) => block,
                 Err(err) => {
                     debug!(target: "rpc", "Failed to build pending block: {:?}", err);
-                    return Ok(None)
+                    return Ok(None);
                 }
             };
 
@@ -297,7 +297,7 @@ pub trait LoadPendingBlock:
                             block_gas_limit,
                         ),
                     );
-                    continue
+                    continue;
                 }
 
                 if pool_tx.origin.is_private() {
@@ -310,7 +310,7 @@ pub trait LoadPendingBlock:
                             InvalidTransactionError::TxTypeNotSupported,
                         ),
                     );
-                    continue
+                    continue;
                 }
 
                 // convert tx to a signed transaction
@@ -318,8 +318,8 @@ pub trait LoadPendingBlock:
 
                 // There's only limited amount of blob space available per block, so we need to
                 // check if the EIP-4844 can still fit in the block
-                if let Some(tx_blob_gas) = tx.blob_gas_used() &&
-                    sum_blob_gas_used + tx_blob_gas > blob_params.max_blob_gas_per_block()
+                if let Some(tx_blob_gas) = tx.blob_gas_used()
+                    && sum_blob_gas_used + tx_blob_gas > blob_params.max_blob_gas_per_block()
                 {
                     // we can't fit this _blob_ transaction into the block, so we mark it as
                     // invalid, which removes its dependent transactions from
@@ -332,7 +332,7 @@ pub trait LoadPendingBlock:
                             blob_params.max_blob_gas_per_block(),
                         ),
                     );
-                    continue
+                    continue;
                 }
 
                 let gas_used = match builder.execute_transaction(tx.clone()) {
@@ -353,7 +353,7 @@ pub trait LoadPendingBlock:
                                 ),
                             );
                         }
-                        continue
+                        continue;
                     }
                     // this is an error that we should treat as fatal for this attempt
                     Err(err) => return Err(Self::Error::from_eth_err(err)),

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -43,7 +43,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             .map_err(Self::Error::from_eth_err)?
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
         if chain_info.best_number.saturating_sub(block_number) > self.max_proof_window() {
-            return Err(EthApiError::ExceedsMaxProofWindow.into())
+            return Err(EthApiError::ExceedsMaxProofWindow.into());
         }
         Ok(())
     }
@@ -270,10 +270,10 @@ pub trait LoadState:
         Self: SpawnBlocking,
     {
         async move {
-            if at.is_pending() &&
-                let Ok(Some(state)) = self.local_pending_state().await
+            if at.is_pending()
+                && let Ok(Some(state)) = self.local_pending_state().await
             {
-                return Ok(state)
+                return Ok(state);
             }
 
             self.provider().state_by_block_id(at).map_err(Self::Error::from_eth_err)

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -273,7 +273,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
 
             if block.body().transactions().is_empty() {
                 // nothing to trace
-                return Ok(Some(Vec::new()))
+                return Ok(Some(Vec::new()));
             }
 
             // replay all transactions of the block

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -113,8 +113,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 while let Some(notification) = stream.next().await {
                     let chain = notification.committed();
                     if let Some((block, tx, receipt, all_receipts)) =
-                        chain.find_transaction_and_receipt_by_hash(hash) &&
-                        let Some(receipt) = convert_transaction_receipt(
+                        chain.find_transaction_and_receipt_by_hash(hash)
+                        && let Some(receipt) = convert_transaction_receipt(
                             block,
                             all_receipts,
                             tx,
@@ -191,7 +191,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             if let Some(tx) =
                 self.pool().get_pooled_transaction_element(hash).map(|tx| tx.encoded_2718().into())
             {
-                return Ok(Some(tx))
+                return Ok(Some(tx));
             }
 
             self.spawn_blocking_io(move |ref this| {
@@ -263,8 +263,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: 'static,
     {
         async move {
-            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await &&
-                let Some(tx) = cached.recovered_transaction().map(|tx| tx.cloned())
+            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
+                && let Some(tx) = cached.recovered_transaction().map(|tx| tx.cloned())
             {
                 let meta = cached.transaction_meta(hash);
 
@@ -280,8 +280,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                     .cache()
                     .get_receipts(cached.block.hash())
                     .await
-                    .map_err(Self::Error::from_eth_err)? &&
-                    let Some(receipt) = receipts.get(cached.tx_index).cloned()
+                    .map_err(Self::Error::from_eth_err)?
+                    && let Some(receipt) = receipts.get(cached.tx_index).cloned()
                 {
                     return Ok(Some((tx, meta, receipt)));
                 }
@@ -336,7 +336,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
 
                     return Ok(Some(
                         self.converter().fill(tx.clone().with_signer(*signer), tx_info)?,
-                    ))
+                    ));
                 }
             }
 
@@ -356,8 +356,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     {
         async move {
             // Check the pool first
-            if include_pending &&
-                let Some(tx) =
+            if include_pending
+                && let Some(tx) =
                     RpcNodeCore::pool(self).get_transaction_by_sender_and_nonce(sender, nonce)
             {
                 let transaction = tx.transaction.clone_into_consensus();
@@ -429,10 +429,10 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: LoadBlock,
     {
         async move {
-            if let Some(block) = self.recovered_block(block_id).await? &&
-                let Some(tx) = block.body().transactions().get(index)
+            if let Some(block) = self.recovered_block(block_id).await?
+                && let Some(tx) = block.body().transactions().get(index)
             {
-                return Ok(Some(tx.encoded_2718().into()))
+                return Ok(Some(tx.encoded_2718().into()));
             }
 
             Ok(None)
@@ -455,7 +455,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             };
 
             if self.find_signer(&from).is_err() {
-                return Err(SignError::NoAccount.into_eth_err())
+                return Err(SignError::NoAccount.into_eth_err());
             }
 
             // set nonce if not already set before
@@ -519,8 +519,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             let chain_id = self.chain_id();
             request.as_mut().set_chain_id(chain_id.to());
 
-            if request.as_ref().has_eip4844_fields() &&
-                request.as_ref().max_fee_per_blob_gas().is_none()
+            if request.as_ref().has_eip4844_fields()
+                && request.as_ref().max_fee_per_blob_gas().is_none()
             {
                 let blob_fee = self.blob_base_fee().await?;
                 request.as_mut().set_max_fee_per_blob_gas(blob_fee.to());
@@ -528,8 +528,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
 
             // Use `sidecar.is_some()` instead of `blob_sidecar().is_some()` to handle
             // both EIP-4844 (v0) and EIP-7594 (v1) sidecar formats
-            if request.as_ref().sidecar.is_some() &&
-                request.as_ref().blob_versioned_hashes.is_none()
+            if request.as_ref().sidecar.is_some()
+                && request.as_ref().blob_versioned_hashes.is_none()
             {
                 request.as_mut().populate_blob_hashes();
             }
@@ -658,8 +658,8 @@ pub trait LoadTransaction: SpawnBlocking + FullEthApiTypes + RpcNodeCoreExt {
     > + Send {
         async move {
             // First, try the RPC cache
-            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await &&
-                let Some(source) = cached.to_transaction_source()
+            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
+                && let Some(source) = cached.to_transaction_source()
             {
                 return Ok(Some(source));
             }

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -350,8 +350,8 @@ where
     fn remove_block_transactions(&mut self, block: &RecoveredBlock<Provider::Block>) {
         let block_hash = block.hash();
         for tx in block.body().transactions() {
-            if let Some((mapped_hash, _)) = self.tx_hash_index.get(tx.tx_hash()) &&
-                *mapped_hash == block_hash
+            if let Some((mapped_hash, _)) = self.tx_hash_index.get(tx.tx_hash())
+                && *mapped_hash == block_hash
             {
                 self.tx_hash_index.remove(tx.tx_hash());
             }
@@ -470,7 +470,7 @@ where
                         CacheAction::GetBlockWithSenders { block_hash, response_tx } => {
                             if let Some(block) = this.full_block_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(Some(block)));
-                                continue
+                                continue;
                             }
 
                             // block is not in the cache, request it if this is the first consumer
@@ -499,7 +499,7 @@ where
                             // check if block is cached
                             if let Some(receipts) = this.receipts_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(Some(receipts)));
-                                continue
+                                continue;
                             }
 
                             // block is not in the cache, request it if this is the first consumer
@@ -524,13 +524,13 @@ where
                             // check if the header is cached
                             if let Some(header) = this.headers_cache.get(&block_hash).cloned() {
                                 let _ = response_tx.send(Ok(header));
-                                continue
+                                continue;
                             }
 
                             // it's possible we have the entire block cached
                             if let Some(block) = this.full_block_cache.get(&block_hash) {
                                 let _ = response_tx.send(Ok(block.clone_header()));
-                                continue
+                                continue;
                             }
 
                             // header is not in the cache, request it if this is the first

--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -100,8 +100,8 @@ where
     {
         let size = value.size();
 
-        if self.cache.limiter().is_over_the_limit(self.cache.len() + 1) &&
-            let Some((_, evicted)) = self.cache.pop_oldest()
+        if self.cache.limiter().is_over_the_limit(self.cache.len() + 1)
+            && let Some((_, evicted)) = self.cache.pop_oldest()
         {
             // update tracked memory with the evicted value
             self.memory_usage = self.memory_usage.saturating_sub(evicted.size());

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -60,7 +60,7 @@ pub trait AsEthApiError {
     /// [`RpcInvalidTransactionError::GasTooHigh`].
     fn is_gas_too_high(&self) -> bool {
         if let Some(err) = self.as_err() {
-            return err.is_gas_too_high()
+            return err.is_gas_too_high();
         }
 
         false
@@ -70,7 +70,7 @@ pub trait AsEthApiError {
     /// [`RpcInvalidTransactionError::GasTooLow`].
     fn is_gas_too_low(&self) -> bool {
         if let Some(err) = self.as_err() {
-            return err.is_gas_too_low()
+            return err.is_gas_too_low();
         }
 
         false

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -232,8 +232,8 @@ impl EthApiError {
         matches!(
             self,
             Self::InvalidTransaction(
-                RpcInvalidTransactionError::GasTooHigh |
-                    RpcInvalidTransactionError::GasLimitTooHigh
+                RpcInvalidTransactionError::GasTooHigh
+                    | RpcInvalidTransactionError::GasLimitTooHigh
             )
         )
     }
@@ -276,26 +276,26 @@ impl EthApiError {
 impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EthApiError) -> Self {
         match error {
-            EthApiError::FailedToDecodeSignedTransaction |
-            EthApiError::InvalidTransactionSignature |
-            EthApiError::EmptyRawTransactionData |
-            EthApiError::InvalidBlockRange |
-            EthApiError::RequestBeyondHead { .. } |
-            EthApiError::ExceedsMaxProofWindow |
-            EthApiError::ConflictingFeeFieldsInRequest |
-            EthApiError::Signing(_) |
-            EthApiError::BothStateAndStateDiffInOverride(_) |
-            EthApiError::InvalidTracerConfig |
-            EthApiError::TransactionConversionError(_) |
-            EthApiError::InvalidRewardPercentiles |
-            EthApiError::InvalidBytecode(_) => invalid_params_rpc_err(error.to_string()),
+            EthApiError::FailedToDecodeSignedTransaction
+            | EthApiError::InvalidTransactionSignature
+            | EthApiError::EmptyRawTransactionData
+            | EthApiError::InvalidBlockRange
+            | EthApiError::RequestBeyondHead { .. }
+            | EthApiError::ExceedsMaxProofWindow
+            | EthApiError::ConflictingFeeFieldsInRequest
+            | EthApiError::Signing(_)
+            | EthApiError::BothStateAndStateDiffInOverride(_)
+            | EthApiError::InvalidTracerConfig
+            | EthApiError::TransactionConversionError(_)
+            | EthApiError::InvalidRewardPercentiles
+            | EthApiError::InvalidBytecode(_) => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),
             EthApiError::PoolError(err) => err.into(),
-            EthApiError::PrevrandaoNotSet |
-            EthApiError::ExcessBlobGasNotSet |
-            EthApiError::InvalidBlockData(_) |
-            EthApiError::Internal(_) |
-            EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
+            EthApiError::PrevrandaoNotSet
+            | EthApiError::ExcessBlobGasNotSet
+            | EthApiError::InvalidBlockData(_)
+            | EthApiError::Internal(_)
+            | EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
             EthApiError::UnknownBlockOrTxIndex | EthApiError::TransactionNotFound => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }
@@ -742,14 +742,14 @@ impl RpcInvalidTransactionError {
     /// Returns the rpc error code for this error.
     pub const fn error_code(&self) -> i32 {
         match self {
-            Self::InvalidChainId |
-            Self::GasTooLow |
-            Self::GasTooHigh |
-            Self::GasRequiredExceedsAllowance { .. } |
-            Self::NonceTooLow { .. } |
-            Self::NonceTooHigh { .. } |
-            Self::FeeCapTooLow |
-            Self::FeeCapVeryHigh => EthRpcErrorCode::InvalidInput.code(),
+            Self::InvalidChainId
+            | Self::GasTooLow
+            | Self::GasTooHigh
+            | Self::GasRequiredExceedsAllowance { .. }
+            | Self::NonceTooLow { .. }
+            | Self::NonceTooHigh { .. }
+            | Self::FeeCapTooLow
+            | Self::FeeCapVeryHigh => EthRpcErrorCode::InvalidInput.code(),
             Self::Revert(_) => EthRpcErrorCode::ExecutionError.code(),
             _ => EthRpcErrorCode::TransactionRejected.code(),
         }
@@ -810,8 +810,8 @@ impl From<InvalidTransaction> for RpcInvalidTransactionError {
             }
             InvalidTransaction::PriorityFeeGreaterThanMaxFee => Self::TipAboveFeeCap,
             InvalidTransaction::GasPriceLessThanBasefee => Self::FeeCapTooLow,
-            InvalidTransaction::CallerGasLimitMoreThanBlock |
-            InvalidTransaction::TxGasLimitGreaterThanCap { .. } => {
+            InvalidTransaction::CallerGasLimitMoreThanBlock
+            | InvalidTransaction::TxGasLimitGreaterThanCap { .. } => {
                 // tx.gas > block.gas_limit
                 Self::GasTooHigh
             }
@@ -848,13 +848,13 @@ impl From<InvalidTransaction> for RpcInvalidTransactionError {
             InvalidTransaction::AuthorizationListNotSupported => {
                 Self::AuthorizationListNotSupported
             }
-            InvalidTransaction::AuthorizationListInvalidFields |
-            InvalidTransaction::EmptyAuthorizationList => Self::AuthorizationListInvalidFields,
-            InvalidTransaction::Eip2930NotSupported |
-            InvalidTransaction::Eip1559NotSupported |
-            InvalidTransaction::Eip4844NotSupported |
-            InvalidTransaction::Eip7702NotSupported |
-            InvalidTransaction::Eip7873NotSupported => Self::TxTypeNotSupported,
+            InvalidTransaction::AuthorizationListInvalidFields
+            | InvalidTransaction::EmptyAuthorizationList => Self::AuthorizationListInvalidFields,
+            InvalidTransaction::Eip2930NotSupported
+            | InvalidTransaction::Eip1559NotSupported
+            | InvalidTransaction::Eip4844NotSupported
+            | InvalidTransaction::Eip7702NotSupported
+            | InvalidTransaction::Eip7873NotSupported => Self::TxTypeNotSupported,
             InvalidTransaction::Eip7873MissingTarget => {
                 Self::other(internal_rpc_err(err.to_string()))
             }
@@ -880,11 +880,11 @@ impl From<InvalidTransactionError> for RpcInvalidTransactionError {
                 Self::OldLegacyChainId
             }
             InvalidTransactionError::ChainIdMismatch => Self::InvalidChainId,
-            InvalidTransactionError::Eip2930Disabled |
-            InvalidTransactionError::Eip1559Disabled |
-            InvalidTransactionError::Eip4844Disabled |
-            InvalidTransactionError::Eip7702Disabled |
-            InvalidTransactionError::TxTypeNotSupported => Self::TxTypeNotSupported,
+            InvalidTransactionError::Eip2930Disabled
+            | InvalidTransactionError::Eip1559Disabled
+            | InvalidTransactionError::Eip4844Disabled
+            | InvalidTransactionError::Eip7702Disabled
+            | InvalidTransactionError::TxTypeNotSupported => Self::TxTypeNotSupported,
             InvalidTransactionError::GasUintOverflow => Self::GasUintOverflow,
             InvalidTransactionError::GasTooLow => Self::GasTooLow,
             InvalidTransactionError::GasTooHigh => Self::GasTooHigh,
@@ -1020,20 +1020,20 @@ impl From<RpcPoolError> for jsonrpsee_types::error::ErrorObject<'static> {
             RpcPoolError::TxPoolOverflow => {
                 rpc_error_with_code(EthRpcErrorCode::TransactionRejected.code(), error.to_string())
             }
-            RpcPoolError::AlreadyKnown |
-            RpcPoolError::InvalidSender |
-            RpcPoolError::Underpriced |
-            RpcPoolError::ReplaceUnderpriced |
-            RpcPoolError::ExceedsGasLimit |
-            RpcPoolError::MaxTxGasLimitExceeded |
-            RpcPoolError::ExceedsFeeCap { .. } |
-            RpcPoolError::NegativeValue |
-            RpcPoolError::OversizedData { .. } |
-            RpcPoolError::ExceedsMaxInitCodeSize |
-            RpcPoolError::PoolTransactionError(_) |
-            RpcPoolError::Eip4844(_) |
-            RpcPoolError::Eip7702(_) |
-            RpcPoolError::AddressAlreadyReserved => {
+            RpcPoolError::AlreadyKnown
+            | RpcPoolError::InvalidSender
+            | RpcPoolError::Underpriced
+            | RpcPoolError::ReplaceUnderpriced
+            | RpcPoolError::ExceedsGasLimit
+            | RpcPoolError::MaxTxGasLimitExceeded
+            | RpcPoolError::ExceedsFeeCap { .. }
+            | RpcPoolError::NegativeValue
+            | RpcPoolError::OversizedData { .. }
+            | RpcPoolError::ExceedsMaxInitCodeSize
+            | RpcPoolError::PoolTransactionError(_)
+            | RpcPoolError::Eip4844(_)
+            | RpcPoolError::Eip7702(_)
+            | RpcPoolError::AddressAlreadyReserved => {
                 rpc_error_with_code(EthRpcErrorCode::InvalidInput.code(), error.to_string())
             }
             RpcPoolError::Other(other) => internal_rpc_err(other.to_string()),

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -110,7 +110,7 @@ where
         if entries.is_empty() {
             self.inner.upper_bound.store(0, SeqCst);
             self.inner.lower_bound.store(0, SeqCst);
-            return
+            return;
         }
 
         let upper_bound = *entries.last_entry().expect("Contains at least one entry").key();
@@ -149,7 +149,7 @@ where
     ) -> Option<Vec<FeeHistoryEntry<H>>> {
         if end_block < start_block {
             // invalid range, return None
-            return None
+            return None;
         }
         let lower_bound = self.lower_bound();
         let upper_bound = self.upper_bound();
@@ -161,7 +161,7 @@ where
                 .collect::<Vec<_>>();
 
             if result.is_empty() {
-                return None
+                return None;
             }
 
             Some(result)
@@ -234,8 +234,8 @@ pub async fn fee_history_cache_new_blocks_task<St, Provider, N>(
     let mut fetch_missing_block = Fuse::terminated();
 
     loop {
-        if fetch_missing_block.is_terminated() &&
-            let Some(block_number) = missing_blocks.pop_front()
+        if fetch_missing_block.is_terminated()
+            && let Some(block_number) = missing_blocks.pop_front()
         {
             trace!(target: "rpc::fee", ?block_number, "Fetching missing block for fee history cache");
             if let Ok(Some(hash)) = provider.block_hash(block_number) {
@@ -325,7 +325,7 @@ where
         // Empty blocks should return in a zero row
         if transactions.is_empty() {
             rewards_in_block.push(0);
-            continue
+            continue;
         }
 
         let threshold = (gas_used as f64 * percentile / 100.) as u64;

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -142,7 +142,7 @@ where
 
         // if we have stored a last price, then we check whether or not it was for the same head
         if inner.last_price.block_hash == header.hash() {
-            return Ok(inner.last_price.price)
+            return Ok(inner.last_price.price);
         }
 
         // if all responses are empty, then we can return a maximum of 2*check_block blocks' worth
@@ -183,7 +183,7 @@ where
 
             // break when we have enough populated blocks
             if populated_blocks >= self.oracle_config.blocks {
-                break
+                break;
             }
 
             current_hash = parent_hash;
@@ -200,8 +200,8 @@ where
         };
 
         // constrain to the max price
-        if let Some(max_price) = self.oracle_config.max_price &&
-            price > max_price
+        if let Some(max_price) = self.oracle_config.max_price
+            && price > max_price
         {
             price = max_price;
         }
@@ -225,7 +225,7 @@ where
     ) -> EthResult<Option<(B256, Vec<U256>)>> {
         // check the cache (this will hit the disk if the block is not cached)
         let Some(block) = self.cache.get_recovered_block(block_hash).await? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         let base_fee_per_gas = block.base_fee_per_gas();
@@ -250,15 +250,15 @@ where
             };
 
             // ignore transactions with a tip under the configured threshold
-            if let Some(ignore_under) = self.ignore_price &&
-                effective_tip < Some(ignore_under)
+            if let Some(ignore_under) = self.ignore_price
+                && effective_tip < Some(ignore_under)
             {
-                continue
+                continue;
             }
 
             // check if the sender was the coinbase, if so, ignore
             if tx.signer() == block.beneficiary() {
-                continue
+                continue;
             }
 
             // a `None` effective_gas_tip represents a transaction where the max_fee_per_gas is
@@ -267,7 +267,7 @@ where
 
             // we have enough entries
             if prices.len() >= limit {
-                break
+                break;
             }
         }
 
@@ -334,8 +334,8 @@ where
         }
 
         // constrain to the max price
-        if let Some(max_price) = self.oracle_config.max_price &&
-            suggestion > max_price
+        if let Some(max_price) = self.oracle_config.max_price
+            && suggestion > max_price
         {
             suggestion = max_price;
         }
@@ -352,7 +352,7 @@ where
     pub async fn get_block_median_tip(&self, block_hash: B256) -> EthResult<Option<U256>> {
         // check the cache (this will hit the disk if the block is not cached)
         let Some(block) = self.cache.get_recovered_block(block_hash).await? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         let base_fee_per_gas = block.base_fee_per_gas();

--- a/crates/rpc/rpc-eth-types/src/id_provider.rs
+++ b/crates/rpc/rpc-eth-types/src/id_provider.rs
@@ -29,7 +29,7 @@ fn to_quantity(val: u128) -> SubscriptionId<'static> {
     let non_zero = b.iter().take_while(|b| **b == 0).count();
     let b = &b[non_zero..];
     if b.is_empty() {
-        return SubscriptionId::Str("0x0".into())
+        return SubscriptionId::Str("0x0".into());
     }
 
     let mut id = String::with_capacity(2 * b.len() + 2);

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -34,7 +34,7 @@ pub fn calculate_gas_used_and_next_log_index(
 /// See [`alloy_eips::eip2718::Decodable2718::decode_2718_exact`]
 pub fn recover_raw_transaction<T: SignedTransaction>(data: &[u8]) -> EthResult<Recovered<T>> {
     if data.is_empty() {
-        return Err(EthApiError::EmptyRawTransactionData)
+        return Err(EthApiError::EmptyRawTransactionData);
     }
 
     let transaction =

--- a/crates/rpc/rpc-layer/src/auth_client_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_client_layer.rs
@@ -66,8 +66,8 @@ pub fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
         "Bearer {}",
         secret
             .encode(&Claims {
-                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
-                    Duration::from_secs(60))
+                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+                    + Duration::from_secs(60))
                 .as_secs(),
                 exp: None,
             })

--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -267,7 +267,7 @@ impl FromStr for RpcModuleSelection {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Ok(Self::Selection(Default::default()))
+            return Ok(Self::Selection(Default::default()));
         }
         let mut modules = s.split(',').map(str::trim).peekable();
         let first = modules.peek().copied().ok_or(ParseError::VariantNotFound)?;

--- a/crates/rpc/rpc-testing-util/tests/it/trace.rs
+++ b/crates/rpc/rpc-testing-util/tests/it/trace.rs
@@ -20,7 +20,7 @@ use std::time::Instant;
 async fn trace_many_blocks() {
     let url = parse_env_url("RETH_RPC_TEST_NODE_URL");
     if url.is_err() {
-        return
+        return;
     }
     let url = url.unwrap();
 
@@ -107,7 +107,7 @@ async fn trace_call() {
 async fn debug_trace_block_entire_chain() {
     let url = parse_env_url("RETH_RPC_TEST_NODE_URL");
     if url.is_err() {
-        return
+        return;
     }
     let url = url.unwrap();
 
@@ -142,7 +142,7 @@ async fn debug_trace_block_opcodes_entire_chain() {
     let opcodes7702 = ["EXTCODESIZE", "EXTCODECOPY", "EXTCODEHASH"];
     let url = parse_env_url("RETH_RPC_TEST_NODE_URL");
     if url.is_err() {
-        return
+        return;
     }
     let url = url.unwrap();
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -73,8 +73,8 @@ where
         // Spawn a task caching bad blocks
         executor.spawn_task(async move {
             while let Some(event) = stream.next().await {
-                if let ConsensusEngineEvent::InvalidBlock(block) = event &&
-                    let Ok(recovered) =
+                if let ConsensusEngineEvent::InvalidBlock(block) = event
+                    && let Ok(recovered) =
                         RecoveredBlock::try_recover_sealed(block.as_ref().clone())
                 {
                     bad_block_store.insert(recovered);
@@ -350,7 +350,7 @@ where
                 tx_index,
                 block.transaction_count()
             ))
-            .into())
+            .into());
         }
 
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
@@ -398,7 +398,7 @@ where
         opts: Option<GethDebugTracingCallOptions>,
     ) -> Result<Vec<Vec<GethTrace>>, Eth::Error> {
         if bundles.is_empty() {
-            return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into())
+            return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into());
         }
 
         let StateContext { transaction_index, block_number } = state_context.unwrap_or_default();

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -68,23 +68,23 @@ where
             return Err(EthApiError::InvalidParams(
                 EthBundleError::EmptyBundleTransactions.to_string(),
             )
-            .into())
+            .into());
         }
         if block_number == 0 {
             return Err(EthApiError::InvalidParams(
                 EthBundleError::BundleMissingBlockNumber.to_string(),
             )
-            .into())
+            .into());
         }
 
         // Validate gas limit against the configured call gas limit before any DB calls
         let call_gas_limit = self.inner.eth_api.call_gas_limit();
-        if let Some(gas_limit) = gas_limit &&
-            gas_limit > call_gas_limit
+        if let Some(gas_limit) = gas_limit
+            && gas_limit > call_gas_limit
         {
             return Err(
                 EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
-            )
+            );
         }
 
         let transactions = txs
@@ -126,7 +126,7 @@ where
                     EthBundleError::Eip4844BlobGasExceeded(blob_params.max_blob_gas_per_block())
                         .to_string(),
                 )
-                .into())
+                .into());
             }
         }
 

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -233,7 +233,7 @@ where
 
             if filter.block > best_number {
                 // no new blocks since the last poll
-                return Ok(FilterChanges::Empty)
+                return Ok(FilterChanges::Empty);
             }
 
             // update filter
@@ -312,7 +312,7 @@ where
                 *inner_filter.clone()
             } else {
                 // Not a log filter
-                return Err(EthFilterError::FilterNotFound(id))
+                return Err(EthFilterError::FilterNotFound(id));
             }
         };
 
@@ -475,7 +475,7 @@ where
                 let Some((receipts, maybe_block)) =
                     self.eth_cache().get_receipts_and_maybe_block(block_hash).await?
                 else {
-                    return Err(ProviderError::HeaderNotFound(block_hash.into()).into())
+                    return Err(ProviderError::HeaderNotFound(block_hash.into()).into());
                 };
 
                 // Get header - from cached block if available, otherwise from provider
@@ -520,8 +520,8 @@ where
                     }
                     // Try to get pending block and receipts
                     if let Ok(Some(pending_block)) = self.eth_api.local_pending_block().await {
-                        if let BlockNumberOrTag::Number(to_block) = to_block &&
-                            to_block < pending_block.block.number()
+                        if let BlockNumberOrTag::Number(to_block) = to_block
+                            && to_block < pending_block.block.number()
                         {
                             // this block range is empty based on the user input
                             return Ok(Vec::new());
@@ -559,14 +559,14 @@ where
                     .flatten();
 
                 // Return error if toBlock exceeds current head
-                if let Some(t) = to &&
-                    t > info.best_number
+                if let Some(t) = to
+                    && t > info.best_number
                 {
                     return Err(EthFilterError::BlockRangeExceedsHead);
                 }
 
-                if let Some(f) = from &&
-                    f > info.best_number
+                if let Some(f) = from
+                    && f > info.best_number
                 {
                     // start block higher than local head, can return empty
                     return Ok(Vec::new());
@@ -627,13 +627,13 @@ where
 
         // perform boundary checks first
         if to_block < from_block {
-            return Err(EthFilterError::InvalidBlockRangeParams)
+            return Err(EthFilterError::InvalidBlockRangeParams);
         }
 
         if let Some(max_blocks_per_filter) =
             limits.max_blocks_per_filter.filter(|limit| to_block - from_block > *limit)
         {
-            return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter))
+            return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter));
         }
 
         let (tx, rx) = oneshot::channel();
@@ -678,7 +678,7 @@ where
 
             while let Some(header) = headers_iter.next() {
                 if !filter.matches_bloom(header.logs_bloom()) {
-                    continue
+                    continue;
                 }
 
                 let current_number = header.number();
@@ -728,9 +728,9 @@ where
             // size check but only if range is multiple blocks, so we always return all
             // logs of a single block
             let is_multi_block_range = from_block != to_block;
-            if let Some(max_logs_per_response) = limits.max_logs_per_response &&
-                is_multi_block_range &&
-                all_logs.len() > max_logs_per_response
+            if let Some(max_logs_per_response) = limits.max_logs_per_response
+                && is_multi_block_range
+                && all_logs.len() > max_logs_per_response
             {
                 debug!(
                     target: "rpc::eth::filter",
@@ -924,7 +924,7 @@ impl Iterator for BlockRangeInclusiveIter {
         let start = self.iter.next()?;
         let end = (start + self.step).min(self.end);
         if start > end {
-            return None
+            return None;
         }
         Some((start, end))
     }
@@ -974,10 +974,10 @@ impl From<EthFilterError> for jsonrpsee::types::error::ErrorObject<'static> {
                 rpc_error_with_code(jsonrpsee::types::error::INTERNAL_ERROR_CODE, err.to_string())
             }
             EthFilterError::EthAPIError(err) => err.into(),
-            err @ (EthFilterError::InvalidBlockRangeParams |
-            EthFilterError::QueryExceedsMaxBlocks(_) |
-            EthFilterError::QueryExceedsMaxResults { .. } |
-            EthFilterError::BlockRangeExceedsHead) => {
+            err @ (EthFilterError::InvalidBlockRangeParams
+            | EthFilterError::QueryExceedsMaxBlocks(_)
+            | EthFilterError::QueryExceedsMaxResults { .. }
+            | EthFilterError::BlockRangeExceedsHead) => {
                 rpc_error_with_code(jsonrpsee::types::error::INVALID_PARAMS_CODE, err.to_string())
             }
         }

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -125,7 +125,7 @@ where
                                 };
                                 std::future::ready(tx_value)
                             });
-                            return pipe_from_stream(accepted_sink, stream).await
+                            return pipe_from_stream(accepted_sink, stream).await;
                         }
                         Params::Bool(false) | Params::None => {
                             // only hashes requested
@@ -158,7 +158,7 @@ where
                 .map_err(SubscriptionSerializeError::new)?;
 
                 if accepted_sink.send(msg).await.is_err() {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 while canon_state.next().await.is_some() {
@@ -178,7 +178,7 @@ where
                         .map_err(SubscriptionSerializeError::new)?;
 
                         if accepted_sink.send(msg).await.is_err() {
-                            break
+                            break;
                         }
                     }
                 }

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -269,8 +269,8 @@ where
                     let max_block_number =
                         item.inclusion.max_block_number().unwrap_or(block_number);
 
-                    if current_block_number < block_number ||
-                        current_block_number > max_block_number
+                    if current_block_number < block_number
+                        || current_block_number > max_block_number
                     {
                         return Err(EthApiError::InvalidParams(
                             EthSimBundleError::InvalidInclusion.to_string(),
@@ -350,9 +350,9 @@ where
                         });
 
                         // Calculate payout transaction fee
-                        let payout_tx_fee = U256::from(basefee) *
-                            U256::from(SBUNDLE_PAYOUT_MAX_COST) *
-                            U256::from(refund_configs.len() as u64);
+                        let payout_tx_fee = U256::from(basefee)
+                            * U256::from(SBUNDLE_PAYOUT_MAX_COST)
+                            * U256::from(refund_configs.len() as u64);
 
                         // Add gas used for payout transactions
                         total_gas_used += SBUNDLE_PAYOUT_MAX_COST * refund_configs.len() as u64;
@@ -360,8 +360,8 @@ where
                         // Calculate allocated refundable value (payout value) based on ORIGINAL
                         // refundable value This ensures all refund_percent
                         // values are calculated from the same base
-                        let payout_value = original_refundable_value * U256::from(refund_percent) /
-                            U256::from(100);
+                        let payout_value = original_refundable_value * U256::from(refund_percent)
+                            / U256::from(100);
 
                         if payout_tx_fee > payout_value {
                             return Err(EthApiError::InvalidParams(

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -229,7 +229,7 @@ where
         if tx_len != receipts.len() {
             return Err(internal_rpc_err(
                 "the number of transactions does not match the number of receipts",
-            ))
+            ));
         }
 
         // make sure the block is full

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -85,7 +85,7 @@ where
 
     fn try_balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
         let Some(block_number) = self.provider().block_number_for_id(block_id)? else {
-            return Err(EthApiError::HeaderNotFound(block_id))
+            return Err(EthApiError::HeaderNotFound(block_id));
         };
 
         let state = self.provider().state_by_block_id(block_id)?;
@@ -128,7 +128,7 @@ where
         if block_count == 0 || block_count > MAX_BLOCK_COUNT {
             return Err(EthApiError::InvalidParams(format!(
                 "block count must be between 1 and {MAX_BLOCK_COUNT}, got {block_count}"
-            )))
+            )));
         }
 
         let permit = self
@@ -151,11 +151,11 @@ where
         block_count: u64,
     ) -> EthResult<Option<ExecutionOutcome<N::Receipt>>> {
         let Some(start_block) = self.provider().block_number_for_id(block_id)? else {
-            return Ok(None)
+            return Ok(None);
         };
 
         if start_block == 0 {
-            return Ok(Some(ExecutionOutcome::default()))
+            return Ok(Some(ExecutionOutcome::default()));
         }
 
         let state_provider = self.provider().history_by_block_number(start_block - 1)?;
@@ -168,7 +168,7 @@ where
                 .recovered_block(block_number.into(), TransactionVariant::WithHash)?
             else {
                 if block_number == start_block {
-                    return Ok(None)
+                    return Ok(None);
                 }
                 break;
             };

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -141,10 +141,10 @@ where
                     let tx_rlp_len = tx.tx().length();
                     if is_osaka {
                         // 1KB overhead for block header
-                        let estimated_block_size = block_transactions_rlp_length +
-                            tx_rlp_len +
-                            withdrawals_rlp_length +
-                            1024;
+                        let estimated_block_size = block_transactions_rlp_length
+                            + tx_rlp_len
+                            + withdrawals_rlp_length
+                            + 1024;
                         if estimated_block_size > MAX_RLP_BLOCK_SIZE {
                             if skip_invalid_transactions {
                                 debug!(

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -217,7 +217,7 @@ where
     ) -> Result<Option<LocalizedTransactionTrace>, Eth::Error> {
         if indices.len() != 1 {
             // The OG impl failed if it gets more than a single index
-            return Ok(None)
+            return Ok(None);
         }
         self.trace_get_index(hash, indices[0]).await
     }
@@ -283,7 +283,7 @@ where
         let chain_spec = self.provider().chain_spec();
 
         if chain_spec.is_paris_active_at_block(header.number()) {
-            return Ok(None)
+            return Ok(None);
         }
 
         Ok(Some(base_block_reward_pre_merge(&chain_spec, header.number())))
@@ -361,7 +361,7 @@ where
             return Err(EthApiError::InvalidParams(
                 "invalid parameters: fromBlock cannot be greater than toBlock".to_string(),
             )
-            .into())
+            .into());
         }
 
         // ensure that the range is not too large, since we need to fetch all blocks in the range
@@ -371,7 +371,7 @@ where
                 "Block range too large; currently limited to {} blocks",
                 self.inner.eth_config.max_trace_filter_blocks
             ))
-            .into())
+            .into());
         }
 
         let mut all_traces = Vec::new();
@@ -437,13 +437,13 @@ where
                 } else {
                     // no block reward, means we're past the Paris hardfork and don't expect any
                     // rewards because the blocks in ascending order
-                    break
+                    break;
                 }
             }
 
             // Skips the first `after` number of matching traces.
-            if let Some(cutoff) = after.map(|a| a as usize) &&
-                cutoff < all_traces.len()
+            if let Some(cutoff) = after.map(|a| a as usize)
+                && cutoff < all_traces.len()
             {
                 all_traces.drain(..cutoff);
                 // we removed the first `after` traces
@@ -455,17 +455,17 @@ where
                 let count = count as usize;
                 if count < all_traces.len() {
                     all_traces.truncate(count);
-                    return Ok(all_traces)
+                    return Ok(all_traces);
                 }
             };
         }
 
         // If `after` is greater than or equal to the number of matched traces, it returns an
         // empty array.
-        if let Some(cutoff) = after.map(|a| a as usize) &&
-            cutoff >= all_traces.len()
+        if let Some(cutoff) = after.map(|a| a as usize)
+            && cutoff >= all_traces.len()
         {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
 
         Ok(all_traces)
@@ -497,8 +497,8 @@ where
             .await?
             .map(|traces| traces.into_iter().flatten().collect::<Vec<_>>());
 
-        if let Some(traces) = traces.as_mut() &&
-            let Some(base_block_reward) = self.calculate_base_block_reward(block.header())?
+        if let Some(traces) = traces.as_mut()
+            && let Some(base_block_reward) = self.calculate_base_block_reward(block.header())?
         {
             traces.extend(self.extract_reward_traces(
                 block.header(),

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -135,19 +135,19 @@ where
 
         if !self.disallow.is_empty() {
             if self.disallow.contains(&block.beneficiary()) {
-                return Err(ValidationApiError::Blacklist(block.beneficiary()))
+                return Err(ValidationApiError::Blacklist(block.beneficiary()));
             }
             if self.disallow.contains(&message.proposer_fee_recipient) {
-                return Err(ValidationApiError::Blacklist(message.proposer_fee_recipient))
+                return Err(ValidationApiError::Blacklist(message.proposer_fee_recipient));
             }
             for (sender, tx) in block.senders_iter().zip(block.body().transactions()) {
                 if self.disallow.contains(sender) {
-                    return Err(ValidationApiError::Blacklist(*sender))
+                    return Err(ValidationApiError::Blacklist(*sender));
                 }
-                if let Some(to) = tx.to() &&
-                    self.disallow.contains(&to)
+                if let Some(to) = tx.to()
+                    && self.disallow.contains(&to)
                 {
-                    return Err(ValidationApiError::Blacklist(to))
+                    return Err(ValidationApiError::Blacklist(to));
                 }
             }
         }
@@ -164,10 +164,10 @@ where
                 .sealed_header_by_hash(block.parent_hash())?
                 .ok_or_else(|| ValidationApiError::MissingParentBlock)?;
 
-            if latest_header.number().saturating_sub(parent_header.number()) >
-                self.validation_window
+            if latest_header.number().saturating_sub(parent_header.number())
+                > self.validation_window
             {
-                return Err(ValidationApiError::BlockTooOld)
+                return Err(ValidationApiError::BlockTooOld);
             }
             parent_header
         };
@@ -196,13 +196,13 @@ where
         })?;
 
         if let Some(account) = accessed_blacklisted {
-            return Err(ValidationApiError::Blacklist(account))
+            return Err(ValidationApiError::Blacklist(account));
         }
 
         // update the cached reads
         self.update_cached_reads(parent_header_hash, request_cache).await;
 
-        self.consensus.validate_block_post_execution(&block, &output, None)?;
+        self.consensus.validate_block_post_execution(&block, &output, None, None, false)?;
 
         self.ensure_payment(&block, &output, &message)?;
 
@@ -213,7 +213,7 @@ where
             return Err(ConsensusError::BodyStateRootDiff(
                 GotExpected { got: state_root, expected: block.header().state_root() }.into(),
             )
-            .into())
+            .into());
         }
 
         Ok(())
@@ -272,7 +272,7 @@ where
             return Err(ValidationApiError::GasLimitMismatch(GotExpected {
                 got: header.gas_limit(),
                 expected: best_gas_limit,
-            }))
+            }));
         }
 
         Ok(())
@@ -310,7 +310,7 @@ where
         }
 
         if balance_after >= balance_before.saturating_add(message.value) {
-            return Ok(())
+            return Ok(());
         }
 
         let (receipt, tx) = output
@@ -320,25 +320,25 @@ where
             .ok_or(ValidationApiError::ProposerPayment)?;
 
         if !receipt.status() {
-            return Err(ValidationApiError::ProposerPayment)
+            return Err(ValidationApiError::ProposerPayment);
         }
 
         if tx.to() != Some(message.proposer_fee_recipient) {
-            return Err(ValidationApiError::ProposerPayment)
+            return Err(ValidationApiError::ProposerPayment);
         }
 
         if tx.value() != message.value {
-            return Err(ValidationApiError::ProposerPayment)
+            return Err(ValidationApiError::ProposerPayment);
         }
 
         if !tx.input().is_empty() {
-            return Err(ValidationApiError::ProposerPayment)
+            return Err(ValidationApiError::ProposerPayment);
         }
 
-        if let Some(block_base_fee) = block.header().base_fee_per_gas() &&
-            tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0
+        if let Some(block_base_fee) = block.header().base_fee_per_gas()
+            && tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0
         {
-            return Err(ValidationApiError::ProposerPayment)
+            return Err(ValidationApiError::ProposerPayment);
         }
 
         Ok(())
@@ -349,10 +349,10 @@ where
         &self,
         mut blobs_bundle: BlobsBundleV1,
     ) -> Result<Vec<B256>, ValidationApiError> {
-        if blobs_bundle.commitments.len() != blobs_bundle.proofs.len() ||
-            blobs_bundle.commitments.len() != blobs_bundle.blobs.len()
+        if blobs_bundle.commitments.len() != blobs_bundle.proofs.len()
+            || blobs_bundle.commitments.len() != blobs_bundle.blobs.len()
         {
-            return Err(ValidationApiError::InvalidBlobsBundle)
+            return Err(ValidationApiError::InvalidBlobsBundle);
         }
 
         let versioned_hashes = blobs_bundle
@@ -458,8 +458,8 @@ where
 
         // Check block size as per EIP-7934 (only applies when Osaka hardfork is active)
         let chain_spec = self.provider.chain_spec();
-        if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) &&
-            block.rlp_length() > MAX_RLP_BLOCK_SIZE
+        if chain_spec.is_osaka_active_at_timestamp(block.timestamp())
+            && block.rlp_length() > MAX_RLP_BLOCK_SIZE
         {
             return Err(ValidationApiError::Consensus(ConsensusError::BlockTooLarge {
                 rlp_length: block.rlp_length(),
@@ -663,20 +663,20 @@ pub enum ValidationApiError {
 impl From<ValidationApiError> for ErrorObject<'static> {
     fn from(error: ValidationApiError) -> Self {
         match error {
-            ValidationApiError::GasLimitMismatch(_) |
-            ValidationApiError::GasUsedMismatch(_) |
-            ValidationApiError::ParentHashMismatch(_) |
-            ValidationApiError::BlockHashMismatch(_) |
-            ValidationApiError::Blacklist(_) |
-            ValidationApiError::ProposerPayment |
-            ValidationApiError::InvalidBlobsBundle |
-            ValidationApiError::Blob(_) => invalid_params_rpc_err(error.to_string()),
+            ValidationApiError::GasLimitMismatch(_)
+            | ValidationApiError::GasUsedMismatch(_)
+            | ValidationApiError::ParentHashMismatch(_)
+            | ValidationApiError::BlockHashMismatch(_)
+            | ValidationApiError::Blacklist(_)
+            | ValidationApiError::ProposerPayment
+            | ValidationApiError::InvalidBlobsBundle
+            | ValidationApiError::Blob(_) => invalid_params_rpc_err(error.to_string()),
 
-            ValidationApiError::MissingLatestBlock |
-            ValidationApiError::MissingParentBlock |
-            ValidationApiError::BlockTooOld |
-            ValidationApiError::Consensus(_) |
-            ValidationApiError::Provider(_) => internal_rpc_err(error.to_string()),
+            ValidationApiError::MissingLatestBlock
+            | ValidationApiError::MissingParentBlock
+            | ValidationApiError::BlockTooOld
+            | ValidationApiError::Consensus(_)
+            | ValidationApiError::Provider(_) => internal_rpc_err(error.to_string()),
             ValidationApiError::Execution(err) => match err {
                 error @ BlockExecutionError::Validation(_) => {
                     invalid_params_rpc_err(error.to_string())

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -123,15 +123,15 @@ impl StageError {
     pub const fn is_fatal(&self) -> bool {
         matches!(
             self,
-            Self::Database(_) |
-                Self::Download(_) |
-                Self::DatabaseIntegrity(_) |
-                Self::StageCheckpoint(_) |
-                Self::MissingDownloadBuffer |
-                Self::MissingSyncGap |
-                Self::ChannelClosed |
-                Self::Internal(_) |
-                Self::Fatal(_)
+            Self::Database(_)
+                | Self::Download(_)
+                | Self::DatabaseIntegrity(_)
+                | Self::StageCheckpoint(_)
+                | Self::MissingDownloadBuffer
+                | Self::MissingSyncGap
+                | Self::ChannelClosed
+                | Self::Internal(_)
+                | Self::Fatal(_)
         )
     }
 }

--- a/crates/stages/api/src/metrics/listener.rs
+++ b/crates/stages/api/src/metrics/listener.rs
@@ -96,7 +96,7 @@ impl Future for MetricsListener {
         loop {
             let Some(event) = ready!(this.events_rx.poll_recv(cx)) else {
                 // Channel has closed
-                return Poll::Ready(())
+                return Poll::Ready(());
             };
 
             this.handle_event(event);

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -159,14 +159,14 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                     PipelineTarget::Sync(tip) => self.set_tip(tip),
                     PipelineTarget::Unwind(target) => {
                         if let Err(err) = self.move_to_static_files() {
-                            return (self, Err(err.into()))
+                            return (self, Err(err.into()));
                         }
                         if let Err(err) = self.unwind(target, None) {
-                            return (self, Err(err))
+                            return (self, Err(err));
                         }
                         self.progress.update(target);
 
-                        return (self, Ok(ControlFlow::Continue { block_number: target }))
+                        return (self, Ok(ControlFlow::Continue { block_number: target }));
                     }
                 }
             }
@@ -186,13 +186,14 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
             let next_action = self.run_loop().await?;
 
             if next_action.is_unwind() && self.fail_on_unwind {
-                return Err(PipelineError::UnexpectedUnwind)
+                return Err(PipelineError::UnexpectedUnwind);
             }
 
             // Terminate the loop early if it's reached the maximum user
             // configured block.
-            if next_action.should_continue() &&
-                self.progress
+            if next_action.should_continue()
+                && self
+                    .progress
                     .minimum_block_number
                     .zip(self.max_block)
                     .is_some_and(|(progress, target)| progress >= target)
@@ -204,7 +205,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                     max_block = ?self.max_block,
                     "Terminating pipeline."
                 );
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -242,7 +243,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                 ControlFlow::Continue { block_number } => self.progress.update(block_number),
                 ControlFlow::Unwind { target, bad_block } => {
                     self.unwind(target, Some(bad_block.block.number))?;
-                    return Ok(ControlFlow::Unwind { target, bad_block })
+                    return Ok(ControlFlow::Unwind { target, bad_block });
                 }
             }
 
@@ -333,7 +334,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                 );
                 self.event_sender.notify(PipelineEvent::Skipped { stage_id });
 
-                continue
+                continue;
             }
 
             info!(
@@ -384,8 +385,8 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
 
                         // If None, that means the finalized block is not written so we should
                         // always save in that case
-                        if last_saved_finalized_block_number.is_none() ||
-                            Some(checkpoint.block_number) < last_saved_finalized_block_number
+                        if last_saved_finalized_block_number.is_none()
+                            || Some(checkpoint.block_number) < last_saved_finalized_block_number
                         {
                             provider_rw.save_finalized_block_number(BlockNumber::from(
                                 checkpoint.block_number,
@@ -401,7 +402,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                     Err(err) => {
                         self.event_sender.notify(PipelineEvent::Error { stage_id });
 
-                        return Err(PipelineError::Stage(StageError::Fatal(Box::new(err))))
+                        return Err(PipelineError::Stage(StageError::Fatal(Box::new(err))));
                     }
                 }
             }
@@ -440,7 +441,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                 // We reached the maximum block, so we skip the stage
                 return Ok(ControlFlow::NoProgress {
                     block_number: prev_checkpoint.map(|progress| progress.block_number),
-                })
+                });
             }
 
             let exec_input = ExecInput { target, checkpoint: prev_checkpoint };
@@ -513,7 +514,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             ControlFlow::Continue { block_number }
                         } else {
                             ControlFlow::NoProgress { block_number: Some(block_number) }
-                        })
+                        });
                     }
                 }
                 Err(err) => {
@@ -521,7 +522,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                     self.event_sender.notify(PipelineEvent::Error { stage_id });
 
                     if let Some(ctrl) = self.on_stage_error(stage_id, prev_checkpoint, err)? {
-                        return Ok(ctrl)
+                        return Ok(ctrl);
                     }
                 }
             }
@@ -538,8 +539,8 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
             warn!(target: "sync::pipeline", stage = %stage_id, ?local_head, ?header, %error, "Stage encountered detached head");
 
             if let Some(last_detached_head_unwind_target) = self.last_detached_head_unwind_target {
-                if local_head.block.hash == last_detached_head_unwind_target &&
-                    header.block.number == local_head.block.number + 1
+                if local_head.block.hash == last_detached_head_unwind_target
+                    && header.block.number == local_head.block.number + 1
                 {
                     self.detached_head_attempts += 1;
                 } else {

--- a/crates/stages/api/src/pipeline/set.rs
+++ b/crates/stages/api/src/pipeline/set.rs
@@ -73,8 +73,8 @@ impl<Provider> StageSetBuilder<Provider> {
 
     fn upsert_stage_state(&mut self, stage: Box<dyn Stage<Provider>>, added_at_index: usize) {
         let stage_id = stage.id();
-        if self.stages.insert(stage.id(), StageEntry { stage, enabled: true }).is_some() &&
-            let Some(to_remove) = self
+        if self.stages.insert(stage.id(), StageEntry { stage, enabled: true }).is_some()
+            && let Some(to_remove) = self
                 .order
                 .iter()
                 .enumerate()
@@ -240,7 +240,7 @@ impl<Provider> StageSetBuilder<Provider> {
         F: FnOnce() -> bool,
     {
         if f() {
-            return self.disable(stage_id)
+            return self.disable(stage_id);
         }
         self
     }
@@ -254,7 +254,7 @@ impl<Provider> StageSetBuilder<Provider> {
         F: FnOnce() -> bool,
     {
         if f() {
-            return self.disable_all(stages)
+            return self.disable_all(stages);
         }
         self
     }
@@ -263,8 +263,8 @@ impl<Provider> StageSetBuilder<Provider> {
     pub fn build(mut self) -> Vec<Box<dyn Stage<Provider>>> {
         let mut stages = Vec::new();
         for id in &self.order {
-            if let Some(entry) = self.stages.remove(id) &&
-                entry.enabled
+            if let Some(entry) = self.stages.remove(id)
+                && entry.enabled
             {
                 stages.push(entry.stage);
             }

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -101,7 +101,7 @@ impl ExecInput {
         let Some(lowest_transactions_block) =
             provider.static_file_provider().get_lowest_range_start(StaticFileSegment::Transactions)
         else {
-            return Ok(None)
+            return Ok(None);
         };
 
         // We can only process transactions that have associated static files, so we cap the start
@@ -117,7 +117,7 @@ impl ExecInput {
         // and we return early. It's possible to trigger this scenario when running `reth
         // stage run` manually for a range of transactions that doesn't exist.
         if start_block > target_block {
-            return Ok(None)
+            return Ok(None);
         }
 
         let start_block_body = provider
@@ -134,7 +134,7 @@ impl ExecInput {
 
         if all_tx_cnt == 0 {
             // if there is no more transaction return back.
-            return Ok(None)
+            return Ok(None);
         }
 
         // get block of this tx

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -125,7 +125,7 @@ where
                         &static_file_provider,
                         provider,
                         StaticFileSegment::Transactions,
-                    )?)
+                    )?);
                 }
             } else {
                 return Err(missing_static_data_error(
@@ -133,7 +133,7 @@ where
                     &static_file_provider,
                     provider,
                     StaticFileSegment::Transactions,
-                )?)
+                )?);
             }
         }
         Ordering::Equal => {}
@@ -162,7 +162,7 @@ where
         input: ExecInput,
     ) -> Poll<Result<(), StageError>> {
         if input.target_reached() || self.buffer.is_some() {
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         // Update the header range on the downloader
@@ -188,7 +188,7 @@ where
     /// header, limited by the stage's batch size.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
         let (from_block, to_block) = input.next_block_range().into_inner();
 
@@ -784,7 +784,7 @@ mod tests {
                 let this = self.get_mut();
 
                 if this.headers.is_empty() {
-                    return Poll::Ready(None)
+                    return Poll::Ready(None);
                 }
 
                 let mut response =
@@ -801,12 +801,12 @@ mod tests {
                     }
 
                     if response.len() as u64 >= this.batch_size {
-                        break
+                        break;
                     }
                 }
 
                 if !response.is_empty() {
-                    return Poll::Ready(Some(Ok(response)))
+                    return Poll::Ready(Some(Ok(response)));
                 }
 
                 panic!("requested bodies without setting headers")

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -149,13 +149,13 @@ where
             return Poll::Ready(Ok(()));
         }
 
-        if self.stream.is_none() &&
-            let Some(source) = self.source.clone()
+        if self.stream.is_none()
+            && let Some(source) = self.source.clone()
         {
             self.stream.replace(source.create(input)?);
         }
-        if let Some(stream) = &mut self.stream &&
-            let Some(next) = ready!(stream.poll_next_unpin(cx))
+        if let Some(stream) = &mut self.stream
+            && let Some(next) = ready!(stream.poll_next_unpin(cx))
                 .transpose()
                 .map_err(|e| StageError::Fatal(e.into()))?
         {
@@ -452,8 +452,8 @@ mod tests {
                     Some(output) if output.checkpoint.block_number > initial_checkpoint => {
                         let provider = self.db.factory.provider()?;
 
-                        for block_num in initial_checkpoint..
-                            output
+                        for block_num in initial_checkpoint
+                            ..output
                                 .checkpoint
                                 .block_number
                                 .min(self.responses.as_ref().map(|v| v.len()).unwrap_or_default()

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -171,8 +171,8 @@ where
     ) -> Result<bool, StageError> {
         // We can only prune changesets if we're not executing MerkleStage from scratch (by
         // threshold or first-sync)
-        Ok(max_block - start_block > self.external_clean_threshold ||
-            provider.count_entries::<tables::AccountsTrie>()?.is_zero())
+        Ok(max_block - start_block > self.external_clean_threshold
+            || provider.count_entries::<tables::AccountsTrie>()?.is_zero())
     }
 
     /// Performs consistency check on static files.
@@ -199,7 +199,7 @@ where
         // On old nodes, if there's any receipts pruning configured, receipts are written directly
         // to database and inconsistencies are expected.
         if EitherWriter::receipts_destination(provider).is_database() {
-            return Ok(())
+            return Ok(());
         }
 
         // Get next expected receipt number
@@ -238,10 +238,10 @@ where
             Ordering::Less => {
                 // If we are already in the process of unwind, this might be fine because we will
                 // fix the inconsistency right away.
-                if let Some(unwind_to) = unwind_to &&
-                    unwind_to <= static_file_block_num
+                if let Some(unwind_to) = unwind_to
+                    && unwind_to <= static_file_block_num
                 {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 // Otherwise, this is a real inconsistency - database has more blocks than static
@@ -251,7 +251,7 @@ where
                     &static_file_provider,
                     provider,
                     StaticFileSegment::Receipts,
-                )?)
+                )?);
             }
         }
 
@@ -293,7 +293,7 @@ where
     /// Execute the stage
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let start_block = input.next_block();
@@ -357,11 +357,13 @@ where
                 })
             })?;
 
-            if let Err(err) = self.consensus.validate_block_post_execution(&block, &result, None) {
+            if let Err(err) =
+                self.consensus.validate_block_post_execution(&block, &result, None, None, false)
+            {
                 return Err(StageError::Block {
                     block: Box::new(block.block_with_parent()),
                     error: BlockErrorKind::Validation(err),
-                })
+                });
             }
             results.push(result);
 
@@ -398,7 +400,7 @@ where
                 cumulative_gas,
                 batch_start.elapsed(),
             ) {
-                break
+                break;
             }
         }
 
@@ -436,7 +438,7 @@ where
                 // means that we didn't send the notification to ExExes
                 return Err(StageError::PostExecuteCommit(
                     "Previous post execute commit input wasn't processed",
-                ))
+                ));
             }
         }
 
@@ -450,15 +452,15 @@ where
                 let Some(reverts) =
                     state.bundle.reverts.get_mut((block_number - start_block) as usize)
                 else {
-                    break
+                    break;
                 };
 
                 // If both account history and storage history pruning is configured, clear reverts
                 // for this block.
                 if prune_modes
                     .account_history
-                    .is_some_and(|m| m.should_prune(block_number, max_block)) &&
-                    prune_modes
+                    .is_some_and(|m| m.should_prune(block_number, max_block))
+                    && prune_modes
                         .storage_history
                         .is_some_and(|m| m.should_prune(block_number, max_block))
                 {
@@ -539,7 +541,7 @@ where
         if range.is_empty() {
             return Ok(UnwindOutput {
                 checkpoint: input.checkpoint.with_block_number(input.unwind_to),
-            })
+            });
         }
 
         reject_cancun_boundary_unwind(provider, input.checkpoint.block_number, unwind_to)?;
@@ -631,7 +633,7 @@ where
                 unwind_to_header.timestamp()
             ))
             .into(),
-        ))
+        ));
     }
 
     Ok(())
@@ -703,8 +705,8 @@ where
                 block_range: CheckpointBlockRange { from: start_block, to: max_block },
                 progress: EntitiesCheckpoint {
                     processed,
-                    total: processed +
-                        calculate_gas_used_from_headers(provider, start_block..=max_block)?,
+                    total: processed
+                        + calculate_gas_used_from_headers(provider, start_block..=max_block)?,
                 },
             }
         }

--- a/crates/stages/stages/src/stages/finish.rs
+++ b/crates/stages/stages/src/stages/finish.rs
@@ -78,7 +78,7 @@ mod tests {
             let end = input.target.unwrap_or_default() + 1;
 
             if start + 1 >= end {
-                return Ok(Vec::default())
+                return Ok(Vec::default());
             }
 
             let mut headers = random_header_range(&mut rng, start + 1..end, head.hash());

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -160,7 +160,7 @@ where
     /// tables.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         // If using hashed state as canonical, execution already writes to `HashedAccounts`,
@@ -529,7 +529,7 @@ mod tests {
                     let start_block = input.next_block();
                     let end_block = output.checkpoint.block_number;
                     if start_block > end_block {
-                        return Ok(())
+                        return Ok(());
                     }
                 }
                 self.check_hashed_accounts()

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -90,7 +90,7 @@ where
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         let tx = provider.tx_ref();
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         // If use_hashed_state is enabled, execution writes directly to `HashedStorages`,
@@ -337,7 +337,7 @@ mod tests {
 
                     // Continue from checkpoint
                     input.checkpoint = Some(checkpoint);
-                    continue
+                    continue;
                 }
                 assert_eq!(checkpoint.block_number, previous_stage);
                 assert_matches!(checkpoint.storage_hashing_stage_checkpoint(), Some(StorageHashingCheckpoint {
@@ -355,7 +355,7 @@ mod tests {
                     "execution validation"
                 );
 
-                break
+                break;
             }
             panic!("Failed execution");
         }
@@ -491,7 +491,7 @@ mod tests {
                 let start_block = input.checkpoint().block_number + 1;
                 let end_block = output.checkpoint.block_number;
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
             }
             self.check_hashed_storage()
@@ -592,7 +592,7 @@ mod tests {
 
                 while let Some((bn_address, entry)) = rev_changeset_walker.next().transpose()? {
                     if bn_address.block_number() < target_block {
-                        break
+                        break;
                     }
 
                     if storage_cursor

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -134,7 +134,7 @@ where
 
             let (header, header_hash) = sealed_header.split_ref();
             if header.number() == 0 {
-                continue
+                continue;
             }
             last_header_number = header.number();
 
@@ -148,9 +148,9 @@ where
             provider.tx_ref().cursor_write::<RawTable<tables::HeaderNumbers>>()?;
         // If we only have the genesis block hash, then we are at first sync, and we can remove it,
         // add it to the collector and use tx.append on all hashes.
-        let first_sync = if provider.tx_ref().entries::<RawTable<tables::HeaderNumbers>>()? == 1 &&
-            let Some((hash, block_number)) = cursor_header_numbers.last()? &&
-            block_number.value()? == 0
+        let first_sync = if provider.tx_ref().entries::<RawTable<tables::HeaderNumbers>>()? == 1
+            && let Some((hash, block_number)) = cursor_header_numbers.last()?
+            && block_number.value()? == 0
         {
             self.hash_collector.insert(hash.key()?, 0)?;
             cursor_header_numbers.delete_current()?;
@@ -206,7 +206,7 @@ where
 
         // Return if stage has already completed the gap on the ETL files
         if self.is_etl_ready {
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         // Lookup the head and tip of the sync range
@@ -225,7 +225,7 @@ where
             );
             self.is_etl_ready = true;
             self.sync_gap = Some(gap);
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         debug!(target: "sync::stages::headers", ?tip, head = ?gap.local_head.hash(), "Commencing sync");
@@ -260,7 +260,7 @@ where
                         // filled the gap.
                         if header_number == local_head_number + 1 {
                             self.is_etl_ready = true;
-                            return Poll::Ready(Ok(()))
+                            return Poll::Ready(Ok(()));
                         }
                     }
                 }
@@ -271,11 +271,11 @@ where
                         local_head: Box::new(local_head.block_with_parent()),
                         header: Box::new(header.block_with_parent()),
                         error,
-                    }))
+                    }));
                 }
                 None => {
                     self.clear_etl_state();
-                    return Poll::Ready(Err(StageError::ChannelClosed))
+                    return Poll::Ready(Err(StageError::ChannelClosed));
                 }
             }
         }
@@ -288,12 +288,12 @@ where
 
         if self.sync_gap.take().ok_or(StageError::MissingSyncGap)?.is_closed() {
             self.is_etl_ready = false;
-            return Ok(ExecOutput::done(current_checkpoint))
+            return Ok(ExecOutput::done(current_checkpoint));
         }
 
         // We should be here only after we have downloaded all headers into the disk buffer (ETL).
         if !self.is_etl_ready {
-            return Err(StageError::MissingDownloadBuffer)
+            return Err(StageError::MissingDownloadBuffer);
         }
 
         // Reset flag
@@ -474,7 +474,7 @@ mod tests {
                 let end = input.target.unwrap_or_default() + 1;
 
                 if start + 1 >= end {
-                    return Ok(Vec::default())
+                    return Ok(Vec::default());
                 }
 
                 let mut headers = random_header_range(&mut rng, start + 1..end, head.hash());

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -78,8 +78,8 @@ where
                 )
             })
             .transpose()?
-            .flatten() &&
-            target_prunable_block > input.checkpoint().block_number
+            .flatten()
+            && target_prunable_block > input.checkpoint().block_number
         {
             input.checkpoint = Some(StageCheckpoint::new(target_prunable_block));
 
@@ -98,7 +98,7 @@ where
         }
 
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let mut range = input.next_block_range();
@@ -597,7 +597,7 @@ mod tests {
                 let start_block = input.next_block();
                 let end_block = output.checkpoint.block_number;
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 assert_eq!(

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -82,8 +82,8 @@ where
                 )
             })
             .transpose()?
-            .flatten() &&
-            target_prunable_block > input.checkpoint().block_number
+            .flatten()
+            && target_prunable_block > input.checkpoint().block_number
         {
             input.checkpoint = Some(StageCheckpoint::new(target_prunable_block));
 
@@ -102,7 +102,7 @@ where
         }
 
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let mut range = input.next_block_range();
@@ -617,7 +617,7 @@ mod tests {
                 let start_block = input.next_block();
                 let end_block = output.checkpoint.block_number;
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 assert_eq!(

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -132,7 +132,7 @@ impl MerkleStage {
             provider.get_stage_checkpoint_progress(StageId::MerkleExecute)?.unwrap_or_default();
 
         if buf.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
 
         let (checkpoint, _) = MerkleCheckpoint::from_compact(&buf, buf.len());
@@ -185,7 +185,7 @@ where
         let (threshold, incremental_threshold) = match self {
             Self::Unwind => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
-                return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
+                return Ok(ExecOutput::done(StageCheckpoint::new(input.target())));
             }
             Self::Execution { rebuild_threshold, incremental_threshold } => {
                 (*rebuild_threshold, *incremental_threshold)
@@ -241,8 +241,8 @@ where
             }
             .unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (provider.count_entries::<tables::HashedAccounts>()? +
-                    provider.count_entries::<tables::HashedStorages>()?)
+                total: (provider.count_entries::<tables::HashedAccounts>()?
+                    + provider.count_entries::<tables::HashedStorages>()?)
                     as u64,
             });
 
@@ -298,7 +298,7 @@ where
                             .checkpoint()
                             .with_entities_stage_checkpoint(entities_checkpoint),
                         done: false,
-                    })
+                    });
                 }
                 StateRootProgress::Complete(root, hashed_entries_walked, updates) => {
                     provider.write_trie_updates(updates)?;
@@ -338,8 +338,8 @@ where
                 "Incremental merkle hashing did not produce a final root".into(),
             ))?;
 
-            let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
-                provider.count_entries::<tables::HashedStorages>()?)
+            let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()?
+                + provider.count_entries::<tables::HashedStorages>()?)
                 as u64;
 
             let entities_checkpoint = EntitiesCheckpoint {
@@ -375,14 +375,14 @@ where
         let range = input.unwind_block_range();
         if matches!(self, Self::Execution { .. }) {
             info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
-            return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
+            return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) });
         }
 
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {
                 processed: 0,
-                total: (tx.entries::<tables::HashedAccounts>()? +
-                    tx.entries::<tables::HashedStorages>()?) as u64,
+                total: (tx.entries::<tables::HashedAccounts>()?
+                    + tx.entries::<tables::HashedStorages>()?) as u64,
             });
 
         if input.unwind_to == 0 {
@@ -394,7 +394,7 @@ where
             return Ok(UnwindOutput {
                 checkpoint: StageCheckpoint::new(input.unwind_to)
                     .with_entities_stage_checkpoint(entities_checkpoint),
-            })
+            });
         }
 
         // Unwind trie only if there are transitions
@@ -794,7 +794,7 @@ mod tests {
                         rev_changeset_walker.next().transpose().unwrap()
                     {
                         if bn_address.block_number() < target_block {
-                            break
+                            break;
                         }
 
                         tree.entry(keccak256(bn_address.address()))
@@ -825,7 +825,7 @@ mod tests {
                         rev_changeset_walker.next().transpose().unwrap()
                     {
                         if block_number < target_block {
-                            break
+                            break;
                         }
 
                         if let Some(acc) = account_before_tx.info {

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -113,8 +113,8 @@ where
 
         for (segment, mut checkpoint) in prune_checkpoints {
             // Only update the checkpoint if unwind_to is lower than the existing checkpoint.
-            if let Some(block) = checkpoint.block_number &&
-                input.unwind_to < block
+            if let Some(block) = checkpoint.block_number
+                && input.unwind_to < block
             {
                 checkpoint.block_number = Some(input.unwind_to);
                 checkpoint.tx_number = unwind_to_last_tx;
@@ -260,7 +260,7 @@ mod tests {
                 let end_block = output.checkpoint.block_number;
 
                 if start_block > end_block {
-                    return Ok(())
+                    return Ok(());
                 }
 
                 let provider = self.db.factory.provider()?;

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -102,8 +102,8 @@ where
                 )
             })
             .transpose()?
-            .flatten() &&
-            target_prunable_block > input.checkpoint().block_number
+            .flatten()
+            && target_prunable_block > input.checkpoint().block_number
         {
             input.checkpoint = Some(StageCheckpoint::new(target_prunable_block));
 
@@ -125,7 +125,7 @@ where
         }
 
         if input.target_reached() {
-            return Ok(ExecOutput::done(input.checkpoint()))
+            return Ok(ExecOutput::done(input.checkpoint()));
         }
 
         let Some(range_output) =
@@ -144,7 +144,7 @@ where
                 checkpoint: StageCheckpoint::new(input.target())
                     .with_entities_stage_checkpoint(stage_checkpoint(provider)?),
                 done: true,
-            })
+            });
         };
         let end_block = *range_output.block_range.end();
 
@@ -175,7 +175,7 @@ where
                 while let Some((block, index)) = blocks_with_indices.peek() {
                     if index.contains_tx(tx) {
                         block_numbers.push(*block);
-                        return block_numbers
+                        return block_numbers;
                     }
                     blocks_with_indices.next();
                 }
@@ -295,7 +295,7 @@ where
                                     .into(),
                             ))
                         }
-                    }
+                    };
                 }
             };
 
@@ -365,7 +365,7 @@ where
                         // We exit early since we could not process this chunk.
                         let _ = recovered_senders_tx
                             .send(Err(Box::new(SenderRecoveryStageError::StageError(err.into()))));
-                        break
+                        break;
                     }
                 };
 
@@ -388,7 +388,7 @@ where
 
                         // Finish early
                         if is_err {
-                            break
+                            break;
                         }
                     }
                 });
@@ -800,7 +800,7 @@ mod tests {
                     let end_block = output.checkpoint.block_number;
 
                     if start_block > end_block {
-                        return Ok(())
+                        return Ok(());
                     }
 
                     let mut body_cursor =

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -91,8 +91,8 @@ where
                 )
             })
             .transpose()?
-            .flatten() &&
-            target_prunable_block > input.checkpoint().block_number
+            .flatten()
+            && target_prunable_block > input.checkpoint().block_number
         {
             input.checkpoint = Some(StageCheckpoint::new(target_prunable_block));
 
@@ -267,8 +267,8 @@ where
         // If `TransactionHashNumbers` table was pruned, we will have a number of entries in it not
         // matching the actual number of processed transactions. To fix that, we add the
         // number of pruned `TransactionHashNumbers` entries.
-        processed: provider.count_entries::<tables::TransactionHashNumbers>()? as u64 +
-            pruned_entries,
+        processed: provider.count_entries::<tables::TransactionHashNumbers>()? as u64
+            + pruned_entries,
         // Count only static files entries. If we count the database entries too, we may have
         // duplicates. We're sure that the static files have all entries that database has,
         // because we run the `StaticFileProducer` before starting the pipeline.
@@ -562,8 +562,8 @@ mod tests {
                         })
                         .transpose()
                         .expect("prune target block for transaction lookup")
-                        .flatten() &&
-                        target_prunable_block > input.checkpoint().block_number
+                        .flatten()
+                        && target_prunable_block > input.checkpoint().block_number
                     {
                         input.checkpoint = Some(StageCheckpoint::new(target_prunable_block));
                     }
@@ -571,7 +571,7 @@ mod tests {
                     let end_block = output.checkpoint.block_number;
 
                     if start_block > end_block {
-                        return Ok(())
+                        return Ok(());
                     }
 
                     let mut body_cursor =

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -277,8 +277,8 @@ where
 
             // On incremental sync, merge with the existing last shard from the database.
             // The last shard is stored with key (address, u64::MAX) so we can find it.
-            if !append_only &&
-                let Some(last_shard) = writer.get_last_account_history_shard(address)?
+            if !append_only
+                && let Some(last_shard) = writer.get_last_account_history_shard(address)?
             {
                 current_list.extend(last_shard.iter());
             }
@@ -415,13 +415,13 @@ where
     // To be extra safe, we make sure that the last tx num matches the last block from its indices.
     // If not, get it.
     loop {
-        if let Some(indices) = provider.block_body_indices(last_block)? &&
-            indices.last_tx_num() <= last_tx_num
+        if let Some(indices) = provider.block_body_indices(last_block)?
+            && indices.last_tx_num() <= last_tx_num
         {
-            break
+            break;
         }
         if last_block == 0 {
-            break
+            break;
         }
         last_block -= 1;
     }
@@ -491,8 +491,8 @@ where
 
             // On incremental sync, merge with the existing last shard from the database.
             // The last shard is stored with key (address, storage_key, u64::MAX) so we can find it.
-            if !append_only &&
-                let Some(last_shard) =
+            if !append_only
+                && let Some(last_shard) =
                     writer.get_last_storage_history_shard(partial_key.0, partial_key.1)?
             {
                 current_list.extend(last_shard.iter());

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -307,8 +307,8 @@ impl TestStageDB {
                     // Backfill: some tests start at a forward block number, but static files
                     // require no gaps.
                     let segment_header = txs_writer.user_header();
-                    if segment_header.block_end().is_none() &&
-                        segment_header.expected_block_start() == 0
+                    if segment_header.block_end().is_none()
+                        && segment_header.expected_block_start() == 0
                     {
                         for block in 0..block.number {
                             txs_writer.increment_block(block)?;

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -322,7 +322,7 @@ impl EntitiesCheckpoint {
     /// Return [None] if `total == 0`.
     pub fn fmt_percentage(&self) -> Option<String> {
         if self.total == 0 {
-            return None
+            return None;
         }
 
         // Calculate percentage with 2 decimal places.
@@ -418,14 +418,14 @@ impl StageCheckpoint {
         match stage_checkpoint {
             StageUnitCheckpoint::Account(AccountHashingCheckpoint {
                 progress: entities, ..
-            }) |
-            StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
+            })
+            | StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
                 progress: entities, ..
-            }) |
-            StageUnitCheckpoint::Entities(entities) |
-            StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. }) |
-            StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. }) |
-            StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
+            })
+            | StageUnitCheckpoint::Entities(entities)
+            | StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. })
+            | StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. })
+            | StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
                 progress: entities,
                 ..
             }) => Some(entities),
@@ -467,10 +467,10 @@ impl StageUnitCheckpoint {
     /// range.
     pub const fn set_block_range(&mut self, from: u64, to: u64) -> Option<CheckpointBlockRange> {
         match self {
-            Self::Account(AccountHashingCheckpoint { block_range, .. }) |
-            Self::Storage(StorageHashingCheckpoint { block_range, .. }) |
-            Self::Execution(ExecutionCheckpoint { block_range, .. }) |
-            Self::IndexHistory(IndexHistoryCheckpoint { block_range, .. }) => {
+            Self::Account(AccountHashingCheckpoint { block_range, .. })
+            | Self::Storage(StorageHashingCheckpoint { block_range, .. })
+            | Self::Execution(ExecutionCheckpoint { block_range, .. })
+            | Self::IndexHistory(IndexHistoryCheckpoint { block_range, .. }) => {
                 let old_range = *block_range;
                 *block_range = CheckpointBlockRange { from, to };
 

--- a/crates/stages/types/src/execution.rs
+++ b/crates/stages/types/src/execution.rs
@@ -39,9 +39,9 @@ impl ExecutionStageThresholds {
         cumulative_gas_used: u64,
         elapsed: Duration,
     ) -> bool {
-        blocks_processed >= self.max_blocks.unwrap_or(u64::MAX) ||
-            changes_processed >= self.max_changes.unwrap_or(u64::MAX) ||
-            cumulative_gas_used >= self.max_cumulative_gas.unwrap_or(u64::MAX) ||
-            elapsed >= self.max_duration.unwrap_or(Duration::MAX)
+        blocks_processed >= self.max_blocks.unwrap_or(u64::MAX)
+            || changes_processed >= self.max_changes.unwrap_or(u64::MAX)
+            || cumulative_gas_used >= self.max_cumulative_gas.unwrap_or(u64::MAX)
+            || elapsed >= self.max_duration.unwrap_or(Duration::MAX)
     }
 }

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -116,7 +116,7 @@ where
     pub fn run(&self, targets: StaticFileTargets) -> StaticFileProducerResult {
         // If there are no targets, do not produce any static files and return early
         if !targets.any() {
-            return Ok(targets)
+            return Ok(targets);
         }
 
         debug_assert!(targets.is_contiguous_to_highest_static_files(
@@ -193,8 +193,8 @@ where
 
         let targets = StaticFileTargets {
             // StaticFile receipts only if they're not pruned according to the user configuration
-            receipts: if self.prune_modes.receipts.is_none() &&
-                self.prune_modes.receipts_log_filter.is_empty()
+            receipts: if self.prune_modes.receipts.is_none()
+                && self.prune_modes.receipts_log_filter.is_empty()
             {
                 finalized_block_numbers.receipts.and_then(|finalized_block_number| {
                     self.get_static_file_target(

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -78,8 +78,8 @@ impl StaticFileTargets {
         core::iter::once(&(self.receipts.as_ref(), static_files.receipts)).all(
             |(target_block_range, highest_static_file_block)| {
                 target_block_range.is_none_or(|target_block_range| {
-                    *target_block_range.start() ==
-                        highest_static_file_block
+                    *target_block_range.start()
+                        == highest_static_file_block
                             .map_or(0, |highest_static_file_block| highest_static_file_block + 1)
                 })
             },

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -118,11 +118,11 @@ impl StaticFileSegment {
     pub const fn columns(&self) -> usize {
         match self {
             Self::Headers => 3,
-            Self::Transactions |
-            Self::Receipts |
-            Self::TransactionSenders |
-            Self::AccountChangeSets |
-            Self::StorageChangeSets => 1,
+            Self::Transactions
+            | Self::Receipts
+            | Self::TransactionSenders
+            | Self::AccountChangeSets
+            | Self::StorageChangeSets => 1,
         }
     }
 
@@ -167,14 +167,14 @@ impl StaticFileSegment {
     pub fn parse_filename(name: &str) -> Option<(Self, SegmentRangeInclusive)> {
         let mut parts = name.split('_');
         if !(parts.next() == Some("static") && parts.next() == Some("file")) {
-            return None
+            return None;
         }
 
         let segment = Self::from_str(parts.next()?).ok()?;
         let (block_start, block_end) = (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?);
 
         if block_start > block_end {
-            return None
+            return None;
         }
 
         Some((segment, SegmentRangeInclusive::new(block_start, block_end)))
@@ -200,11 +200,11 @@ impl StaticFileSegment {
     pub const fn is_block_based(&self) -> bool {
         match self {
             Self::Headers => true,
-            Self::Receipts |
-            Self::Transactions |
-            Self::TransactionSenders |
-            Self::AccountChangeSets |
-            Self::StorageChangeSets => false,
+            Self::Receipts
+            | Self::Transactions
+            | Self::TransactionSenders
+            | Self::AccountChangeSets
+            | Self::StorageChangeSets => false,
         }
     }
 
@@ -583,11 +583,11 @@ impl SegmentHeader {
     /// Returns the row offset which depends on whether the segment is block or transaction based.
     pub fn start(&self) -> Option<u64> {
         if self.segment.is_change_based() {
-            return Some(0)
+            return Some(0);
         }
 
         if self.segment.is_block_based() {
-            return self.block_start()
+            return self.block_start();
         }
         self.tx_start()
     }

--- a/crates/storage/codecs/derive/src/arbitrary.rs
+++ b/crates/storage/codecs/derive/src/arbitrary.rs
@@ -23,8 +23,8 @@ pub fn maybe_generate_tests(
     let mut iter = args.into_iter().peekable();
 
     // we check if there's a crate argument which is used from inside the codecs crate directly
-    if let Some(arg) = iter.peek() &&
-        arg.to_string() == "crate"
+    if let Some(arg) = iter.peek()
+        && arg.to_string() == "crate"
     {
         is_crate = true;
         iter.next();

--- a/crates/storage/codecs/derive/src/compact/flags.rs
+++ b/crates/storage/codecs/derive/src/compact/flags.rs
@@ -30,7 +30,7 @@ pub(crate) fn generate_flag_struct(
                 .iter()
                 .filter_map(|f| {
                     if let FieldTypes::StructField(f) = f {
-                        return Some(f)
+                        return Some(f);
                     }
                     None
                 })
@@ -41,7 +41,7 @@ pub(crate) fn generate_flag_struct(
     };
 
     if total_bits == 0 {
-        return placeholder_flag_struct(ident, &flags_ident)
+        return placeholder_flag_struct(ident, &flags_ident);
     }
 
     let (total_bytes, unused_bits) = pad_flag_struct(total_bits, &mut field_flags);

--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -113,7 +113,7 @@ fn generate_from_compact(
                     let ident = format_ident!("{}", field.name);
                     return Some(quote! {
                         #ident: #ident,
-                    })
+                    });
                 }
                 None
             });

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -150,10 +150,11 @@ fn load_field_from_segments(
         if is_enum {
             fields.push(FieldTypes::EnumUnnamedField((ftype, use_alt_impl)));
         } else {
-            let should_compact = is_flag_type(&ftype) ||
-                field.attrs.iter().any(|attr| {
-                    attr.path().segments.iter().any(|path| path.ident == "maybe_zero")
-                });
+            let should_compact = is_flag_type(&ftype)
+                || field
+                    .attrs
+                    .iter()
+                    .any(|attr| attr.path().segments.iter().any(|path| path.ident == "maybe_zero"));
 
             fields.push(FieldTypes::StructField(StructFieldDescriptor {
                 name: field.ident.as_ref().map(|i| i.to_string()).unwrap_or_default(),
@@ -171,15 +172,15 @@ fn load_field_from_segments(
 ///
 /// If so, we use another impl to code/decode its data.
 fn should_use_alt_impl(ftype: &str, segment: &syn::PathSegment) -> bool {
-    if (ftype == "Vec" || ftype == "Option") &&
-        let syn::PathArguments::AngleBracketed(ref args) = segment.arguments &&
-        let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) = args.args.last() &&
-        let (Some(path), 1) = (arg_path.path.segments.first(), arg_path.path.segments.len()) &&
-        ["B256", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
+    if (ftype == "Vec" || ftype == "Option")
+        && let syn::PathArguments::AngleBracketed(ref args) = segment.arguments
+        && let Some(syn::GenericArgument::Type(syn::Type::Path(arg_path))) = args.args.last()
+        && let (Some(path), 1) = (arg_path.path.segments.first(), arg_path.path.segments.len())
+        && ["B256", "Address", "Bloom", "TxHash", "BlockHash", "CompactPlaceholder"]
             .iter()
             .any(|&s| path.ident == s)
     {
-        return true
+        return true;
     }
     false
 }

--- a/crates/storage/codecs/derive/src/compact/structs.rs
+++ b/crates/storage/codecs/derive/src/compact/structs.rs
@@ -67,7 +67,7 @@ impl<'a> StructHandler<'a> {
                 })
             }
 
-            return
+            return;
         }
 
         let name = format_ident!("{name}");

--- a/crates/storage/codecs/derive/src/lib.rs
+++ b/crates/storage/codecs/derive/src/lib.rs
@@ -69,8 +69,8 @@ pub fn derive_zstd(input: TokenStream) -> TokenStream {
     let mut decompressor = None;
 
     for attr in &input.attrs {
-        if attr.path().is_ident("reth_zstd") &&
-            let Err(err) = attr.parse_nested_meta(|meta| {
+        if attr.path().is_ident("reth_zstd")
+            && let Err(err) = attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("compressor") {
                     let value = meta.value()?;
                     let path: syn::Path = value.parse()?;
@@ -80,12 +80,12 @@ pub fn derive_zstd(input: TokenStream) -> TokenStream {
                     let path: syn::Path = value.parse()?;
                     decompressor = Some(path);
                 } else {
-                    return Err(meta.error("unsupported attribute"))
+                    return Err(meta.error("unsupported attribute"));
                 }
                 Ok(())
             })
         {
-            return err.to_compile_error().into()
+            return err.to_compile_error().into();
         }
     }
 
@@ -93,7 +93,7 @@ pub fn derive_zstd(input: TokenStream) -> TokenStream {
         return quote! {
             compile_error!("missing compressor or decompressor attribute");
         }
-        .into()
+        .into();
     };
 
     compact::derive(input, Some(ZstdConfig { compressor, decompressor }))

--- a/crates/storage/codecs/src/lib.rs
+++ b/crates/storage/codecs/src/lib.rs
@@ -309,7 +309,7 @@ where
     #[inline]
     fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return (None, buf)
+            return (None, buf);
         }
 
         let (len, buf) = decode_varuint(buf);
@@ -337,7 +337,7 @@ where
     #[inline]
     fn specialized_from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return (None, buf)
+            return (None, buf);
         }
 
         let (element, buf) = T::from_compact(buf, len);
@@ -386,7 +386,7 @@ impl Compact for U256 {
     #[inline]
     fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return (Self::ZERO, buf)
+            return (Self::ZERO, buf);
         }
 
         let mut arr = [0; 32];
@@ -426,7 +426,7 @@ impl<const N: usize> Compact for [u8; N] {
     #[inline]
     fn from_compact(mut buf: &[u8], len: usize) -> (Self, &[u8]) {
         if len == 0 {
-            return ([0; N], buf)
+            return ([0; N], buf);
         }
 
         let v = buf[..N].try_into().unwrap();
@@ -511,7 +511,7 @@ fn decode_varuint(buf: &[u8]) -> (usize, &[u8]) {
         let byte = buf[i];
         value |= usize::from(byte & 0x7F) << (i * 7);
         if byte < 0x80 {
-            return (value, &buf[i + 1..])
+            return (value, &buf[i + 1..]);
         }
     }
 

--- a/crates/storage/codecs/src/test_utils.rs
+++ b/crates/storage/codecs/src/test_utils.rs
@@ -32,7 +32,7 @@
 ///    validate_bitflag_backwards_compat!(TExtension, UnusedBits::NotZero);
 /// }   
 /// ```
-/// 
+///
 /// ### 2. `Zero` -> `NotZero`
 /// If it becomes `NotZero`, it would break backwards compatibility, so there is not an action item,
 /// and should be handled with care in a case by case scenario.

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -231,7 +231,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for ReverseWalker<'_, T, CURSOR> 
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {
-            return start
+            return start;
         }
 
         self.cursor.prev().transpose()
@@ -271,7 +271,7 @@ impl<T: Table, CURSOR: DbCursorRO<T>> Iterator for RangeWalker<'_, T, CURSOR> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.is_done {
-            return None
+            return None;
         }
 
         let next_item = self.start.take().or_else(|| self.cursor.next().transpose());
@@ -370,7 +370,7 @@ impl<T: DupSort, CURSOR: DbDupCursorRO<T>> Iterator for DupWalker<'_, T, CURSOR>
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start.take();
         if start.is_some() {
-            return start
+            return start;
         }
         self.cursor.next_dup().transpose()
     }

--- a/crates/storage/db-api/src/models/storage_sharded_key.rs
+++ b/crates/storage/db-api/src/models/storage_sharded_key.rs
@@ -77,7 +77,7 @@ impl Encode for StorageShardedKey {
 impl Decode for StorageShardedKey {
     fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
         if value.len() != STORAGE_SHARD_KEY_BYTES_SIZE {
-            return Err(DatabaseError::Decode)
+            return Err(DatabaseError::Decode);
         }
         let block_num_index = value.len() - 8;
 

--- a/crates/storage/db-api/src/unwind.rs
+++ b/crates/storage/db-api/src/unwind.rs
@@ -31,7 +31,7 @@ pub trait DbTxUnwindExt: DbTxMut {
 
         while let Some(Ok((entry_key, _))) = reverse_walker.next() {
             if selector(entry_key) <= key {
-                break
+                break;
             }
             reverse_walker.delete_current()?;
             deleted += 1;

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -50,18 +50,18 @@ impl<N: NodeTypesWithDB> DbTool<N> {
                     let (key, value) = (k.into_key(), v.into_value());
 
                     if key.len() + value.len() < filter.min_row_size {
-                        return None
+                        return None;
                     }
                     if key.len() < filter.min_key_size {
-                        return None
+                        return None;
                     }
                     if value.len() < filter.min_value_size {
-                        return None
+                        return None;
                     }
 
                     let result = || {
                         if filter.only_count {
-                            return None
+                            return None;
                         }
                         Some((
                             <T as Table>::Key::decode(&key).unwrap(),
@@ -71,16 +71,16 @@ impl<N: NodeTypesWithDB> DbTool<N> {
 
                     match &*bmb {
                         Some(searcher) => {
-                            if searcher.find_first_in(&value).is_some() ||
-                                searcher.find_first_in(&key).is_some()
+                            if searcher.find_first_in(&value).is_some()
+                                || searcher.find_first_in(&key).is_some()
                             {
                                 hits += 1;
-                                return result()
+                                return result();
                             }
                         }
                         None => {
                             hits += 1;
-                            return result()
+                            return result();
                         }
                     }
                 }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -173,7 +173,7 @@ where
                 // make sure that our database has been written to, and throw error if it's empty.
                 if factory.get_stage_checkpoint(StageId::Headers)?.is_none() {
                     error!(target: "reth::storage", "Genesis header found on static files, but database is uninitialized.");
-                    return Err(InitStorageError::UninitializedDatabase)
+                    return Err(InitStorageError::UninitializedDatabase);
                 }
 
                 let stored = factory.storage_settings()?.unwrap_or_else(StorageSettings::v1);
@@ -187,13 +187,13 @@ where
                 }
 
                 debug!("Genesis already written, skipping.");
-                return Ok(hash)
+                return Ok(hash);
             }
 
             return Err(InitStorageError::GenesisHashMismatch {
                 chainspec_hash: hash,
                 storage_hash: block_hash,
-            })
+            });
         }
         Err(e) => {
             debug!(?e);
@@ -623,7 +623,7 @@ where
         + AsRef<Provider>,
 {
     if etl_config.file_size == 0 {
-        return Err(eyre::eyre!("ETL file size cannot be zero"))
+        return Err(eyre::eyre!("ETL file size cannot be zero"));
     }
 
     let block = provider_rw.last_block_number()?;
@@ -651,7 +651,7 @@ where
             got: dump_state_root,
             expected: expected_state_root,
         })
-        .into())
+        .into());
     }
 
     debug!(target: "reth::cli",
@@ -687,7 +687,7 @@ where
             got: computed_state_root,
             expected: expected_state_root,
         })
-        .into())
+        .into());
     }
 
     // insert sync stages for stages that require state
@@ -722,14 +722,14 @@ fn parse_accounts(
     loop {
         let n = reader.read_line(&mut line)?;
         if n == 0 {
-            break
+            break;
         }
 
         let GenesisAccountWithAddress { genesis_account, address } = serde_json::from_str(&line)?;
         collector.insert(address, genesis_account)?;
 
-        if !collector.is_empty() &&
-            collector.len().is_multiple_of(AVERAGE_COUNT_ACCOUNTS_PER_GB_STATE_DUMP)
+        if !collector.is_empty()
+            && collector.len().is_multiple_of(AVERAGE_COUNT_ACCOUNTS_PER_GB_STATE_DUMP)
         {
             info!(target: "reth::cli",
                 parsed_new_accounts=collector.len(),
@@ -788,8 +788,8 @@ where
 
         accounts.push((address, account));
 
-        if (index > 0 && index.is_multiple_of(AVERAGE_COUNT_ACCOUNTS_PER_GB_STATE_DUMP)) ||
-            index == accounts_len - 1
+        if (index > 0 && index.is_multiple_of(AVERAGE_COUNT_ACCOUNTS_PER_GB_STATE_DUMP))
+            || index == accounts_len - 1
         {
             total_inserted_accounts += accounts.len();
 
@@ -891,7 +891,7 @@ where
                     "State root has been computed"
                 );
 
-                return Ok(root)
+                return Ok(root);
             }
         }
     }

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -504,7 +504,7 @@ impl DatabaseEnv {
                     LogLevel::Extra => 7,
                 });
             } else {
-                return Err(DatabaseError::LogLevelUnavailable(log_level))
+                return Err(DatabaseError::LogLevelUnavailable(log_level));
             }
         }
 
@@ -618,7 +618,7 @@ impl DatabaseEnv {
     /// Records version that accesses the database with write privileges.
     pub fn record_client_version(&self, version: ClientVersion) -> Result<(), DatabaseError> {
         if version.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         let tx = self.tx_mut()?;

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -241,9 +241,9 @@ impl<K: TransactionKind> MetricsHandler<K> {
     /// NOTE: Backtrace is recorded using [`Backtrace::force_capture`], so `RUST_BACKTRACE` env var
     /// is not needed.
     fn log_backtrace_on_long_read_transaction(&self) {
-        if self.record_backtrace &&
-            !self.backtrace_recorded.load(Ordering::Relaxed) &&
-            self.transaction_mode().is_read_only()
+        if self.record_backtrace
+            && !self.backtrace_recorded.load(Ordering::Relaxed)
+            && self.transaction_mode().is_read_only()
         {
             let open_duration = self.start.elapsed();
             if open_duration >= self.long_transaction_duration {

--- a/crates/storage/db/src/lockfile.rs
+++ b/crates/storage/db/src/lockfile.rs
@@ -44,9 +44,9 @@ impl StorageLock {
     #[cfg(any(test, not(feature = "disable-lock")))]
     fn try_acquire_file_lock(path: &Path) -> Result<Self, StorageLockError> {
         let file_path = path.join(LOCKFILE_NAME);
-        if let Some(process_lock) = ProcessUID::parse(&file_path)? &&
-            process_lock.pid != (process::id() as usize) &&
-            process_lock.is_active()
+        if let Some(process_lock) = ProcessUID::parse(&file_path)?
+            && process_lock.pid != (process::id() as usize)
+            && process_lock.is_active()
         {
             reth_tracing::tracing::error!(
                 target: "reth::db::lockfile",
@@ -55,7 +55,7 @@ impl StorageLock {
                 start_time = process_lock.start_time,
                 "Storage lock already taken."
             );
-            return Err(StorageLockError::Taken(process_lock.pid))
+            return Err(StorageLockError::Taken(process_lock.pid));
         }
 
         Ok(Self(Arc::new(StorageLockInner::new(file_path)?)))
@@ -142,8 +142,8 @@ impl ProcessUID {
 
     /// Parses [`Self`] from a file.
     fn parse(path: &Path) -> Result<Option<Self>, StorageLockError> {
-        if path.exists() &&
-            let Ok(contents) = reth_fs_util::read_to_string(path)
+        if path.exists()
+            && let Ok(contents) = reth_fs_util::read_to_string(path)
         {
             let mut lines = contents.lines();
             if let (Some(Ok(pid)), Some(Ok(start_time))) = (

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -33,7 +33,7 @@ impl<'a> StaticFileCursor<'a> {
         mask: usize,
     ) -> ProviderResult<Option<Vec<&'_ [u8]>>> {
         if self.jar().rows() == 0 {
-            return Ok(None)
+            return Ok(None);
         }
 
         let row = match key_or_num {
@@ -41,7 +41,7 @@ impl<'a> StaticFileCursor<'a> {
             KeyOrNumber::Number(n) => match self.jar().user_header().start() {
                 Some(offset) => {
                     if offset > n {
-                        return Ok(None)
+                        return Ok(None);
                     }
                     self.row_by_number_with_cols((n - offset) as usize, mask)
                 }

--- a/crates/storage/db/src/static_file/mod.rs
+++ b/crates/storage/db/src/static_file/mod.rs
@@ -31,8 +31,8 @@ pub fn iter_static_files(path: &Path) -> Result<SortedStaticFiles, NippyJarError
         .map_err(|err| NippyJarError::Custom(err.to_string()))?
         .filter_map(Result::ok);
     for entry in entries {
-        if entry.metadata().is_ok_and(|metadata| metadata.is_file()) &&
-            let Some((segment, _)) =
+        if entry.metadata().is_ok_and(|metadata| metadata.is_file())
+            && let Some((segment, _)) =
                 StaticFileSegment::parse_filename(&entry.file_name().to_string_lossy())
         {
             let jar = NippyJar::<SegmentHeader>::load(&entry.path())?;

--- a/crates/storage/db/src/version.rs
+++ b/crates/storage/db/src/version.rs
@@ -48,7 +48,7 @@ pub enum DatabaseVersionError {
 pub fn check_db_version_file<P: AsRef<Path>>(db_path: P) -> Result<(), DatabaseVersionError> {
     let version = get_db_version(db_path)?;
     if version != DB_VERSION {
-        return Err(DatabaseVersionError::VersionMismatch { version })
+        return Err(DatabaseVersionError::VersionMismatch { version });
     }
 
     Ok(())

--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -32,8 +32,8 @@ fn main() {
 
     // Propagate `-C target-cpu=native`
     let rustflags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
-    if rustflags.contains("target-cpu=native") &&
-        env::var("CARGO_CFG_TARGET_ENV").unwrap() != "msvc"
+    if rustflags.contains("target-cpu=native")
+        && env::var("CARGO_CFG_TARGET_ENV").unwrap() != "msvc"
     {
         cc.flag("-march=native");
     }
@@ -53,42 +53,42 @@ fn generate_bindings(mdbx: &Path, out_file: &Path) {
     impl ParseCallbacks for Callbacks {
         fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
             match name {
-                "MDBX_SUCCESS" |
-                "MDBX_KEYEXIST" |
-                "MDBX_NOTFOUND" |
-                "MDBX_PAGE_NOTFOUND" |
-                "MDBX_CORRUPTED" |
-                "MDBX_PANIC" |
-                "MDBX_VERSION_MISMATCH" |
-                "MDBX_INVALID" |
-                "MDBX_MAP_FULL" |
-                "MDBX_DBS_FULL" |
-                "MDBX_READERS_FULL" |
-                "MDBX_TLS_FULL" |
-                "MDBX_TXN_FULL" |
-                "MDBX_CURSOR_FULL" |
-                "MDBX_PAGE_FULL" |
-                "MDBX_MAP_RESIZED" |
-                "MDBX_INCOMPATIBLE" |
-                "MDBX_BAD_RSLOT" |
-                "MDBX_BAD_TXN" |
-                "MDBX_BAD_VALSIZE" |
-                "MDBX_BAD_DBI" |
-                "MDBX_LOG_DONTCHANGE" |
-                "MDBX_DBG_DONTCHANGE" |
-                "MDBX_RESULT_TRUE" |
-                "MDBX_UNABLE_EXTEND_MAPSIZE" |
-                "MDBX_PROBLEM" |
-                "MDBX_LAST_LMDB_ERRCODE" |
-                "MDBX_BUSY" |
-                "MDBX_EMULTIVAL" |
-                "MDBX_EBADSIGN" |
-                "MDBX_WANNA_RECOVERY" |
-                "MDBX_EKEYMISMATCH" |
-                "MDBX_TOO_LARGE" |
-                "MDBX_THREAD_MISMATCH" |
-                "MDBX_TXN_OVERLAPPING" |
-                "MDBX_LAST_ERRCODE" => Some(IntKind::Int),
+                "MDBX_SUCCESS"
+                | "MDBX_KEYEXIST"
+                | "MDBX_NOTFOUND"
+                | "MDBX_PAGE_NOTFOUND"
+                | "MDBX_CORRUPTED"
+                | "MDBX_PANIC"
+                | "MDBX_VERSION_MISMATCH"
+                | "MDBX_INVALID"
+                | "MDBX_MAP_FULL"
+                | "MDBX_DBS_FULL"
+                | "MDBX_READERS_FULL"
+                | "MDBX_TLS_FULL"
+                | "MDBX_TXN_FULL"
+                | "MDBX_CURSOR_FULL"
+                | "MDBX_PAGE_FULL"
+                | "MDBX_MAP_RESIZED"
+                | "MDBX_INCOMPATIBLE"
+                | "MDBX_BAD_RSLOT"
+                | "MDBX_BAD_TXN"
+                | "MDBX_BAD_VALSIZE"
+                | "MDBX_BAD_DBI"
+                | "MDBX_LOG_DONTCHANGE"
+                | "MDBX_DBG_DONTCHANGE"
+                | "MDBX_RESULT_TRUE"
+                | "MDBX_UNABLE_EXTEND_MAPSIZE"
+                | "MDBX_PROBLEM"
+                | "MDBX_LAST_LMDB_ERRCODE"
+                | "MDBX_BUSY"
+                | "MDBX_EMULTIVAL"
+                | "MDBX_EBADSIGN"
+                | "MDBX_WANNA_RECOVERY"
+                | "MDBX_EKEYMISMATCH"
+                | "MDBX_TOO_LARGE"
+                | "MDBX_THREAD_MISMATCH"
+                | "MDBX_TXN_OVERLAPPING"
+                | "MDBX_LAST_ERRCODE" => Some(IntKind::Int),
                 _ => Some(IntKind::UInt),
             }
         }

--- a/crates/storage/libmdbx-rs/src/codec.rs
+++ b/crates/storage/libmdbx-rs/src/codec.rs
@@ -41,8 +41,8 @@ impl TableObject for Cow<'_, [u8]> {
 
         #[cfg(not(feature = "return-borrowed"))]
         {
-            let is_dirty = (!K::IS_READ_ONLY) &&
-                crate::error::mdbx_result(unsafe {
+            let is_dirty = (!K::IS_READ_ONLY)
+                && crate::error::mdbx_result(unsafe {
                     ffi::mdbx_is_dirty(_txn, data_val.iov_base)
                 })?;
 
@@ -83,7 +83,7 @@ impl TableObject for ObjectLength {
 impl<const LEN: usize> TableObject for [u8; LEN] {
     fn decode(data_val: &[u8]) -> Result<Self, Error> {
         if data_val.len() != LEN {
-            return Err(Error::DecodeErrorLenDiff)
+            return Err(Error::DecodeErrorLenDiff);
         }
         let mut a = [0; LEN];
         a[..].copy_from_slice(data_val);

--- a/crates/storage/libmdbx-rs/src/cursor.rs
+++ b/crates/storage/libmdbx-rs/src/cursor.rs
@@ -371,7 +371,7 @@ where
     {
         let res: Result<Option<((), ())>> = self.set_range(key);
         if let Err(error) = res {
-            return Iter::Err(Some(error))
+            return Iter::Err(Some(error));
         };
         Iter::new(self, ffi::MDBX_GET_CURRENT, ffi::MDBX_NEXT)
     }
@@ -406,7 +406,7 @@ where
     {
         let res: Result<Option<((), ())>> = self.set_range(key);
         if let Err(error) = res {
-            return IterDup::Err(Some(error))
+            return IterDup::Err(Some(error));
         };
         IterDup::new(self, ffi::MDBX_GET_CURRENT)
     }
@@ -422,7 +422,7 @@ where
             Ok(Some(_)) => (),
             Ok(None) => {
                 let _: Result<Option<((), ())>> = self.last();
-                return Iter::new(self, ffi::MDBX_NEXT, ffi::MDBX_NEXT)
+                return Iter::new(self, ffi::MDBX_NEXT, ffi::MDBX_NEXT);
             }
             Err(error) => return Iter::Err(Some(error)),
         };

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -131,10 +131,10 @@ impl Environment {
                     warn!(target: "libmdbx", "Process stalled, awaiting read-write transaction lock.");
                 }
                 sleep(Duration::from_millis(250));
-                continue
+                continue;
             }
 
-            break res
+            break res;
         }?;
         Ok(Transaction::new_from_ptr(self.clone(), txn.0))
     }
@@ -229,7 +229,7 @@ impl Environment {
         for result in cursor.iter_slices() {
             let (_key, value) = result?;
             if value.len() < size_of::<u32>() {
-                return Err(Error::Corrupted)
+                return Err(Error::Corrupted);
             }
             let s = &value[..size_of::<u32>()];
             freelist += NativeEndian::read_u32(s) as usize;
@@ -745,7 +745,7 @@ impl EnvironmentBuilder {
             })() {
                 ffi::mdbx_env_close_ex(env, false);
 
-                return Err(e)
+                return Err(e);
             }
         }
 

--- a/crates/storage/libmdbx-rs/src/error.rs
+++ b/crates/storage/libmdbx-rs/src/error.rs
@@ -206,9 +206,9 @@ impl Error {
             Self::DecodeErrorLenDiff | Self::DecodeError => ffi::MDBX_EINVAL,
             Self::TooLarge => ffi::MDBX_TOO_LARGE,
             Self::BadSignature => ffi::MDBX_EBADSIGN,
-            Self::Access |
-            Self::WriteTransactionUnsupportedInReadOnlyMode |
-            Self::NestedTransactionsUnsupportedWithWriteMap => ffi::MDBX_EACCESS,
+            Self::Access
+            | Self::WriteTransactionUnsupportedInReadOnlyMode
+            | Self::NestedTransactionsUnsupportedWithWriteMap => ffi::MDBX_EACCESS,
             Self::ReadTransactionTimeout => -96000, // Custom non-MDBX error code
             Self::BotchedTransaction => -96001,
             Self::Permission => ffi::MDBX_EPERM,

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -522,7 +522,7 @@ impl Transaction<RW> {
     /// Begins a new nested transaction inside of this transaction.
     pub fn begin_nested_txn(&mut self) -> Result<Self> {
         if self.inner.env.is_write_map() {
-            return Err(Error::NestedTransactionsUnsupportedWithWriteMap)
+            return Err(Error::NestedTransactionsUnsupportedWithWriteMap);
         }
         self.txn_execute(|txn| {
             let (tx, rx) = sync_channel(0);
@@ -606,7 +606,7 @@ impl TransactionPtr {
         // to the `mdbx_txn_reset`.
         #[cfg(feature = "read-tx-timeouts")]
         if self.is_timed_out() {
-            return Err(Error::ReadTransactionTimeout)
+            return Err(Error::ReadTransactionTimeout);
         }
 
         Ok((f)(self.txn))

--- a/crates/storage/nippy-jar/src/compression/lz4.rs
+++ b/crates/storage/nippy-jar/src/compression/lz4.rs
@@ -42,7 +42,7 @@ impl Compression for Lz4 {
                 Err(err) => {
                     multiplier *= 2;
                     if multiplier == 16 {
-                        return Err(NippyJarError::Custom(err.to_string()))
+                        return Err(NippyJarError::Custom(err.to_string()));
                     }
                 }
             }

--- a/crates/storage/nippy-jar/src/compression/zstd.rs
+++ b/crates/storage/nippy-jar/src/compression/zstd.rs
@@ -64,7 +64,7 @@ impl Zstd {
     pub fn decompressors(&self) -> Result<Vec<Decompressor<'_>>, NippyJarError> {
         if let Some(dictionaries) = &self.dictionaries {
             debug_assert!(dictionaries.len() == self.columns);
-            return dictionaries.decompressors()
+            return dictionaries.decompressors();
         }
 
         Ok(vec![])
@@ -76,12 +76,12 @@ impl Zstd {
             ZstdState::PendingDictionary => Err(NippyJarError::CompressorNotReady),
             ZstdState::Ready => {
                 if !self.use_dict {
-                    return Ok(None)
+                    return Ok(None);
                 }
 
                 if let Some(dictionaries) = &self.dictionaries {
                     debug!(target: "nippy-jar", count=?dictionaries.len(), "Generating ZSTD compressor dictionaries.");
-                    return Ok(Some(dictionaries.compressors()?))
+                    return Ok(Some(dictionaries.compressors()?));
                 }
                 Ok(None)
             }
@@ -106,7 +106,7 @@ impl Zstd {
                 buffer.reserve(column_value.len() * multiplier);
                 multiplier += 1;
                 if multiplier == 5 {
-                    return Err(NippyJarError::Disconnect(err))
+                    return Err(NippyJarError::Disconnect(err));
                 }
             }
 
@@ -196,7 +196,7 @@ impl Compression for Zstd {
         columns: Vec<impl IntoIterator<Item = Vec<u8>>>,
     ) -> Result<(), NippyJarError> {
         if !self.use_dict {
-            return Ok(())
+            return Ok(());
         }
 
         // There's a per 2GB hard limit on each column data set for training
@@ -210,7 +210,7 @@ impl Compression for Zstd {
         // ```
 
         if columns.len() != self.columns {
-            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()))
+            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()));
         }
 
         let mut dictionaries = Vec::with_capacity(columns.len());
@@ -369,7 +369,7 @@ impl Serialize for ZstdDictionary<'_> {
 impl PartialEq for ZstdDictionary<'_> {
     fn eq(&self, other: &Self) -> bool {
         if let (Self::Raw(a), Self::Raw(b)) = (self, &other) {
-            return a == b
+            return a == b;
         }
         unimplemented!(
             "`DecoderDictionary` can't be compared. So comparison should be done after decompressing a value."

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -56,7 +56,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
         // When an offset size is smaller than the initial (8), we are dealing with immutable
         // data.
         if reader.offset_size() != OFFSET_SIZE_BYTES {
-            return Err(NippyJarError::FrozenJar)
+            return Err(NippyJarError::FrozenJar);
         }
 
         let expected_offsets_file_size: u64 = (1 + // first byte is the size of one offset
@@ -64,10 +64,10 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 OFFSET_SIZE_BYTES as usize) as u64; // expected size of the data file
         let actual_offsets_file_size = self.offsets_file().get_ref().metadata()?.len();
 
-        if mode.should_err() &&
-            expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
+        if mode.should_err()
+            && expected_offsets_file_size.cmp(&actual_offsets_file_size) != Ordering::Equal
         {
-            return Err(NippyJarError::InconsistentState)
+            return Err(NippyJarError::InconsistentState);
         }
 
         // Offsets configuration wasn't properly committed
@@ -89,8 +89,8 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 self.jar.rows = ((actual_offsets_file_size.
                         saturating_sub(1). // first byte is the size of one offset
                         saturating_sub(OFFSET_SIZE_BYTES as u64) / // expected size of the data file
-                        (self.jar.columns as u64)) /
-                    OFFSET_SIZE_BYTES as u64) as usize;
+                        (self.jar.columns as u64))
+                    / OFFSET_SIZE_BYTES as u64) as usize;
 
                 // Freeze row count changed
                 self.jar.freeze_config()?;
@@ -103,7 +103,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
         let data_file_len = self.data_file().get_ref().metadata()?.len();
 
         if mode.should_err() && last_offset.cmp(&data_file_len) != Ordering::Equal {
-            return Err(NippyJarError::InconsistentState)
+            return Err(NippyJarError::InconsistentState);
         }
 
         // Offset list wasn't properly committed
@@ -138,7 +138,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                         // Since we decrease the offset list, we need to check the consistency of
                         // `self.jar.rows` again
                         self.handle_consistency(ConsistencyFailStrategy::Heal)?;
-                        break
+                        break;
                     }
                 }
             }

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -80,7 +80,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
 
         if self.row as usize >= self.jar.rows {
             // Has reached the end
-            return Ok(None)
+            return Ok(None);
         }
 
         let mut row = Vec::with_capacity(self.jar.columns);
@@ -120,7 +120,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
 
         if self.row as usize >= self.jar.rows {
             // Has reached the end
-            return Ok(None)
+            return Ok(None);
         }
 
         let columns = self.jar.columns;

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -323,13 +323,13 @@ impl<H: NippyJarHeader> NippyJar<H> {
         columns: &[impl IntoIterator<Item = ColumnResult<Vec<u8>>>],
     ) -> Result<(), NippyJarError> {
         if columns.len() != self.columns {
-            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()))
+            return Err(NippyJarError::ColumnLenMismatch(self.columns, columns.len()));
         }
 
-        if let Some(compression) = &self.compressor &&
-            !compression.is_ready()
+        if let Some(compression) = &self.compressor
+            && !compression.is_ready()
         {
-            return Err(NippyJarError::CompressorNotReady)
+            return Err(NippyJarError::CompressorNotReady);
         }
 
         Ok(())
@@ -370,9 +370,9 @@ impl DataReader {
 
         // Ensure that the size of an offset is at most 8 bytes.
         if offset_size > 8 {
-            return Err(NippyJarError::OffsetSizeTooBig { offset_size })
+            return Err(NippyJarError::OffsetSizeTooBig { offset_size });
         } else if offset_size == 0 {
-            return Err(NippyJarError::OffsetSizeTooSmall { offset_size })
+            return Err(NippyJarError::OffsetSizeTooSmall { offset_size });
         }
 
         Ok(Self { data_file, data_mmap, offset_file, offset_size, offset_mmap })
@@ -412,7 +412,7 @@ impl DataReader {
 
         let offset_end = index.saturating_add(self.offset_size as usize);
         if offset_end > self.offset_mmap.len() {
-            return Err(NippyJarError::OffsetOutOfBounds { index })
+            return Err(NippyJarError::OffsetOutOfBounds { index });
         }
 
         buffer[..self.offset_size as usize].copy_from_slice(&self.offset_mmap[index..offset_end]);

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -284,7 +284,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                     return Err(NippyJarError::InvalidPruning(
                         num_offsets,
                         remaining_to_prune as u64,
-                    ))
+                    ));
                 }
 
                 let new_num_offsets = num_offsets.saturating_sub(remaining_to_prune as u64);
@@ -315,7 +315,7 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
                     self.data_file.get_mut().set_len(last_offset)?;
                 }
             } else {
-                return Err(NippyJarError::InvalidPruning(0, remaining_to_prune as u64))
+                return Err(NippyJarError::InvalidPruning(0, remaining_to_prune as u64));
             }
         }
 
@@ -425,10 +425,10 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
 
         // Appends new offsets to disk
         for offset in self.offsets.drain(..) {
-            if let Some(last_offset_ondisk) = last_offset_ondisk.take() &&
-                last_offset_ondisk == offset
+            if let Some(last_offset_ondisk) = last_offset_ondisk.take()
+                && last_offset_ondisk == offset
             {
-                continue
+                continue;
             }
             self.offsets_file.write_all(&offset.to_le_bytes())?;
         }

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -998,7 +998,7 @@ where
                 let Some(highest) = highest_static_block else {
                     return Err(ProviderError::MissingHighestStaticFileBlock(
                         StaticFileSegment::AccountChangeSets,
-                    ))
+                    ));
                 };
 
                 let start = *range.start();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -600,8 +600,8 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
     }
 
     fn pending_state_by_hash(&self, block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
-        if let Some(pending) = self.canonical_in_memory_state.pending_state() &&
-            pending.hash() == block_hash
+        if let Some(pending) = self.canonical_in_memory_state.pending_state()
+            && pending.hash() == block_hash
         {
             return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
         }
@@ -610,7 +610,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
     fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
         if let Some(pending) = self.canonical_in_memory_state.pending_state() {
-            return Ok(Some(Box::new(self.block_state_provider(&pending)?)))
+            return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
         }
 
         Ok(None)
@@ -942,7 +942,6 @@ mod tests {
                             requests: Default::default(),
                             gas_used: 0,
                             blob_gas_used: 0,
-                            block_access_list: Default::default(),
                         },
                         state: BundleState::default(),
                     };
@@ -1007,8 +1006,8 @@ mod tests {
     ) {
         let hook_provider = provider.clone();
         provider.database.db_ref().set_post_transaction_hook(Box::new(move || {
-            if let Some(state) = hook_provider.canonical_in_memory_state.head_state() &&
-                state.anchor().number + 1 == block_number
+            if let Some(state) = hook_provider.canonical_in_memory_state.head_state()
+                && state.anchor().number + 1 == block_number
             {
                 let mut lowest_memory_block =
                     state.parent_state_chain().last().expect("qed").block();
@@ -1745,7 +1744,6 @@ mod tests {
                                 requests: Default::default(),
                                 gas_used: 0,
                                 blob_gas_used: 0,
-                                block_access_list: Default::default(),
                             },
                         }),
                         ..Default::default()

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -148,7 +148,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         range: RangeInclusive<BlockNumber>,
     ) -> ProviderResult<Option<ExecutionOutcome<ReceiptTy<N>>>> {
         if range.is_empty() {
-            return Ok(None)
+            return Ok(None);
         }
         let start_block_number = *range.start();
         let end_block_number = *range.end();
@@ -165,10 +165,10 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         // get transaction receipts
         let Some(from_transaction_num) = block_bodies.first().map(|body| body.1.first_tx_num())
         else {
-            return Ok(None)
+            return Ok(None);
         };
         let Some(to_transaction_num) = block_bodies.last().map(|body| body.1.last_tx_num()) else {
-            return Ok(None)
+            return Ok(None);
         };
 
         let mut account_changeset = Vec::new();
@@ -330,7 +330,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         });
 
         if start > end {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
 
         // Split range into storage_range and in-memory range. If the in-memory range is not
@@ -378,7 +378,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             // The predicate was not met, if the number of items differs from the expected. So, we
             // return what we have.
             if items.len() as u64 != storage_range.end() - storage_range.start() + 1 {
-                return Ok(items)
+                return Ok(items);
             }
         }
 
@@ -388,7 +388,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
                 if let Some(item) = map_block_state_item(block, &mut predicate) {
                     items.push(item);
                 } else {
-                    break
+                    break;
                 }
             }
         }
@@ -446,12 +446,12 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             in_mem_chain
                 .iter()
                 .map(|b| b.block_ref().recovered_block().body().transactions().len() as u64)
-                .sum::<u64>() +
-                last_block_body_index.last_tx_num()
+                .sum::<u64>()
+                + last_block_body_index.last_tx_num()
         });
 
         if start > end {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
 
         let mut tx_range = start..=end;
@@ -485,7 +485,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             // transaction, advance
             if *tx_range.start() >= in_memory_tx_num + block_tx_count as u64 {
                 in_memory_tx_num += block_tx_count as u64;
-                continue
+                continue;
             }
 
             // This should only be more than 0 once, in case of a partial range inside a block.
@@ -500,7 +500,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
 
             // Break if the range has been fully processed
             if in_memory_tx_num > *tx_range.end() {
-                break
+                break;
             }
 
             // Set updated range
@@ -541,10 +541,10 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
 
         // If the transaction number is less than the first in-memory transaction number, make a
         // database lookup
-        if let HashOrNumber::Number(id) = id &&
-            id < in_memory_tx_num
+        if let HashOrNumber::Number(id) = id
+            && id < in_memory_tx_num
         {
-            return fetch_from_db(provider)
+            return fetch_from_db(provider);
         }
 
         // Iterate from the lowest block to the highest
@@ -556,12 +556,12 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
                 match id {
                     HashOrNumber::Hash(tx_hash) => {
                         if tx_hash == block.body().transactions()[tx_index].trie_hash() {
-                            return fetch_from_block_state(tx_index, in_memory_tx_num, block_state)
+                            return fetch_from_block_state(tx_index, in_memory_tx_num, block_state);
                         }
                     }
                     HashOrNumber::Number(id) => {
                         if id == in_memory_tx_num {
-                            return fetch_from_block_state(tx_index, in_memory_tx_num, block_state)
+                            return fetch_from_block_state(tx_index, in_memory_tx_num, block_state);
                         }
                     }
                 }
@@ -572,7 +572,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
 
         // Not found in-memory, so check database.
         if let HashOrNumber::Hash(_) = id {
-            return fetch_from_db(provider)
+            return fetch_from_db(provider);
         }
 
         Ok(None)
@@ -590,7 +590,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         M: Fn(&BlockState<N::Primitives>) -> ProviderResult<R>,
     {
         if let Some(Some(block_state)) = self.head_block.as_ref().map(|b| b.block_on_chain(id)) {
-            return fetch_from_block_state(block_state)
+            return fetch_from_block_state(block_state);
         }
         fetch_from_db(&self.storage_provider)
     }
@@ -798,14 +798,14 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
         hash: B256,
         source: BlockSource,
     ) -> ProviderResult<Option<Self::Block>> {
-        if matches!(source, BlockSource::Canonical | BlockSource::Any) &&
-            let Some(block) = self.get_in_memory_or_storage_by_block(
+        if matches!(source, BlockSource::Canonical | BlockSource::Any)
+            && let Some(block) = self.get_in_memory_or_storage_by_block(
                 hash.into(),
                 |db_provider| db_provider.find_block_by_hash(hash, BlockSource::Canonical),
                 |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_block())),
             )?
         {
-            return Ok(Some(block))
+            return Ok(Some(block));
         }
 
         if matches!(source, BlockSource::Pending | BlockSource::Any) {
@@ -813,7 +813,7 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
                 .canonical_in_memory_state
                 .pending_block()
                 .filter(|b| b.hash() == hash)
-                .map(|b| b.into_block()))
+                .map(|b| b.into_block()));
         }
 
         Ok(None)
@@ -957,7 +957,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
 
     fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
         if let Some(tx) = self.head_block.as_ref().and_then(|b| b.transaction_on_chain(hash)) {
-            return Ok(Some(tx))
+            return Ok(Some(tx));
         }
 
         self.storage_provider.transaction_by_hash(hash)
@@ -970,7 +970,7 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         if let Some((tx, meta)) =
             self.head_block.as_ref().and_then(|b| b.transaction_meta_on_chain(tx_hash))
         {
-            return Ok(Some((tx, meta)))
+            return Ok(Some((tx, meta)));
         }
 
         self.storage_provider.transaction_by_hash_with_meta(tx_hash)
@@ -1115,9 +1115,9 @@ impl<N: ProviderNodeTypes> ReceiptProviderIdExt for ConsistentProvider<N> {
         match block {
             BlockId::Hash(rpc_block_hash) => {
                 let mut receipts = self.receipts_by_block(rpc_block_hash.block_hash.into())?;
-                if receipts.is_none() &&
-                    !rpc_block_hash.require_canonical.unwrap_or(false) &&
-                    let Some(state) = self
+                if receipts.is_none()
+                    && !rpc_block_hash.require_canonical.unwrap_or(false)
+                    && let Some(state) = self
                         .head_block
                         .as_ref()
                         .and_then(|b| b.block_on_chain(rpc_block_hash.block_hash.into()))
@@ -1347,7 +1347,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
                 .unwrap_or(true);
 
             if !storage_history_exists {
-                return Err(ProviderError::StateAtBlockPruned(block_number))
+                return Err(ProviderError::StateAtBlockPruned(block_number));
             }
 
             self.storage_provider.storage_changeset(block_number)
@@ -1375,7 +1375,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
                 .flatten()
                 .find_map(|revert: PlainStorageRevert| {
                     if revert.address != address {
-                        return None
+                        return None;
                     }
                     revert.storage_revert.into_iter().find_map(|(key, value)| {
                         let slot_key = B256::from(key.to_be_bytes());
@@ -1396,7 +1396,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
                 .unwrap_or(true);
 
             if !storage_history_exists {
-                return Err(ProviderError::StateAtBlockPruned(block_number))
+                return Err(ProviderError::StateAtBlockPruned(block_number));
             }
 
             self.storage_provider.get_storage_before_block(block_number, address, storage_key)
@@ -1452,7 +1452,7 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
                 .unwrap_or(true);
 
             if !storage_history_exists {
-                return Err(ProviderError::StateAtBlockPruned(database_start))
+                return Err(ProviderError::StateAtBlockPruned(database_start));
             }
 
             let db_changesets = self
@@ -1529,7 +1529,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
                 .unwrap_or(true);
 
             if !account_history_exists {
-                return Err(ProviderError::StateAtBlockPruned(block_number))
+                return Err(ProviderError::StateAtBlockPruned(block_number));
             }
 
             self.storage_provider.account_block_changeset(block_number)
@@ -1574,7 +1574,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
                 .unwrap_or(true);
 
             if !account_history_exists {
-                return Err(ProviderError::StateAtBlockPruned(block_number))
+                return Err(ProviderError::StateAtBlockPruned(block_number));
             }
 
             // Delegate to the storage provider for database lookups
@@ -1628,7 +1628,7 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
                 .unwrap_or(true);
 
             if !account_history_exists {
-                return Err(ProviderError::StateAtBlockPruned(database_start))
+                return Err(ProviderError::StateAtBlockPruned(database_start));
             }
 
             let db_changesets =
@@ -2036,7 +2036,6 @@ mod tests {
                                 requests: Default::default(),
                                 gas_used: 0,
                                 blob_gas_used: 0,
-                                block_access_list: Default::default(),
                             },
                         }),
                         ..Default::default()
@@ -2390,7 +2389,6 @@ mod tests {
                         requests: Default::default(),
                         gas_used: 0,
                         blob_gas_used: 0,
-                        block_access_list: Default::default(),
                     },
                 }),
                 ..Default::default()
@@ -2489,7 +2487,6 @@ mod tests {
                         requests: Default::default(),
                         gas_used: 0,
                         blob_gas_used: 0,
-                        block_access_list: Default::default(),
                     },
                 }),
                 ..Default::default()
@@ -2592,7 +2589,6 @@ mod tests {
                         requests: Default::default(),
                         gas_used: 0,
                         blob_gas_used: 0,
-                        block_access_list: Default::default(),
                     },
                 }),
                 ..Default::default()
@@ -2689,7 +2685,6 @@ mod tests {
                         requests: Default::default(),
                         gas_used: 0,
                         blob_gas_used: 0,
-                        block_access_list: Default::default(),
                     },
                 }),
                 ..Default::default()

--- a/crates/storage/provider/src/providers/consistent_view.rs
+++ b/crates/storage/provider/src/providers/consistent_view.rs
@@ -67,10 +67,10 @@ where
         //
         // To ensure this doesn't happen, we just have to make sure that we fetch from the same
         // data source that we used during initialization. In this case, that is static files
-        if let Some((hash, number)) = self.tip &&
-            provider_ro.sealed_header(number)?.is_none_or(|header| header.hash() != hash)
+        if let Some((hash, number)) = self.tip
+            && provider_ro.sealed_header(number)?.is_none_or(|header| header.hash() != hash)
         {
-            return Err(ConsistentViewError::Reorged { block: hash }.into())
+            return Err(ConsistentViewError::Reorged { block: hash }.into());
         }
 
         Ok(provider_ro)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -255,10 +255,10 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
         let mut block_number =
             self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
-        if block_number == self.best_block_number().unwrap_or_default() &&
-            block_number == self.last_block_number().unwrap_or_default()
+        if block_number == self.best_block_number().unwrap_or_default()
+            && block_number == self.last_block_number().unwrap_or_default()
         {
-            return Ok(Box::new(LatestStateProviderRef::new(self)))
+            return Ok(Box::new(LatestStateProviderRef::new(self)));
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.
@@ -482,22 +482,22 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<StaticFileWriteCtx> {
         let tip = self.last_block_number()?.max(last_block);
         Ok(StaticFileWriteCtx {
-            write_senders: EitherWriterDestination::senders(self).is_static_file() &&
-                self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
-            write_receipts: save_mode.with_state() &&
-                EitherWriter::receipts_destination(self).is_static_file(),
-            write_account_changesets: save_mode.with_state() &&
-                EitherWriterDestination::account_changesets(self).is_static_file(),
-            write_storage_changesets: save_mode.with_state() &&
-                EitherWriterDestination::storage_changesets(self).is_static_file(),
+            write_senders: EitherWriterDestination::senders(self).is_static_file()
+                && self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
+            write_receipts: save_mode.with_state()
+                && EitherWriter::receipts_destination(self).is_static_file(),
+            write_account_changesets: save_mode.with_state()
+                && EitherWriterDestination::account_changesets(self).is_static_file(),
+            write_storage_changesets: save_mode.with_state()
+                && EitherWriterDestination::storage_changesets(self).is_static_file(),
             tip,
             receipts_prune_mode: self.prune_modes.receipts,
             // Receipts are prunable if no receipts exist in SF yet and within pruning distance
             receipts_prunable: self
                 .static_file_provider
                 .get_highest_static_file_tx(StaticFileSegment::Receipts)
-                .is_none() &&
-                PruneMode::Distance(self.minimum_pruning_distance)
+                .is_none()
+                && PruneMode::Distance(self.minimum_pruning_distance)
                     .should_prune(first_block, tip),
         })
     }
@@ -529,7 +529,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<()> {
         if blocks.is_empty() {
             debug!(target: "providers::db", "Attempted to write empty block range");
-            return Ok(())
+            return Ok(());
         }
 
         let total_start = Instant::now();
@@ -608,8 +608,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let mdbx_start = Instant::now();
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
-            if !self.cached_storage_settings().storage_v2 &&
-                self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
+            if !self.cached_storage_settings().storage_v2
+                && self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
             {
                 let start = Instant::now();
                 let total_tx_count: usize =
@@ -739,8 +739,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         block: &RecoveredBlock<BlockTy<N>>,
         first_tx_num: TxNumber,
     ) -> ProviderResult<StoredBlockBodyIndices> {
-        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) &&
-            EitherWriterDestination::senders(self).is_database()
+        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full())
+            && EitherWriterDestination::senders(self).is_database()
         {
             let start = Instant::now();
             let tx_nums_iter = std::iter::successors(Some(first_tx_num), |n| Some(n + 1));
@@ -952,7 +952,7 @@ where
     while let Some((sharded_key, list)) = item {
         // If the shard does not belong to the key, break.
         if !shard_belongs_to_key(&sharded_key) {
-            break
+            break;
         }
 
         // Always delete the current shard from the database first
@@ -967,18 +967,18 @@ where
         // Keep it deleted (don't return anything for reinsertion)
         if first >= block_number {
             item = cursor.prev()?;
-            continue
+            continue;
         }
         // Case 2: This is a boundary shard (spans across the unwinding point)
         // The shard contains some blocks below and some at/above the unwinding point
         else if block_number <= sharded_key.as_ref().highest_block_number {
             // Return only the block numbers that are below the unwinding point
             // These will be reinserted to preserve the historical data
-            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>())
+            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>());
         }
         // Case 3: Entire shard is below the unwinding point
         // Return all block numbers for reinsertion (preserve entire shard)
-        return Ok(list.iter().collect::<Vec<_>>())
+        return Ok(list.iter().collect::<Vec<_>>());
     }
 
     // No shards found or all processed
@@ -1121,7 +1121,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         F: FnMut(H, BodyTy<N>, Range<TxNumber>) -> ProviderResult<R>,
     {
         if range.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         let len = range.end().saturating_sub(*range.start()) as usize;
@@ -1474,8 +1474,8 @@ impl<TX: DbTx + 'static, N: NodeTypes> AccountExtReader for DatabaseProvider<TX,
             .static_file_provider
             .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
 
-        if let Some(highest) = highest_static_block &&
-            self.cached_storage_settings().storage_v2
+        if let Some(highest) = highest_static_block
+            && self.cached_storage_settings().storage_v2
         {
             let start = *range.start();
             let static_end = (*range.end()).min(highest);
@@ -1673,7 +1673,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderSyncGapProvider
             }
             Ordering::Less => {
                 // There's either missing or corrupted files.
-                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()))
+                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()));
             }
             Ordering::Equal => {}
         }
@@ -1789,7 +1789,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
         if let Some(number) = self.convert_hash_or_number(id)? {
             let earliest_available = self.static_file_provider.earliest_history_height();
             if number < earliest_available {
-                return Err(ProviderError::BlockExpired { requested: number, earliest_available })
+                return Err(ProviderError::BlockExpired { requested: number, earliest_available });
             }
 
             let Some(header) = self.header_by_number(number)? else { return Ok(None) };
@@ -1799,7 +1799,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
             // If they exist but are not indexed, we don't have enough
             // information to return the block anyways, so we return `None`.
             let Some(transactions) = self.transactions_by_block(number.into())? else {
-                return Ok(None)
+                return Ok(None);
             };
 
             let body = self
@@ -1809,7 +1809,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
                 .pop()
                 .ok_or(ProviderError::InvalidStorageOutput)?;
 
-            return Ok(Some(Self::Block::new(header, body)))
+            return Ok(Some(Self::Block::new(header, body)));
         }
 
         Ok(None)
@@ -1969,10 +1969,10 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         &self,
         tx_hash: TxHash,
     ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
-        if let Some(transaction_id) = self.transaction_id(tx_hash)? &&
-            let Some(transaction) = self.transaction_by_id_unhashed(transaction_id)? &&
-            let Some(block_number) = self.block_by_transaction_id(transaction_id)? &&
-            let Some(sealed_header) = self.sealed_header(block_number)?
+        if let Some(transaction_id) = self.transaction_id(tx_hash)?
+            && let Some(transaction) = self.transaction_by_id_unhashed(transaction_id)?
+            && let Some(block_number) = self.block_by_transaction_id(transaction_id)?
+            && let Some(sealed_header) = self.sealed_header(block_number)?
         {
             let (header, block_hash) = sealed_header.split();
             if let Some(block_body) = self.block_body_indices(block_number)? {
@@ -1992,7 +1992,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
                     timestamp: header.timestamp(),
                 };
 
-                return Ok(Some((transaction, meta)))
+                return Ok(Some((transaction, meta)));
             }
         }
 
@@ -2003,15 +2003,15 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         &self,
         id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
-        if let Some(block_number) = self.convert_hash_or_number(id)? &&
-            let Some(body) = self.block_body_indices(block_number)?
+        if let Some(block_number) = self.convert_hash_or_number(id)?
+            && let Some(body) = self.block_body_indices(block_number)?
         {
             let tx_range = body.tx_num_range();
             return if tx_range.is_empty() {
                 Ok(Some(Vec::new()))
             } else {
                 self.transactions_by_tx_range(tx_range).map(Some)
-            }
+            };
         }
         Ok(None)
     }
@@ -2086,15 +2086,15 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         &self,
         block: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
-        if let Some(number) = self.convert_hash_or_number(block)? &&
-            let Some(body) = self.block_body_indices(number)?
+        if let Some(number) = self.convert_hash_or_number(block)?
+            && let Some(body) = self.block_body_indices(number)?
         {
             let tx_range = body.tx_num_range();
             return if tx_range.is_empty() {
                 Ok(Some(Vec::new()))
             } else {
                 self.receipts_by_tx_range(tx_range).map(Some)
-            }
+            };
         }
         Ok(None)
     }
@@ -2379,10 +2379,10 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
     ) -> ProviderResult<()> {
         let execution_outcome = execution_outcome.into();
 
-        if self.cached_storage_settings().use_hashed_state() &&
-            !config.write_receipts &&
-            !config.write_account_changesets &&
-            !config.write_storage_changesets
+        if self.cached_storage_settings().use_hashed_state()
+            && !config.write_receipts
+            && !config.write_account_changesets
+            && !config.write_storage_changesets
         {
             // In storage v2 with all outputs directed to static files, plain state and changesets
             // are written elsewhere. Only bytecodes need MDBX writes, so skip the expensive
@@ -2437,11 +2437,12 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         // Database, OR if receipts_in_static_files is enabled but no receipts exist in static
         // files yet. Once receipts exist in static files, we must continue writing to maintain
         // continuity and have no gaps.
-        let prunable_receipts = (EitherWriter::receipts_destination(self).is_database() ||
-            self.static_file_provider()
+        let prunable_receipts = (EitherWriter::receipts_destination(self).is_database()
+            || self
+                .static_file_provider()
                 .get_highest_static_file_tx(StaticFileSegment::Receipts)
-                .is_none()) &&
-            PruneMode::Distance(self.minimum_pruning_distance).should_prune(first_block, tip);
+                .is_none())
+            && PruneMode::Distance(self.minimum_pruning_distance).should_prune(first_block, tip);
 
         // Prepare set of addresses which logs should not be pruned.
         let mut allowed_addresses: AddressSet = AddressSet::default();
@@ -2458,12 +2459,13 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             receipts_writer.increment_block(block_number)?;
 
             // Skip writing receipts if pruning configuration requires us to.
-            if prunable_receipts &&
-                self.prune_modes
+            if prunable_receipts
+                && self
+                    .prune_modes
                     .receipts
                     .is_some_and(|mode| mode.should_prune(block_number, tip))
             {
-                continue
+                continue;
             }
 
             // If there are new addresses to retain after this block number, track them
@@ -2475,11 +2477,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 let receipt_idx = first_tx_index + idx as u64;
                 // Skip writing receipt if log filter is active and it does not have any logs to
                 // retain
-                if prunable_receipts &&
-                    has_contract_log_filter &&
-                    !receipt.logs().iter().any(|log| allowed_addresses.contains(&log.address))
+                if prunable_receipts
+                    && has_contract_log_filter
+                    && !receipt.logs().iter().any(|log| allowed_addresses.contains(&log.address))
                 {
-                    continue
+                    continue;
                 }
 
                 receipts_writer.append_receipt(receipt_idx, receipt)?;
@@ -2610,8 +2612,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 for entry in storage {
                     tracing::trace!(?address, ?entry.key, "Updating plain state storage");
                     if let Some(db_entry) =
-                        storages_cursor.seek_by_key_subkey(address, entry.key)? &&
-                        db_entry.key == entry.key
+                        storages_cursor.seek_by_key_subkey(address, entry.key)?
+                        && db_entry.key == entry.key
                     {
                         storages_cursor.delete_current()?;
                     }
@@ -2657,8 +2659,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 let entry = StorageEntry { key: *hashed_slot, value: *value };
 
                 if let Some(db_entry) =
-                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&
-                    db_entry.key == entry.key
+                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)?
+                    && db_entry.key == entry.key
                 {
                     hashed_storage_cursor.delete_current()?;
                 }
@@ -2842,7 +2844,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let range = block + 1..=self.last_block_number()?;
 
         if range.is_empty() {
-            return Ok(ExecutionOutcome::default())
+            return Ok(ExecutionOutcome::default());
         }
         let start_block_number = *range.start();
 
@@ -2858,8 +2860,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let storage_range = BlockNumberAddress::range(range.clone());
         let storage_changeset = if let Some(highest_block) = self
             .static_file_provider
-            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets) &&
-            self.cached_storage_settings().storage_v2
+            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+            && self.cached_storage_settings().storage_v2
         {
             let changesets = self.storage_changesets_range(block + 1..=highest_block)?;
             let mut changeset_writer =
@@ -2874,8 +2876,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let highest_changeset_block = self
             .static_file_provider
             .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
-        let account_changeset = if let Some(highest_block) = highest_changeset_block &&
-            self.cached_storage_settings().storage_v2
+        let account_changeset = if let Some(highest_block) = highest_changeset_block
+            && self.cached_storage_settings().storage_v2
         {
             // TODO: add a `take` method that removes and returns the items instead of doing this
             let changesets = self.account_changesets_range(block + 1..highest_block + 1)?;
@@ -3082,7 +3084,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
     #[instrument(level = "debug", target = "providers::db", skip_all)]
     fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize> {
         if trie_updates.is_empty() {
-            return Ok(0)
+            return Ok(0);
         }
 
         // Track the number of inserted entries.
@@ -3346,8 +3348,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HistoryWriter for DatabaseProvi
                     StorageShardedKey::last(address, storage_key),
                     rem_index,
                     |storage_sharded_key| {
-                        storage_sharded_key.address == address &&
-                            storage_sharded_key.sharded_key.key == storage_key
+                        storage_sharded_key.address == address
+                            && storage_sharded_key.sharded_key.key == storage_key
                     },
                 )?;
 
@@ -3641,7 +3643,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
     ) -> ProviderResult<()> {
         if blocks.is_empty() {
             debug!(target: "providers::db", "Attempted to append empty block range");
-            return Ok(())
+            return Ok(());
         }
 
         // Blocks are not empty, so no need to handle the case of `blocks.first()` being
@@ -4992,8 +4994,8 @@ mod tests {
                     ..Default::default()
                 };
 
-                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1..=
-                    slots_per_account as u64)
+                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1
+                    ..=slots_per_account as u64)
                     .map(|s| {
                         (
                             U256::from(s + acct_idx as u64 * 100),

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -62,22 +62,22 @@ impl RocksDBProvider {
         let mut unwind_target: Option<BlockNumber> = None;
 
         // Heal TransactionHashNumbers if stored in RocksDB
-        if provider.cached_storage_settings().storage_v2 &&
-            let Some(target) = self.heal_transaction_hash_numbers(provider)?
+        if provider.cached_storage_settings().storage_v2
+            && let Some(target) = self.heal_transaction_hash_numbers(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }
 
         // Heal StoragesHistory if stored in RocksDB
-        if provider.cached_storage_settings().storage_v2 &&
-            let Some(target) = self.heal_storages_history(provider)?
+        if provider.cached_storage_settings().storage_v2
+            && let Some(target) = self.heal_storages_history(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }
 
         // Heal AccountsHistory if stored in RocksDB
-        if provider.cached_storage_settings().storage_v2 &&
-            let Some(target) = self.heal_accounts_history(provider)?
+        if provider.cached_storage_settings().storage_v2
+            && let Some(target) = self.heal_accounts_history(provider)?
         {
             unwind_target = Some(unwind_target.map_or(target, |t| t.min(target)));
         }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -621,8 +621,8 @@ impl Drop for RocksDBProviderInner {
                     tracing::warn!(target: "providers::rocksdb", ?e, "Failed to flush WAL on drop");
                 }
                 for cf_name in ROCKSDB_TABLES {
-                    if let Some(cf) = db.cf_handle(cf_name) &&
-                        let Err(e) = db.flush_cf(&cf)
+                    if let Some(cf) = db.cf_handle(cf_name)
+                        && let Err(e) = db.flush_cf(&cf)
                     {
                         tracing::warn!(target: "providers::rocksdb", cf = cf_name, ?e, "Failed to flush CF on drop");
                     }
@@ -1457,8 +1457,8 @@ impl<'a> RocksDBBatch<'a> {
     /// This is called after each `put` or `delete` operation to prevent unbounded memory growth.
     /// Returns immediately if auto-commit is disabled or threshold not reached.
     fn maybe_auto_commit(&mut self) -> ProviderResult<()> {
-        if let Some(threshold) = self.auto_commit_threshold &&
-            self.inner.size_in_bytes() >= threshold
+        if let Some(threshold) = self.auto_commit_threshold
+            && self.inner.size_in_bytes() >= threshold
         {
             tracing::debug!(
                 target: "providers::rocksdb",
@@ -1776,8 +1776,8 @@ impl<'a> RocksDBBatch<'a> {
             }
         }
 
-        if let Some((last_key, last_value)) = last_remaining &&
-            !is_sentinel(&last_key)
+        if let Some((last_key, last_value)) = last_remaining
+            && !is_sentinel(&last_key)
         {
             delete_shard(self, last_key)?;
             put_shard(self, create_sentinel(), &last_value)?;
@@ -2067,8 +2067,8 @@ impl<'a> RocksDBBatch<'a> {
         // Find the first shard that might contain blocks > keep_to.
         // A shard is affected if it's the sentinel (u64::MAX) or its highest_block_number > keep_to
         let boundary_idx = shards.iter().position(|(key, _)| {
-            key.sharded_key.highest_block_number == u64::MAX ||
-                key.sharded_key.highest_block_number > keep_to
+            key.sharded_key.highest_block_number == u64::MAX
+                || key.sharded_key.highest_block_number > keep_to
         });
 
         // Repair path: no shards affected means all blocks <= keep_to, just ensure sentinel exists

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -91,10 +91,10 @@ impl HistoryInfo {
             if let (Some(_), Some(block_number)) = (lowest_available, found_block) {
                 // The key may have been written, but due to pruning we may not have changesets
                 // and history, so we need to make a changeset lookup.
-                return Self::InChangeset(block_number)
+                return Self::InChangeset(block_number);
             }
             // The key is written to, but only after our block.
-            return Self::NotYetWritten
+            return Self::NotYetWritten;
         }
 
         if let Some(block_number) = found_block {
@@ -153,7 +153,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
         Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
     {
         if !self.lowest_available_blocks.is_account_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         self.provider.with_rocksdb_tx(|rocks_tx_ref| {
@@ -178,7 +178,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
         Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
     {
         if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         self.provider.with_rocksdb_tx(|rocks_tx_ref| {
@@ -252,10 +252,10 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
     where
         Provider: StorageSettingsCache,
     {
-        if !self.lowest_available_blocks.is_account_history_available(self.block_number) ||
-            !self.lowest_available_blocks.is_storage_history_available(self.block_number)
+        if !self.lowest_available_blocks.is_account_history_available(self.block_number)
+            || !self.lowest_available_blocks.is_storage_history_available(self.block_number)
         {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         if self.check_distance_against_limit(EPOCH_SLOTS)? {
@@ -275,7 +275,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
         Provider: StorageSettingsCache,
     {
         if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
-            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+            return Err(ProviderError::StateAtBlockPruned(self.block_number));
         }
 
         if self.check_distance_against_limit(EPOCH_SLOTS * 10)? {
@@ -727,8 +727,8 @@ where
         // This check is worth it, the `cursor.prev()` check is rarely triggered (the if will
         // short-circuit) and when it passes we save a full seek into the changeset/plain state
         // table.
-        let is_before_first_write = needs_prev_shard_check(rank, found_block, block_number) &&
-            !cursor.prev()?.is_some_and(|(k, _)| key_filter(&k));
+        let is_before_first_write = needs_prev_shard_check(rank, found_block, block_number)
+            && !cursor.prev()?.is_some_and(|(k, _)| key_filter(&k));
 
         Ok(HistoryInfo::from_lookup(
             found_block,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -265,8 +265,8 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             )
         } else {
             let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
-            if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)? &&
-                entry.key == storage_key
+            if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)?
+                && entry.key == storage_key
             {
                 return Ok(Some(entry.value));
             }

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -256,7 +256,7 @@ where
         // If the requested block is the DB tip then there won't be any reverts necessary, and we
         // can simply return Ok.
         if db_tip_block == requested_block {
-            return Ok(false)
+            return Ok(false);
         }
 
         // Check account history prune checkpoint to determine the lower bound of available data.
@@ -303,8 +303,8 @@ where
 
         // If block_hash is provided, collect reverts
         let (trie_updates, hashed_post_state) = if let Some(from_block) =
-            self.get_requested_block_number(provider)? &&
-            self.reverts_required(provider, db_tip_block, from_block)?
+            self.get_requested_block_number(provider)?
+            && self.reverts_required(provider, db_tip_block, from_block)?
         {
             debug!(
                 target: "providers::state::overlay",
@@ -412,7 +412,7 @@ where
         // return the in-memory overlay (resolving lazy overlay if set).
         if self.block_hash.is_none() {
             let (trie_updates, hashed_post_state) = self.resolve_overlays();
-            return Ok(Overlay { trie_updates, hashed_post_state })
+            return Ok(Overlay { trie_updates, hashed_post_state });
         }
 
         let db_tip_block = self.get_db_tip_block_number(provider)?;

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -205,7 +205,7 @@ impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileJarProv
             {
                 let sealed = SealedHeader::new(header, hash);
                 if !predicate(&sealed) {
-                    break
+                    break;
                 }
                 headers.push(sealed);
             }
@@ -360,10 +360,10 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction, Receipt: Decomp
     }
 
     fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
-        if let Some(tx_static_file) = &self.auxiliary_jar &&
-            let Some(num) = tx_static_file.transaction_id(hash)?
+        if let Some(tx_static_file) = &self.auxiliary_jar
+            && let Some(num) = tx_static_file.transaction_id(hash)?
         {
-            return self.receipt(num)
+            return self.receipt(num);
         }
         Ok(None)
     }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -295,9 +295,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         // We only care about modified data events
                         if !matches!(
                             event.kind,
-                            notify::EventKind::Modify(_) |
-                                notify::EventKind::Create(_) |
-                                notify::EventKind::Remove(_)
+                            notify::EventKind::Modify(_)
+                                | notify::EventKind::Create(_)
+                                | notify::EventKind::Remove(_)
                         ) {
                             continue;
                         }
@@ -590,11 +590,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             w.increment_block(block_number)?;
 
             // skip writing receipts if pruning configuration requires us to.
-            if ctx.receipts_prunable &&
-                ctx.receipts_prune_mode
+            if ctx.receipts_prunable
+                && ctx
+                    .receipts_prune_mode
                     .is_some_and(|mode| mode.should_prune(block_number, ctx.tip))
             {
-                continue
+                continue;
             }
 
             for (i, receipt) in block.execution_outcome().receipts.iter().enumerate() {
@@ -815,8 +816,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         match provider {
             Ok(provider) => Ok(Some(provider)),
             Err(
-                ProviderError::MissingStaticFileBlock(_, _) |
-                ProviderError::MissingStaticFileTx(_, _),
+                ProviderError::MissingStaticFileBlock(_, _)
+                | ProviderError::MissingStaticFileTx(_, _),
             ) => Ok(None),
             Err(err) => Err(err),
         }
@@ -1366,8 +1367,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         //
         // If we detect an OVM import was done (block #1 <https://optimistic.etherscan.io/block/1>), skip it.
         // More on [#11099](https://github.com/paradigmxyz/reth/pull/11099).
-        if provider.chain_spec().is_optimism() &&
-            reth_chainspec::Chain::optimism_mainnet() == provider.chain_spec().chain_id()
+        if provider.chain_spec().is_optimism()
+            && reth_chainspec::Chain::optimism_mainnet() == provider.chain_spec().chain_id()
         {
             // check whether we have the first OVM block: <https://optimistic.etherscan.io/block/0xbee7192e575af30420cae0c7776304ac196077ee72b048970549e4f08e875453>
             const OVM_HEADER_1_HASH: B256 =
@@ -1437,18 +1438,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         // If the block body indices can not be found, then it means that static
                         // files is ahead of database, and the `ensure_invariants` check will fix
                         // it by comparing with stage checkpoints.
-                        break
+                        break;
                     };
 
                     debug!(target: "reth::providers::static_file", last_block, last_tx_num = indices.last_tx_num(), "Found block body indices");
 
                     if indices.last_tx_num() <= highest_tx {
-                        break
+                        break;
                     }
 
                     if last_block == 0 {
                         debug!(target: "reth::providers::static_file", "Reached block 0 in verification loop");
-                        break
+                        break;
                     }
 
                     last_block -= 1;
@@ -1534,8 +1535,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     return false;
                 }
 
-                if NamedChain::Gnosis == provider.chain_spec().chain_id() ||
-                    NamedChain::Chiado == provider.chain_spec().chain_id()
+                if NamedChain::Gnosis == provider.chain_spec().chain_id()
+                    || NamedChain::Chiado == provider.chain_spec().chain_id()
                 {
                     // Gnosis and Chiado's historical import is broken and does not work with
                     // this check. They are importing receipts along
@@ -1569,7 +1570,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             StaticFileSegment::StorageChangeSets => {
                 if EitherWriter::storage_changesets_destination(provider).is_database() {
                     debug!(target: "reth::providers::static_file", ?segment, "Skipping storage changesets segment: changesets stored in database");
-                    return false
+                    return false;
                 }
                 true
             }
@@ -1760,12 +1761,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 }
             }
 
-            if let Some((db_last_entry, _)) = db_cursor.last()? &&
-                highest_static_file_entry
+            if let Some((db_last_entry, _)) = db_cursor.last()?
+                && highest_static_file_entry
                     .is_none_or(|highest_entry| db_last_entry > highest_entry)
             {
                 debug!(target: "reth::providers::static_file", db_last_entry, "Database has entries beyond static files, no unwind needed");
-                return Ok(None)
+                return Ok(None);
             }
         } else {
             debug!(target: "reth::providers::static_file", "No database entries found");
@@ -1818,9 +1819,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 // TODO(joshie): is_block_meta
                 writer.prune_headers(prune_count)?;
             }
-            StaticFileSegment::Transactions |
-            StaticFileSegment::Receipts |
-            StaticFileSegment::TransactionSenders => {
+            StaticFileSegment::Transactions
+            | StaticFileSegment::Receipts
+            | StaticFileSegment::TransactionSenders => {
                 if let Some(block) = provider.block_body_indices(checkpoint_block_number)? {
                     let number = highest_static_file_entry - block.last_tx_num();
                     debug!(target: "reth::providers::static_file", prune_count = number, checkpoint_block_number, "Pruning transaction based segment");
@@ -1835,9 +1836,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         StaticFileSegment::TransactionSenders => {
                             writer.prune_transaction_senders(number, checkpoint_block_number)?
                         }
-                        StaticFileSegment::Headers |
-                        StaticFileSegment::AccountChangeSets |
-                        StaticFileSegment::StorageChangeSets => {
+                        StaticFileSegment::Headers
+                        | StaticFileSegment::AccountChangeSets
+                        | StaticFileSegment::StorageChangeSets => {
                             unreachable!()
                         }
                     }
@@ -1883,8 +1884,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
         if let Some((db_first_key, _)) = db_cursor.first()? {
             let db_first_block = block_from_key(&db_first_key);
-            if let Some(highest_block) = highest_static_file_block &&
-                !(db_first_block <= highest_block || highest_block + 1 == db_first_block)
+            if let Some(highest_block) = highest_static_file_block
+                && !(db_first_block <= highest_block || highest_block + 1 == db_first_block)
             {
                 info!(
                     target: "reth::providers::static_file",
@@ -1894,11 +1895,11 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     ?segment,
                     "Setting unwind target."
                 );
-                return Ok(Some(highest_block))
+                return Ok(Some(highest_block));
             }
 
-            if let Some((db_last_key, _)) = db_cursor.last()? &&
-                highest_static_file_block
+            if let Some((db_last_key, _)) = db_cursor.last()?
+                && highest_static_file_block
                     .is_none_or(|highest_block| block_from_key(&db_last_key) > highest_block)
             {
                 debug!(
@@ -1906,7 +1907,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     ?segment,
                     "Database has entries beyond static files, no unwind needed"
                 );
-                return Ok(None)
+                return Ok(None);
             }
         } else {
             debug!(target: "reth::providers::static_file", ?segment, "No database entries found");
@@ -1926,7 +1927,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 ?segment,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block))
+            return Ok(Some(highest_static_file_block));
         }
 
         if checkpoint_block_number < highest_static_file_block {
@@ -2088,8 +2089,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 match self.get_segment_provider(segment, $number) {
                     Ok(provider) => provider,
                     Err(
-                        ProviderError::MissingStaticFileBlock(_, _) |
-                        ProviderError::MissingStaticFileTx(_, _),
+                        ProviderError::MissingStaticFileBlock(_, _)
+                        | ProviderError::MissingStaticFileTx(_, _),
                     ) => return Ok(result),
                     Err(err) => return Err(err),
                 }
@@ -2481,8 +2482,8 @@ impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
             }
         }
 
-        if low < range.end &&
-            let Some(change) = cursor
+        if low < range.end
+            && let Some(change) = cursor
                 .get_one::<reth_db::static_file::AccountChangesetMask>(low.into())?
                 .filter(|change| change.address == address)
         {
@@ -2607,8 +2608,8 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
             }
         }
 
-        if low < range.end &&
-            let Some(change) = cursor
+        if low < range.end
+            && let Some(change) = cursor
                 .get_one::<StorageChangesetMask>(low.into())?
                 .filter(|change| change.address == address && change.key == storage_key)
         {
@@ -3122,9 +3123,9 @@ impl<N: NodePrimitives> BlockBodyIndicesProvider for StaticFileProvider<N> {
 impl<N: NodePrimitives> StatsReader for StaticFileProvider<N> {
     fn count_entries<T: Table>(&self) -> ProviderResult<usize> {
         match T::NAME {
-            tables::CanonicalHeaders::NAME |
-            tables::Headers::<Header>::NAME |
-            tables::HeaderTerminalDifficulties::NAME => Ok(self
+            tables::CanonicalHeaders::NAME
+            | tables::Headers::<Header>::NAME
+            | tables::HeaderTerminalDifficulties::NAME => Ok(self
                 .get_highest_static_file_block(StaticFileSegment::Headers)
                 .map(|block| block + 1)
                 .unwrap_or_default()

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -331,9 +331,9 @@ mod tests {
                 // Append transaction/receipt if there's still a transaction count to append
                 if tx_count > 0 {
                     match segment {
-                        StaticFileSegment::Headers |
-                        StaticFileSegment::AccountChangeSets |
-                        StaticFileSegment::StorageChangeSets => {
+                        StaticFileSegment::Headers
+                        | StaticFileSegment::AccountChangeSets
+                        | StaticFileSegment::StorageChangeSets => {
                             panic!("non tx based segment")
                         }
                         StaticFileSegment::Transactions => {
@@ -450,9 +450,9 @@ mod tests {
 
             // Prune transactions or receipts based on the segment type
             match segment {
-                StaticFileSegment::Headers |
-                StaticFileSegment::AccountChangeSets |
-                StaticFileSegment::StorageChangeSets => {
+                StaticFileSegment::Headers
+                | StaticFileSegment::AccountChangeSets
+                | StaticFileSegment::StorageChangeSets => {
                     panic!("non tx based segment")
                 }
                 StaticFileSegment::Transactions => {
@@ -477,9 +477,9 @@ mod tests {
             // cumulative_gas_used & nonce as ids.
             if let Some(id) = expected_tx_tip {
                 match segment {
-                    StaticFileSegment::Headers |
-                    StaticFileSegment::AccountChangeSets |
-                    StaticFileSegment::StorageChangeSets => {
+                    StaticFileSegment::Headers
+                    | StaticFileSegment::AccountChangeSets
+                    | StaticFileSegment::StorageChangeSets => {
                         panic!("non tx based segment")
                     }
                     StaticFileSegment::Transactions => assert_eyre(

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -152,10 +152,10 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             &self.storage_change_sets,
         ] {
             let writer = writer_lock.read();
-            if let Some(writer) = writer.as_ref() &&
-                writer.will_prune_on_commit()
+            if let Some(writer) = writer.as_ref()
+                && writer.will_prune_on_commit()
             {
-                return true
+                return true;
             }
         }
         false
@@ -516,8 +516,8 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             return Ok(());
         }
 
-        if let Some(offset) = self.current_changeset_offset.take() &&
-            let Some(writer) = &mut self.changeset_offsets
+        if let Some(offset) = self.current_changeset_offset.take()
+            && let Some(writer) = &mut self.changeset_offsets
         {
             writer.append(&offset).map_err(ProviderError::other)?;
         }
@@ -711,8 +711,8 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             .as_ref()
             .map(|block_range| block_range.end())
             .or_else(|| {
-                (self.writer.user_header().expected_block_start() >
-                    self.reader().genesis_block_number())
+                (self.writer.user_header().expected_block_start()
+                    > self.reader().genesis_block_number())
                 .then(|| self.writer.user_header().expected_block_start() - 1)
             });
 
@@ -792,8 +792,8 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         // Handle changeset offset tracking for changeset segments
         if segment.is_change_based() {
             // Write previous block's offset if we have one
-            if let Some(offset) = self.current_changeset_offset.take() &&
-                let Some(writer) = &mut self.changeset_offsets
+            if let Some(offset) = self.current_changeset_offset.take()
+                && let Some(writer) = &mut self.changeset_offsets
             {
                 writer.append(&offset).map_err(ProviderError::other)?;
             }
@@ -840,7 +840,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 self.writer.user_header().segment(),
                 expected_block_number,
                 next_static_file_block,
-            ))
+            ));
         }
         Ok(())
     }
@@ -863,7 +863,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
 
         // If we're already at or before the target block, nothing to do
         if current_block_end <= last_block {
-            return Ok(())
+            return Ok(());
         }
 
         // Navigate to the correct file if the target block is in a previous file
@@ -972,15 +972,15 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 // * it's a tx-based segment AND `last_block` is lower than the first block of this
                 //   file's block range. Otherwise, having no rows simply means that this block
                 //   range has no transactions, but the file should remain.
-                if block_start != 0 &&
-                    (segment.is_headers() || last_block.is_some_and(|b| b < block_start))
+                if block_start != 0
+                    && (segment.is_headers() || last_block.is_some_and(|b| b < block_start))
                 {
                     self.delete_current_and_open_previous()?;
                 } else {
                     // Update `SegmentHeader`
                     self.writer.user_header_mut().prune(len);
                     self.writer.prune_rows(len as usize).map_err(ProviderError::other)?;
-                    break
+                    break;
                 }
 
                 remaining_rows -= len;
@@ -1078,7 +1078,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                     self.writer.user_header().segment(),
                     tx_num,
                     next_tx,
-                ))
+                ));
             }
             self.writer.user_header_mut().increment_tx();
         } else {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -410,7 +410,7 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> TransactionsProvider
                         excess_blob_gas: block.header().excess_blob_gas(),
                         timestamp: block.header().timestamp(),
                     };
-                    return Ok(Some((tx.clone(), meta)))
+                    return Ok(Some((tx.clone(), meta)));
                 }
             }
         }

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -118,8 +118,8 @@ where
             }
 
             // Write withdrawals if any
-            if let Some(withdrawals) = body.withdrawals.clone() &&
-                !withdrawals.is_empty()
+            if let Some(withdrawals) = body.withdrawals.clone()
+                && !withdrawals.is_empty()
             {
                 withdrawals_cursor.append(block_number, &StoredBlockWithdrawals { withdrawals })?;
             }

--- a/crates/storage/storage-api/src/receipts.rs
+++ b/crates/storage/storage-api/src/receipts.rs
@@ -73,7 +73,7 @@ pub trait ReceiptProviderIdExt: ReceiptProvider + BlockIdReader {
                 if let Some(num) = self.convert_block_number(num_tag)? {
                     BlockHashOrNumber::Number(num)
                 } else {
-                    return Ok(None)
+                    return Ok(None);
                 }
             }
         };

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -60,10 +60,10 @@ pub trait StateProvider:
 
         if let Some(code_hash) = acc.bytecode_hash {
             if code_hash == KECCAK_EMPTY {
-                return Ok(None)
+                return Ok(None);
             }
             // Get the code from the code hash
-            return self.bytecode_by_hash(&code_hash)
+            return self.bytecode_by_hash(&code_hash);
         }
 
         // Return `None` if no code hash is set

--- a/crates/storage/zstd-compressors/src/lib.rs
+++ b/crates/storage/zstd-compressors/src/lib.rs
@@ -172,10 +172,10 @@ impl ReusableDecompressor {
                 // source.
                 if !reserved_upper_bound {
                     reserved_upper_bound = true;
-                    if let Some(upper_bound) = Decompressor::upper_bound(src) &&
-                        let Some(additional) = upper_bound.checked_sub(self.buf.capacity())
+                    if let Some(upper_bound) = Decompressor::upper_bound(src)
+                        && let Some(additional) = upper_bound.checked_sub(self.buf.capacity())
                     {
-                        break 'b additional
+                        break 'b additional;
                     }
                 }
 

--- a/crates/tokio-util/src/ratelimit.rs
+++ b/crates/tokio-util/src/ratelimit.rs
@@ -38,7 +38,7 @@ impl RateLimit {
             State::Ready { .. } => return Poll::Ready(()),
             State::Limited => {
                 if Pin::new(&mut self.sleep).poll(cx).is_pending() {
-                    return Poll::Pending
+                    return Poll::Pending;
                 }
             }
         }

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -110,8 +110,8 @@ impl Layers {
         // When reloadable, always show target since the user may switch to DEBUG/TRACE
         // at runtime via RPC — freezing target=false at init would hide module paths.
         // Otherwise, only show target when initial level is higher than INFO.
-        let show_target = reloadable ||
-            filter.max_level_hint().is_none_or(|max_level| max_level > tracing::Level::INFO);
+        let show_target = reloadable
+            || filter.max_level_hint().is_none_or(|max_level| max_level > tracing::Level::INFO);
 
         if reloadable {
             let (reloadable_filter, handle) = reload::Layer::new(filter);

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -77,7 +77,7 @@ where
         if batch.len() == 1 {
             Self::process_request(pool, batch.into_iter().next().expect("batch is not empty"))
                 .await;
-            return
+            return;
         }
 
         let (transactions, response_txs): (Vec<_>, Vec<_>) =

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -145,7 +145,7 @@ impl BlobStore for DiskFileBlobStore {
         txs: Vec<(B256, BlobTransactionSidecarVariant)>,
     ) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         self.inner.insert_many(txs)
     }
@@ -159,7 +159,7 @@ impl BlobStore for DiskFileBlobStore {
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         let txs = self.inner.retain_existing(txs)?;
         self.inner.txs_to_delete.write().extend(txs);
@@ -208,7 +208,7 @@ impl BlobStore for DiskFileBlobStore {
         txs: Vec<B256>,
     ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
         if txs.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
         self.inner.get_all(txs)
     }
@@ -218,7 +218,7 @@ impl BlobStore for DiskFileBlobStore {
         txs: Vec<B256>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
         if txs.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
         self.inner.get_exact(txs)
     }
@@ -441,7 +441,7 @@ impl DiskFileBlobStoreInner {
     /// Returns true if the blob for the given transaction hash is in the blob cache or on disk.
     fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
         if self.blob_cache.lock().get(&tx).is_some() {
-            return Ok(true)
+            return Ok(true);
         }
         // we only check if the file exists and assume it's valid
         Ok(self.blob_disk_file(tx).is_file())
@@ -470,13 +470,13 @@ impl DiskFileBlobStoreInner {
         tx: B256,
     ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
         if let Some(blob) = self.blob_cache.lock().get(&tx) {
-            return Ok(Some(blob.clone()))
+            return Ok(Some(blob.clone()));
         }
 
         if let Some(blob) = self.read_one(tx)? {
             let blob_arc = Arc::new(blob);
             self.blob_cache.lock().insert(tx, blob_arc.clone());
-            return Ok(Some(blob_arc))
+            return Ok(Some(blob_arc));
         }
 
         Ok(None)
@@ -583,11 +583,11 @@ impl DiskFileBlobStoreInner {
             }
         }
         if cache_miss.is_empty() {
-            return Ok(res)
+            return Ok(res);
         }
         let from_disk = self.read_many_decoded(cache_miss);
         if from_disk.is_empty() {
-            return Ok(res)
+            return Ok(res);
         }
         let from_disk = from_disk
             .into_iter()

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -76,7 +76,7 @@ impl BlobStore for InMemoryBlobStore {
         txs: Vec<(B256, BlobTransactionSidecarVariant)>,
     ) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         let mut store = self.inner.store.write();
         let mut total_add = 0;
@@ -99,7 +99,7 @@ impl BlobStore for InMemoryBlobStore {
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
         if txs.is_empty() {
-            return Ok(())
+            return Ok(());
         }
         let mut store = self.inner.store.write();
         let mut total_sub = 0;

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -180,8 +180,8 @@ impl BlobStoreSize {
 
 impl PartialEq for BlobStoreSize {
     fn eq(&self, other: &Self) -> bool {
-        self.data_size.load(Ordering::Relaxed) == other.data_size.load(Ordering::Relaxed) &&
-            self.num_blobs.load(Ordering::Relaxed) == other.num_blobs.load(Ordering::Relaxed)
+        self.data_size.load(Ordering::Relaxed) == other.data_size.load(Ordering::Relaxed)
+            && self.num_blobs.load(Ordering::Relaxed) == other.num_blobs.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/transaction-pool/src/blobstore/noop.rs
+++ b/crates/transaction-pool/src/blobstore/noop.rs
@@ -59,7 +59,7 @@ impl BlobStore for NoopBlobStore {
         txs: Vec<B256>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
         if txs.is_empty() {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
         Err(BlobStoreError::MissingSidecar(txs[0]))
     }

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -65,7 +65,7 @@ impl BlobStoreCanonTracker {
             if *entry.key() <= finalized_block {
                 finalized.extend(entry.remove_entry().1);
             } else {
-                break
+                break;
             }
         }
 

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -103,10 +103,10 @@ impl PoolConfig {
     /// Returns whether the size and amount constraints in any sub-pools are exceeded.
     #[inline]
     pub const fn is_exceeded(&self, pool_size: PoolSize) -> bool {
-        self.blob_limit.is_exceeded(pool_size.blob, pool_size.blob_size) ||
-            self.pending_limit.is_exceeded(pool_size.pending, pool_size.pending_size) ||
-            self.basefee_limit.is_exceeded(pool_size.basefee, pool_size.basefee_size) ||
-            self.queued_limit.is_exceeded(pool_size.queued, pool_size.queued_size)
+        self.blob_limit.is_exceeded(pool_size.blob, pool_size.blob_size)
+            || self.pending_limit.is_exceeded(pool_size.pending, pool_size.pending_size)
+            || self.basefee_limit.is_exceeded(pool_size.basefee, pool_size.basefee_size)
+            || self.queued_limit.is_exceeded(pool_size.queued, pool_size.queued_size)
     }
 }
 
@@ -198,7 +198,7 @@ impl PriceBumpConfig {
     #[inline]
     pub const fn price_bump(&self, tx_type: u8) -> u128 {
         if tx_type == EIP4844_TX_TYPE_ID {
-            return self.replace_blob_tx_price_bump
+            return self.replace_blob_tx_price_bump;
         }
         self.default_price_bump
     }
@@ -259,7 +259,7 @@ impl LocalTransactionConfig {
     #[inline]
     pub fn is_local(&self, origin: TransactionOrigin, sender: &Address) -> bool {
         if self.no_local_exemptions() {
-            return false
+            return false;
         }
         origin.is_local() || self.contains_local_address(sender)
     }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -306,14 +306,14 @@ impl InvalidPoolTransactionError {
                 // depend on dynamic environmental conditions and should not be assumed to have been
                 // intentionally caused by the sender
                 match err {
-                    InvalidTransactionError::InsufficientFunds { .. } |
-                    InvalidTransactionError::NonceNotConsistent { .. } => {
+                    InvalidTransactionError::InsufficientFunds { .. }
+                    | InvalidTransactionError::NonceNotConsistent { .. } => {
                         // transaction could just have arrived late/early
                         false
                     }
-                    InvalidTransactionError::GasTooLow |
-                    InvalidTransactionError::GasTooHigh |
-                    InvalidTransactionError::TipAboveFeeCap => {
+                    InvalidTransactionError::GasTooLow
+                    | InvalidTransactionError::GasTooHigh
+                    | InvalidTransactionError::TipAboveFeeCap => {
                         // these are technically not invalid
                         false
                     }
@@ -321,19 +321,19 @@ impl InvalidPoolTransactionError {
                         // dynamic, but not used during validation
                         false
                     }
-                    InvalidTransactionError::Eip2930Disabled |
-                    InvalidTransactionError::Eip1559Disabled |
-                    InvalidTransactionError::Eip4844Disabled |
-                    InvalidTransactionError::Eip7702Disabled => {
+                    InvalidTransactionError::Eip2930Disabled
+                    | InvalidTransactionError::Eip1559Disabled
+                    | InvalidTransactionError::Eip4844Disabled
+                    | InvalidTransactionError::Eip7702Disabled => {
                         // settings
                         false
                     }
-                    InvalidTransactionError::OldLegacyChainId |
-                    InvalidTransactionError::ChainIdMismatch |
-                    InvalidTransactionError::GasUintOverflow |
-                    InvalidTransactionError::TxTypeNotSupported |
-                    InvalidTransactionError::SignerAccountHasBytecode |
-                    InvalidTransactionError::GasLimitTooHigh => true,
+                    InvalidTransactionError::OldLegacyChainId
+                    | InvalidTransactionError::ChainIdMismatch
+                    | InvalidTransactionError::GasUintOverflow
+                    | InvalidTransactionError::TxTypeNotSupported
+                    | InvalidTransactionError::SignerAccountHasBytecode
+                    | InvalidTransactionError::GasLimitTooHigh => true,
                 }
             }
             Self::ExceedsGasLimit(_, _) => true,
@@ -376,9 +376,9 @@ impl InvalidPoolTransactionError {
                         // this is a malformed transaction and should not be sent over the network
                         true
                     }
-                    Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka |
-                    Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka |
-                    Eip4844PoolTransactionError::Eip7594SidecarDisallowed => {
+                    Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka
+                    | Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka
+                    | Eip4844PoolTransactionError::Eip7594SidecarDisallowed => {
                         // for now we do not want to penalize peers for broadcasting different
                         // sidecars
                         false
@@ -424,8 +424,8 @@ impl InvalidPoolTransactionError {
 
     /// Returns `true` if an import failed due to nonce gap.
     pub const fn is_nonce_gap(&self) -> bool {
-        matches!(self, Self::Consensus(InvalidTransactionError::NonceNotConsistent { .. })) ||
-            matches!(self, Self::Eip4844(Eip4844PoolTransactionError::Eip4844NonceGap))
+        matches!(self, Self::Consensus(InvalidTransactionError::NonceNotConsistent { .. }))
+            || matches!(self, Self::Eip4844(Eip4844PoolTransactionError::Eip4844NonceGap))
     }
 
     /// Returns the arbitrary error if it is [`InvalidPoolTransactionError::Other`]

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -505,7 +505,7 @@ where
         transactions: Vec<Self::Transaction>,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
         if transactions.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let validated = self
             .pool
@@ -520,7 +520,7 @@ where
         transactions: Vec<(TransactionOrigin, Self::Transaction)>,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
         if transactions.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let origins: Vec<_> = transactions.iter().map(|(origin, _)| *origin).collect();
         let validated = self.pool.validator().validate_transactions(transactions).await;

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -232,8 +232,8 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
 
         // check if we have a new finalized block
         if let Some(finalized) =
-            last_finalized_block.update(client.finalized_block_number().ok().flatten()) &&
-            let BlobStoreUpdates::Finalized(blobs) =
+            last_finalized_block.update(client.finalized_block_number().ok().flatten())
+            && let BlobStoreUpdates::Finalized(blobs) =
                 blob_store_tracker.on_finalized_block(finalized)
         {
             metrics.inc_deleted_tracked_blobs(blobs.len());
@@ -326,8 +326,8 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                 let old_first = old_blocks.first();
 
                 // check if the reorg is not canonical with the pool's block
-                if !(old_first.parent_hash() == pool_info.last_seen_block_hash ||
-                    new_first.parent_hash() == pool_info.last_seen_block_hash)
+                if !(old_first.parent_hash() == pool_info.last_seen_block_hash
+                    || new_first.parent_hash() == pool_info.last_seen_block_hash)
                 {
                     // the new block points to a higher block than the oldest block in the old chain
                     maintained_state = MaintainedPoolState::Drifted;
@@ -473,7 +473,7 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                     // keep track of mined blob transactions
                     blob_store_tracker.add_new_chain_blocks(&blocks);
 
-                    continue
+                    continue;
                 }
 
                 let mut changed_accounts = Vec::with_capacity(state.state().len());
@@ -508,9 +508,9 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                 blob_store_tracker.add_new_chain_blocks(&blocks);
 
                 // If Osaka activates in 2 slots we need to convert blobs to new format.
-                if !chain_spec.is_osaka_active_at_timestamp(tip.timestamp()) &&
-                    !chain_spec.is_osaka_active_at_timestamp(tip.timestamp().saturating_add(12)) &&
-                    chain_spec.is_osaka_active_at_timestamp(tip.timestamp().saturating_add(24))
+                if !chain_spec.is_osaka_active_at_timestamp(tip.timestamp())
+                    && !chain_spec.is_osaka_active_at_timestamp(tip.timestamp().saturating_add(12))
+                    && chain_spec.is_osaka_active_at_timestamp(tip.timestamp().saturating_add(24))
                 {
                     let pool = pool.clone();
                     let spawner = task_spawner.clone();
@@ -703,14 +703,14 @@ where
     P: TransactionPool<Transaction: PoolTransaction<Consensus: SignedTransaction>>,
 {
     if !file_path.exists() {
-        return Ok(())
+        return Ok(());
     }
 
     debug!(target: "txpool", txs_file =?file_path, "Check local persistent storage for saved transactions");
     let data = reth_fs_util::read(file_path)?;
 
     if data.is_empty() {
-        return Ok(())
+        return Ok(());
     }
 
     let pool_transactions: Vec<(TransactionOrigin, <P as TransactionPool>::Transaction)> =
@@ -762,7 +762,7 @@ where
     let local_transactions = pool.get_local_transactions();
     if local_transactions.is_empty() {
         trace!(target: "txpool", "no local transactions to save");
-        return
+        return;
     }
 
     let local_transactions = local_transactions
@@ -779,7 +779,7 @@ where
         Ok(data) => data,
         Err(err) => {
             warn!(target: "txpool", %err, txs_file=?file_path, "failed to serialize local transactions to json");
-            return
+            return;
         }
     };
 
@@ -834,7 +834,7 @@ pub async fn backup_local_transactions_task<P>(
 {
     let Some(transactions_path) = config.transactions_path else {
         // nothing to do
-        return
+        return;
     };
 
     if let Err(err) = load_and_reinsert_transactions(pool.clone(), &transactions_path).await {

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -355,7 +355,7 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         tx_hashes: Vec<TxHash>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
         if tx_hashes.is_empty() {
-            return Ok(vec![])
+            return Ok(vec![]);
         }
         Err(BlobStoreError::MissingSidecar(tx_hashes[0]))
     }

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -57,8 +57,9 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
             let best = Iterator::next(&mut self.best)?;
             // If both the base fee and blob fee (if applicable for EIP-4844) are satisfied, return
             // the transaction
-            if best.transaction.max_fee_per_gas() >= self.base_fee as u128 &&
-                best.transaction
+            if best.transaction.max_fee_per_gas() >= self.base_fee as u128
+                && best
+                    .transaction
                     .max_fee_per_blob_gas()
                     .is_none_or(|fee| fee >= self.base_fee_per_blob_gas as u128)
             {
@@ -129,14 +130,14 @@ impl<T: TransactionOrdering> BestTransactions<T> {
         loop {
             match self.new_transaction_receiver.as_mut()?.try_recv() {
                 Ok(tx) => {
-                    if let Some(last_priority) = &self.last_priority &&
-                        &tx.priority > last_priority
+                    if let Some(last_priority) = &self.last_priority
+                        && &tx.priority > last_priority
                     {
                         // we skip transactions if we already yielded a transaction with lower
                         // priority
-                        return Some(IncomingTransaction::Stash(tx))
+                        return Some(IncomingTransaction::Stash(tx));
                     }
-                    return Some(IncomingTransaction::Process(tx))
+                    return Some(IncomingTransaction::Process(tx));
                 }
                 // note TryRecvError::Lagged can be returned here, which is an error that attempts
                 // to correct itself on consecutive try_recv() attempts
@@ -207,7 +208,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                     "[{:?}] skipping invalid transaction",
                     best.transaction.hash()
                 );
-                continue
+                continue;
             }
 
             // Insert transactions that just got unlocked.
@@ -228,7 +229,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                 if self.new_transaction_receiver.is_some() {
                     self.last_priority = Some(best.priority.clone())
                 }
-                return Some((best.transaction, best.priority))
+                return Some((best.transaction, best.priority));
             }
         }
     }
@@ -316,7 +317,7 @@ where
         loop {
             let best = self.best.next()?;
             if (self.predicate)(&best) {
-                return Some(best)
+                return Some(best);
             }
             self.best.mark_invalid(
                 &best,
@@ -398,12 +399,12 @@ where
         // If we have space, try prioritizing transactions
         if self.prioritized_gas < self.max_prioritized_gas {
             for item in &mut self.inner {
-                if self.prioritized_senders.contains(&item.transaction.sender()) &&
-                    self.prioritized_gas + item.transaction.gas_limit() <=
-                        self.max_prioritized_gas
+                if self.prioritized_senders.contains(&item.transaction.sender())
+                    && self.prioritized_gas + item.transaction.gas_limit()
+                        <= self.max_prioritized_gas
                 {
                     self.prioritized_gas += item.transaction.gas_limit();
-                    return Some(item)
+                    return Some(item);
                 }
                 self.buffer.push_back(item);
             }

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -97,16 +97,16 @@ impl<T: PoolTransaction> BlobTransactions<T> {
                 let mut iter = self.by_id.iter().peekable();
 
                 while let Some((id, tx)) = iter.next() {
-                    if tx.transaction.max_fee_per_blob_gas().unwrap_or_default() <
-                        blob_fee_to_satisfy ||
-                        tx.transaction.max_fee_per_gas() <
-                            best_transactions_attributes.basefee as u128
+                    if tx.transaction.max_fee_per_blob_gas().unwrap_or_default()
+                        < blob_fee_to_satisfy
+                        || tx.transaction.max_fee_per_gas()
+                            < best_transactions_attributes.basefee as u128
                     {
                         // does not satisfy the blob fee or base fee
                         // still parked in blob pool -> skip descendant transactions
                         'this: while let Some((peek, _)) = iter.peek() {
                             if peek.sender != id.sender {
-                                break 'this
+                                break 'this;
                             }
                             iter.next();
                         }
@@ -150,13 +150,13 @@ impl<T: PoolTransaction> BlobTransactions<T> {
             let mut iter = self.by_id.iter().peekable();
 
             while let Some((id, tx)) = iter.next() {
-                if tx.transaction.max_fee_per_blob_gas() < Some(pending_fees.blob_fee) ||
-                    tx.transaction.max_fee_per_gas() < pending_fees.base_fee as u128
+                if tx.transaction.max_fee_per_blob_gas() < Some(pending_fees.blob_fee)
+                    || tx.transaction.max_fee_per_gas() < pending_fees.base_fee as u128
                 {
                     // still parked in blob pool -> skip descendant transactions
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this
+                            break 'this;
                         }
                         iter.next();
                     }
@@ -347,7 +347,7 @@ const LOG_2_1_125: f64 = 0.16992500144231237;
 pub fn fee_delta(max_tx_fee: u128, current_fee: u128) -> i64 {
     if max_tx_fee == current_fee {
         // if these are equal, then there's no fee jump
-        return 0
+        return 0;
     }
 
     let max_tx_fee_jumps = if max_tx_fee == 0 {

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -190,7 +190,7 @@ impl<T: PoolTransaction> PoolEventBroadcast<T> {
     #[inline]
     pub fn discarded_many(&mut self, discarded: &[Arc<ValidPoolTransaction<T>>]) {
         if self.is_empty() {
-            return
+            return;
         }
         for tx in discarded {
             self.discarded(tx.hash());

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -298,7 +298,7 @@ where
     /// transaction events.
     pub fn add_transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {
         if !self.get_pool_data().contains(&tx_hash) {
-            return None
+            return None;
         }
         let mut listener = self.event_listener.write();
         let events = listener.subscribe(tx_hash);
@@ -337,7 +337,7 @@ where
         F: FnOnce(&mut PoolEventBroadcast<T::Transaction>),
     {
         if !self.has_event_listeners() {
-            return
+            return;
         }
         let mut listener = self.event_listener.write();
         if !listener.is_empty() {
@@ -407,7 +407,7 @@ where
             out.push(pooled.into_inner());
 
             if limit.exceeds(size) {
-                break
+                break;
             }
         }
     }
@@ -666,8 +666,8 @@ where
                     let (result, meta) = self.add_transaction(&mut pool, origin, tx);
 
                     // Only collect metadata for successful insertions
-                    if result.is_ok() &&
-                        let Some(meta) = meta
+                    if result.is_ok()
+                        && let Some(meta) = meta
                     {
                         added_metas.push(meta);
                     }
@@ -701,8 +701,8 @@ where
             // A newly added transaction may be immediately discarded, so we need to
             // adjust the result here
             for res in &mut results {
-                if let Ok(AddedTransactionOutcome { hash, .. }) = res &&
-                    discarded_hashes.contains(hash)
+                if let Ok(AddedTransactionOutcome { hash, .. }) = res
+                    && discarded_hashes.contains(hash)
                 {
                     *res = Err(PoolError::new(*hash, PoolErrorKind::DiscardedOnInsert))
                 }
@@ -794,7 +794,7 @@ where
                         needs_cleanup = true;
                     }
                     // Skip non-propagate transactions for propagate-only listeners
-                    continue
+                    continue;
                 }
 
                 if !listener.send(event.clone()) {
@@ -813,7 +813,7 @@ where
     fn on_new_blob_sidecar(&self, tx_hash: &TxHash, sidecar: &BlobTransactionSidecarVariant) {
         let mut sidecar_listeners = self.blob_transaction_sidecar_listener.lock();
         if sidecar_listeners.is_empty() {
-            return
+            return;
         }
         let sidecar = Arc::new(sidecar.clone());
         sidecar_listeners.retain_mut(|listener| {
@@ -1044,7 +1044,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let removed = self.pool.write().remove_transactions(hashes);
 
@@ -1060,7 +1060,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let removed = self.pool.write().remove_transactions_and_descendants(hashes);
 
@@ -1095,7 +1095,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
 
         self.pool.write().prune_transactions(hashes)
@@ -1107,7 +1107,7 @@ where
         A: HandleMempoolData,
     {
         if announcement.is_empty() {
-            return
+            return;
         }
         let pool = self.get_pool_data();
         announcement.retain_by_hash(|tx| !pool.contains(tx))
@@ -1218,7 +1218,7 @@ where
     /// If no transaction exists, it is skipped.
     pub fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         self.get_pool_data().get_all(txs).collect()
     }
@@ -1231,7 +1231,7 @@ where
         txs: &[TxHash],
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let pool = self.get_pool_data();
         txs.iter().filter_map(|tx| pool.get(tx).filter(|tx| tx.propagate)).collect()
@@ -1240,7 +1240,7 @@ where
     /// Notify about propagated transactions.
     pub fn on_propagated(&self, txs: PropagatedTransactions) {
         if txs.is_empty() {
-            return
+            return;
         }
         self.with_event_listener(|listener| {
             txs.into_iter().for_each(|(hash, peers)| listener.propagated(&hash, peers));
@@ -1372,9 +1372,9 @@ where
         loop {
             let next = self.iter.next()?;
             if self.kind.is_propagate_only() && !next.propagate {
-                continue
+                continue;
             }
-            return Some(*next.hash())
+            return Some(*next.hash());
         }
     }
 }
@@ -1396,12 +1396,12 @@ where
         loop {
             let next = self.iter.next()?;
             if self.kind.is_propagate_only() && !next.propagate {
-                continue
+                continue;
             }
             return Some(NewTransactionEvent {
                 subpool: SubPool::Pending,
                 transaction: next.clone(),
-            })
+            });
         }
     }
 }

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -99,7 +99,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
                 if value.count == 0 {
                     entry.remove()
                 } else {
-                    return
+                    return;
                 }
             }
             Entry::Vacant(_) => {
@@ -189,7 +189,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if !self.exceeds(&limit) {
             // if we are below the limits, we don't need to drop anything
-            return Vec::new()
+            return Vec::new();
         }
 
         let mut removed = Vec::with_capacity(limit.tx_excess(self.len()).unwrap_or(1));
@@ -207,7 +207,7 @@ impl<T: ParkedOrd> ParkedPool<T> {
                 }
 
                 if !self.exceeds(&limit) {
-                    break
+                    break;
                 }
             }
         }
@@ -291,7 +291,7 @@ impl<T: PoolTransaction> ParkedPool<BasefeeOrd<T>> {
                 // still parked -> skip descendant transactions
                 'this: while let Some((peek, _)) = iter.peek() {
                     if peek.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     iter.next();
                 }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -191,7 +191,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -233,7 +233,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -319,8 +319,8 @@ impl<T: TransactionOrdering> PendingPool<T> {
         &mut self,
         id: &TransactionId,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
-        if let Some(lowest) = self.independent_transactions.get(&id.sender) &&
-            lowest.transaction.nonce() == id.nonce
+        if let Some(lowest) = self.independent_transactions.get(&id.sender)
+            && lowest.transaction.nonce() == id.nonce
         {
             self.independent_transactions.remove(&id.sender);
             // mark the next as independent if it exists
@@ -434,8 +434,8 @@ impl<T: TransactionOrdering> PendingPool<T> {
             // loop through the highest nonces set, removing transactions until we reach the limit
             for tx in worst_transactions {
                 // return early if the pool is under limits
-                if !limit.is_exceeded(original_length - total_removed, original_size - total_size) ||
-                    non_local_senders == 0
+                if !limit.is_exceeded(original_length - total_removed, original_size - total_size)
+                    || non_local_senders == 0
                 {
                     // need to remove remaining transactions before exiting
                     for id in &removed {
@@ -444,7 +444,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                         }
                     }
 
-                    return
+                    return;
                 }
 
                 if !remove_locals && tx.transaction.is_local() {
@@ -452,7 +452,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                     if local_senders.insert(sender_id) {
                         non_local_senders -= 1;
                     }
-                    continue
+                    continue;
                 }
 
                 total_size += tx.transaction.size();
@@ -470,7 +470,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
             // return if either the pool is under limits or there are no more _eligible_
             // transactions to remove
             if !self.exceeds(limit) || non_local_senders == 0 {
-                return
+                return;
             }
         }
     }
@@ -492,13 +492,13 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let mut removed = Vec::new();
         // return early if the pool is already under the limits
         if !self.exceeds(&limit) {
-            return removed
+            return removed;
         }
 
         // first truncate only non-local transactions, returning if the pool end up under the limit
         self.remove_to_limit(&limit, false, &mut removed);
         if !self.exceeds(&limit) {
-            return removed
+            return removed;
         }
 
         // now repeat for local transactions, since local transactions must be removed now for the

--- a/crates/transaction-pool/src/pool/state.rs
+++ b/crates/transaction-pool/src/pool/state.rs
@@ -230,10 +230,10 @@ mod tests {
         let state = TxState::default();
         assert_eq!(SubPool::Queued, state.into());
 
-        let state = TxState::NO_PARKED_ANCESTORS |
-            TxState::NO_NONCE_GAPS |
-            TxState::NOT_TOO_MUCH_GAS |
-            TxState::ENOUGH_FEE_CAP_BLOCK;
+        let state = TxState::NO_PARKED_ANCESTORS
+            | TxState::NO_NONCE_GAPS
+            | TxState::NOT_TOO_MUCH_GAS
+            | TxState::ENOUGH_FEE_CAP_BLOCK;
         assert_eq!(SubPool::Queued, state.into());
     }
 
@@ -330,12 +330,12 @@ mod tests {
     #[test]
     fn test_blob_reason_insufficient_base_fee() {
         // Blob tx with all structural bits set and blob fee sufficient, but base fee insufficient
-        let state = TxState::NO_PARKED_ANCESTORS |
-            TxState::NO_NONCE_GAPS |
-            TxState::ENOUGH_BALANCE |
-            TxState::NOT_TOO_MUCH_GAS |
-            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
-            TxState::BLOB_TRANSACTION;
+        let state = TxState::NO_PARKED_ANCESTORS
+            | TxState::NO_NONCE_GAPS
+            | TxState::ENOUGH_BALANCE
+            | TxState::NOT_TOO_MUCH_GAS
+            | TxState::ENOUGH_BLOB_FEE_CAP_BLOCK
+            | TxState::BLOB_TRANSACTION;
         // ENOUGH_FEE_CAP_BLOCK intentionally not set
         let subpool: SubPool = state.into();
         assert_eq!(subpool, SubPool::Blob);
@@ -346,12 +346,12 @@ mod tests {
     #[test]
     fn test_blob_reason_insufficient_blob_fee() {
         // Blob tx with all structural bits set and base fee sufficient, but blob fee insufficient
-        let state = TxState::NO_PARKED_ANCESTORS |
-            TxState::NO_NONCE_GAPS |
-            TxState::ENOUGH_BALANCE |
-            TxState::NOT_TOO_MUCH_GAS |
-            TxState::ENOUGH_FEE_CAP_BLOCK |
-            TxState::BLOB_TRANSACTION;
+        let state = TxState::NO_PARKED_ANCESTORS
+            | TxState::NO_NONCE_GAPS
+            | TxState::ENOUGH_BALANCE
+            | TxState::NOT_TOO_MUCH_GAS
+            | TxState::ENOUGH_FEE_CAP_BLOCK
+            | TxState::BLOB_TRANSACTION;
         // ENOUGH_BLOB_FEE_CAP_BLOCK intentionally not set
         let subpool: SubPool = state.into();
         assert_eq!(subpool, SubPool::Blob);
@@ -362,12 +362,12 @@ mod tests {
     #[test]
     fn test_blob_reason_nonce_gap() {
         // Blob tx with nonce gap should report NonceGap regardless of fee bits
-        let mut state = TxState::NO_PARKED_ANCESTORS |
-            TxState::ENOUGH_BALANCE |
-            TxState::NOT_TOO_MUCH_GAS |
-            TxState::ENOUGH_FEE_CAP_BLOCK |
-            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
-            TxState::BLOB_TRANSACTION;
+        let mut state = TxState::NO_PARKED_ANCESTORS
+            | TxState::ENOUGH_BALANCE
+            | TxState::NOT_TOO_MUCH_GAS
+            | TxState::ENOUGH_FEE_CAP_BLOCK
+            | TxState::ENOUGH_BLOB_FEE_CAP_BLOCK
+            | TxState::BLOB_TRANSACTION;
         state.remove(TxState::NO_NONCE_GAPS);
         let subpool: SubPool = state.into();
         assert_eq!(subpool, SubPool::Blob);
@@ -378,12 +378,12 @@ mod tests {
     #[test]
     fn test_blob_reason_insufficient_balance() {
         // Blob tx with insufficient balance
-        let state = TxState::NO_PARKED_ANCESTORS |
-            TxState::NO_NONCE_GAPS |
-            TxState::NOT_TOO_MUCH_GAS |
-            TxState::ENOUGH_FEE_CAP_BLOCK |
-            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
-            TxState::BLOB_TRANSACTION;
+        let state = TxState::NO_PARKED_ANCESTORS
+            | TxState::NO_NONCE_GAPS
+            | TxState::NOT_TOO_MUCH_GAS
+            | TxState::ENOUGH_FEE_CAP_BLOCK
+            | TxState::ENOUGH_BLOB_FEE_CAP_BLOCK
+            | TxState::BLOB_TRANSACTION;
         // ENOUGH_BALANCE intentionally not set
         let subpool: SubPool = state.into();
         assert_eq!(subpool, SubPool::Blob);
@@ -394,12 +394,12 @@ mod tests {
     #[test]
     fn test_blob_reason_too_much_gas() {
         // Blob tx exceeding gas limit
-        let mut state = TxState::NO_PARKED_ANCESTORS |
-            TxState::NO_NONCE_GAPS |
-            TxState::ENOUGH_BALANCE |
-            TxState::ENOUGH_FEE_CAP_BLOCK |
-            TxState::ENOUGH_BLOB_FEE_CAP_BLOCK |
-            TxState::BLOB_TRANSACTION;
+        let mut state = TxState::NO_PARKED_ANCESTORS
+            | TxState::NO_NONCE_GAPS
+            | TxState::ENOUGH_BALANCE
+            | TxState::ENOUGH_FEE_CAP_BLOCK
+            | TxState::ENOUGH_BLOB_FEE_CAP_BLOCK
+            | TxState::BLOB_TRANSACTION;
         state.remove(TxState::NOT_TOO_MUCH_GAS);
         let subpool: SubPool = state.into();
         assert_eq!(subpool, SubPool::Blob);

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -171,7 +171,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         let mut next_expected_nonce = on_chain.nonce;
         for (id, tx) in self.all().descendant_txs_inclusive(&on_chain) {
             if next_expected_nonce != id.nonce {
-                break
+                break;
             }
             next_expected_nonce = id.next_nonce();
             last_consecutive_tx = Some(tx);
@@ -753,7 +753,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         on_chain_code_hash: Option<B256>,
     ) -> PoolResult<AddedTransaction<T::Transaction>> {
         if self.contains(tx.hash()) {
-            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported))
+            return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported));
         }
 
         self.validate_auth(&tx, on_chain_nonce, on_chain_code_hash)?;
@@ -896,10 +896,10 @@ impl<T: TransactionOrdering> TxPool<T> {
         on_chain_code_hash: Option<B256>,
     ) -> Result<(), PoolError> {
         // Short circuit if the sender has neither delegation nor pending delegation.
-        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY)) &&
-            !self.all_transactions.auths.contains_key(&transaction.sender_id())
+        if (on_chain_code_hash.is_none() || on_chain_code_hash == Some(KECCAK_EMPTY))
+            && !self.all_transactions.auths.contains_key(&transaction.sender_id())
         {
-            return Ok(())
+            return Ok(());
         }
 
         let mut txs_by_sender =
@@ -917,23 +917,23 @@ impl<T: TransactionOrdering> TxPool<T> {
                     PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
                         Eip7702PoolTransactionError::OutOfOrderTxFromDelegated,
                     )),
-                ))
+                ));
             }
-            return Ok(())
+            return Ok(());
         }
 
         let mut count = 0;
         for id in txs_by_sender {
             if id == &transaction.transaction_id {
                 // Transaction replacement is supported
-                return Ok(())
+                return Ok(());
             }
             count += 1;
         }
 
         if count < self.config.max_inflight_delegated_slot_limit {
             // account still has an available slot
-            return Ok(())
+            return Ok(());
         }
 
         Err(PoolError::new(
@@ -971,7 +971,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(
                             Eip7702PoolTransactionError::AuthorityReserved,
                         )),
-                    ))
+                    ));
                 }
             }
         }
@@ -997,8 +997,8 @@ impl<T: TransactionOrdering> TxPool<T> {
                 Destination::Pool(move_to) => {
                     debug_assert_ne!(&move_to, &current, "destination must be different");
                     let moved = self.move_transaction(current, move_to, &id);
-                    if matches!(move_to, SubPool::Pending) &&
-                        let Some(tx) = moved
+                    if matches!(move_to, SubPool::Pending)
+                        && let Some(tx) = moved
                     {
                         trace!(target: "txpool", hash=%tx.transaction.hash(), "Promoted transaction to pending");
                         outcome.promoted.push(tx);
@@ -1188,7 +1188,7 @@ impl<T: TransactionOrdering> TxPool<T> {
                 }
                 id = descendant;
             } else {
-                return
+                return;
             }
         }
     }
@@ -1461,7 +1461,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 entry.remove();
                 self.sender_info.remove(&sender);
                 self.metrics.all_transactions_by_all_senders.decrement(1.0);
-                return
+                return;
             }
             *count -= 1;
             self.metrics.all_transactions_by_all_senders.decrement(1.0);
@@ -1536,7 +1536,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 ($iter:ident) => {
                     'this: while let Some((peek, _)) = iter.peek() {
                         if peek.sender != id.sender {
-                            break 'this
+                            break 'this;
                         }
                         iter.next();
                     }
@@ -1553,7 +1553,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                         current: tx.subpool,
                         destination: Destination::Discard,
                     });
-                    continue 'transactions
+                    continue 'transactions;
                 }
 
                 let ancestor = TransactionId::ancestor(id.nonce, info.state_nonce, id.sender);
@@ -1578,7 +1578,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // If there's a nonce gap, we can shortcircuit, because there's nothing to update yet.
             if tx.state.has_nonce_gap() {
                 next_sender!(iter);
-                continue 'transactions
+                continue 'transactions;
             }
 
             // Since this is the first transaction of the sender, it has no parked ancestors
@@ -1601,7 +1601,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             while let Some((peek, tx)) = iter.peek_mut() {
                 if peek.sender != id.sender {
                     // Found the next sender we need to check
-                    continue 'transactions
+                    continue 'transactions;
                 }
 
                 if tx.transaction.nonce() == next_nonce_in_line {
@@ -1610,7 +1610,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 } else {
                     // can short circuit if there's still a nonce gap
                     next_sender!(iter);
-                    continue 'transactions
+                    continue 'transactions;
                 }
 
                 // update for next iteration of this sender's loop
@@ -1865,7 +1865,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
             if current_txs >= self.max_account_slots && transaction.nonce() > on_chain_nonce {
                 return Err(InsertErr::ExceededSenderTransactionsCapacity {
                     transaction: Arc::new(transaction),
-                })
+                });
             }
         }
         if transaction.gas_limit() > self.block_gas_limit {
@@ -1873,12 +1873,12 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 block_gas_limit: self.block_gas_limit,
                 tx_gas_limit: transaction.gas_limit(),
                 transaction: Arc::new(transaction),
-            })
+            });
         }
 
         if self.contains_conflicting_transaction(&transaction) {
             // blob vs non blob transactions are mutually exclusive for the same sender
-            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) })
+            return Err(InsertErr::TxTypeConflict { transaction: Arc::new(transaction) });
         }
 
         Ok(transaction)
@@ -1899,13 +1899,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
             let Some(ancestor_tx) = self.txs.get(&ancestor) else {
                 // ancestor tx is missing, so we can't insert the new blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
             };
             if ancestor_tx.state.has_nonce_gap() {
                 // the ancestor transaction already has a nonce gap, so we can't insert the new
                 // blob
                 self.metrics.blob_transactions_nonce_gaps.increment(1);
-                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::BlobTxHasNonceGap { transaction: Arc::new(new_blob_tx) });
             }
 
             // the max cost executing this transaction requires
@@ -1914,15 +1914,15 @@ impl<T: PoolTransaction> AllTransactions<T> {
             // check if the new blob would go into overdraft
             if cumulative_cost > on_chain_balance {
                 // the transaction would go into overdraft
-                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+                return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
             }
 
             // ensure that a replacement would not shift already propagated blob transactions into
             // overdraft
             let id = new_blob_tx.transaction_id;
             let mut descendants = self.descendant_txs_inclusive(&id).peekable();
-            if let Some((maybe_replacement, _)) = descendants.peek() &&
-                **maybe_replacement == new_blob_tx.transaction_id
+            if let Some((maybe_replacement, _)) = descendants.peek()
+                && **maybe_replacement == new_blob_tx.transaction_id
             {
                 // replacement transaction
                 descendants.next();
@@ -1932,13 +1932,13 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     cumulative_cost += tx.transaction.cost();
                     if tx.transaction.is_eip4844() && cumulative_cost > on_chain_balance {
                         // the transaction would shift
-                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+                        return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
                     }
                 }
             }
         } else if new_blob_tx.cost() > &on_chain_balance {
             // the transaction would go into overdraft
-            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) })
+            return Err(InsertErr::Overdraft { transaction: Arc::new(new_blob_tx) });
         }
 
         Ok(new_blob_tx)
@@ -2029,7 +2029,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
         let fee_cap = transaction.max_fee_per_gas();
 
         if fee_cap < self.minimal_protocol_basefee as u128 {
-            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap })
+            return Err(InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap });
         }
         if fee_cap >= self.pending_fees.base_fee as u128 {
             state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
@@ -2062,7 +2062,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
                     return Err(InsertErr::Underpriced {
                         transaction: pool_tx.transaction,
                         existing: *entry.get().transaction.hash(),
-                    })
+                    });
                 }
                 let new_hash = *pool_tx.transaction.hash();
                 let new_transaction = pool_tx.transaction.clone();
@@ -2102,7 +2102,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
                 // If there's a nonce gap, we can shortcircuit
                 if next_nonce != id.nonce {
-                    break
+                    break;
                 }
 
                 // close the nonce gap

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -81,11 +81,11 @@ macro_rules! set_value {
     ($this:expr => $field:ident) => {{
         let new_value = $field;
         match $this {
-            MockTransaction::Legacy { ref mut $field, .. } |
-            MockTransaction::Eip1559 { ref mut $field, .. } |
-            MockTransaction::Eip4844 { ref mut $field, .. } |
-            MockTransaction::Eip2930 { ref mut $field, .. } |
-            MockTransaction::Eip7702 { ref mut $field, .. } => {
+            MockTransaction::Legacy { ref mut $field, .. }
+            | MockTransaction::Eip1559 { ref mut $field, .. }
+            | MockTransaction::Eip4844 { ref mut $field, .. }
+            | MockTransaction::Eip2930 { ref mut $field, .. }
+            | MockTransaction::Eip7702 { ref mut $field, .. } => {
                 *$field = new_value;
             }
         }
@@ -98,11 +98,11 @@ macro_rules! set_value {
 macro_rules! get_value {
     ($this:tt => $field:ident) => {
         match $this {
-            MockTransaction::Legacy { $field, .. } |
-            MockTransaction::Eip1559 { $field, .. } |
-            MockTransaction::Eip4844 { $field, .. } |
-            MockTransaction::Eip2930 { $field, .. } |
-            MockTransaction::Eip7702 { $field, .. } => $field,
+            MockTransaction::Legacy { $field, .. }
+            | MockTransaction::Eip1559 { $field, .. }
+            | MockTransaction::Eip4844 { $field, .. }
+            | MockTransaction::Eip2930 { $field, .. }
+            | MockTransaction::Eip7702 { $field, .. } => $field,
         }
     };
 }
@@ -446,8 +446,8 @@ impl MockTransaction {
 
     /// Sets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
     pub const fn set_priority_fee(&mut self, val: u128) -> &mut Self {
-        if let Self::Eip1559 { max_priority_fee_per_gas, .. } |
-        Self::Eip4844 { max_priority_fee_per_gas, .. } = self
+        if let Self::Eip1559 { max_priority_fee_per_gas, .. }
+        | Self::Eip4844 { max_priority_fee_per_gas, .. } = self
         {
             *max_priority_fee_per_gas = val;
         }
@@ -463,18 +463,18 @@ impl MockTransaction {
     /// Gets the priority fee for dynamic fee transactions (EIP-1559 and EIP-4844)
     pub const fn get_priority_fee(&self) -> Option<u128> {
         match self {
-            Self::Eip1559 { max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_priority_fee_per_gas, .. } |
-            Self::Eip7702 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
+            Self::Eip1559 { max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_priority_fee_per_gas, .. }
+            | Self::Eip7702 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
             _ => None,
         }
     }
 
     /// Sets the max fee for dynamic fee transactions (EIP-1559 and EIP-4844)
     pub const fn set_max_fee(&mut self, val: u128) -> &mut Self {
-        if let Self::Eip1559 { max_fee_per_gas, .. } |
-        Self::Eip4844 { max_fee_per_gas, .. } |
-        Self::Eip7702 { max_fee_per_gas, .. } = self
+        if let Self::Eip1559 { max_fee_per_gas, .. }
+        | Self::Eip4844 { max_fee_per_gas, .. }
+        | Self::Eip7702 { max_fee_per_gas, .. } = self
         {
             *max_fee_per_gas = val;
         }
@@ -490,9 +490,9 @@ impl MockTransaction {
     /// Gets the max fee for dynamic fee transactions (EIP-1559 and EIP-4844)
     pub const fn get_max_fee(&self) -> Option<u128> {
         match self {
-            Self::Eip1559 { max_fee_per_gas, .. } |
-            Self::Eip4844 { max_fee_per_gas, .. } |
-            Self::Eip7702 { max_fee_per_gas, .. } => Some(*max_fee_per_gas),
+            Self::Eip1559 { max_fee_per_gas, .. }
+            | Self::Eip4844 { max_fee_per_gas, .. }
+            | Self::Eip7702 { max_fee_per_gas, .. } => Some(*max_fee_per_gas),
             _ => None,
         }
     }
@@ -501,10 +501,10 @@ impl MockTransaction {
     pub fn set_accesslist(&mut self, list: AccessList) -> &mut Self {
         match self {
             Self::Legacy { .. } => {}
-            Self::Eip1559 { access_list: accesslist, .. } |
-            Self::Eip4844 { access_list: accesslist, .. } |
-            Self::Eip2930 { access_list: accesslist, .. } |
-            Self::Eip7702 { access_list: accesslist, .. } => {
+            Self::Eip1559 { access_list: accesslist, .. }
+            | Self::Eip4844 { access_list: accesslist, .. }
+            | Self::Eip2930 { access_list: accesslist, .. }
+            | Self::Eip7702 { access_list: accesslist, .. } => {
                 *accesslist = list;
             }
         }
@@ -526,9 +526,9 @@ impl MockTransaction {
             Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => {
                 *gas_price = val;
             }
-            Self::Eip1559 { max_fee_per_gas, max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_fee_per_gas, max_priority_fee_per_gas, .. } |
-            Self::Eip7702 { max_fee_per_gas, max_priority_fee_per_gas, .. } => {
+            Self::Eip1559 { max_fee_per_gas, max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_fee_per_gas, max_priority_fee_per_gas, .. }
+            | Self::Eip7702 { max_fee_per_gas, max_priority_fee_per_gas, .. } => {
                 *max_fee_per_gas = val;
                 *max_priority_fee_per_gas = val;
             }
@@ -542,9 +542,9 @@ impl MockTransaction {
             Self::Legacy { ref mut gas_price, .. } | Self::Eip2930 { ref mut gas_price, .. } => {
                 *gas_price = val;
             }
-            Self::Eip1559 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } |
-            Self::Eip7702 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } => {
+            Self::Eip1559 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. }
+            | Self::Eip7702 { ref mut max_fee_per_gas, ref mut max_priority_fee_per_gas, .. } => {
                 *max_fee_per_gas = val;
                 *max_priority_fee_per_gas = val;
             }
@@ -556,9 +556,9 @@ impl MockTransaction {
     pub const fn get_gas_price(&self) -> u128 {
         match self {
             Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
-            Self::Eip1559 { max_fee_per_gas, .. } |
-            Self::Eip4844 { max_fee_per_gas, .. } |
-            Self::Eip7702 { max_fee_per_gas, .. } => *max_fee_per_gas,
+            Self::Eip1559 { max_fee_per_gas, .. }
+            | Self::Eip4844 { max_fee_per_gas, .. }
+            | Self::Eip7702 { max_fee_per_gas, .. } => *max_fee_per_gas,
         }
     }
 
@@ -692,13 +692,13 @@ impl MockTransaction {
 
     fn update_cost(&mut self) {
         match self {
-            Self::Legacy { cost, gas_limit, gas_price, value, .. } |
-            Self::Eip2930 { cost, gas_limit, gas_price, value, .. } => {
+            Self::Legacy { cost, gas_limit, gas_price, value, .. }
+            | Self::Eip2930 { cost, gas_limit, gas_price, value, .. } => {
                 *cost = U256::from(*gas_limit) * U256::from(*gas_price) + *value
             }
-            Self::Eip1559 { cost, gas_limit, max_fee_per_gas, value, .. } |
-            Self::Eip4844 { cost, gas_limit, max_fee_per_gas, value, .. } |
-            Self::Eip7702 { cost, gas_limit, max_fee_per_gas, value, .. } => {
+            Self::Eip1559 { cost, gas_limit, max_fee_per_gas, value, .. }
+            | Self::Eip4844 { cost, gas_limit, max_fee_per_gas, value, .. }
+            | Self::Eip7702 { cost, gas_limit, max_fee_per_gas, value, .. } => {
                 *cost = U256::from(*gas_limit) * U256::from(*max_fee_per_gas) + *value
             }
         };
@@ -742,11 +742,11 @@ impl PoolTransaction for MockTransaction {
     // not to be manually set.
     fn cost(&self) -> &U256 {
         match self {
-            Self::Legacy { cost, .. } |
-            Self::Eip2930 { cost, .. } |
-            Self::Eip1559 { cost, .. } |
-            Self::Eip4844 { cost, .. } |
-            Self::Eip7702 { cost, .. } => cost,
+            Self::Legacy { cost, .. }
+            | Self::Eip2930 { cost, .. }
+            | Self::Eip1559 { cost, .. }
+            | Self::Eip4844 { cost, .. }
+            | Self::Eip7702 { cost, .. } => cost,
         }
     }
 
@@ -778,10 +778,10 @@ impl alloy_consensus::Transaction for MockTransaction {
     fn chain_id(&self) -> Option<u64> {
         match self {
             Self::Legacy { chain_id, .. } => *chain_id,
-            Self::Eip1559 { chain_id, .. } |
-            Self::Eip4844 { chain_id, .. } |
-            Self::Eip2930 { chain_id, .. } |
-            Self::Eip7702 { chain_id, .. } => Some(*chain_id),
+            Self::Eip1559 { chain_id, .. }
+            | Self::Eip4844 { chain_id, .. }
+            | Self::Eip2930 { chain_id, .. }
+            | Self::Eip7702 { chain_id, .. } => Some(*chain_id),
         }
     }
 
@@ -803,18 +803,18 @@ impl alloy_consensus::Transaction for MockTransaction {
     fn max_fee_per_gas(&self) -> u128 {
         match self {
             Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
-            Self::Eip1559 { max_fee_per_gas, .. } |
-            Self::Eip4844 { max_fee_per_gas, .. } |
-            Self::Eip7702 { max_fee_per_gas, .. } => *max_fee_per_gas,
+            Self::Eip1559 { max_fee_per_gas, .. }
+            | Self::Eip4844 { max_fee_per_gas, .. }
+            | Self::Eip7702 { max_fee_per_gas, .. } => *max_fee_per_gas,
         }
     }
 
     fn max_priority_fee_per_gas(&self) -> Option<u128> {
         match self {
             Self::Legacy { .. } | Self::Eip2930 { .. } => None,
-            Self::Eip1559 { max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_priority_fee_per_gas, .. } |
-            Self::Eip7702 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
+            Self::Eip1559 { max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_priority_fee_per_gas, .. }
+            | Self::Eip7702 { max_priority_fee_per_gas, .. } => Some(*max_priority_fee_per_gas),
         }
     }
 
@@ -828,9 +828,9 @@ impl alloy_consensus::Transaction for MockTransaction {
     fn priority_fee_or_price(&self) -> u128 {
         match self {
             Self::Legacy { gas_price, .. } | Self::Eip2930 { gas_price, .. } => *gas_price,
-            Self::Eip1559 { max_priority_fee_per_gas, .. } |
-            Self::Eip4844 { max_priority_fee_per_gas, .. } |
-            Self::Eip7702 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
+            Self::Eip1559 { max_priority_fee_per_gas, .. }
+            | Self::Eip4844 { max_priority_fee_per_gas, .. }
+            | Self::Eip7702 { max_priority_fee_per_gas, .. } => *max_priority_fee_per_gas,
         }
     }
 
@@ -877,11 +877,11 @@ impl alloy_consensus::Transaction for MockTransaction {
 
     fn value(&self) -> U256 {
         match self {
-            Self::Legacy { value, .. } |
-            Self::Eip1559 { value, .. } |
-            Self::Eip2930 { value, .. } |
-            Self::Eip4844 { value, .. } |
-            Self::Eip7702 { value, .. } => *value,
+            Self::Legacy { value, .. }
+            | Self::Eip1559 { value, .. }
+            | Self::Eip2930 { value, .. }
+            | Self::Eip4844 { value, .. }
+            | Self::Eip7702 { value, .. } => *value,
         }
     }
 
@@ -892,10 +892,10 @@ impl alloy_consensus::Transaction for MockTransaction {
     fn access_list(&self) -> Option<&AccessList> {
         match self {
             Self::Legacy { .. } => None,
-            Self::Eip1559 { access_list: accesslist, .. } |
-            Self::Eip4844 { access_list: accesslist, .. } |
-            Self::Eip2930 { access_list: accesslist, .. } |
-            Self::Eip7702 { access_list: accesslist, .. } => Some(accesslist),
+            Self::Eip1559 { access_list: accesslist, .. }
+            | Self::Eip4844 { access_list: accesslist, .. }
+            | Self::Eip2930 { access_list: accesslist, .. }
+            | Self::Eip7702 { access_list: accesslist, .. } => Some(accesslist),
         }
     }
 

--- a/crates/transaction-pool/src/test_utils/pool.rs
+++ b/crates/transaction-pool/src/test_utils/pool.rs
@@ -138,8 +138,8 @@ impl<R: Rng> MockTransactionSimulator<R> {
                         Ok(res) => res,
                         Err(e) => match e.kind {
                             // skip pool capacity/replacement errors (not relevant)
-                            PoolErrorKind::SpammerExceededCapacity(_) |
-                            PoolErrorKind::ReplacementUnderpriced => return,
+                            PoolErrorKind::SpammerExceededCapacity(_)
+                            | PoolErrorKind::ReplacementUnderpriced => return,
                             _ => panic!("unexpected error: {e:?}"),
                         },
                     };
@@ -181,8 +181,8 @@ impl<R: Rng> MockTransactionSimulator<R> {
                         Ok(res) => res,
                         Err(e) => match e.kind {
                             // skip pool capacity/replacement errors (not relevant)
-                            PoolErrorKind::SpammerExceededCapacity(_) |
-                            PoolErrorKind::ReplacementUnderpriced => return,
+                            PoolErrorKind::SpammerExceededCapacity(_)
+                            | PoolErrorKind::ReplacementUnderpriced => return,
                             _ => panic!("unexpected error: {e:?}"),
                         },
                     };
@@ -229,8 +229,8 @@ impl<R: Rng> MockTransactionSimulator<R> {
                         Ok(res) => res,
                         Err(e) => match e.kind {
                             // skip pool capacity/replacement errors (not relevant)
-                            PoolErrorKind::SpammerExceededCapacity(_) |
-                            PoolErrorKind::ReplacementUnderpriced => return,
+                            PoolErrorKind::SpammerExceededCapacity(_)
+                            | PoolErrorKind::ReplacementUnderpriced => return,
                             _ => panic!("unexpected error: {e:?}"),
                         },
                     };
@@ -283,8 +283,8 @@ impl<R: Rng> MockTransactionSimulator<R> {
                         Ok(res) => res,
                         Err(e) => match e.kind {
                             // skip pool capacity/replacement errors (not relevant)
-                            PoolErrorKind::SpammerExceededCapacity(_) |
-                            PoolErrorKind::ReplacementUnderpriced => return,
+                            PoolErrorKind::SpammerExceededCapacity(_)
+                            | PoolErrorKind::ReplacementUnderpriced => return,
                             _ => panic!("unexpected error: {e:?}"),
                         },
                     };

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1804,7 +1804,7 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
             match self.st.try_recv() {
                 Ok(event) => {
                     if event.subpool == self.subpool {
-                        return Ok(event)
+                        return Ok(event);
                     }
                 }
                 Err(e) => return Err(e),
@@ -1821,7 +1821,7 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
             match ready!(self.st.poll_recv(cx)) {
                 Some(event) => {
                     if event.subpool == self.subpool {
-                        return Poll::Ready(Some(event))
+                        return Poll::Ready(Some(event));
                     }
                 }
                 None => return Poll::Ready(None),

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -434,8 +434,8 @@ where
                 ))
             }
             // Accept known transaction types when their respective fork is active
-            LEGACY_TX_TYPE_ID | EIP2930_TX_TYPE_ID | EIP1559_TX_TYPE_ID | EIP4844_TX_TYPE_ID |
-            EIP7702_TX_TYPE_ID => {}
+            LEGACY_TX_TYPE_ID | EIP2930_TX_TYPE_ID | EIP1559_TX_TYPE_ID | EIP4844_TX_TYPE_ID
+            | EIP7702_TX_TYPE_ID => {}
 
             ty if !self.other_tx_types.bit(ty as usize) => {
                 return Err(TransactionValidationOutcome::Invalid(
@@ -453,7 +453,7 @@ where
             return Err(TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::Eip2681,
-            ))
+            ));
         }
 
         // Reject transactions over defined size to prevent DOS attacks
@@ -470,7 +470,7 @@ where
                         size: tx_input_len,
                         limit: self.max_tx_input_bytes,
                     },
-                ))
+                ));
             }
         } else {
             // ensure the size of the non-blob transaction
@@ -482,7 +482,7 @@ where
                         size: tx_size,
                         limit: self.max_tx_input_bytes,
                     },
-                ))
+                ));
             }
         }
 
@@ -491,7 +491,7 @@ where
             let max_initcode_size =
                 self.fork_tracker.max_initcode_size.load(std::sync::atomic::Ordering::Relaxed);
             if let Err(err) = transaction.ensure_max_init_code_size(max_initcode_size) {
-                return Err(TransactionValidationOutcome::Invalid(transaction, err))
+                return Err(TransactionValidationOutcome::Invalid(transaction, err));
             }
         }
 
@@ -505,12 +505,12 @@ where
                     transaction_gas_limit,
                     block_gas_limit,
                 ),
-            ))
+            ));
         }
 
         // Check individual transaction gas limit if configured
-        if let Some(max_tx_gas_limit) = self.max_tx_gas_limit &&
-            transaction_gas_limit > max_tx_gas_limit
+        if let Some(max_tx_gas_limit) = self.max_tx_gas_limit
+            && transaction_gas_limit > max_tx_gas_limit
         {
             return Err(TransactionValidationOutcome::Invalid(
                 transaction,
@@ -518,7 +518,7 @@ where
                     transaction_gas_limit,
                     max_tx_gas_limit,
                 ),
-            ))
+            ));
         }
 
         // Ensure max_priority_fee_per_gas (if EIP1559) is less than max_fee_per_gas if any.
@@ -526,7 +526,7 @@ where
             return Err(TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::TipAboveFeeCap.into(),
-            ))
+            ));
         }
 
         // determine whether the transaction should be treated as local
@@ -546,7 +546,7 @@ where
                                 max_tx_fee_wei: max_tx_fee_wei.saturating_to(),
                                 tx_fee_cap_wei,
                             },
-                        ))
+                        ));
                     }
                 }
             }
@@ -554,9 +554,9 @@ where
 
         // Drop non-local transactions with a fee lower than the configured fee for acceptance into
         // the pool.
-        if !is_local &&
-            transaction.is_dynamic_fee() &&
-            transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
+        if !is_local
+            && transaction.is_dynamic_fee()
+            && transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
             return Err(TransactionValidationOutcome::Invalid(
                 transaction,
@@ -565,17 +565,17 @@ where
                         .minimum_priority_fee
                         .expect("minimum priority fee is expected inside if statement"),
                 },
-            ))
+            ));
         }
 
         // Checks for chainid
-        if let Some(chain_id) = transaction.chain_id() &&
-            chain_id != self.chain_id()
+        if let Some(chain_id) = transaction.chain_id()
+            && chain_id != self.chain_id()
         {
             return Err(TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::ChainIdMismatch.into(),
-            ))
+            ));
         }
 
         if transaction.is_eip7702() {
@@ -584,19 +584,19 @@ where
                 return Err(TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                ))
+                ));
             }
 
             if transaction.authorization_list().is_none_or(|l| l.is_empty()) {
                 return Err(TransactionValidationOutcome::Invalid(
                     transaction,
                     Eip7702PoolTransactionError::MissingEip7702AuthorizationList.into(),
-                ))
+                ));
             }
         }
 
         if let Err(err) = ensure_intrinsic_gas(&transaction, &self.fork_tracker) {
-            return Err(TransactionValidationOutcome::Invalid(transaction, err))
+            return Err(TransactionValidationOutcome::Invalid(transaction, err));
         }
 
         // light blob tx pre-checks
@@ -606,7 +606,7 @@ where
                 return Err(TransactionValidationOutcome::Invalid(
                     transaction,
                     InvalidTransactionError::TxTypeNotSupported.into(),
-                ))
+                ));
             }
 
             let blob_count = transaction.blob_count().unwrap_or(0);
@@ -617,7 +617,7 @@ where
                     InvalidPoolTransactionError::Eip4844(
                         Eip4844PoolTransactionError::NoEip4844Blobs,
                     ),
-                ))
+                ));
             }
 
             let max_blob_count = self.fork_tracker.max_blob_count();
@@ -630,7 +630,7 @@ where
                             permitted: max_blob_count,
                         },
                     ),
-                ))
+                ));
             }
         }
 
@@ -641,14 +641,14 @@ where
             return Err(TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidTransactionError::GasLimitTooHigh.into(),
-            ))
+            ));
         }
 
         // Run additional stateless validation if configured
-        if let Some(check) = &self.additional_stateless_validation &&
-            let Err(err) = check(origin, &transaction)
+        if let Some(check) = &self.additional_stateless_validation
+            && let Err(err) = check(origin, &transaction)
         {
-            return Err(TransactionValidationOutcome::Invalid(transaction, err))
+            return Err(TransactionValidationOutcome::Invalid(transaction, err));
         }
 
         Ok(transaction)
@@ -683,15 +683,15 @@ where
         };
 
         // Checks for nonce
-        if transaction.requires_nonce_check() &&
-            let Err(err) = self.validate_sender_nonce(&transaction, &account)
+        if transaction.requires_nonce_check()
+            && let Err(err) = self.validate_sender_nonce(&transaction, &account)
         {
-            return TransactionValidationOutcome::Invalid(transaction, err)
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         // checks for max cost not exceedng account_balance
         if let Err(err) = self.validate_sender_balance(&transaction, &account) {
-            return TransactionValidationOutcome::Invalid(transaction, err)
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         // heavy blob tx validation
@@ -701,10 +701,10 @@ where
         };
 
         // Run additional stateful validation if configured
-        if let Some(check) = &self.additional_stateful_validation &&
-            let Err(err) = check(origin, &transaction, &state)
+        if let Some(check) = &self.additional_stateful_validation
+            && let Err(err) = check(origin, &transaction, &state)
         {
-            return TransactionValidationOutcome::Invalid(transaction, err)
+            return TransactionValidationOutcome::Invalid(transaction, err);
         }
 
         let authorities = self.recover_authorities(&transaction);
@@ -755,7 +755,7 @@ where
             };
 
             if !is_eip7702 {
-                return Ok(Err(InvalidTransactionError::SignerAccountHasBytecode.into()))
+                return Ok(Err(InvalidTransactionError::SignerAccountHasBytecode.into()));
             }
         }
         Ok(Ok(()))
@@ -774,7 +774,7 @@ where
                 tx: tx_nonce,
                 state: sender.nonce,
             }
-            .into())
+            .into());
         }
         Ok(())
     }
@@ -792,7 +792,7 @@ where
             return Err(InvalidTransactionError::InsufficientFunds(
                 GotExpected { got: sender.balance, expected }.into(),
             )
-            .into())
+            .into());
         }
         Ok(())
     }
@@ -810,7 +810,7 @@ where
             match transaction.take_blob() {
                 EthBlobTransactionSidecar::None => {
                     // this should not happen
-                    return Err(InvalidTransactionError::TxTypeNotSupported.into())
+                    return Err(InvalidTransactionError::TxTypeNotSupported.into());
                 }
                 EthBlobTransactionSidecar::Missing => {
                     // This can happen for re-injected blob transactions (on re-org), since the blob
@@ -822,7 +822,7 @@ where
                     } else {
                         return Err(InvalidPoolTransactionError::Eip4844(
                             Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
-                        ))
+                        ));
                     }
                 }
                 EthBlobTransactionSidecar::Present(sidecar) => {
@@ -835,19 +835,19 @@ where
                             if sidecar.is_eip4844() {
                                 return Err(InvalidPoolTransactionError::Eip4844(
                                     Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka,
-                                ))
+                                ));
                             }
                         } else if sidecar.is_eip7594() && !self.allow_7594_sidecars() {
                             return Err(InvalidPoolTransactionError::Eip4844(
                                 Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka,
-                            ))
+                            ));
                         }
                     } else {
                         // EIP-7594 disabled: always reject v1 sidecars, accept v0
                         if sidecar.is_eip7594() {
                             return Err(InvalidPoolTransactionError::Eip4844(
                                 Eip4844PoolTransactionError::Eip7594SidecarDisallowed,
-                            ))
+                            ));
                         }
                     }
 
@@ -855,7 +855,7 @@ where
                     if let Err(err) = transaction.validate_blob(&sidecar, self.kzg_settings.get()) {
                         return Err(InvalidPoolTransactionError::Eip4844(
                             Eip4844PoolTransactionError::InvalidEip4844Blob(err),
-                        ))
+                        ));
                     }
                     // Record the duration of successful blob validation as histogram
                     self.validation_metrics.blob_validation_duration.record(now.elapsed());

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -458,7 +458,7 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
 
         // Check if the max fee per gas is underpriced.
         if maybe_replacement.max_fee_per_gas() < self.max_fee_per_gas() * (100 + price_bump) / 100 {
-            return true
+            return true;
         }
 
         let existing_max_priority_fee_per_gas =
@@ -467,12 +467,12 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
             maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or_default();
 
         // Check max priority fee per gas (relevant for EIP-1559 transactions only)
-        if existing_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas <
-                existing_max_priority_fee_per_gas * (100 + price_bump) / 100
+        if existing_max_priority_fee_per_gas != 0
+            && replacement_max_priority_fee_per_gas != 0
+            && replacement_max_priority_fee_per_gas
+                < existing_max_priority_fee_per_gas * (100 + price_bump) / 100
         {
-            return true
+            return true;
         }
 
         // Check max blob fee per gas
@@ -480,10 +480,10 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
             // This enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
                 maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or_default();
-            if replacement_max_blob_fee_per_gas <
-                existing_max_blob_fee_per_gas * (100 + price_bump) / 100
+            if replacement_max_blob_fee_per_gas
+                < existing_max_blob_fee_per_gas * (100 + price_bump) / 100
             {
-                return true
+                return true;
             }
         }
 

--- a/crates/trie/common/src/added_removed_keys.rs
+++ b/crates/trie/common/src/added_removed_keys.rs
@@ -49,7 +49,7 @@ impl MultiAddedRemovedKeys {
                 if account.is_empty() {
                     self.account.insert_removed(*hashed_address);
                 }
-                continue
+                continue;
             }
 
             let storage_removed_keys =

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -187,10 +187,10 @@ impl HashedPostState {
                 Some(storage_in_targets) => {
                     let mut storage_not_in_targets = HashedStorage::default();
                     storage.storage.retain(|&slot, value| {
-                        if storage_in_targets.contains(&slot) &&
-                            !storage_added_removed_keys.is_some_and(|k| k.is_removed(&slot))
+                        if storage_in_targets.contains(&slot)
+                            && !storage_added_removed_keys.is_some_and(|k| k.is_removed(&slot))
                         {
-                            return true
+                            return true;
                         }
 
                         storage_not_in_targets.storage.insert(slot, *value);
@@ -225,7 +225,7 @@ impl HashedPostState {
         });
         self.accounts.retain(|&address, account| {
             if targets.contains_key(&address) {
-                return true
+                return true;
             }
 
             state_updates_not_in_targets.accounts.insert(address, *account);
@@ -244,8 +244,9 @@ impl HashedPostState {
 
     /// Returns the number of items that will be considered during chunking in `[Self::chunks]`.
     pub fn chunking_length(&self) -> usize {
-        self.accounts.len() +
-            self.storages
+        self.accounts.len()
+            + self
+                .storages
                 .values()
                 .map(|storage| if storage.wiped { 1 } else { 0 } + storage.storage.len())
                 .sum::<usize>()

--- a/crates/trie/common/src/nibbles.rs
+++ b/crates/trie/common/src/nibbles.rs
@@ -10,14 +10,14 @@ pub use nybbles::Nibbles;
 /// - Siblings are ordered lexicographically
 pub fn depth_first_cmp(a: &Nibbles, b: &Nibbles) -> Ordering {
     if a.len() == b.len() {
-        return a.cmp(b)
+        return a.cmp(b);
     }
 
     let common_prefix_len = a.common_prefix_length(b);
     if a.len() == common_prefix_len {
-        return Ordering::Greater
+        return Ordering::Greater;
     } else if b.len() == common_prefix_len {
-        return Ordering::Less
+        return Ordering::Less;
     }
 
     a.get_unchecked(common_prefix_len).cmp(&b.get_unchecked(common_prefix_len))

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -17,9 +17,9 @@ pub struct TriePrefixSetsMut {
 impl TriePrefixSetsMut {
     /// Returns `true` if all prefix sets are empty.
     pub fn is_empty(&self) -> bool {
-        self.account_prefix_set.is_empty() &&
-            self.storage_prefix_sets.is_empty() &&
-            self.destroyed_accounts.is_empty()
+        self.account_prefix_set.is_empty()
+            && self.storage_prefix_sets.is_empty()
+            && self.destroyed_accounts.is_empty()
     }
 
     /// Extends prefix sets with contents of another prefix set.
@@ -203,7 +203,7 @@ impl PrefixSet {
     #[inline]
     pub fn contains(&mut self, prefix: &Nibbles) -> bool {
         if self.all {
-            return true
+            return true;
         }
 
         while self.index > 0 && &self.keys[self.index] > prefix {
@@ -213,12 +213,12 @@ impl PrefixSet {
         for (idx, key) in self.keys[self.index..].iter().enumerate() {
             if key.starts_with(prefix) {
                 self.index += idx;
-                return true
+                return true;
             }
 
             if key > prefix {
                 self.index += idx;
-                return false
+                return false;
             }
         }
 

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -183,9 +183,9 @@ pub struct MultiProof {
 impl MultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
-        self.account_subtree.is_empty() &&
-            self.branch_node_masks.is_empty() &&
-            self.storages.is_empty()
+        self.account_subtree.is_empty()
+            && self.branch_node_masks.is_empty()
+            && self.storages.is_empty()
     }
 
     /// Return the account proof nodes for the given account path.
@@ -232,16 +232,16 @@ impl MultiProof {
         // Inspect the last node in the proof. If it's a leaf node with matching suffix,
         // then the node contains the encoded trie account.
         let info = 'info: {
-            if let Some(last) = proof.last() &&
-                let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? &&
-                nibbles.ends_with(&leaf.key)
+            if let Some(last) = proof.last()
+                && let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])?
+                && nibbles.ends_with(&leaf.key)
             {
                 let account = TrieAccount::decode(&mut &leaf.value[..])?;
                 break 'info Some(Account {
                     balance: account.balance,
                     nonce: account.nonce,
                     bytecode_hash: (account.code_hash != KECCAK_EMPTY).then_some(account.code_hash),
-                })
+                });
             }
             None
         };
@@ -313,9 +313,9 @@ pub struct DecodedMultiProof {
 impl DecodedMultiProof {
     /// Returns true if the multiproof is empty.
     pub fn is_empty(&self) -> bool {
-        self.account_subtree.is_empty() &&
-            self.branch_node_masks.is_empty() &&
-            self.storages.is_empty()
+        self.account_subtree.is_empty()
+            && self.branch_node_masks.is_empty()
+            && self.storages.is_empty()
     }
 
     /// Return the account proof nodes for the given account path.
@@ -362,15 +362,15 @@ impl DecodedMultiProof {
         // Inspect the last node in the proof. If it's a leaf node with matching suffix,
         // then the node contains the encoded trie account.
         let info = 'info: {
-            if let Some(TrieNode::Leaf(leaf)) = proof.last() &&
-                nibbles.ends_with(&leaf.key)
+            if let Some(TrieNode::Leaf(leaf)) = proof.last()
+                && nibbles.ends_with(&leaf.key)
             {
                 let account = TrieAccount::decode(&mut &leaf.value[..])?;
                 break 'info Some(Account {
                     balance: account.balance,
                     nonce: account.nonce,
                     bytecode_hash: (account.code_hash != KECCAK_EMPTY).then_some(account.code_hash),
-                })
+                });
             }
             None
         };
@@ -545,11 +545,11 @@ impl StorageMultiProof {
         // Inspect the last node in the proof. If it's a leaf node with matching suffix,
         // then the node contains the encoded slot value.
         let value = 'value: {
-            if let Some(last) = proof.last() &&
-                let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])? &&
-                nibbles.ends_with(&leaf.key)
+            if let Some(last) = proof.last()
+                && let TrieNode::Leaf(leaf) = TrieNode::decode(&mut &last[..])?
+                && nibbles.ends_with(&leaf.key)
             {
-                break 'value U256::decode(&mut &leaf.value[..])?
+                break 'value U256::decode(&mut &leaf.value[..])?;
             }
             U256::ZERO
         };
@@ -595,10 +595,10 @@ impl DecodedStorageMultiProof {
         // Inspect the last node in the proof. If it's a leaf node with matching suffix,
         // then the node contains the encoded slot value.
         let value = 'value: {
-            if let Some(TrieNode::Leaf(leaf)) = proof.last() &&
-                nibbles.ends_with(&leaf.key)
+            if let Some(TrieNode::Leaf(leaf)) = proof.last()
+                && nibbles.ends_with(&leaf.key)
             {
-                break 'value U256::decode(&mut &leaf.value[..])?
+                break 'value U256::decode(&mut &leaf.value[..])?;
             }
             U256::ZERO
         };
@@ -682,10 +682,10 @@ impl AccountProof {
         } = proof;
         let storage_proofs = storage_proof.into_iter().map(Into::into).collect();
 
-        let (storage_root, info) = if nonce == 0 &&
-            balance.is_zero() &&
-            storage_hash.is_zero() &&
-            code_hash == KECCAK_EMPTY
+        let (storage_root, info) = if nonce == 0
+            && balance.is_zero()
+            && storage_hash.is_zero()
+            && code_hash == KECCAK_EMPTY
         {
             // Account does not exist in state. Return `None` here to prevent proof
             // verification.

--- a/crates/trie/common/src/target_v2.rs
+++ b/crates/trie/common/src/target_v2.rs
@@ -64,8 +64,8 @@ impl MultiProofTargetsV2 {
 
     /// Returns the number of items that will be considered during chunking.
     pub fn chunking_length(&self) -> usize {
-        self.account_targets.len() +
-            self.storage_targets.values().map(|slots| slots.len()).sum::<usize>()
+        self.account_targets.len()
+            + self.storage_targets.values().map(|slots| slots.len()).sum::<usize>()
     }
 
     /// Returns an iterator that yields chunks of the specified size.
@@ -162,8 +162,8 @@ impl Iterator for ChunkedMultiProofTargetsV2 {
         }
 
         // Process any remaining storage-only entries (accounts not in account_targets)
-        while let Some((account_addr, storage_slots)) = self.storage_targets.iter_mut().next() &&
-            count < self.size
+        while let Some((account_addr, storage_slots)) = self.storage_targets.iter_mut().next()
+            && count < self.size
         {
             let account_addr = *account_addr;
             let storage_slots = core::mem::take(storage_slots);

--- a/crates/trie/common/src/trie_node_v2.rs
+++ b/crates/trie/common/src/trie_node_v2.rs
@@ -61,9 +61,9 @@ impl ProofTrieNodeV2 {
                     let expected_branch_path = path.join(&ext.key);
 
                     // Check if the last item in result is the child branch
-                    if let Some(last) = result.last_mut() &&
-                        last.path == expected_branch_path &&
-                        let TrieNodeV2::Branch(branch_v2) = &mut last.node
+                    if let Some(last) = result.last_mut()
+                        && last.path == expected_branch_path
+                        && let TrieNodeV2::Branch(branch_v2) = &mut last.node
                     {
                         debug_assert!(
                             branch_v2.key.is_empty(),

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -37,9 +37,9 @@ impl TrieUpdates {
 
     /// Returns `true` if the updates are empty.
     pub fn is_empty(&self) -> bool {
-        self.account_nodes.is_empty() &&
-            self.removed_nodes.is_empty() &&
-            self.storage_tries.is_empty()
+        self.account_nodes.is_empty()
+            && self.removed_nodes.is_empty()
+            && self.storage_tries.is_empty()
     }
 
     /// Returns reference to updated account nodes.
@@ -596,8 +596,8 @@ impl TrieUpdatesSorted {
 
     /// Returns the total number of updates including account nodes and all storage updates.
     pub fn total_len(&self) -> usize {
-        self.account_nodes.len() +
-            self.storage_tries.values().map(|storage| storage.len()).sum::<usize>()
+        self.account_nodes.len()
+            + self.storage_tries.values().map(|storage| storage.len()).sum::<usize>()
     }
 
     /// Extends the trie updates with another set of sorted updates.

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -698,7 +698,7 @@ impl Drop for PendingChangesetGuard {
     fn drop(&mut self) {
         let Some(pending) = self.pending.take() else {
             // Guard was resolved successfully already, no-op
-            return
+            return;
         };
 
         let removed = self.cache.inner.write().pending.remove(&self.block_hash);

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -40,7 +40,7 @@ where
     let tip = provider.last_block_number()?;
 
     if from > tip {
-        return Ok(storage)
+        return Ok(storage);
     }
 
     for (BlockNumberAddress((_, storage_address)), storage_change) in

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -107,19 +107,15 @@ fn includes_nodes_for_destroyed_storage_nodes() {
             )]))
             .unwrap();
 
-        let witness =
-            TrieWitness::new(
-                DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
-                DatabaseHashedCursorFactory::new(provider.tx_ref()),
-            )
-            .compute(HashedPostState {
-                accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
-                storages: HashMap::from_iter([(
-                    hashed_address,
-                    HashedStorage::from_iter(true, []),
-                )]), // destroyed
-            })
-            .unwrap();
+        let witness = TrieWitness::new(
+            DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref()),
+            DatabaseHashedCursorFactory::new(provider.tx_ref()),
+        )
+        .compute(HashedPostState {
+            accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
+            storages: HashMap::from_iter([(hashed_address, HashedStorage::from_iter(true, []))]), // destroyed
+        })
+        .unwrap();
         assert!(witness.contains_key(&state_root));
         for node in multiproof.account_subtree.values() {
             assert_eq!(witness.get(&keccak256(node)), Some(node));

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1208,8 +1208,8 @@ fn dispatch_v2_storage_proofs(
     // For storage targets with associated account proofs, ensure the first target has
     // min_len(0) so the root node is returned for storage root computation
     for (hashed_address, targets) in &mut storage_targets {
-        if account_target_addresses.contains(hashed_address) &&
-            let Some(first) = targets.first_mut()
+        if account_target_addresses.contains(hashed_address)
+            && let Some(first) = targets.first_mut()
         {
             *first = first.with_min_len(0);
         }

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -314,7 +314,7 @@ where
                 stats: self.stats.clone(),
                 storage_calculator: self.storage_calculator.clone(),
                 cached_storage_roots: self.cached_storage_roots.clone(),
-            }
+            };
         }
 
         // If the address didn't have a job dispatched for it then we can assume it has no targets,
@@ -323,7 +323,7 @@ where
         // If the root is already calculated then just use it directly
         if let Some(root) = self.cached_storage_roots.get(&hashed_address) {
             self.stats.borrow_mut().from_cache_count += 1;
-            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root }
+            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root };
         }
 
         // Compute storage root synchronously using the shared calculator

--- a/crates/trie/sparse/src/lfu.rs
+++ b/crates/trie/sparse/src/lfu.rs
@@ -77,8 +77,8 @@ impl<K: fmt::Debug + Copy + Eq + hash::Hash> BucketedLfu<K> {
         }
 
         // Advance min_freq to the next non-empty bucket.
-        while (self.min_freq as usize) < self.buckets.len() &&
-            self.buckets[self.min_freq as usize].is_empty()
+        while (self.min_freq as usize) < self.buckets.len()
+            && self.buckets[self.min_freq as usize].is_empty()
         {
             self.min_freq += 1;
         }
@@ -91,8 +91,8 @@ impl<K: fmt::Debug + Copy + Eq + hash::Hash> BucketedLfu<K> {
         if let Some(key) = self.buckets[self.min_freq as usize].pop() {
             self.entries.remove(&key);
 
-            while (self.min_freq as usize) < self.buckets.len() &&
-                self.buckets[self.min_freq as usize].is_empty()
+            while (self.min_freq as usize) < self.buckets.len()
+                && self.buckets[self.min_freq as usize].is_empty()
             {
                 self.min_freq += 1;
             }

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -199,7 +199,7 @@ impl SparseTrie for ParallelSparseTrie {
 
     fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()> {
         if nodes.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         #[cfg(feature = "trie-debug")]
@@ -222,8 +222,8 @@ impl SparseTrie for ParallelSparseTrie {
         for ProofTrieNodeV2 { path, masks, node } in nodes.iter() {
             if let Some(branch_masks) = masks {
                 // Use proper path for branch nodes by combining path and extension key.
-                let path = if let TrieNodeV2::Branch(branch) = node &&
-                    !branch.key.is_empty()
+                let path = if let TrieNodeV2::Branch(branch) = node
+                    && !branch.key.is_empty()
                 {
                     let mut path = *path;
                     path.extend(&branch.key);
@@ -258,9 +258,9 @@ impl SparseTrie for ParallelSparseTrie {
         let hashes_from_upper = nodes
             .iter()
             .filter_map(|node| {
-                if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
-                    reachable_subtries.get(path_subtrie_index_unchecked(&node.path)) &&
-                    let SparseNode::Branch { blinded_mask, blinded_hashes, .. } = self
+                if node.path.len() == UPPER_TRIE_MAX_DEPTH
+                    && reachable_subtries.get(path_subtrie_index_unchecked(&node.path))
+                    && let SparseNode::Branch { blinded_mask, blinded_hashes, .. } = self
                         .upper_subtrie
                         .nodes
                         .get_mut(&node.path.slice(0..UPPER_TRIE_MAX_DEPTH - 1))
@@ -289,8 +289,8 @@ impl SparseTrie for ParallelSparseTrie {
                     continue;
                 }
                 // For boundary leaves, check reachability from upper subtrie's parent branch
-                if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
-                    !Self::is_boundary_leaf_reachable(
+                if node.path.len() == UPPER_TRIE_MAX_DEPTH
+                    && !Self::is_boundary_leaf_reachable(
                         &self.upper_subtrie.nodes,
                         &node.path,
                         &node.node,
@@ -311,7 +311,7 @@ impl SparseTrie for ParallelSparseTrie {
                     hashes_from_upper.get(&node.path).copied(),
                 )?;
             }
-            return Ok(())
+            return Ok(());
         }
 
         #[cfg(not(feature = "std"))]
@@ -332,8 +332,8 @@ impl SparseTrie for ParallelSparseTrie {
             // Group the nodes by lower subtrie.
             let results = lower_nodes
                 .chunk_by(|node_a, node_b| {
-                    SparseSubtrieType::from_path(&node_a.path) ==
-                        SparseSubtrieType::from_path(&node_b.path)
+                    SparseSubtrieType::from_path(&node_a.path)
+                        == SparseSubtrieType::from_path(&node_b.path)
                 })
                 // Filter out chunks for unreachable subtries.
                 .filter_map(|nodes| {
@@ -342,8 +342,8 @@ impl SparseTrie for ParallelSparseTrie {
                         .filter(|node| {
                             // For boundary leaves, check reachability from upper subtrie's parent
                             // branch.
-                            if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
-                                !Self::is_boundary_leaf_reachable(
+                            if node.path.len() == UPPER_TRIE_MAX_DEPTH
+                                && !Self::is_boundary_leaf_reachable(
                                     upper_nodes,
                                     &node.path,
                                     &node.node,
@@ -407,7 +407,7 @@ impl SparseTrie for ParallelSparseTrie {
                             hashes_from_upper.get(&node.path).copied(),
                         );
                         if res.is_err() {
-                            return (subtrie_idx, subtrie, res.map(|_| ()))
+                            return (subtrie_idx, subtrie, res.map(|_| ()));
                         }
                     }
                     (subtrie_idx, subtrie, Ok(()))
@@ -455,8 +455,8 @@ impl SparseTrie for ParallelSparseTrie {
             return Ok(());
         }
         // Also check lower subtries for existing value
-        if let Some(subtrie) = self.lower_subtrie_for_path(&full_path) &&
-            subtrie.inner.values.contains_key(&full_path)
+        if let Some(subtrie) = self.lower_subtrie_for_path(&full_path)
+            && subtrie.inner.values.contains_key(&full_path)
         {
             self.prefix_set.insert(full_path);
             self.lower_subtrie_for_path_mut(&full_path)
@@ -514,7 +514,7 @@ impl SparseTrie for ParallelSparseTrie {
         for node_path in &new_nodes {
             // Skip nodes that belong in the upper subtrie
             if SparseSubtrieType::path_len_is_upper(node_path.len()) {
-                continue
+                continue;
             }
 
             let node =
@@ -693,8 +693,8 @@ impl SparseTrie for ParallelSparseTrie {
 
                     // Update subtrie type if we're crossing into the lower trie.
                     let next_subtrie_type = SparseSubtrieType::from_path(&curr_path);
-                    if matches!(curr_subtrie_type, SparseSubtrieType::Upper) &&
-                        matches!(next_subtrie_type, SparseSubtrieType::Lower(_))
+                    if matches!(curr_subtrie_type, SparseSubtrieType::Upper)
+                        && matches!(next_subtrie_type, SparseSubtrieType::Lower(_))
                     {
                         curr_subtrie_type = next_subtrie_type;
                     }
@@ -761,7 +761,7 @@ impl SparseTrie for ParallelSparseTrie {
         // here, all remaining logic is related to the ancestors of the leaf.
         if leaf_path.is_empty() {
             self.upper_subtrie.nodes.insert(leaf_path, SparseNode::Empty);
-            return Ok(())
+            return Ok(());
         }
 
         // If there is a parent branch node (very likely, unless the leaf is at the root) execute
@@ -870,8 +870,8 @@ impl SparseTrie for ParallelSparseTrie {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::Root);
 
-        if self.prefix_set.is_empty() &&
-            let Some(rlp_node) = self
+        if self.prefix_set.is_empty()
+            && let Some(rlp_node) = self
                 .upper_subtrie
                 .nodes
                 .get(&Nibbles::default())
@@ -879,7 +879,7 @@ impl SparseTrie for ParallelSparseTrie {
         {
             return rlp_node
                 .as_hash()
-                .expect("RLP-encoding of the root node cannot be less than 32 bytes")
+                .expect("RLP-encoding of the root node cannot be less than 32 bytes");
         }
 
         // Update all lower subtrie hashes
@@ -895,8 +895,9 @@ impl SparseTrie for ParallelSparseTrie {
     }
 
     fn is_root_cached(&self) -> bool {
-        self.prefix_set.is_empty() &&
-            self.upper_subtrie
+        self.prefix_set.is_empty()
+            && self
+                .upper_subtrie
                 .nodes
                 .get(&Nibbles::default())
                 .is_some_and(|node| node.cached_rlp_node().is_some())
@@ -933,7 +934,7 @@ impl SparseTrie for ParallelSparseTrie {
             }
 
             self.insert_changed_subtries(changed_subtries);
-            return
+            return;
         }
 
         #[cfg(not(feature = "std"))]
@@ -965,8 +966,8 @@ impl SparseTrie for ParallelSparseTrie {
         // we need to check if the subtrie that the key might belong to has any nodes; if not then
         // the key's portion of the trie doesn't have enough depth to reach into the subtrie, and
         // the key will be in the upper subtrie
-        if let Some(subtrie) = self.subtrie_for_path(full_path) &&
-            !subtrie.is_empty()
+        if let Some(subtrie) = self.subtrie_for_path(full_path)
+            && !subtrie.is_empty()
         {
             return subtrie.inner.values.get(full_path);
         }
@@ -1039,7 +1040,7 @@ impl SparseTrie for ParallelSparseTrie {
                     path: *full_path,
                     expected: expected_value.cloned(),
                     actual: actual_value.clone(),
-                })
+                });
         }
 
         // If the value does not exist in the `values` map, then this means that the leaf either:
@@ -1059,39 +1060,39 @@ impl SparseTrie for ParallelSparseTrie {
                     let mut found_full_path = curr_path;
                     found_full_path.extend(key);
                     assert!(&found_full_path != full_path, "target leaf {full_path:?} found, even though value wasn't in values hashmap");
-                    return Ok(LeafLookup::NonExistent)
+                    return Ok(LeafLookup::NonExistent);
                 }
                 SparseNode::Extension { key, .. } => {
                     if full_path.len() == curr_path.len() {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                     curr_path.extend(key);
                     if !full_path.starts_with(&curr_path) {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                 }
                 SparseNode::Branch { state_mask, blinded_mask, blinded_hashes, .. } => {
                     if full_path.len() == curr_path.len() {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                     let nibble = full_path.get_unchecked(curr_path.len());
                     if !state_mask.is_bit_set(nibble) {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                     curr_path.push_unchecked(nibble);
                     if blinded_mask.is_bit_set(nibble) {
                         return Err(LeafLookupError::BlindedNode {
                             path: curr_path,
                             hash: blinded_hashes[nibble as usize],
-                        })
+                        });
                     }
                 }
             }
 
             // If we were previously looking at the upper trie, and the new path is in the
             // lower trie, we need to pull out a ref to the lower trie.
-            if curr_subtrie_is_upper &&
-                let Some(lower_subtrie) = self.lower_subtrie_for_path(&curr_path)
+            if curr_subtrie_is_upper
+                && let Some(lower_subtrie) = self.lower_subtrie_for_path(&curr_path)
             {
                 curr_subtrie = lower_subtrie;
                 curr_subtrie_is_upper = false;
@@ -1421,8 +1422,8 @@ impl ParallelSparseTrie {
     /// occurs when `retain_updates` is enabled and an extension node's child needs revealing.
     const fn get_retriable_path(e: &SparseTrieError) -> Option<Nibbles> {
         match e.kind() {
-            SparseTrieErrorKind::BlindedNode(path) |
-            SparseTrieErrorKind::NodeNotFoundInProvider { path } => Some(*path),
+            SparseTrieErrorKind::BlindedNode(path)
+            | SparseTrieErrorKind::NodeNotFoundInProvider { path } => Some(*path),
             _ => None,
         }
     }
@@ -1639,31 +1640,31 @@ impl ParallelSparseTrie {
                 found_full_path.extend(key);
 
                 if &found_full_path == leaf_full_path {
-                    return FindNextToLeafOutcome::Found
+                    return FindNextToLeafOutcome::Found;
                 }
                 FindNextToLeafOutcome::NotFound
             }
             SparseNode::Extension { key, .. } => {
                 if leaf_full_path.len() == from_path.len() {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let mut child_path = *from_path;
                 child_path.extend(key);
 
                 if !leaf_full_path.starts_with(&child_path) {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
                 FindNextToLeafOutcome::ContinueFrom(child_path)
             }
             SparseNode::Branch { state_mask, blinded_mask, .. } => {
                 if leaf_full_path.len() == from_path.len() {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let nibble = leaf_full_path.get_unchecked(from_path.len());
                 if !state_mask.is_bit_set(nibble) {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let mut child_path = *from_path;
@@ -1969,8 +1970,8 @@ impl ParallelSparseTrie {
 
         for (index, subtrie) in self.lower_subtries.iter_mut().enumerate() {
             if let Some(subtrie) = subtrie.take_revealed_if(|subtrie| {
-                prefix_set.contains(&subtrie.path) ||
-                    subtrie
+                prefix_set.contains(&subtrie.path)
+                    || subtrie
                         .nodes
                         .get(&subtrie.path)
                         .is_some_and(|n| n.cached_rlp_node().is_none())
@@ -1997,7 +1998,7 @@ impl ParallelSparseTrie {
                             // If we're past the subtrie path, we're done with this subtrie. Do not
                             // advance the iterator, the next key will be processed either by the
                             // next subtrie or inserted into the unchanged prefix set.
-                            break
+                            break;
                         }
                     }
                     PrefixSetMut::from(new_prefix_set)
@@ -2070,7 +2071,7 @@ impl ParallelSparseTrie {
         // Only reveal nodes that can be reached given the current state of the upper trie. If they
         // can't be reached, it means that they were removed.
         if !self.is_path_reachable_from_upper(&path) {
-            return Ok(())
+            return Ok(());
         }
 
         // Exit early if the node was already revealed before.
@@ -2083,7 +2084,7 @@ impl ParallelSparseTrie {
                 // We might still potentially need to reveal a child branch node in the lower
                 // subtrie, even if the upper subtrie already knew about the extension node.
                 if SparseSubtrieType::path_len_is_upper(path.len() + branch.key.len()) {
-                    return Ok(())
+                    return Ok(());
                 }
             } else {
                 return Ok(());
@@ -2200,13 +2201,13 @@ impl ParallelSparseTrie {
         size += self.prefix_set.len() * core::mem::size_of::<Nibbles>();
 
         // Branch node masks map
-        size += self.branch_node_masks.len() *
-            (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeMasks>());
+        size += self.branch_node_masks.len()
+            * (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeMasks>());
 
         // Updates if present
         if let Some(updates) = &self.updates {
-            size += updates.updated_nodes.len() *
-                (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeCompact>());
+            size += updates.updated_nodes.len()
+                * (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeCompact>());
             size += updates.removed_nodes.len() * core::mem::size_of::<Nibbles>();
         }
 
@@ -2226,14 +2227,14 @@ impl ParallelSparseTrie {
             match node {
                 SparseNode::Branch { state_mask, .. } => {
                     if !state_mask.is_bit_set(path.get_unchecked(current.len())) {
-                        return false
+                        return false;
                     }
 
                     current.push_unchecked(path.get_unchecked(current.len()));
                 }
                 SparseNode::Extension { key, .. } => {
                     if *key != path.slice(current.len()..current.len() + key.len()) {
-                        return false
+                        return false;
                     }
                     current.extend(key);
                 }
@@ -2256,7 +2257,7 @@ impl ParallelSparseTrie {
         debug_assert_eq!(path.len(), UPPER_TRIE_MAX_DEPTH);
 
         if !matches!(node, TrieNodeV2::Leaf(_)) {
-            return true
+            return true;
         }
 
         let parent_path = path.slice(..path.len() - 1);
@@ -2388,7 +2389,7 @@ impl SparseSubtrie {
     /// for this leaf's nibble, meaning the leaf is not reachable.
     fn is_leaf_reachable_from_parent(&self, path: &Nibbles) -> bool {
         if path.is_empty() {
-            return true
+            return true;
         }
 
         let parent_path = path.slice(..path.len() - 1);
@@ -2421,7 +2422,7 @@ impl SparseSubtrie {
         // Check if value already exists - if so, just update it (no structural changes needed)
         if let Entry::Occupied(mut e) = self.inner.values.entry(full_path) {
             e.insert(value);
-            return Ok(())
+            return Ok(());
         }
 
         // Here we are starting at the root of the subtrie, and traversing from there.
@@ -2536,7 +2537,7 @@ impl SparseSubtrie {
                         inserted_nodes.push(ext_path);
                     }
 
-                    return Ok(LeafUpdateStep::complete_with_insertions(inserted_nodes))
+                    return Ok(LeafUpdateStep::complete_with_insertions(inserted_nodes));
                 }
 
                 Ok(LeafUpdateStep::Continue)
@@ -2549,7 +2550,7 @@ impl SparseSubtrie {
                     state_mask.set_bit(nibble);
                     let new_leaf = SparseNode::new_leaf(path.slice(current.len()..));
                     self.nodes.insert(*current, new_leaf);
-                    return Ok(LeafUpdateStep::complete_with_insertions(vec![*current]))
+                    return Ok(LeafUpdateStep::complete_with_insertions(vec![*current]));
                 }
 
                 if blinded_mask.is_bit_set(nibble) {
@@ -2749,7 +2750,7 @@ impl SparseSubtrie {
                         ?path,
                         "Leaf not reachable from parent branch, skipping",
                     );
-                    return Ok(false)
+                    return Ok(false);
                 }
 
                 let mut full_key = path;
@@ -2763,7 +2764,7 @@ impl SparseSubtrie {
                             ?full_key,
                             "Leaf full key value already present, skipping",
                         );
-                        return Ok(false)
+                        return Ok(false);
                     }
                     Entry::Vacant(entry) => {
                         entry.insert(leaf.value.clone());
@@ -3048,7 +3049,7 @@ impl SparseSubtrieInner {
                         },
                         RlpNodePathStackItem { path: child_path, is_in_prefix_set: None },
                     ]);
-                    return
+                    return;
                 }
             }
             SparseNode::Branch { state_mask, state, blinded_mask, blinded_hashes } => {
@@ -3075,7 +3076,7 @@ impl SparseSubtrieInner {
                         rlp_node: rlp_node.clone(),
                         node_type,
                     });
-                    return
+                    return;
                 }
 
                 let retain_updates = update_actions.is_some() && prefix_set_contains(&path);
@@ -3135,24 +3136,24 @@ impl SparseSubtrieInner {
                                 .drain(..)
                                 .map(|path| RlpNodePathStackItem { path, is_in_prefix_set: None }),
                         );
-                        return
+                        return;
                     };
 
                     // Update the masks only if we need to retain trie updates
                     if retain_updates {
                         // Determine whether we need to set trie mask bit.
-                        let should_set_tree_mask_bit =
-                            if let Some(store_in_db_trie) = child_node_type.store_in_db_trie() {
-                                // A branch or an extension node explicitly set the
-                                // `store_in_db_trie` flag
-                                store_in_db_trie
-                            } else {
-                                // A blinded node has the tree mask bit set
-                                child_node_type.is_hash() &&
-                                    path_masks().is_some_and(|masks| {
-                                        masks.tree_mask.is_bit_set(child_nibble)
-                                    })
-                            };
+                        let should_set_tree_mask_bit = if let Some(store_in_db_trie) =
+                            child_node_type.store_in_db_trie()
+                        {
+                            // A branch or an extension node explicitly set the
+                            // `store_in_db_trie` flag
+                            store_in_db_trie
+                        } else {
+                            // A blinded node has the tree mask bit set
+                            child_node_type.is_hash()
+                                && path_masks()
+                                    .is_some_and(|masks| masks.tree_mask.is_bit_set(child_nibble))
+                        };
                         if should_set_tree_mask_bit {
                             tree_mask.set_bit(child_nibble);
                         }
@@ -3160,9 +3161,9 @@ impl SparseSubtrieInner {
                         // is a blinded node that has its hash mask bit set according to the
                         // database, set the hash mask bit and save the hash.
                         let hash = child.as_hash().filter(|_| {
-                            child_node_type.is_branch() ||
-                                (child_node_type.is_hash() &&
-                                    path_masks().is_some_and(|masks| {
+                            child_node_type.is_branch()
+                                || (child_node_type.is_hash()
+                                    && path_masks().is_some_and(|masks| {
                                         masks.hash_mask.is_bit_set(child_nibble)
                                     }))
                         });
@@ -8202,8 +8203,9 @@ mod tests {
 
         // Record state before update_leaves
         let prefix_set_len_before = trie.prefix_set.len();
-        let node_count_before = trie.upper_subtrie.nodes.len() +
-            trie.lower_subtries
+        let node_count_before = trie.upper_subtrie.nodes.len()
+            + trie
+                .lower_subtries
                 .iter()
                 .filter_map(|s| s.as_revealed_ref())
                 .map(|s| s.nodes.len())
@@ -8238,8 +8240,9 @@ mod tests {
         );
 
         // Assert: node count unchanged
-        let node_count_after = trie.upper_subtrie.nodes.len() +
-            trie.lower_subtries
+        let node_count_after = trie.upper_subtrie.nodes.len()
+            + trie
+                .lower_subtries
                 .iter()
                 .filter_map(|s| s.as_revealed_ref())
                 .map(|s| s.nodes.len())

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -629,7 +629,7 @@ where
                 EMPTY_ROOT_HASH
             }
         } else {
-            return Err(SparseTrieErrorKind::Blind.into())
+            return Err(SparseTrieErrorKind::Blind.into());
         };
 
         if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
@@ -658,7 +658,7 @@ where
         provider_factory: impl TrieNodeProviderFactory,
     ) -> SparseStateTrieResult<bool> {
         if !self.is_account_revealed(address) {
-            return Err(SparseTrieErrorKind::Blind.into())
+            return Err(SparseTrieErrorKind::Blind.into());
         }
 
         // Nothing to update if the account doesn't exist in the trie.
@@ -668,7 +668,7 @@ where
             .transpose()?
         else {
             trace!(target: "trie::sparse", ?address, "Account not found in trie, skipping storage root update");
-            return Ok(true)
+            return Ok(true);
         };
 
         // Calculate the new storage root. If the storage trie doesn't exist, the storage root will
@@ -685,7 +685,7 @@ where
 
         // If the account is empty, indicate that it should be removed.
         if trie_account == TrieAccount::default() {
-            return Ok(false)
+            return Ok(false);
         }
 
         // Otherwise, update the account leaf.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -404,9 +404,9 @@ impl SparseNode {
     pub fn cached_rlp_node(&self) -> Option<Cow<'_, RlpNode>> {
         match &self {
             Self::Empty => None,
-            Self::Leaf { state, .. } |
-            Self::Extension { state, .. } |
-            Self::Branch { state, .. } => state.cached_rlp_node().map(Cow::Borrowed),
+            Self::Leaf { state, .. }
+            | Self::Extension { state, .. }
+            | Self::Branch { state, .. } => state.cached_rlp_node().map(Cow::Borrowed),
         }
     }
 
@@ -414,9 +414,9 @@ impl SparseNode {
     pub fn cached_hash(&self) -> Option<B256> {
         match &self {
             Self::Empty => None,
-            Self::Leaf { state, .. } |
-            Self::Extension { state, .. } |
-            Self::Branch { state, .. } => state.cached_hash(),
+            Self::Leaf { state, .. }
+            | Self::Extension { state, .. }
+            | Self::Branch { state, .. } => state.cached_hash(),
         }
     }
 
@@ -429,9 +429,9 @@ impl SparseNode {
             Self::Empty => {
                 panic!("Cannot set hash for Empty or Hash nodes")
             }
-            Self::Leaf { state, .. } |
-            Self::Extension { state, .. } |
-            Self::Branch { state, .. } => {
+            Self::Leaf { state, .. }
+            | Self::Extension { state, .. }
+            | Self::Branch { state, .. } => {
                 *state = new_state;
             }
         }

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -247,7 +247,7 @@ where
                 {
                     // If overlay returns a value prior to the DB's value, or the DB is exhausted,
                     // then we return the overlay's value.
-                    return Ok(Some((mem_key, value)))
+                    return Ok(Some((mem_key, value)));
                 }
                 // All other cases:
                 // - mem_key > db_key
@@ -301,14 +301,14 @@ where
 
         // If either cursor is currently pointing to the last entry which was returned then consume
         // that entry so that `choose_next_entry` is looking at the subsequent one.
-        if let Some((key, _)) = self.post_state_cursor.current() &&
-            key == &last_key
+        if let Some((key, _)) = self.post_state_cursor.current()
+            && key == &last_key
         {
             self.post_state_cursor.first_after(&last_key);
         }
 
-        if let Some((key, _)) = &self.cursor_entry &&
-            key == &last_key
+        if let Some((key, _)) = &self.cursor_entry
+            && key == &last_key
         {
             self.cursor_next()?;
         }

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -122,8 +122,8 @@ where
     ///
     /// If `metrics` feature is enabled, it also updates the metrics.
     fn seek_hashed_entry(&mut self, key: B256) -> Result<Option<(B256, H::Value)>, DatabaseError> {
-        if let Some((last_key, last_value)) = self.last_next_result &&
-            last_key == key
+        if let Some((last_key, last_value)) = self.last_next_result
+            && last_key == key
         {
             trace!(target: "trie::node_iter", seek_key = ?key, "reusing result from last next() call instead of seeking");
             self.last_next_result = None; // Consume the cached value
@@ -217,7 +217,7 @@ where
                             *key,
                             self.walker.hash().unwrap(),
                             self.walker.children_are_in_trie(),
-                        ))))
+                        ))));
                     }
                 }
             }
@@ -227,7 +227,7 @@ where
                 // Check if the walker's key is less than the key of the current hashed entry
                 if self.walker.key().is_some_and(|key| key < &Nibbles::unpack(hashed_key)) {
                     self.should_check_walker_key = false;
-                    continue
+                    continue;
                 }
 
                 // Set the next hashed entry as a leaf node and return
@@ -236,7 +236,7 @@ where
 
                 #[cfg(feature = "metrics")]
                 self.metrics.inc_leaf_nodes_returned();
-                return Ok(Some(TrieElement::Leaf(hashed_key, value)))
+                return Ok(Some(TrieElement::Leaf(hashed_key, value)));
             }
 
             // Handle seeking and advancing based on the previous hashed key
@@ -280,9 +280,9 @@ where
                     // the database, so the walker will advance to the branch node after it. Because
                     // of this, we need to check that the current walker key has a prefix of the key
                     // that we seeked to.
-                    if can_skip_node &&
-                        self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix)) &&
-                        self.walker.children_are_in_trie()
+                    if can_skip_node
+                        && self.walker.key().is_some_and(|key| key.starts_with(&seek_prefix))
+                        && self.walker.children_are_in_trie()
                     {
                         trace!(
                             target: "trie::node_iter",
@@ -292,7 +292,7 @@ where
                         );
 
                         self.should_check_walker_key = false;
-                        continue
+                        continue;
                     }
 
                     self.current_hashed_entry = self.seek_hashed_entry(seek_key)?;

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -426,7 +426,7 @@ where
 
         // short circuit on empty storage
         if hashed_storage_cursor.is_storage_empty()? {
-            return Ok(StorageMultiProof::empty())
+            return Ok(StorageMultiProof::empty());
         }
 
         let mut discard_trie_cursor_metrics = TrieCursorMetricsCache::default();

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -217,16 +217,16 @@ where
             // point the target for 0xabc2 will not match the branch due to its prefix, but any of
             // the other targets would, so we need to check those as well.
             if lower.key_nibbles.starts_with(path) {
-                return !check_min_len ||
-                    (path.len() >= lower.min_len as usize ||
-                        targets
+                return !check_min_len
+                    || (path.len() >= lower.min_len as usize
+                        || targets
                             .skip_iter()
                             .take_while(|target| target.key_nibbles.starts_with(path))
-                            .any(|target| path.len() >= target.min_len as usize) ||
-                        targets
+                            .any(|target| path.len() >= target.min_len as usize)
+                        || targets
                             .rev_iter()
                             .take_while(|target| target.key_nibbles.starts_with(path))
-                            .any(|target| path.len() >= target.min_len as usize))
+                            .any(|target| path.len() >= target.min_len as usize));
             }
 
             // If the path isn't in the current range then iterate forward until it is (or until
@@ -237,7 +237,7 @@ where
                 (lower, upper) = targets.next();
                 trace!(target: TRACE_TARGET, target = ?lower, "upper target <= path, next target");
             } else {
-                return false
+                return false;
             }
         }
     }
@@ -255,7 +255,7 @@ where
     ) -> Result<RlpNode, StateProofError> {
         // If the child is already an `RlpNode` then there is nothing to do.
         if let ProofTrieBranchChild::RlpNode(rlp_node) = child {
-            return Ok(rlp_node)
+            return Ok(rlp_node);
         }
 
         // If we should retain the child then do so.
@@ -346,7 +346,7 @@ where
         // changes.
         if let ProofTrieBranchChild::RlpNode(_) = child {
             self.child_stack.push(child);
-            return Ok(())
+            return Ok(());
         }
 
         // Only commit immediately if retained for the proof. Otherwise, defer conversion
@@ -589,7 +589,7 @@ where
                     // If the child stack is empty then this is the first leaf, push it and be done
                     self.child_stack
                         .push(ProofTrieBranchChild::Leaf { short_key: key, value: val });
-                    return Ok(())
+                    return Ok(());
                 }
                 None => {
                     // If the child stack is not empty then it must only have a single other child
@@ -603,7 +603,7 @@ where
                         .is_empty());
                     let (nibble, short_key) = self.push_new_branch(key);
                     self.push_new_leaf(targets, nibble, short_key, val)?;
-                    return Ok(())
+                    return Ok(());
                 }
             };
 
@@ -616,7 +616,7 @@ where
             // children. We can pop it and loop back to the top to try again with its parent branch.
             if common_prefix_len < self.branch_path.len() {
                 self.pop_branch(targets)?;
-                continue
+                continue;
             }
 
             // If the current branch is a prefix of the new key then the leaf is a child of the
@@ -635,7 +635,7 @@ where
                 self.push_new_leaf(targets, nibble, short_key, val)?;
             }
 
-            return Ok(())
+            return Ok(());
         }
     }
 
@@ -684,8 +684,8 @@ where
         }
 
         // Loop over all keys in the range, calling `push_leaf` on each.
-        while let Some((key, _)) = hashed_cursor_current.as_ref() &&
-            upper_bound.is_none_or(|upper_bound| key < &upper_bound)
+        while let Some((key, _)) = hashed_cursor_current.as_ref()
+            && upper_bound.is_none_or(|upper_bound| key < &upper_bound)
         {
             let (key, val) =
                 core::mem::take(hashed_cursor_current).expect("while-let checks for Some");
@@ -739,7 +739,7 @@ where
             self.branch_path = cached_path;
             self.branch_stack
                 .push(Self::new_from_cached_branch(cached_branch, cached_path.len() as u8));
-            return Ok(())
+            return Ok(());
         }
 
         // Get the nibble which should be set in the parent branch's `state_mask` for this new
@@ -826,13 +826,13 @@ where
         // If the `uncalculated_lower_bound` is None it indicates that there can be no more
         // leaf data, so similarly there can be no more branches.
         let Some(uncalculated_lower_bound) = uncalculated_lower_bound else {
-            return Ok(PopCachedBranchOutcome::Exhausted)
+            return Ok(PopCachedBranchOutcome::Exhausted);
         };
 
         // If [`TrieCursorState::path`] returns None it means that the cursor has been
         // exhausted, so there can be no more cached data.
         let Some(mut trie_cursor_path) = trie_cursor_state.path() else {
-            return Ok(PopCachedBranchOutcome::Exhausted)
+            return Ok(PopCachedBranchOutcome::Exhausted);
         };
 
         // If the trie cursor is seeked to a branch whose leaves have already been processed
@@ -846,13 +846,13 @@ where
             if let Some(new_trie_cursor_path) = trie_cursor_state.path() {
                 trie_cursor_path = new_trie_cursor_path
             } else {
-                return Ok(PopCachedBranchOutcome::Exhausted)
+                return Ok(PopCachedBranchOutcome::Exhausted);
             };
         }
 
         // If the trie cursor has exceeded the sub-trie then we consider it to be exhausted.
         if !trie_cursor_path.starts_with(sub_trie_prefix) {
-            return Ok(PopCachedBranchOutcome::Exhausted)
+            return Ok(PopCachedBranchOutcome::Exhausted);
         }
 
         // At this point we can be sure that the cursor is in an `Available` state. We know for
@@ -1007,7 +1007,7 @@ where
                 // be the next possible prefix, if any.
                 uncalculated_lower_bound = cached_path.next_without_prefix();
 
-                continue
+                continue;
             }
 
             // Determine the next nibble of the branch which has not yet been constructed, and
@@ -1061,7 +1061,7 @@ where
                     // Push the current cached branch back onto the stack before looping.
                     self.cached_branch_stack.push((cached_path, cached_branch));
 
-                    continue
+                    continue;
                 }
             }
 
@@ -1080,8 +1080,8 @@ where
             // the cached branch for this child. We push it onto the `cached_branch_stack` and loop
             // back to the top.
             if let TrieCursorState::Available(next_cached_path, next_cached_branch) =
-                &trie_cursor_state &&
-                next_cached_path.starts_with(&child_path)
+                &trie_cursor_state
+                && next_cached_path.starts_with(&child_path)
             {
                 // Push the current cached branch back on before pushing its child and then looping
                 self.cached_branch_stack.push((cached_path, cached_branch));
@@ -1188,8 +1188,8 @@ where
             //
             // This can specifically happen when there is a cached branch which shouldn't exist, or
             // if state mask bit is set on a cached branch which shouldn't be.
-            if let Some(prev_lower) = prev_uncalculated_lower_bound.as_ref() &&
-                calc_lower_bound < *prev_lower
+            if let Some(prev_lower) = prev_uncalculated_lower_bound.as_ref()
+                && calc_lower_bound < *prev_lower
             {
                 let msg = format!(
                     "next_uncached_key_range went backwards: calc_lower={calc_lower_bound:?} < \
@@ -1297,7 +1297,7 @@ where
         // If there are no targets then nothing could be returned, return early.
         if targets.is_empty() {
             trace!(target: TRACE_TARGET, "Empty targets, returning");
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         // Initialize the variables which track the state of the two cursors. Both indicate the
@@ -1458,7 +1458,7 @@ where
                 path: Nibbles::default(),
                 node: TrieNodeV2::EmptyRoot,
                 masks: None,
-            }])
+            }]);
         }
 
         // Don't call `set_hashed_address` on the trie cursor until after the previous shortcut has
@@ -1486,7 +1486,7 @@ where
                 path: Nibbles::default(),
                 node: TrieNodeV2::EmptyRoot,
                 masks: None,
-            })
+            });
         }
 
         // Don't call `set_hashed_address` on the trie cursor until after the previous shortcut has

--- a/crates/trie/trie/src/proof_v2/node.rs
+++ b/crates/trie/trie/src/proof_v2/node.rs
@@ -101,8 +101,8 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
     /// [`Self::RlpNode`].
     pub(crate) fn short_key(&self) -> &Nibbles {
         match self {
-            Self::Leaf { short_key, .. } |
-            Self::Branch { node: BranchNodeV2 { key: short_key, .. }, .. } => short_key,
+            Self::Leaf { short_key, .. }
+            | Self::Branch { node: BranchNodeV2 { key: short_key, .. }, .. } => short_key,
             Self::RlpNode(_) => {
                 static EMPTY_NIBBLES: Nibbles = Nibbles::new();
                 &EMPTY_NIBBLES

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -229,7 +229,7 @@ where
                         hash_builder,
                         account_root_state.last_hashed_key,
                         Some(storage_state),
-                    ))
+                    ));
                 }
             }
 
@@ -288,7 +288,7 @@ where
                             hash_builder,
                             hashed_address,
                             Some(storage_state),
-                        ))
+                        ));
                     }
 
                     // decide if we need to return intermediate progress
@@ -300,7 +300,7 @@ where
                             hash_builder,
                             hashed_address,
                             None,
-                        ))
+                        ));
                     }
                 }
             }
@@ -394,9 +394,9 @@ impl StateRootContext {
         H: HashedCursor,
         K: AsRef<AddedRemovedKeys>,
     {
-        (self.updated_storage_nodes +
-            account_node_iter.walker.removed_keys_len() +
-            hash_builder.updates_len()) as u64
+        (self.updated_storage_nodes
+            + account_node_iter.walker.removed_keys_len()
+            + hash_builder.updates_len()) as u64
     }
 
     /// Processes the result of a storage root calculation.
@@ -625,7 +625,7 @@ where
                 EMPTY_ROOT_HASH,
                 0,
                 StorageTrieUpdates::deleted(),
-            ))
+            ));
         }
 
         let mut tracker = TrieTracker::default();
@@ -689,7 +689,7 @@ where
                             Box::new(state),
                             hashed_entries_walked,
                             trie_updates,
-                        ))
+                        ));
                     }
                 }
             }

--- a/crates/trie/trie/src/trie_cursor/depth_first.rs
+++ b/crates/trie/trie/src/trie_cursor/depth_first.rs
@@ -49,14 +49,14 @@ impl<C: TrieCursor> DepthFirstTrieIterator<C> {
                     // If the stack is empty then we push this node onto it, as it may have child
                     // nodes which need to be yielded first.
                     self.stack.push((path, node));
-                    break
+                    break;
                 }
                 Some((top_path, _)) if path.starts_with(top_path) => {
                     // If the top of the stack is a prefix of this node, it means this node is a
                     // child of the top of the stack (and all other nodes on the stack). Push this
                     // node onto the stack, as future nodes may be children of it.
                     self.stack.push((path, node));
-                    break
+                    break;
                 }
                 Some((_, _)) => {
                     // The top of the stack is not a prefix of this node, therefore it is not a
@@ -87,7 +87,7 @@ impl<C: TrieCursor> DepthFirstTrieIterator<C> {
                 // reverse it.
                 self.complete = true;
                 self.next = core::mem::take(&mut self.stack);
-                return Ok(())
+                return Ok(());
             };
 
             trace!(
@@ -98,7 +98,7 @@ impl<C: TrieCursor> DepthFirstTrieIterator<C> {
 
             self.push(path, node);
             if !self.next.is_empty() {
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -110,15 +110,15 @@ impl<C: TrieCursor> Iterator for DepthFirstTrieIterator<C> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(next) = self.next.pop() {
-                return Some(Ok(next))
+                return Some(Ok(next));
             }
 
             if self.complete {
-                return None
+                return None;
             }
 
             if let Err(err) = self.fill_next() {
-                return Some(Err(err))
+                return Some(Err(err));
             }
         }
     }

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -192,7 +192,7 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
                 {
                     // If overlay returns a node prior to the DB's node, or the DB is exhausted,
                     // then we return the overlay's node.
-                    return Ok(Some((mem_key, node)))
+                    return Ok(Some((mem_key, node)));
                 }
                 // All other cases:
                 // - mem_key > db_key
@@ -250,14 +250,14 @@ impl<C: TrieCursor> TrieCursor for InMemoryTrieCursor<'_, C> {
 
         // If either cursor is currently pointing to the last entry which was returned then consume
         // that entry so that `choose_next_entry` is looking at the subsequent one.
-        if let Some((key, _)) = self.in_memory_cursor.current() &&
-            key == &last_key
+        if let Some((key, _)) = self.in_memory_cursor.current()
+            && key == &last_key
         {
             self.in_memory_cursor.first_after(&last_key);
         }
 
-        if let Some((key, _)) = &self.cursor_entry &&
-            key == &last_key
+        if let Some((key, _)) = &self.cursor_entry
+            && key == &last_key
         {
             self.cursor_next()?;
         }
@@ -330,8 +330,8 @@ mod tests {
 
         let mut results = Vec::new();
 
-        if let Some(first_expected) = test_case.expected_results.first() &&
-            let Ok(Some(entry)) = cursor.seek(first_expected.0)
+        if let Some(first_expected) = test_case.expected_results.first()
+            && let Ok(Some(entry)) = cursor.seek(first_expected.0)
         {
             results.push(entry);
         }

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -73,11 +73,11 @@ impl<H: HashedCursorFactory + Clone> Iterator for StateRootBranchNodesIter<H> {
         loop {
             // If we already started iterating through a storage trie's updates, continue doing
             // so.
-            if let Some((account, storage_updates)) = self.curr_storage.as_mut() &&
-                let Some((path, node)) = storage_updates.pop()
+            if let Some((account, storage_updates)) = self.curr_storage.as_mut()
+                && let Some((path, node)) = storage_updates.pop()
             {
                 let node = BranchNode::Storage(*account, path, node);
-                return Some(Ok(node))
+                return Some(Ok(node));
             }
 
             // If there's not a storage trie already being iterated over then check if there's a
@@ -91,14 +91,14 @@ impl<H: HashedCursorFactory + Clone> Iterator for StateRootBranchNodesIter<H> {
 
             // `storage_updates` is empty, check if there are account updates.
             if let Some((path, node)) = self.account_nodes.pop() {
-                return Some(Ok(BranchNode::Account(path, node)))
+                return Some(Ok(BranchNode::Account(path, node)));
             }
 
             // All data from any previous runs of the `StateRoot` has been produced, run the next
             // partial computation, unless `StateRootProgress::Complete` has been returned in which
             // case iteration is over.
             if self.complete {
-                return None
+                return None;
             }
 
             let state_root =
@@ -246,7 +246,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
             // found must be considered missing.
             if self.curr.is_none() {
                 outputs.push(self.output_missing(path, node));
-                return Ok(())
+                return Ok(());
             }
 
             let (curr_path, curr_node) = self.curr.as_ref().expect("not None");
@@ -258,7 +258,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
                     // If the given path comes before the cursor's current path in depth-first
                     // order, then the given path was not produced by the cursor.
                     outputs.push(self.output_missing(path, node));
-                    return Ok(())
+                    return Ok(());
                 }
                 Ordering::Equal => {
                     // If the current path matches the given one (happy path) but the nodes
@@ -268,7 +268,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
                         outputs.push(self.output_wrong(path, node, curr_node.clone()))
                     }
                     self.curr = self.trie_iter.next().transpose()?;
-                    return Ok(())
+                    return Ok(());
                 }
                 Ordering::Greater => {
                     // If the given path comes after the current path in depth-first order,
@@ -291,7 +291,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
                 outputs.push(self.output_extra(curr_path, curr_node));
                 self.curr = self.trie_iter.next().transpose()?;
             } else {
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -369,7 +369,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
                 account_seeked = true;
                 account_cursor.seek(last_account)?
             }) else {
-                return Ok(())
+                return Ok(());
             };
 
             if curr_account < next_account || (end_inclusive && curr_account == next_account) {
@@ -387,7 +387,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
                     self.outputs.push(Output::StorageExtra(curr_account, path, node));
                 }
             } else {
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -453,15 +453,15 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Iterator for Veri
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(output) = self.outputs.pop() {
-                return Some(Ok(output))
+                return Some(Ok(output));
             }
 
             if self.complete {
-                return None
+                return None;
             }
 
             if let Err(err) = self.try_next() {
-                return Some(Err(err))
+                return Some(Err(err));
             }
         }
     }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -188,9 +188,9 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
                 "Checked for only non-removed child",
             );
 
-            !self.changes.contains(node.full_key()) &&
-                node.hash_flag() &&
-                !key_is_only_nonremoved_child
+            !self.changes.contains(node.full_key())
+                && node.hash_flag()
+                && !key_is_only_nonremoved_child
         });
         trace!(
             target: "trie::walker",
@@ -302,7 +302,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
         let Some((key, node)) = self.node(false)? else {
             // If no next node is found, clear the stack.
             self.stack.clear();
-            return Ok(())
+            return Ok(());
         };
 
         // Overwrite the root node's first nibble
@@ -316,13 +316,13 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
         // Sanity check that the newly retrieved trie node key is the child of the last item
         // on the stack. If not, advance to the next sibling instead of adding the node to the
         // stack.
-        if let Some(subnode) = self.stack.last() &&
-            !key.starts_with(subnode.full_key())
+        if let Some(subnode) = self.stack.last()
+            && !key.starts_with(subnode.full_key())
         {
             #[cfg(feature = "metrics")]
             self.metrics.inc_out_of_order_subnode(1);
             self.move_to_next_sibling(false)?;
-            return Ok(())
+            return Ok(());
         }
 
         // Create a new CursorSubNode and push it to the stack.
@@ -333,8 +333,8 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
 
         // Delete the current node if it's included in the prefix set or it doesn't contain the root
         // hash.
-        if (!self.can_skip_current_node || position.is_child()) &&
-            let Some((keys, key)) = self.removed_keys.as_mut().zip(self.cursor.current()?)
+        if (!self.can_skip_current_node || position.is_child())
+            && let Some((keys, key)) = self.removed_keys.as_mut().zip(self.cursor.current()?)
         {
             keys.insert(key);
         }
@@ -352,18 +352,18 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
 
         // Check if the walker needs to backtrack to the previous level in the trie during its
         // traversal.
-        if subnode.position().is_last_child() ||
-            (subnode.position().is_parent() && !allow_root_to_child_nibble)
+        if subnode.position().is_last_child()
+            || (subnode.position().is_parent() && !allow_root_to_child_nibble)
         {
             self.stack.pop();
             self.move_to_next_sibling(false)?;
-            return Ok(())
+            return Ok(());
         }
 
         subnode.inc_nibble();
 
         if subnode.node.is_none() {
-            return self.consume_node()
+            return self.consume_node();
         }
 
         // Find the next sibling with state.
@@ -371,11 +371,11 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
             let position = subnode.position();
             if subnode.state_flag() {
                 trace!(target: "trie::walker", ?position, "found next sibling with state");
-                return Ok(())
+                return Ok(());
             }
             if position.is_last_child() {
                 trace!(target: "trie::walker", ?position, "checked all siblings");
-                break
+                break;
             }
             subnode.inc_nibble();
         }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -95,7 +95,7 @@ where
     pub fn compute(mut self, state: HashedPostState) -> Result<B256Map<Bytes>, TrieWitnessError> {
         let is_state_empty = state.is_empty();
         if is_state_empty && !self.always_include_root_node {
-            return Ok(Default::default())
+            return Ok(Default::default());
         }
 
         let proof_targets = if is_state_empty {
@@ -117,7 +117,7 @@ where
             } else {
                 (EMPTY_ROOT_HASH, Bytes::from([EMPTY_STRING_CODE]))
             };
-            return Ok(B256Map::from_iter([(root_hash, root_node)]))
+            return Ok(B256Map::from_iter([(root_hash, root_node)]));
         }
 
         // Record all nodes from multiproof in the witness

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -110,7 +110,7 @@ where
         let mut actions_to_queue: Vec<BlobTransactionEvent> = Vec::new();
 
         if txs.is_empty() {
-            return
+            return;
         }
 
         match self.pool.get_all_blobs_exact(txs.iter().map(|(tx, _)| *tx.tx_hash()).collect()) {
@@ -168,7 +168,7 @@ where
         // Request locally first, otherwise request from CL
         loop {
             if let Some(mined_sidecar) = this.queued_actions.pop_front() {
-                return Poll::Ready(Some(Ok(mined_sidecar)))
+                return Poll::Ready(Some(Ok(mined_sidecar)));
             }
 
             // Check if any pending requests are ready and append to buffer
@@ -253,7 +253,7 @@ async fn fetch_blobs_for_block(
                 response.status().as_u16(),
                 "Unhandled HTTP status.".to_string(),
             )),
-        }
+        };
     }
 
     let bytes = match response.bytes().await {

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -244,7 +244,7 @@ impl EngineApiValidator<CustomEngineTypes> for CustomEngineValidator {
         if attributes.custom == 0 {
             return Err(EngineObjectValidationError::invalid_params(
                 CustomError::CustomFieldIsNotZero,
-            ))
+            ));
         }
 
         Ok(())

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -56,8 +56,8 @@ fn main() {
                     let tx = event.transaction;
                     println!("Transaction received: {tx:?}");
 
-                    if let Some(recipient) = tx.to() &&
-                        args.is_match(&recipient)
+                    if let Some(recipient) = tx.to()
+                        && args.is_match(&recipient)
                     {
                         // convert the pool transaction
                         let call_request =

--- a/examples/custom-rlpx-subprotocol/src/subprotocol/connection/mod.rs
+++ b/examples/custom-rlpx-subprotocol/src/subprotocol/connection/mod.rs
@@ -35,7 +35,7 @@ impl Stream for CustomRlpxConnection {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         if let Some(initial_ping) = this.initial_ping.take() {
-            return Poll::Ready(Some(initial_ping.encoded()))
+            return Poll::Ready(Some(initial_ping.encoded()));
         }
 
         loop {
@@ -45,13 +45,13 @@ impl Stream for CustomRlpxConnection {
                         this.pending_pong = Some(response);
                         Poll::Ready(Some(CustomRlpxProtoMessage::ping_message(msg).encoded()))
                     }
-                }
+                };
             }
 
             let Some(msg) = ready!(this.conn.poll_next_unpin(cx)) else { return Poll::Ready(None) };
 
             let Some(msg) = CustomRlpxProtoMessage::decode_message(&mut &msg[..]) else {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             };
 
             match msg.message {
@@ -66,11 +66,11 @@ impl Stream for CustomRlpxConnection {
                     if let Some(sender) = this.pending_pong.take() {
                         sender.send(msg).ok();
                     }
-                    continue
+                    continue;
                 }
             }
 
-            return Poll::Pending
+            return Poll::Pending;
         }
     }
 }

--- a/examples/custom-rlpx-subprotocol/src/subprotocol/protocol/proto.rs
+++ b/examples/custom-rlpx-subprotocol/src/subprotocol/protocol/proto.rs
@@ -75,8 +75,8 @@ impl CustomRlpxProtoMessage {
         buf.put_u8(self.message_type as u8);
         match &self.message {
             CustomRlpxProtoMessageKind::Ping | CustomRlpxProtoMessageKind::Pong => {}
-            CustomRlpxProtoMessageKind::PingMessage(msg) |
-            CustomRlpxProtoMessageKind::PongMessage(msg) => {
+            CustomRlpxProtoMessageKind::PingMessage(msg)
+            | CustomRlpxProtoMessageKind::PongMessage(msg) => {
                 buf.put(msg.as_bytes());
             }
         }
@@ -86,7 +86,7 @@ impl CustomRlpxProtoMessage {
     /// Decodes a `CustomRlpxProtoMessage` from the given message buffer.
     pub fn decode_message(buf: &mut &[u8]) -> Option<Self> {
         if buf.is_empty() {
-            return None
+            return None;
         }
         let id = buf[0];
         buf.advance(1);

--- a/examples/manual-p2p/src/main.rs
+++ b/examples/manual-p2p/src/main.rs
@@ -54,14 +54,14 @@ async fn main() -> eyre::Result<()> {
             if let DiscoveryUpdate::Added(peer) = update {
                 // Boot nodes hard at work, lets not disturb them
                 if MAINNET_BOOT_NODES.contains(&peer) {
-                    return
+                    return;
                 }
 
                 let (p2p_stream, their_hello) = match handshake_p2p(peer, our_key).await {
                     Ok(s) => s,
                     Err(e) => {
                         println!("Failed P2P handshake with peer {}, {}", peer.address, e);
-                        return
+                        return;
                     }
                 };
 
@@ -69,7 +69,7 @@ async fn main() -> eyre::Result<()> {
                     Ok(s) => s,
                     Err(e) => {
                         println!("Failed ETH handshake with peer {}, {}", peer.address, e);
-                        return
+                        return;
                     }
                 };
 

--- a/examples/node-custom-rpc/src/main.rs
+++ b/examples/node-custom-rpc/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
                 // extend the rpc modules with our custom `TxpoolExt` endpoints
                 .extend_rpc_modules(move |ctx| {
                     if !args.enable_ext {
-                        return Ok(())
+                        return Ok(());
                     }
 
                     // here we get the configured pool.

--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -139,7 +139,7 @@ impl Precompile for WrappedPrecompile {
 
         // get the result if it exists
         if let Some(result) = cache.cache.get(&key) {
-            return result.clone()
+            return result.clone();
         }
 
         // call the precompile if cache miss

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -44,8 +44,8 @@ fn main() {
                     let tx = event.transaction;
                     println!("Transaction received: {tx:?}");
 
-                    if let Some(recipient) = tx.to() &&
-                        args.is_match(&recipient)
+                    if let Some(recipient) = tx.to()
+                        && args.is_match(&recipient)
                     {
                         // trace the transaction with `trace_call`
                         let callrequest =

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -64,12 +64,12 @@ impl BlockchainTestCase {
     const fn excluded_fork(network: ForkSpec) -> bool {
         matches!(
             network,
-            ForkSpec::ByzantiumToConstantinopleAt5 |
-                ForkSpec::Constantinople |
-                ForkSpec::ConstantinopleFix |
-                ForkSpec::MergeEOF |
-                ForkSpec::MergeMeterInitCode |
-                ForkSpec::MergePush0
+            ForkSpec::ByzantiumToConstantinopleAt5
+                | ForkSpec::Constantinople
+                | ForkSpec::ConstantinopleFix
+                | ForkSpec::MergeEOF
+                | ForkSpec::MergeMeterInitCode
+                | ForkSpec::MergePush0
         )
     }
 
@@ -258,7 +258,8 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
             &output.receipts,
             &output.requests,
             None,
-            &output.block_access_list,
+            &None,
+            false,
             Some(output.gas_used),
         )
         .map_err(|err| Error::block_failed(block_number, err))?;

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -250,12 +250,12 @@ impl Account {
                 } else {
                     return Err(Error::Assertion(format!(
                         "Slot {slot:?} is missing from the database. Expected {value:?}"
-                    )))
+                    )));
                 }
             } else {
                 return Err(Error::Assertion(format!(
                     "Slot {slot:?} is missing from the database. Expected {value:?}"
-                )))
+                )));
             }
         }
 

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -345,7 +345,7 @@ where
                 let old = if entry.value.is_zero() {
                     let old = storage.remove(&entry.key);
                     if matches!(old, Some(U256::ZERO)) {
-                        return None
+                        return None;
                     }
                     old
                 } else {


### PR DESCRIPTION
## Summary
- Adapts to upstream `alloy-evm` `bal-devnet2` branch removing `block_access_list` from `BlockExecutionResult`
- BAL tracking now uses `db.take_built_alloy_bal()` and `db.bump_bal_index()` from the database `State` object
- Updates `FullConsensus::validate_block_post_execution` trait to accept `block_access_list` and `allow_bal_check` params
- Adds `gas_limit()` to `ExecutionPayload` trait for BAL gas validation
- Fixes `Withdrawals` type changes and `map_cacheable_precompiles` rename from alloy-evm
- Includes formatting fixes from `cargo fmt` after merging main

## Test plan
- [x] `cargo check --bin reth` passes
- [ ] CI should build the Docker image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)