### PR TITLE
feat(prune): make minimum pruning distance configurable

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -187,7 +187,6 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
     where
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        let prune_modes = config.prune.segments.clone();
         let factory = ProviderFactory::<NodeTypesWithDBAdapter<N, DatabaseEnv>>::new(
             db,
             self.chain.clone(),
@@ -195,7 +194,8 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             rocksdb_provider,
             runtime,
         )?
-        .with_prune_modes(prune_modes.clone());
+        .with_prune_modes(config.prune.segments.clone())
+        .with_minimum_pruning_distance(config.prune.minimum_pruning_distance);
 
         // Check for consistency between database and static files.
         if !access.is_read_only_inconsistent() &&

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -229,10 +229,13 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
                     NoopBodiesDownloader::default(),
                     NoopEvmConfig::<N::Evm>::default(),
                     config.stages.clone(),
-                    prune_modes.clone(),
+                    config.prune.segments.clone(),
                     None,
                 ))
-                .build(factory.clone(), StaticFileProducer::new(factory.clone(), prune_modes));
+                .build(
+                    factory.clone(),
+                    StaticFileProducer::new(factory.clone(), config.prune.segments.clone()),
+                );
 
             // Move all applicable data from database to static files.
             pipeline.move_to_static_files()?;

--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -199,11 +199,7 @@ pub(crate) fn config_for_selections(
         }
 
         return Config {
-            prune: PruneConfig {
-                block_interval: PruneConfig::default().block_interval,
-                minimum_pruning_distance: PruneConfig::default().minimum_pruning_distance,
-                segments,
-            },
+            prune: PruneConfig { segments, ..Default::default() },
             static_files,
             ..Default::default()
         };

--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -199,7 +199,11 @@ pub(crate) fn config_for_selections(
         }
 
         return Config {
-            prune: PruneConfig { block_interval: PruneConfig::default().block_interval, segments },
+            prune: PruneConfig {
+                block_interval: PruneConfig::default().block_interval,
+                minimum_pruning_distance: PruneConfig::default().minimum_pruning_distance,
+                segments,
+            },
             static_files,
             ..Default::default()
         };

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -547,7 +547,7 @@ pub struct PruneConfig {
 }
 
 /// Returns the default minimum pruning distance.
