### PR TITLE
ci(bench): use reth download for snapshot management

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -118,6 +118,7 @@ RETH_ARGS=(
   --authrpc.port 8551
   --disable-discovery
   --no-persist-peers
+  --debug.startup-sync-state-idle
 )
 
 # Big blocks mode requires the testing API and skip-invalid-transactions

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -118,8 +118,12 @@ RETH_ARGS=(
   --authrpc.port 8551
   --disable-discovery
   --no-persist-peers
-  --debug.startup-sync-state-idle
 )
+
+# Gate flag on binary support (older baselines may not have it)
+if "$BINARY" node --help 2>/dev/null | grep -q -- '--debug.startup-sync-state-idle'; then
+  RETH_ARGS+=(--debug.startup-sync-state-idle)
+fi
 
 # Big blocks mode requires the testing API and skip-invalid-transactions
 if [ "$BIG_BLOCKS" = "true" ]; then
@@ -212,7 +216,7 @@ for i in $(seq 1 300); do
   SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
-  if [ -n "$SYNC_RESULT" ] && echo "$SYNC_RESULT" | jq -e '.result == false' > /dev/null 2>&1; then
+  if [ -n "$SYNC_RESULT" ] && jq -e '.result == false' <<< "$SYNC_RESULT" > /dev/null 2>&1; then
     echo "reth (${LABEL}) pipeline finished after ${i}s, engine is live"
     break
   fi

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -194,11 +194,29 @@ for i in $(seq 1 60); do
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
     > /dev/null 2>&1; then
-    echo "reth (${LABEL}) is ready after ${i}s"
+    echo "reth (${LABEL}) RPC is up after ${i}s"
     break
   fi
   if [ "$i" -eq 60 ]; then
     echo "::error::reth (${LABEL}) failed to start within 60s"
+    cat "$LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+# Wait for the pipeline to finish (eth_syncing returns false) so the
+# engine is in live mode and can accept newPayload calls.
+for i in $(seq 1 300); do
+  SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
+  if [ -n "$SYNC_RESULT" ] && echo "$SYNC_RESULT" | jq -e '.result == false' > /dev/null 2>&1; then
+    echo "reth (${LABEL}) pipeline finished after ${i}s, engine is live"
+    break
+  fi
+  if [ "$i" -eq 300 ]; then
+    echo "::error::reth (${LABEL}) pipeline did not finish within 300s"
     cat "$LOG"
     exit 1
   fi

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -121,8 +121,10 @@ RETH_ARGS=(
 )
 
 # Gate flag on binary support (older baselines may not have it)
+SYNC_STATE_IDLE=false
 if "$BINARY" node --help 2>/dev/null | grep -q -- '--debug.startup-sync-state-idle'; then
   RETH_ARGS+=(--debug.startup-sync-state-idle)
+  SYNC_STATE_IDLE=true
 fi
 
 # Big blocks mode requires the testing API and skip-invalid-transactions
@@ -212,21 +214,26 @@ done
 
 # Wait for the pipeline to finish (eth_syncing returns false) so the
 # engine is in live mode and can accept newPayload calls.
-for i in $(seq 1 300); do
-  SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
-    -H 'Content-Type: application/json' \
-    -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
-  if [ -n "$SYNC_RESULT" ] && jq -e '.result == false' <<< "$SYNC_RESULT" > /dev/null 2>&1; then
-    echo "reth (${LABEL}) pipeline finished after ${i}s, engine is live"
-    break
-  fi
-  if [ "$i" -eq 300 ]; then
-    echo "::error::reth (${LABEL}) pipeline did not finish within 300s"
-    cat "$LOG"
-    exit 1
-  fi
-  sleep 1
-done
+# Only possible when --debug.startup-sync-state-idle is supported.
+if [ "$SYNC_STATE_IDLE" = "true" ]; then
+  for i in $(seq 1 300); do
+    SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
+      -H 'Content-Type: application/json' \
+      -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
+    if [ -n "$SYNC_RESULT" ] && jq -e '.result == false' <<< "$SYNC_RESULT" > /dev/null 2>&1; then
+      echo "reth (${LABEL}) pipeline finished after ${i}s, engine is live"
+      break
+    fi
+    if [ "$i" -eq 300 ]; then
+      echo "::error::reth (${LABEL}) pipeline did not finish within 300s"
+      cat "$LOG"
+      exit 1
+    fi
+    sleep 1
+  done
+else
+  echo "reth (${LABEL}) binary does not support --debug.startup-sync-state-idle, skipping sync wait"
+fi
 
 # Run reth-bench with high priority but as the current user so output
 # files are not root-owned (avoids EACCES on next checkout).

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -120,9 +120,10 @@ RETH_ARGS=(
   --no-persist-peers
 )
 
-# Gate flag on binary support (older baselines may not have it)
+# Gate flag on binary support (older baselines may not have it).
+# Uses --help which exits immediately via clap without node init.
 SYNC_STATE_IDLE=false
-if "$BINARY" node --help 2>/dev/null | grep -q -- '--debug.startup-sync-state-idle'; then
+if "$BINARY" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
   RETH_ARGS+=(--debug.startup-sync-state-idle)
   SYNC_STATE_IDLE=true
 fi

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -202,7 +202,7 @@ for i in $(seq 1 60); do
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
     > /dev/null 2>&1; then
-    echo "reth (${LABEL}) RPC is up after ${i}s"
+    echo "reth (${LABEL}) is ready after ${i}s"
     break
   fi
   if [ "$i" -eq 60 ]; then

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -115,7 +115,7 @@ for i in $(seq 1 300); do
   SYNCING=$(curl -sf http://127.0.0.1:8545 -X POST \
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null \
-    | jq -r '.result' 2>/dev/null)
+    | jq -r '.result' 2>/dev/null) || true
   if [ "$SYNCING" = "false" ]; then
     echo "reth finished syncing after ${i}s"
     break

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -11,7 +11,7 @@
 #
 # Required env:
 #   SCHELK_MOUNT       – schelk mount point (e.g. /reth-bench)
-#   BENCH_RETH_BINARY  – path to the reth binary (only for download, not --check)
+#   BENCH_RETH_BINARY  – path to the reth binary (required for download, not --check)
 #   GITHUB_TOKEN       – token for GitHub API calls (only for download)
 #   BENCH_COMMENT_ID   – PR comment ID to update (optional)
 #   BENCH_REPO         – owner/repo (e.g. paradigmxyz/reth)
@@ -27,7 +27,10 @@ DATADIR="$SCHELK_MOUNT/datadir"
 HASH_FILE="$HOME/.reth-bench-snapshot-hash"
 
 # Fetch manifest and compute content hash for reliable freshness check
-REMOTE_HASH=$($MC cat "${BUCKET}/${MANIFEST_PATH}" | sha256sum | awk '{print $1}')
+if ! REMOTE_HASH=$($MC cat "${BUCKET}/${MANIFEST_PATH}" 2>/dev/null | sha256sum | awk '{print $1}'); then
+  echo "::error::Failed to fetch snapshot manifest from ${BUCKET}/${MANIFEST_PATH}"
+  exit 2
+fi
 
 LOCAL_HASH=""
 [ -f "$HASH_FILE" ] && LOCAL_HASH=$(cat "$HASH_FILE")
@@ -39,17 +42,13 @@ fi
 
 echo "Snapshot needs update (local: ${LOCAL_HASH:+${LOCAL_HASH:0:16}…}${LOCAL_HASH:-<none>}, remote: ${REMOTE_HASH:0:16}…)"
 if [ "${1:-}" = "--check" ]; then
-  exit 1
+  exit 10
 fi
 
-RETH="${BENCH_RETH_BINARY:-$(cd "$(dirname "$0")/../.." && pwd)/../reth-feature/target/profiling/reth}"
-# When running in parallel with builds, the binary may not exist yet — wait for it.
-for _i in $(seq 1 600); do
-  [ -x "$RETH" ] && break
-  sleep 1
-done
+: "${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set to the reth binary path}"
+RETH="$BENCH_RETH_BINARY"
 if [ ! -x "$RETH" ]; then
-  echo "::error::reth binary not found or not executable at $RETH after 600s"
+  echo "::error::reth binary not found or not executable at $RETH"
   exit 1
 fi
 
@@ -65,7 +64,7 @@ BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-minimal-stable"
 
 # Download manifest and replace base_url with the runner-reachable endpoint
 MANIFEST_TMP=$(mktemp --suffix=.json)
-trap 'rm -f "$MANIFEST_TMP"' EXIT
+trap 'rm -f -- "$MANIFEST_TMP"' EXIT
 $MC cat "${BUCKET}/${MANIFEST_PATH}" \
   | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 MC="mc"
 BUCKET="minio/reth-snapshots"
-MANIFEST_PATH="reth-1-archive-edge-v2/manifest.json"
+MANIFEST_PATH="reth-1-minimal-stable/manifest.json"
 DATADIR="$SCHELK_MOUNT/datadir"
 HASH_FILE="$HOME/.reth-bench-snapshot-hash"
 
@@ -56,7 +56,7 @@ if [ -z "$MINIO_ENDPOINT" ] || [ "$MINIO_ENDPOINT" = "null" ]; then
   echo "::error::Failed to resolve MinIO endpoint from mc alias"
   exit 1
 fi
-BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-archive-edge-v2"
+BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-minimal-stable"
 
 # Download manifest and replace base_url with the runner-reachable endpoint
 MANIFEST_TMP=$(mktemp --suffix=.json)

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -109,34 +109,6 @@ if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
   exit 1
 fi
 
-# Run reth to complete any pending pipeline stages so the promoted
-# baseline has a fully-synced DB (avoids SYNCING responses during benchmarks).
-update_comment "Syncing snapshot…"
-echo "Starting reth to complete pipeline stages..."
-sudo "$RETH" node --datadir "$DATADIR" --http --http.port 8545 --disable-discovery --no-persist-peers \
-  > /tmp/reth-snapshot-sync.log 2>&1 &
-SYNC_PID=$!
-for i in $(seq 1 300); do
-  SYNCING=$(curl -sf http://127.0.0.1:8545 -X POST \
-    -H 'Content-Type: application/json' \
-    -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null \
-    | jq -r '.result' 2>/dev/null) || true
-  if [ "$SYNCING" = "false" ]; then
-    echo "reth finished syncing after ${i}s"
-    break
-  fi
-  if [ "$i" -eq 300 ]; then
-    echo "::error::reth failed to finish syncing within 300s"
-    cat /tmp/reth-snapshot-sync.log
-    sudo kill "$SYNC_PID" 2>/dev/null || true
-    exit 1
-  fi
-  sleep 1
-done
-sudo kill "$SYNC_PID" 2>/dev/null || true
-wait "$SYNC_PID" 2>/dev/null || true
-update_comment "Syncing snapshot… done"
-
 # Promote the new snapshot to become the schelk baseline (virgin volume).
 # This copies changed blocks from scratch → virgin so that future
 # `schelk recover` calls restore to this new state.

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -42,9 +42,14 @@ if [ "${1:-}" = "--check" ]; then
   exit 1
 fi
 
-RETH="${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set}"
+RETH="${BENCH_RETH_BINARY:-$(cd "$(dirname "$0")/../.." && pwd)/../reth-feature/target/profiling/reth}"
+# When running in parallel with builds, the binary may not exist yet — wait for it.
+for _i in $(seq 1 600); do
+  [ -x "$RETH" ] && break
+  sleep 1
+done
 if [ ! -x "$RETH" ]; then
-  echo "::error::reth binary not found or not executable at $RETH"
+  echo "::error::reth binary not found or not executable at $RETH after 600s"
   exit 1
 fi
 

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -104,6 +104,34 @@ if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
   exit 1
 fi
 
