### PR TITLE
perf(rpc): avoid redundant block fetch in `sim_bundle_inner`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -93,7 +93,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
             let mut parent = base_block.sealed_header().clone();
 
-            self.spawn_with_state_at_block(block, move |this, mut db| {
+            self.spawn_with_state_at_block(base_block.hash(), move |this, mut db| {
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -93,7 +93,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
             let mut parent = base_block.sealed_header().clone();
 
-            self.spawn_with_state_at_block(base_block.hash(), move |this, mut db| {
+            self.spawn_with_state_at_block(block, move |this, mut db| {
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
 

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -231,16 +231,18 @@ where
         let flattened_bundle = self.parse_and_flatten_bundle(&request)?;
 
         let block_id = parent_block.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
-        let (mut evm_env, current_block_id) = self.eth_api().evm_env_at(block_id).await?;
-        let current_block = self.eth_api().recovered_block(current_block_id).await?;
+        let current_block = self.eth_api().recovered_block(block_id).await?;
         let current_block = current_block.ok_or(EthApiError::HeaderNotFound(block_id))?;
+        let mut evm_env =
+            self.eth_api().evm_env_for_header(current_block.sealed_block().sealed_header())?;
+        let current_block_hash = current_block.hash();
 
         let eth_api = self.inner.eth_api.clone();
 
         let sim_response = self
             .inner
             .eth_api
-            .spawn_with_state_at_block(current_block_id, move |_, mut db| {
+            .spawn_with_state_at_block(current_block_hash, move |_, mut db| {
                 // Setup environment
                 let current_block_number = current_block.number();
                 let coinbase = evm_env.block_env.beneficiary();

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -235,14 +235,13 @@ where
         let current_block = current_block.ok_or(EthApiError::HeaderNotFound(block_id))?;
         let mut evm_env =
             self.eth_api().evm_env_for_header(current_block.sealed_block().sealed_header())?;
-        let current_block_hash = current_block.hash();
 
         let eth_api = self.inner.eth_api.clone();
 
         let sim_response = self
             .inner
             .eth_api
-            .spawn_with_state_at_block(current_block_hash, move |_, mut db| {
+            .spawn_with_state_at_block(block_id, move |_, mut db| {
                 // Setup environment
                 let current_block_number = current_block.number();
                 let coinbase = evm_env.block_env.beneficiary();


### PR DESCRIPTION
`sim_bundle_inner` was fetching the block header twice — once inside `evm_env_at` and again via `recovered_block`. Derive the evm env directly from the already-fetched block via `evm_env_for_header` instead.