### PR TITLE
fix(engine): backfill cache on BAL prewarm miss

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -356,7 +356,7 @@ where
         let ctx = self.ctx.clone();
         self.executor.prewarming_pool().install_fn(|| {
             bal.par_iter().for_each_init(
-                || (ctx.clone(), None::<CachedStateProvider<reth_provider::StateProviderBox>>),
+                || (ctx.clone(), None::<CachedStateProvider<reth_provider::StateProviderBox, true>>),
                 |(ctx, provider), account| {
                     if ctx.should_stop() {
                         return;
@@ -600,7 +600,7 @@ where
     /// thread.
     fn prefetch_bal_account(
         &self,
-        provider: &mut Option<CachedStateProvider<reth_provider::StateProviderBox>>,
+        provider: &mut Option<CachedStateProvider<reth_provider::StateProviderBox, true>>,
         account: &alloy_eip7928::AccountChanges,
     ) {
         let state_provider = match provider {
@@ -621,7 +621,7 @@ where
                     self.saved_cache.as_ref().expect("BAL prewarm should only run with cache");
                 let caches = saved_cache.cache().clone();
                 let cache_metrics = saved_cache.metrics().clone();
-                slot.insert(CachedStateProvider::new(built, caches, cache_metrics))
+                slot.insert(CachedStateProvider::new_prewarm(built, caches, cache_metrics))
             }
         };
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -356,7 +356,12 @@ where
         let ctx = self.ctx.clone();
         self.executor.prewarming_pool().install_fn(|| {
             bal.par_iter().for_each_init(
-                || (ctx.clone(), None::<CachedStateProvider<reth_provider::StateProviderBox, true>>),
+                || {
+                    (
+                        ctx.clone(),
+                        None::<CachedStateProvider<reth_provider::StateProviderBox, true>>,
+                    )
+                },
                 |(ctx, provider), account| {
                     if ctx.should_stop() {
                         return;


### PR DESCRIPTION
BAL prewarm used `CachedStateProvider::new()` (PREWARM=false), which only reads the cache but never writes back on miss. This made the prewarm a no-op for uncached accounts/storage. Switched to `new_prewarm()` (PREWARM=true) so cache misses are backfilled, matching the transaction prewarm path.