### PR TITLE
feat(bench): show baseline/feature CLI args in Slack notification

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -7,6 +7,8 @@
 //   BENCH_PR               – PR number (may be empty)
 //   BENCH_ACTOR            – GitHub user who triggered the bench
 //   BENCH_JOB_URL          – URL to the Actions job page
+//   BENCH_BASELINE_ARGS    – Extra CLI args for the baseline reth node
+//   BENCH_FEATURE_ARGS     – Extra CLI args for the feature reth node
 //   BENCH_SAMPLY           – 'true' if samply profiling was enabled
 //
 // Usage from actions/github-script:
@@ -132,7 +134,13 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
   if (cores !== '0') countsParts.push(`*Cores:* ${cores}`);
   const countsLine = countsParts.join(' | ');
 
-  const sectionText = [metaParts.join(' | '), '', baselineLine, featureLine, countsLine].join('\n');
+  const baselineArgs = process.env.BENCH_BASELINE_ARGS || '';
+  const featureArgs = process.env.BENCH_FEATURE_ARGS || '';
+  const argsLines = [];
+  if (baselineArgs) argsLines.push(`*Baseline Args:* \`${baselineArgs}\``);
+  if (featureArgs) argsLines.push(`*Feature Args:* \`${featureArgs}\``);
+
+  const sectionText = [metaParts.join(' | '), '', baselineLine, featureLine, ...argsLines, countsLine].join('\n');
 
   // Action buttons
   const diffUrl = `https://github.com/${repo}/compare/${summary.baseline.ref}...${summary.feature.ref}`;


### PR DESCRIPTION
When `baseline-args` or `feature-args` are set (e.g. `--engine.enable-arena-sparse-trie`), they now appear in the Slack notification between the baseline/feature ref lines and the block counts.

Only shown when non-empty, so existing notifications are unchanged.

Prompted by: alexey