### PR TITLE
feat(storage): return --storage.v2 flag

### DIFF
--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -78,7 +78,7 @@ pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 
 /// `StorageArgs` for configuring storage settings.
 mod storage;
-pub use storage::StorageArgs;
+pub use storage::{DefaultStorageValues, StorageArgs};
 
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -1,6 +1,42 @@
 //! clap [Args](clap::Args) for storage configuration
 
 use clap::Args;
+use std::sync::OnceLock;
+
+/// Global static storage defaults
+static STORAGE_DEFAULTS: OnceLock<DefaultStorageValues> = OnceLock::new();
+
+/// Default values for storage that can be customized
+///
+/// Global defaults can be set via [`DefaultStorageValues::try_init`].
+#[derive(Debug, Clone)]
+pub struct DefaultStorageValues {
+    v2: bool,
+}
+
+impl DefaultStorageValues {
+    /// Initialize the global storage defaults with this configuration
+    pub fn try_init(self) -> Result<(), Self> {
+        STORAGE_DEFAULTS.set(self)
+    }
+
+    /// Get a reference to the global storage defaults
+    pub fn get_global() -> &'static Self {
+        STORAGE_DEFAULTS.get_or_init(Self::default)
+    }
+
+    /// Set the default V2 storage layout flag
+    pub const fn with_v2(mut self, v: bool) -> Self {
+        self.v2 = v;
+        self
+    }
+}
+
+impl Default for DefaultStorageValues {
+    fn default() -> Self {
+        Self { v2: true }
+    }
+}
 
 /// Parameters for storage configuration.
 ///
@@ -16,13 +52,14 @@ pub struct StorageArgs {
     /// When set, new databases will be initialized with the V2 storage layout that
     /// separates hot and cold data. Existing databases always use the settings
     /// persisted in their metadata regardless of this flag.
-    #[arg(long = "storage.v2", default_value = "true", action = clap::ArgAction::Set)]
+    #[arg(long = "storage.v2", default_value_t = DefaultStorageValues::get_global().v2, action = clap::ArgAction::Set)]
     pub v2: bool,
 }
 
 impl Default for StorageArgs {
     fn default() -> Self {
-        Self { v2: true }
+        let defaults = DefaultStorageValues::get_global();
+        Self { v2: defaults.v2 }
     }
 }
 

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -1,24 +1,29 @@
 //! clap [Args](clap::Args) for storage configuration
 
-use clap::{ArgAction, Args};
+use clap::Args;
 
 /// Parameters for storage configuration.
 ///
-/// V2 storage is now the default for all new databases. The `--storage.v2` flag is
-/// accepted for backwards compatibility but has no effect — v2 is always used.
+/// `--storage.v2` controls whether new databases use the hot/cold V2 storage layout.
+/// Defaults to `true`.
 ///
 /// Existing databases always use the settings persisted in their metadata.
-///
-/// Individual storage settings can be overridden with `--static-files.*` and `--rocksdb.*` flags.
-#[derive(Debug, Args, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, Args, PartialEq, Eq, Clone, Copy)]
 #[command(next_help_heading = "Storage")]
 pub struct StorageArgs {
-    /// Deprecated no-op: v2 storage is now always enabled for new databases.
+    /// Enable V2 (hot/cold) storage layout for new databases.
     ///
-    /// Kept for backwards compatibility with existing scripts and configurations.
-    /// Existing databases always use the settings persisted in their metadata.
-    #[arg(long = "storage.v2", action = ArgAction::SetTrue, hide = true)]
+    /// When set, new databases will be initialized with the V2 storage layout that
+    /// separates hot and cold data. Existing databases always use the settings
+    /// persisted in their metadata regardless of this flag.
+    #[arg(long = "storage.v2", default_value = "true", action = clap::ArgAction::Set)]
     pub v2: bool,
+}
+
+impl Default for StorageArgs {
+    fn default() -> Self {
+        Self { v2: true }
+    }
 }
 
 #[cfg(test)]
@@ -36,13 +41,18 @@ mod tests {
     #[test]
     fn test_default_storage_args() {
         let args = CommandParser::<StorageArgs>::parse_from(["reth"]).args;
-        assert_eq!(args, StorageArgs::default());
+        assert!(args.v2);
     }
 
     #[test]
-    fn test_parse_v2_flag_accepted() {
-        // Flag is accepted for backwards compatibility but is a no-op
-        let args = CommandParser::<StorageArgs>::parse_from(["reth", "--storage.v2"]).args;
+    fn test_storage_v2_explicit_true() {
+        let args = CommandParser::<StorageArgs>::parse_from(["reth", "--storage.v2=true"]).args;
         assert!(args.v2);
+    }
+
+    #[test]
+    fn test_storage_v2_explicit_false() {
+        let args = CommandParser::<StorageArgs>::parse_from(["reth", "--storage.v2=false"]).args;
+        assert!(!args.v2);
     }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -373,14 +373,15 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
 
     /// Returns the effective storage settings for this node.
     ///
-    /// Always returns [`StorageSettings::v2()`] — v2 storage is the default for
-    /// new nodes. Existing nodes retain whatever settings are persisted in their
-    /// database metadata (checked during genesis init).
-    ///
+    /// Determined by the `--storage.v2` flag (defaults to `true`).
     /// Existing databases retain whatever settings are persisted in their
     /// metadata (checked during genesis init).
     pub const fn storage_settings(&self) -> StorageSettings {
-        StorageSettings::v2()
+        if self.storage.v2 {
+            StorageSettings::v2()
+        } else {
+            StorageSettings::v1()
+        }
     }
 
     /// Returns the max block that the node should run to, looking it up from the network if

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -131,6 +131,15 @@ Static Files:
       --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
           Number of blocks per file for the storage changesets segment
 
+Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --first-block-number <first-block-number>
           Optional first block number to export from the db.
           It is by default 0.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --no-state
           Disables stages that require state.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -111,6 +111,15 @@ Static Files:
       --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
           Number of blocks per file for the storage changesets segment
 
+Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1057,6 +1057,15 @@ Static Files:
       --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
           Number of blocks per file for the storage changesets segment
 
+Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -111,6 +111,15 @@ Static Files:
       --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
           Number of blocks per file for the storage changesets segment
 
+Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
 Metrics:
       --metrics <PROMETHEUS>
           Enable Prometheus metrics.

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -118,6 +118,15 @@ Static Files:
       --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
           Number of blocks per file for the storage changesets segment
 
+Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -112,6 +112,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -117,6 +117,14 @@ Static Files:
           Number of blocks per file for the storage changesets segment
 
 Storage:
+      --storage.v2 <V2>
+          Enable V2 (hot/cold) storage layout for new databases.
+
+          When set, new databases will be initialized with the V2 storage layout that separates hot and cold data. Existing databases always use the settings persisted in their metadata regardless of this flag.
+
+          [default: true]
+          [possible values: true, false]
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 


### PR DESCRIPTION
## Summary
De-deprecates `--storage.v2` from a hidden no-op back to a functional flag that controls whether new databases use V2 storage layout.

Prompted by: alexey