### PR TITLE
fix(net): treat malformed blob sidecar responses as peer misbehavior

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -468,6 +468,8 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         self.transaction_fetcher.remove_peer(peer_id);
     }
 
+    /// Penalizes and disconnects a peer that violated the protocol (e.g. sent malformed blob
+    /// sidecar data).
     fn disconnect_peer_for_protocol_violation(&self, peer_id: PeerId) {
         self.report_peer_bad_transactions(peer_id);
         self.network.disconnect_peer_with_reason(peer_id, DisconnectReason::SubprotocolSpecific);

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -44,8 +44,8 @@ use alloy_primitives::{TxHash, B256};
 use constants::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use reth_eth_wire::{
-    DedupPayload, EthNetworkPrimitives, EthVersion, GetPooledTransactions, HandleMempoolData,
-    HandleVersionedMempoolData, NetworkPrimitives, NewPooledTransactionHashes,
+    DedupPayload, DisconnectReason, EthNetworkPrimitives, EthVersion, GetPooledTransactions,
+    HandleMempoolData, HandleVersionedMempoolData, NetworkPrimitives, NewPooledTransactionHashes,
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, PooledTransactions,
     RequestTxHashes, Transactions, ValidAnnouncementData,
 };
@@ -468,13 +468,24 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         self.transaction_fetcher.remove_peer(peer_id);
     }
 
+    fn disconnect_peer_for_protocol_violation(&self, peer_id: PeerId) {
+        self.report_peer_bad_transactions(peer_id);
+        self.network.disconnect_peer_with_reason(peer_id, DisconnectReason::SubprotocolSpecific);
+    }
+
     /// Clear the transaction
     fn on_good_import(&mut self, hash: TxHash) {
         self.transactions_by_peers.remove(&hash);
     }
 
-    /// Penalize the peers that intentionally sent the bad transaction, and cache it to avoid
-    /// fetching or importing it again.
+    /// Handles a failed transaction import.
+    ///
+    /// Protocol violations (e.g. malformed blob sidecars) result in immediate peer disconnect
+    /// without caching the hash as bad — the transaction may be valid when fetched from another
+    /// peer.
+    ///
+    /// Other bad transactions are penalized and cached in `bad_imports` to avoid fetching or
+    /// importing them again.
     ///
     /// Errors that count as bad transactions are:
     ///
