### PR TITLE
fix(engine): split persistence and pruning into separate transactions

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -9,6 +9,10 @@ pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;
 /// How close to the canonical head we persist blocks.
 pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 
+/// Default maximum number of entries the persistence pruner may delete per run.
+/// Caps MDBX dirty page accumulation to ~400 MB (100k entries × ~4 KB pages).
+pub const DEFAULT_PERSISTENCE_PRUNER_DELETE_LIMIT: usize = 100_000;
+
 /// The size of proof targets chunk to spawn in one multiproof calculation.
 pub const DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE: usize = 5;
 
@@ -153,6 +157,13 @@ pub struct TreeConfig {
     /// computation is spawned in parallel and whichever finishes first is used.
     /// If `None`, the timeout fallback is disabled.
     state_root_task_timeout: Option<Duration>,
+    /// Maximum number of entries the persistence pruner may delete in a single run.
+    /// Limits MDBX dirty page accumulation to prevent OOM during the first prune after startup.
+    persistence_pruner_delete_limit: usize,
+    /// Timeout for the persistence pruner per run. Prevents a single prune from blocking
+    /// block persistence for too long. Account and Storage History segments treat this as
+    /// a soft limit.
+    persistence_pruner_timeout: Option<Duration>,
     /// Maximum random jitter applied before each proof computation (trie-debug only).
     /// When set, each proof worker sleeps for a random duration up to this value
     /// before starting a proof calculation.
@@ -189,6 +200,8 @@ impl Default for TreeConfig {
             disable_sparse_trie_cache_pruning: false,
             enable_arena_sparse_trie: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
+            persistence_pruner_delete_limit: DEFAULT_PERSISTENCE_PRUNER_DELETE_LIMIT,
+            persistence_pruner_timeout: None,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -251,6 +264,8 @@ impl TreeConfig {
             disable_sparse_trie_cache_pruning: false,
             enable_arena_sparse_trie: false,
             state_root_task_timeout,
+            persistence_pruner_delete_limit: DEFAULT_PERSISTENCE_PRUNER_DELETE_LIMIT,
+            persistence_pruner_timeout: None,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -571,6 +586,28 @@ impl TreeConfig {
     /// Setter for state root task timeout.
     pub const fn with_state_root_task_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.state_root_task_timeout = timeout;
+        self
+    }
+
+    /// Returns the persistence pruner delete limit.
+    pub const fn persistence_pruner_delete_limit(&self) -> usize {
+        self.persistence_pruner_delete_limit
+    }
+
+    /// Setter for persistence pruner delete limit.
+    pub const fn with_persistence_pruner_delete_limit(mut self, limit: usize) -> Self {
+        self.persistence_pruner_delete_limit = limit;
+        self
+    }
+
+    /// Returns the persistence pruner timeout.
+    pub const fn persistence_pruner_timeout(&self) -> Option<Duration> {
+        self.persistence_pruner_timeout
+    }
+
+    /// Setter for persistence pruner timeout.
+    pub const fn with_persistence_pruner_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.persistence_pruner_timeout = timeout;
         self
     }
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -161,6 +161,11 @@ where
         let start_time = Instant::now();
 
         if let Some(last) = last_block {
+            // Commit block data immediately so persistence is not blocked by pruning.
+            // The pruner can take hours on the first run after startup (its
+            // previous_tip_block_number starts at None, triggering a full segment scan
+            // even when the pipeline already pruned). Running it in a separate transaction
+            // ensures blocks become durable on disk without waiting for pruning to finish.
             let provider_rw = self.provider.database_provider_rw()?;
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
 
@@ -177,14 +182,16 @@ where
                 }
             }
 
+            provider_rw.commit()?;
+
             if self.pruner.is_pruning_needed(last.number) {
                 debug!(target: "engine::persistence", block_num=?last.number, "Running pruner");
                 let prune_start = Instant::now();
+                let provider_rw = self.provider.database_provider_rw()?;
                 let _ = self.pruner.run_with_provider(&provider_rw, last.number)?;
+                provider_rw.commit()?;
                 self.metrics.prune_before_duration_seconds.record(prune_start.elapsed());
             }
-
-            provider_rw.commit()?;
         }
 
         debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1305,6 +1305,15 @@ where
             } else if self.should_persist() {
                 let blocks_to_persist =
                     self.get_canonical_blocks_to_persist(PersistTarget::Threshold)?;
+                if blocks_to_persist.is_empty() {
+                    warn!(
+                        target: "engine::tree",
+                        canonical_head = ?self.state.tree_state.canonical_head(),
+                        last_persisted = ?self.persistence_state.last_persisted_block,
+                        "should_persist=true but no blocks found to persist; \
+                         canonical head may not be in memory"
+                    );
+                }
                 self.persist_blocks(blocks_to_persist);
             }
         }

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -170,6 +170,11 @@ impl EngineNodeLauncher {
             pruner_builder =
                 pruner_builder.finished_exex_height(exex_manager_handle.finished_height());
         }
+        pruner_builder =
+            pruner_builder.delete_limit(engine_tree_config.persistence_pruner_delete_limit());
+        if let Some(timeout) = engine_tree_config.persistence_pruner_timeout() {
+            pruner_builder = pruner_builder.timeout(timeout);
+        }
         let pruner = pruner_builder.build_with_provider_factory(ctx.provider_factory().clone());
         let pruner_events = pruner.events();
         info!(target: "reth::cli", prune_config=?ctx.prune_config(), "Pruner initialized");

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -3,8 +3,8 @@
 use clap::{builder::Resettable, Args};
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
 use reth_engine_primitives::{
-    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS,
-    DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
+    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_PERSISTENCE_PRUNER_DELETE_LIMIT,
+    DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS, DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -403,6 +403,25 @@ pub struct EngineArgs {
     )]
     pub state_root_task_timeout: Option<Duration>,
 
