### PR TITLE
fix: move payload validation metric to EngineValidator

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -636,9 +636,6 @@ where
             return Ok(TreeOutcome::new(status));
         }
 
-        // record pre-execution phase duration
-        self.metrics.block_validation.record_payload_validation(start.elapsed().as_secs_f64());
-
         let status = if self.backfill_sync_state.is_idle() {
             self.try_insert_payload(payload)?
         } else {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1949,7 +1949,10 @@ where
         payload: Types::ExecutionData,
         ctx: TreeCtx<'_, N>,
     ) -> ValidationOutcome<N> {
-        self.validate_block_with_state(BlockOrPayload::Payload(payload), ctx)
+        let start = Instant::now();
+        let result = self.validate_block_with_state(BlockOrPayload::Payload(payload), ctx);
+        self.metrics.block_validation.record_payload_validation(start.elapsed().as_secs_f64());
+        result
     }
 
     fn validate_block(


### PR DESCRIPTION
The `record_payload_validation` metric in `on_new_payload()` was recorded before any actual validation work, measuring only pre-validation overhead (invalid ancestor check + event emission). This made the metric stale and misleading.

Move the metric recording into `BasicEngineValidator::validate_payload`, which delegates to `validate_block_with_state()` — where all actual validation work happens (payload conversion, EVM execution, state root computation, and post-execution validation).

This ensures the metric captures the true payload validation duration regardless of the outcome (success or error), while preserving the original scope of measuring only Engine API `newPayload` calls.

Closes #18014