### PR TITLE
fix(provider): prevent stale state reads during pipeline sync

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -104,6 +104,11 @@ pub enum ProviderError {
     /// State is not available for the given block number because it is pruned.
     #[error("state at block #{_0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+    /// State is temporarily unavailable because a pipeline sync is in progress and plain state
+    /// has been modified past this block. The block was fully executed in a prior pipeline run,
+    /// but its state cannot be safely read until the current run completes.
+    #[error("state at block #{_0} is temporarily unavailable, pipeline sync in progress")]
+    StateUnavailableDuringSync(BlockNumber),
     /// State is not available because the block has not been executed yet.
     #[error("state at block #{requested} is not available, block has not been executed yet (latest executed: #{executed})")]
     BlockNotExecuted {

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -760,7 +760,10 @@ impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
-        self.head_block.as_ref().map(|b| Ok(b.number())).unwrap_or_else(|| self.last_block_number())
+        self.head_block
+            .as_ref()
+            .map(|b| Ok(b.number()))
+            .unwrap_or_else(|| self.storage_provider.best_block_number())
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -14,11 +14,11 @@ use crate::{
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
-    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
-    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
-    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+    LatestStateProviderRef, OriginalValuesKnown, ProviderError, PruneCheckpointReader,
+    PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory,
+    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
+    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
+    TransactionsProviderExt, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -871,10 +871,13 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
             });
         }
 
-        // If requesting state at the best block, use the latest state provider
-        if block_number == best_block {
-            return Ok(Box::new(LatestStateProvider::new(self)));
-        }
+        // Note: we intentionally do NOT short-circuit with `LatestStateProvider` when
+        // `block_number == best_block`. `best_block` is the `StageId::Finish` checkpoint, but
+        // during pipeline sync the Execution stage may have already committed state changes for
+        // later blocks, advancing the plain/hashed state tables past `best_block`.
+        // `LatestStateProvider` reads those tables directly and would return state from the
+        // execution frontier instead of the requested block. `HistoricalStateProvider` correctly
+        // reconstructs state via changesets regardless of where plain state currently sits.
 
         // +1 as the changeset that we want is the one that was applied after this block.
         block_number += 1;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -14,11 +14,11 @@ use crate::{
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProviderRef, OriginalValuesKnown, ProviderError, PruneCheckpointReader,
-    PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory,
-    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
-    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, TrieWriter,
+    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
+    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
+    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
+    TransactionsProvider, TransactionsProviderExt, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -871,13 +871,25 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
             });
         }
 
-        // Note: we intentionally do NOT short-circuit with `LatestStateProvider` when
-        // `block_number == best_block`. `best_block` is the `StageId::Finish` checkpoint, but
-        // during pipeline sync the Execution stage may have already committed state changes for
-        // later blocks, advancing the plain/hashed state tables past `best_block`.
-        // `LatestStateProvider` reads those tables directly and would return state from the
-        // execution frontier instead of the requested block. `HistoricalStateProvider` correctly
-        // reconstructs state via changesets regardless of where plain state currently sits.
+        if block_number == best_block {
+            // Check whether the Execution stage has committed past the Finish checkpoint.
+            // If so, plain state is ahead and neither `LatestStateProvider` (reads plain state
+            // directly) nor `HistoricalStateProvider` (falls back to `InPlainState` for keys
+            // without indexed modifications after the target) can safely serve this block.
+            let execution_tip = self
+                .get_stage_checkpoint(StageId::Execution)?
+                .map(|c| c.block_number)
+                .unwrap_or_default();
+
+            if execution_tip > best_block {
+                return Err(ProviderError::BlockNotExecuted {
+                    requested: block_number,
+                    executed: best_block,
+                });
+            }
+
+            return Ok(Box::new(LatestStateProvider::new(self)));
+        }
 
         // +1 as the changeset that we want is the one that was applied after this block.
         block_number += 1;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -882,10 +882,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
                 .unwrap_or_default();
 
             if execution_tip > best_block {
-                return Err(ProviderError::BlockNotExecuted {
-                    requested: block_number,
-                    executed: best_block,
-                });
+                return Err(ProviderError::StateUnavailableDuringSync(block_number));
             }
 
             return Ok(Box::new(LatestStateProvider::new(self)));


### PR DESCRIPTION
Closes #22873 (Bug 2)

Companion to #22876 (Bug 1). Three changes to prevent stale state during pipeline sync:

**1. `ConsistentProvider::best_block_number()`** — falls back to `storage_provider.best_block_number()` (`StageId::Finish` checkpoint) instead of `last_block_number()` (header download frontier). Without this, `ensure_canonical_block` passes for blocks whose headers exist but state hasn't been computed.

**2. `try_into_history_at_block`** — when `block_number == best_block` (Finish), checks whether `StageId::Execution` has moved past it. Pipeline stages commit independently, so after Execution commits N+1..N+K the plain/hashed state is at N+K while Finish is at N. In this window neither `LatestStateProvider` nor `HistoricalStateProvider` can safely serve the Finish-tip block — `LatestStateProvider` reads plain state at N+K, and `HistoricalStateProvider`'s `InPlainState` fallback does the same when the history index has no modification after the target. Returns `StateUnavailableDuringSync` instead of wrong data.

**3. `StateUnavailableDuringSync` error variant** — replaces the misleading `BlockNotExecuted` (the block *was* executed, we just can't safely read it while the pipeline is running). Gives callers a clear "try again later" signal.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie