### PR TITLE
fix(provider): heal finalized/safe block numbers ahead of highest header

### DIFF
--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -394,8 +394,8 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
 
                         let last_saved_safe_block_number = provider_rw.last_safe_block_number()?;
 
-                        if last_saved_safe_block_number.is_none()
-                            || Some(checkpoint.block_number) < last_saved_safe_block_number
+                        if last_saved_safe_block_number.is_none() ||
+                            Some(checkpoint.block_number) < last_saved_safe_block_number
                         {
                             provider_rw.save_safe_block_number(BlockNumber::from(
                                 checkpoint.block_number,

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -378,7 +378,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             });
                         }
 
-                        // update finalized block if needed
+                        // update finalized and safe block if needed
                         let last_saved_finalized_block_number =
                             provider_rw.last_finalized_block_number()?;
 
@@ -388,6 +388,16 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             Some(checkpoint.block_number) < last_saved_finalized_block_number
                         {
                             provider_rw.save_finalized_block_number(BlockNumber::from(
+                                checkpoint.block_number,
+                            ))?;
+                        }
+
+                        let last_saved_safe_block_number = provider_rw.last_safe_block_number()?;
+
+                        if last_saved_safe_block_number.is_none()
+                            || Some(checkpoint.block_number) < last_saved_safe_block_number
+                        {
+                            provider_rw.save_safe_block_number(BlockNumber::from(
                                 checkpoint.block_number,
                             ))?;
                         }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -367,55 +367,47 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             },
         );
 
-        drop(provider_ro);
-
-        // Step 4: Heal finalized/safe block numbers if they are ahead of the
-        // highest header. This can happen on 1.10.x when the node shuts down
-        // after flushing the finalized block number but before persisting the
-        // corresponding blocks/state.
-        self.heal_chain_state_block_numbers()?;
+        // Step 4: Heal finalized/safe block numbers that may be ahead of the
+        // highest header on nodes coming from <=1.10.2.
+        if rocksdb_unwind.is_none() && static_file_unwind.is_none() {
+            self.heal_chain_state_block_numbers(&provider_ro)?;
+        }
 
         Ok((rocksdb_unwind, static_file_unwind))
     }
 
     /// Checks if the stored finalized or safe block numbers exceed the highest
     /// known header and corrects them if so.
-    ///
-    /// On 1.10.x, the finalized block number is always flushed but blocks and
-    /// state are batched, so a shutdown can leave the finalized number ahead of
-    /// the actual tip. This also handles the analogous case for the safe block.
-    fn heal_chain_state_block_numbers(&self) -> ProviderResult<()> {
+    fn heal_chain_state_block_numbers(
+        &self,
+        provider_ro: &DatabaseProvider<<N::DB as Database>::TX, N>,
+    ) -> ProviderResult<()> {
         let highest_header = self.last_block_number()?;
 
-        // Read with a RO provider first to avoid opening a write tx unnecessarily.
-        let provider_ro = self.database_provider_ro()?;
         let finalized = provider_ro.last_finalized_block_number()?;
         let safe = provider_ro.last_safe_block_number()?;
-        drop(provider_ro);
 
-        let heal_finalized = finalized.is_some_and(|f| f > highest_header);
-        let heal_safe = safe.is_some_and(|s| s > highest_header);
-
-        if !heal_finalized && !heal_safe {
+        if finalized.is_none_or(|f| f <= highest_header) && safe.is_none_or(|s| s <= highest_header)
+        {
             return Ok(());
         }
 
         let provider_rw = self.provider_rw()?;
 
-        if heal_finalized {
+        if let Some(finalized) = finalized.filter(|&f| f > highest_header) {
             info!(
                 target: "providers::db",
-                finalized = finalized.expect("checked above"),
+                finalized,
                 highest_header,
                 "Healing finalized block number",
             );
             provider_rw.save_finalized_block_number(highest_header)?;
         }
 
-        if heal_safe {
+        if let Some(safe) = safe.filter(|&s| s > highest_header) {
             info!(
                 target: "providers::db",
-                safe = safe.expect("checked above"),
+                safe,
                 highest_header,
                 "Healing safe block number",
             );

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -28,8 +28,8 @@ use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{PipelineTarget, StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
-    BlockBodyIndicesProvider, NodePrimitivesProvider, StorageSettings, StorageSettingsCache,
-    TryIntoHistoricalStateProvider,
+    BlockBodyIndicesProvider, ChainStateBlockReader, ChainStateBlockWriter, NodePrimitivesProvider,
+    StorageSettings, StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::HashedPostState;
@@ -40,7 +40,7 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use tracing::{instrument, trace};
+use tracing::{info, instrument, trace};
 
 mod provider;
 pub use provider::{
@@ -367,7 +367,64 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             },
         );
 
+        drop(provider_ro);
+
+        // Step 4: Heal finalized/safe block numbers if they are ahead of the
+        // highest header. This can happen on 1.10.x when the node shuts down
+        // after flushing the finalized block number but before persisting the
+        // corresponding blocks/state.
+        self.heal_chain_state_block_numbers()?;
+
         Ok((rocksdb_unwind, static_file_unwind))
+    }
+
+    /// Checks if the stored finalized or safe block numbers exceed the highest
+    /// known header and corrects them if so.
+    ///
+    /// On 1.10.x, the finalized block number is always flushed but blocks and
+    /// state are batched, so a shutdown can leave the finalized number ahead of
+    /// the actual tip. This also handles the analogous case for the safe block.
+    fn heal_chain_state_block_numbers(&self) -> ProviderResult<()> {
+        let highest_header = self.last_block_number()?;
+
+        // Read with a RO provider first to avoid opening a write tx unnecessarily.
+        let provider_ro = self.database_provider_ro()?;
+        let finalized = provider_ro.last_finalized_block_number()?;
+        let safe = provider_ro.last_safe_block_number()?;
+        drop(provider_ro);
+
+        let heal_finalized = finalized.is_some_and(|f| f > highest_header);
+        let heal_safe = safe.is_some_and(|s| s > highest_header);
+
+        if !heal_finalized && !heal_safe {
+            return Ok(());
+        }
+
+        let provider_rw = self.provider_rw()?;
+
+        if heal_finalized {
+            info!(
+                target: "providers::db",
+                finalized = finalized.expect("checked above"),
+                highest_header,
+                "Healing finalized block number",
+            );
+            provider_rw.save_finalized_block_number(highest_header)?;
+        }
+
+        if heal_safe {
+            info!(
+                target: "providers::db",
+                safe = safe.expect("checked above"),
+                highest_header,
+                "Healing safe block number",
+            );
+            provider_rw.save_safe_block_number(highest_header)?;
+        }
+
+        provider_rw.commit()?;
+
+        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -378,8 +378,8 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
         Ok((rocksdb_unwind, static_file_unwind))
     }
 
-    /// Checks if the stored finalized or safe block numbers exceed the highest
-    /// known header and corrects them if so.
+    /// If the stored finalized or safe block number is ahead of the highest
+    /// header, resets it to the highest header.
     fn heal_chain_state_block_numbers(
         &self,
         provider_ro: &DatabaseProvider<<N::DB as Database>::TX, N>,

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -369,6 +369,8 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
 
         // Step 4: Heal finalized/safe block numbers that may be ahead of the
         // highest header on nodes coming from <=1.10.2.
+        //
+        // Unwinds already set it to the target block.
         if rocksdb_unwind.is_none() && static_file_unwind.is_none() {
             self.heal_chain_state_block_numbers(&provider_ro)?;
         }


### PR DESCRIPTION
## Summary

On 1.10.x shutdown, the finalized block number is always flushed but blocks/state are batched. This can leave finalized (and safe) block numbers ahead of the actual tip in the database. Any node upgrading from 1.10.x starts with this inconsistent state.

## Changes

- Added `heal_chain_state_block_numbers()` to `ProviderFactory`, called as Step 4 at the end of `check_consistency()` when no unwind is needed
- Reads finalized/safe block numbers and compares against `last_block_number()` (highest header from static files)
- If either exceeds the highest header, opens a write tx and corrects them

### Drive-by

- Pipeline unwind was only bringing down finalized but not safe — added `save_safe_block_number` next to the existing `save_finalized_block_number` in the unwind loop

## Testing

- `cargo check -p reth-provider reth-stages-api` ✅
- `cargo clippy -p reth-provider --no-deps -- -D warnings` ✅

Prompted by: joshie

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>