### PR TITLE
fix(bench): add --debug.startup-sync-state-idle to bench runs

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -118,6 +118,7 @@ RETH_ARGS=(
   --authrpc.port 8551
   --disable-discovery
   --no-persist-peers
+  --debug.startup-sync-state-idle
 )
 
 # Big blocks mode requires the testing API and skip-invalid-transactions


### PR DESCRIPTION
Without this flag, reth starts a pipeline sync on startup to rebuild history indices (StoragesHistory, AccountsHistory from checkpoint 0), and reth-bench sends `newPayload` while the node is still syncing — causing it to return `SYNCING` status and fail the benchmark with `invalid range: no canonical state found for parent of requested block`.

Example failure: https://github.com/paradigmxyz/reth/actions/runs/23287289756/job/67713750402

Prompted by: YK