### PR TITLE
ci: disable PGO by default, rename input to `pgo`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,8 +28,8 @@ on:
         required: false
         type: boolean
         default: false
-      disable_pgo:
-        description: "Disable PGO profiling entirely"
+      pgo:
+        description: "Enable PGO profiling"
         required: false
         type: boolean
         default: false
@@ -41,10 +41,10 @@ on:
 
 jobs:
   collect-pgo-profile:
-    if: github.repository == 'paradigmxyz/reth' && !(github.event_name == 'workflow_dispatch' && inputs.disable_pgo)
+    if: github.repository == 'paradigmxyz/reth' && github.event_name == 'workflow_dispatch' && inputs.pgo
     uses: ./.github/workflows/pgo-profile.yml
     with:
-      pgo_blocks: ${{ github.event_name == 'workflow_dispatch' && inputs.pgo_blocks || '20' }}
+      pgo_blocks: ${{ inputs.pgo_blocks || '20' }}
     secrets: inherit
 
   build:
@@ -77,7 +77,7 @@ jobs:
           echo "dirty=false" >> "$GITHUB_OUTPUT"
 
       - name: Download pre-collected PGO profile
-        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.disable_pgo) }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.pgo }}
         uses: actions/download-artifact@v7
         with:
           name: pgo-profdata
@@ -86,11 +86,7 @@ jobs:
       - name: Configure PGO build args
         id: pgo
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ inputs.disable_pgo }}" == "true" ]]; then
-            echo "use_pgo_bolt=false" >> "$GITHUB_OUTPUT"
-            echo "pgo_profdata=" >> "$GITHUB_OUTPUT"
-            echo "PGO disabled via workflow input"
-          else
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ inputs.pgo }}" == "true" ]]; then
             if [ ! -f dist/merged.profdata ]; then
               echo "::error::Expected dist/merged.profdata from collect-pgo-profile job"
               exit 1
@@ -98,6 +94,10 @@ jobs:
             echo "use_pgo_bolt=true" >> "$GITHUB_OUTPUT"
             echo "pgo_profdata=dist/merged.profdata" >> "$GITHUB_OUTPUT"
             echo "Using pre-collected PGO profile from collect-pgo-profile job"
+          else
+            echo "use_pgo_bolt=false" >> "$GITHUB_OUTPUT"
+            echo "pgo_profdata=" >> "$GITHUB_OUTPUT"
+            echo "PGO disabled"
           fi
 
       - name: Determine build parameters

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
         description: "Enable dry run mode (builds artifacts but skips uploads and release creation)"
         type: boolean
         default: false
+      pgo:
+        description: "Enable PGO profiling"
+        type: boolean
+        default: false
       pgo_blocks:
         description: "Number of blocks to execute for PGO profiling on self-hosted runner"
         type: string
@@ -154,12 +158,14 @@ jobs:
           path: ${{ matrix.build.binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.asc
 
   collect-pgo-profile:
+    if: github.event_name == 'workflow_dispatch' && inputs.pgo
     uses: ./.github/workflows/pgo-profile.yml
     with:
-      pgo_blocks: ${{ github.event_name == 'workflow_dispatch' && inputs.pgo_blocks || '20' }}
+      pgo_blocks: ${{ inputs.pgo_blocks || '20' }}
     secrets: inherit
 
   build-pgo:
+    if: github.event_name == 'workflow_dispatch' && inputs.pgo
     name: build release (x86_64-linux PGO+BOLT)
     runs-on: [self-hosted, Linux, X64]
     needs: [extract-version, collect-pgo-profile]
@@ -237,7 +243,7 @@ jobs:
     name: draft release
     runs-on: ubuntu-latest
     needs: [build, build-pgo, extract-version]
-    if: ${{ github.event.inputs.dry_run != 'true' }}
+    if: ${{ !failure() && !cancelled() && github.event.inputs.dry_run != 'true' }}
     env:
       VERSION: ${{ needs.extract-version.outputs.VERSION }}
     permissions:


### PR DESCRIPTION
Disables PGO by default across all triggers (scheduled, tag-push, and manual). PGO now only runs when explicitly enabled via `workflow_dispatch` with the `pgo` checkbox.

Changes:
- `docker.yml`: rename `disable_pgo` → `pgo`, default `false`, gate all PGO steps on opt-in
- `release.yml`: add `pgo` input (default `false`), gate `collect-pgo-profile` and `build-pgo` on it, allow `draft-release` to proceed when PGO is skipped

Prompted by: DaniPopes