### PR TITLE
feat: add scheduled regression benchmarks via GitHub Actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,10 +89,6 @@ on:
         required: false
         default: ""
         type: string
-      wait_time:
-        required: false
-        default: ""
-        type: string
       baseline_args:
         required: false
         default: ""
@@ -109,10 +105,6 @@ on:
         required: false
         default: true
         type: boolean
-      cores:
-        required: false
-        default: "0"
-        type: string
       no_slack:
         required: false
         default: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -71,6 +71,56 @@ on:
         required: false
         default: "true"
         type: boolean
+  workflow_call:
+    inputs:
+      blocks:
+        required: false
+        default: "500"
+        type: string
+      warmup:
+        required: false
+        default: "100"
+        type: string
+      baseline:
+        required: false
+        default: ""
+        type: string
+      feature:
+        required: false
+        default: ""
+        type: string
+      wait_time:
+        required: false
+        default: ""
+        type: string
+      baseline_args:
+        required: false
+        default: ""
+        type: string
+      feature_args:
+        required: false
+        default: ""
+        type: string
+      samply:
+        required: false
+        default: false
+        type: boolean
+      reth_newPayload:
+        required: false
+        default: true
+        type: boolean
+      cores:
+        required: false
+        default: "0"
+        type: string
+      no_slack:
+        required: false
+        default: false
+        type: boolean
+      abba:
+        required: false
+        default: true
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -89,7 +139,8 @@ jobs:
   reth-bench-ack:
     if: |
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && (startsWith(github.event.comment.body, '@decofe bench') || startsWith(github.event.comment.body, 'derek bench'))) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call'
     name: reth-bench-ack
     runs-on: ubuntu-latest
     outputs:
@@ -137,23 +188,25 @@ jobs:
         with:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
+            // inputs.* works for both workflow_dispatch and workflow_call
+            const wfInputs = ${{ toJSON(inputs) }};
             let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks;
 
-            if (context.eventName === 'workflow_dispatch') {
+            if (context.eventName === 'workflow_dispatch' || context.eventName === 'workflow_call') {
               actor = '${{ github.actor }}';
-              blocks = '${{ github.event.inputs.blocks }}' || '500';
-              warmup = '${{ github.event.inputs.warmup }}' || '100';
-              baseline = '${{ github.event.inputs.baseline }}';
-              feature = '${{ github.event.inputs.feature }}';
-              samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
-              var noSlack = '${{ github.event.inputs.no_slack }}' !== 'false' ? 'true' : 'false';
-              cores = '${{ github.event.inputs.cores }}' || '0';
+              blocks = (wfInputs.blocks || '500').toString();
+              warmup = (wfInputs.warmup || '100').toString();
+              baseline = (wfInputs.baseline || '').toString();
+              feature = (wfInputs.feature || '').toString();
+              samply = wfInputs.samply === true || wfInputs.samply === 'true' ? 'true' : 'false';
+              var noSlack = wfInputs.no_slack === true || wfInputs.no_slack === 'true' ? 'true' : 'false';
+              cores = (wfInputs.cores || '0').toString();
               bigBlocks = blocks === 'big' ? 'true' : 'false';
-              var rethNewPayload = '${{ github.event.inputs.reth_newPayload }}' !== 'false' ? 'true' : 'false';
-              var abba = '${{ github.event.inputs.abba }}' !== 'false' ? 'true' : 'false';
-              var waitTime = '${{ github.event.inputs.wait_time }}' || '';
-              var baselineNodeArgs = '${{ github.event.inputs.baseline_args }}' || '';
-              var featureNodeArgs = '${{ github.event.inputs.feature_args }}' || '';
+              var rethNewPayload = wfInputs.reth_newPayload === false || wfInputs.reth_newPayload === 'false' ? 'false' : 'true';
+              var abba = wfInputs.abba === false || wfInputs.abba === 'false' ? 'false' : 'true';
+              var waitTime = (wfInputs.wait_time || '').toString();
+              var baselineNodeArgs = (wfInputs.baseline_args || '').toString();
+              var featureNodeArgs = (wfInputs.feature_args || '').toString();
 
               // Find PR for the selected branch
               const branch = '${{ github.ref_name }}';
@@ -347,7 +400,7 @@ jobs:
                 });
                 allRuns.push(...r);
               }
-              const benchRuns = allRuns.filter(r => r.event === 'issue_comment' || r.event === 'workflow_dispatch');
+              const benchRuns = allRuns.filter(r => ['issue_comment', 'workflow_dispatch', 'workflow_call'].includes(r.event));
               const thisRun = benchRuns.find(r => r.id === context.runId);
               const thisCreatedAt = thisRun ? new Date(thisRun.created_at) : new Date();
               const totalAhead = benchRuns.filter(r => r.id !== context.runId && new Date(r.created_at) <= thisCreatedAt).length;
