### PR TITLE
fix(net): actually send disconnect on protocol breach in EthStream::start_send

### DIFF
--- a/crates/net/eth-wire/src/disconnect.rs
+++ b/crates/net/eth-wire/src/disconnect.rs
@@ -21,6 +21,15 @@ pub trait CanDisconnect<T>: Sink<T> + Unpin {
         &mut self,
         reason: DisconnectReason,
     ) -> Pin<Box<dyn Future<Output = DisconnectResult<Self::Error>> + Send + '_>>;
+
+    /// Queues a disconnect message for sending without requiring an async context.
+    ///
+    /// This is useful in synchronous trait methods (e.g. `Sink::start_send`) where awaiting a
+    /// future is not possible. The default implementation is a no-op; transports that support
+    /// synchronous disconnect queueing (like `P2PStream`) should override this.
+    fn start_disconnect(&mut self, _reason: DisconnectReason) -> DisconnectResult<Self::Error> {
+        Ok(())
+    }
 }
 
 // basic impls for things like Framed<TcpStream, etc>

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -277,13 +277,9 @@ where
 
     fn start_send(self: Pin<&mut Self>, item: EthMessage<N>) -> Result<(), Self::Error> {
         if matches!(item, EthMessage::Status(_)) {
-            // Attempt to disconnect the peer for protocol breach when trying to send Status
-            // message after handshake is complete
-            let mut this = self.project();
-            // We can't await the disconnect future here since this is a synchronous method,
-            // but we can start the disconnect process. The actual disconnect will be handled
-            // asynchronously by the caller or the stream's poll methods.
-            let _disconnect_future = this.inner.disconnect(DisconnectReason::ProtocolBreach);
+            // Queue a disconnect for protocol breach - sending Status after handshake is invalid
+            let this = self.project();
+            let _ = this.inner.get_mut().start_disconnect(DisconnectReason::ProtocolBreach);
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -202,6 +202,10 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<(), P2PStreamError>> + Send + '_>> {
         Box::pin(async move { self.disconnect(reason).await })
     }
+
+    fn start_disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
+        DisconnectP2P::start_disconnect(self, reason)
+    }
 }
 
 /// A `P2PStream` wraps over any `Stream` that yields bytes and makes it compatible with `p2p`


### PR DESCRIPTION
The async `disconnect()` future was assigned to `_disconnect_future` and immediately dropped in the synchronous `start_send` — Rust futures are lazy, so the disconnect never happened. Added a synchronous `start_disconnect` method to `CanDisconnect` so transports like `P2PStream` can queue the disconnect message without needing an async context.