+# Run reth to complete any pending pipeline stages so the promoted
+# baseline has a fully-synced DB (avoids SYNCING responses during benchmarks).
+update_comment "Syncing snapshot…"
+echo "Starting reth to complete pipeline stages..."
+sudo "$RETH" node --datadir "$DATADIR" --http --http.port 8545 --disable-discovery --no-persist-peers \
+  > /tmp/reth-snapshot-sync.log 2>&1 &
+SYNC_PID=$!
+for i in $(seq 1 300); do
+  SYNCING=$(curl -sf http://127.0.0.1:8545 -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null \
+    | jq -r '.result' 2>/dev/null)
+  if [ "$SYNCING" = "false" ]; then
+    echo "reth finished syncing after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 300 ]; then
+    echo "::error::reth failed to finish syncing within 300s"
+    cat /tmp/reth-snapshot-sync.log
+    sudo kill "$SYNC_PID" 2>/dev/null || true
+    exit 1
+  fi
+  sleep 1
+done
+sudo kill "$SYNC_PID" 2>/dev/null || true
+wait "$SYNC_PID" 2>/dev/null || true
+update_comment "Syncing snapshot… done"
+
 # Promote the new snapshot to become the schelk baseline (virgin volume).
 # This copies changed blocks from scratch → virgin so that future
 # `schelk recover` calls restore to this new state.

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 #
-# Downloads the latest nightly snapshot into the schelk volume with
-# progress reporting to the GitHub PR comment.
+# Downloads the latest snapshot into the schelk volume using
+# `reth download` with progress reporting to the GitHub PR comment.
 #
-# Skips the download if the local ETag marker matches the remote one.
+# Skips the download if the manifest content hasn't changed since
+# the last successful download (checked via SHA-256 of the manifest).
 #
 # Usage: bench-reth-snapshot.sh [--check]
 #   --check   Only check if a download is needed; exits 0 if up-to-date, 1 if not.
 #
 # Required env:
 #   SCHELK_MOUNT       – schelk mount point (e.g. /reth-bench)
+#   BENCH_RETH_BINARY  – path to the reth binary (only for download, not --check)
 #   GITHUB_TOKEN       – token for GitHub API calls (only for download)
 #   BENCH_COMMENT_ID   – PR comment ID to update (optional)
 #   BENCH_REPO         – owner/repo (e.g. paradigmxyz/reth)
@@ -18,52 +20,60 @@
 #   BENCH_CONFIG       – config summary line
 set -euo pipefail
 
-BUCKET="minio/reth-snapshots/reth-1-minimal-nightly-previous.tar.zst"
+MC="mc"
+BUCKET="minio/reth-snapshots"
+MANIFEST_PATH="reth-1-archive-edge-v2/manifest.json"
 DATADIR="$SCHELK_MOUNT/datadir"
-ETAG_FILE="$HOME/.reth-bench-snapshot-etag"
+HASH_FILE="$HOME/.reth-bench-snapshot-hash"
 
-# Get remote metadata via JSON for reliable parsing
-MC_STAT=$(mc stat --json "$BUCKET" 2>/dev/null || true)
-REMOTE_ETAG=$(echo "$MC_STAT" | jq -r '.etag // empty')
-if [ -z "$REMOTE_ETAG" ]; then
-  echo "::warning::Failed to get ETag from mc stat, will re-download"
-  REMOTE_ETAG="unknown-$(date +%s)"
-fi
+# Fetch manifest and compute content hash for reliable freshness check
+REMOTE_HASH=$($MC cat "${BUCKET}/${MANIFEST_PATH}" | sha256sum | awk '{print $1}')
 
-LOCAL_ETAG=""
-[ -f "$ETAG_FILE" ] && LOCAL_ETAG=$(cat "$ETAG_FILE")
+LOCAL_HASH=""
+[ -f "$HASH_FILE" ] && LOCAL_HASH=$(cat "$HASH_FILE")
 
-if [ "$REMOTE_ETAG" = "$LOCAL_ETAG" ]; then
-  echo "Snapshot is up-to-date (ETag: ${REMOTE_ETAG})"
-  if [ "${1:-}" = "--check" ]; then
-    exit 0
-  fi
+if [ "$REMOTE_HASH" = "$LOCAL_HASH" ]; then
+  echo "Snapshot is up-to-date (manifest hash: ${REMOTE_HASH:0:16}…)"
   exit 0
 fi
 
-echo "Snapshot needs update (local: ${LOCAL_ETAG:-<none>}, remote: ${REMOTE_ETAG})"
+echo "Snapshot needs update (local: ${LOCAL_HASH:+${LOCAL_HASH:0:16}…}${LOCAL_HASH:-<none>}, remote: ${REMOTE_HASH:0:16}…)"
 if [ "${1:-}" = "--check" ]; then
   exit 1
 fi
 