-fn default_minimum_pruning_distance() -> u64 {
+const fn default_minimum_pruning_distance() -> u64 {
     MINIMUM_UNWIND_SAFE_DISTANCE
 }
 
@@ -642,7 +642,9 @@ mod tests {
     use crate::PruneConfig;
     use alloy_primitives::Address;
     use reth_network_peers::TrustedPeer;
-    use reth_prune_types::{PruneMode, PruneModes, ReceiptsLogPruneConfig};
+    use reth_prune_types::{
+        PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_UNWIND_SAFE_DISTANCE,
+    };
     use std::{collections::BTreeMap, path::Path, str::FromStr, time::Duration};
 
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
@@ -1112,6 +1114,7 @@ receipts = { distance = 16384 }
     fn test_prune_config_merge() {
         let mut config1 = PruneConfig {
             block_interval: 5,
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             segments: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
                 transaction_lookup: None,
@@ -1128,6 +1131,7 @@ receipts = { distance = 16384 }
 
         let config2 = PruneConfig {
             block_interval: 10,
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             segments: PruneModes {
                 sender_recovery: Some(PruneMode::Distance(500)),
                 transaction_lookup: Some(PruneMode::Full),

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration files.
 use reth_network_types::{PeersConfig, SessionsConfig};
-use reth_prune_types::PruneModes;
+use reth_prune_types::{PruneModes, MINIMUM_UNWIND_SAFE_DISTANCE};
 use reth_stages_types::ExecutionStageThresholds;
 use reth_static_file_types::{StaticFileMap, StaticFileSegment};
 use std::{
@@ -540,11 +540,24 @@ pub struct PruneConfig {
     /// Pruning configuration for every part of the data that can be pruned.
     #[cfg_attr(feature = "serde", serde(alias = "parts"))]
     pub segments: PruneModes,
+    /// Minimum distance from the tip required for pruning. Controls the safety margin for
+    /// reorgs and manual unwinds. Defaults to [`MINIMUM_UNWIND_SAFE_DISTANCE`].
+    #[cfg_attr(feature = "serde", serde(default = "default_minimum_pruning_distance"))]
+    pub minimum_pruning_distance: u64,
+}
+
+/// Returns the default minimum pruning distance.
+fn default_minimum_pruning_distance() -> u64 {
+    MINIMUM_UNWIND_SAFE_DISTANCE
 }
 
 impl Default for PruneConfig {
     fn default() -> Self {
-        Self { block_interval: DEFAULT_BLOCK_INTERVAL, segments: PruneModes::default() }
+        Self {
+            block_interval: DEFAULT_BLOCK_INTERVAL,
+            segments: PruneModes::default(),
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
+        }
     }
 }
 
@@ -577,11 +590,17 @@ impl PruneConfig {
                     bodies_history,
                     receipts_log_filter,
                 },
+            minimum_pruning_distance,
         } = other;
 
         // Merge block_interval, only update if it's the default interval
         if self.block_interval == DEFAULT_BLOCK_INTERVAL {
             self.block_interval = block_interval;
+        }
+
+        // Merge minimum_pruning_distance, only update if it's the default
+        if self.minimum_pruning_distance == MINIMUM_UNWIND_SAFE_DISTANCE {
+            self.minimum_pruning_distance = minimum_pruning_distance;
         }
 
         // Merge the various segment prune modes

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -96,6 +96,11 @@ where
         self
     }
 
+    /// Sets the pruning arguments for the test nodes.
+    pub fn with_pruning(self, pruning: reth_node_core::args::PruningArgs) -> Self {
+        self.with_node_config_modifier(move |config| config.with_pruning(pruning.clone()))
+    }
+
     /// Enables v2 storage defaults (`--storage.v2`), routing tx hashes, history
     /// indices, etc. to `RocksDB` and changesets/senders to static files.
     pub fn with_storage_v2(self) -> Self {

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -501,6 +501,7 @@ where
                 .build()?
         };
 
+        let prune_config = self.prune_config();
         let factory = ProviderFactory::new(
             self.right().clone(),
             self.chain_spec(),
@@ -508,7 +509,8 @@ where
             rocksdb_provider,
             self.task_executor().clone(),
         )?
-        .with_prune_modes(self.prune_modes())
+        .with_prune_modes(prune_config.segments)
+        .with_minimum_pruning_distance(prune_config.minimum_pruning_distance)
         .with_changeset_cache(changeset_cache);
 
         // Check consistency between the database and static files, returning

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1312,6 +1312,7 @@ mod tests {
                     bodies_distance: None,
                     receipts_log_filter: None,
                     bodies_before: None,
+                    minimum_distance: None,
                 },
                 ..NodeConfig::test()
             };

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -196,6 +196,11 @@ pub struct PruningArgs {
     /// pruned.
     #[arg(long = "prune.bodies.before", value_name = "BLOCK_NUMBER", conflicts_with_all = &["bodies_distance", "bodies_pre_merge"])]
     pub bodies_before: Option<BlockNumber>,
+
+    /// Minimum pruning distance from the tip. This controls the safety margin for reorgs and
+    /// manual unwinds.
+    #[arg(long = "prune.minimum-distance", value_name = "BLOCKS")]
+    pub minimum_distance: Option<u64>,
 }
 
 impl PruningArgs {
@@ -220,7 +225,11 @@ impl PruningArgs {
                     .block_number()
                     .map(PruneMode::Before);
             }
-            config = PruneConfig { block_interval: config.block_interval, segments }
+            config = PruneConfig {
+                block_interval: config.block_interval,
+                segments,
+                ..Default::default()
+            }
         }
 
         // If --minimal is set, use minimal storage mode with aggressive pruning.
@@ -228,12 +237,16 @@ impl PruningArgs {
             config = PruneConfig {
                 block_interval: config.block_interval,
                 segments: DefaultPruningValues::get_global().minimal_prune_modes.clone(),
+                ..Default::default()
             }
         }
 
         // Override with any explicitly set prune.* flags.
         if let Some(block_interval) = self.block_interval {
             config.block_interval = block_interval as usize;
+        }
+        if let Some(distance) = self.minimum_distance {
+            config.minimum_pruning_distance = distance;
         }
         if let Some(mode) = self.sender_recovery_prune_mode() {
             config.segments.sender_recovery = Some(mode);

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -228,7 +228,7 @@ impl PruningArgs {
             config = PruneConfig {
                 block_interval: config.block_interval,
                 segments,
-                ..Default::default()
+                minimum_pruning_distance: config.minimum_pruning_distance,
             }
         }
 
@@ -237,7 +237,7 @@ impl PruningArgs {
             config = PruneConfig {
                 block_interval: config.block_interval,
                 segments: DefaultPruningValues::get_global().minimal_prune_modes.clone(),
-                ..Default::default()
+                minimum_pruning_distance: config.minimum_pruning_distance,
             }
         }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -268,19 +268,21 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     /// open.
     #[track_caller]
     pub fn provider_rw(&self) -> ProviderResult<DatabaseProviderRW<N::DB, N>> {
-        Ok(DatabaseProviderRW(DatabaseProvider::new_rw(
-            self.db.tx_mut()?,
-            self.chain_spec.clone(),
-            self.static_file_provider.clone(),
-            self.prune_modes.clone(),
-            self.storage.clone(),
-            self.storage_settings.clone(),
-            self.rocksdb_provider.clone(),
-            self.changeset_cache.clone(),
-            self.runtime.clone(),
-            self.db.path(),
-        )
-        .with_minimum_pruning_distance(self.minimum_pruning_distance)))
+        Ok(DatabaseProviderRW(
+            DatabaseProvider::new_rw(
+                self.db.tx_mut()?,
+                self.chain_spec.clone(),
+                self.static_file_provider.clone(),
+                self.prune_modes.clone(),
+                self.storage.clone(),
+                self.storage_settings.clone(),
+                self.rocksdb_provider.clone(),
+                self.changeset_cache.clone(),
+                self.runtime.clone(),
+                self.db.path(),
+            )
+            .with_minimum_pruning_distance(self.minimum_pruning_distance),
+        ))
     }
 
     /// Returns a provider with a created `DbTxMut` inside, configured for unwind operations.

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -175,7 +175,7 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
     ///
     /// This controls the minimum distance from tip required before pruning can occur.
     /// The default is [`MINIMUM_UNWIND_SAFE_DISTANCE`].
-    pub fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
+    pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
         self.minimum_pruning_distance = distance;
         self
     }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -24,7 +24,7 @@ use reth_node_types::{
     BlockTy, HeaderTy, NodeTypesWithDB, NodeTypesWithDBAdapter, ReceiptTy, TxTy,
 };
 use reth_primitives_traits::{RecoveredBlock, SealedHeader};
-use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
+use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment, MINIMUM_UNWIND_SAFE_DISTANCE};
 use reth_stages_types::{PipelineTarget, StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
@@ -80,6 +80,8 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     changeset_cache: ChangesetCache,
     /// Task runtime for spawning parallel I/O work.
     runtime: reth_tasks::Runtime,
+    /// Minimum distance from tip required before pruning can occur.
+    minimum_pruning_distance: u64,
 }
 
 impl<N: NodeTypesForProvider> ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>> {
@@ -134,6 +136,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             rocksdb_provider,
             changeset_cache: ChangesetCache::new(),
             runtime,
+            minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
         })
     }
 
@@ -165,6 +168,15 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
     /// Sets the changeset cache for an existing [`ProviderFactory`].
     pub fn with_changeset_cache(mut self, changeset_cache: ChangesetCache) -> Self {
         self.changeset_cache = changeset_cache;
+        self
+    }
+
+    /// Sets the minimum pruning distance for an existing [`ProviderFactory`].
+    ///
+    /// This controls the minimum distance from tip required before pruning can occur.
+    /// The default is [`MINIMUM_UNWIND_SAFE_DISTANCE`].
+    pub fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
+        self.minimum_pruning_distance = distance;
         self
     }
 
