### PR TITLE
refactor(storage): use RocksReadSnapshot for read-only compatible RocksDB reads

### DIFF
--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -68,11 +68,11 @@ pub type RocksBatchArg<'a> = crate::providers::rocksdb::RocksDBBatch<'a>;
 /// The raw `RocksDB` batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
 pub type RawRocksDBBatch = rocksdb::WriteBatchWithTransaction<true>;
 
-/// Helper type for `RocksDB` transaction reference argument in reader constructors.
+/// Helper type for `RocksDB` provider reference argument in reader constructors.
 ///
-/// The `Option` allows callers to skip transaction creation when `RocksDB` isn't needed
+/// The `Option` allows callers to skip `RocksDB` access when it isn't needed
 /// (e.g., on legacy MDBX-only nodes).
-pub type RocksTxRefArg<'a> = Option<&'a crate::providers::rocksdb::RocksTx<'a>>;
+pub type RocksDBRefArg<'a> = Option<&'a crate::providers::RocksDBProvider>;
 
 /// Represents a destination for writing data, either to database, static files, or `RocksDB`.
 #[derive(Debug, Display)]
@@ -672,8 +672,8 @@ pub enum EitherReader<'a, CURSOR, N> {
     Database(CURSOR, PhantomData<&'a ()>),
     /// Read from static file
     StaticFile(StaticFileProvider<N>, PhantomData<&'a ()>),
-    /// Read from `RocksDB` transaction
-    RocksDB(&'a crate::providers::rocksdb::RocksTx<'a>),
+    /// Read from `RocksDB` provider (works in both read-only and read-write modes)
+    RocksDB(&'a crate::providers::RocksDBProvider),
 }
 
 impl<'a> EitherReader<'a, (), ()> {
@@ -698,7 +698,7 @@ impl<'a> EitherReader<'a, (), ()> {
     /// Creates a new [`EitherReader`] for storages history based on storage settings.
     pub fn new_storages_history<P>(
         provider: &P,
-        _rocksdb_tx: RocksTxRefArg<'a>,
+        rocksdb: RocksDBRefArg<'a>,
     ) -> ProviderResult<EitherReaderTy<'a, P, tables::StoragesHistory>>
     where
         P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
@@ -706,7 +706,7 @@ impl<'a> EitherReader<'a, (), ()> {
     {
         if provider.cached_storage_settings().storage_v2 {
             return Ok(EitherReader::RocksDB(
-                _rocksdb_tx.expect("storages_history_in_rocksdb requires rocksdb tx"),
+                rocksdb.expect("storages_history_in_rocksdb requires rocksdb provider"),
             ));
         }
 
@@ -719,7 +719,7 @@ impl<'a> EitherReader<'a, (), ()> {
     /// Creates a new [`EitherReader`] for transaction hash numbers based on storage settings.
     pub fn new_transaction_hash_numbers<P>(
         provider: &P,
-        _rocksdb_tx: RocksTxRefArg<'a>,
+        rocksdb: RocksDBRefArg<'a>,
     ) -> ProviderResult<EitherReaderTy<'a, P, tables::TransactionHashNumbers>>
     where
         P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
@@ -727,7 +727,7 @@ impl<'a> EitherReader<'a, (), ()> {
     {
         if provider.cached_storage_settings().storage_v2 {
             return Ok(EitherReader::RocksDB(
-                _rocksdb_tx.expect("transaction_hash_numbers_in_rocksdb requires rocksdb tx"),
+                rocksdb.expect("transaction_hash_numbers_in_rocksdb requires rocksdb provider"),
             ));
         }
 
@@ -740,7 +740,7 @@ impl<'a> EitherReader<'a, (), ()> {
     /// Creates a new [`EitherReader`] for account history based on storage settings.
     pub fn new_accounts_history<P>(
         provider: &P,
-        _rocksdb_tx: RocksTxRefArg<'a>,
+        rocksdb: RocksDBRefArg<'a>,
     ) -> ProviderResult<EitherReaderTy<'a, P, tables::AccountsHistory>>
     where
         P: DBProvider + NodePrimitivesProvider + StorageSettingsCache,
@@ -748,7 +748,7 @@ impl<'a> EitherReader<'a, (), ()> {
     {
         if provider.cached_storage_settings().storage_v2 {
             return Ok(EitherReader::RocksDB(
-                _rocksdb_tx.expect("account_history_in_rocksdb requires rocksdb tx"),
+                rocksdb.expect("account_history_in_rocksdb requires rocksdb provider"),
             ));
         }
 
@@ -820,7 +820,7 @@ where
         match self {
             Self::Database(cursor, _) => Ok(cursor.seek_exact(hash)?.map(|(_, v)| v)),
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(tx) => tx.get::<tables::TransactionHashNumbers>(hash),
+            Self::RocksDB(provider) => provider.get::<tables::TransactionHashNumbers>(hash),
         }
     }
 }
@@ -837,7 +837,7 @@ where
         match self {
             Self::Database(cursor, _) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(tx) => tx.get::<tables::StoragesHistory>(key),
+            Self::RocksDB(provider) => provider.get::<tables::StoragesHistory>(key),
         }
     }
 
@@ -861,7 +861,7 @@ where
                 )
             }
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(tx) => tx.storage_history_info(
+            Self::RocksDB(provider) => provider.storage_history_info(
                 address,
                 storage_key,
                 block_number,
@@ -883,7 +883,7 @@ where
         match self {
             Self::Database(cursor, _) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(tx) => tx.get::<tables::AccountsHistory>(key),
+            Self::RocksDB(provider) => provider.get::<tables::AccountsHistory>(key),
         }
     }
 
@@ -906,8 +906,8 @@ where
                 )
             }
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(tx) => {
-                tx.account_history_info(address, block_number, lowest_available_block_number)
+            Self::RocksDB(provider) => {
+                provider.account_history_info(address, block_number, lowest_available_block_number)
             }
         }
     }
@@ -1428,7 +1428,6 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
-        let rocks_tx = rocks_provider.tx();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader
@@ -1443,7 +1442,7 @@ mod rocksdb_tests {
 
             // RocksDB query via EitherReader
             let mut rocks_reader: EitherReader<'_, AccountsHistoryReadCursor, EthPrimitives> =
-                EitherReader::RocksDB(&rocks_tx);
+                EitherReader::RocksDB(&rocks_provider);
             let rocks_result = rocks_reader
                 .account_history_info(address, query.block_number, query.lowest_available)
                 .unwrap();
@@ -1477,7 +1476,6 @@ mod rocksdb_tests {
             );
         }
 
-        rocks_tx.rollback().unwrap();
         drop(temp_dir);
     }
 
@@ -1520,7 +1518,6 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
-        let rocks_tx = rocks_provider.tx();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader
@@ -1540,7 +1537,7 @@ mod rocksdb_tests {
 
             // RocksDB query via EitherReader
             let mut rocks_reader: EitherReader<'_, StoragesHistoryReadCursor, EthPrimitives> =
-                EitherReader::RocksDB(&rocks_tx);
+                EitherReader::RocksDB(&rocks_provider);
             let rocks_result = rocks_reader
                 .storage_history_info(
                     address,
@@ -1579,7 +1576,6 @@ mod rocksdb_tests {
             );
         }
 
-        rocks_tx.rollback().unwrap();
         drop(temp_dir);
     }
 
@@ -1809,10 +1805,10 @@ mod rocksdb_tests {
     }
 
     /// Test that `EitherReader::new_accounts_history` panics when settings require
-    /// `RocksDB` but no tx is provided (`None`). This is an invariant violation that
-    /// indicates a bug - `with_rocksdb_tx` should always provide a tx when needed.
+    /// `RocksDB` but no provider is given (`None`). This is an invariant violation that
+    /// indicates a bug - `with_rocksdb_provider` should always provide a provider when needed.
     #[test]
-    #[should_panic(expected = "account_history_in_rocksdb requires rocksdb tx")]
+    #[should_panic(expected = "account_history_in_rocksdb requires rocksdb provider")]
     fn test_settings_mismatch_panics() {
         let factory = create_test_provider_factory();
 

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -1428,6 +1428,7 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
+        let rocks_snapshot = rocks_provider.snapshot();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader
@@ -1440,10 +1441,8 @@ mod rocksdb_tests {
                 .account_history_info(address, query.block_number, query.lowest_available)
                 .unwrap();
 
-            // RocksDB query via EitherReader
-            let mut rocks_reader: EitherReader<'_, AccountsHistoryReadCursor, EthPrimitives> =
-                EitherReader::RocksDB(rocks_provider.snapshot());
-            let rocks_result = rocks_reader
+            // RocksDB query via EitherReader — reuse snapshot for consistent view
+            let rocks_result = rocks_snapshot
                 .account_history_info(address, query.block_number, query.lowest_available)
                 .unwrap();
 
@@ -1518,6 +1517,7 @@ mod rocksdb_tests {
 
         // Run queries against both backends using EitherReader
         let mdbx_ro = factory.database_provider_ro().unwrap();
+        let rocks_snapshot = rocks_provider.snapshot();
 
         for (i, query) in queries.iter().enumerate() {
             // MDBX query via EitherReader
@@ -1535,10 +1535,8 @@ mod rocksdb_tests {
                 )
                 .unwrap();
 
-            // RocksDB query via EitherReader
-            let mut rocks_reader: EitherReader<'_, StoragesHistoryReadCursor, EthPrimitives> =
-                EitherReader::RocksDB(rocks_provider.snapshot());
-            let rocks_result = rocks_reader
+            // RocksDB query via snapshot — reuse for consistent view
+            let rocks_result = rocks_snapshot
                 .storage_history_info(
                     address,
                     storage_key,

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -68,11 +68,11 @@ pub type RocksBatchArg<'a> = crate::providers::rocksdb::RocksDBBatch<'a>;
 /// The raw `RocksDB` batch type returned by [`EitherWriter::into_raw_rocksdb_batch`].
 pub type RawRocksDBBatch = rocksdb::WriteBatchWithTransaction<true>;
 
-/// Helper type for `RocksDB` provider reference argument in reader constructors.
+/// Helper type for `RocksDB` snapshot argument in reader constructors.
 ///
 /// The `Option` allows callers to skip `RocksDB` access when it isn't needed
 /// (e.g., on legacy MDBX-only nodes).
-pub type RocksDBRefArg<'a> = Option<&'a crate::providers::RocksDBProvider>;
+pub type RocksDBRefArg<'a> = Option<crate::providers::rocksdb::RocksReadSnapshot<'a>>;
 
 /// Represents a destination for writing data, either to database, static files, or `RocksDB`.
 #[derive(Debug, Display)]
@@ -672,8 +672,8 @@ pub enum EitherReader<'a, CURSOR, N> {
     Database(CURSOR, PhantomData<&'a ()>),
     /// Read from static file
     StaticFile(StaticFileProvider<N>, PhantomData<&'a ()>),
-    /// Read from `RocksDB` provider (works in both read-only and read-write modes)
-    RocksDB(&'a crate::providers::RocksDBProvider),
+    /// Read from `RocksDB` snapshot (works in both read-only and read-write modes)
+    RocksDB(crate::providers::rocksdb::RocksReadSnapshot<'a>),
 }
 
 impl<'a> EitherReader<'a, (), ()> {
@@ -706,7 +706,7 @@ impl<'a> EitherReader<'a, (), ()> {
     {
         if provider.cached_storage_settings().storage_v2 {
             return Ok(EitherReader::RocksDB(
-                rocksdb.expect("storages_history_in_rocksdb requires rocksdb provider"),
+                rocksdb.expect("storages_history_in_rocksdb requires rocksdb snapshot"),
             ));
         }
 
@@ -727,7 +727,7 @@ impl<'a> EitherReader<'a, (), ()> {
     {
         if provider.cached_storage_settings().storage_v2 {
             return Ok(EitherReader::RocksDB(
-                rocksdb.expect("transaction_hash_numbers_in_rocksdb requires rocksdb provider"),
+                rocksdb.expect("transaction_hash_numbers_in_rocksdb requires rocksdb snapshot"),
             ));
         }
 
@@ -748,7 +748,7 @@ impl<'a> EitherReader<'a, (), ()> {
     {
         if provider.cached_storage_settings().storage_v2 {
             return Ok(EitherReader::RocksDB(
-                rocksdb.expect("account_history_in_rocksdb requires rocksdb provider"),
+                rocksdb.expect("account_history_in_rocksdb requires rocksdb snapshot"),
             ));
         }
 
@@ -820,7 +820,7 @@ where
         match self {
             Self::Database(cursor, _) => Ok(cursor.seek_exact(hash)?.map(|(_, v)| v)),
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(provider) => provider.get::<tables::TransactionHashNumbers>(hash),
+            Self::RocksDB(snapshot) => snapshot.get::<tables::TransactionHashNumbers>(hash),
         }
     }
 }
@@ -837,7 +837,7 @@ where
         match self {
             Self::Database(cursor, _) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(provider) => provider.get::<tables::StoragesHistory>(key),
+            Self::RocksDB(snapshot) => snapshot.get::<tables::StoragesHistory>(key),
         }
     }
 
@@ -861,7 +861,7 @@ where
                 )
             }
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(provider) => provider.storage_history_info(
+            Self::RocksDB(snapshot) => snapshot.storage_history_info(
                 address,
                 storage_key,
                 block_number,
@@ -883,7 +883,7 @@ where
         match self {
             Self::Database(cursor, _) => Ok(cursor.seek_exact(key)?.map(|(_, v)| v)),
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(provider) => provider.get::<tables::AccountsHistory>(key),
+            Self::RocksDB(snapshot) => snapshot.get::<tables::AccountsHistory>(key),
         }
     }
 
@@ -906,8 +906,8 @@ where
                 )
             }
             Self::StaticFile(_, _) => Err(ProviderError::UnsupportedProvider),
-            Self::RocksDB(provider) => {
-                provider.account_history_info(address, block_number, lowest_available_block_number)
+            Self::RocksDB(snapshot) => {
+                snapshot.account_history_info(address, block_number, lowest_available_block_number)
             }
         }
     }
@@ -1442,7 +1442,7 @@ mod rocksdb_tests {
 
             // RocksDB query via EitherReader
             let mut rocks_reader: EitherReader<'_, AccountsHistoryReadCursor, EthPrimitives> =
-                EitherReader::RocksDB(&rocks_provider);
+                EitherReader::RocksDB(rocks_provider.snapshot());
             let rocks_result = rocks_reader
                 .account_history_info(address, query.block_number, query.lowest_available)
                 .unwrap();
@@ -1537,7 +1537,7 @@ mod rocksdb_tests {
 
             // RocksDB query via EitherReader
             let mut rocks_reader: EitherReader<'_, StoragesHistoryReadCursor, EthPrimitives> =
-                EitherReader::RocksDB(&rocks_provider);
+                EitherReader::RocksDB(rocks_provider.snapshot());
             let rocks_result = rocks_reader
                 .storage_history_info(
                     address,
@@ -1805,10 +1805,10 @@ mod rocksdb_tests {
     }
 
     /// Test that `EitherReader::new_accounts_history` panics when settings require
-    /// `RocksDB` but no provider is given (`None`). This is an invariant violation that
-    /// indicates a bug - `with_rocksdb_provider` should always provide a provider when needed.
+    /// `RocksDB` but no snapshot is given (`None`). This is an invariant violation that
+    /// indicates a bug - `with_rocksdb_snapshot` should always provide a snapshot when needed.
     #[test]
-    #[should_panic(expected = "account_history_in_rocksdb requires rocksdb provider")]
+    #[should_panic(expected = "account_history_in_rocksdb requires rocksdb snapshot")]
     fn test_settings_mismatch_panics() {
         let factory = create_test_provider_factory();
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1925,7 +1925,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
     type Transaction = TxTy<N>;
 
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
-        self.with_rocksdb_provider(|rocksdb_ref| {
+        self.with_rocksdb_snapshot(|rocksdb_ref| {
             let mut reader = EitherReader::new_transaction_hash_numbers(self, rocksdb_ref)?;
             reader.get_transaction_hash_number(tx_hash)
         })

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1925,8 +1925,8 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
     type Transaction = TxTy<N>;
 
     fn transaction_id(&self, tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
-        self.with_rocksdb_tx(|tx_ref| {
-            let mut reader = EitherReader::new_transaction_hash_numbers(self, tx_ref)?;
+        self.with_rocksdb_provider(|rocksdb_ref| {
+            let mut reader = EitherReader::new_transaction_hash_numbers(self, rocksdb_ref)?;
             reader.get_transaction_hash_number(tx_hash)
         })
     }

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -36,7 +36,7 @@ pub(crate) mod rocksdb;
 
 pub use rocksdb::{
     PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
-    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksTx,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksReadSnapshot, RocksTx,
 };
 
 /// Helper trait to bound [`NodeTypes`] so that combined with database they satisfy

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -7,5 +7,5 @@ mod provider;
 pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
 pub use provider::{
     PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
-    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksTx,
+    RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksReadSnapshot, RocksTx,
 };

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -430,16 +430,6 @@ impl RocksDBProviderInner {
         cf.ok_or_else(|| DatabaseError::Other(format!("Column family '{}' not found", T::NAME)))
     }
 
-    /// Gets the column family handle for a table from the read-write database.
-    ///
-    /// # Panics
-    /// Panics if in read-only mode.
-    fn cf_handle_rw(&self, name: &str) -> Result<&rocksdb::ColumnFamily, DatabaseError> {
-        self.db_rw()
-            .cf_handle(name)
-            .ok_or_else(|| DatabaseError::Other(format!("Column family '{}' not found", name)))
-    }
-
     /// Gets a value from a column family.
     fn get_cf(
         &self,
@@ -1369,8 +1359,8 @@ impl RocksDBProvider {
 impl RocksDBProvider {
     /// Lookup account history and return [`HistoryInfo`] directly.
     ///
-    /// Unlike [`RocksTx::account_history_info`], this works in both read-only and read-write
-    /// modes since it uses the provider's mode-agnostic raw iterator.
+    /// Works in both read-only and read-write modes since it uses the provider's mode-agnostic
+    /// raw iterator.
     pub fn account_history_info(
         &self,
         address: Address,
@@ -1378,7 +1368,7 @@ impl RocksDBProvider {
         lowest_available_block_number: Option<BlockNumber>,
     ) -> ProviderResult<HistoryInfo> {
         let key = ShardedKey::new(address, block_number);
-        self.history_info_on_provider::<tables::AccountsHistory>(
+        self.history_info::<tables::AccountsHistory>(
             key.encode().as_ref(),
             block_number,
             lowest_available_block_number,
@@ -1393,8 +1383,8 @@ impl RocksDBProvider {
 
     /// Lookup storage history and return [`HistoryInfo`] directly.
     ///
-    /// Unlike [`RocksTx::storage_history_info`], this works in both read-only and read-write
-    /// modes since it uses the provider's mode-agnostic raw iterator.
+    /// Works in both read-only and read-write modes since it uses the provider's mode-agnostic
+    /// raw iterator.
     pub fn storage_history_info(
         &self,
         address: Address,
@@ -1403,7 +1393,7 @@ impl RocksDBProvider {
         lowest_available_block_number: Option<BlockNumber>,
     ) -> ProviderResult<HistoryInfo> {
         let key = StorageShardedKey::new(address, storage_key, block_number);
-        self.history_info_on_provider::<tables::StoragesHistory>(
+        self.history_info::<tables::StoragesHistory>(
             key.encode().as_ref(),
             block_number,
             lowest_available_block_number,
@@ -1421,9 +1411,8 @@ impl RocksDBProvider {
 
     /// Generic history lookup using the provider's mode-agnostic raw iterator.
     ///
-    /// This is the provider-level equivalent of [`RocksTx::history_info`] and works
-    /// in both read-only and read-write modes.
-    fn history_info_on_provider<T>(
+    /// Works in both read-only and read-write modes.
+    fn history_info<T>(
         &self,
         encoded_key: &[u8],
         block_number: BlockNumber,
@@ -2397,151 +2386,6 @@ impl<'db> RocksTx<'db> {
             ProviderError::Database(DatabaseError::Other(format!("rollback failed: {e}")))
         })
     }
-
-    /// Lookup account history and return [`HistoryInfo`] directly.
-    ///
-    /// This is a thin wrapper around `history_info` that:
-    /// - Builds the `ShardedKey` for the address + target block.
-    /// - Validates that the found shard belongs to the same address.
-    pub fn account_history_info(
-        &self,
-        address: Address,
-        block_number: BlockNumber,
-        lowest_available_block_number: Option<BlockNumber>,
-    ) -> ProviderResult<HistoryInfo> {
-        let key = ShardedKey::new(address, block_number);
-        self.history_info::<tables::AccountsHistory>(
-            key.encode().as_ref(),
-            block_number,
-            lowest_available_block_number,
-            |key_bytes| Ok(<ShardedKey<Address> as Decode>::decode(key_bytes)?.key == address),
-            |prev_bytes| {
-                <ShardedKey<Address> as Decode>::decode(prev_bytes)
-                    .map(|k| k.key == address)
-                    .unwrap_or(false)
-            },
-        )
-    }
-
-    /// Lookup storage history and return [`HistoryInfo`] directly.
-    ///
-    /// This is a thin wrapper around `history_info` that:
-    /// - Builds the `StorageShardedKey` for address + storage key + target block.
-    /// - Validates that the found shard belongs to the same address and storage slot.
-    pub fn storage_history_info(
-        &self,
-        address: Address,
-        storage_key: B256,
-        block_number: BlockNumber,
-        lowest_available_block_number: Option<BlockNumber>,
-    ) -> ProviderResult<HistoryInfo> {
-        let key = StorageShardedKey::new(address, storage_key, block_number);
-        self.history_info::<tables::StoragesHistory>(
-            key.encode().as_ref(),
-            block_number,
-            lowest_available_block_number,
-            |key_bytes| {
-                let k = <StorageShardedKey as Decode>::decode(key_bytes)?;
-                Ok(k.address == address && k.sharded_key.key == storage_key)
-            },
-            |prev_bytes| {
-                <StorageShardedKey as Decode>::decode(prev_bytes)
-                    .map(|k| k.address == address && k.sharded_key.key == storage_key)
-                    .unwrap_or(false)
-            },
-        )
-    }
-
-    /// Generic history lookup for sharded history tables.
-    ///
-    /// Seeks to the shard containing `block_number`, checks if the key matches via `key_matches`,
-    /// and uses `prev_key_matches` to detect if a previous shard exists for the same key.
-    fn history_info<T>(
-        &self,
-        encoded_key: &[u8],
-        block_number: BlockNumber,
-        lowest_available_block_number: Option<BlockNumber>,
-        key_matches: impl FnOnce(&[u8]) -> Result<bool, reth_db_api::DatabaseError>,
-        prev_key_matches: impl Fn(&[u8]) -> bool,
-    ) -> ProviderResult<HistoryInfo>
-    where
-        T: Table<Value = BlockNumberList>,
-    {
-        // History may be pruned if a lowest available block is set.
-        let is_maybe_pruned = lowest_available_block_number.is_some();
-        let fallback = || {
-            Ok(if is_maybe_pruned {
-                HistoryInfo::MaybeInPlainState
-            } else {
-                HistoryInfo::NotYetWritten
-            })
-        };
-
-        let cf = self.provider.0.cf_handle_rw(T::NAME)?;
-
-        // Create a raw iterator to access key bytes directly.
-        let mut iter: DBRawIteratorWithThreadMode<'_, Transaction<'_, OptimisticTransactionDB>> =
-            self.inner.raw_iterator_cf(&cf);
-
-        // Seek to the smallest key >= encoded_key.
-        iter.seek(encoded_key);
-        Self::raw_iter_status_ok(&iter)?;
-
-        if !iter.valid() {
-            // No shard found at or after target block.
-            //
-            // (MaybeInPlainState) The key may have been written, but due to pruning we may not have
-            // changesets and history, so we need to make a plain state lookup.
-            // (HistoryInfo::NotYetWritten) The key has not been written to at all.
-            return fallback();
-        }
-
-        // Check if the found key matches our target entity.
-        let Some(key_bytes) = iter.key() else {
-            return fallback();
-        };
-        if !key_matches(key_bytes)? {
-            // The found key is for a different entity.
-            return fallback();
-        }
-
-        // Decompress the block list for this shard.
-        let Some(value_bytes) = iter.value() else {
-            return fallback();
-        };
-        let chunk = BlockNumberList::decompress(value_bytes)?;
-        let (rank, found_block) = compute_history_rank(&chunk, block_number);
-
-        // Lazy check for previous shard - only called when needed.
-        // If we can step to a previous shard for this same key, history already exists,
-        // so the target block is not before the first write.
-        let is_before_first_write = if needs_prev_shard_check(rank, found_block, block_number) {
-            iter.prev();
-            Self::raw_iter_status_ok(&iter)?;
-            let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
-            !has_prev
-        } else {
-            false
-        };
-
-        Ok(HistoryInfo::from_lookup(
-            found_block,
-            is_before_first_write,
-            lowest_available_block_number,
-        ))
-    }
-
-    /// Returns an error if the raw iterator is in an invalid state due to an I/O error.
-    fn raw_iter_status_ok(
-        iter: &DBRawIteratorWithThreadMode<'_, Transaction<'_, OptimisticTransactionDB>>,
-    ) -> ProviderResult<()> {
-        iter.status().map_err(|e| {
-            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
-                message: e.to_string().into(),
-                code: -1,
-            }))
-        })
-    }
 }
 
 /// Wrapper enum for `RocksDB` iterators that works in both read-write and read-only modes.
@@ -3083,16 +2927,12 @@ mod tests {
         let shard_key = ShardedKey::new(address, u64::MAX);
         provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
 
-        let tx = provider.tx();
-
         // Query for block 50 with lowest_available_block_number = 100
         // This simulates a pruned state where data before block 100 is not available.
         // Since we're before the first write AND pruning boundary is set, we need to
         // check the changeset at the first write block.
-        let result = tx.account_history_info(address, 50, Some(100)).unwrap();
+        let result = provider.account_history_info(address, 50, Some(100)).unwrap();
         assert_eq!(result, HistoryInfo::InChangeset(100));
-
-        tx.rollback().unwrap();
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1517,6 +1517,16 @@ enum RocksReadSnapshotInner<'db> {
     ReadOnly(SnapshotWithThreadMode<'db, DB>),
 }
 
+impl<'db> RocksReadSnapshotInner<'db> {
+    /// Returns a raw iterator over a column family.
+    fn raw_iterator_cf(&self, cf: &rocksdb::ColumnFamily) -> RocksDBRawIterEnum<'_> {
+        match self {
+            Self::ReadWrite(snap) => RocksDBRawIterEnum::ReadWrite(snap.raw_iterator_cf(cf)),
+            Self::ReadOnly(snap) => RocksDBRawIterEnum::ReadOnly(snap.raw_iterator_cf(cf)),
+        }
+    }
+}
+
 impl fmt::Debug for RocksReadSnapshot<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RocksReadSnapshot")
@@ -1617,67 +1627,52 @@ impl<'db> RocksReadSnapshot<'db> {
         };
 
         let cf = self.cf_handle::<T>()?;
+        let mut iter = self.inner.raw_iterator_cf(cf);
 
-        macro_rules! history_info_with_iter {
-            ($snap:expr) => {{
-                let mut iter = $snap.raw_iterator_cf(cf);
+        iter.seek(encoded_key);
+        iter.status().map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
 
-                iter.seek(encoded_key);
-                iter.status().map_err(|e| {
-                    ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
-                        message: e.to_string().into(),
-                        code: -1,
-                    }))
-                })?;
-
-                if !iter.valid() {
-                    return fallback();
-                }
-
-                let Some(key_bytes) = iter.key() else {
-                    return fallback();
-                };
-                if !key_matches(key_bytes)? {
-                    return fallback();
-                }
-
-                let Some(value_bytes) = iter.value() else {
-                    return fallback();
-                };
-                let chunk = BlockNumberList::decompress(value_bytes)?;
-                let (rank, found_block) = compute_history_rank(&chunk, block_number);
-
-                let is_before_first_write =
-                    if needs_prev_shard_check(rank, found_block, block_number) {
-                        iter.prev();
-                        iter.status().map_err(|e| {
-                            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
-                                message: e.to_string().into(),
-                                code: -1,
-                            }))
-                        })?;
-                        let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
-                        !has_prev
-                    } else {
-                        false
-                    };
-
-                Ok(HistoryInfo::from_lookup(
-                    found_block,
-                    is_before_first_write,
-                    lowest_available_block_number,
-                ))
-            }};
+        if !iter.valid() {
+            return fallback();
         }
 
-        match &self.inner {
-            RocksReadSnapshotInner::ReadWrite(snap) => {
-                history_info_with_iter!(snap)
-            }
-            RocksReadSnapshotInner::ReadOnly(snap) => {
-                history_info_with_iter!(snap)
-            }
+        let Some(key_bytes) = iter.key() else {
+            return fallback();
+        };
+        if !key_matches(key_bytes)? {
+            return fallback();
         }
+
+        let Some(value_bytes) = iter.value() else {
+            return fallback();
+        };
+        let chunk = BlockNumberList::decompress(value_bytes)?;
+        let (rank, found_block) = compute_history_rank(&chunk, block_number);
+
+        let is_before_first_write = if needs_prev_shard_check(rank, found_block, block_number) {
+            iter.prev();
+            iter.status().map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+            let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
+            !has_prev
+        } else {
+            false
+        };
+
+        Ok(HistoryInfo::from_lookup(
+            found_block,
+            is_before_first_write,
+            lowest_available_block_number,
+        ))
     }
 }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1371,132 +1371,6 @@ impl RocksDBProvider {
     }
 }
 
-impl RocksDBProvider {
-    /// Lookup account history and return [`HistoryInfo`] directly.
-    ///
-    /// Reads committed data only (uncommitted transaction writes are not visible).
-    /// Prefer [`RocksReadSnapshot::account_history_info`] for point-in-time consistent reads.
-    pub fn account_history_info(
-        &self,
-        address: Address,
-        block_number: BlockNumber,
-        lowest_available_block_number: Option<BlockNumber>,
-    ) -> ProviderResult<HistoryInfo> {
-        let key = ShardedKey::new(address, block_number);
-        self.history_info::<tables::AccountsHistory>(
-            key.encode().as_ref(),
-            block_number,
-            lowest_available_block_number,
-            |key_bytes| Ok(<ShardedKey<Address> as Decode>::decode(key_bytes)?.key == address),
-            |prev_bytes| {
-                <ShardedKey<Address> as Decode>::decode(prev_bytes)
-                    .map(|k| k.key == address)
-                    .unwrap_or(false)
-            },
-        )
-    }
-
-    /// Lookup storage history and return [`HistoryInfo`] directly.
-    ///
-    /// Reads committed data only (uncommitted transaction writes are not visible).
-    /// Prefer [`RocksReadSnapshot::storage_history_info`] for point-in-time consistent reads.
-    pub fn storage_history_info(
-        &self,
-        address: Address,
-        storage_key: B256,
-        block_number: BlockNumber,
-        lowest_available_block_number: Option<BlockNumber>,
-    ) -> ProviderResult<HistoryInfo> {
-        let key = StorageShardedKey::new(address, storage_key, block_number);
-        self.history_info::<tables::StoragesHistory>(
-            key.encode().as_ref(),
-            block_number,
-            lowest_available_block_number,
-            |key_bytes| {
-                let k = <StorageShardedKey as Decode>::decode(key_bytes)?;
-                Ok(k.address == address && k.sharded_key.key == storage_key)
-            },
-            |prev_bytes| {
-                <StorageShardedKey as Decode>::decode(prev_bytes)
-                    .map(|k| k.address == address && k.sharded_key.key == storage_key)
-                    .unwrap_or(false)
-            },
-        )
-    }
-
-    /// Generic history lookup using a raw `RocksDB` iterator.
-    ///
-    /// Reads committed data only. Used internally and by [`RocksReadSnapshot::history_info`].
-    fn history_info<T>(
-        &self,
-        encoded_key: &[u8],
-        block_number: BlockNumber,
-        lowest_available_block_number: Option<BlockNumber>,
-        key_matches: impl FnOnce(&[u8]) -> Result<bool, reth_db_api::DatabaseError>,
-        prev_key_matches: impl Fn(&[u8]) -> bool,
-    ) -> ProviderResult<HistoryInfo>
-    where
-        T: Table<Value = BlockNumberList>,
-    {
-        let is_maybe_pruned = lowest_available_block_number.is_some();
-        let fallback = || {
-            Ok(if is_maybe_pruned {
-                HistoryInfo::MaybeInPlainState
-            } else {
-                HistoryInfo::NotYetWritten
-            })
-        };
-
-        let cf = self.0.cf_handle::<T>()?;
-        let mut iter = self.0.raw_iterator_cf(&cf);
-
-        iter.seek(encoded_key);
-        iter.status().map_err(|e| {
-            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
-                message: e.to_string().into(),
-                code: -1,
-            }))
-        })?;
-
-        if !iter.valid() {
-            return fallback();
-        }
-
-        let Some(key_bytes) = iter.key() else {
-            return fallback();
-        };
-        if !key_matches(key_bytes)? {
-            return fallback();
-        }
-
-        let Some(value_bytes) = iter.value() else {
-            return fallback();
-        };
-        let chunk = BlockNumberList::decompress(value_bytes)?;
-        let (rank, found_block) = compute_history_rank(&chunk, block_number);
-
-        let is_before_first_write = if needs_prev_shard_check(rank, found_block, block_number) {
-            iter.prev();
-            iter.status().map_err(|e| {
-                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
-                    message: e.to_string().into(),
-                    code: -1,
-                }))
-            })?;
-            let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
-            !has_prev
-        } else {
-            false
-        };
-
-        Ok(HistoryInfo::from_lookup(
-            found_block,
-            is_before_first_write,
-            lowest_available_block_number,
-        ))
-    }
-}
-
 /// A point-in-time read snapshot of the `RocksDB` database.
 ///
 /// All reads through this snapshot see a consistent view of the database at the point
@@ -3125,7 +2999,7 @@ mod tests {
         // This simulates a pruned state where data before block 100 is not available.
         // Since we're before the first write AND pruning boundary is set, we need to
         // check the changeset at the first write block.
-        let result = provider.account_history_info(address, 50, Some(100)).unwrap();
+        let result = provider.snapshot().account_history_info(address, 50, Some(100)).unwrap();
         assert_eq!(result, HistoryInfo::InChangeset(100));
     }
 
@@ -3152,13 +3026,13 @@ mod tests {
             .build()
             .unwrap();
 
-        let result = ro_provider.account_history_info(address, 200, None).unwrap();
+        let result = ro_provider.snapshot().account_history_info(address, 200, None).unwrap();
         assert_eq!(result, HistoryInfo::InChangeset(200));
 
-        let result = ro_provider.account_history_info(address, 50, None).unwrap();
+        let result = ro_provider.snapshot().account_history_info(address, 50, None).unwrap();
         assert_eq!(result, HistoryInfo::NotYetWritten);
 
-        let result = ro_provider.account_history_info(address, 400, None).unwrap();
+        let result = ro_provider.snapshot().account_history_info(address, 400, None).unwrap();
         assert_eq!(result, HistoryInfo::InPlainState);
     }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -27,8 +27,8 @@ use reth_storage_errors::{
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
     DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
-    OptimisticTransactionOptions, Options, Transaction, WriteBatchWithTransaction, WriteOptions,
-    DB,
+    OptimisticTransactionOptions, Options, SnapshotWithThreadMode, Transaction,
+    WriteBatchWithTransaction, WriteOptions, DB,
 };
 use std::{
     collections::BTreeMap,
@@ -494,6 +494,14 @@ impl RocksDBProviderInner {
         }
     }
 
+    /// Returns a read-only, point-in-time snapshot of the database.
+    fn snapshot(&self) -> RocksReadSnapshotInner<'_> {
+        match self {
+            Self::ReadWrite { db, .. } => RocksReadSnapshotInner::ReadWrite(db.snapshot()),
+            Self::ReadOnly { db, .. } => RocksReadSnapshotInner::ReadOnly(db.snapshot()),
+        }
+    }
+
     /// Returns the path to the database directory.
     fn path(&self) -> &Path {
         match self {
@@ -691,6 +699,13 @@ impl RocksDBProvider {
     /// Returns `true` if this provider is in read-only mode.
     pub fn is_read_only(&self) -> bool {
         matches!(self.0.as_ref(), RocksDBProviderInner::ReadOnly { .. })
+    }
+
+    /// Returns a read-only, point-in-time snapshot of the database.
+    ///
+    /// Lighter weight than [`RocksTx`] — no write-conflict tracking, and `Send + Sync`.
+    pub fn snapshot(&self) -> RocksReadSnapshot<'_> {
+        RocksReadSnapshot { inner: self.0.snapshot(), provider: self }
     }
 
     /// Creates a new transaction with MDBX-like semantics (read-your-writes, rollback).
@@ -1359,10 +1374,8 @@ impl RocksDBProvider {
 impl RocksDBProvider {
     /// Lookup account history and return [`HistoryInfo`] directly.
     ///
-    /// Works in both read-only and read-write modes since it uses the provider's mode-agnostic
-    /// raw iterator.
-    ///
-    /// Note: only sees committed data; uncommitted transaction writes are not visible.
+    /// Reads committed data only (uncommitted transaction writes are not visible).
+    /// Prefer [`RocksReadSnapshot::account_history_info`] for point-in-time consistent reads.
     pub fn account_history_info(
         &self,
         address: Address,
@@ -1385,10 +1398,8 @@ impl RocksDBProvider {
 
     /// Lookup storage history and return [`HistoryInfo`] directly.
     ///
-    /// Works in both read-only and read-write modes since it uses the provider's mode-agnostic
-    /// raw iterator.
-    ///
-    /// Note: only sees committed data; uncommitted transaction writes are not visible.
+    /// Reads committed data only (uncommitted transaction writes are not visible).
+    /// Prefer [`RocksReadSnapshot::storage_history_info`] for point-in-time consistent reads.
     pub fn storage_history_info(
         &self,
         address: Address,
@@ -1413,11 +1424,9 @@ impl RocksDBProvider {
         )
     }
 
-    /// Generic history lookup using the provider's mode-agnostic raw iterator.
+    /// Generic history lookup using a raw `RocksDB` iterator.
     ///
-    /// Works in both read-only and read-write modes.
-    ///
-    /// Note: only sees committed data; uncommitted transaction writes are not visible.
+    /// Reads committed data only. Used internally and by [`RocksReadSnapshot::history_info`].
     fn history_info<T>(
         &self,
         encoded_key: &[u8],
@@ -1485,6 +1494,190 @@ impl RocksDBProvider {
             is_before_first_write,
             lowest_available_block_number,
         ))
+    }
+}
+
+/// A point-in-time read snapshot of the `RocksDB` database.
+///
+/// All reads through this snapshot see a consistent view of the database at the point
+/// the snapshot was created, regardless of concurrent writes. This is the primary reader
+/// used by [`EitherReader::RocksDB`](crate::either_writer::EitherReader) for history lookups.
+///
+/// Lighter weight than [`RocksTx`] — no transaction overhead, no write support.
+pub struct RocksReadSnapshot<'db> {
+    inner: RocksReadSnapshotInner<'db>,
+    provider: &'db RocksDBProvider,
+}
+
+/// Inner enum to hold the snapshot for either read-write or read-only mode.
+enum RocksReadSnapshotInner<'db> {
+    /// Snapshot from read-write `OptimisticTransactionDB`.
+    ReadWrite(SnapshotWithThreadMode<'db, OptimisticTransactionDB>),
+    /// Snapshot from read-only `DB`.
+    ReadOnly(SnapshotWithThreadMode<'db, DB>),
+}
+
+impl fmt::Debug for RocksReadSnapshot<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RocksReadSnapshot")
+            .field("provider", &self.provider)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'db> RocksReadSnapshot<'db> {
+    /// Gets the column family handle for a table.
+    fn cf_handle<T: Table>(&self) -> Result<&'db rocksdb::ColumnFamily, DatabaseError> {
+        self.provider.get_cf_handle::<T>()
+    }
+
+    /// Gets a value from the specified table.
+    pub fn get<T: Table>(&self, key: T::Key) -> ProviderResult<Option<T::Value>> {
+        let encoded_key = key.encode();
+        let cf = self.cf_handle::<T>()?;
+        let result = match &self.inner {
+            RocksReadSnapshotInner::ReadWrite(snap) => snap.get_cf(cf, encoded_key.as_ref()),
+            RocksReadSnapshotInner::ReadOnly(snap) => snap.get_cf(cf, encoded_key.as_ref()),
+        }
+        .map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        Ok(result.and_then(|value| T::Value::decompress(&value).ok()))
+    }
+
+    /// Lookup account history and return [`HistoryInfo`] directly.
+    pub fn account_history_info(
+        &self,
+        address: Address,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+    ) -> ProviderResult<HistoryInfo> {
+        let key = ShardedKey::new(address, block_number);
+        self.history_info::<tables::AccountsHistory>(
+            key.encode().as_ref(),
+            block_number,
+            lowest_available_block_number,
+            |key_bytes| Ok(<ShardedKey<Address> as Decode>::decode(key_bytes)?.key == address),
+            |prev_bytes| {
+                <ShardedKey<Address> as Decode>::decode(prev_bytes)
+                    .map(|k| k.key == address)
+                    .unwrap_or(false)
+            },
+        )
+    }
+
+    /// Lookup storage history and return [`HistoryInfo`] directly.
+    pub fn storage_history_info(
+        &self,
+        address: Address,
+        storage_key: B256,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+    ) -> ProviderResult<HistoryInfo> {
+        let key = StorageShardedKey::new(address, storage_key, block_number);
+        self.history_info::<tables::StoragesHistory>(
+            key.encode().as_ref(),
+            block_number,
+            lowest_available_block_number,
+            |key_bytes| {
+                let k = <StorageShardedKey as Decode>::decode(key_bytes)?;
+                Ok(k.address == address && k.sharded_key.key == storage_key)
+            },
+            |prev_bytes| {
+                <StorageShardedKey as Decode>::decode(prev_bytes)
+                    .map(|k| k.address == address && k.sharded_key.key == storage_key)
+                    .unwrap_or(false)
+            },
+        )
+    }
+
+    /// Generic history lookup using the snapshot's raw iterator.
+    fn history_info<T>(
+        &self,
+        encoded_key: &[u8],
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        key_matches: impl FnOnce(&[u8]) -> Result<bool, reth_db_api::DatabaseError>,
+        prev_key_matches: impl Fn(&[u8]) -> bool,
+    ) -> ProviderResult<HistoryInfo>
+    where
+        T: Table<Value = BlockNumberList>,
+    {
+        let is_maybe_pruned = lowest_available_block_number.is_some();
+        let fallback = || {
+            Ok(if is_maybe_pruned {
+                HistoryInfo::MaybeInPlainState
+            } else {
+                HistoryInfo::NotYetWritten
+            })
+        };
+
+        let cf = self.cf_handle::<T>()?;
+
+        macro_rules! history_info_with_iter {
+            ($snap:expr) => {{
+                let mut iter = $snap.raw_iterator_cf(cf);
+
+                iter.seek(encoded_key);
+                iter.status().map_err(|e| {
+                    ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                        message: e.to_string().into(),
+                        code: -1,
+                    }))
+                })?;
+
+                if !iter.valid() {
+                    return fallback();
+                }
+
+                let Some(key_bytes) = iter.key() else {
+                    return fallback();
+                };
+                if !key_matches(key_bytes)? {
+                    return fallback();
+                }
+
+                let Some(value_bytes) = iter.value() else {
+                    return fallback();
+                };
+                let chunk = BlockNumberList::decompress(value_bytes)?;
+                let (rank, found_block) = compute_history_rank(&chunk, block_number);
+
+                let is_before_first_write =
+                    if needs_prev_shard_check(rank, found_block, block_number) {
+                        iter.prev();
+                        iter.status().map_err(|e| {
+                            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                                message: e.to_string().into(),
+                                code: -1,
+                            }))
+                        })?;
+                        let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
+                        !has_prev
+                    } else {
+                        false
+                    };
+
+                Ok(HistoryInfo::from_lookup(
+                    found_block,
+                    is_before_first_write,
+                    lowest_available_block_number,
+                ))
+            }};
+        }
+
+        match &self.inner {
+            RocksReadSnapshotInner::ReadWrite(snap) => {
+                history_info_with_iter!(snap)
+            }
+            RocksReadSnapshotInner::ReadOnly(snap) => {
+                history_info_with_iter!(snap)
+            }
+        }
     }
 }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -3003,7 +3003,7 @@ mod tests {
         assert_eq!(result, HistoryInfo::InChangeset(100));
     }
 
-    /// Verifies that history lookups work on a read-only RocksDB provider.
+    /// Verifies that history lookups work on a read-only `RocksDB` provider.
     /// This was the original bug — read-only mode panicked on `account_history_info`.
     #[test]
     fn test_account_history_info_read_only() {

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1366,6 +1366,133 @@ impl RocksDBProvider {
     }
 }
 
+impl RocksDBProvider {
+    /// Lookup account history and return [`HistoryInfo`] directly.
+    ///
+    /// Unlike [`RocksTx::account_history_info`], this works in both read-only and read-write
+    /// modes since it uses the provider's mode-agnostic raw iterator.
+    pub fn account_history_info(
+        &self,
+        address: Address,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+    ) -> ProviderResult<HistoryInfo> {
+        let key = ShardedKey::new(address, block_number);
+        self.history_info_on_provider::<tables::AccountsHistory>(
+            key.encode().as_ref(),
+            block_number,
+            lowest_available_block_number,
+            |key_bytes| Ok(<ShardedKey<Address> as Decode>::decode(key_bytes)?.key == address),
+            |prev_bytes| {
+                <ShardedKey<Address> as Decode>::decode(prev_bytes)
+                    .map(|k| k.key == address)
+                    .unwrap_or(false)
+            },
+        )
+    }
+
+    /// Lookup storage history and return [`HistoryInfo`] directly.
+    ///
+    /// Unlike [`RocksTx::storage_history_info`], this works in both read-only and read-write
+    /// modes since it uses the provider's mode-agnostic raw iterator.
+    pub fn storage_history_info(
+        &self,
+        address: Address,
+        storage_key: B256,
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+    ) -> ProviderResult<HistoryInfo> {
+        let key = StorageShardedKey::new(address, storage_key, block_number);
+        self.history_info_on_provider::<tables::StoragesHistory>(
+            key.encode().as_ref(),
+            block_number,
+            lowest_available_block_number,
+            |key_bytes| {
+                let k = <StorageShardedKey as Decode>::decode(key_bytes)?;
+                Ok(k.address == address && k.sharded_key.key == storage_key)
+            },
+            |prev_bytes| {
+                <StorageShardedKey as Decode>::decode(prev_bytes)
+                    .map(|k| k.address == address && k.sharded_key.key == storage_key)
+                    .unwrap_or(false)
+            },
+        )
+    }
+
+    /// Generic history lookup using the provider's mode-agnostic raw iterator.
+    ///
+    /// This is the provider-level equivalent of [`RocksTx::history_info`] and works
+    /// in both read-only and read-write modes.
+    fn history_info_on_provider<T>(
+        &self,
+        encoded_key: &[u8],
+        block_number: BlockNumber,
+        lowest_available_block_number: Option<BlockNumber>,
+        key_matches: impl FnOnce(&[u8]) -> Result<bool, reth_db_api::DatabaseError>,
+        prev_key_matches: impl Fn(&[u8]) -> bool,
+    ) -> ProviderResult<HistoryInfo>
+    where
+        T: Table<Value = BlockNumberList>,
+    {
+        let is_maybe_pruned = lowest_available_block_number.is_some();
+        let fallback = || {
+            Ok(if is_maybe_pruned {
+                HistoryInfo::MaybeInPlainState
+            } else {
+                HistoryInfo::NotYetWritten
+            })
+        };
+
+        let cf = self.0.cf_handle::<T>()?;
+        let mut iter = self.0.raw_iterator_cf(&cf);
+
+        iter.seek(encoded_key);
+        iter.status().map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        if !iter.valid() {
+            return fallback();
+        }
+
+        let Some(key_bytes) = iter.key() else {
+            return fallback();
+        };
+        if !key_matches(key_bytes)? {
+            return fallback();
+        }
+
+        let Some(value_bytes) = iter.value() else {
+            return fallback();
+        };
+        let chunk = BlockNumberList::decompress(value_bytes)?;
+        let (rank, found_block) = compute_history_rank(&chunk, block_number);
+
+        let is_before_first_write = if needs_prev_shard_check(rank, found_block, block_number) {
+            iter.prev();
+            iter.status().map_err(|e| {
+                ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                    message: e.to_string().into(),
+                    code: -1,
+                }))
+            })?;
+            let has_prev = iter.valid() && iter.key().is_some_and(&prev_key_matches);
+            !has_prev
+        } else {
+            false
+        };
+
+        Ok(HistoryInfo::from_lookup(
+            found_block,
+            is_before_first_write,
+            lowest_available_block_number,
+        ))
+    }
+}
+
 /// Outcome of pruning a history shard in `RocksDB`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PruneShardOutcome {
@@ -2485,6 +2612,14 @@ impl RocksDBRawIterEnum<'_> {
         match self {
             Self::ReadWrite(iter) => iter.next(),
             Self::ReadOnly(iter) => iter.next(),
+        }
+    }
+
+    /// Moves the iterator to the previous key.
+    fn prev(&mut self) {
+        match self {
+            Self::ReadWrite(iter) => iter.prev(),
+            Self::ReadOnly(iter) => iter.prev(),
         }
     }
 

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1361,6 +1361,8 @@ impl RocksDBProvider {
     ///
     /// Works in both read-only and read-write modes since it uses the provider's mode-agnostic
     /// raw iterator.
+    ///
+    /// Note: only sees committed data; uncommitted transaction writes are not visible.
     pub fn account_history_info(
         &self,
         address: Address,
@@ -1385,6 +1387,8 @@ impl RocksDBProvider {
     ///
     /// Works in both read-only and read-write modes since it uses the provider's mode-agnostic
     /// raw iterator.
+    ///
+    /// Note: only sees committed data; uncommitted transaction writes are not visible.
     pub fn storage_history_info(
         &self,
         address: Address,
@@ -1412,6 +1416,8 @@ impl RocksDBProvider {
     /// Generic history lookup using the provider's mode-agnostic raw iterator.
     ///
     /// Works in both read-only and read-write modes.
+    ///
+    /// Note: only sees committed data; uncommitted transaction writes are not visible.
     fn history_info<T>(
         &self,
         encoded_key: &[u8],
@@ -2933,6 +2939,39 @@ mod tests {
         // check the changeset at the first write block.
         let result = provider.account_history_info(address, 50, Some(100)).unwrap();
         assert_eq!(result, HistoryInfo::InChangeset(100));
+    }
+
+    /// Verifies that history lookups work on a read-only RocksDB provider.
+    /// This was the original bug — read-only mode panicked on `account_history_info`.
+    #[test]
+    fn test_account_history_info_read_only() {
+        let temp_dir = TempDir::new().unwrap();
+        let address = Address::from([0x42; 20]);
+        let chunk = IntegerList::new([100, 200, 300]).unwrap();
+        let shard_key = ShardedKey::new(address, u64::MAX);
+
+        // Write data with a read-write provider, then drop it.
+        {
+            let provider =
+                RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+            provider.put::<tables::AccountsHistory>(shard_key, &chunk).unwrap();
+        }
+
+        // Reopen in read-only mode and verify the lookup succeeds (no panic).
+        let ro_provider = RocksDBBuilder::new(temp_dir.path())
+            .with_default_tables()
+            .with_read_only(true)
+            .build()
+            .unwrap();
+
+        let result = ro_provider.account_history_info(address, 200, None).unwrap();
+        assert_eq!(result, HistoryInfo::InChangeset(200));
+
+        let result = ro_provider.account_history_info(address, 50, None).unwrap();
+        assert_eq!(result, HistoryInfo::NotYetWritten);
+
+        let result = ro_provider.account_history_info(address, 400, None).unwrap();
+        assert_eq!(result, HistoryInfo::InPlainState);
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -156,8 +156,8 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        self.provider.with_rocksdb_tx(|rocks_tx_ref| {
-            let mut reader = EitherReader::new_accounts_history(self.provider, rocks_tx_ref)?;
+        self.provider.with_rocksdb_provider(|rocksdb_ref| {
+            let mut reader = EitherReader::new_accounts_history(self.provider, rocksdb_ref)?;
             reader.account_history_info(
                 address,
                 self.block_number,
@@ -181,8 +181,8 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        self.provider.with_rocksdb_tx(|rocks_tx_ref| {
-            let mut reader = EitherReader::new_storages_history(self.provider, rocks_tx_ref)?;
+        self.provider.with_rocksdb_provider(|rocksdb_ref| {
+            let mut reader = EitherReader::new_storages_history(self.provider, rocksdb_ref)?;
             reader.storage_history_info(
                 address,
                 lookup_key,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -156,7 +156,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        self.provider.with_rocksdb_provider(|rocksdb_ref| {
+        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
             let mut reader = EitherReader::new_accounts_history(self.provider, rocksdb_ref)?;
             reader.account_history_info(
                 address,
@@ -181,7 +181,7 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        self.provider.with_rocksdb_provider(|rocksdb_ref| {
+        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
             let mut reader = EitherReader::new_storages_history(self.provider, rocksdb_ref)?;
             reader.storage_history_info(
                 address,

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -25,22 +25,24 @@ pub trait RocksDBProviderFactory {
     /// full commit path.
     fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()>;
 
-    /// Executes a closure with a `RocksDB` provider reference for reading.
+    /// Executes a closure with a `RocksDB` point-in-time snapshot for consistent reads.
     ///
     /// This helper encapsulates `RocksDB` access for read operations.
     /// On legacy MDBX-only nodes (where `storage_v2` is false), this skips creating
-    /// the `RocksDB` provider entirely, avoiding unnecessary overhead.
+    /// the `RocksDB` snapshot entirely, avoiding unnecessary overhead.
     ///
     /// Unlike a transaction-based approach, this works in both read-only and read-write
-    /// modes since it uses the provider's mode-agnostic read methods directly.
-    fn with_rocksdb_provider<F, R>(&self, f: F) -> ProviderResult<R>
+    /// modes since the snapshot provides a consistent view of the data at the time it
+    /// was created.
+    fn with_rocksdb_snapshot<F, R>(&self, f: F) -> ProviderResult<R>
     where
         Self: StorageSettingsCache,
         F: FnOnce(RocksDBRefArg<'_>) -> ProviderResult<R>,
     {
         if self.cached_storage_settings().storage_v2 {
             let rocksdb = self.rocksdb_provider();
-            return f(Some(&rocksdb));
+            let snapshot = rocksdb.snapshot();
+            return f(Some(snapshot));
         }
         f(None)
     }
@@ -86,7 +88,7 @@ mod tests {
     use reth_db_api::models::StorageSettings;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Mock `RocksDB` provider that tracks `tx()` calls.
+    /// Mock `RocksDB` provider that tracks snapshot creation calls.
     struct MockRocksDBProvider {
         tx_call_count: AtomicUsize,
     }
@@ -148,10 +150,10 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_settings_skip_rocksdb_provider() {
+    fn test_legacy_settings_skip_rocksdb_snapshot() {
         let provider = TestProvider::new(StorageSettings::v1());
 
-        let result = provider.with_rocksdb_provider(|rocksdb| {
+        let result = provider.with_rocksdb_snapshot(|rocksdb| {
             assert!(rocksdb.is_none(), "legacy settings should pass None");
             Ok(42)
         });
@@ -165,12 +167,12 @@ mod tests {
     }
 
     #[test]
-    fn test_rocksdb_settings_create_provider() {
+    fn test_rocksdb_settings_create_snapshot() {
         let settings = StorageSettings::v2();
         let provider = TestProvider::new(settings);
 
-        let result = provider.with_rocksdb_provider(|rocksdb| {
-            assert!(rocksdb.is_some(), "rocksdb settings should pass Some provider");
+        let result = provider.with_rocksdb_snapshot(|rocksdb| {
+            assert!(rocksdb.is_some(), "rocksdb settings should pass Some snapshot");
             Ok(42)
         });
 

--- a/crates/storage/provider/src/traits/rocksdb_provider.rs
+++ b/crates/storage/provider/src/traits/rocksdb_provider.rs
@@ -1,5 +1,5 @@
 use crate::{
-    either_writer::{RawRocksDBBatch, RocksBatchArg, RocksTxRefArg},
+    either_writer::{RawRocksDBBatch, RocksBatchArg, RocksDBRefArg},
     providers::RocksDBProvider,
 };
 use reth_storage_api::StorageSettingsCache;
@@ -25,20 +25,22 @@ pub trait RocksDBProviderFactory {
     /// full commit path.
     fn commit_pending_rocksdb_batches(&self) -> ProviderResult<()>;
 
-    /// Executes a closure with a `RocksDB` transaction for reading.
+    /// Executes a closure with a `RocksDB` provider reference for reading.
     ///
-    /// This helper encapsulates all the cfg-gated `RocksDB` transaction handling for reads.
-    /// On legacy MDBX-only nodes (where `any_in_rocksdb()` is false), this skips creating
-    /// the `RocksDB` transaction entirely, avoiding unnecessary overhead.
-    fn with_rocksdb_tx<F, R>(&self, f: F) -> ProviderResult<R>
+    /// This helper encapsulates `RocksDB` access for read operations.
+    /// On legacy MDBX-only nodes (where `storage_v2` is false), this skips creating
+    /// the `RocksDB` provider entirely, avoiding unnecessary overhead.
+    ///
+    /// Unlike a transaction-based approach, this works in both read-only and read-write
+    /// modes since it uses the provider's mode-agnostic read methods directly.
+    fn with_rocksdb_provider<F, R>(&self, f: F) -> ProviderResult<R>
     where
         Self: StorageSettingsCache,
-        F: FnOnce(RocksTxRefArg<'_>) -> ProviderResult<R>,
+        F: FnOnce(RocksDBRefArg<'_>) -> ProviderResult<R>,
     {
         if self.cached_storage_settings().storage_v2 {
             let rocksdb = self.rocksdb_provider();
-            let tx = rocksdb.tx();
-            return f(Some(&tx));
+            return f(Some(&rocksdb));
         }
         f(None)
     }
@@ -146,25 +148,29 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_settings_skip_rocksdb_tx_creation() {
+    fn test_legacy_settings_skip_rocksdb_provider() {
         let provider = TestProvider::new(StorageSettings::v1());
 
-        let result = provider.with_rocksdb_tx(|tx| {
-            assert!(tx.is_none(), "legacy settings should pass None tx");
+        let result = provider.with_rocksdb_provider(|rocksdb| {
+            assert!(rocksdb.is_none(), "legacy settings should pass None");
             Ok(42)
         });
 
         assert_eq!(result.unwrap(), 42);
-        assert_eq!(provider.tx_call_count(), 0, "should not create RocksDB tx for legacy settings");
+        assert_eq!(
+            provider.tx_call_count(),
+            0,
+            "should not create RocksDB provider for legacy settings"
+        );
     }
 
     #[test]
-    fn test_rocksdb_settings_create_tx() {
+    fn test_rocksdb_settings_create_provider() {
         let settings = StorageSettings::v2();
         let provider = TestProvider::new(settings);
 
-        let result = provider.with_rocksdb_tx(|tx| {
-            assert!(tx.is_some(), "rocksdb settings should pass Some tx");
+        let result = provider.with_rocksdb_provider(|rocksdb| {
+            assert!(rocksdb.is_some(), "rocksdb settings should pass Some provider");
             Ok(42)
         });
 
@@ -172,7 +178,7 @@ mod tests {
         assert_eq!(
             provider.tx_call_count(),
             1,
-            "should create RocksDB tx when any_in_rocksdb is true"
+            "should create RocksDB provider when storage_v2 is true"
         );
     }
 }


### PR DESCRIPTION
The `re-execute` command opens RocksDB with `AccessRights::RO`, but the read path created a write transaction via `RocksTx::tx()` → `db_rw()`, which panics on read-only providers.

Introduces `RocksReadSnapshot` — a point-in-time snapshot enum over `SnapshotWithThreadMode<OptimisticTransactionDB>` and `SnapshotWithThreadMode<DB>` — that works in both read-only and read-write modes. Snapshots are lighter than transactions (no write-conflict tracking) and are `Send + Sync`.

- `EitherReader::RocksDB` now holds `RocksReadSnapshot` instead of `&RocksTx`
- `with_rocksdb_tx` replaced by `with_rocksdb_snapshot` which passes a snapshot instead of creating a write transaction
- Deleted duplicated `RocksTx` history methods (`account_history_info`, `storage_history_info`, `history_info`) — `RocksReadSnapshot` is now the sole owner
- Deleted unused `cf_handle_rw` helper
- Added read-only regression test

Co-Authored-By: Tim <12827757+laibe@users.noreply.github.com>