### PR TITLE
fix(p2p): apply sessions config from reth.toml in p2p subcommand

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -201,6 +201,7 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
         let net =
             NetworkConfigBuilder::<N::NetworkPrimitives>::new(p2p_secret_key, Runtime::test())
                 .peer_config(config.peers_config_with_basic_nodes_from_file(None))
+                .sessions_config(config.sessions)
                 .external_ip_resolver(self.network.nat.clone())
                 .network_id(self.network.network_id)
                 .boot_nodes(boot_nodes.clone())


### PR DESCRIPTION
The `reth p2p` subcommand was building `NetworkConfigBuilder` without passing `sessions_config`, so any session buffer/timeout/limit settings in `reth.toml` were silently ignored. The main node path already does this correctly — this was just missed here.