### PR TITLE
fix(provider): heal finalized/safe block numbers ahead of highest header

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -66,8 +66,9 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BlockHashReader, BlockNumReader, DatabaseProviderFactory, ProviderError, ProviderFactory,
-    ProviderResult, RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
+    BlockHashReader, BlockNumReader, ChainStateBlockReader, ChainStateBlockWriter,
+    DatabaseProviderFactory, ProviderError, ProviderFactory, ProviderResult,
+    RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
     StaticFileProviderFactory,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
@@ -528,6 +529,45 @@ where
                 PipelineTarget::Unwind(block) => block,
                 PipelineTarget::Sync(_) => unreachable!("check_consistency returns Unwind"),
             });
+
+        // Step 4: Heal finalized/safe block numbers that may be ahead of the
+        // highest header on nodes coming from <=1.10.2.
+        //
+        // Unwinds already set it to the target block, so only heal when no
+        // unwind is required.
+        if rocksdb_unwind.is_none() && static_file_unwind.is_none() {
+            let highest_header = factory.last_block_number()?;
+            let finalized = provider_ro.last_finalized_block_number()?;
+            let safe = provider_ro.last_safe_block_number()?;
+
+            if finalized.is_some_and(|f| f > highest_header) ||
+                safe.is_some_and(|s| s > highest_header)
+            {
+                let provider_rw = factory.provider_rw()?;
+
+                if let Some(finalized) = finalized.filter(|&f| f > highest_header) {
+                    info!(
+                        target: "reth::cli",
+                        finalized,
+                        highest_header,
+                        "Healing finalized block number",
+                    );
+                    provider_rw.save_finalized_block_number(highest_header)?;
+                }
+
+                if let Some(safe) = safe.filter(|&s| s > highest_header) {
+                    info!(
+                        target: "reth::cli",
+                        safe,
+                        highest_header,
+                        "Healing safe block number",
+                    );
+                    provider_rw.save_safe_block_number(highest_header)?;
+                }
+
+                provider_rw.commit()?;
+            }
+        }
 
         // Take the minimum block number to ensure all storage layers are consistent.
         let unwind_target = [rocksdb_unwind, static_file_unwind].into_iter().flatten().min();

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -378,7 +378,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             });
                         }
 
-                        // update finalized block if needed
+                        // update finalized and safe block if needed
                         let last_saved_finalized_block_number =
                             provider_rw.last_finalized_block_number()?;
 
@@ -388,6 +388,16 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             Some(checkpoint.block_number) < last_saved_finalized_block_number
                         {
                             provider_rw.save_finalized_block_number(BlockNumber::from(
+                                checkpoint.block_number,
+                            ))?;
+                        }
+
+                        let last_saved_safe_block_number = provider_rw.last_safe_block_number()?;
+
+                        if last_saved_safe_block_number.is_none() ||
+                            Some(checkpoint.block_number) < last_saved_safe_block_number
+                        {
+                            provider_rw.save_safe_block_number(BlockNumber::from(
                                 checkpoint.block_number,
                             ))?;
                         }


### PR DESCRIPTION
## Summary
Backport of [294e215](https://github.com/paradigmxyz/reth/commit/294e215) (`fix(provider): heal finalized/safe block numbers ahead of highest header (#22995)`) adapted for `tempo/v1.10.2`.

The upstream commit couldn't be cherry-picked cleanly because it relies on `ProviderFactory::check_consistency` and `ProviderError::MustUnwind` which don't exist on this branch. This PR manually adapts the fix to the branch's architecture.

## Changes

- `crates/node/builder/src/launch/common.rs`: Added Step 4 to the startup consistency check — if the stored finalized or safe block number is ahead of the highest header, reset it to the highest header. Only runs when no unwind is needed (unwinds already set it to the target block).
- `crates/stages/api/src/pipeline/mod.rs`: Update safe block number during pipeline unwind, matching the existing finalized block number logic.

## Testing
- `cargo check -p reth-stages-api -p reth-node-builder` passes
- `cargo +nightly fmt --all --check` passes

Prompted by: joshie

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>