### PR TITLE
fix(p2p): respect --bootnodes flag in `reth p2p` commands

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -193,7 +193,10 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
         let default_secret_key_path = data_dir.p2p_secret();
         let p2p_secret_key = self.network.secret_key(default_secret_key_path)?;
         let rlpx_socket = (self.network.addr, self.network.port).into();
-        let boot_nodes = self.chain.bootnodes().unwrap_or_default();
+        let boot_nodes = self
+            .network
+            .resolved_bootnodes()
+            .unwrap_or_else(|| self.chain.bootnodes().unwrap_or_default());
 
         let net =
             NetworkConfigBuilder::<N::NetworkPrimitives>::new(p2p_secret_key, Runtime::test())


### PR DESCRIPTION
`reth p2p header` and `reth p2p body` ignored `--bootnodes` and always used the chain spec defaults. Now uses `resolved_bootnodes()` first, matching the behavior of the main node startup path.