### PR TITLE
feat(txpool): add max priority fee per gas metric for pending transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,7 +399,9 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives = { path = "crates/primitives", default-features = false, features = ["__internal"] }
+reth-primitives = { path = "crates/primitives", default-features = false, features = [
+    "__internal",
+] }
 reth-primitives-traits = { path = "crates/primitives-traits", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
@@ -448,14 +450,18 @@ revm-inspectors = "0.36.0"
 
 # eth
 alloy-dyn-abi = "1.5.6"
-alloy-primitives = { version = "1.5.6", default-features = false, features = ["map-foldhash"] }
+alloy-primitives = { version = "1.5.6", default-features = false, features = [
+    "map-foldhash",
+] }
 alloy-sol-types = { version = "1.5.6", default-features = false }
 
 alloy-chains = { version = "0.2.5", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.0", default-features = false }
 alloy-evm = { version = "0.29.2", default-features = false }
-alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
+alloy-rlp = { version = "0.3.13", default-features = false, features = [
+    "core-net",
+] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
 alloy-hardforks = "0.4.5"
@@ -467,10 +473,15 @@ alloy-genesis = { version = "1.7.3", default-features = false }
 alloy-json-rpc = { version = "1.7.3", default-features = false }
 alloy-network = { version = "1.7.3", default-features = false }
 alloy-network-primitives = { version = "1.7.3", default-features = false }
-alloy-provider = { version = "1.7.3", features = ["reqwest", "debug-api"], default-features = false }
+alloy-provider = { version = "1.7.3", features = [
+    "reqwest",
+    "debug-api",
+], default-features = false }
 alloy-pubsub = { version = "1.7.3", default-features = false }
 alloy-rpc-client = { version = "1.7.3", default-features = false }
-alloy-rpc-types = { version = "1.7.3", features = ["eth"], default-features = false }
+alloy-rpc-types = { version = "1.7.3", features = [
+    "eth",
+], default-features = false }
 alloy-rpc-types-admin = { version = "1.7.3", default-features = false }
 alloy-rpc-types-anvil = { version = "1.7.3", default-features = false }
 alloy-rpc-types-beacon = { version = "1.7.3", default-features = false }
@@ -484,7 +495,9 @@ alloy-serde = { version = "1.7.3", default-features = false }
 alloy-signer = { version = "1.7.3", default-features = false }
 alloy-signer-local = { version = "1.7.3", default-features = false }
 alloy-transport = { version = "1.7.3" }
-alloy-transport-http = { version = "1.7.3", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-http = { version = "1.7.3", features = [
+    "reqwest-rustls-tls",
+], default-features = false }
 alloy-transport-ipc = { version = "1.7.3", default-features = false }
 alloy-transport-ws = { version = "1.7.3", default-features = false }
 
@@ -498,7 +511,10 @@ either = { version = "1.15.0", default-features = false }
 arrayvec = { version = "0.7.6", default-features = false }
 aquamarine = "0.6"
 auto_impl = "1"
-backon = { version = "1.2", default-features = false, features = ["std-blocking-sleep", "tokio-sleep"] }
+backon = { version = "1.2", default-features = false, features = [
+    "std-blocking-sleep",
+    "tokio-sleep",
+] }
 bincode = "1.3"
 bitflags = "2.4"
 boyer-moore-magiclen = "0.2.16"
@@ -522,9 +538,13 @@ linked_hash_set = "0.1"
 libc = "0.2"
 lz4 = "1.28.1"
 modular-bitfield = "0.13.1"
-notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
+notify = { version = "8.0.0", default-features = false, features = [
+    "macos_fsevent",
+] }
 nybbles = { version = "0.4.8", default-features = false }
-once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.19", default-features = false, features = [
+    "critical-section",
+] }
 parking_lot = "0.12"
 quanta = "0.12"
 paste = "1.0"
@@ -546,7 +566,9 @@ strum_macros = "0.27"
 syn = "2.0"
 thiserror = { version = "2.0.0", default-features = false }
 tar = "0.4.44"
-tracing = { version = "0.1.0", default-features = false, features = ["attributes"] }
+tracing = { version = "0.1.0", default-features = false, features = [
+    "attributes",
+] }
 tracing-appender = "0.2"
 url = { version = "2.3", default-features = false }
 zstd = "0.13"
@@ -584,7 +606,11 @@ futures-util = { version = "0.3", default-features = false }
 hyper = "1.3"
 hyper-util = "0.1.5"
 pin-project = "1.0.12"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "rustls-tls-native-roots",
+    "stream",
+] }
 tracing-futures = "0.2"
 tower = "0.5"
 tower-http = "0.6"
@@ -609,7 +635,10 @@ proptest-arbitrary-interop = "0.1.0"
 # crypto
 enr = { version = "0.13", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
-secp256k1 = { version = "0.30", default-features = false, features = ["global-context", "recovery"] }
+secp256k1 = { version = "0.30", default-features = false, features = [
+    "global-context",
+    "recovery",
+] }
 # rand 8 for secp256k1
 rand_08 = { package = "rand", version = "0.8" }
 

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -62,6 +62,8 @@ pub struct TxPoolMetrics {
     pub blob_transactions_evicted: Counter,
     /// Counter for the number of queued transactions evicted
     pub queued_transactions_evicted: Counter,
+    /// The max priority fee per gas of the most recently inserted pending transaction
+    pub pending_tx_max_priority_fee_per_gas: Gauge,
 }
 
 /// Transaction pool blobstore metrics

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -806,6 +806,9 @@ impl<T: TransactionOrdering> TxPool<T> {
 
                 // This transaction was moved to the pending pool.
                 let res = if move_to.is_pending() {
+                    self.metrics
+                        .pending_tx_max_priority_fee_per_gas
+                        .set(transaction.priority_fee_or_price() as f64);
                     AddedTransaction::Pending(AddedPendingTransaction {
                         transaction,
                         promoted,


### PR DESCRIPTION
Adds a `transaction_pool_pending_tx_max_priority_fee_per_gas` gauge that records the priority fee of each transaction entering the pending pool. This enables Grafana dashboards to track priority fee trends over time.

The metric is set only when a transaction moves to the pending sub-pool (not on every insertion), keeping it off the hot path — same callsite where `inserted_transactions` is already incremented.