### PR TITLE
feat(engine): expose max_targets_for_chunking as CLI arg

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -15,6 +15,10 @@ pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 0;
 /// The size of proof targets chunk to spawn in one multiproof calculation.
 pub const DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE: usize = 5;
 
+/// The default max targets for limiting the number of account and storage proof targets to be
+/// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.
+pub const DEFAULT_MULTIPROOF_MAX_TARGETS_FOR_CHUNKING: usize = 300;
+
 /// Gas threshold below which the small block chunk size is used.
 pub const SMALL_BLOCK_GAS_THRESHOLD: u64 = 20_000_000;
 
@@ -125,6 +129,8 @@ pub struct TreeConfig {
     has_enough_parallelism: bool,
     /// Multiproof task chunk size for proof targets.
     multiproof_chunk_size: usize,
+    /// Max targets for forcing multiproof chunking regardless of worker availability.
+    multiproof_max_targets_for_chunking: usize,
     /// Number of reserved CPU cores for non-reth processes
     reserved_cpu_cores: usize,
     /// Whether to disable the precompile cache
@@ -198,6 +204,7 @@ impl Default for TreeConfig {
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE,
             has_enough_parallelism: has_enough_parallelism(),
             multiproof_chunk_size: DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
+            multiproof_max_targets_for_chunking: DEFAULT_MULTIPROOF_MAX_TARGETS_FOR_CHUNKING,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_disabled: false,
             state_root_fallback: false,
@@ -269,6 +276,7 @@ impl TreeConfig {
             cross_block_cache_size,
             has_enough_parallelism,
             multiproof_chunk_size,
+            multiproof_max_targets_for_chunking: DEFAULT_MULTIPROOF_MAX_TARGETS_FOR_CHUNKING,
             reserved_cpu_cores,
             precompile_cache_disabled,
             state_root_fallback,
@@ -326,6 +334,11 @@ impl TreeConfig {
     /// Return the effective multiproof task chunk size.
     pub const fn effective_multiproof_chunk_size(&self) -> usize {
         self.multiproof_chunk_size
+    }
+
+    /// Return the max targets threshold for forcing multiproof chunking.
+    pub const fn multiproof_max_targets_for_chunking(&self) -> usize {
+        self.multiproof_max_targets_for_chunking
     }
 
     /// Return the number of reserved CPU cores for non-reth processes
@@ -501,6 +514,15 @@ impl TreeConfig {
     /// Setter for multiproof task chunk size for proof targets.
     pub const fn with_multiproof_chunk_size(mut self, multiproof_chunk_size: usize) -> Self {
         self.multiproof_chunk_size = multiproof_chunk_size;
+        self
+    }
+
+    /// Setter for max targets threshold for forcing multiproof chunking.
+    pub const fn with_multiproof_max_targets_for_chunking(
+        mut self,
+        max_targets_for_chunking: usize,
+    ) -> Self {
+        self.multiproof_max_targets_for_chunking = max_targets_for_chunking;
         self
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -349,6 +349,7 @@ where
             from_multi_proof,
             parent_state_root,
             config.multiproof_chunk_size(),
+            config.multiproof_max_targets_for_chunking(),
         );
 
         StateRootHandle::new(parent_state_root, updates_tx, state_root_rx)
@@ -542,6 +543,7 @@ where
         from_multi_proof: CrossbeamReceiver<StateRootMessage>,
         parent_state_root: B256,
         chunk_size: usize,
+        max_targets_for_chunking: usize,
     ) {
         let preserved_sparse_trie = self.sparse_state_trie.clone();
         let trie_metrics = self.trie_metrics.clone();
@@ -591,6 +593,7 @@ where
                 trie_metrics.clone(),
                 sparse_state_trie,
                 chunk_size,
+                max_targets_for_chunking,
             );
 
             let result = task.run();

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -8,9 +8,6 @@ pub use reth_trie_parallel::state_root_task::{
     StateRootHandle, StateRootMessage,
 };
 
-/// The default max targets, for limiting the number of account and storage proof targets to be
-/// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.
-pub(crate) const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tree.root")]

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::tree::{
     multiproof::{
         dispatch_with_chunking, evm_state_to_hashed_post_state, StateRootComputeOutcome,
-        StateRootMessage, DEFAULT_MAX_TARGETS_FOR_CHUNKING,
+        StateRootMessage,
     },
     payload_processor::multiproof::MultiProofTaskMetrics,
 };
@@ -121,6 +121,7 @@ where
         metrics: MultiProofTaskMetrics,
         trie: SparseStateTrie<A, S>,
         chunk_size: usize,
+        max_targets_for_chunking: usize,
     ) -> Self {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
@@ -139,7 +140,7 @@ where
             proof_worker_handle,
             trie,
             chunk_size,
-            max_targets_for_chunking: DEFAULT_MAX_TARGETS_FOR_CHUNKING,
+            max_targets_for_chunking,
             account_updates: Default::default(),
             storage_updates: Default::default(),
             new_account_updates: Default::default(),

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -4,7 +4,8 @@ use clap::{builder::Resettable, Args};
 use eyre::ensure;
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
 use reth_engine_primitives::{
-    TreeConfig, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+    TreeConfig, DEFAULT_MULTIPROOF_MAX_TARGETS_FOR_CHUNKING, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
+    DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
     DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS, DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
 };
 use std::{sync::OnceLock, time::Duration};
@@ -33,6 +34,7 @@ pub struct DefaultEngineValues {
     state_root_task_compare_updates: bool,
     accept_execution_requests_hash: bool,
     multiproof_chunk_size: usize,
+    multiproof_max_targets_for_chunking: usize,
     reserved_cpu_cores: usize,
     precompile_cache_disabled: bool,
     state_root_fallback: bool,
@@ -125,6 +127,12 @@ impl DefaultEngineValues {
     /// Set the default multiproof chunk size
     pub const fn with_multiproof_chunk_size(mut self, v: usize) -> Self {
         self.multiproof_chunk_size = v;
+        self
+    }
+
+    /// Set the default max targets threshold for forcing multiproof chunking
+    pub const fn with_multiproof_max_targets_for_chunking(mut self, v: usize) -> Self {
+        self.multiproof_max_targets_for_chunking = v;
         self
     }
 
@@ -242,6 +250,7 @@ impl Default for DefaultEngineValues {
             state_root_task_compare_updates: false,
             accept_execution_requests_hash: false,
             multiproof_chunk_size: DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
+            multiproof_max_targets_for_chunking: DEFAULT_MULTIPROOF_MAX_TARGETS_FOR_CHUNKING,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_disabled: false,
             state_root_fallback: false,
@@ -335,6 +344,12 @@ pub struct EngineArgs {
     /// Multiproof task chunk size for proof targets.
     #[arg(long = "engine.multiproof-chunk-size", default_value_t = DefaultEngineValues::get_global().multiproof_chunk_size)]
     pub multiproof_chunk_size: usize,
+
+    /// Max targets threshold for forcing multiproof chunking regardless of worker availability.
+    /// If the number of proof targets exceeds this value, chunking is forced even when no
+    /// additional workers are available.
+    #[arg(long = "engine.multiproof-max-targets-for-chunking", default_value_t = DefaultEngineValues::get_global().multiproof_max_targets_for_chunking)]
+    pub multiproof_max_targets_for_chunking: usize,
 
     /// Configure the number of reserved CPU cores for non-reth processes
     #[arg(long = "engine.reserved-cpu-cores", default_value_t = DefaultEngineValues::get_global().reserved_cpu_cores)]
@@ -488,6 +503,7 @@ impl Default for EngineArgs {
             state_root_task_compare_updates,
             accept_execution_requests_hash,
             multiproof_chunk_size,
+            multiproof_max_targets_for_chunking,
             reserved_cpu_cores,
             precompile_cache_disabled,
             state_root_fallback,
@@ -520,6 +536,7 @@ impl Default for EngineArgs {
             cross_block_cache_size,
             accept_execution_requests_hash,
             multiproof_chunk_size,
+            multiproof_max_targets_for_chunking,
             reserved_cpu_cores,
             precompile_cache_enabled: true,
             precompile_cache_disabled,
@@ -570,6 +587,7 @@ impl EngineArgs {
             .with_always_compare_trie_updates(self.state_root_task_compare_updates)
             .with_cross_block_cache_size(self.cross_block_cache_size * 1024 * 1024)
             .with_multiproof_chunk_size(self.multiproof_chunk_size)
+            .with_multiproof_max_targets_for_chunking(self.multiproof_max_targets_for_chunking)
             .with_reserved_cpu_cores(self.reserved_cpu_cores)
             .without_precompile_cache(self.precompile_cache_disabled)
             .with_state_root_fallback(self.state_root_fallback)
@@ -632,6 +650,7 @@ mod tests {
             state_root_task_compare_updates: true,
             accept_execution_requests_hash: true,
             multiproof_chunk_size: 512,
+            multiproof_max_targets_for_chunking: 600,
             reserved_cpu_cores: 4,
             precompile_cache_enabled: true,
             precompile_cache_disabled: true,
@@ -671,6 +690,8 @@ mod tests {
             "--engine.accept-execution-requests-hash",
             "--engine.multiproof-chunk-size",
             "512",
+            "--engine.multiproof-max-targets-for-chunking",
+            "600",
             "--engine.reserved-cpu-cores",
             "4",
             "--engine.disable-precompile-cache",

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -968,6 +968,11 @@ Engine:
 
           [default: 5]
 
+      --engine.multiproof-max-targets-for-chunking <MULTIPROOF_MAX_TARGETS_FOR_CHUNKING>
+          Max targets threshold for forcing multiproof chunking regardless of worker availability. If the number of proof targets exceeds this value, chunking is forced even when no additional workers are available
+
+          [default: 300]
+
       --engine.reserved-cpu-cores <RESERVED_CPU_CORES>
           Configure the number of reserved CPU cores for non-reth processes
 


### PR DESCRIPTION
`chunk_size` was already configurable via `--engine.multiproof-chunk-size` but `max_targets_for_chunking` was hardcoded to 300 in `sparse_trie.rs`. This adds `--engine.multiproof-max-targets-for-chunking` so both knobs are available for tuning or disabling chunking entirely (e.g. set to a huge value to benchmark without chunking).