### PR TITLE
chore(docker): bump lighthouse to v8.1.2

### DIFF
--- a/etc/lighthouse.yml
+++ b/etc/lighthouse.yml
@@ -3,7 +3,7 @@ name: reth
 services:
   lighthouse:
     restart: unless-stopped
-    image: sigp/lighthouse:v8.0.1
+    image: sigp/lighthouse:v8.1.2
     depends_on:
       - reth
     ports:


### PR DESCRIPTION
Bumps the Lighthouse Docker image from v8.0.1 to v8.1.2.

v8.1.2 is a mandatory security release — all prior versions are affected by undisclosed vulnerabilities (CVEs pending).

https://github.com/sigp/lighthouse/releases/tag/v8.1.2