### PR TITLE
refactor(chainspec): remove unused once_cell_set utility

### DIFF
--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -36,15 +36,6 @@ pub use spec::{
     DepositContract, ForkBaseFeeParams, DEV, HOLESKY, HOODI, MAINNET, SEPOLIA,
 };
 
-use reth_primitives_traits::sync::OnceLock;
-
-/// Simple utility to create a thread-safe sync cell with a value set.
-pub fn once_cell_set<T>(value: T) -> OnceLock<T> {
-    let once = OnceLock::new();
-    let _ = once.set(value);
-    once
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Removes unused `once_cell_set` function that became dead code after #14514.

Close if intentionally kept for future use.