### PR TITLE
fix: change `DEFAULT_IGNORE_GAS_PRICE`

### DIFF
--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -427,19 +427,3 @@ impl Default for GasCap {
         RPC_DEFAULT_GAS_CAP
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn max_price_sanity() {
-        assert_eq!(DEFAULT_MAX_GAS_PRICE, U256::from(500_000_000_000u64));
-        assert_eq!(DEFAULT_MAX_GAS_PRICE, U256::from(500 * GWEI_TO_WEI))
-    }
-
-    #[test]
-    fn ignore_price_sanity() {
-        assert_eq!(DEFAULT_IGNORE_GAS_PRICE, U256::from(2u64));
-    }
-}

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -95,7 +95,7 @@ pub mod gas_oracle {
     pub const DEFAULT_MAX_GAS_PRICE: U256 = U256::from_limbs([500_000_000_000u64, 0, 0, 0]);
 
     /// The default minimum gas price, under which the sample will be ignored
-    pub const DEFAULT_IGNORE_GAS_PRICE: U256 = U256::from_limbs([2u64, 0, 0, 0]);
+    pub const DEFAULT_IGNORE_GAS_PRICE: U256 = U256::ZERO;
 
     /// The default gas limit for `eth_call` and adjacent calls.
     ///

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -520,7 +520,7 @@ Gas Price Oracle:
       --gpo.ignoreprice <IGNORE_PRICE>
           Gas Price below which gpo will ignore transactions
 
-          [default: 2]
+          [default: 0]
 
       --gpo.maxprice <MAX_PRICE>
           Maximum transaction priority fee(or gasprice before London Fork) to be recommended by gpo


### PR DESCRIPTION
Right now transactions with priority fee less than 2 wei are getting ignored when suggesting a priority fee

It doesn't seem reasonable to ignore 0 wei values but keep 2 wei values and the fact that transactions not paying any priority fee are still landing should definietly be accounted for in calculation