### PR TITLE
perf(rpc): avoid redundant receipt cache lookup in `eth_getTransactionReceipt`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -1,6 +1,8 @@
 //! Loads a receipt from database. Helper trait for `eth_` block and transaction RPC methods, that
 //! loads receipt data w.r.t. network.
 
+use std::sync::Arc;
+
 use crate::{EthApiTypes, RpcNodeCoreExt, RpcReceipt};
 use alloy_consensus::{transaction::TransactionMeta, TxReceipt};
 use futures::Future;
@@ -18,21 +20,27 @@ pub trait LoadReceipt:
     EthApiTypes<RpcConvert: RpcConvert<Primitives = Self::Primitives>> + RpcNodeCoreExt + Send + Sync
 {
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
+    ///
+    /// If `all_receipts` is `Some`, skips the cache lookup for receipts entirely.
     fn build_transaction_receipt(
         &self,
         tx: Recovered<ProviderTx<Self::Provider>>,
         meta: TransactionMeta,
         receipt: ProviderReceipt<Self::Provider>,
+        all_receipts: Option<Arc<Vec<ProviderReceipt<Self::Provider>>>>,
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send {
         async move {
             let hash = meta.block_hash;
-            // get all receipts for the block
-            let all_receipts = self
-                .cache()
-                .get_receipts(hash)
-                .await
-                .map_err(Self::Error::from_eth_err)?
-                .ok_or(EthApiError::HeaderNotFound(hash.into()))?;
+            // Use pre-fetched receipts if available, otherwise fetch from cache.
+            let all_receipts = match all_receipts {
+                Some(receipts) => receipts,
+                None => self
+                    .cache()
+                    .get_receipts(hash)
+                    .await
+                    .map_err(Self::Error::from_eth_err)?
+                    .ok_or(EthApiError::HeaderNotFound(hash.into()))?,
+            };
 
             let (gas_used, next_log_index) =
                 calculate_gas_used_and_next_log_index(meta.index, &all_receipts);

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -234,8 +234,8 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     {
         async move {
             match self.load_transaction_and_receipt(hash).await? {
-                Some((tx, meta, receipt)) => {
-                    self.build_transaction_receipt(tx, meta, receipt).await.map(Some)
+                Some((tx, meta, receipt, all_receipts)) => {
+                    self.build_transaction_receipt(tx, meta, receipt, all_receipts).await.map(Some)
                 }
                 None => Ok(None),
             }
@@ -255,6 +255,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 Recovered<ProviderTx<Self::Provider>>,
                 TransactionMeta,
                 ProviderReceipt<Self::Provider>,
+                Option<Arc<Vec<ProviderReceipt<Self::Provider>>>>,
             )>,
             Self::Error,
         >,
@@ -269,13 +270,15 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 let meta = cached.transaction_meta(hash);
 
                 // Best case: receipts are also cached.
-                if let Some(receipt) = cached.receipt().cloned() {
-                    return Ok(Some((tx, meta, receipt)));
+                if let Some(all_receipts) = cached.receipts.clone() &&
+                    let Some(receipt) = all_receipts.get(cached.tx_index).cloned()
+                {
+                    return Ok(Some((tx, meta, receipt, Some(all_receipts))));
                 }
 
                 // Block still cached but receipts evicted — fetch via cache since
-                // the block is recent and `build_transaction_receipt` needs all
-                // receipts for gas accounting anyway.
+                // `build_transaction_receipt` needs all receipts for gas accounting
+                // anyway.
                 if let Some(receipts) = self
                     .cache()
                     .get_receipts(cached.block.hash())
@@ -283,7 +286,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                     .map_err(Self::Error::from_eth_err)? &&
                     let Some(receipt) = receipts.get(cached.tx_index).cloned()
                 {
-                    return Ok(Some((tx, meta, receipt)));
+                    return Ok(Some((tx, meta, receipt, Some(receipts))));
                 }
             }
 
@@ -301,7 +304,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
 
                 let receipt = provider.receipt_by_hash(hash).map_err(Self::Error::from_eth_err)?;
 
-                Ok(receipt.map(|receipt| (tx, meta, receipt)))
+                Ok(receipt.map(|receipt| (tx, meta, receipt, None)))
             })
             .await
         }


### PR DESCRIPTION
closes #23066