### PR TITLE
refactor(engine): make arena sparse trie the default and remove flag

### DIFF
--- a/.changelog/warm-trees-grow.md
+++ b/.changelog/warm-trees-grow.md
@@ -1,0 +1,7 @@
+---
+reth-engine-primitives: patch
+reth-engine-tree: patch
+reth-node-core: patch
+---
+
+Removed `--engine.enable-arena-sparse-trie` CLI flag and made the arena-based sparse trie the default implementation. The hash-map-based `ParallelSparseTrie` variant is no longer selectable.

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -146,8 +146,6 @@ pub struct TreeConfig {
     slow_block_threshold: Option<Duration>,
     /// Whether to fully disable sparse trie cache pruning between blocks.
     disable_sparse_trie_cache_pruning: bool,
-    /// Whether to use the arena-based sparse trie implementation.
-    enable_arena_sparse_trie: bool,
     /// Timeout for the state root task before spawning a sequential fallback computation.
     /// If `Some`, after waiting this duration for the state root task, a sequential state root
     /// computation is spawned in parallel and whichever finishes first is used.
@@ -187,7 +185,6 @@ impl Default for TreeConfig {
             sparse_trie_max_hot_accounts: DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS,
             slow_block_threshold: None,
             disable_sparse_trie_cache_pruning: false,
-            enable_arena_sparse_trie: false,
             state_root_task_timeout: Some(DEFAULT_STATE_ROOT_TASK_TIMEOUT),
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
@@ -249,7 +246,6 @@ impl TreeConfig {
             sparse_trie_max_hot_accounts,
             slow_block_threshold,
             disable_sparse_trie_cache_pruning: false,
-            enable_arena_sparse_trie: false,
             state_root_task_timeout,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
@@ -549,17 +545,6 @@ impl TreeConfig {
     /// Setter for whether to disable sparse trie cache pruning.
     pub const fn with_disable_sparse_trie_cache_pruning(mut self, value: bool) -> Self {
         self.disable_sparse_trie_cache_pruning = value;
-        self
-    }
-
-    /// Returns whether the arena-based sparse trie is enabled.
-    pub const fn enable_arena_sparse_trie(&self) -> bool {
-        self.enable_arena_sparse_trie
-    }
-
-    /// Setter for whether to enable the arena-based sparse trie.
-    pub const fn with_enable_arena_sparse_trie(mut self, value: bool) -> Self {
-        self.enable_arena_sparse_trie = value;
         self
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -39,8 +39,7 @@ use reth_trie_parallel::{
     root::ParallelStateRootError,
 };
 use reth_trie_sparse::{
-    ArenaParallelSparseTrie, ConfigurableSparseTrie, ParallelSparseTrie, ParallelismThresholds,
-    RevealableSparseTrie, SparseStateTrie,
+    ArenaParallelSparseTrie, ConfigurableSparseTrie, RevealableSparseTrie, SparseStateTrie,
 };
 use std::{
     ops::Not,
@@ -61,14 +60,6 @@ pub mod receipt_root_task;
 pub mod sparse_trie;
 
 use preserved_sparse_trie::{PreservedSparseTrie, SharedPreservedSparseTrie};
-
-/// Default parallelism thresholds to use with the [`ParallelSparseTrie`].
-///
-/// These values were determined by performing benchmarks using gradually increasing values to judge
-/// the effects. Below 100 throughput would generally be equal or slightly less, while above 150 it
-/// would deteriorate to the point where PST might as well not be used.
-const PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS: ParallelismThresholds =
-    ParallelismThresholds { min_revealed_nodes: 100, min_updated_nodes: 100 };
 
 /// Default node capacity for shrinking the sparse trie. This is used to limit the number of trie
 /// nodes in allocated sparse tries.
@@ -138,8 +129,6 @@ where
     sparse_trie_max_hot_accounts: usize,
     /// Whether sparse trie cache pruning is fully disabled.
     disable_sparse_trie_cache_pruning: bool,
-    /// Whether to use the arena-based sparse trie implementation.
-    enable_arena_sparse_trie: bool,
     /// Whether to disable cache metrics recording.
     disable_cache_metrics: bool,
 }
@@ -175,7 +164,6 @@ where
             sparse_trie_max_hot_slots: config.sparse_trie_max_hot_slots(),
             sparse_trie_max_hot_accounts: config.sparse_trie_max_hot_accounts(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
-            enable_arena_sparse_trie: config.enable_arena_sparse_trie(),
             disable_cache_metrics: config.disable_cache_metrics(),
         }
     }
@@ -567,7 +555,6 @@ where
         let max_hot_slots = self.sparse_trie_max_hot_slots;
         let max_hot_accounts = self.sparse_trie_max_hot_accounts;
         let disable_cache_pruning = self.disable_sparse_trie_cache_pruning;
-        let enable_arena_sparse_trie = self.enable_arena_sparse_trie;
         let executor = self.executor.clone();
 
         let parent_span = Span::current();
@@ -594,19 +581,9 @@ where
                         target: "engine::tree::payload_processor",
                         "Creating new sparse trie - no preserved trie available"
                     );
-                    let default_trie = if enable_arena_sparse_trie {
-                        RevealableSparseTrie::blind_from(
-                            ConfigurableSparseTrie::Arena(ArenaParallelSparseTrie::default()),
-                        )
-                    } else {
-                        RevealableSparseTrie::blind_from(
-                            ConfigurableSparseTrie::HashMap(
-                                ParallelSparseTrie::default().with_parallelism_thresholds(
-                                    PARALLEL_SPARSE_TRIE_PARALLELISM_THRESHOLDS,
-                                ),
-                            ),
-                        )
-                    };
+                    let default_trie = RevealableSparseTrie::blind_from(
+                        ConfigurableSparseTrie::Arena(ArenaParallelSparseTrie::default()),
+                    );
                     SparseStateTrie::default()
                         .with_accounts_trie(default_trie.clone())
                         .with_default_storage_trie(default_trie)

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -383,11 +383,6 @@ pub struct EngineArgs {
     #[arg(long = "engine.disable-sparse-trie-cache-pruning", default_value_t = DefaultEngineValues::get_global().disable_sparse_trie_cache_pruning)]
     pub disable_sparse_trie_cache_pruning: bool,
 
-    /// Enable the arena-based sparse trie implementation instead of the default hash-map-based
-    /// one.
-    #[arg(long = "engine.enable-arena-sparse-trie", default_value_t = false)]
-    pub enable_arena_sparse_trie: bool,
-
     /// Configure the timeout for the state root task before spawning a sequential fallback.
     /// If the state root task takes longer than this, a sequential computation starts in
     /// parallel and whichever finishes first is used.
@@ -474,7 +469,6 @@ impl Default for EngineArgs {
             sparse_trie_max_hot_accounts,
             slow_block_threshold,
             disable_sparse_trie_cache_pruning,
-            enable_arena_sparse_trie: false,
             state_root_task_timeout: state_root_task_timeout
                 .as_deref()
                 .map(|s| humantime::parse_duration(s).expect("valid default duration")),
@@ -509,7 +503,6 @@ impl EngineArgs {
             .with_sparse_trie_max_hot_accounts(self.sparse_trie_max_hot_accounts)
             .with_slow_block_threshold(self.slow_block_threshold)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
-            .with_enable_arena_sparse_trie(self.enable_arena_sparse_trie)
             .with_state_root_task_timeout(self.state_root_task_timeout.filter(|d| !d.is_zero()));
         #[cfg(feature = "trie-debug")]
         let config = config.with_proof_jitter(self.proof_jitter);
@@ -567,7 +560,6 @@ mod tests {
             sparse_trie_max_hot_accounts: 500,
             slow_block_threshold: None,
             disable_sparse_trie_cache_pruning: true,
-            enable_arena_sparse_trie: true,
             state_root_task_timeout: Some(Duration::from_secs(2)),
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
@@ -607,7 +599,6 @@ mod tests {
             "--engine.sparse-trie-max-hot-accounts",
             "500",
             "--engine.disable-sparse-trie-cache-pruning",
-            "--engine.enable-arena-sparse-trie",
             "--engine.state-root-task-timeout",
             "2s",
         ])

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1011,9 +1011,6 @@ Engine:
       --engine.disable-sparse-trie-cache-pruning
           Fully disable sparse trie cache pruning. When set, the cached sparse trie is preserved without any node pruning or storage trie eviction between blocks. Useful for benchmarking the effects of retaining the full trie cache
 
-      --engine.enable-arena-sparse-trie
-          Enable the arena-based sparse trie implementation instead of the default hash-map-based one
-
       --engine.state-root-task-timeout <STATE_ROOT_TASK_TIMEOUT>
           Configure the timeout for the state root task before spawning a sequential fallback. If the state root task takes longer than this, a sequential computation starts in parallel and whichever finishes first is used.
 


### PR DESCRIPTION
Removes the `--engine.enable-arena-sparse-trie` CLI flag and makes the arena-based sparse trie the only implementation. The hash-map-based `ParallelSparseTrie` variant is no longer selectable at runtime.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: brian