### PR TITLE
fix(arena): recreate arena not shrink.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11695,7 +11695,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slotmap"
 version = "1.1.1"
-source = "git+https://github.com/DaniPopes/slotmap.git?branch=dani%2Fshrink-methods#09fbd360968f9ecef19fc9559037cf869d33858b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,8 +539,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 sha2 = { version = "0.10", default-features = false }
 shlex = "1.3"
-# https://github.com/orlp/slotmap/pull/148
-slotmap = { git = "https://github.com/DaniPopes/slotmap.git", branch = "dani/shrink-methods" }
+slotmap = "1"
 smallvec = "1"
 strum = { version = "0.27", default-features = false }
 strum_macros = "0.27"

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -9,7 +9,7 @@ use nodes::{
 };
 
 use crate::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdates};
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
 use alloy_primitives::{
     keccak256,
     map::{B256Map, HashMap, HashSet},
@@ -58,6 +58,54 @@ fn prefix_range(
         end += 1;
     }
     begin..end
+}
+
+/// Compacts an arena by BFS-copying all reachable nodes into a fresh `SlotMap`, dropping
+/// unreachable (pruned) slots. Parents are stored before children for cache-friendly top-down
+/// traversal.
+fn compact_arena(arena: &mut NodeArena, root: &mut Index) {
+    let mut new_arena = SlotMap::with_capacity(arena.len());
+    let mut queue = VecDeque::new();
+
+    let root_node = arena.remove(*root).expect("root exists");
+    let new_root = new_arena.insert(root_node);
+    queue.push_back(new_root);
+
+    while let Some(new_idx) = queue.pop_front() {
+        // Invariant: any node popped from `queue` has been moved into `new_arena` but
+        // its Branch.children have not been rewritten yet — every Revealed(idx) here is
+        // still an old-arena index, and the child is still present in `arena` because
+        // only this parent's iteration can remove it (each child has exactly one parent).
+        let old_children: SmallVec<[(usize, Index); 16]> = match &new_arena[new_idx] {
+            ArenaSparseNode::Branch(b) => b
+                .children
+                .iter()
+                .enumerate()
+                .filter_map(|(i, c)| match c {
+                    ArenaSparseNodeBranchChild::Revealed(old_idx) => Some((i, *old_idx)),
+                    _ => None,
+                })
+                .collect(),
+            _ => continue,
+        };
+
+        for (child_pos, old_child_idx) in old_children {
+            let child_node = arena.remove(old_child_idx).expect("child exists");
+            let new_child_idx = new_arena.insert(child_node);
+            let ArenaSparseNode::Branch(b) = &mut new_arena[new_idx] else { unreachable!() };
+            b.children[child_pos] = ArenaSparseNodeBranchChild::Revealed(new_child_idx);
+            queue.push_back(new_child_idx);
+        }
+    }
+
+    debug_assert!(
+        arena.is_empty(),
+        "compact_arena: {} orphaned nodes remaining after BFS drain",
+        arena.len(),
+    );
+
+    *arena = new_arena;
+    *root = new_root;
 }
 
 /// Reusable buffers shared by both [`ArenaSparseSubtrie`] and [`ArenaParallelSparseTrie`].
@@ -207,6 +255,11 @@ impl ArenaSparseSubtrie {
         }
 
         self.num_leaves -= pruned_leaves;
+
+        if pruned > 0 {
+            compact_arena(&mut self.arena, &mut self.root);
+        }
+
         #[cfg(debug_assertions)]
         self.debug_assert_counters();
         pruned
@@ -2722,6 +2775,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
             for (child_idx, subtrie, _) in taken {
                 self.upper_arena[child_idx] = ArenaSparseNode::Subtrie(subtrie);
             }
+        }
+
+        if pruned > 0 {
+            compact_arena(&mut self.upper_arena, &mut self.root);
         }
 
         #[cfg(feature = "trie-debug")]

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -126,7 +126,7 @@ impl ArenaSparseSubtrie {
     }
 
     fn clear(&mut self) {
-        self.arena.clear();
+        self.arena = SlotMap::new();
         self.buffers.clear();
         self.required_proofs.clear();
         self.num_leaves = 0;
@@ -2530,7 +2530,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 self.cleared_subtries.push(subtrie);
             }
         }
-        self.upper_arena.clear();
+        self.upper_arena = SlotMap::new();
         self.root = self.upper_arena.insert(ArenaSparseNode::EmptyRoot);
         if let Some(updates) = self.updates.as_mut() {
             updates.clear()
@@ -2539,14 +2539,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
     }
 
     fn shrink_nodes_to(&mut self, size: usize) {
-        self.upper_arena.shrink_to(size);
-        for (_, node) in &mut self.upper_arena {
-            if let ArenaSparseNode::Subtrie(s) = node {
-                s.arena.shrink_to(size);
-            }
-        }
+        // We do not shrink the upper trie for now.
+        //
+        // As soon as a trie rotates from a live subtrie into the
+        // cleared_subtrie it will be properly shrunk.
         for s in &mut self.cleared_subtries {
-            s.arena.shrink_to(size);
+            if s.arena.capacity() > size {
+                s.arena = SlotMap::with_capacity(size);
+            }
         }
     }
 


### PR DESCRIPTION
Shrinking a slot map does not really work because it is usually full of holes and thus does not really help cleaning. This PR admits that and instead just recreates the slotmap.

Somehow this was faster on my devbox. Let's see if this holds derek bench.