### PR TITLE
fix(cli): use skip_consistency_checks flag in db stats command

### DIFF
--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -51,14 +51,13 @@ impl Command {
         data_dir: ChainPath<DataDirPath>,
         tool: &DbTool<NodeTypesWithDBAdapter<N, DatabaseEnv>>,
     ) -> eyre::Result<()> {
-        if !self.skip_consistency_checks {
-            if let Err(err) = tool
+        if !self.skip_consistency_checks
+            && let Err(err) = tool
                 .provider_factory
                 .static_file_provider()
                 .check_consistency(&tool.provider_factory.provider()?)
-            {
-                warn!(target: "reth::cli", %err, "Static file consistency check failed");
-            }
+        {
+            warn!(target: "reth::cli", %err, "Static file consistency check failed");
         }
 
         if self.checksum {

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -51,8 +51,8 @@ impl Command {
         data_dir: ChainPath<DataDirPath>,
         tool: &DbTool<NodeTypesWithDBAdapter<N, DatabaseEnv>>,
     ) -> eyre::Result<()> {
-        if !self.skip_consistency_checks
-            && let Err(err) = tool
+        if !self.skip_consistency_checks &&
+            let Err(err) = tool
                 .provider_factory
                 .static_file_provider()
                 .check_consistency(&tool.provider_factory.provider()?)

--- a/crates/cli/commands/src/db/stats.rs
+++ b/crates/cli/commands/src/db/stats.rs
@@ -13,10 +13,11 @@ use reth_node_builder::{NodePrimitives, NodeTypesWithDB, NodeTypesWithDBAdapter}
 use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_provider::{
     providers::{ProviderNodeTypes, StaticFileProvider},
-    RocksDBProviderFactory,
+    RocksDBProviderFactory, StaticFileProviderFactory,
 };
 use reth_static_file_types::SegmentRangeInclusive;
 use std::time::Duration;
+use tracing::warn;
 
 #[derive(Parser, Debug)]
 /// The arguments for the `reth db stats` command
@@ -50,6 +51,16 @@ impl Command {
         data_dir: ChainPath<DataDirPath>,
         tool: &DbTool<NodeTypesWithDBAdapter<N, DatabaseEnv>>,
     ) -> eyre::Result<()> {
+        if !self.skip_consistency_checks {
+            if let Err(err) = tool
+                .provider_factory
+                .static_file_provider()
+                .check_consistency(&tool.provider_factory.provider()?)
+            {
+                warn!(target: "reth::cli", %err, "Static file consistency check failed");
+            }
+        }
+
         if self.checksum {
             let checksum_report = self.checksum_report(tool)?;
             println!("{checksum_report}");


### PR DESCRIPTION
The `--skip-consistency-checks` flag was added in #19754 but never actually wired up.
This adds the missing `check_consistency()` call, matching behavior in `static_file_header` and `checksum` commands.