### PR TITLE
feat(node-core): add DefaultLogArgs for customizable log defaults

### DIFF
--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -6,7 +6,7 @@ use reth_tracing::{
     tracing_subscriber::filter::Directive, FileInfo, FileWorkerGuard, LayerInfo, Layers, LogFormat,
     RethTracer, Tracer,
 };
-use std::{fmt, fmt::Display};
+use std::{fmt, fmt::Display, sync::OnceLock};
 use tracing::{level_filters::LevelFilter, Level};
 
 /// Constant to convert megabytes to bytes
@@ -14,24 +14,27 @@ const MB_TO_BYTES: u64 = 1024 * 1024;
 
 const PROFILER_TRACING_FILTER: &str = "debug";
 
+/// Global static log defaults
+static LOG_DEFAULTS: OnceLock<DefaultLogArgs> = OnceLock::new();
+
 /// The log configuration.
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Logging")]
 pub struct LogArgs {
     /// The format to use for logs written to stdout.
-    #[arg(long = "log.stdout.format", value_name = "FORMAT", global = true, default_value_t = LogFormat::Terminal)]
+    #[arg(long = "log.stdout.format", value_name = "FORMAT", global = true, default_value_t = DefaultLogArgs::get_global().log_stdout_format)]
     pub log_stdout_format: LogFormat,
 
     /// The filter to use for logs written to stdout.
-    #[arg(long = "log.stdout.filter", value_name = "FILTER", global = true, default_value = "")]
+    #[arg(long = "log.stdout.filter", value_name = "FILTER", global = true, default_value_t = DefaultLogArgs::get_global().log_stdout_filter.clone())]
     pub log_stdout_filter: String,
 
     /// The format to use for logs written to the log file.
-    #[arg(long = "log.file.format", value_name = "FORMAT", global = true, default_value_t = LogFormat::Terminal)]
+    #[arg(long = "log.file.format", value_name = "FORMAT", global = true, default_value_t = DefaultLogArgs::get_global().log_file_format)]
     pub log_file_format: LogFormat,
 
     /// The filter to use for logs written to the log file.
-    #[arg(long = "log.file.filter", value_name = "FILTER", global = true, default_value = "debug")]
+    #[arg(long = "log.file.filter", value_name = "FILTER", global = true, default_value_t = DefaultLogArgs::get_global().log_file_filter.clone())]
     pub log_file_filter: String,
 
     /// The path to put log files in.
@@ -39,11 +42,11 @@ pub struct LogArgs {
     pub log_file_directory: PlatformPath<LogsDir>,
 
     /// The prefix name of the log files.
-    #[arg(long = "log.file.name", value_name = "NAME", global = true, default_value = "reth.log")]
+    #[arg(long = "log.file.name", value_name = "NAME", global = true, default_value_t = DefaultLogArgs::get_global().log_file_name.clone())]
     pub log_file_name: String,
 
     /// The maximum size (in MB) of one log file.
-    #[arg(long = "log.file.max-size", value_name = "SIZE", global = true, default_value_t = 200)]
+    #[arg(long = "log.file.max-size", value_name = "SIZE", global = true, default_value_t = DefaultLogArgs::get_global().log_file_max_size)]
     pub log_file_max_size: u64,
 
     /// The maximum amount of log files that will be stored. If set to 0, background file logging
@@ -54,7 +57,7 @@ pub struct LogArgs {
     pub log_file_max_files: Option<usize>,
 
     /// Write logs to journald.
-    #[arg(long = "log.journald", global = true)]
+    #[arg(long = "log.journald", global = true, default_value_t = DefaultLogArgs::get_global().journald)]
     pub journald: bool,
 
     /// The filter to use for logs written to journald.
@@ -62,12 +65,12 @@ pub struct LogArgs {
         long = "log.journald.filter",
         value_name = "FILTER",
         global = true,
-        default_value = "error"
+        default_value_t = DefaultLogArgs::get_global().journald_filter.clone()
     )]
     pub journald_filter: String,
 
     /// Emit traces to samply. Only useful when profiling.
-    #[arg(long = "log.samply", global = true, hide = true)]
+    #[arg(long = "log.samply", global = true, hide = true, default_value_t = DefaultLogArgs::get_global().samply)]
     pub samply: bool,
 
     /// The filter to use for traces emitted to samply.
@@ -75,13 +78,13 @@ pub struct LogArgs {
         long = "log.samply.filter",
         value_name = "FILTER",
         global = true,
-        default_value = PROFILER_TRACING_FILTER,
+        default_value_t = DefaultLogArgs::get_global().samply_filter.clone(),
         hide = true
     )]
     pub samply_filter: String,
 
     /// Emit traces to tracy. Only useful when profiling.
-    #[arg(long = "log.tracy", global = true, hide = true)]
+    #[arg(long = "log.tracy", global = true, hide = true, default_value_t = DefaultLogArgs::get_global().tracy)]
     pub tracy: bool,
 
     /// The filter to use for traces emitted to tracy.
@@ -89,7 +92,7 @@ pub struct LogArgs {
         long = "log.tracy.filter",
         value_name = "FILTER",
         global = true,
-        default_value = PROFILER_TRACING_FILTER,
+        default_value_t = DefaultLogArgs::get_global().tracy_filter.clone(),
         hide = true
     )]
     pub tracy_filter: String,
