### PR TITLE
fix: gracefully shut down engine

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -372,7 +372,7 @@ impl EngineNodeLauncher {
                             );
                         }
                     }
-                    _ = &mut on_graceful_shutdown => {
+                    _guard = &mut on_graceful_shutdown => {
                         // Shutdown signal received.
                         // Send Terminate so the engine OS thread can exit cleanly before we
                         // drop the orchestrator.
@@ -390,7 +390,7 @@ impl EngineNodeLauncher {
             let _ = exit.send(res);
         };
         ctx.task_executor()
-            .spawn_critical_with_shutdown_signal("consensus engine", consensus_engine);
+            .spawn_critical_with_graceful_shutdown_signal("consensus engine", consensus_engine);
 
         let engine_events_for_ethstats = engine_events.new_listener();
 

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -576,35 +576,6 @@ impl Runtime {
     /// This spawns a critical task onto the runtime.
     ///
     /// If this task panics, the [`TaskManager`] is notified.
-    pub fn spawn_critical_with_shutdown_signal<F>(
-        &self,
-        name: &'static str,
-        f: impl FnOnce(Shutdown) -> F,
-    ) -> JoinHandle<()>
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        let panicked_tasks_tx = self.0.task_events_tx.clone();
-        let on_shutdown = self.0.on_shutdown.clone();
-        let fut = f(on_shutdown);
-
-        // wrap the task in catch unwind
-        let task = std::panic::AssertUnwindSafe(fut)
-            .catch_unwind()
-            .map_err(move |error| {
-                let task_error = PanickedTaskError::new(name, error);
-                error!("{task_error}");
-                let _ = panicked_tasks_tx.send(TaskEvent::Panic(task_error));
-            })
-            .map(drop)
-            .in_current_span();
-
-        self.0.handle.spawn(task)
-    }
-
-    /// This spawns a critical task onto the runtime.
-    ///
-    /// If this task panics, the [`TaskManager`] is notified.
     /// The [`TaskManager`] will wait until the given future has completed before shutting down.
     ///
     /// # Example


### PR DESCRIPTION
Right now on runtime shutdown we start persisting blocks but don't actually wait for persistence to finish before exiting which results in inconsistencies on startup,

This PR changes how engine is spawned so that we keep the graceful shutdown guard and properly wait for persistence to finish