### PR TITLE
chore(bench): remove unnecessary 5s sleep in start_node

### DIFF
--- a/bin/reth-bench-compare/src/node.rs
+++ b/bin/reth-bench-compare/src/node.rs
@@ -362,9 +362,6 @@ impl NodeManager {
             });
         }
 
-        // Give the node a moment to start up
-        sleep(Duration::from_secs(5)).await;
-
         Ok((child, reth_command))
     }
 


### PR DESCRIPTION
All callers of start_node immediately follow up with wait_for_node_ready_and_get_tip or wait_for_rpc_and_get_tip, both of which already poll readiness with retries. The fixed 5s sleep is dead wait time on every benchmark round.