### PR TITLE
ci: bump state tests runner to depot-ubuntu-latest-8

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -55,7 +55,7 @@ jobs:
 
   state:
     name: Ethereum state tests
-    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-4' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-8' || 'ubuntu-latest' }}
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1


### PR DESCRIPTION
Bumps the Ethereum state tests runner from `depot-ubuntu-latest-4` to `depot-ubuntu-latest-8`.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes