### PR TITLE
perf(rpc): avoid storage access clone

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -603,12 +603,14 @@ where
                 block_id,
                 Some(block.clone()),
                 StorageInspector::default,
-                move |tx_info, ctx| {
+                move |tx_info, mut ctx| {
+                    let unique_loads = ctx.inspector.unique_loads();
+                    let warm_loads = ctx.inspector.warm_loads();
                     let trace = TransactionStorageAccess {
                         transaction_hash: tx_info.hash.expect("tx hash is set"),
-                        storage_access: ctx.inspector.accessed_slots().clone(),
-                        unique_loads: ctx.inspector.unique_loads(),
-                        warm_loads: ctx.inspector.warm_loads(),
+                        storage_access: ctx.take_inspector().into_accessed_slots(),
+                        unique_loads,
+                        warm_loads,
                     };
                     Ok(trace)
                 },


### PR DESCRIPTION
Use `into_accessed_slots()` instead of `accessed_slots().clone()` in `trace_block_storage_access`. Moves the data out of the inspector rather than cloning it.

`take_inspector()` internally clones the fused inspector, but this was already happening unconditionally after the callback in `TracerIter::next()` via `fuse_inspector()`. The new code just moves that clone into the callback by calling `take_inspector()`, which sets `was_fused = true` and causes `TracerIter` to skip the redundant `fuse_inspector()` call.