-# Get compressed size for progress tracking
-TOTAL_BYTES=$(echo "$MC_STAT" | jq -r '.size // empty')
-if [ -z "$TOTAL_BYTES" ] || [ "$TOTAL_BYTES" = "0" ]; then
-  echo "::error::Failed to get snapshot size from mc stat"
+RETH="${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set}"
+if [ ! -x "$RETH" ]; then
+  echo "::error::reth binary not found or not executable at $RETH"
   exit 1
 fi
-echo "Snapshot size: $TOTAL_BYTES bytes ($(numfmt --to=iec "$TOTAL_BYTES"))"
+
+# Resolve the MinIO HTTP endpoint from the mc alias so reth can
+# fetch archives over HTTP (the manifest's embedded base_url points
+# to the cluster-internal address which is unreachable from runners).
+MINIO_ENDPOINT=$($MC alias list minio --json | jq -r '.URL')
+if [ -z "$MINIO_ENDPOINT" ] || [ "$MINIO_ENDPOINT" = "null" ]; then
+  echo "::error::Failed to resolve MinIO endpoint from mc alias"
+  exit 1
+fi
+BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-archive-edge-v2"
+
+# Download manifest and replace base_url with the runner-reachable endpoint
+MANIFEST_TMP=$(mktemp --suffix=.json)
+trap 'rm -f "$MANIFEST_TMP"' EXIT
+$MC cat "${BUCKET}/${MANIFEST_PATH}" \
+  | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 
 # Prepare mount
 mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"
+sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
 
 update_comment() {
-  local pct="$1"
+  local status="$1"
   [ -z "${BENCH_COMMENT_ID:-}" ] && return 0
-  local status="Building binaries & downloading snapshot… ${pct}%"
   local body
   body="$(printf 'cc @%s\n\n🚀 Benchmark started! [View job](%s)\n\n⏳ **Status:** %s\n\n%s' \
     "$BENCH_ACTOR" "$BENCH_JOB_URL" "$status" "$BENCH_CONFIG")"
@@ -75,46 +85,24 @@ update_comment() {
     > /dev/null 2>&1 || true
 }
 
-# Track compressed bytes flowing through the pipe
-DL_BYTES_FILE=$(mktemp)
-echo 0 > "$DL_BYTES_FILE"
+update_comment "Downloading snapshot…"
 
-# Start progress reporter in background
-(
-  while true; do
-    sleep 10
-    CURRENT=$(cat "$DL_BYTES_FILE" 2>/dev/null || echo 0)
-    if [ "$TOTAL_BYTES" -gt 0 ]; then
-      PCT=$(( CURRENT * 100 / TOTAL_BYTES ))
-      [ "$PCT" -gt 100 ] && PCT=100
-      echo "Snapshot download: $(numfmt --to=iec "$CURRENT") / $(numfmt --to=iec "$TOTAL_BYTES") (${PCT}%)"
-      update_comment "$PCT"
-    fi
-  done
-) &
-PROGRESS_PID=$!
-trap 'kill $PROGRESS_PID 2>/dev/null || true; rm -f "$DL_BYTES_FILE"' EXIT
+# Download using reth download (manifest-path with rewritten base_url)
+"$RETH" download \
+  --manifest-path "$MANIFEST_TMP" \
+  -y \
+  --minimal \
+  --datadir "$DATADIR"
 
-# Download and extract; python byte counter tracks compressed bytes received
-mc cat "$BUCKET" | python3 -c "
-import sys
-count = 0
-while True:
-    data = sys.stdin.buffer.read(1048576)
-    if not data:
-        break
-    count += len(data)
-    sys.stdout.buffer.write(data)
-    with open('$DL_BYTES_FILE', 'w') as f:
-        f.write(str(count))
-" | pzstd -d -p 6 | sudo tar -xf - -C "$DATADIR"
-
-# Stop progress reporter
-kill $PROGRESS_PID 2>/dev/null || true
-wait $PROGRESS_PID 2>/dev/null || true
-
-update_comment "100"
+update_comment "Downloading snapshot… done"
 echo "Snapshot download complete"
+
+# Sanity check: verify expected directories exist
+if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
+  echo "::error::Snapshot download did not produce expected directory layout (missing db/ or static_files/)"
+  ls -la "$DATADIR" || true
+  exit 1
+fi
 
 # Promote the new snapshot to become the schelk baseline (virgin volume).
 # This copies changed blocks from scratch → virgin so that future
@@ -122,6 +110,6 @@ echo "Snapshot download complete"
 sync
 sudo schelk promote -y
 
-# Save ETag marker
-echo "$REMOTE_ETAG" > "$ETAG_FILE"
-echo "Snapshot promoted to schelk baseline (ETag: ${REMOTE_ETAG})"
+# Save manifest hash
+echo "$REMOTE_HASH" > "$HASH_FILE"
+echo "Snapshot promoted to schelk baseline (manifest hash: ${REMOTE_HASH:0:16}…)"

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -55,9 +55,9 @@ fi
 # Resolve the MinIO HTTP endpoint from the mc alias so reth can
 # fetch archives over HTTP (the manifest's embedded base_url points
 # to the cluster-internal address which is unreachable from runners).
-MINIO_ENDPOINT=$($MC alias list minio --json | jq -r '.URL')
-if [ -z "$MINIO_ENDPOINT" ] || [ "$MINIO_ENDPOINT" = "null" ]; then
-  echo "::error::Failed to resolve MinIO endpoint from mc alias"
+MINIO_ENDPOINT=$($MC alias list minio --json 2>/dev/null | jq -r '.URL // empty') || true
+if [ -z "$MINIO_ENDPOINT" ]; then
+  echo "::error::Failed to resolve MinIO endpoint from mc alias 'minio'"
   exit 1
 fi
 BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-minimal-stable"

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -27,10 +27,11 @@ DATADIR="$SCHELK_MOUNT/datadir"
 HASH_FILE="$HOME/.reth-bench-snapshot-hash"
 
 # Fetch manifest and compute content hash for reliable freshness check
-if ! REMOTE_HASH=$($MC cat "${BUCKET}/${MANIFEST_PATH}" 2>/dev/null | sha256sum | awk '{print $1}'); then
+MANIFEST_CONTENT=$($MC cat "${BUCKET}/${MANIFEST_PATH}" 2>&1) || {
   echo "::error::Failed to fetch snapshot manifest from ${BUCKET}/${MANIFEST_PATH}"
   exit 2
-fi
+}
+REMOTE_HASH=$(echo "$MANIFEST_CONTENT" | sha256sum | awk '{print $1}')
 
 LOCAL_HASH=""
 [ -f "$HASH_FILE" ] && LOCAL_HASH=$(cat "$HASH_FILE")

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -7,7 +7,7 @@
 # the last successful download (checked via SHA-256 of the manifest).
 #
 # Usage: bench-reth-snapshot.sh [--check]
-#   --check   Only check if a download is needed; exits 0 if up-to-date, 1 if not.
+#   --check   Only check if a download is needed; exits 0 if up-to-date, 10 if not.
 #
 # Required env:
 #   SCHELK_MOUNT       – schelk mount point (e.g. /reth-bench)
@@ -27,7 +27,7 @@ DATADIR="$SCHELK_MOUNT/datadir"
 HASH_FILE="$HOME/.reth-bench-snapshot-hash"
 
 # Fetch manifest and compute content hash for reliable freshness check
-MANIFEST_CONTENT=$($MC cat "${BUCKET}/${MANIFEST_PATH}" 2>&1) || {
+MANIFEST_CONTENT=$($MC cat "${BUCKET}/${MANIFEST_PATH}" 2>/dev/null) || {
   echo "::error::Failed to fetch snapshot manifest from ${BUCKET}/${MANIFEST_PATH}"
   exit 2
 }
@@ -67,10 +67,10 @@ if [ -z "$MINIO_ENDPOINT" ]; then
 fi
 BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-minimal-stable"
 
-# Download manifest and replace base_url with the runner-reachable endpoint
+# Rewrite manifest's base_url with the runner-reachable endpoint
 MANIFEST_TMP=$(mktemp --suffix=.json)
 trap 'rm -f -- "$MANIFEST_TMP"' EXIT
-$MC cat "${BUCKET}/${MANIFEST_PATH}" \
+echo "$MANIFEST_CONTENT" \
   | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 
 # Prepare mount
@@ -78,6 +78,7 @@ mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"
+# reth download runs as current user (not root), needs write access
 sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
 
 update_comment() {

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -11,7 +11,7 @@
 #
 # Required env:
 #   SCHELK_MOUNT       – schelk mount point (e.g. /reth-bench)
-#   BENCH_RETH_BINARY  – path to the reth binary (required for download, not --check)
+#   BENCH_RETH_BINARY  – path to the reth binary (optional; auto-discovers if unset)
 #   GITHUB_TOKEN       – token for GitHub API calls (only for download)
 #   BENCH_COMMENT_ID   – PR comment ID to update (optional)
 #   BENCH_REPO         – owner/repo (e.g. paradigmxyz/reth)
@@ -46,10 +46,14 @@ if [ "${1:-}" = "--check" ]; then
   exit 10
 fi
 
-: "${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set to the reth binary path}"
-RETH="$BENCH_RETH_BINARY"
+RETH="${BENCH_RETH_BINARY:-$(cd "$(dirname "$0")/../.." && pwd)/../reth-feature/target/profiling/reth}"
+# Binary may not exist yet if running in parallel with builds — wait up to 600s
+for _i in $(seq 1 600); do
+  [ -x "$RETH" ] && break
+  sleep 1
+done
 if [ ! -x "$RETH" ]; then
-  echo "::error::reth binary not found or not executable at $RETH"
+  echo "::error::reth binary not found or not executable at $RETH after 600s"
   exit 1
 fi
 

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -11,7 +11,7 @@
 #
 # Required env:
 #   SCHELK_MOUNT       – schelk mount point (e.g. /reth-bench)
-#   BENCH_RETH_BINARY  – path to the reth binary (optional; auto-discovers if unset)
+#   BENCH_RETH_BINARY  – path to the reth binary
 #   GITHUB_TOKEN       – token for GitHub API calls (only for download)
 #   BENCH_COMMENT_ID   – PR comment ID to update (optional)
 #   BENCH_REPO         – owner/repo (e.g. paradigmxyz/reth)
@@ -46,14 +46,9 @@ if [ "${1:-}" = "--check" ]; then
   exit 10
 fi
 
-RETH="${BENCH_RETH_BINARY:-$(cd "$(dirname "$0")/../.." && pwd)/../reth-feature/target/profiling/reth}"
-# Binary may not exist yet if running in parallel with builds — wait up to 600s
-for _i in $(seq 1 600); do
-  [ -x "$RETH" ] && break
-  sleep 1
-done
+RETH="${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set}"
 if [ ! -x "$RETH" ]; then
-  echo "::error::reth binary not found or not executable at $RETH after 600s"
+  echo "::error::reth binary not found or not executable at $RETH"
   exit 1
 fi
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -476,7 +476,7 @@ jobs:
   reth-bench:
     needs: reth-bench-ack
     name: reth-bench
-    runs-on: [self-hosted, Linux, X64, unavailable]
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 120
     env:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -74,8 +74,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  BASELINE: base
-  SEED: reth
   RUSTC_WRAPPER: "sccache"
   BENCH_RUNNERS: 2
 
@@ -712,11 +710,16 @@ jobs:
       - name: Check if snapshot needs update
         id: snapshot-check
         run: |
-          if .github/scripts/bench-reth-snapshot.sh --check; then
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-          fi
+          set +e
+          .github/scripts/bench-reth-snapshot.sh --check
+          rc=$?
+          set -e
+          case "$rc" in
+            0)  echo "needed=false" >> "$GITHUB_OUTPUT" ;;
+            10) echo "needed=true"  >> "$GITHUB_OUTPUT" ;;
+            *)  echo "::error::Snapshot check failed (exit $rc)"
+                exit "$rc" ;;
+          esac
 
       - name: Update status (snapshot needed)
         if: env.BENCH_COMMENT_ID && steps.snapshot-check.outputs.needed == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -476,7 +476,7 @@ jobs:
   reth-bench:
     needs: reth-bench-ack
     name: reth-bench
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, unavailable]
     timeout-minutes: 120
     env:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -723,7 +723,7 @@ jobs:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Building binaries & downloading snapshot...'});
+            await s({github, context, status: 'Building binaries (snapshot update pending)...'});
 
       - name: Prepare source dirs
         run: |
@@ -743,12 +743,11 @@ jobs:
           fi
           git -C ../reth-feature checkout "$FEATURE_REF"
 
-      - name: Build binaries and download snapshot in parallel
+      - name: Build binaries
         id: build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_REPO: ${{ github.repository }}
-          SNAPSHOT_NEEDED: ${{ steps.snapshot-check.outputs.needed }}
         run: |
           BASELINE_DIR="$(cd ../reth-baseline && pwd)"
           FEATURE_DIR="$(cd ../reth-feature && pwd)"
@@ -758,20 +757,22 @@ jobs:
           .github/scripts/bench-reth-build.sh feature "${FEATURE_DIR}" "${{ steps.refs.outputs.feature-ref }}" &
           PID_FEATURE=$!
 
-          PID_SNAPSHOT=
-          if [ "$SNAPSHOT_NEEDED" = "true" ]; then
-            .github/scripts/bench-reth-snapshot.sh &
-            PID_SNAPSHOT=$!
-          fi
-
           FAIL=0
           wait $PID_BASELINE || FAIL=1
           wait $PID_FEATURE || FAIL=1
-          [ -n "$PID_SNAPSHOT" ] && { wait $PID_SNAPSHOT || FAIL=1; }
           if [ $FAIL -ne 0 ]; then
-            echo "::error::One or more parallel tasks failed (builds / snapshot download)"
+            echo "::error::One or more build tasks failed"
             exit 1
           fi
+
+      - name: Download snapshot
+        id: snapshot-download
+        if: steps.snapshot-check.outputs.needed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCH_REPO: ${{ github.repository }}
+          BENCH_RETH_BINARY: ${{ github.workspace }}/../reth-feature/target/profiling/reth
+        run: .github/scripts/bench-reth-snapshot.sh
 
       # System tuning for reproducible benchmarks
       - name: System setup
@@ -1213,7 +1214,8 @@ jobs:
           script: |
             const abba = (process.env.BENCH_ABBA || 'true') !== 'false';
             const steps_status = [
-              ['building binaries${{ steps.snapshot-check.outputs.needed == 'true' && ' & downloading snapshot' || '' }}', '${{ steps.build.outcome }}'],
+              ['building binaries', '${{ steps.build.outcome }}'],
+              ['downloading snapshot', '${{ steps.snapshot-download.outcome }}'],
               ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
               ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
               ...(abba ? [['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}']] : []),
@@ -1248,7 +1250,8 @@ jobs:
           script: |
             const abba = (process.env.BENCH_ABBA || 'true') !== 'false';
             const steps_status = [
-              ['building binaries${{ steps.snapshot-check.outputs.needed == 'true' && ' & downloading snapshot' || '' }}', '${{ steps.build.outcome }}'],
+              ['building binaries', '${{ steps.build.outcome }}'],
+              ['downloading snapshot', '${{ steps.snapshot-download.outcome }}'],
               ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
               ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
               ...(abba ? [['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}']] : []),


### PR DESCRIPTION
## Summary

Switches bench snapshots from the v1 monolithic tarball (`reth-1-minimal-nightly-previous.tar.zst`) to v2 modular snapshots (`reth-1-minimal-stable/manifest.json`), using `reth download --manifest-path --minimal` instead of `mc cat | pzstd | tar`.

Closes [RETH-558](https://linear.app/tempoxyz/issue/RETH-558/switch-benchmarking-to-20-snapshots)

## Changes

- **Storage v2**: switched from v1 single tarball to v2 modular snapshot format with manifest-based downloads
- **Snapshot download method**: replaced `mc cat | pzstd | tar` pipeline with `reth download --manifest-path --minimal`
- **Freshness check**: switched from ETag comparison to SHA-256 of manifest content (`mc cat | sha256sum`)
- **Build/download ordering**: snapshot download now runs _after_ builds (needs the reth binary) instead of in parallel
- **MinIO endpoint resolution**: resolves HTTP endpoint from the runner `mc` alias at runtime so `reth download` can reach archives
- **Post-download sanity check**: verifies `db/` and `static_files/` exist after download
- **Pipeline sync wait**: waits for `eth_syncing == false` (up to 300s) before benchmarking when `--debug.startup-sync-state-idle` is supported, so the engine is in live mode for `newPayload` calls