### PR TITLE
fix(pool): prevent sender-id map growth on read-only sender+nonce lookups

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -740,7 +740,8 @@ where
         sender: Address,
         nonce: u64,
     ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
-        let transaction_id = TransactionId::new(self.pool.get_sender_id(sender), nonce);
+        let sender_id = self.pool.sender_id(&sender)?;
+        let transaction_id = TransactionId::new(sender_id, nonce);
 
         self.inner().get_pool_data().all().get(&transaction_id).map(|tx| tx.transaction.clone())
     }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -220,6 +220,11 @@ where
         self.identifiers.write().sender_id_or_create(addr)
     }
 
+    /// Returns the internal [`SenderId`] for this address if it already exists.
+    pub fn sender_id(&self, addr: &Address) -> Option<SenderId> {
+        self.identifiers.read().sender_id(addr)
+    }
+
     /// Returns the internal [`SenderId`]s for the given addresses.
     pub fn get_sender_ids(&self, addrs: impl IntoIterator<Item = Address>) -> Vec<SenderId> {
         self.identifiers.write().sender_ids_or_create(addrs)

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -215,12 +215,20 @@ where
         self.notify_on_transaction_updates(outcome.promoted, outcome.discarded);
     }
 
-    /// Returns the internal [`SenderId`] for this address
+    /// Returns the internal [`SenderId`] for this address, allocating a new mapping when the
+    /// address is first observed.
+    ///
+    /// This must only be used on paths that intentionally begin tracking a sender, such as
+    /// transaction insertion. Read-only lookups should prefer [`Self::sender_id`] to avoid
+    /// growing the sender-id map for unknown addresses.
     pub fn get_sender_id(&self, addr: Address) -> SenderId {
         self.identifiers.write().sender_id_or_create(addr)
     }
 
-    /// Returns the internal [`SenderId`] for this address if it already exists.
+    /// Returns the internal [`SenderId`] for this address if it is already tracked.
+    ///
+    /// Unlike [`Self::get_sender_id`], this never allocates a new sender mapping and is therefore
+    /// suitable for read-only queries or best-effort cleanup on unknown addresses.
     pub fn sender_id(&self, addr: &Address) -> Option<SenderId> {
         self.identifiers.read().sender_id(addr)
     }
@@ -1083,7 +1091,7 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
         let removed = self.pool.write().remove_transactions_by_sender(sender_id);
 
         self.with_event_listener(|listener| listener.discarded_many(&removed));
@@ -1128,7 +1136,7 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
         self.get_pool_data().get_transactions_by_sender(sender_id)
     }
 
@@ -1138,7 +1146,7 @@ where
         sender: Address,
         nonce: u64,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let sender_id = self.sender_id(&sender)?;
         self.get_pool_data().get_pending_transaction_by_sender_and_nonce(sender_id, nonce)
     }
 
@@ -1147,7 +1155,7 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
         self.get_pool_data().queued_txs_by_sender(sender_id)
     }
 
@@ -1164,7 +1172,7 @@ where
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
         self.get_pool_data().pending_txs_by_sender(sender_id)
     }
 
@@ -1173,7 +1181,7 @@ where
         &self,
         sender: Address,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let sender_id = self.sender_id(&sender)?;
         self.get_pool_data().get_highest_transaction_by_sender(sender_id)
     }
 
@@ -1183,7 +1191,7 @@ where
         sender: Address,
         on_chain_nonce: u64,
     ) -> Option<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let sender_id = self.get_sender_id(sender);
+        let sender_id = self.sender_id(&sender)?;
         self.get_pool_data().get_highest_consecutive_transaction_by_sender(
             sender_id.into_transaction_id(on_chain_nonce),
         )
@@ -1751,5 +1759,21 @@ mod tests {
 
         let identifiers = test_pool.identifiers.read();
         assert_eq!(identifiers.sender_id(&auth), Some(SenderId::from(1)));
+    }
+
+    #[test]
+    fn sender_queries_do_not_allocate_ids_for_unknown_addresses() {
+        let test_pool = &TestPoolBuilder::default().with_config(Default::default()).pool;
+        let sender = Address::new([9; 20]);
+
+        assert_eq!(test_pool.sender_id(&sender), None);
+        assert!(test_pool.get_transactions_by_sender(sender).is_empty());
+        assert!(test_pool.get_pending_transaction_by_sender_and_nonce(sender, 0).is_none());
+        assert!(test_pool.get_queued_transactions_by_sender(sender).is_empty());
+        assert!(test_pool.get_pending_transactions_by_sender(sender).is_empty());
+        assert!(test_pool.get_highest_transaction_by_sender(sender).is_none());
+        assert!(test_pool.get_highest_consecutive_transaction_by_sender(sender, 0).is_none());
+        assert!(test_pool.remove_transactions_by_sender(sender).is_empty());
+        assert_eq!(test_pool.sender_id(&sender), None);
     }
 }


### PR DESCRIPTION
### Motivation
- Sender-address lookups should not allocate new `SenderId` entries for unknown addresses.
- The original issue affected the read-only RPC path `eth_getTransactionBySenderAndNonce`, and the same allocation pattern also existed in other sender-based query and cleanup helpers.

### Description
- Add a non-allocating accessor `PoolInner::sender_id(&Address) -> Option<SenderId>` for read-only sender lookups.
- Keep `PoolInner::get_sender_id(Address) -> SenderId` for insertion paths, and document clearly that it allocates.
- Update sender-based read/remove helpers in `PoolInner` to early-return when the sender is not already tracked instead of calling `sender_id_or_create`.
- Preserve the original fix for `TransactionPool::get_transaction_by_sender_and_nonce`, which now uses the non-allocating accessor.
- Add a regression test covering sender-based queries/removal on an unknown address.

### Provenance
- Cherry-picked from the original fork PR: https://github.com/theobhau183919-ux/gravity-reth/pull/19
- Original authored commit preserved on this branch.

### Testing
- `cargo test -p reth-transaction-pool sender_queries_do_not_allocate_ids_for_unknown_addresses`
- `cargo test -p reth-transaction-pool test_auths_stored_in_identifiers`