### PR TITLE
fix(chain-state): correct return type of NewCanonicalChain::tip()

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -992,7 +992,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
     ///
     /// Returns the new tip for [`Self::Reorg`] and [`Self::Commit`] variants which commit at least
     /// 1 new block.
-    pub fn tip(&self) -> &SealedBlock<N::Block> {
+    pub fn tip(&self) -> &RecoveredBlock<N::Block> {
         match self {
             Self::Commit { new } | Self::Reorg { new, .. } => {
                 new.last().expect("non empty blocks").recovered_block()


### PR DESCRIPTION
In commit 13ecd6afa the function body was changed from `.block()` to `.recovered_block()` but the return type was not updated. The function returns `&RecoveredBlock<N::Block>` but was typed as `&SealedBlock<N::Block>`. Only compiled due to Deref coercion.