### PR TITLE
fix(rpc): apply evm_memory_limit to all execution RPC methods

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -138,6 +138,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     // Always disable EIP-3607
                     evm_env.cfg_env.disable_eip3607 = true;
 
+                    // Apply the configured EVM memory limit per RPC request.
+                    evm_env.cfg_env.memory_limit = this.evm_memory_limit();
+
                     if !validation {
                         // If not explicitly required, we disable nonce check <https://github.com/paradigmxyz/reth/issues/16108>
                         evm_env.cfg_env.disable_nonce_check = true;
@@ -500,6 +503,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // Disable additional fee charges (e.g. L2 operator fees),
             // consistent with prepare_call_env and estimate_gas_with.
             evm_env.cfg_env.disable_fee_charge = true;
+
+            // Apply the configured EVM memory limit per RPC request.
+            evm_env.cfg_env.memory_limit = this.evm_memory_limit();
 
             // Disable EIP-7825 transaction gas limit cap so that the gas limit
             // fallback (block gas limit) is not rejected when it exceeds the

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -67,6 +67,9 @@ pub trait EstimateCall: Call {
         // consistent with `prepare_call_env` for `eth_call`.
         evm_env.cfg_env.disable_fee_charge = true;
 
+        // Apply the configured EVM memory limit per RPC request.
+        evm_env.cfg_env.memory_limit = self.evm_memory_limit();
+
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
 


### PR DESCRIPTION
Was poking around `cfg_env` setup across the RPC handlers and noticed `memory_limit` only gets set in one place:


`call.rs:899: evm_env.cfg_env.memory_limit = self.evm_memory_limit();  // prepare_call_env — eth_call only`
`eth_estimateGas`, `eth_createAccessList`, and `eth_simulateV1` all skip it, so they run with revm's default of `u64::MAX` — effectively no cap. Someone could craft a call through any of those three endpoints and blow past the configured limit without touching `eth_call`.

Added `evm_env.cfg_env.memory_limit = self.evm_memory_limit()` to `estimate_gas_with`, `create_access_list_with`, and `simulate_v1` to match what `prepare_call_env` already does.