### PR TITLE
fix(rpc): include tx hash cache in `set_zero_lengths`

### DIFF
--- a/crates/node/core/src/args/rpc_state_cache.rs
+++ b/crates/node/core/src/args/rpc_state_cache.rs
@@ -51,6 +51,7 @@ impl RpcStateCacheArgs {
         self.max_blocks = 0;
         self.max_receipts = 0;
         self.max_headers = 0;
+        self.max_cached_tx_hashes = 0;
     }
 }
 


### PR DESCRIPTION
`set_zero_lengths()` missed `max_cached_tx_hashes`, so `with_disabled_rpc_cache()` left the tx hash lookup cache active.
