### PR TITLE
refactor: remove bincode usage from `HeaderStage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10080,7 +10080,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
- "bincode",
  "eyre",
  "futures-util",
  "itertools 0.14.0",

--- a/crates/primitives-traits/src/transaction/signed.rs
+++ b/crates/primitives-traits/src/transaction/signed.rs
@@ -1,6 +1,6 @@
 //! API of a signed transaction.
 
-use crate::{InMemorySize, MaybeCompact, MaybeSerde, MaybeSerdeBincodeCompat};
+use crate::{InMemorySize, MaybeCompact, MaybeSerde};
 use alloc::fmt;
 use alloy_consensus::{
     transaction::{Recovered, RlpEcdsaEncodableTx, SignerRecoverable, TxHashRef},
@@ -14,8 +14,8 @@ use core::hash::Hash;
 pub use alloy_consensus::crypto::RecoveryError;
 
 /// Helper trait that unifies all behaviour required by block to support full node operations.
-pub trait FullSignedTx: SignedTransaction + MaybeCompact + MaybeSerdeBincodeCompat {}
-impl<T> FullSignedTx for T where T: SignedTransaction + MaybeCompact + MaybeSerdeBincodeCompat {}
+pub trait FullSignedTx: SignedTransaction + MaybeCompact {}
+impl<T> FullSignedTx for T where T: SignedTransaction + MaybeCompact {}
 
 /// A signed transaction.
 ///

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -28,7 +28,7 @@ reth-era.workspace = true
 reth-exex.workspace = true
 reth-fs-util.workspace = true
 reth-network-p2p.workspace = true
-reth-primitives-traits = { workspace = true, features = ["serde-bincode-compat"] }
+reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-execution-types.workspace = true
 reth-ethereum-primitives = { workspace = true, optional = true }
@@ -48,6 +48,7 @@ reth-testing-utils = { workspace = true, optional = true }
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
+alloy-rlp.workspace = true
 
 # async
 tokio = { workspace = true, features = ["sync"] }
@@ -63,7 +64,6 @@ rayon.workspace = true
 page_size.workspace = true
 num-traits.workspace = true
 tempfile = { workspace = true, optional = true }
-bincode.workspace = true
 reqwest.workspace = true
 eyre.workspace = true
 

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -1,5 +1,6 @@
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256};
+use alloy_rlp::Decodable;
 use futures_util::StreamExt;
 use reth_config::config::EtlConfig;
 use reth_db_api::{
@@ -14,9 +15,7 @@ use reth_network_p2p::headers::{
     downloader::{HeaderDownloader, HeaderSyncGap, SyncTarget},
     error::HeadersDownloaderError,
 };
-use reth_primitives_traits::{
-    serde_bincode_compat, FullBlockHeader, HeaderTy, NodePrimitives, SealedHeader,
-};
+use reth_primitives_traits::{FullBlockHeader, HeaderTy, NodePrimitives, SealedHeader};
 use reth_provider::{
     providers::StaticFileWriter, BlockHashReader, DBProvider, HeaderSyncGapProvider,
     StaticFileProviderFactory,
@@ -127,10 +126,10 @@ where
                 info!(target: "sync::stages::headers", progress = %format!("{:.2}%", (index as f64 / total_headers as f64) * 100.0), "Writing headers");
             }
 
-            let sealed_header: SealedHeader<Downloader::Header> =
-                bincode::deserialize::<serde_bincode_compat::SealedHeader<'_, _>>(&header_buf)
-                    .map_err(|err| StageError::Fatal(Box::new(err)))?
-                    .into();
+            let sealed_header: SealedHeader<Downloader::Header> = SealedHeader::new_unhashed(
+                Decodable::decode(&mut header_buf.as_slice())
+                    .map_err(|err| StageError::Fatal(Box::new(err)))?,
+            );
 
             let (header, header_hash) = sealed_header.split_ref();
             if header.number() == 0 {
@@ -246,15 +245,8 @@ where
                         let header_number = header.number();
 
                         self.hash_collector.insert(header.hash(), header_number)?;
-                        self.header_collector.insert(
-                            header_number,
-                            Bytes::from(
-                                bincode::serialize(&serde_bincode_compat::SealedHeader::from(
-                                    &header,
-                                ))
-                                .map_err(|err| StageError::Fatal(Box::new(err)))?,
-                            ),
-                        )?;
+                        self.header_collector
+                            .insert(header_number, Bytes::from(alloy_rlp::encode(&*header)))?;
 
                         // Headers are downloaded in reverse, so if we reach here, we know we have
                         // filled the gap.

--- a/crates/stages/stages/tests/preimage.rs
+++ b/crates/stages/stages/tests/preimage.rs
@@ -1,6 +1,9 @@
 //! Preimage-specific pipeline tests for storage v2 selfdestruct behavior around Cancun.
 
-use alloy_consensus::{constants::ETH_TO_WEI, Header, TxEip1559, TxReceipt};
+use alloy_consensus::{
+    constants::{EMPTY_WITHDRAWALS, ETH_TO_WEI},
+    Header, TxEip1559, TxReceipt,
+};
 use alloy_eips::eip1559::INITIAL_BASE_FEE;
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{bytes, keccak256, Address, Bytes, TxKind, B256, U256};
@@ -977,6 +980,7 @@ fn execute_and_commit_block(
         parent_beacon_block_root: (timestamp >= 30).then_some(B256::ZERO),
         blob_gas_used: (timestamp >= 30).then_some(0),
         excess_blob_gas: (timestamp >= 30).then_some(0),
+        withdrawals_root: Some(EMPTY_WITHDRAWALS),
         ..Default::default()
     };
 


### PR DESCRIPTION
bincode is unmaintained and can be fully replaced with rlp for primitives, this is a first step towards it 