### PR TITLE
perf(rpc): avoid header clone in `logs_for_filter`

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -478,22 +478,24 @@ where
                     return Err(ProviderError::HeaderNotFound(block_hash.into()).into())
                 };
 
-                // Get header - from cached block if available, otherwise from provider
-                let header = if let Some(block) = &maybe_block {
-                    block.header().clone()
+                // Read number and timestamp from cached block or provider header
+                let (block_number, block_timestamp) = if let Some(block) = &maybe_block {
+                    (block.header().number(), block.header().timestamp())
                 } else {
-                    self.provider()
+                    let header = self
+                        .provider()
                         .header_by_hash_or_number(block_hash.into())?
-                        .ok_or_else(|| ProviderError::HeaderNotFound(block_hash.into()))?
+                        .ok_or_else(|| ProviderError::HeaderNotFound(block_hash.into()))?;
+                    (header.number(), header.timestamp())
                 };
 
                 // Check if the block has been pruned (EIP-4444)
                 let earliest_block = self.provider().earliest_block_number()?;
-                if header.number() < earliest_block {
+                if block_number < earliest_block {
                     return Err(EthApiError::PrunedHistoryUnavailable.into());
                 }
 
-                let block_num_hash = BlockNumHash::new(header.number(), block_hash);
+                let block_num_hash = BlockNumHash::new(block_number, block_hash);
 
                 let mut all_logs = Vec::new();
                 append_matching_block_logs(
@@ -505,7 +507,7 @@ where
                     block_num_hash,
                     &receipts,
                     false,
-                    header.timestamp(),
+                    block_timestamp,
                 )?;
 
                 Ok(all_logs)


### PR DESCRIPTION
When the block is cached, only `number()` and `timestamp()` are needed from the header. Extracting those directly avoids cloning the full header on every `eth_getLogs` call by block hash.