### PR TITLE
fix(provider): disable read transaction timeout during check_consistency

### DIFF
--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -18,7 +18,7 @@ use core::fmt;
 use parking_lot::RwLock;
 use reth_chainspec::ChainInfo;
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
-use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
+use reth_db_api::{database::Database, models::StoredBlockBodyIndices, transaction::DbTx};
 use reth_errors::{RethError, RethResult};
 use reth_node_types::{
     BlockTy, HeaderTy, NodeTypesWithDB, NodeTypesWithDBAdapter, ReceiptTy, TxTy,
@@ -349,7 +349,12 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     /// consistency. I.e. this MAY result in writes to the static files.
     #[instrument(err, skip(self))]
     pub fn check_consistency(&self) -> ProviderResult<(Option<u64>, Option<u64>)> {
-        let provider_ro = self.database_provider_ro()?;
+        let mut provider_ro = self.database_provider_ro()?;
+
+        // Healing can run long-lived read transactions (e.g. iterating changesets
+        // over millions of blocks). Disable the default timeout so MDBX doesn't
+        // kill the transaction mid-heal, which causes a crash loop on startup.
+        provider_ro.tx_mut().disable_long_read_transaction_safety();
 
         // Step 1: heal file-level inconsistencies (no pruning)
         self.static_file_provider().check_file_consistency(&provider_ro)?;

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -18,7 +18,7 @@ use core::fmt;
 use parking_lot::RwLock;
 use reth_chainspec::ChainInfo;
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
-use reth_db_api::{database::Database, models::StoredBlockBodyIndices, transaction::DbTx};
+use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
 use reth_node_types::{
     BlockTy, HeaderTy, NodeTypesWithDB, NodeTypesWithDBAdapter, ReceiptTy, TxTy,
@@ -28,8 +28,8 @@ use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{PipelineTarget, StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
-    BlockBodyIndicesProvider, ChainStateBlockReader, ChainStateBlockWriter, NodePrimitivesProvider,
-    StorageSettings, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    BlockBodyIndicesProvider, ChainStateBlockReader, ChainStateBlockWriter, DBProvider,
+    NodePrimitivesProvider, StorageSettings, StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::HashedPostState;
@@ -349,12 +349,12 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     /// consistency. I.e. this MAY result in writes to the static files.
     #[instrument(err, skip(self))]
     pub fn check_consistency(&self) -> ProviderResult<(Option<u64>, Option<u64>)> {
-        let mut provider_ro = self.database_provider_ro()?;
-
-        // Healing can run long-lived read transactions (e.g. iterating changesets
-        // over millions of blocks). Disable the default timeout so MDBX doesn't
-        // kill the transaction mid-heal, which causes a crash loop on startup.
-        provider_ro.tx_mut().disable_long_read_transaction_safety();
+        let provider_ro = self
+            .database_provider_ro()?
+            // Healing can run long-lived read transactions (e.g., iterating changesets
+            // over millions of blocks). Disable the default timeout so MDBX doesn't
+            // kill the transaction mid-heal, which causes a crash loop on startup.
+            .disable_long_read_transaction_safety();
 
         // Step 1: heal file-level inconsistencies (no pruning)
         self.static_file_provider().check_file_consistency(&provider_ro)?;


### PR DESCRIPTION
Healing can iterate changesets over millions of blocks, easily exceeding the default 5-minute MDBX read transaction timeout. When the transaction gets killed mid-heal, the node restarts and re-enters healing, creating an infinite crash loop.

Calls `disable_long_read_transaction_safety()` on the read transaction in `check_consistency` so healing can complete regardless of the configured timeout.

Co-Authored-By: Arsenii Kulikov <62447812+klkvr@users.noreply.github.com>

Prompted by: klkvr