@@ -100,7 +103,7 @@ pub struct LogArgs {
         long,
         value_name = "COLOR",
         global = true,
-        default_value_t = ColorMode::Always
+        default_value_t = DefaultLogArgs::get_global().color
     )]
     pub color: ColorMode,
 
@@ -207,6 +210,136 @@ impl LogArgs {
         }
 
         tracer.with_reload(enable_reload).init_with_layers(layers)
+    }
+}
+
+/// Default values for log configuration that can be customized.
+///
+/// Global defaults can be set via [`DefaultLogArgs::try_init`].
+#[derive(Debug, Clone)]
+pub struct DefaultLogArgs {
+    log_stdout_format: LogFormat,
+    log_stdout_filter: String,
+    log_file_format: LogFormat,
+    log_file_filter: String,
+    log_file_name: String,
+    log_file_max_size: u64,
+    journald: bool,
+    journald_filter: String,
+    samply: bool,
+    samply_filter: String,
+    tracy: bool,
+    tracy_filter: String,
+    color: ColorMode,
+}
+
+impl DefaultLogArgs {
+    /// Initialize the global log defaults with this configuration.
+    pub fn try_init(self) -> Result<(), Self> {
+        LOG_DEFAULTS.set(self)
+    }
+
+    /// Get a reference to the global log defaults.
+    pub fn get_global() -> &'static Self {
+        LOG_DEFAULTS.get_or_init(Self::default)
+    }
+
+    /// Set the default stdout log format.
+    pub const fn with_log_stdout_format(mut self, v: LogFormat) -> Self {
+        self.log_stdout_format = v;
+        self
+    }
+
+    /// Set the default stdout log filter.
+    pub fn with_log_stdout_filter(mut self, v: String) -> Self {
+        self.log_stdout_filter = v;
+        self
+    }
+
+    /// Set the default file log format.
+    pub const fn with_log_file_format(mut self, v: LogFormat) -> Self {
+        self.log_file_format = v;
+        self
+    }
+
+    /// Set the default file log filter.
+    pub fn with_log_file_filter(mut self, v: String) -> Self {
+        self.log_file_filter = v;
+        self
+    }
+
+    /// Set the default log file name.
+    pub fn with_log_file_name(mut self, v: String) -> Self {
+        self.log_file_name = v;
+        self
+    }
+
+    /// Set the default max log file size in MB.
+    pub const fn with_log_file_max_size(mut self, v: u64) -> Self {
+        self.log_file_max_size = v;
+        self
+    }
+
+    /// Set whether journald logging is enabled by default.
+    pub const fn with_journald(mut self, v: bool) -> Self {
+        self.journald = v;
+        self
+    }
+
+    /// Set the default journald filter.
+    pub fn with_journald_filter(mut self, v: String) -> Self {
+        self.journald_filter = v;
+        self
+    }
+
+    /// Set whether samply tracing is enabled by default.
+    pub const fn with_samply(mut self, v: bool) -> Self {
+        self.samply = v;
+        self
+    }
+
+    /// Set the default samply filter.
+    pub fn with_samply_filter(mut self, v: String) -> Self {
+        self.samply_filter = v;
+        self
+    }
+
+    /// Set whether tracy tracing is enabled by default.
+    pub const fn with_tracy(mut self, v: bool) -> Self {
+        self.tracy = v;
+        self
+    }
+
+    /// Set the default tracy filter.
+    pub fn with_tracy_filter(mut self, v: String) -> Self {
+        self.tracy_filter = v;
+        self
+    }
+
+    /// Set the default color mode.
+    pub const fn with_color(mut self, v: ColorMode) -> Self {
+        self.color = v;
+        self
+    }
+}
+
+impl Default for DefaultLogArgs {
+    fn default() -> Self {
+        Self {
+            log_stdout_format: LogFormat::Terminal,
+            log_stdout_filter: String::new(),
+            log_file_format: LogFormat::Terminal,
+            log_file_filter: "debug".to_string(),
+            log_file_name: "reth.log".to_string(),
+            log_file_max_size: 200,
+            journald: false,
+            journald_filter: "error".to_string(),
+            samply: false,
+            samply_filter: PROFILER_TRACING_FILTER.to_string(),
+            tracy: false,
+            tracy_filter: PROFILER_TRACING_FILTER.to_string(),
+            color: ColorMode::Always,
+        }
     }
 }
 

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -22,7 +22,7 @@ pub use database::DatabaseArgs;
 
 /// LogArgs struct for configuring the logger
 mod log;
-pub use log::{ColorMode, LogArgs, Verbosity};
+pub use log::{ColorMode, DefaultLogArgs, LogArgs, Verbosity};
 
 /// `TraceArgs` for tracing and spans support
 mod trace;


### PR DESCRIPTION
Adds `DefaultLogArgs` to `LogArgs`, following the same pattern as `DefaultRpcServerArgs` for `RpcServerArgs`.

This lets downstream consumers override log configuration defaults via `DefaultLogArgs::try_init()` before CLI parsing, so custom nodes can ship with different default log formats, filters, or file settings without forking the arg definitions.

Co-Authored-By: Matthias Seitz <19890894+mattsse@users.noreply.github.com>

Prompted by: mattsse