### PR TITLE
fix(trie): blinded-sibling collapse when multiple subtries empty in parallel

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -3249,105 +3249,37 @@ mod tests {
         }
     }
 
-    /// Reproduction of the blinded-sibling collapse panic triggered by the `if true`
-    /// forced parallel path in `update_leaves`.
+    /// Minimal reproduction of the blinded-sibling collapse panic.
     ///
-    /// Minimized from a proptest failure. `check_subtrie_collapse_needs_proof` runs
-    /// before subtries are taken and processed, but the actual collapse happens after
-    /// restoration. The check cannot predict the post-update state when a subtrie
-    /// ends up empty (e.g., all its leaves are deleted while the net changeset for
-    /// the subtrie is all-removals). After the subtrie is emptied and removed,
-    /// `maybe_collapse_or_remove_branch` finds the parent branch with a single
-    /// blinded sibling and panics.
+    /// A parent branch at nibble `0xd` has 3 children: subtries `0xd7`, `0xd8`,
+    /// `0xdd` — each containing a single leaf.  When `min_updates = 1` forces the
+    /// parallel path, subtries `0xd7` and `0xdd` are both taken and emptied by
+    /// all-removal updates.  `check_subtrie_collapse_needs_proof` evaluates each
+    /// independently and sees the parent with 3 children (safe), so it lets both
+    /// through.  During the post-restore unwrap phase, unwrapping `0xd7` drops the
+    /// parent to 2 children, then unwrapping `0xdd` drops it to 1 — the still-
+    /// blinded `0xd8` — triggering the panic in `maybe_collapse_or_remove_branch`.
     #[test]
     fn test_blinded_sibling_collapse_with_forced_parallel_path() {
-        reth_tracing::init_test_tracing();
+        let key = |b0: u8| {
+            let mut k = [0u8; 32];
+            k[0] = b0;
+            B256::from(k)
+        };
 
-        // Construct the initial dataset from the shrunk proptest failure.
-        let mut initial = BTreeMap::new();
-        let keys_and_values: &[(u8, u8, U256)] = &[
-            (0x00, 0x00, U256::from(250u64)),
-            (0x01, 0x00, U256::from(174u64)),
-            (0x03, 0x00, U256::from(94u64)),
-            (0x06, 0x00, U256::from(225u64)),
-            (0x08, 0x00, U256::from(91u64)),
-            (0x0a, 0x00, U256::from(179u64)),
-            (0x0d, 0x00, U256::from(102u64)),
-            (0x11, 0x00, U256::from(125u64)),
-            (0x15, 0x00, U256::from(250u64)),
-            (0x17, 0x00, U256::from(3u64)),
-            (0x23, 0x00, U256::from(110u64)),
-            (0x2a, 0x00, U256::from(98u64)),
-            (0x37, 0x00, U256::from(136u64)),
-            (0x38, 0x00, U256::from(227u64)),
-            (0x3c, 0x00, U256::from(90u64)),
-            (0x43, 0x00, U256::from(96u64)),
-            (0x47, 0x00, U256::from(173u64)),
-            (0x48, 0x00, U256::from(220u64)),
-            (0x52, 0x00, U256::from(120u64)),
-            (0x55, 0x00, U256::from(39u64)),
-            (0x56, 0x00, U256::from(88u64)),
-            (0x5a, 0x00, U256::from(21u64)),
-            (0x5f, 0x00, U256::from(221u64)),
-            (0x60, 0x00, U256::from(125u64)),
-            (0x64, 0x00, U256::from(26u64)),
-            (0x68, 0x00, U256::from(125u64)),
-            (0x6f, 0x00, U256::from(154u64)),
-            (0x71, 0x00, U256::from(91u64)),
-            (0x7b, 0x00, U256::from(174u64)),
-            (0x7f, 0x00, U256::from(243u64)),
-            (0x88, 0x00, U256::from(103u64)),
-            (0x8b, 0x00, U256::from(105u64)),
-            (0x94, 0x00, U256::from(184u64)),
-            (0x96, 0x00, U256::from(152u64)),
-            (0x9e, 0x00, U256::from(30u64)),
-            (0xa1, 0x00, U256::from(184u64)),
-            (0xa7, 0x00, U256::from(155u64)),
-            (0xa8, 0x00, U256::from(55u64)),
-            (0xaa, 0x00, U256::from(59u64)),
-            (0xac, 0x00, U256::from(191u64)),
-            (0xb7, 0x00, U256::from(238u64)),
-            (0xba, 0x00, U256::from(239u64)),
-            (0xbf, 0x00, U256::from(100u64)),
-            (0xc8, 0x00, U256::from(29u64)),
-            (0xca, 0x00, U256::from(241u64)),
-            (0xcb, 0x00, U256::from(37u64)),
-            (0xce, 0x00, U256::from(137u64)),
-            (0xd7, 0x00, U256::from(202u64)),
-            (0xd8, 0x00, U256::from(209u64)),
-            (0xdd, 0x00, U256::from(22u64)),
-            (0xe5, 0x00, U256::from(224u64)),
-            (0xee, 0x00, U256::from(228u64)),
-            (0xf2, 0x00, U256::from(240u64)),
-            (0xf3, 0x00, U256::from(51u64)),
-            (0xf7, 0x00, U256::from(67u64)),
-            (0xfb, 0x00, U256::from(10u64)),
-        ];
-        // Keys with subtrie-level structure (2+ keys sharing first 2 nibbles).
-        let subtrie_keys: &[(u8, u8, U256)] = &[
-            (0x0a, 0x14, U256::from(81u64)),
-            (0x0d, 0x11, U256::from(39u64)),
-            (0x0d, 0x23, U256::from(82u64)),
-            (0xa7, 0x0d, U256::from(23u64)),
-            (0xa7, 0xa6, U256::from(85u64)),
-            (0xca, 0x4f, U256::from(164u64)),
-        ];
+        // Three keys under nibble 0xd (each becomes its own subtrie at depth 2).
+        // A fourth key under a different nibble so the root is a multi-child branch.
+        let initial: BTreeMap<B256, U256> = [
+            (key(0xd7), U256::from(1)),
+            (key(0xd8), U256::from(2)),
+            (key(0xdd), U256::from(3)),
+            (key(0xaa), U256::from(4)),
+        ]
+        .into();
 
-        for &(b0, b1, val) in keys_and_values.iter().chain(subtrie_keys.iter()) {
-            let mut key = [0u8; 32];
-            key[0] = b0;
-            key[1] = b1;
-            initial.insert(B256::from(key), val);
-        }
-
-        let mut rng = rand::rngs::StdRng::seed_from_u64(4323023);
-        let changeset = build_changeset(
-            &initial,
-            BTreeMap::new(),
-            0.4401021905950668,
-            0.22302515352148555,
-            &mut rng,
-        );
+        // Delete the two outer siblings; leave 0xd8 untouched (blinded).
+        let changeset: BTreeMap<B256, U256> =
+            [(key(0xd7), U256::ZERO), (key(0xdd), U256::ZERO)].into();
 
         let harness = ArenaTrieTestHarness::new(initial);
 
@@ -3364,8 +3296,6 @@ mod tests {
         apst.set_root(root_node.node, root_node.masks, true)
             .expect("set_root should succeed");
 
-        // This panics with "single remaining child is blinded" when min_updates=1
-        // forces all subtrie updates through the taken (parallel) path.
         harness.assert_changes(&mut apst, changeset);
     }
 }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -3248,4 +3248,124 @@ mod tests {
             harness.assert_changes(&mut apst, changeset2);
         }
     }
