### PR TITLE
fix(stages): overwrite Destroyed revert slots when injecting preimages

### DIFF
--- a/crates/stages/stages/src/stages/execution/slot_preimages.rs
+++ b/crates/stages/stages/src/stages/execution/slot_preimages.rs
@@ -206,6 +206,10 @@ fn inject_preimage_entry(
 
     // Convert B256 plain slot to U256 StorageKey for the revert map.
     let plain_key = alloy_primitives::U256::from_be_bytes(plain_slot.0);
+    // Overwrite `Destroyed` entries with the actual DB value. revm marks slots as
+    // `Destroyed` for selfdestructed contracts when the original DB value is unknown
+    // (e.g. CREATE2'd contracts that never read the slot). `or_insert` alone would
+    // skip these, leaving `Destroyed` to resolve to zero via `to_previous_value()`.
     revert
         .storage
         .entry(plain_key)

--- a/crates/stages/stages/src/stages/execution/slot_preimages.rs
+++ b/crates/stages/stages/src/stages/execution/slot_preimages.rs
@@ -206,10 +206,11 @@ fn inject_preimage_entry(
 
     // Convert B256 plain slot to U256 StorageKey for the revert map.
     let plain_key = alloy_primitives::U256::from_be_bytes(plain_slot.0);
-    // Overwrite `Destroyed` entries with the actual DB value. revm marks slots as
-    // `Destroyed` for selfdestructed contracts when the original DB value is unknown
-    // (e.g. CREATE2'd contracts that never read the slot). `or_insert` alone would
-    // skip these, leaving `Destroyed` to resolve to zero via `to_previous_value()`.
+    // When a contract is selfdestructed and then re-created at the same address via
+    // CREATE2 in the same block, revm treats the new contract as fresh and never reads
+    // the slot's original DB value. Slots touched by the new contract are marked as
+    // `Destroyed` instead of `Some(previous_value)`. We must overwrite these with the
+    // actual DB value here, otherwise `to_previous_value()` resolves them to zero.
     revert
         .storage
         .entry(plain_key)

--- a/crates/stages/stages/src/stages/execution/slot_preimages.rs
+++ b/crates/stages/stages/src/stages/execution/slot_preimages.rs
@@ -206,7 +206,15 @@ fn inject_preimage_entry(
 
     // Convert B256 plain slot to U256 StorageKey for the revert map.
     let plain_key = alloy_primitives::U256::from_be_bytes(plain_slot.0);
-    revert.storage.entry(plain_key).or_insert(RevertToSlot::Some(value));
+    revert
+        .storage
+        .entry(plain_key)
+        .and_modify(|slot| {
+            if matches!(slot, RevertToSlot::Destroyed) {
+                *slot = RevertToSlot::Some(value);
+            }
+        })
+        .or_insert(RevertToSlot::Some(value));
     Ok(())
 }
 


### PR DESCRIPTION
Fixes incorrect storage changeset values for selfdestructed-then-recreated contracts in storage v2.

**Example**: contract at `0x00..9a` has slot X = 1 since block 9,982,387. At block 10,094,566, the contract is selfdestructed and re-created via CREATE2. The new contract does SSTORE(X, 1) then SSTORE(X, 0) before the selfdestruct. The slot ends at value 1 (no net change: 1→1), but the changeset records the previous value as `0` instead of `1`.

**Root cause**: revm marks these slots as `RevertToSlot::Destroyed` because for a CREATE2'd contract it never reads the pre-existing DB value — it assumes all slots start empty. When `inject_plain_wipe_slots` runs for the wiped account (`wipe_storage=true`), it walks `HashedStorages`, finds slot X = 1 in the DB, and calls `inject_preimage_entry`. But `or_insert(Some(1))` doesn't overwrite the existing `Destroyed` entry, so it survives through to `to_previous_value()` → `0`.

**Fix**: use `and_modify` to overwrite `Destroyed` entries with the actual DB value before falling back to `or_insert`. This replicates what storage v1 does via `StorageRevertsIter`: when `wiped=true`, v1 reads all slots from `PlainStorageState` and the iterator's `Equal` branch [prefers the DB value](https://github.com/paradigmxyz/reth/blob/7f12c9d993b6a23e31999b29b2018fc27272b6a3/crates/storage/provider/src/providers/database/provider.rs#L2519-L2534) over `Destroyed`. The v2 `inject_preimage_entry` now does the same — overwrites `Destroyed` with the DB value, preserves existing `Some(value)`, and adds DB-only slots via `or_insert`.

Pre-Cancun blocks (the only blocks that produce `Destroyed` reverts via `SELFDESTRUCT`) are exclusively processed through the execution stage pipeline, where `inject_plain_wipe_slots` runs before `write_state`. Post-Cancun, `SELFDESTRUCT` no longer wipes storage so this codepath is not reached.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie