### PR TITLE
fix(node): fail fast on invalid storage settings metadata

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -66,8 +66,8 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BlockHashReader, BlockNumReader, ProviderError, ProviderFactory, ProviderResult,
-    RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
+    BlockHashReader, BlockNumReader, MetadataProvider, ProviderError, ProviderFactory,
+    ProviderResult, RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
     StaticFileProviderFactory,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
@@ -510,6 +510,10 @@ where
         )?
         .with_prune_modes(self.prune_modes())
         .with_changeset_cache(changeset_cache);
+
+        // Node startup uses strict metadata parsing: invalid persisted storage settings
+        // should fail fast instead of silently falling back to legacy defaults.
+        let _ = factory.provider()?.strict_storage_settings()?;
 
         // Check consistency between the database and static files, returning
         // the unwind targets for each storage layer if inconsistencies are

--- a/crates/storage/storage-api/src/metadata.rs
+++ b/crates/storage/storage-api/src/metadata.rs
@@ -16,15 +16,28 @@ pub trait MetadataProvider: Send {
     /// Get a metadata value by key
     fn get_metadata(&self, key: &str) -> ProviderResult<Option<Vec<u8>>>;
 
-    /// Get storage settings for this node.
+    /// Get storage settings for this node in a lossy/compatibility mode.
     ///
     /// If the stored metadata can't be deserialized (e.g. the format changed),
-    /// this returns `None` instead of an error so commands like `db clear` can
-    /// still operate without requiring a compatible metadata schema.
+    /// this returns `None` instead of an error so tooling commands (for example
+    /// `db clear`) can still operate without requiring a compatible metadata schema.
+    ///
+    /// Node startup paths that require strict correctness should use
+    /// [`Self::strict_storage_settings`].
     fn storage_settings(&self) -> ProviderResult<Option<StorageSettings>> {
         Ok(self
             .get_metadata(keys::STORAGE_SETTINGS)?
             .and_then(|bytes| serde_json::from_slice(&bytes).ok()))
+    }
+
+    /// Get storage settings for this node in strict mode.
+    ///
+    /// In contrast to [`Self::storage_settings`], deserialization failures are
+    /// returned as errors instead of silently being mapped to `None`.
+    fn strict_storage_settings(&self) -> ProviderResult<Option<StorageSettings>> {
+        self.get_metadata(keys::STORAGE_SETTINGS)?
+            .map(|bytes| serde_json::from_slice(&bytes).map_err(ProviderError::other))
+            .transpose()
     }
 }
 
@@ -62,4 +75,35 @@ pub trait StorageSettingsCache: Send {
 pub trait StoragePath: Send {
     /// Returns the path to the database directory (e.g. `<datadir>/db`).
     fn storage_path(&self) -> std::path::PathBuf;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestMetadataProvider {
+        value: Option<Vec<u8>>,
+    }
+
+    impl MetadataProvider for TestMetadataProvider {
+        fn get_metadata(&self, _key: &str) -> ProviderResult<Option<Vec<u8>>> {
+            Ok(self.value.clone())
+        }
+    }
+
+    #[test]
+    fn lossy_storage_settings_ignores_deserialization_error() {
+        let provider = TestMetadataProvider { value: Some(b"{invalid json".to_vec()) };
+
+        assert_eq!(provider.storage_settings().unwrap(), None);
+    }
+
+    #[test]
+    fn strict_storage_settings_surfaces_deserialization_error() {
+        let provider = TestMetadataProvider { value: Some(b"{invalid json".to_vec()) };
+
+        let err = provider.strict_storage_settings().unwrap_err();
+        assert!(err.is_other::<serde_json::Error>());
+    }
 }


### PR DESCRIPTION
Fail node startup when persisted storage_settings metadata is malformed, while keeping lossy parsing for compatibility tooling paths.