@@ -441,7 +494,7 @@ jobs:
                 });
                 allRuns.push(...r);
               }
-              const benchRuns = allRuns.filter(r => r.event === 'issue_comment' || r.event === 'workflow_dispatch');
+              const benchRuns = allRuns.filter(r => ['issue_comment', 'workflow_dispatch', 'workflow_call'].includes(r.event));
               const thisRun = benchRuns.find(r => r.id === context.runId);
               const thisCreatedAt = thisRun ? new Date(thisRun.created_at) : new Date();
               const totalAhead = benchRuns.filter(r => r.id !== context.runId && new Date(r.created_at) <= thisCreatedAt).length;

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,6 +89,10 @@ on:
         required: false
         default: ""
         type: string
+      wait_time:
+        required: false
+        default: ""
+        type: string
       baseline_args:
         required: false
         default: ""
@@ -105,6 +109,10 @@ on:
         required: false
         default: true
         type: boolean
+      cores:
+        required: false
+        default: "0"
+        type: string
       no_slack:
         required: false
         default: false
@@ -181,7 +189,7 @@ jobs:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
             // inputs.* works for both workflow_dispatch and workflow_call
-            const wfInputs = ${{ toJSON(inputs) }};
+            const wfInputs = ${{ toJSON(inputs) }} || {};
             let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks;
 
             if (context.eventName === 'workflow_dispatch' || context.eventName === 'workflow_call') {

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -8,7 +8,6 @@
 # single benchmark; if all runners are busy the job queues naturally.
 
 on:
-  pull_request: # TEMPORARY: remove after test run
   schedule:
     # Main regression: hourly, compares previous main HEAD vs current
     - cron: "0 * * * *"
@@ -51,8 +50,6 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "benchmark=${{ inputs.benchmark }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "benchmark=release-regression" >> "$GITHUB_OUTPUT" # TEMPORARY
           else
             CRON="${{ github.event.schedule }}"
             case "$CRON" in

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -1,0 +1,170 @@
+# Scheduled regression benchmarks.
+#
+# Replicates the nightly/hourly benchmark suite by calling bench.yml
+# with the appropriate parameters on a cron schedule.
+#
+# Runner contention is managed by the self-hosted runner pool itself
+# (label: [self-hosted, Linux, X64, available]). Each cron fires a
+# single benchmark; if all runners are busy the job queues naturally.
+
+on:
+  schedule:
+    # Main regression: hourly, compares previous main HEAD vs current
+    - cron: "0 * * * *"
+    # Nightly regression: daily 04:30 UTC
+    - cron: "30 4 * * *"
+    # Nightly regression (big blocks): daily 05:00 UTC
+    - cron: "0 5 * * *"
+    # Release regression: daily 08:00 UTC
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      benchmark:
+        description: "Which benchmark to run"
+        required: true
+        type: choice
+        options:
+          - main-regression
+          - nightly-regression
+          - nightly-regression-bigblocks
+          - release-regression
+
+name: scheduled benchmarks
+
+jobs:
+  # Determine which benchmark to run based on cron schedule or manual input
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      benchmark: ${{ steps.resolve.outputs.benchmark }}
+      baseline: ${{ steps.refs.outputs.baseline }}
+      feature: ${{ steps.refs.outputs.feature }}
+      skip: ${{ steps.refs.outputs.skip }}
+    steps:
+      - name: Determine benchmark type
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "benchmark=${{ inputs.benchmark }}" >> "$GITHUB_OUTPUT"
+          else
+            CRON="${{ github.event.schedule }}"
+            case "$CRON" in
+              "0 * * * *")    echo "benchmark=main-regression" >> "$GITHUB_OUTPUT" ;;
+              "30 4 * * *")   echo "benchmark=nightly-regression" >> "$GITHUB_OUTPUT" ;;
+              "0 5 * * *")    echo "benchmark=nightly-regression-bigblocks" >> "$GITHUB_OUTPUT" ;;
+              "0 8 * * *")    echo "benchmark=release-regression" >> "$GITHUB_OUTPUT" ;;
+              *)              echo "::error::Unknown cron schedule: $CRON"; exit 1 ;;
+            esac
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve refs
+        id: refs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
+            const benchmark = '${{ steps.resolve.outputs.benchmark }}';
+
+            let baseline, feature, skip = 'false';
+
+            if (benchmark === 'main-regression') {
+              // Compare the commit before HEAD vs HEAD on main
+              feature = run('git rev-parse HEAD');
+              try {
+                baseline = run('git rev-parse HEAD~1');
+              } catch {
+                core.info('No previous commit found, skipping');
+                skip = 'true';
+                baseline = feature;
+              }
+
+            } else if (benchmark === 'nightly-regression' || benchmark === 'nightly-regression-bigblocks') {
+              // Compare the latest release tag vs main HEAD
+              feature = run('git rev-parse HEAD');
+              try {
+                // Find the latest vX.Y.Z release tag
+                const tags = run('git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname');
+                const latestTag = tags.split('\n')[0];
+                if (!latestTag) throw new Error('No release tags found');
+                baseline = run(`git rev-parse "${latestTag}"`);
+                core.info(`Nightly: baseline=${latestTag} (${baseline}), feature=main (${feature})`);
+              } catch (e) {
+                core.info(`Could not resolve nightly baseline: ${e.message}, skipping`);
+                skip = 'true';
+                baseline = feature;
+              }
+
+            } else if (benchmark === 'release-regression') {
+              // Compare the two most recent release tags
+              try {
+                const tags = run('git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-version:refname');
+                const tagList = tags.split('\n').filter(Boolean);
+                if (tagList.length < 2) throw new Error('Need at least 2 release tags');
+                feature = run(`git rev-parse "${tagList[0]}"`);
+                baseline = run(`git rev-parse "${tagList[1]}"`);
+                core.info(`Release: baseline=${tagList[1]} (${baseline}), feature=${tagList[0]} (${feature})`);
+              } catch (e) {
+                core.info(`Could not resolve release refs: ${e.message}, skipping`);
+                skip = 'true';
+                baseline = '';
+                feature = '';
+              }
+            }
+
+            core.setOutput('baseline', baseline);
+            core.setOutput('feature', feature);
+            core.setOutput('skip', skip);
+
+  main-regression:
+    needs: resolve
+    if: needs.resolve.outputs.benchmark == 'main-regression' && needs.resolve.outputs.skip != 'true'
+    uses: ./.github/workflows/bench.yml
+    secrets: inherit
+    with:
+      blocks: "2000"
+      warmup: "2000"
+      baseline: ${{ needs.resolve.outputs.baseline }}
+      feature: ${{ needs.resolve.outputs.feature }}
+      no_slack: false
+
+  nightly-regression:
+    needs: resolve
+    if: needs.resolve.outputs.benchmark == 'nightly-regression' && needs.resolve.outputs.skip != 'true'
+    uses: ./.github/workflows/bench.yml
+    secrets: inherit
+    with:
+      blocks: "2000"
+      warmup: "2000"
+      baseline: ${{ needs.resolve.outputs.baseline }}
+      feature: ${{ needs.resolve.outputs.feature }}
+      no_slack: false
+
+  nightly-regression-bigblocks:
+    needs: resolve
+    if: needs.resolve.outputs.benchmark == 'nightly-regression-bigblocks' && needs.resolve.outputs.skip != 'true'
+    uses: ./.github/workflows/bench.yml
+    secrets: inherit
+    with:
+      blocks: "big"
+      warmup: "2000"
+      baseline: ${{ needs.resolve.outputs.baseline }}
+      feature: ${{ needs.resolve.outputs.feature }}
+      no_slack: false
+
+  release-regression:
+    needs: resolve
+    if: needs.resolve.outputs.benchmark == 'release-regression' && needs.resolve.outputs.skip != 'true'
+    uses: ./.github/workflows/bench.yml
+    secrets: inherit
+    with:
+      blocks: "2000"
+      warmup: "2000"
+      baseline: ${{ needs.resolve.outputs.baseline }}
+      feature: ${{ needs.resolve.outputs.feature }}
+      no_slack: false

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -31,6 +31,10 @@ on:
 
 name: scheduled benchmarks
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   # Determine which benchmark to run based on cron schedule or manual input
   resolve:
