### PR TITLE
fix(download): retry on extraction failure in resumable modular downloads

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -1520,6 +1520,7 @@ fn blocking_process_modular_archive(
     }
 
     let format = CompressionFormat::from_url(&archive.file_name)?;
+    let mut last_error: Option<eyre::Error> = None;
     for attempt in 1..=MAX_DOWNLOAD_RETRIES {
         cleanup_output_files(target_dir, &archive.output_files);
 
@@ -1527,13 +1528,35 @@ fn blocking_process_modular_archive(
             let cache_dir = cache_dir.ok_or_else(|| eyre::eyre!("Missing cache directory"))?;
             let archive_path = cache_dir.join(&archive.file_name);
             let part_path = cache_dir.join(format!("{}.part", archive.file_name));
-            let (downloaded_path, _downloaded_size) =
-                resumable_download(&archive.url, cache_dir, shared.as_ref(), cancel_token.clone())?;
-            let file = fs::open(&downloaded_path)?;
-            extract_archive_raw(file, format, target_dir)?;
+            let result = resumable_download(
+                &archive.url,
+                cache_dir,
+                shared.as_ref(),
+                cancel_token.clone(),
+            )
+            .and_then(|(downloaded_path, _)| {
+                let file = fs::open(&downloaded_path)?;
+                extract_archive_raw(file, format, target_dir)
+            });
             let _ = fs::remove_file(&archive_path);
             let _ = fs::remove_file(&part_path);
+
+            if let Err(e) = result {
+                warn!(target: "reth::cli",
+                    file = %archive.file_name,
+                    component = %planned.component,
+                    attempt,
+                    err = %e,
+                    "Download or extraction failed, retrying"
+                );
+                last_error = Some(e);
+                if attempt < MAX_DOWNLOAD_RETRIES {
+                    std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
+                }
+                continue;
+            }
         } else {
+            // streaming_download_and_extract already has its own internal retry loop
             streaming_download_and_extract(
                 &archive.url,
                 format,
@@ -1551,6 +1574,13 @@ fn blocking_process_modular_archive(
         }
 
         warn!(target: "reth::cli", file = %archive.file_name, component = %planned.component, attempt, "Extracted files failed integrity checks, retrying");
+    }
+
+    if let Some(e) = last_error {
+        return Err(e.wrap_err(format!(
+            "Failed after {} attempts for {}",
+            MAX_DOWNLOAD_RETRIES, archive.file_name
+        )));
     }
 
     eyre::bail!(

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -1528,16 +1528,12 @@ fn blocking_process_modular_archive(
             let cache_dir = cache_dir.ok_or_else(|| eyre::eyre!("Missing cache directory"))?;
             let archive_path = cache_dir.join(&archive.file_name);
             let part_path = cache_dir.join(format!("{}.part", archive.file_name));
-            let result = resumable_download(
-                &archive.url,
-                cache_dir,
-                shared.as_ref(),
-                cancel_token.clone(),
-            )
-            .and_then(|(downloaded_path, _)| {
-                let file = fs::open(&downloaded_path)?;
-                extract_archive_raw(file, format, target_dir)
-            });
+            let result =
+                resumable_download(&archive.url, cache_dir, shared.as_ref(), cancel_token.clone())
+                    .and_then(|(downloaded_path, _)| {
+                        let file = fs::open(&downloaded_path)?;
+                        extract_archive_raw(file, format, target_dir)
+                    });
             let _ = fs::remove_file(&archive_path);
             let _ = fs::remove_file(&part_path);
 


### PR DESCRIPTION
## Summary

Fixes `reth download` aborting with "failed to unpack X into Y" caused by "end of file before message length reached" when using the modular resumable download path. These are transient network errors (server drops connection mid-transfer) that should be retried.

## Problem

In `blocking_process_modular_archive`, the resumable path used `?` to propagate errors from `resumable_download` and `extract_archive_raw`, which immediately exited the retry loop. The non-resumable streaming path already handled this correctly via `streaming_download_and_extract`'s internal retry loop.

## Changes

- Catch download/extraction errors in the resumable path and retry with backoff (up to `MAX_DOWNLOAD_RETRIES` attempts), matching the behavior of the streaming path
- Log a warning on each failed attempt with the error details
- Report the last error if all retries are exhausted

## Testing

The error is caused by CDN/remote connection drops — not reproducible in unit tests. Verified by code review that the retry loop correctly catches `eyre::Error` from both `resumable_download` and `extract_archive_raw`, cleans up partial files, and retries.

Co-Authored-By: Dan Cline <6798349+Rjected@users.noreply.github.com>

Prompted by: Dan