### PR TITLE
fix(tasks): install panic handler on all worker pools

### DIFF
--- a/.changelog/dark-ants-write.md
+++ b/.changelog/dark-ants-write.md
@@ -1,0 +1,5 @@
+---
+reth-tasks: patch
+---
+
+Added panic handler to `WorkerPool::from_builder` that logs panics via `tracing::error` instead of aborting the process.

--- a/.changelog/dark-ants-write.md
+++ b/.changelog/dark-ants-write.md
@@ -2,4 +2,4 @@
 reth-tasks: patch
 ---
 
-Added panic handler to `WorkerPool::from_builder` that logs panics via `tracing::error` instead of aborting the process.
+Added panic handler to all rayon thread pools that logs panics via `tracing::error` instead of aborting the process.

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -40,7 +40,7 @@ pub(crate) mod worker_map;
 #[cfg(feature = "rayon")]
 pub mod pool;
 #[cfg(feature = "rayon")]
-pub use pool::{Worker, WorkerPool};
+pub use pool::{build_pool_with_panic_handler, Worker, WorkerPool};
 
 /// Lock-free ordered parallel iterator extension trait.
 #[cfg(feature = "rayon")]

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -180,10 +180,23 @@ impl WorkerPool {
     }
 
     /// Creates a new `WorkerPool` from a [`rayon::ThreadPoolBuilder`].
+    ///
+    /// Installs a panic handler that logs panics instead of aborting the process.
     pub fn from_builder(
         builder: rayon::ThreadPoolBuilder,
     ) -> Result<Self, rayon::ThreadPoolBuildError> {
-        Ok(Self { pool: builder.build()? })
+        Ok(Self {
+            pool: builder
+                .panic_handler(|payload| {
+                    let msg = payload
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
+                        .unwrap_or("(no message)");
+                    tracing::error!(target: "reth::tasks", %msg, "panic in worker pool thread");
+                })
+                .build()?,
+        })
     }
 
     /// Returns the total number of threads in the underlying rayon pool.

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -185,18 +185,7 @@ impl WorkerPool {
     pub fn from_builder(
         builder: rayon::ThreadPoolBuilder,
     ) -> Result<Self, rayon::ThreadPoolBuildError> {
-        Ok(Self {
-            pool: builder
-                .panic_handler(|payload| {
-                    let msg = payload
-                        .downcast_ref::<&str>()
-                        .copied()
-                        .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
-                        .unwrap_or("(no message)");
-                    tracing::error!(target: "reth::tasks", %msg, "panic in worker pool thread");
-                })
-                .build()?,
-        })
+        Ok(Self { pool: build_pool_with_panic_handler(builder)? })
     }
 
     /// Returns the total number of threads in the underlying rayon pool.
@@ -294,6 +283,23 @@ impl WorkerPool {
     pub fn with_worker_mut<R>(f: impl FnOnce(&mut Worker) -> R) -> R {
         WORKER.with_borrow_mut(|worker| f(worker))
     }
+}
+
+/// Builds a rayon thread pool with a panic handler that logs panics via `tracing::error` instead of
+/// aborting the process.
+pub fn build_pool_with_panic_handler(
+    builder: rayon::ThreadPoolBuilder,
+) -> Result<rayon::ThreadPool, rayon::ThreadPoolBuildError> {
+    builder
+        .panic_handler(|payload| {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
+                .unwrap_or("(no message)");
+            tracing::error!(target: "reth::tasks", %msg, "panic in rayon thread pool thread");
+        })
+        .build()
 }
 
 /// Per-thread state container for a [`WorkerPool`].

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -285,21 +285,14 @@ impl WorkerPool {
     }
 }
 
-/// Builds a rayon thread pool with a panic handler that logs panics via `tracing::error` instead of
-/// aborting the process.
+/// Builds a rayon thread pool with a panic handler that prevents aborting the process.
+///
+/// Rust's default panic hook already logs the panic message and backtrace to stderr, so the handler
+/// itself is intentionally a no-op.
 pub fn build_pool_with_panic_handler(
     builder: rayon::ThreadPoolBuilder,
 ) -> Result<rayon::ThreadPool, rayon::ThreadPoolBuildError> {
-    builder
-        .panic_handler(|payload| {
-            let msg = payload
-                .downcast_ref::<&str>()
-                .copied()
-                .or_else(|| payload.downcast_ref::<String>().map(|s| s.as_str()))
-                .unwrap_or("(no message)");
-            tracing::error!(target: "reth::tasks", %msg, "panic in rayon thread pool thread");
-        })
-        .build()
+    builder.panic_handler(|_| {}).build()
 }
 
 /// Per-thread state container for a [`WorkerPool`].

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -7,7 +7,7 @@
 //! - [`BlockingTaskGuard`] for rate-limiting expensive operations (with `rayon` feature)
 
 #[cfg(feature = "rayon")]
-use crate::pool::{BlockingTaskGuard, BlockingTaskPool, WorkerPool};
+use crate::pool::{build_pool_with_panic_handler, BlockingTaskGuard, BlockingTaskPool, WorkerPool};
 use crate::{
     metrics::{IncCounterOnDrop, TaskExecutorMetrics},
     shutdown::{GracefulShutdown, GracefulShutdownGuard, Shutdown},
@@ -790,23 +790,26 @@ impl RuntimeBuilder {
             let default_threads = config.rayon.default_thread_count();
             let rpc_threads = config.rayon.rpc_threads.unwrap_or(default_threads);
 
-            let cpu_pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(default_threads)
-                .thread_name(|i| format!("cpu-{i:02}"))
-                .build()?;
+            let cpu_pool = build_pool_with_panic_handler(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(default_threads)
+                    .thread_name(|i| format!("cpu-{i:02}")),
+            )?;
 
-            let rpc_raw = rayon::ThreadPoolBuilder::new()
-                .num_threads(rpc_threads)
-                .thread_name(|i| format!("rpc-{i:02}"))
-                .build()?;
+            let rpc_raw = build_pool_with_panic_handler(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(rpc_threads)
+                    .thread_name(|i| format!("rpc-{i:02}")),
+            )?;
             let rpc_pool = BlockingTaskPool::new(rpc_raw);
 
             let storage_threads =
                 config.rayon.storage_threads.unwrap_or(DEFAULT_STORAGE_POOL_THREADS);
-            let storage_pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(storage_threads)
-                .thread_name(|i| format!("storage-{i:02}"))
-                .build()?;
+            let storage_pool = build_pool_with_panic_handler(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(storage_threads)
+                    .thread_name(|i| format!("storage-{i:02}")),
+            )?;
 
             let blocking_guard = BlockingTaskGuard::new(config.rayon.max_blocking_tasks);
 


### PR DESCRIPTION
Without a panic handler, a panic on any WorkerPool thread (proof-acct, proof-stg, prewarm) aborts the process. Install a handler in WorkerPool::from_builder that logs the panic instead.