### PR TITLE
perf: avoid redundant seal_slow when hash is known

### DIFF
--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -633,7 +633,7 @@ where
         .ok_or_else(|| eyre::eyre!("Block hash not found for block {}", block))?;
     let header = provider_rw
         .header_by_number(block)?
-        .map(SealedHeader::seal_slow)
+        .map(|h| SealedHeader::new(h, hash))
         .ok_or_else(|| ProviderError::HeaderNotFound(block.into()))?;
 
     let expected_state_root = header.state_root();

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1287,7 +1287,9 @@ impl<N: ProviderNodeTypes> BlockReaderIdExt for ConsistentProvider<N> {
     ) -> ProviderResult<Option<SealedHeader<HeaderTy<N>>>> {
         Ok(match id {
             BlockId::Number(num) => self.sealed_header_by_number_or_tag(num)?,
-            BlockId::Hash(hash) => self.header(hash.block_hash)?.map(SealedHeader::seal_slow),
+            BlockId::Hash(hash) => self
+                .header(hash.block_hash)?
+                .map(|header| SealedHeader::new(header, hash.block_hash)),
         })
     }
 


### PR DESCRIPTION
`sealed_header_by_id` in `ConsistentProvider` and `init_from_state_dump` in `db-common` call `SealedHeader::seal_slow` (RLP encode + keccak256) despite already having the block hash. Use `SealedHeader::new` instead.