### PR TITLE
feat(bench): add retry CLI arg to reth-bench for RPC block fetches

### DIFF
--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -35,6 +35,10 @@ The `new-payload-fcu` command supports two optional waiting modes that can be us
 - `--wait-time <duration>`: Fixed sleep interval between blocks (e.g., `--wait-time 100ms` or `--wait-time 400` for 400ms)
 - `--wait-for-persistence`: Waits for blocks to be persisted using the `reth_subscribePersistedBlock` subscription
 
+Both `new-payload-fcu` and `new-payload-only` support `--rpc-block-fetch-retries <RETRIES>`
+to control how many times block fetches are retried after an RPC failure. The default is `0`
+(fail immediately). Use `--rpc-block-fetch-retries forever` to keep retrying indefinitely.
+
 When using `--wait-for-persistence`, the benchmark waits after every `(threshold + 1)` blocks, where the threshold defaults to the engine's persistence threshold (2). This can be customized with `--persistence-threshold <N>`.
 
 By default, the WebSocket URL for persistence subscriptions is derived from `--engine-rpc-url` (converting to ws:// on port 8546). Use `--ws-rpc-url` to override this.

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -9,8 +9,44 @@ use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::JwtSecret;
 use alloy_transport::layers::{RateLimitRetryPolicy, RetryBackoffLayer};
 use reqwest::Url;
-use reth_node_core::args::BenchmarkArgs;
-use tracing::info;
+use reth_node_core::args::{BenchmarkArgs, RpcBlockFetchRetries};
+use std::{future::Future, time::Duration};
+use tracing::{info, warn};
+
+/// Runs an RPC fetch operation with retry behavior controlled by
+/// [`RpcBlockFetchRetries`].
+pub(crate) async fn retry_rpc_fetch<T, F, Fut>(
+    mut operation: F,
+    retries: RpcBlockFetchRetries,
+    context: &'static str,
+) -> eyre::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = eyre::Result<T>>,
+{
+    let mut retries_used = 0u64;
+
+    loop {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                if !retries.should_retry(retries_used) {
+                    return Err(error)
+                }
+
+                retries_used += 1;
+                warn!(
+                    target: "reth-bench",
+                    retries_used,
+                    retry_mode = ?retries,
+                    %error,
+                    "{context}; retrying"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
 
 /// This is intended to be used by benchmarks that replay blocks from an RPC.
 ///
@@ -125,30 +161,59 @@ impl BenchContext {
 
         // If `--to` are not provided, we will run the benchmark continuously,
         // starting at the latest block.
-        let latest_block = block_provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .full()
-            .await?
-            .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from RPC"))?;
+        let latest_block = retry_rpc_fetch(
+            || async {
+                block_provider
+                    .get_block_by_number(BlockNumberOrTag::Latest)
+                    .full()
+                    .await?
+                    .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from RPC"))
+            },
+            bench_args.rpc_block_fetch_retries,
+            "Failed to fetch latest block from RPC",
+        )
+        .await?;
         let mut benchmark_mode = BenchMode::new(from, to, latest_block.into_inner().number());
 
         let first_block = match benchmark_mode {
             BenchMode::Continuous(start) => {
-                block_provider.get_block_by_number(start.into()).full().await?.ok_or_else(|| {
-                    eyre::eyre!("Failed to fetch block {} from RPC for continuous mode", start)
-                })?
+                retry_rpc_fetch(
+                    || async {
+                        block_provider.get_block_by_number(start.into()).full().await?.ok_or_else(
+                            || {
+                                eyre::eyre!(
+                                    "Failed to fetch block {} from RPC for continuous mode",
+                                    start
+                                )
+                            },
+                        )
+                    },
+                    bench_args.rpc_block_fetch_retries,
+                    "Failed to fetch first block for continuous mode",
+                )
+                .await?
             }
             BenchMode::Range(ref mut range) => {
                 match range.next() {
                     Some(block_number) => {
-                        // fetch first block in range
-                        block_provider
-                            .get_block_by_number(block_number.into())
-                            .full()
-                            .await?
-                            .ok_or_else(|| {
-                                eyre::eyre!("Failed to fetch block {} from RPC", block_number)
-                            })?
+                        retry_rpc_fetch(
+                            || async {
+                                // fetch first block in range
+                                block_provider
+                                    .get_block_by_number(block_number.into())
+                                    .full()
+                                    .await?
+                                    .ok_or_else(|| {
+                                        eyre::eyre!(
+                                            "Failed to fetch block {} from RPC",
+                                            block_number
+                                        )
+                                    })
+                            },
+                            bench_args.rpc_block_fetch_retries,
+                            "Failed to fetch first block in range",
+                        )
+                        .await?
                     }
                     None => {
                         return Err(eyre::eyre!(

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -11,7 +11,7 @@
 
 use crate::{
     bench::{
-        context::BenchContext,
+        context::{retry_rpc_fetch, BenchContext},
         helpers::parse_duration,
         metrics_scraper::MetricsScraper,
         output::{
@@ -166,6 +166,7 @@ impl Command {
         }
 
         let buffer_size = self.rpc_block_buffer_size;
+        let rpc_block_fetch_retries = self.benchmark.rpc_block_fetch_retries;
 
         // Use a oneshot channel to propagate errors from the spawned task
         let (error_sender, mut error_receiver) = tokio::sync::oneshot::channel();
@@ -173,12 +174,22 @@ impl Command {
 
         tokio::task::spawn(async move {
             while benchmark_mode.contains(next_block) {
-                let block_res = block_provider
-                    .get_block_by_number(next_block.into())
-                    .full()
-                    .await
-                    .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"));
-                let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
+                let block = match retry_rpc_fetch(
+                    || async {
+                        block_provider
+                            .get_block_by_number(next_block.into())
+                            .full()
+                            .await
+                            .wrap_err_with(|| {
+                                format!("Failed to fetch block by number {next_block}")
+                            })?
+                            .ok_or_eyre("Block not found")
+                    },
+                    rpc_block_fetch_retries,
+                    "Failed to fetch block from RPC",
+                )
+                .await
+                {
                     Ok(block) => block,
                     Err(e) => {
                         tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
@@ -188,12 +199,22 @@ impl Command {
                 };
 
                 let rlp = if rlp_blocks {
-                    let rlp = match block_provider.debug_get_raw_block(next_block.into()).await {
+                    let rlp = match retry_rpc_fetch(
+                        || async {
+                            block_provider
+                                .debug_get_raw_block(next_block.into())
+                                .await
+                                .wrap_err_with(|| format!("Failed to fetch raw block {next_block}"))
+                        },
+                        rpc_block_fetch_retries,
+                        "Failed to fetch raw block from RPC",
+                    )
+                    .await
+                    {
                         Ok(rlp) => rlp,
                         Err(e) => {
                             tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
-                            let _ = error_sender
-                                .send(eyre::eyre!("Failed to fetch raw block {next_block}: {e}"));
+                            let _ = error_sender.send(e);
                             break;
                         }
                     };

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bench::{
-        context::BenchContext,
+        context::{retry_rpc_fetch, BenchContext},
         metrics_scraper::MetricsScraper,
         output::{
             NewPayloadResult, TotalGasOutput, TotalGasRow, GAS_OUTPUT_SUFFIX,
@@ -63,6 +63,7 @@ impl Command {
         }
 
         let buffer_size = self.rpc_block_buffer_size;
+        let rpc_block_fetch_retries = self.benchmark.rpc_block_fetch_retries;
 
         // Use a oneshot channel to propagate errors from the spawned task
         let (error_sender, mut error_receiver) = tokio::sync::oneshot::channel();
@@ -70,12 +71,22 @@ impl Command {
 
         tokio::task::spawn(async move {
             while benchmark_mode.contains(next_block) {
-                let block_res = block_provider
-                    .get_block_by_number(next_block.into())
-                    .full()
-                    .await
-                    .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"));
-                let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
+                let block = match retry_rpc_fetch(
+                    || async {
+                        block_provider
+                            .get_block_by_number(next_block.into())
+                            .full()
+                            .await
+                            .wrap_err_with(|| {
+                                format!("Failed to fetch block by number {next_block}")
+                            })?
+                            .ok_or_eyre("Block not found")
+                    },
+                    rpc_block_fetch_retries,
+                    "Failed to fetch block from RPC",
+                )
+                .await
+                {
                     Ok(block) => block,
                     Err(e) => {
                         tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
@@ -85,14 +96,25 @@ impl Command {
                 };
 
                 let rlp = if rlp_blocks {
-                    let Ok(rlp) = block_provider.debug_get_raw_block(next_block.into()).await
-                    else {
-                        tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}");
-                        let _ = error_sender
-                            .send(eyre::eyre!("Failed to fetch raw block {next_block}"));
-                        break;
-                    };
-                    Some(rlp)
+                    match retry_rpc_fetch(
+                        || async {
+                            block_provider
+                                .debug_get_raw_block(next_block.into())
+                                .await
+                                .wrap_err_with(|| format!("Failed to fetch raw block {next_block}"))
+                        },
+                        rpc_block_fetch_retries,
+                        "Failed to fetch raw block from RPC",
+                    )
+                    .await
+                    {
+                        Ok(rlp) => Some(rlp),
+                        Err(e) => {
+                            tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
+                            let _ = error_sender.send(e);
+                            break;
+                        }
+                    }
                 } else {
                     None
                 };

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -1,7 +1,7 @@
 //! clap [Args](clap::Args) for benchmark configuration
 
 use clap::Args;
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 /// Parameters for benchmark configuration
 #[derive(Debug, Args, PartialEq, Eq, Default, Clone)]
@@ -71,6 +71,18 @@ pub struct BenchmarkArgs {
     #[arg(long = "metrics-url", value_name = "URL", verbatim_doc_comment)]
     pub metrics_url: Option<String>,
 
+    /// Number of retries for fetching blocks from `--rpc-url` after a failure.
+    ///
+    /// Use `0` to fail immediately (default), or `forever` to never stop retrying.
+    #[arg(
+        long = "rpc-block-fetch-retries",
+        value_name = "RETRIES",
+        default_value = "0",
+        value_parser = parse_rpc_block_fetch_retries,
+        verbatim_doc_comment
+    )]
+    pub rpc_block_fetch_retries: RpcBlockFetchRetries,
+
     /// Use `reth_newPayload` endpoint instead of `engine_newPayload*`.
     ///
     /// The `reth_newPayload` endpoint is a reth-specific extension that takes `ExecutionData`
@@ -82,6 +94,54 @@ pub struct BenchmarkArgs {
     /// Fetch and replay RLP-encoded blocks. Implies `reth_new_payload`.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub rlp_blocks: bool,
+}
+
+/// Retry strategy for fetching blocks from the benchmark RPC provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcBlockFetchRetries {
+    /// Retry up to `u64` times after the first failed attempt.
+    Finite(u64),
+    /// Retry forever.
+    Forever,
+}
+
+impl RpcBlockFetchRetries {
+    /// Returns `true` if another retry should be attempted.
+    pub const fn should_retry(self, retries_used: u64) -> bool {
+        match self {
+            Self::Finite(max_retries) => retries_used < max_retries,
+            Self::Forever => true,
+        }
+    }
+}
+
+impl Default for RpcBlockFetchRetries {
+    fn default() -> Self {
+        Self::Finite(0)
+    }
+}
+
+impl FromStr for RpcBlockFetchRetries {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.eq_ignore_ascii_case("forever") ||
+            s.eq_ignore_ascii_case("infinite") ||
+            s.eq_ignore_ascii_case("inf")
+        {
+            return Ok(Self::Forever)
+        }
+
+        let retries = s
+            .parse::<u64>()
+            .map_err(|_| format!("invalid retry value {s:?}, expected a number or 'forever'"))?;
+        Ok(Self::Finite(retries))
+    }
+}
+
+fn parse_rpc_block_fetch_retries(value: &str) -> Result<RpcBlockFetchRetries, String> {
+    value.parse()
 }
 
 #[cfg(test)]
@@ -104,5 +164,27 @@ mod tests {
         };
         let args = CommandParser::<BenchmarkArgs>::parse_from(["reth-bench"]).args;
         assert_eq!(args, default_args);
+    }
+
+    #[test]
+    fn test_parse_rpc_block_fetch_retries_forever() {
+        let args = CommandParser::<BenchmarkArgs>::parse_from([
+            "reth-bench",
+            "--rpc-block-fetch-retries",
+            "forever",
+        ])
+        .args;
+        assert_eq!(args.rpc_block_fetch_retries, RpcBlockFetchRetries::Forever);
+    }
+
+    #[test]
+    fn test_parse_rpc_block_fetch_retries_number() {
+        let args = CommandParser::<BenchmarkArgs>::parse_from([
+            "reth-bench",
+            "--rpc-block-fetch-retries",
+            "7",
+        ])
+        .args;
+        assert_eq!(args.rpc_block_fetch_retries, RpcBlockFetchRetries::Finite(7));
     }
 }

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -62,7 +62,7 @@ pub use datadir_args::DatadirArgs;
 
 /// BenchmarkArgs struct for configuring the benchmark to run
 mod benchmark_args;
-pub use benchmark_args::BenchmarkArgs;
+pub use benchmark_args::{BenchmarkArgs, RpcBlockFetchRetries};
 
 /// EngineArgs for configuring the engine
 mod engine;


### PR DESCRIPTION
Adds `--rpc-block-fetch-retries` arg to reth-bench to allow for retrying failed RPC calls, also supports `--rpc-block-fetch-retries forever` to never stop retrying. Useful for long-running reth-benches which are testing correctness rather than performance.