### PR TITLE
fix(pool): clean up blob sidecars when removing transactions

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1061,6 +1061,7 @@ where
         }
         let removed = self.pool.write().remove_transactions(hashes);
 
+        self.delete_discarded_blobs(removed.iter());
         self.with_event_listener(|listener| listener.discarded_many(&removed));
 
         removed


### PR DESCRIPTION
`remove_transactions` was the only discard path that didn't call `delete_discarded_blobs`, leaving orphaned blob data in the store.
