### PR TITLE
perf(rpc): avoid cloning InvalidBlock sealed block

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -75,7 +75,7 @@ where
             while let Some(event) = stream.next().await {
                 if let ConsensusEngineEvent::InvalidBlock(block) = event &&
                     let Ok(recovered) =
-                        RecoveredBlock::try_recover_sealed(block.as_ref().clone())
+                        RecoveredBlock::try_recover_sealed(*block)
                 {
                     bad_block_store.insert(recovered);
                 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -74,8 +74,7 @@ where
         executor.spawn_task(async move {
             while let Some(event) = stream.next().await {
                 if let ConsensusEngineEvent::InvalidBlock(block) = event &&
-                    let Ok(recovered) =
-                        RecoveredBlock::try_recover_sealed(*block)
+                    let Ok(recovered) = RecoveredBlock::try_recover_sealed(*block)
                 {
                     bad_block_store.insert(recovered);
                 }


### PR DESCRIPTION
Use the owned InvalidBlock payload by moving out of `Box<SealedBlock>`, removing an unnecessary deep clone before sender recovery.