@@ -498,6 +509,18 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     /// - wrong versioned kzg commitment hash
     fn on_bad_import(&mut self, err: PoolError) {
         let peers = self.transactions_by_peers.remove(&err.hash);
+
+        if err.is_protocol_violation() {
+            // Protocol violations (e.g. malformed blob sidecars) warrant immediate disconnect.
+            // The tx hash is NOT added to bad_imports because the transaction itself may be valid
+            // — the issue is peer-specific (bad sidecar data), not transaction-specific.
+            if let Some(peers) = peers {
+                for peer_id in peers {
+                    self.disconnect_peer_for_protocol_violation(peer_id);
+                }
+            }
+            return
+        }
 
         // if we're _currently_ syncing, we ignore a bad transaction
         if !err.is_bad_transaction() || self.network.is_syncing() {
@@ -2169,6 +2192,7 @@ mod tests {
         NetworkConfigBuilder, NetworkManager,
     };
     use alloy_consensus::{TxEip1559, TxLegacy};
+    use alloy_eips::eip4844::BlobTransactionValidationError;
     use alloy_primitives::{hex, Signature, TxKind, B256, U256};
     use alloy_rlp::Decodable;
     use futures::FutureExt;
@@ -2181,11 +2205,13 @@ mod tests {
     };
     use reth_storage_api::noop::NoopProvider;
     use reth_tasks::Runtime;
-    use reth_transaction_pool::test_utils::{
-        testing_pool, MockTransaction, MockTransactionFactory, TestPool,
+    use reth_transaction_pool::{
+        error::{Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError},
+        test_utils::{testing_pool, MockTransaction, MockTransactionFactory, TestPool},
     };
     use secp256k1::SecretKey;
     use std::{
+        collections::HashSet,
         future::poll_fn,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
@@ -2551,6 +2577,67 @@ mod tests {
             tx_manager.transaction_fetcher.get_idle_peer_for(hash_shared),
             Some(&fallback_peer)
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_protocol_violation_not_cached_as_bad_import() {
+        let (mut tx_manager, _network) = new_tx_manager().await;
+        let peer_id = PeerId::new([1; 64]);
+        let hash = B256::from_slice(&[1; 32]);
+
+        tx_manager.network.update_sync_state(SyncState::Idle);
+        tx_manager.transactions_by_peers.insert(hash, HashSet::from([peer_id]));
+
+        let err = PoolError::new(
+            hash,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::InvalidEip4844Blob(
+                BlobTransactionValidationError::InvalidProof,
+            )),
+        );
+
+        tx_manager.on_bad_import(err);
+
+        assert!(!tx_manager.bad_imports.contains(&hash));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_missing_blob_sidecar_not_cached_as_bad_import() {
+        let (mut tx_manager, _network) = new_tx_manager().await;
+        let peer_id = PeerId::new([1; 64]);
+        let hash = B256::from_slice(&[3; 32]);
+
+        tx_manager.network.update_sync_state(SyncState::Idle);
+        tx_manager.transactions_by_peers.insert(hash, HashSet::from([peer_id]));
+
+        let err = PoolError::new(
+            hash,
+            InvalidPoolTransactionError::Eip4844(
+                Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
+            ),
+        );
+
+        tx_manager.on_bad_import(err);
+
+        assert!(!tx_manager.bad_imports.contains(&hash));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_non_protocol_violation_still_cached_as_bad_import() {
+        let (mut tx_manager, _network) = new_tx_manager().await;
+        let peer_id = PeerId::new([1; 64]);
+        let hash = B256::from_slice(&[2; 32]);
+
+        tx_manager.network.update_sync_state(SyncState::Idle);
+        tx_manager.transactions_by_peers.insert(hash, HashSet::from([peer_id]));
+
+        let err = PoolError::new(
+            hash,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::NoEip4844Blobs),
+        );
+
+        tx_manager.on_bad_import(err);
+
+        assert!(tx_manager.bad_imports.contains(&hash));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -44,8 +44,8 @@ use alloy_primitives::{TxHash, B256};
 use constants::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use reth_eth_wire::{
-    DedupPayload, DisconnectReason, EthNetworkPrimitives, EthVersion, GetPooledTransactions,
-    HandleMempoolData, HandleVersionedMempoolData, NetworkPrimitives, NewPooledTransactionHashes,
+    DedupPayload, EthNetworkPrimitives, EthVersion, GetPooledTransactions, HandleMempoolData,
+    HandleVersionedMempoolData, NetworkPrimitives, NewPooledTransactionHashes,
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, PooledTransactions,
     RequestTxHashes, Transactions, ValidAnnouncementData,
 };
@@ -468,13 +468,6 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         self.transaction_fetcher.remove_peer(peer_id);
     }
 
-    /// Penalizes and disconnects a peer that violated the protocol (e.g. sent malformed blob
-    /// sidecar data).
-    fn disconnect_peer_for_protocol_violation(&self, peer_id: PeerId) {
-        self.report_peer_bad_transactions(peer_id);
-        self.network.disconnect_peer_with_reason(peer_id, DisconnectReason::SubprotocolSpecific);
-    }
-
     /// Clear the transaction
     fn on_good_import(&mut self, hash: TxHash) {
         self.transactions_by_peers.remove(&hash);
@@ -482,9 +475,9 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
 
     /// Handles a failed transaction import.
     ///
-    /// Protocol violations (e.g. malformed blob sidecars) result in immediate peer disconnect
-    /// without caching the hash as bad — the transaction may be valid when fetched from another
-    /// peer.
+    /// Blob sidecar errors (e.g. invalid proof, missing sidecar) are penalized via
+    /// `report_peer_bad_transactions` but NOT cached in `bad_imports` — the transaction itself
+    /// may be valid when fetched from another peer with correct sidecar data.
     ///
     /// Other bad transactions are penalized and cached in `bad_imports` to avoid fetching or
     /// importing them again.
@@ -512,13 +505,13 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
     fn on_bad_import(&mut self, err: PoolError) {
         let peers = self.transactions_by_peers.remove(&err.hash);
 
-        if err.is_protocol_violation() {
-            // Protocol violations (e.g. malformed blob sidecars) warrant immediate disconnect.
-            // The tx hash is NOT added to bad_imports because the transaction itself may be valid
-            // — the issue is peer-specific (bad sidecar data), not transaction-specific.
+        if err.is_bad_blob_sidecar() {
+            // Blob sidecar errors: penalize but do NOT cache the hash as bad.
+            // The transaction may be valid — only the sidecar from this peer was wrong.
+            // Using regular penalties means repeated offenders still get disconnected.
             if let Some(peers) = peers {
                 for peer_id in peers {
-                    self.disconnect_peer_for_protocol_violation(peer_id);
+                    self.report_peer_bad_transactions(peer_id);
                 }
             }
             return
@@ -2582,7 +2575,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_protocol_violation_not_cached_as_bad_import() {
+    async fn test_bad_blob_sidecar_not_cached_as_bad_import() {
         let (mut tx_manager, _network) = new_tx_manager().await;
         let peer_id = PeerId::new([1; 64]);
         let hash = B256::from_slice(&[1; 32]);
@@ -2624,7 +2617,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_non_protocol_violation_still_cached_as_bad_import() {
+    async fn test_non_blob_sidecar_error_still_cached_as_bad_import() {
         let (mut tx_manager, _network) = new_tx_manager().await;
         let peer_id = PeerId::new([1; 64]);
         let hash = B256::from_slice(&[2; 32]);

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -145,6 +145,17 @@ impl PoolError {
             }
         }
     }
+
+    /// Returns `true` if the error indicates a protocol violation that should result in an
+    /// immediate peer disconnect, without proving that the transaction hash itself is globally
+    /// invalid.
+    #[inline]
+    pub const fn is_protocol_violation(&self) -> bool {
+        match &self.kind {
+            PoolErrorKind::InvalidTransaction(err) => err.is_protocol_violation(),
+            _ => false,
+        }
+    }
 }
 
 /// Represents all errors that can happen when validating transactions for the pool for EIP-4844
@@ -400,6 +411,22 @@ impl InvalidPoolTransactionError {
         }
     }
 
+    /// Returns `true` if the failure indicates a protocol violation that should result in an
+    /// immediate peer disconnect.
+    #[inline]
+    pub const fn is_protocol_violation(&self) -> bool {
+        matches!(
+            self,
+            Self::Eip4844(
+                Eip4844PoolTransactionError::MissingEip4844BlobSidecar |
+                    Eip4844PoolTransactionError::InvalidEip4844Blob(_) |
+                    Eip4844PoolTransactionError::UnexpectedEip7594SidecarBeforeOsaka |
+                    Eip4844PoolTransactionError::UnexpectedEip4844SidecarAfterOsaka |
+                    Eip4844PoolTransactionError::Eip7594SidecarDisallowed
+            )
+        )
+    }
+
     /// Returns true if this is a [`Self::Consensus`] variant.
     pub const fn as_consensus(&self) -> Option<&InvalidTransactionError> {
         match self {
@@ -474,5 +501,33 @@ mod tests {
         assert!(err.is_other::<E>());
 
         assert!(err.downcast_other_ref::<E>().is_some());
+    }
+
+    #[test]
+    fn protocol_violation_detection() {
+        let err = PoolError::new(
+            TxHash::ZERO,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::InvalidEip4844Blob(
+                BlobTransactionValidationError::InvalidProof,
+            )),
+        );
+
+        assert!(err.is_protocol_violation());
+
+        let err = PoolError::new(
+            TxHash::ZERO,
+            InvalidPoolTransactionError::Eip4844(
+                Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
+            ),
+        );
+
+        assert!(err.is_protocol_violation());
+
+        let err = PoolError::new(
+            TxHash::ZERO,
+            InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::NoEip4844Blobs),
+        );
+
+        assert!(!err.is_protocol_violation());
     }
 }

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -146,13 +146,14 @@ impl PoolError {
         }
     }
 
-    /// Returns `true` if the error indicates a protocol violation that should result in an
-    /// immediate peer disconnect, without proving that the transaction hash itself is globally
-    /// invalid.
+    /// Returns `true` if this is a blob sidecar error that should NOT be cached as a bad import.
+    ///
+    /// The transaction hash may be valid — the issue is peer-specific (e.g. malformed sidecar
+    /// data), so we penalize the peer but allow re-fetching from other peers.
     #[inline]
-    pub const fn is_protocol_violation(&self) -> bool {
+    pub const fn is_bad_blob_sidecar(&self) -> bool {
         match &self.kind {
-            PoolErrorKind::InvalidTransaction(err) => err.is_protocol_violation(),
+            PoolErrorKind::InvalidTransaction(err) => err.is_bad_blob_sidecar(),
             _ => false,
         }
     }
@@ -411,10 +412,12 @@ impl InvalidPoolTransactionError {
         }
     }
 
-    /// Returns `true` if the failure indicates a protocol violation that should result in an
-    /// immediate peer disconnect.
+    /// Returns `true` if this is a blob sidecar error (e.g. invalid proof, missing sidecar).
+    ///
+    /// These errors indicate the sidecar data from a specific peer was bad, but the transaction
+    /// hash itself may be valid when fetched from another peer.
     #[inline]
-    pub const fn is_protocol_violation(&self) -> bool {
+    pub const fn is_bad_blob_sidecar(&self) -> bool {
         matches!(
             self,
             Self::Eip4844(
@@ -504,7 +507,7 @@ mod tests {
     }
 
     #[test]
-    fn protocol_violation_detection() {
+    fn bad_blob_sidecar_detection() {
         let err = PoolError::new(
             TxHash::ZERO,
             InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::InvalidEip4844Blob(
@@ -512,7 +515,7 @@ mod tests {
             )),
         );
 
-        assert!(err.is_protocol_violation());
+        assert!(err.is_bad_blob_sidecar());
 
         let err = PoolError::new(
             TxHash::ZERO,
@@ -521,13 +524,13 @@ mod tests {
             ),
         );
 
-        assert!(err.is_protocol_violation());
+        assert!(err.is_bad_blob_sidecar());
 
         let err = PoolError::new(
             TxHash::ZERO,
             InvalidPoolTransactionError::Eip4844(Eip4844PoolTransactionError::NoEip4844Blobs),
         );
 
-        assert!(!err.is_protocol_violation());
+        assert!(!err.is_bad_blob_sidecar());
     }
 }


### PR DESCRIPTION
Blob-sidecar-specific import failures were previously folded into generic bad-import handling in the tx manager.

That meant a malformed blob sidecar response could be treated like a globally bad
transaction:

- the sender was only handled through generic bad-transaction penalties
- the transaction hash could be inserted into `bad_imports`
- subsequent announcements for the same hash could be filtered out even if another peer
could serve valid blob data

This change treats response-sourced malformed blob sidecar failures as peer misbehavior instead.
