### PR TITLE
fix(rpc): export Client traits instead of Server in clients module

### DIFF
--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -81,7 +81,7 @@ pub mod clients {
         otterscan::OtterscanClient,
         reth::RethApiClient,
         reth_engine::RethEngineApiClient,
-        rpc::RpcApiServer,
+        rpc::RpcApiClient,
         testing::TestingApiClient,
         trace::TraceApiClient,
         txpool::TxPoolApiClient,
@@ -90,6 +90,6 @@ pub mod clients {
     };
     pub use reth_rpc_eth_api::{
         EthApiClient, EthBundleApiClient, EthCallBundleApiClient, EthFilterApiClient,
-        L2EthApiExtServer,
+        L2EthApiExtClient,
     };
 }


### PR DESCRIPTION
The `clients` aggregation module was re-exporting `RpcApiServer` and `L2EthApiExtServer` — should be `RpcApiClient` and `L2EthApiExtClient`. Copy-paste typo from the `servers` module.