### PR TITLE
fix(rpc): disable fee charge in eth_createAccessList

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -491,6 +491,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // Disabled because eth_createAccessList is sometimes used with non-eoa senders
             evm_env.cfg_env.disable_eip3607 = true;
 
+            // Disable additional fee charges (e.g. L2 operator fees),
+            // consistent with prepare_call_env and estimate_gas_with.
+            evm_env.cfg_env.disable_fee_charge = true;
+
             // Disable EIP-7825 transaction gas limit cap so that the gas limit
             // fallback (block gas limit) is not rejected when it exceeds the
             // per-tx cap (2^24 ≈ 16.7M post-Osaka).


### PR DESCRIPTION
Same fix as #22959 did for eth_estimateGas — eth_createAccessList is also a simulation call but was missing `disable_fee_charge = true`, which causes inflated gas_used or outright failures on L2s that charge operator fees.