@@ -62,11 +66,24 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      # Restore the last-benchmarked SHA for main-regression.
+      # The cache key is stable so we always get the latest saved value.
+      # We save a new cache (with a unique restoreKey suffix) after a
+      # successful benchmark run in the update-state job.
+      - name: Restore main-regression state
+        if: steps.resolve.outputs.benchmark == 'main-regression'
+        id: state-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .bench-state
+          key: bench-main-regression-last-sha
+
       - name: Resolve refs
         id: refs
         uses: actions/github-script@v8
         with:
           script: |
+            const fs = require('fs');
             const { execSync } = require('child_process');
             const run = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
             const benchmark = '${{ steps.resolve.outputs.benchmark }}';
@@ -74,14 +91,36 @@ jobs:
             let baseline, feature, skip = 'false';
 
             if (benchmark === 'main-regression') {
-              // Compare the commit before HEAD vs HEAD on main
+              // Baseline = last successfully benchmarked SHA (from cache)
+              // Feature = current main HEAD
+              // Skip if no new commits since last benchmark
               feature = run('git rev-parse HEAD');
+
+              let lastBenchmarkedSha = '';
               try {
-                baseline = run('git rev-parse HEAD~1');
+                lastBenchmarkedSha = fs.readFileSync('.bench-state/last-sha.txt', 'utf8').trim();
+                core.info(`Last benchmarked SHA: ${lastBenchmarkedSha}`);
               } catch {
-                core.info('No previous commit found, skipping');
+                core.info('No previous state found (first run)');
+              }
+
+              if (lastBenchmarkedSha && lastBenchmarkedSha === feature) {
+                core.info('No new commits since last regression check — skipping');
                 skip = 'true';
                 baseline = feature;
+              } else if (lastBenchmarkedSha) {
+                baseline = lastBenchmarkedSha;
+                core.info(`Main regression: baseline=${baseline}, feature=${feature}`);
+              } else {
+                // First run: fall back to parent commit
+                try {
+                  baseline = run('git rev-parse HEAD~1');
+                } catch {
+                  core.info('No parent commit found, skipping');
+                  skip = 'true';
+                  baseline = feature;
+                }
+                core.info(`Main regression (first run): baseline=${baseline}, feature=${feature}`);
               }
 
             } else if (benchmark === 'nightly-regression' || benchmark === 'nightly-regression-bigblocks') {
@@ -168,3 +207,28 @@ jobs:
       baseline: ${{ needs.resolve.outputs.baseline }}
       feature: ${{ needs.resolve.outputs.feature }}
       no_slack: false
+
+  # After a successful main-regression benchmark, persist the feature SHA
+  # so the next run uses it as baseline (tracks last-benchmarked commit).
+  update-main-regression-state:
+    needs: [resolve, main-regression]
+    if: needs.resolve.outputs.benchmark == 'main-regression'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save last-benchmarked SHA
+        run: |
+          mkdir -p .bench-state
+          echo "${{ needs.resolve.outputs.feature }}" > .bench-state/last-sha.txt
+
+      - name: Delete old cache
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache delete bench-main-regression-last-sha \
+            --repo ${{ github.repository }} 2>/dev/null || true
+
+      - uses: actions/cache/save@v4
+        with:
+          path: .bench-state
+          key: bench-main-regression-last-sha

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -8,6 +8,7 @@
 # single benchmark; if all runners are busy the job queues naturally.
 
 on:
+  pull_request: # TEMPORARY: remove after test run
   schedule:
     # Main regression: hourly, compares previous main HEAD vs current
     - cron: "0 * * * *"
@@ -50,6 +51,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "benchmark=${{ inputs.benchmark }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "benchmark=release-regression" >> "$GITHUB_OUTPUT" # TEMPORARY
           else
             CRON="${{ github.event.schedule }}"
             case "$CRON" in


### PR DESCRIPTION
Adds `scheduled-benchmarks.yml` that calls `bench.yml` on cron schedules to run automated regression benchmarks.

## Benchmarks

| Job | Schedule (UTC) | Baseline | Feature |
|-----|----------------|----------|---------|
| **main-regression** | Hourly | Last successfully benchmarked SHA (cached) | `main` HEAD |
| **nightly-regression** | Daily 04:30 | Latest release tag | `main` HEAD |
| **nightly-regression-bigblocks** | Daily 05:00 | Latest release tag | `main` HEAD (big blocks) |
| **release-regression** | Daily 08:00 | Previous release tag | Latest release tag |

Main regression tracks state across runs: after a successful benchmark, the feature SHA is persisted to GHA cache. Next run uses it as baseline. Skips if `main` HEAD hasn't changed.

## Changes

- **`bench.yml`**: Added `workflow_call` trigger, switched input parsing from `github.event.inputs` to `inputs` context (works for both `workflow_dispatch` and `workflow_call`), updated queue tracking to include `workflow_call` runs
- **`scheduled-benchmarks.yml`** (new): Cron schedules + manual dispatch, resolves baseline/feature refs per benchmark type, calls `bench.yml`

Runner contention is handled by the self-hosted runner pool — jobs queue naturally when all runners are busy.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey