### PR TITLE
fix(net): fully remove disconnected peers from transaction state

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -92,6 +92,9 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     /// Removes the peer from the active set.
     pub(crate) fn remove_peer(&mut self, peer_id: &PeerId) {
         self.active_peers.remove(peer_id);
+        for (_, metadata) in self.hashes_fetch_inflight_and_pending_fetch.iter_mut() {
+            metadata.fallback_peers_mut().remove(peer_id);
+        }
     }
 
     /// Updates metrics.
@@ -1447,6 +1450,33 @@ mod test {
             requested_hashes.into_iter().collect::<HashSet<_>>(),
             seen_hashes.into_iter().collect::<HashSet<_>>()
         )
+    }
+
+    #[test]
+    fn remove_peer_clears_fallback_entries() {
+        let tx_fetcher = &mut TransactionFetcher::default();
+        let peer_1 = PeerId::new([1; 64]);
+        let peer_2 = PeerId::new([2; 64]);
+        let hash_1 = B256::from_slice(&[1; 32]);
+        let hash_2 = B256::from_slice(&[2; 32]);
+
+        tx_fetcher.active_peers.insert(peer_1, 1);
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash_1, peer_1, 0, Some(128));
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash_1, peer_2, 0, Some(128));
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash_2, peer_1, 0, None);
+
+        tx_fetcher.remove_peer(&peer_1);
+
+        assert!(tx_fetcher.active_peers.peek(&peer_1).is_none());
+
+        let hash_1_metadata =
+            tx_fetcher.hashes_fetch_inflight_and_pending_fetch.peek(&hash_1).unwrap();
+        assert!(!hash_1_metadata.fallback_peers.iter().any(|id| id == &peer_1));
+        assert!(hash_1_metadata.fallback_peers.iter().any(|id| id == &peer_2));
+
+        let hash_2_metadata =
+            tx_fetcher.hashes_fetch_inflight_and_pending_fetch.peek(&hash_2).unwrap();
+        assert!(!hash_2_metadata.fallback_peers.iter().any(|id| id == &peer_1));
     }
 
     #[test]

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -92,9 +92,6 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     /// Removes the peer from the active set.
     pub(crate) fn remove_peer(&mut self, peer_id: &PeerId) {
         self.active_peers.remove(peer_id);
-        for (_, metadata) in self.hashes_fetch_inflight_and_pending_fetch.iter_mut() {
-            metadata.fallback_peers_mut().remove(peer_id);
-        }
     }
 
     /// Updates metrics.
@@ -445,8 +442,12 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
             search_durations.find_idle_peer
         );
 
-        // peer should always exist since `is_session_active` already checked
-        let Some(peer) = peers.get(&peer_id) else { return false };
+        // peer may have disconnected between idle check and here, re-buffer hashes so they
+        // aren't lost from the pending fetch cache
+        let Some(peer) = peers.get(&peer_id) else {
+            self.buffer_hashes(hashes_to_request, None);
+            return false
+        };
         let conn_eth_version = peer.version;
 
         // fill the request with more hashes pending fetch that have been announced by the peer.
@@ -1453,30 +1454,23 @@ mod test {
     }
 
     #[test]
-    fn remove_peer_clears_fallback_entries() {
+    fn on_fetch_pending_hashes_rebuffers_on_disconnected_peer() {
         let tx_fetcher = &mut TransactionFetcher::default();
         let peer_1 = PeerId::new([1; 64]);
         let peer_2 = PeerId::new([2; 64]);
         let hash_1 = B256::from_slice(&[1; 32]);
-        let hash_2 = B256::from_slice(&[2; 32]);
 
-        tx_fetcher.active_peers.insert(peer_1, 1);
         buffer_hash_to_tx_fetcher(tx_fetcher, hash_1, peer_1, 0, Some(128));
         buffer_hash_to_tx_fetcher(tx_fetcher, hash_1, peer_2, 0, Some(128));
-        buffer_hash_to_tx_fetcher(tx_fetcher, hash_2, peer_1, 0, None);
 
-        tx_fetcher.remove_peer(&peer_1);
+        assert_eq!(tx_fetcher.num_pending_hashes(), 1);
 
-        assert!(tx_fetcher.active_peers.peek(&peer_1).is_none());
+        // pass empty peers map — both peers are "disconnected"
+        let peers = HashMap::new();
+        tx_fetcher.on_fetch_pending_hashes(&peers, |_| true);
 
-        let hash_1_metadata =
-            tx_fetcher.hashes_fetch_inflight_and_pending_fetch.peek(&hash_1).unwrap();
-        assert!(!hash_1_metadata.fallback_peers.iter().any(|id| id == &peer_1));
-        assert!(hash_1_metadata.fallback_peers.iter().any(|id| id == &peer_2));
-
-        let hash_2_metadata =
-            tx_fetcher.hashes_fetch_inflight_and_pending_fetch.peek(&hash_2).unwrap();
-        assert!(!hash_2_metadata.fallback_peers.iter().any(|id| id == &peer_1));
+        // hash should be re-buffered, not lost
+        assert_eq!(tx_fetcher.num_pending_hashes(), 1);
     }
 
     #[test]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -2186,7 +2186,6 @@ mod tests {
     };
     use secp256k1::SecretKey;
     use std::{
-        collections::HashSet,
         future::poll_fn,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
@@ -2544,8 +2543,10 @@ mod tests {
             reason: None,
         }));
 