+
+    /// Reproduction of the blinded-sibling collapse panic triggered by the `if true`
+    /// forced parallel path in `update_leaves`.
+    ///
+    /// Minimized from a proptest failure. `check_subtrie_collapse_needs_proof` runs
+    /// before subtries are taken and processed, but the actual collapse happens after
+    /// restoration. The check cannot predict the post-update state when a subtrie
+    /// ends up empty (e.g., all its leaves are deleted while the net changeset for
+    /// the subtrie is all-removals). After the subtrie is emptied and removed,
+    /// `maybe_collapse_or_remove_branch` finds the parent branch with a single
+    /// blinded sibling and panics.
+    #[test]
+    fn test_blinded_sibling_collapse_with_forced_parallel_path() {
+        reth_tracing::init_test_tracing();
+
+        // Construct the initial dataset from the shrunk proptest failure.
+        let mut initial = BTreeMap::new();
+        let keys_and_values: &[(u8, u8, U256)] = &[
+            (0x00, 0x00, U256::from(250u64)),
+            (0x01, 0x00, U256::from(174u64)),
+            (0x03, 0x00, U256::from(94u64)),
+            (0x06, 0x00, U256::from(225u64)),
+            (0x08, 0x00, U256::from(91u64)),
+            (0x0a, 0x00, U256::from(179u64)),
+            (0x0d, 0x00, U256::from(102u64)),
+            (0x11, 0x00, U256::from(125u64)),
+            (0x15, 0x00, U256::from(250u64)),
+            (0x17, 0x00, U256::from(3u64)),
+            (0x23, 0x00, U256::from(110u64)),
+            (0x2a, 0x00, U256::from(98u64)),
+            (0x37, 0x00, U256::from(136u64)),
+            (0x38, 0x00, U256::from(227u64)),
+            (0x3c, 0x00, U256::from(90u64)),
+            (0x43, 0x00, U256::from(96u64)),
+            (0x47, 0x00, U256::from(173u64)),
+            (0x48, 0x00, U256::from(220u64)),
+            (0x52, 0x00, U256::from(120u64)),
+            (0x55, 0x00, U256::from(39u64)),
+            (0x56, 0x00, U256::from(88u64)),
+            (0x5a, 0x00, U256::from(21u64)),
+            (0x5f, 0x00, U256::from(221u64)),
+            (0x60, 0x00, U256::from(125u64)),
+            (0x64, 0x00, U256::from(26u64)),
+            (0x68, 0x00, U256::from(125u64)),
+            (0x6f, 0x00, U256::from(154u64)),
+            (0x71, 0x00, U256::from(91u64)),
+            (0x7b, 0x00, U256::from(174u64)),
+            (0x7f, 0x00, U256::from(243u64)),
+            (0x88, 0x00, U256::from(103u64)),
+            (0x8b, 0x00, U256::from(105u64)),
+            (0x94, 0x00, U256::from(184u64)),
+            (0x96, 0x00, U256::from(152u64)),
+            (0x9e, 0x00, U256::from(30u64)),
+            (0xa1, 0x00, U256::from(184u64)),
+            (0xa7, 0x00, U256::from(155u64)),
+            (0xa8, 0x00, U256::from(55u64)),
+            (0xaa, 0x00, U256::from(59u64)),
+            (0xac, 0x00, U256::from(191u64)),
+            (0xb7, 0x00, U256::from(238u64)),
+            (0xba, 0x00, U256::from(239u64)),
+            (0xbf, 0x00, U256::from(100u64)),
+            (0xc8, 0x00, U256::from(29u64)),
+            (0xca, 0x00, U256::from(241u64)),
+            (0xcb, 0x00, U256::from(37u64)),
+            (0xce, 0x00, U256::from(137u64)),
+            (0xd7, 0x00, U256::from(202u64)),
+            (0xd8, 0x00, U256::from(209u64)),
+            (0xdd, 0x00, U256::from(22u64)),
+            (0xe5, 0x00, U256::from(224u64)),
+            (0xee, 0x00, U256::from(228u64)),
+            (0xf2, 0x00, U256::from(240u64)),
+            (0xf3, 0x00, U256::from(51u64)),
+            (0xf7, 0x00, U256::from(67u64)),
+            (0xfb, 0x00, U256::from(10u64)),
+        ];
+        // Keys with subtrie-level structure (2+ keys sharing first 2 nibbles).
+        let subtrie_keys: &[(u8, u8, U256)] = &[
+            (0x0a, 0x14, U256::from(81u64)),
+            (0x0d, 0x11, U256::from(39u64)),
+            (0x0d, 0x23, U256::from(82u64)),
+            (0xa7, 0x0d, U256::from(23u64)),
+            (0xa7, 0xa6, U256::from(85u64)),
+            (0xca, 0x4f, U256::from(164u64)),
+        ];
+
+        for &(b0, b1, val) in keys_and_values.iter().chain(subtrie_keys.iter()) {
+            let mut key = [0u8; 32];
+            key[0] = b0;
+            key[1] = b1;
+            initial.insert(B256::from(key), val);
+        }
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(4323023);
+        let changeset = build_changeset(
+            &initial,
+            BTreeMap::new(),
+            0.4401021905950668,
+            0.22302515352148555,
+            &mut rng,
+        );
+
+        let harness = ArenaTrieTestHarness::new(initial);
+
+        let mut apst = ArenaParallelSparseTrie::default().with_parallelism_thresholds(
+            ArenaParallelismThresholds {
+                min_dirty_leaves: 1,
+                min_revealed_nodes: 1,
+                min_updates: 1,
+                min_leaves_for_prune: 1,
+            },
+        );
+
+        let root_node = harness.root_node();
+        apst.set_root(root_node.node, root_node.masks, true)
+            .expect("set_root should succeed");
+
+        // This panics with "single remaining child is blinded" when min_updates=1
+        // forces all subtrie updates through the taken (parallel) path.
+        harness.assert_changes(&mut apst, changeset);
+    }
 }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1725,26 +1725,25 @@ impl ArenaParallelSparseTrie {
             return None;
         }
 
+        // This subtrie would be fully emptied by all-removal updates. If the parent
+        // has any blinded children, removing this subtrie could eventually leave the
+        // parent with a single blinded child — especially when multiple sibling
+        // subtries are taken in the same batch and also emptied. Conservatively
+        // request a proof for the first blinded sibling found.
         let child_nibble =
             subtrie_entry.path.last().expect("subtrie path must have at least one nibble");
 
         let parent_entry = cursor.parent()?;
         let parent_branch = arena[parent_entry.index].branch_ref();
-        if parent_branch.state_mask.count_bits() != 2 {
-            return None;
-        }
 
-        if !parent_branch.sibling_child(child_nibble).is_blinded() {
-            return None;
-        }
+        // Find any blinded sibling under the parent.
+        let blinded_sibling_nibble = parent_branch
+            .child_iter()
+            .find(|(nibble, child)| *nibble != child_nibble && child.is_blinded())
+            .map(|(nibble, _)| nibble)?;
 
-        let sibling_nibble = parent_branch
-            .state_mask
-            .iter()
-            .find(|&n| n != child_nibble)
-            .expect("branch has two children");
         let mut sibling_path = cursor.parent_logical_branch_path(arena);
-        sibling_path.push_unchecked(sibling_nibble);
+        sibling_path.push_unchecked(blinded_sibling_nibble);
 
         Some(ArenaRequiredProof {
             key: Self::nibbles_to_padded_b256(&sibling_path),

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -3292,8 +3292,7 @@ mod tests {
         );
 
         let root_node = harness.root_node();
-        apst.set_root(root_node.node, root_node.masks, true)
-            .expect("set_root should succeed");
+        apst.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
 
         harness.assert_changes(&mut apst, changeset);
     }


### PR DESCRIPTION
## The Bug

### Trie structure at the time of `update_leaves`

```
root (branch)
 └─ 0xd (branch, 3 children)
      ├─ 0xd7 → Subtrie (1 leaf, revealed)
      ├─ 0xd8 → Subtrie (1 leaf, BLINDED — no update touches it)
      └─ 0xdd → Subtrie (1 leaf, revealed)
```

### What happens

1. `update_leaves` walks the sorted updates sequentially and encounters subtrie `0xd7` (all-removal update).

2. **Pre-check** `check_subtrie_collapse_needs_proof` runs for `0xd7`:
   - All updates are removals? ✓ (`num_removals == subtrie_updates.len()`)
   - Would empty the subtrie? ✓ (`num_removals >= num_leaves`)
   - **Parent has exactly 2 children?** ✗ — it has **3** → `count_bits() != 2` → **returns `None`** (no proof needed)

3. `0xd7` is taken for parallel processing.

4. Same thing for `0xdd` — identical check, identical result. Taken.

5. Both subtries are processed in parallel. Both become `EmptyRoot`.

6. **Post-restore unwrap phase** iterates taken paths:
   - Seek to `0xd7` → empty → `maybe_unwrap_subtrie` → removes child from parent. Parent `0xd` now has **2 children**: `{0xd8 (blinded), 0xdd (empty subtrie)}`.
   - `maybe_collapse_or_remove_branch` runs → count=2, no-op.
   - Seek to `0xdd` → empty → `maybe_unwrap_subtrie` → removes child from parent. Parent `0xd` now has **1 child**: `{0xd8 (blinded)}`.
   - `maybe_collapse_or_remove_branch` runs → count=1, sole remaining child is **blinded** → **panic**.

### Why the pre-check missed it

`check_subtrie_collapse_needs_proof` evaluated each subtrie **independently** against the **pre-update** parent shape. It only requested a proof when the parent had **exactly 2 children** (the subtrie being emptied + one blinded sibling). With 3+ children, it assumed removing one subtrie was safe — without considering that **other siblings in the same batch would also be removed**.

## The Fix

Remove the `count_bits() == 2` gate and `sibling_child()` call (which asserts exactly 2 children). Instead, scan **all** parent children for **any** blinded sibling. If a subtrie would be fully emptied and the parent has any blinded child anywhere, conservatively request a proof upfront.

### Diff

The change is entirely within `check_subtrie_collapse_needs_proof`. The early-exit conditions (not all removals, wouldn't empty the subtrie) are unchanged. Only the parent-shape check changes:

**Before:**
```rust
if parent_branch.state_mask.count_bits() != 2 {
    return None;
}
if !parent_branch.sibling_child(child_nibble).is_blinded() {
    return None;
}
let sibling_nibble = parent_branch
    .state_mask
    .iter()
    .find(|&n| n != child_nibble)
    .expect("branch has two children");
```

**After:**
```rust
let blinded_sibling_nibble = parent_branch
    .child_iter()
    .find(|(nibble, child)| *nibble != child_nibble && child.is_blinded())
    .map(|(nibble, _)| nibble)?;
```

### Conservatism

When `check_subtrie_collapse_needs_proof` returns `Some`, the subtrie's updates are **put back** into the `updates` map, the subtrie is **skipped entirely**, and a proof is requested. On the next reveal-update cycle, the proof reveals the blinded sibling, and the subtrie's updates are retried — this time the parent has no blinded children so the check passes and the deletions go through normally.

**The false-positive scenario:**

```
Parent branch at nibble 0xd, 4 children:
  0xd3 → Subtrie (revealed, NOT being updated)
  0xd7 → Subtrie (revealed, being emptied by all-deletion updates)
  0xd8 → BLINDED (no updates)
  0xdd → Subtrie (revealed, NOT being updated)
```

- **Old code**: parent has 4 children → `count_bits() != 2` → returns `None` → subtrie `0xd7` is taken and emptied → post-restore unwrap removes it → parent has 3 children `{0xd3, 0xd8, 0xdd}` → `count >= 2` → no collapse → **safe, no problem**.

- **New code**: parent has a blinded child `0xd8` → returns `Some(proof for 0xd8)` → subtrie `0xd7`'s updates are **skipped and re-queued** → proof for `0xd8` is requested → extra reveal-update round-trip to apply the same deletions that would have worked fine the first time.

**Cost**: one extra iteration of the reveal-update loop. The deletions still succeed, the hash is still correct — just one unnecessary round-trip through `update_leaves` → proof request → `reveal_nodes` → `update_leaves`.

**How often**: requires ALL of these simultaneously:
1. A subtrie where every single update is a deletion
2. Those deletions empty the subtrie completely (`num_removals >= num_leaves`)
3. The parent has a blinded child
4. The parent has **other revealed children that survive** (so the collapse-to-blinded never actually happens)

This is very narrow. In typical usage, subtries at depth 2 under the same parent rarely have all-deletion batches that fully empty them, and if the parent has blinded children it usually means the trie is partially revealed — which is the exact scenario where an extra proof round-trip is near-free anyway.

A tighter fix would need to predict which **other** sibling subtries will also be emptied in the same batch, but `check_subtrie_collapse_needs_proof` runs per-subtrie during a sequential walk — it doesn't have lookahead into future subtries. You'd need a two-pass approach or parent-level grouping, which is more code for a marginal improvement on a rare edge case.
