### PR TITLE
fix(rpc): export EthConfigApi in aggregate modules

### DIFF
--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -57,8 +57,8 @@ pub mod servers {
         web3::Web3ApiServer,
     };
     pub use reth_rpc_eth_api::{
-        self as eth, EthApiServer, EthBundleApiServer, EthCallBundleApiServer, EthFilterApiServer,
-        EthPubSubApiServer, L2EthApiExtServer,
+        self as eth, EthApiServer, EthBundleApiServer, EthCallBundleApiServer, EthConfigApiServer,
+        EthFilterApiServer, EthPubSubApiServer, L2EthApiExtServer,
     };
 }
 
@@ -89,7 +89,7 @@ pub mod clients {
         web3::Web3ApiClient,
     };
     pub use reth_rpc_eth_api::{
-        EthApiClient, EthBundleApiClient, EthCallBundleApiClient, EthFilterApiClient,
-        L2EthApiExtClient,
+        EthApiClient, EthBundleApiClient, EthCallBundleApiClient, EthConfigApiClient,
+        EthFilterApiClient, L2EthApiExtClient,
     };
 }

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -25,6 +25,7 @@ pub use bundle::{EthBundleApiServer, EthCallBundleApiServer};
 pub use core::{EthApiServer, FullEthApiServer};
 pub use ext::L2EthApiExtServer;
 pub use filter::{EngineEthFilter, EthFilterApiServer, QueryLimits};
+pub use helpers::config::EthConfigApiServer;
 pub use node::{RpcNodeCore, RpcNodeCoreExt};
 pub use pubsub::EthPubSubApiServer;
 pub use reth_rpc_convert::*;
@@ -41,5 +42,7 @@ pub use core::EthApiClient;
 pub use ext::L2EthApiExtClient;
 #[cfg(feature = "client")]
 pub use filter::EthFilterApiClient;
+#[cfg(feature = "client")]
+pub use helpers::config::EthConfigApiClient;
 
 use reth_trie_common as _;


### PR DESCRIPTION
Export EthConfigApi server/client traits from rpc-eth-api and rpc-api aggregate modules, ensuring downstream imports stay consistent under the client feature.