@@ -246,7 +258,8 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             self.changeset_cache.clone(),
             self.runtime.clone(),
             self.db.path(),
-        ))
+        )
+        .with_minimum_pruning_distance(self.minimum_pruning_distance))
     }
 
     /// Returns a provider with a created `DbTxMut` inside, which allows fetching and updating
@@ -266,7 +279,8 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             self.changeset_cache.clone(),
             self.runtime.clone(),
             self.db.path(),
-        )))
+        )
+        .with_minimum_pruning_distance(self.minimum_pruning_distance)))
     }
 
     /// Returns a provider with a created `DbTxMut` inside, configured for unwind operations.
@@ -287,7 +301,8 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             self.changeset_cache.clone(),
             self.runtime.clone(),
             self.db.path(),
-        ))
+        )
+        .with_minimum_pruning_distance(self.minimum_pruning_distance))
     }
 
     /// State provider for latest block
@@ -797,6 +812,7 @@ where
             rocksdb_provider,
             changeset_cache,
             runtime,
+            minimum_pruning_distance,
         } = self;
         f.debug_struct("ProviderFactory")
             .field("db", &db)
@@ -808,6 +824,7 @@ where
             .field("rocksdb_provider", &rocksdb_provider)
             .field("changeset_cache", &changeset_cache)
             .field("runtime", &runtime)
