### PR TITLE
fix: use zero gas price for empty blocks

### DIFF
--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -175,7 +175,8 @@ where
                 };
 
             if block_values.is_empty() {
-                results.push(U256::from(inner.last_price.price));
+                // For empty blocks, use zero gas price to signal no demand
+                results.push(U256::ZERO);
             } else {
                 results.extend(block_values);
                 populated_blocks += 1;

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -179,8 +179,9 @@ where
                 results.push(U256::ZERO);
             } else {
                 results.extend(block_values);
-                populated_blocks += 1;
             }
+
+            populated_blocks += 1;
 
             // break when we have enough populated blocks
             if populated_blocks >= self.oracle_config.blocks {


### PR DESCRIPTION
RIght now if any of the sampled blocks are empty in gas price oracle we will use previous gas price estimate for them.

For chains with a lot of activity this logic is effectively unreachable, but for chains with low activity and many empty blocks this might be problematic because priority fee estimate will basically never be updated.