### PR TITLE
refactor(rpc): simplify `block_transaction_count`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -78,40 +78,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
         &self,
         block_id: BlockId,
     ) -> impl Future<Output = Result<Option<usize>, Self::Error>> + Send {
-        async move {
-            if block_id.is_pending() {
-                if self.pending_block_kind().is_none() {
-                    return Ok(None);
-                }
-
-                // If no pending block from provider, build the pending block locally.
-                if let Some(pending) = self.local_pending_block().await? {
-                    return Ok(Some(pending.block.body().transaction_count()));
-                }
-                // Pending block can be fetched directly without need for caching
-                return Ok(self
-                    .provider()
-                    .pending_block()
-                    .map_err(Self::Error::from_eth_err)?
-                    .map(|block| block.body().transaction_count()));
-            }
-
-            let block_hash = match self
-                .provider()
-                .block_hash_for_id(block_id)
-                .map_err(Self::Error::from_eth_err)?
-            {
-                Some(block_hash) => block_hash,
-                None => return Ok(None),
-            };
-
-            Ok(self
-                .cache()
-                .get_recovered_block(block_hash)
-                .await
-                .map_err(Self::Error::from_eth_err)?
-                .map(|b| b.body().transaction_count()))
-        }
+        async move { Ok(self.recovered_block(block_id).await?.map(|b| b.body().transaction_count())) }
     }
 
     /// Helper function for `eth_getBlockReceipts`.


### PR DESCRIPTION
Delegates `block_transaction_count` to `recovered_block`