### PR TITLE
ci(bench): schedule bench job only on runners tagged `available`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - depot-ubuntu-latest-4
     - depot-ubuntu-latest-8
     - depot-ubuntu-latest-16
+    - available

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -476,7 +476,7 @@ jobs:
   reth-bench:
     needs: reth-bench-ack
     name: reth-bench
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, available]
     timeout-minutes: 120
     env:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc


### PR DESCRIPTION
Adds the `available` tag to the `runs-on` labels for the `reth-bench` job so it only gets scheduled on runners that are currently marked available.

Prompted by: alexey