+        // peer removed from peers map and active_peers
         assert!(!tx_manager.peers.contains_key(&peer_id));
         assert!(tx_manager.transaction_fetcher.active_peers.peek(&peer_id).is_none());
+        // fallback peer is still available for the hash
         assert_eq!(
             tx_manager.transaction_fetcher.get_idle_peer_for(hash_shared),
             Some(&fallback_peer)

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -460,6 +460,18 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         self.network.reputation_change(peer_id, ReputationChangeKind::AlreadySeenTransaction);
     }
 
+    /// Removes a peer from transaction-local tracking state.
+    fn remove_peer_from_transaction_state(&mut self, peer_id: &PeerId) {
+        if let Some(mut peer) = self.peers.remove(peer_id) {
+            self.policies.propagation_policy_mut().on_session_closed(&mut peer);
+        }
+        self.transaction_fetcher.remove_peer(peer_id);
+        self.transactions_by_peers.retain(|_, peers| {
+            peers.remove(peer_id);
+            !peers.is_empty()
+        });
+    }
+
     /// Clear the transaction
     fn on_good_import(&mut self, hash: TxHash) {
         self.transactions_by_peers.remove(&hash);
@@ -1246,13 +1258,7 @@ where
     fn on_network_event(&mut self, event_result: NetworkEvent<PeerRequest<N>>) {
         match event_result {
             NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, .. }) => {
-                // remove the peer
-
-                let peer = self.peers.remove(&peer_id);
-                if let Some(mut peer) = peer {
-                    self.policies.propagation_policy_mut().on_session_closed(&mut peer);
-                }
-                self.transaction_fetcher.remove_peer(&peer_id);
+                self.remove_peer_from_transaction_state(&peer_id);
             }
             NetworkEvent::ActivePeerSession { info, messages } => {
                 // process active peer session and broadcast available transaction from the pool
@@ -2167,7 +2173,7 @@ mod tests {
         NetworkConfigBuilder, NetworkManager,
     };
     use alloy_consensus::{TxEip1559, TxLegacy};
-    use alloy_primitives::{hex, Signature, TxKind, U256};
+    use alloy_primitives::{hex, Signature, TxKind, B256, U256};
     use alloy_rlp::Decodable;
     use futures::FutureExt;
     use reth_chainspec::MIN_TRANSACTION_GAS;
@@ -2184,6 +2190,7 @@ mod tests {
     };
     use secp256k1::SecretKey;
     use std::{
+        collections::HashSet,
         future::poll_fn,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
@@ -2509,6 +2516,54 @@ mod tests {
         assert!(!pool.is_empty());
         assert!(pool.get(signed_tx.tx_hash()).is_some());
         handle.terminate().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_session_closed_cleans_transaction_peer_state() {
+        let (mut tx_manager, _network) = new_tx_manager().await;
+        let peer_id = PeerId::new([1; 64]);
+        let fallback_peer = PeerId::new([2; 64]);
+        let (peer, _) = new_mock_session(peer_id, EthVersion::Eth66);
+        let hash_shared = B256::from_slice(&[1; 32]);
+        let hash_unique = B256::from_slice(&[2; 32]);
+
+        tx_manager.peers.insert(peer_id, peer);
+        tx_manager
+            .transactions_by_peers
+            .insert(hash_shared, HashSet::from([peer_id, fallback_peer]));
+        tx_manager.transactions_by_peers.insert(hash_unique, HashSet::from([peer_id]));
+        buffer_hash_to_tx_fetcher(
+            &mut tx_manager.transaction_fetcher,
+            hash_shared,
+            peer_id,
+            0,
+            None,
+        );
+        buffer_hash_to_tx_fetcher(
+            &mut tx_manager.transaction_fetcher,
+            hash_shared,
+            fallback_peer,
+            0,
+            None,
+        );
+        tx_manager.transaction_fetcher.active_peers.insert(peer_id, 1);
+
+        tx_manager.on_network_event(NetworkEvent::Peer(PeerEvent::SessionClosed {
+            peer_id,
+            reason: None,
+        }));
+
+        assert!(!tx_manager.peers.contains_key(&peer_id));
+        assert_eq!(
+            tx_manager.transactions_by_peers.get(&hash_shared),
+            Some(&HashSet::from([fallback_peer]))
+        );
+        assert!(!tx_manager.transactions_by_peers.contains_key(&hash_unique));
+        assert!(tx_manager.transaction_fetcher.active_peers.peek(&peer_id).is_none());
+        assert_eq!(
+            tx_manager.transaction_fetcher.get_idle_peer_for(hash_shared),
+            Some(&fallback_peer)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -460,16 +460,12 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         self.network.reputation_change(peer_id, ReputationChangeKind::AlreadySeenTransaction);
     }
 
-    /// Removes a peer from transaction-local tracking state.
-    fn remove_peer_from_transaction_state(&mut self, peer_id: &PeerId) {
+    /// Handles a closed peer session, removing the peer from transaction-local tracking state.
+    fn on_peer_session_closed(&mut self, peer_id: &PeerId) {
         if let Some(mut peer) = self.peers.remove(peer_id) {
             self.policies.propagation_policy_mut().on_session_closed(&mut peer);
         }
         self.transaction_fetcher.remove_peer(peer_id);
-        self.transactions_by_peers.retain(|_, peers| {
-            peers.remove(peer_id);
-            !peers.is_empty()
-        });
     }
 
     /// Clear the transaction
@@ -1258,7 +1254,7 @@ where
     fn on_network_event(&mut self, event_result: NetworkEvent<PeerRequest<N>>) {
         match event_result {
             NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, .. }) => {
-                self.remove_peer_from_transaction_state(&peer_id);
+                self.on_peer_session_closed(&peer_id);
             }
             NetworkEvent::ActivePeerSession { info, messages } => {
                 // process active peer session and broadcast available transaction from the pool
@@ -2525,13 +2521,8 @@ mod tests {
         let fallback_peer = PeerId::new([2; 64]);
         let (peer, _) = new_mock_session(peer_id, EthVersion::Eth66);
         let hash_shared = B256::from_slice(&[1; 32]);
-        let hash_unique = B256::from_slice(&[2; 32]);
 
         tx_manager.peers.insert(peer_id, peer);
-        tx_manager
-            .transactions_by_peers
-            .insert(hash_shared, HashSet::from([peer_id, fallback_peer]));
-        tx_manager.transactions_by_peers.insert(hash_unique, HashSet::from([peer_id]));
         buffer_hash_to_tx_fetcher(
             &mut tx_manager.transaction_fetcher,
             hash_shared,
@@ -2554,11 +2545,6 @@ mod tests {
         }));
 
         assert!(!tx_manager.peers.contains_key(&peer_id));
-        assert_eq!(
-            tx_manager.transactions_by_peers.get(&hash_shared),
-            Some(&HashSet::from([fallback_peer]))
-        );
-        assert!(!tx_manager.transactions_by_peers.contains_key(&hash_unique));
         assert!(tx_manager.transaction_fetcher.active_peers.peek(&peer_id).is_none());
         assert_eq!(
             tx_manager.transaction_fetcher.get_idle_peer_for(hash_shared),


### PR DESCRIPTION
When a peer session closes, the tx manager removed the peer from its main peer map, but tx-local state could still retain references to that peer. This will waste retry/search work against peers that are already gone, and those gone peers should also not treated as fallback candidates. 

Propose to make changes to make peer removal consistent across tx-local state.