### PR TITLE
feat(fs-util): add remove_file_if_exists helper

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -4,7 +4,7 @@ use eyre::{eyre, OptionExt};
 use futures_util::{stream::StreamExt, Stream, TryStreamExt};
 use reqwest::{Client, IntoUrl, Url};
 use reth_era::common::file_ops::EraFileType;
-use reth_fs_util::FsPathError;
+use reth_fs_util;
 use sha2::{Digest, Sha256};
 use std::{future::Future, path::Path, str::FromStr};
 use tokio::{
@@ -137,7 +137,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                     let Some(number) = self.file_name_to_number(name) &&
                     (number < index || number >= last)
                 {
-                    remove_file_ignore_not_found(entry.path())?;
+                    reth_fs_util::remove_file_if_exists(entry.path())?;
                 }
             }
         }
@@ -322,16 +322,6 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     }
 }
 
-fn remove_file_ignore_not_found(path: impl AsRef<Path>) -> eyre::Result<()> {
-    match reth_fs_util::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(FsPathError::RemoveFile { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
-            Ok(())
-        }
-        Err(err) => Err(err.into()),
-    }
-}
-
 async fn checksum(mut reader: impl AsyncRead + Unpin) -> eyre::Result<Vec<u8>> {
     let mut hasher = Sha256::new();
 
@@ -377,26 +367,5 @@ mod tests {
         let actual_number = client.file_name_to_number(file_name);
 
         assert_eq!(actual_number, expected_number);
-    }
-
-    #[test]
-    fn test_remove_file_ignore_not_found() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("missing.era1");
-
-        assert!(remove_file_ignore_not_found(&path).is_ok());
-    }
-
-    #[test]
-    fn test_remove_file_ignore_not_found_preserves_other_errors() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("dir");
-        std::fs::create_dir_all(&path).unwrap();
-
-        let err = remove_file_ignore_not_found(&path).unwrap_err();
-        assert!(matches!(
-            err.downcast_ref::<FsPathError>(),
-            Some(FsPathError::RemoveFile { source, .. }) if source.kind() != io::ErrorKind::NotFound
-        ));
     }
 }

--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -4,7 +4,6 @@ use eyre::{eyre, OptionExt};
 use futures_util::{stream::StreamExt, Stream, TryStreamExt};
 use reqwest::{Client, IntoUrl, Url};
 use reth_era::common::file_ops::EraFileType;
-use reth_fs_util;
 use sha2::{Digest, Sha256};
 use std::{future::Future, path::Path, str::FromStr};
 use tokio::{

--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -260,6 +260,17 @@ pub fn remove_file(path: impl AsRef<Path>) -> Result<()> {
     fs::remove_file(path).map_err(|err| FsPathError::remove_file(err, path))
 }
 
+/// Removes a file at the given path, ignoring the error if the file does not exist
+/// (`ErrorKind::NotFound`).
+pub fn remove_file_if_exists(path: impl AsRef<Path>) -> Result<()> {
+    match remove_file(&path) {
+        Err(FsPathError::RemoveFile { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+            Ok(())
+        }
+        result => result,
+    }
+}
+
 /// Wrapper for `std::fs::create_dir_all`
 pub fn create_dir_all(path: impl AsRef<Path>) -> Result<()> {
     let path = path.as_ref();


### PR DESCRIPTION
Adds `remove_file_if_exists` to `reth_fs_util` — removes a file, silently ignoring `NotFound`. Replaces the local copy in `era-downloader`.

Context: https://github.com/paradigmxyz/reth/pull/23062

Prompted by: mattsse