### PR TITLE
fix(provider): open RocksDB read-only in ProviderFactoryBuilder::open_read_only

### DIFF
--- a/crates/storage/provider/src/providers/database/builder.rs
+++ b/crates/storage/provider/src/providers/database/builder.rs
@@ -106,8 +106,10 @@ impl<N> ProviderFactoryBuilder<N> {
         let db = open_db_read_only(db_dir, db_args)?;
         let static_file_provider =
             StaticFileProvider::read_only(static_files_dir, watch_static_files)?;
-        let rocksdb_provider =
-            RocksDBProvider::builder(&rocksdb_dir).with_default_tables().build()?;
+        let rocksdb_provider = RocksDBProvider::builder(&rocksdb_dir)
+            .with_default_tables()
+            .with_read_only(true)
+            .build()?;
         ProviderFactory::new(db, chainspec, static_file_provider, rocksdb_provider, runtime)
             .map_err(Into::into)
     }


### PR DESCRIPTION
`ProviderFactoryBuilder::open_read_only` opens MDBX and static files read-only but opens RocksDB via `OptimisticTransactionDB` (read-write), which grabs an exclusive lock and blocks concurrent access from a running node.

Adds `.with_read_only(true)` so RocksDB uses `DB::open_cf_descriptors_read_only` instead, matching the other storage layers.

**Note:** datadirs without an initialized `rocksdb/` dir will now fail on open instead of silently creating one. The CLI already handles this case separately (`crates/cli/commands/src/common.rs`).

Prompted by: yk