### PR TITLE
refactor(storage): precompute plain state reverts before parallel RocksDB writes

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -24,6 +24,7 @@ use reth_storage_errors::{
     db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation, LogLevel},
     provider::{ProviderError, ProviderResult},
 };
+use revm_database::states::PlainStateReverts;
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
     DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
@@ -1228,6 +1229,18 @@ impl RocksDBProvider {
         let write_account_history = ctx.storage_settings.storage_v2;
         let write_storage_history = ctx.storage_settings.storage_v2;
 
+        // Pre-compute plain state reverts once per block so the parallel history
+        // writers can share them instead of each recomputing independently.
+        let block_reverts: Vec<PlainStateReverts> =
+            if write_account_history || write_storage_history {
+                blocks
+                    .iter()
+                    .map(|b| b.execution_outcome().state.reverts.to_plain_state_reverts())
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
         // Propagate tracing context into rayon-spawned threads so that RocksDB
         // write spans appear as children of write_blocks_data in traces.
         let span = tracing::Span::current();
@@ -1242,14 +1255,14 @@ impl RocksDBProvider {
             if write_account_history {
                 s.spawn(|_| {
                     let _guard = span.enter();
-                    r_account_history = Some(self.write_account_history(blocks, &ctx));
+                    r_account_history = Some(self.write_account_history(&block_reverts, &ctx));
                 });
             }
 
             if write_storage_history {
                 s.spawn(|_| {
                     let _guard = span.enter();
-                    r_storage_history = Some(self.write_storage_history(blocks, &ctx));
+                    r_storage_history = Some(self.write_storage_history(&block_reverts, &ctx));
                 });
             }
         });
@@ -1300,25 +1313,25 @@ impl RocksDBProvider {
 
     /// Writes account history indices for the given blocks.
     ///
-    /// Derives history indices from reverts (same source as changesets) to ensure consistency.
+    /// Accepts pre-computed [`PlainStateReverts`] (one per block) to avoid redundant conversion
+    /// when account and storage history are written in parallel.
     #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
-    fn write_account_history<N: reth_node_types::NodePrimitives>(
+    fn write_account_history(
         &self,
-        blocks: &[ExecutedBlock<N>],
+        block_reverts: &[PlainStateReverts],
         ctx: &RocksDBWriteCtx,
     ) -> ProviderResult<()> {
         let mut batch = self.batch();
         let mut account_history: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
 
-        for (block_idx, block) in blocks.iter().enumerate() {
+        for (block_idx, reverts) in block_reverts.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
 
             // Iterate through account reverts - these are exactly the accounts that have
             // changesets written, ensuring history indices match changeset entries.
-            for account_block_reverts in reverts.accounts {
+            for account_block_reverts in &reverts.accounts {
                 for (address, _) in account_block_reverts {
-                    account_history.entry(address).or_default().push(block_number);
+                    account_history.entry(*address).or_default().push(block_number);
                 }
             }
         }
@@ -1333,25 +1346,25 @@ impl RocksDBProvider {
 
     /// Writes storage history indices for the given blocks.
     ///
-    /// Derives history indices from reverts (same source as changesets) to ensure consistency.
+    /// Accepts pre-computed [`PlainStateReverts`] (one per block) to avoid redundant conversion
+    /// when account and storage history are written in parallel.
     #[instrument(level = "debug", target = "providers::rocksdb", skip_all)]
-    fn write_storage_history<N: reth_node_types::NodePrimitives>(
+    fn write_storage_history(
         &self,
-        blocks: &[ExecutedBlock<N>],
+        block_reverts: &[PlainStateReverts],
         ctx: &RocksDBWriteCtx,
     ) -> ProviderResult<()> {
         let mut batch = self.batch();
         let mut storage_history: BTreeMap<(Address, B256), Vec<u64>> = BTreeMap::new();
 
-        for (block_idx, block) in blocks.iter().enumerate() {
+        for (block_idx, reverts) in block_reverts.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
 
             // Iterate through storage reverts - these are exactly the slots that have
             // changesets written, ensuring history indices match changeset entries.
-            for storage_block_reverts in reverts.storage {
+            for storage_block_reverts in &reverts.storage {
                 for revert in storage_block_reverts {
-                    for (slot, _) in revert.storage_revert {
+                    for (slot, _) in &revert.storage_revert {
                         let plain_key = B256::new(slot.to_be_bytes());
                         storage_history
                             .entry((revert.address, plain_key))


### PR DESCRIPTION
`write_account_history` and `write_storage_history` both called
`to_plain_state_reverts()` independently per block inside their parallel
rayon tasks. Hoist the conversion into `write_blocks_data` so it runs once
per block, then pass the shared slice to both writers.

Marginal perf win (sub-μs per block in live sync), mainly a cleanup to
remove redundant work and make the data flow explicit.

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk