### PR TITLE
fix(provider): gate rocksdb jemalloc behind feature flag

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -124,6 +124,7 @@ jemalloc = [
     "reth-node-core/jemalloc",
     "reth-node-metrics/jemalloc",
     "reth-ethereum-cli/jemalloc",
+    "reth-provider/jemalloc",
 ]
 jemalloc-prof = [
     "reth-cli-util/jemalloc",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -152,6 +152,7 @@ jemalloc = [
     "reth-cli-util?/jemalloc",
     "reth-ethereum-cli?/jemalloc",
     "reth-node-core?/jemalloc",
+    "reth-provider?/jemalloc",
 ]
 jemalloc-prof = [
     "jemalloc",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -63,7 +63,7 @@ tokio = { workspace = true, features = ["sync"], optional = true }
 # parallel utils
 rayon.workspace = true
 
-rocksdb = { workspace = true, features = ["jemalloc"] }
+rocksdb.workspace = true
 
 [dev-dependencies]
 reth-db = { workspace = true, features = ["test-utils"] }
@@ -85,6 +85,7 @@ rand.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
+jemalloc = ["rocksdb/jemalloc"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",


### PR DESCRIPTION
Closes the issue where `reth-provider` unconditionally enables `rocksdb/jemalloc`, making it impossible for downstream crates (e.g. e2e tests) to build without jemalloc.

`reth-provider` now has a `jemalloc` feature that gates `rocksdb/jemalloc`. The feature is propagated through `reth-ethereum` and `bin/reth` so existing builds are unaffected — jemalloc is still on by default for the `reth` binary.

Co-Authored-By: Dan Cline <6798349+Rjected@users.noreply.github.com>

Prompted by: Dan