### PR TITLE
fix(net): gate serde-only imports behind feature flag

### DIFF
--- a/crates/net/network-types/Cargo.toml
+++ b/crates/net/network-types/Cargo.toml
@@ -21,7 +21,7 @@ alloy-eip2124.workspace = true
 # misc
 serde = { workspace = true, optional = true }
 humantime-serde = { workspace = true, optional = true }
-serde_json = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"], optional = true }
 
 # misc
 tracing.workspace = true
@@ -30,6 +30,7 @@ tracing.workspace = true
 serde = [
     "dep:serde",
     "dep:humantime-serde",
+    "dep:serde_json",
     "alloy-eip2124/serde",
 ]
 test-utils = []

--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -1,15 +1,9 @@
 //! Configuration for peering.
 
-use std::{
-    collections::HashSet,
-    io::{self, ErrorKind},
-    path::Path,
-    time::Duration,
-};
+use std::{collections::HashSet, time::Duration};
 
 use reth_net_banlist::{BanList, IpFilter};
 use reth_network_peers::{NodeRecord, TrustedPeer};
-use tracing::info;
 
 use crate::{peers::PersistedPeerInfo, BackoffKind, ReputationChangeWeights};
 
@@ -311,16 +305,16 @@ impl PeersConfig {
     #[cfg(feature = "serde")]
     pub fn with_basic_nodes_from_file(
         mut self,
-        optional_file: Option<impl AsRef<Path>>,
-    ) -> Result<Self, io::Error> {
+        optional_file: Option<impl AsRef<std::path::Path>>,
+    ) -> Result<Self, std::io::Error> {
         let Some(file_path) = optional_file else { return Ok(self) };
         let raw = match std::fs::read_to_string(file_path.as_ref()) {
             Ok(contents) => contents,
-            Err(e) if e.kind() == ErrorKind::NotFound => return Ok(self),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(self),
             Err(e) => return Err(e),
         };
 
-        info!(target: "net::peers", file = %file_path.as_ref().display(), "Loading saved peers");
+        tracing::info!(target: "net::peers", file = %file_path.as_ref().display(), "Loading saved peers");
 
         // Try the new format first, fall back to legacy Vec<NodeRecord>
         let peers: Vec<PersistedPeerInfo> = serde_json::from_str(&raw)
@@ -330,9 +324,9 @@ impl PeersConfig {
                     nodes.into_iter().map(PersistedPeerInfo::from_node_record).collect(),
                 )
             })
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
-        info!(target: "net::peers", count = peers.len(), "Loaded persisted peers");
+        tracing::info!(target: "net::peers", count = peers.len(), "Loaded persisted peers");
         self.persisted_peers = peers;
         Ok(self)
     }


### PR DESCRIPTION
Imports for `std::io`, `std::path::Path`, `tracing::info`, and the `serde_json` crate in `reth-network-types` are only used inside `#[cfg(feature = "serde")]` code. Without the feature enabled, they produce unused warnings.

Switches to full paths inside the serde-gated method and makes `serde_json` an optional dependency activated by the `serde` feature.