### PR TITLE
fix(engine): propagate fatal errors from payload validation in on_downloaded_block

### DIFF
--- a/.changelog/shy-lakes-shake.md
+++ b/.changelog/shy-lakes-shake.md
@@ -1,0 +1,5 @@
+---
+reth-engine-tree: patch
+---
+
+Fixed fatal error propagation from payload validation in `on_downloaded_block` by properly handling `InsertPayloadError::Payload` variants, treating `NewPayloadError::Other` errors as fatal instead of silently ignoring them.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -22,7 +22,7 @@ use reth_engine_primitives::{
     ForkchoiceStateTracker, NewPayloadTimings, OnForkChoiceUpdated, SlowBlockInfo,
 };
 use reth_errors::{ConsensusError, ProviderResult};
-use reth_evm::ConfigureEvm;
+use reth_evm::{execute::InternalBlockExecutionError, ConfigureEvm};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
     BuiltPayload, EngineApiMessageVersion, NewPayloadError, PayloadBuilderAttributes, PayloadTypes,
@@ -2700,15 +2700,25 @@ where
             Ok(InsertPayloadOk::AlreadySeen(_)) => {
                 trace!(target: "engine::tree", "downloaded block already executed");
             }
-            Err(err) => {
-                if let InsertPayloadError::Block(err) = err {
+            Err(err) => match err {
+                InsertPayloadError::Block(err) => {
                     debug!(target: "engine::tree", err=%err.kind(), "failed to insert downloaded block");
                     if let Err(fatal) = self.on_insert_block_error(err) {
                         warn!(target: "engine::tree", %fatal, "fatal error occurred while inserting downloaded block");
                         return Err(fatal)
                     }
                 }
-            }
+                InsertPayloadError::Payload(err) => match err {
+                    NewPayloadError::Eth(ref payload_err) => {
+                        debug!(target: "engine::tree", %payload_err, "failed to validate downloaded block payload");
+                    }
+                    NewPayloadError::Other(err) => {
+                        return Err(InsertBlockFatalError::BlockExecutionError(
+                            InternalBlockExecutionError::Other(err),
+                        ))
+                    }
+                },
+            },
         }
         Ok(None)
     }


### PR DESCRIPTION
## Motivation

Previously, InsertPayloadError::Payload errors were silently dropped in on_downloaded_block, while InsertPayloadError::Block errors were properly handled. This meant fatal errors (e.g. provider errors) wrapped in NewPayloadError::Other would be ignored, leaving the engine tree task alive but unable to execute blocks — causing the node to stall indefinitely instead of exiting.

This can occur when validate_block_with_state fails during EVM environment construction (evm_env_for), which converts provider errors like InsufficientChangesets into NewPayloadError::other(). Since downloaded blocks are fire-and-forget (no CL request/response loop to retry), the silently dropped error means nothing triggers another download attempt and the node sits idle permanently.

## Fix

Now NewPayloadError::Other is propagated as InsertBlockFatalError to trigger a node exit, while NewPayloadError::Eth (validation errors) is logged and treated as non-fatal.