### PR TITLE
chore(ci): remove pull_request trigger from bench-scheduled

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -10,8 +10,6 @@
 on:
   schedule:
     - cron: "30 5 * * *" # 06:30 UTC daily
-  pull_request: # TODO: remove before merging — hack to test from branch
-    branches: [main]
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
Removes the `pull_request` trigger that was added as a testing hack (per the TODO comment).

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey