### PR TITLE
perf(rpc): avoid request clone in `eth_createAccessList`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -479,7 +479,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     .map_err(Self::Error::from_eth_err)?;
             }
 
-            let mut tx_env = this.create_txn_env(&evm_env, request.clone(), &mut db)?;
+            // Read fields from request before consuming it in create_txn_env
+            let request_has_gas_limit = request.as_ref().gas_limit().is_some();
+            let initial = request.as_ref().access_list().cloned().unwrap_or_default();
+
+            let mut tx_env = this.create_txn_env(&evm_env, request, &mut db)?;
 
             // we want to disable this in eth_createAccessList, since this is common practice used
             // by other node impls and providers <https://github.com/foundry-rs/foundry/issues/4388>
@@ -502,15 +506,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // per-tx cap (2^24 ≈ 16.7M post-Osaka).
             evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
 
-            if request.as_ref().gas_limit().is_none() && tx_env.gas_price() > 0 {
+            if !request_has_gas_limit && tx_env.gas_price() > 0 {
                 let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
                 // no gas limit was provided in the request, so we need to cap the request's gas
                 // limit
                 tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit()));
             }
-
-            // can consume the list since we're not using the request anymore
-            let initial = request.as_ref().access_list().cloned().unwrap_or_default();
 
             let mut inspector = AccessListInspector::new(initial);
 


### PR DESCRIPTION
Read `gas_limit` and `access_list` from the request upfront to avoid cloning the full `RpcTxReq` in `create_access_list_with`.