### PR TITLE
Docs: clarify transaction pool link wording

### DIFF
--- a/docs/vocs/docs/pages/sdk/node-components/rpc.mdx
+++ b/docs/vocs/docs/pages/sdk/node-components/rpc.mdx
@@ -16,5 +16,5 @@ The RPC component provides:
 ## Next Steps
 
 - Explore [Network](/sdk/node-components/network) component integration
-- Learn about [Transaction Pool](/sdk/node-components/pool) APIs
+- Learn about [Transaction Pool](/sdk/node-components/pool) 
 - Understand [EVM](/sdk/node-components/evm) execution context


### PR DESCRIPTION
Replace "Transaction Pool APIs" with "Transaction Pool" for accuracy and consistency.

The linked page describes the transaction pool itself rather than specific APIs, so this simplifies the wording and better matches the content.