### PR TITLE
perf(rpc): fast path `transaction_receipt` when block & receipts are cached

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -233,6 +233,13 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: LoadReceipt + 'static,
     {
         async move {
+            // Fast path: block and receipts both cached — convert in-place.
+            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await &&
+                let Some(result) = cached.into_receipt::<Self::Primitives, _>(self.converter())
+            {
+                return Ok(Some(result?));
+            }
+
             match self.load_transaction_and_receipt(hash).await? {
                 Some((tx, meta, receipt)) => {
                     self.build_transaction_receipt(tx, meta, receipt).await.map(Some)


### PR DESCRIPTION
When both the block and receipts are already in the cache, `eth_getTransactionReceipt` was redundantly calling `get_receipts` a second time inside `build_transaction_receipt`. This adds an early return that converts the receipt in-place from the cached data.