+            .field("minimum_pruning_distance", &minimum_pruning_distance)
             .finish()
     }
 }
@@ -824,6 +841,7 @@ impl<N: NodeTypesWithDB> Clone for ProviderFactory<N> {
             rocksdb_provider: self.rocksdb_provider.clone(),
             changeset_cache: self.changeset_cache.clone(),
             runtime: self.runtime.clone(),
+            minimum_pruning_distance: self.minimum_pruning_distance,
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -238,6 +238,12 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
     pub const fn prune_modes_ref(&self) -> &PruneModes {
         &self.prune_modes
     }
+
+    /// Sets the minimum pruning distance.
+    pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
+        self.minimum_pruning_distance = distance;
+        self
+    }
 }
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -914,6 +914,9 @@ Pruning:
       --prune.bodies.before <BLOCK_NUMBER>
           Prune storage history before the specified block number. The specified block number is not pruned
 
+      --prune.minimum-distance <BLOCKS>
+          Minimum pruning distance from the tip. This controls the safety margin for reorgs and manual unwinds
+
 Engine:
       --engine.persistence-threshold <PERSISTENCE_THRESHOLD>
           Configure persistence threshold for the engine. This determines how many canonical blocks must be in-memory, ahead of the last persisted block, before flushing canonical blocks to disk again.


### PR DESCRIPTION
## Summary

Make the minimum safe unwind / pruning distance configurable instead of hardcoded to `MINIMUM_UNWIND_SAFE_DISTANCE` (10,064).

## Motivation

Chains with different reorg assumptions need lower pruning distances. E2E tests also need smaller values to test pruning without producing 10k+ blocks.

## Testing

Existing tests pass — the default value (10,064) preserves current behavior. The new field is only active when explicitly set via CLI or config.

Co-Authored-By: Dan Cline <6798349+Rjected@users.noreply.github.com>

Prompted by: Dan