### PR TITLE
revert: "fix(engine/tree): continue sync-target progression for already-seen downloaded blocks"

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2688,10 +2688,7 @@ where
 
         // try to append the block
         match self.insert_block(block) {
-            Ok(
-                InsertPayloadOk::Inserted(BlockStatus::Valid) |
-                InsertPayloadOk::AlreadySeen(BlockStatus::Valid),
-            ) => {
+            Ok(InsertPayloadOk::Inserted(BlockStatus::Valid)) => {
                 return self.on_valid_downloaded_block(block_num_hash);
             }
             Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected { head, missing_ancestor })) => {


### PR DESCRIPTION
Reverts paradigmxyz/reth#22628

we cant invoke on_valid_downloaded_block on alreadyseen because this can cause side-effects