### PR TITLE
chore(engine): lower "yielded transaction" log from debug to trace

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -50,7 +50,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, instrument, warn, Span};
+use tracing::{debug, debug_span, instrument, trace, warn, Span};
 
 pub mod bal;
 pub mod multiproof;
@@ -449,7 +449,7 @@ where
                             tx
                         });
                         let _ = execute_tx.send(tx);
-                        debug!(target: "engine::tree::payload_processor", idx, "yielded transaction");
+                        trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
                     });
             });
         }
@@ -742,7 +742,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
             let _ = prewarm_tx.send((idx, tx.clone()));
         }
         let _ = execute_tx.send(tx);
-        debug!(target: "engine::tree::payload_processor", idx, "yielded transaction");
+        trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
     }
 }
 


### PR DESCRIPTION
Fires once per transaction per block, making it too noisy at debug level. Both the parallel and serial paths in `payload_processor` are updated.

Prompted by: joshie