+    /// Maximum number of entries the persistence pruner may delete in a single run.
+    /// Limits MDBX dirty page accumulation to prevent OOM when the pruner runs for the
+    /// first time after startup on a large database.
+    ///
+    /// Set to 0 to disable the limit (unlimited).
+    #[arg(long = "engine.persistence-pruner-delete-limit", default_value_t = DEFAULT_PERSISTENCE_PRUNER_DELETE_LIMIT)]
+    pub persistence_pruner_delete_limit: usize,
+
+    /// Timeout for the persistence pruner per run. Prevents a single prune from blocking
+    /// block persistence for too long.
+    ///
+    /// CAUTION: Account and Storage History segments treat this as a soft limit.
+    ///
+    /// Set to 0s to disable.
+    ///
+    /// --engine.persistence-pruner-timeout 30s
+    #[arg(long = "engine.persistence-pruner-timeout", value_parser = humantime::parse_duration)]
+    pub persistence_pruner_timeout: Option<Duration>,
+
     /// Add random jitter before each proof computation (trie-debug only).
     /// Each proof worker sleeps for a random duration up to this value before
     /// starting work. Useful for stress-testing timing-sensitive proof logic.
@@ -478,6 +497,8 @@ impl Default for EngineArgs {
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
+            persistence_pruner_delete_limit: DEFAULT_PERSISTENCE_PRUNER_DELETE_LIMIT,
+            persistence_pruner_timeout: None,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -510,7 +531,15 @@ impl EngineArgs {
             .with_slow_block_threshold(self.slow_block_threshold)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
             .with_enable_arena_sparse_trie(self.enable_arena_sparse_trie)
-            .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()));
+            .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()))
+            .with_persistence_pruner_delete_limit(if self.persistence_pruner_delete_limit == 0 {
+                usize::MAX
+            } else {
+                self.persistence_pruner_delete_limit
+            })
+            .with_persistence_pruner_timeout(
+                self.persistence_pruner_timeout.filter(|d| !d.is_zero()),
+            );
         #[cfg(feature = "trie-debug")]
         let config = config.with_proof_jitter(self.proof_jitter);
         config
@@ -569,6 +598,8 @@ mod tests {
             disable_sparse_trie_cache_pruning: true,
             enable_arena_sparse_trie: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
+            persistence_pruner_delete_limit: 100_000,
+            persistence_pruner_timeout: Some(Duration::from_secs(30)),
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         };
@@ -610,6 +641,10 @@ mod tests {
             "--engine.enable-arena-sparse-trie",
             "--engine.state-root-task-timeout",
             "2s",
+            "--engine.persistence-pruner-delete-limit",
+            "100000",
+            "--engine.persistence-pruner-timeout",
+            "30s",
         ])
         .args;
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1020,6 +1020,22 @@ Engine:
 
           [default: 1s]
 
+      --engine.persistence-pruner-delete-limit <PERSISTENCE_PRUNER_DELETE_LIMIT>
+          Maximum number of entries the persistence pruner may delete in a single run. Limits MDBX dirty page accumulation to prevent OOM when the pruner runs for the first time after startup on a large database.
+
+          Set to 0 to disable the limit (unlimited).
+
+          [default: 100000]
+
+      --engine.persistence-pruner-timeout <PERSISTENCE_PRUNER_TIMEOUT>
+          Timeout for the persistence pruner per run. Prevents a single prune from blocking block persistence for too long.
+
+          CAUTION: Account and Storage History segments treat this as a soft limit.
+
+          Set to 0s to disable.
+
+          --engine.persistence-pruner-timeout 30s
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/reth/issues/21093

## Problem

When running reth with `--full --engine.persistence-threshold=0 --engine.memory-block-buffer-target=0`, blocks accumulate in memory and are never committed to disk. Killing and restarting the node repeats the same behavior indefinitely.

The root cause is that `save_blocks` and the pruner share a single MDBX write transaction. On every startup the pruner's `previous_tip_block_number` resets to `None`, which unconditionally triggers `is_pruning_needed`. With `--full` mode, pruner segments (sender_recovery, receipts, account_history, storage_history) activate with unlimited `delete_limit` and no timeout. The pruner then scans and deletes across the entire history in one transaction, accumulating dirty pages in RAM until the process is OOM-killed or I give up and restart -- which rolls back the transaction, losing both the pruned data *and* the blocks that were supposed to be saved.

## Fix

**Split the write transaction** so blocks are committed to disk immediately, before the pruner runs. The pruner then opens its own write transaction. If the pruner is slow or crashes, the blocks are already durable.

**Add configurable pruner limits** to cap how much work the persistence pruner does per cycle:

- `--engine.persistence-pruner-delete-limit` (default: 100,000; 0 = unlimited) -- caps MDBX dirty page accumulation to ~400 MB per run
- `--engine.persistence-pruner-timeout` (default: none; 0s = disabled) -- soft time bound per pruner run

**Add a diagnostic warning** when `should_persist` is true but no blocks are found to persist, which helps identify the case where the canonical head is not in memory.

I verified the fix on three different reth node deployments