### PR TITLE
fix(net): disable Discv5 ENR auto-update when NAT disabled or explicit addr set

### DIFF
--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -815,12 +815,11 @@ impl DiscoveryArgs {
             SocketAddr::V6(addr) => Some(*addr.ip()),
         });
 
-        let mut discv5_config_builder = reth_discv5::discv5::ConfigBuilder::new(
-            ListenConfig::from_two_sockets(
+        let mut discv5_config_builder =
+            reth_discv5::discv5::ConfigBuilder::new(ListenConfig::from_two_sockets(
                 discv5_addr_ipv4.map(|addr| SocketAddrV4::new(addr, *discv5_port)),
                 discv5_addr_ipv6.map(|addr| SocketAddrV6::new(addr, *discv5_port_ipv6, 0, 0)),
-            ),
-        );
+            ));
         if discv5_addr.is_some() || discv5_addr_ipv6.is_some() || self.disable_nat {
             discv5_config_builder.disable_enr_update();
         }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -815,14 +815,17 @@ impl DiscoveryArgs {
             SocketAddr::V6(addr) => Some(*addr.ip()),
         });
 
+        let mut discv5_config_builder = reth_discv5::discv5::ConfigBuilder::new(
+            ListenConfig::from_two_sockets(
+                discv5_addr_ipv4.map(|addr| SocketAddrV4::new(addr, *discv5_port)),
+                discv5_addr_ipv6.map(|addr| SocketAddrV6::new(addr, *discv5_port_ipv6, 0, 0)),
+            ),
+        );
+        if discv5_addr.is_some() || discv5_addr_ipv6.is_some() || self.disable_nat {
+            discv5_config_builder.disable_enr_update();
+        }
         reth_discv5::Config::builder(rlpx_tcp_socket)
-            .discv5_config(
-                reth_discv5::discv5::ConfigBuilder::new(ListenConfig::from_two_sockets(
-                    discv5_addr_ipv4.map(|addr| SocketAddrV4::new(addr, *discv5_port)),
-                    discv5_addr_ipv6.map(|addr| SocketAddrV6::new(addr, *discv5_port_ipv6, 0, 0)),
-                ))
-                .build(),
-            )
+            .discv5_config(discv5_config_builder.build())
             .add_unsigned_boot_nodes(boot_nodes)
             .lookup_interval(*discv5_lookup_interval)
             .bootstrap_lookup_interval(*discv5_bootstrap_lookup_interval)


### PR DESCRIPTION
## Summary
Disables Discv5 ENR auto-update when `--disable-nat` is set or when explicit `--discovery.v5.addr` / `--discovery.v5.addr.ipv6` are configured.

## Problem
When running a node with fixed public IP + port (e.g. in Kubernetes), manually set addresses get overwritten by the ENR auto-update. The UDP port gets replaced with a different value from PONG responses.

Example: `--discovery.v5.port=30303` and `--discovery.v5.addr=34.159.243.134` with `--disable-nat` still results in ENR advertising UDP port 45056 instead of 30303.

## Solution
Call `disable_enr_update()` on the discv5 ConfigBuilder when:
- `discv5_addr` is explicitly set (user specified discovery.v5.addr)
- `discv5_addr_ipv6` is explicitly set (user specified discovery.v5.addr.ipv6)
- `disable_nat` is set (user does not want NAT discovery)

This matches the upstream discv5 behavior: when the user has explicitly configured their address or disabled NAT, the ENR should not be auto-updated from peer responses.

## Testing
- Manual verification with the reported params
- Existing discovery tests remain unchanged

Fixes #20008

Made with [Cursor](https://cursor.com)