### PR TITLE
feat: use mimalloc as the default memory allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -650,6 +650,7 @@ ethereum_ssz_derive = "0.10.1"
 
 # allocators
 jemalloc_pprof = { version = "0.8", default-features = false }
+mimalloc = { version = "0.1.48", default-features = false }
 tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = "0.6"
 tracy-client = { version = "0.18.0", features = ["demangle"] }

--- a/bin/reth-bench-compare/Cargo.toml
+++ b/bin/reth-bench-compare/Cargo.toml
@@ -56,12 +56,14 @@ shlex.workspace = true
 nix = { version = "0.31", features = ["signal", "process"] }
 
 [features]
-default = ["jemalloc"]
+default = ["mimalloc"]
 
 asm-keccak = [
     "reth-node-core/asm-keccak",
     "alloy-primitives/asm-keccak",
 ]
+
+mimalloc = ["reth-cli-util/mimalloc"]
 
 jemalloc = [
     "reth-cli-util/jemalloc",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -78,12 +78,14 @@ csv.workspace = true
 [dev-dependencies]
 
 [features]
-default = ["jemalloc"]
+default = ["mimalloc"]
 
 asm-keccak = [
     "reth-node-core/asm-keccak",
     "alloy-primitives/asm-keccak",
 ]
+
+mimalloc = ["reth-cli-util/mimalloc"]
 
 jemalloc = [
     "reth-cli-util/jemalloc",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -81,7 +81,7 @@ toml.workspace = true
 
 [features]
 default = [
-    "jemalloc",
+    "mimalloc",
     "otlp",
     "otlp-logs",
     "reth-revm/portable",
@@ -118,6 +118,10 @@ keccak-cache-global = [
     "reth-node-core/keccak-cache-global",
     "reth-node-ethereum/keccak-cache-global",
     "alloy-primitives/keccak-cache-global",
+]
+mimalloc = [
+    "reth-cli-util/mimalloc",
+    "reth-ethereum-cli/mimalloc",
 ]
 jemalloc = [
     "reth-cli-util/jemalloc",

--- a/crates/cli/util/Cargo.toml
+++ b/crates/cli/util/Cargo.toml
@@ -37,7 +37,13 @@ tikv-jemallocator = { workspace = true, optional = true }
 snmalloc-rs = { workspace = true, optional = true }
 libc = "0.2"
 
+[dependencies.mimalloc]
+workspace = true
+optional = true
+
 [features]
+mimalloc = ["dep:mimalloc"]
+
 jemalloc = ["dep:tikv-jemallocator"]
 
 # Enables jemalloc profiling features

--- a/crates/cli/util/src/allocator.rs
+++ b/crates/cli/util/src/allocator.rs
@@ -1,12 +1,14 @@
 //! Custom allocator implementation.
 //!
-//! We provide support for jemalloc and snmalloc on unix systems, and prefer jemalloc if both are
-//! enabled.
+//! We provide support for mimalloc, jemalloc and snmalloc on unix systems. If multiple allocator
+//! features are enabled, mimalloc is preferred, then jemalloc, then snmalloc.
 
-// We provide jemalloc allocator support, alongside snmalloc. If both features are enabled, jemalloc
-// is prioritized.
+// We provide multiple allocator options. If multiple features are enabled, mimalloc is prioritized,
+// then jemalloc, then snmalloc.
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "jemalloc", unix))] {
+    if #[cfg(feature = "mimalloc")] {
+        type AllocatorInner = mimalloc::MiMalloc;
+    } else if #[cfg(all(feature = "jemalloc", unix))] {
         type AllocatorInner = tikv_jemallocator::Jemalloc;
     } else if #[cfg(all(feature = "snmalloc", unix))] {
         type AllocatorInner = snmalloc_rs::SnMalloc;
@@ -17,8 +19,14 @@ cfg_if::cfg_if! {
 
 // This is to prevent clippy unused warnings when we do `--all-features`
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "snmalloc", feature = "jemalloc", unix))] {
+    if #[cfg(all(feature = "snmalloc", any(feature = "jemalloc", feature = "mimalloc"), unix))] {
         use snmalloc_rs as _;
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "jemalloc", feature = "mimalloc", unix))] {
+        use tikv_jemallocator as _;
     }
 }
 

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -46,6 +46,8 @@ asm-keccak = [
     "reth-node-ethereum/asm-keccak",
 ]
 
+mimalloc = []
+
 jemalloc = [
     "reth-node-core/jemalloc",
     "reth-node-metrics/jemalloc",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -148,6 +148,10 @@ rpc = [
     "dep:alloy-rpc-types-engine",
 ]
 tasks = ["dep:reth-tasks"]
+mimalloc = [
+    "reth-cli-util?/mimalloc",
+    "reth-ethereum-cli?/mimalloc",
+]
 jemalloc = [
     "reth-cli-util?/jemalloc",
     "reth-ethereum-cli?/jemalloc",


### PR DESCRIPTION
## Summary

Switch the default allocator from jemalloc to mimalloc for all binary crates (`reth`, `reth-bench`, `reth-bench-compare`).

## Changes

- Add `mimalloc` (v0.1.48) workspace dependency
- Add `mimalloc` feature to `reth-cli-util`, `reth-ethereum-cli`, `reth-ethereum`, and all binary crates
- Update `allocator.rs` to select mimalloc when the feature is enabled (prioritized over jemalloc and snmalloc)
- Switch `default` features from `jemalloc` to `mimalloc` in `bin/reth`, `bin/reth-bench`, `bin/reth-bench-compare`

jemalloc remains available via `--features jemalloc` (or `--no-default-features --features jemalloc`).

## Testing

`cargo clippy -p reth-cli-util --features mimalloc` and `cargo clippy -p reth-cli-util --all-features` pass cleanly.

Prompted by: DaniPopes