### PR TITLE
perf(txpool): replace sender hash maps with Vec-backed SenderSlotMap

### DIFF
--- a/crates/transaction-pool/src/identifier.rs
+++ b/crates/transaction-pool/src/identifier.rs
@@ -1,6 +1,5 @@
 //! Identifier types for transactions and senders.
 use alloy_primitives::{map::AddressMap, Address};
-use rustc_hash::FxHashMap;
 
 /// An internal mapping of addresses.
 ///
@@ -13,7 +12,7 @@ pub struct SenderIdentifiers {
     /// Assigned [`SenderId`] for an [`Address`].
     address_to_id: AddressMap<SenderId>,
     /// Reverse mapping of [`SenderId`] to [`Address`].
-    sender_to_address: FxHashMap<SenderId, Address>,
+    sender_to_address: SenderSlotMap<Address>,
 }
 
 impl SenderIdentifiers {
@@ -76,11 +75,132 @@ impl SenderId {
     pub const fn into_transaction_id(self, nonce: u64) -> TransactionId {
         TransactionId::new(self, nonce)
     }
+
+    /// Returns the inner id as a `usize` index for use with [`SenderSlotMap`].
+    #[inline]
+    const fn index(self) -> usize {
+        self.0 as usize
+    }
 }
 
 impl From<u64> for SenderId {
     fn from(value: u64) -> Self {
         Self(value)
+    }
+}
+
+/// A dense, `Vec`-backed map keyed by [`SenderId`].
+///
+/// Since `SenderId` values are monotonically assigned starting from 0, this avoids all hashing
+/// overhead and provides O(1) indexed access with better cache locality than a `HashMap`.
+#[derive(Debug, Clone)]
+pub struct SenderSlotMap<T> {
+    slots: Vec<Option<T>>,
+    len: usize,
+}
+
+impl<T> Default for SenderSlotMap<T> {
+    fn default() -> Self {
+        Self { slots: Vec::new(), len: 0 }
+    }
+}
+
+impl<T> SenderSlotMap<T> {
+    /// Returns a reference to the value for the given sender, if present.
+    #[inline]
+    pub fn get(&self, id: &SenderId) -> Option<&T> {
+        self.slots.get(id.index())?.as_ref()
+    }
+
+    /// Returns a mutable reference to the value for the given sender, if present.
+    #[inline]
+    pub fn get_mut(&mut self, id: &SenderId) -> Option<&mut T> {
+        self.slots.get_mut(id.index())?.as_mut()
+    }
+
+    /// Inserts a value for the given sender, returning the previous value if any.
+    pub fn insert(&mut self, id: SenderId, value: T) -> Option<T> {
+        let idx = id.index();
+        if idx >= self.slots.len() {
+            self.slots.resize_with(idx + 1, || None);
+        }
+        let old = self.slots[idx].replace(value);
+        if old.is_none() {
+            self.len += 1;
+        }
+        old
+    }
+
+    /// Removes and returns the value for the given sender.
+    pub fn remove(&mut self, id: &SenderId) -> Option<T> {
+        let slot = self.slots.get_mut(id.index())?;
+        let old = slot.take()?;
+        self.len -= 1;
+        Some(old)
+    }
+
+    /// Returns `true` if the map contains a value for the given sender.
+    #[inline]
+    pub fn contains_key(&self, id: &SenderId) -> bool {
+        self.slots.get(id.index()).is_some_and(|s| s.is_some())
+    }
+
+    /// Returns the number of occupied entries.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if there are no occupied entries.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Removes all entries.
+    pub fn clear(&mut self) {
+        self.slots.clear();
+        self.len = 0;
+    }
+
+    /// Returns an iterator over all values.
+    pub fn values(&self) -> impl Iterator<Item = &T> {
+        self.slots.iter().filter_map(|s| s.as_ref())
+    }
+
+    /// Returns an iterator over all `(SenderId, &T)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (SenderId, &T)> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.as_ref().map(|v| (SenderId(i as u64), v)))
+    }
+
+    /// Returns a mutable reference to the value for the given sender, inserting the default if
+    /// absent.
+    pub fn get_or_insert_default(&mut self, id: SenderId) -> &mut T
+    where
+        T: Default,
+    {
+        let idx = id.index();
+        if idx >= self.slots.len() {
+            self.slots.resize_with(idx + 1, || None);
+        }
+        if self.slots[idx].is_none() {
+            self.slots[idx] = Some(T::default());
+            self.len += 1;
+        }
+        self.slots[idx].as_mut().unwrap()
+    }
+
+    /// Extends the map with the contents of an iterator.
+    pub fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = (SenderId, T)>,
+    {
+        for (id, value) in iter {
+            self.insert(id, value);
+        }
     }
 }
 
@@ -274,5 +394,74 @@ mod tests {
         } else {
             panic!("Expected included bound");
         }
+    }
+
+    #[test]
+    fn test_sender_slot_map_insert_get_remove() {
+        let mut map = SenderSlotMap::default();
+        let id0 = SenderId(0);
+        let id5 = SenderId(5);
+
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+
+        map.insert(id0, 10u32);
+        map.insert(id5, 50u32);
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&id0), Some(&10));
+        assert_eq!(map.get(&id5), Some(&50));
+        assert_eq!(map.get(&SenderId(3)), None);
+        assert!(map.contains_key(&id0));
+        assert!(!map.contains_key(&SenderId(3)));
+
+        // overwrite
+        map.insert(id0, 11);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&id0), Some(&11));
+
+        // remove
+        assert_eq!(map.remove(&id0), Some(11));
+        assert_eq!(map.len(), 1);
+        assert!(!map.contains_key(&id0));
+
+        // remove non-existent
+        assert_eq!(map.remove(&SenderId(99)), None);
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_sender_slot_map_values_and_iter() {
+        let mut map = SenderSlotMap::default();
+        map.insert(SenderId(1), "a");
+        map.insert(SenderId(3), "b");
+        map.insert(SenderId(5), "c");
+
+        let values: Vec<_> = map.values().collect();
+        assert_eq!(values, vec![&"a", &"b", &"c"]);
+
+        let pairs: Vec<_> = map.iter().collect();
+        assert_eq!(pairs, vec![(SenderId(1), &"a"), (SenderId(3), &"b"), (SenderId(5), &"c")]);
+    }
+
+    #[test]
+    fn test_sender_slot_map_get_or_insert_default() {
+        let mut map = SenderSlotMap::<usize>::default();
+        let id = SenderId(2);
+        *map.get_or_insert_default(id) += 1;
+        *map.get_or_insert_default(id) += 1;
+        assert_eq!(map.get(&id), Some(&2));
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_sender_slot_map_clear() {
+        let mut map = SenderSlotMap::default();
+        map.insert(SenderId(0), 1);
+        map.insert(SenderId(1), 2);
+        assert_eq!(map.len(), 2);
+        map.clear();
+        assert!(map.is_empty());
+        assert_eq!(map.get(&SenderId(0)), None);
     }
 }

--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -1,13 +1,12 @@
 use crate::{
-    identifier::{SenderId, TransactionId},
+    identifier::{SenderId, SenderSlotMap, TransactionId},
     pool::size::SizeTracker,
     PoolTransaction, SubPoolLimit, ValidPoolTransaction, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
 };
-use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{
     cmp::Ordering,
-    collections::{hash_map::Entry, BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet},
     ops::{Bound::Unbounded, Deref},
     sync::Arc,
 };
@@ -33,7 +32,7 @@ pub struct ParkedPool<T: ParkedOrd> {
     last_sender_submission: BTreeSet<SubmissionSenderId>,
     /// Keeps track of the number of transactions in the pool by the sender and the last submission
     /// id.
-    sender_transaction_count: FxHashMap<SenderId, SenderTransactionCount>,
+    sender_transaction_count: SenderSlotMap<SenderTransactionCount>,
     /// Keeps track of the size of this pool.
     ///
     /// See also [`reth_primitives_traits::InMemorySize::size`].
@@ -66,20 +65,18 @@ impl<T: ParkedOrd> ParkedPool<T> {
     /// Increments the count of transactions for the given sender and updates the tracked submission
     /// id.
     fn add_sender_count(&mut self, sender: SenderId, submission_id: u64) {
-        match self.sender_transaction_count.entry(sender) {
-            Entry::Occupied(mut entry) => {
-                let value = entry.get_mut();
-                // remove the __currently__ tracked submission id
-                self.last_sender_submission
-                    .remove(&SubmissionSenderId::new(sender, value.last_submission_id));
+        if let Some(value) = self.sender_transaction_count.get_mut(&sender) {
+            // remove the __currently__ tracked submission id
+            self.last_sender_submission
+                .remove(&SubmissionSenderId::new(sender, value.last_submission_id));
 
-                value.count += 1;
-                value.last_submission_id = submission_id;
-            }
-            Entry::Vacant(entry) => {
-                entry
-                    .insert(SenderTransactionCount { count: 1, last_submission_id: submission_id });
-            }
+            value.count += 1;
+            value.last_submission_id = submission_id;
+        } else {
+            self.sender_transaction_count.insert(
+                sender,
+                SenderTransactionCount { count: 1, last_submission_id: submission_id },
+            );
         }
         // insert a new entry
         self.last_sender_submission.insert(SubmissionSenderId::new(sender, submission_id));
@@ -92,21 +89,17 @@ impl<T: ParkedOrd> ParkedPool<T> {
     /// Note: this does not update the tracked submission id for the sender, because we're only
     /// interested in the __last__ submission id when truncating the pool.
     fn remove_sender_count(&mut self, sender_id: SenderId) {
-        let removed_sender = match self.sender_transaction_count.entry(sender_id) {
-            Entry::Occupied(mut entry) => {
-                let value = entry.get_mut();
-                value.count -= 1;
-                if value.count == 0 {
-                    entry.remove()
-                } else {
-                    return
-                }
-            }
-            Entry::Vacant(_) => {
-                // This should never happen because the bisection between the two maps
-                unreachable!("sender count not found {:?}", sender_id);
-            }
+        let Some(value) = self.sender_transaction_count.get_mut(&sender_id) else {
+            unreachable!("sender count not found {:?}", sender_id);
         };
+
+        value.count -= 1;
+        if value.count > 0 {
+            return;
+        }
+
+        let removed_sender =
+            self.sender_transaction_count.remove(&sender_id).expect("sender count not found");
 
         // all transactions for this sender have been removed
         assert!(

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -1,20 +1,15 @@
 //! Pending transactions
 
 use crate::{
-    identifier::{SenderId, TransactionId},
+    identifier::{SenderId, SenderSlotMap, TransactionId},
     pool::{
         best::{BestTransactions, BestTransactionsWithFees},
         size::SizeTracker,
     },
     Priority, SubPoolLimit, TransactionOrdering, ValidPoolTransaction,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
-use std::{
-    cmp::Ordering,
-    collections::{hash_map::Entry, BTreeMap},
-    ops::Bound::Unbounded,
-    sync::Arc,
-};
+use rustc_hash::FxHashSet;
+use std::{cmp::Ordering, collections::BTreeMap, ops::Bound::Unbounded, sync::Arc};
 use tokio::sync::broadcast;
 
 /// A pool of validated and gapless transactions that are ready to be executed on the current state
@@ -39,10 +34,10 @@ pub struct PendingPool<T: TransactionOrdering> {
     by_id: BTreeMap<TransactionId, PendingTransaction<T>>,
     /// The highest nonce transactions for each sender - like the `independent` set, but the
     /// highest instead of lowest nonce.
-    highest_nonces: FxHashMap<SenderId, PendingTransaction<T>>,
+    highest_nonces: SenderSlotMap<PendingTransaction<T>>,
     /// Independent transactions that can be included directly and don't require other
     /// transactions.
-    independent_transactions: FxHashMap<SenderId, PendingTransaction<T>>,
+    independent_transactions: SenderSlotMap<PendingTransaction<T>>,
     /// Keeps track of the size of this pool.
     ///
     /// See also [`reth_primitives_traits::InMemorySize::size`].
@@ -254,25 +249,20 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// Updates the independent transaction and highest nonces set, assuming the given transaction
     /// is being _added_ to the pool.
     fn update_independents_and_highest_nonces(&mut self, tx: &PendingTransaction<T>) {
-        match self.highest_nonces.entry(tx.transaction.sender_id()) {
-            Entry::Occupied(mut entry) => {
-                if entry.get().transaction.nonce() < tx.transaction.nonce() {
-                    *entry.get_mut() = tx.clone();
-                }
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(tx.clone());
-            }
+        let sender = tx.transaction.sender_id();
+        if self
+            .highest_nonces
+            .get(&sender)
+            .is_none_or(|existing| existing.transaction.nonce() < tx.transaction.nonce())
+        {
+            self.highest_nonces.insert(sender, tx.clone());
         }
-        match self.independent_transactions.entry(tx.transaction.sender_id()) {
-            Entry::Occupied(mut entry) => {
-                if entry.get().transaction.nonce() > tx.transaction.nonce() {
-                    *entry.get_mut() = tx.clone();
-                }
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(tx.clone());
-            }
+        if self
+            .independent_transactions
+            .get(&sender)
+            .is_none_or(|existing| existing.transaction.nonce() > tx.transaction.nonce())
+        {
+            self.independent_transactions.insert(sender, tx.clone());
         }
     }
 
@@ -332,33 +322,25 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let tx = self.by_id.remove(id)?;
         self.size_of -= tx.transaction.size();
 
-        match self.highest_nonces.entry(id.sender) {
-            Entry::Occupied(mut entry) => {
-                if entry.get().transaction.nonce() == id.nonce {
-                    // we just removed the tx with the highest nonce for this sender, find the
-                    // highest remaining tx from that sender
-                    if let Some((_, new_highest)) = self
-                        .by_id
-                        .range((
-                            id.sender.start_bound(),
-                            std::ops::Bound::Included(TransactionId::new(id.sender, u64::MAX)),
-                        ))
-                        .last()
-                    {
-                        // insert the new highest nonce for this sender
-                        entry.insert(new_highest.clone());
-                    } else {
-                        entry.remove();
-                    }
+        if let Some(highest) = self.highest_nonces.get(&id.sender) {
+            if highest.transaction.nonce() == id.nonce {
+                // we just removed the tx with the highest nonce for this sender, find the
+                // highest remaining tx from that sender
+                if let Some((_, new_highest)) = self
+                    .by_id
+                    .range((
+                        id.sender.start_bound(),
+                        std::ops::Bound::Included(TransactionId::new(id.sender, u64::MAX)),
+                    ))
+                    .last()
+                {
+                    self.highest_nonces.insert(id.sender, new_highest.clone());
+                } else {
+                    self.highest_nonces.remove(&id.sender);
                 }
             }
-            Entry::Vacant(_) => {
-                debug_assert!(
-                    false,
-                    "removed transaction without a tracked highest nonce {:?}",
-                    id
-                );
-            }
+        } else {
+            debug_assert!(false, "removed transaction without a tracked highest nonce {:?}", id);
         }
 
         Some(tx.transaction)
@@ -530,7 +512,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
     }
 
     /// Independent transactions
-    pub const fn independent_transactions(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
+    pub const fn independent_transactions(&self) -> &SenderSlotMap<PendingTransaction<T>> {
         &self.independent_transactions
     }
 
@@ -585,7 +567,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
     /// Returns a reference to the independent transactions in the pool
     #[cfg(test)]
-    pub(crate) const fn independent(&self) -> &FxHashMap<SenderId, PendingTransaction<T>> {
+    pub(crate) const fn independent(&self) -> &SenderSlotMap<PendingTransaction<T>> {
         &self.independent_transactions
     }
 

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -6,7 +6,7 @@ use crate::{
         Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
         PoolError, PoolErrorKind,
     },
-    identifier::{SenderId, TransactionId},
+    identifier::{SenderId, SenderSlotMap, TransactionId},
     metrics::{AllTransactionsMetrics, TxPoolMetrics},
     pool::{
         best::BestTransactions,
@@ -37,7 +37,7 @@ use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{
     cmp::Ordering,
-    collections::{btree_map::Entry, hash_map, BTreeMap, HashMap, HashSet},
+    collections::{btree_map::Entry, BTreeMap, HashMap, HashSet},
     fmt,
     ops::Bound::{Excluded, Unbounded},
     sync::Arc,
@@ -761,8 +761,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         // Update sender info with balance and nonce
         self.all_transactions
             .sender_info
-            .entry(tx.sender_id())
-            .or_default()
+            .get_or_insert_default(tx.sender_id())
             .update(on_chain_nonce, on_chain_balance);
 
         match self.all_transactions.insert_tx(tx, on_chain_balance, on_chain_nonce) {
@@ -1391,9 +1390,9 @@ pub(crate) struct AllTransactions<T: PoolTransaction> {
     /// _All_ transaction in the pool sorted by their sender and nonce pair.
     txs: BTreeMap<TransactionId, PoolInternalTransaction<T>>,
     /// Contains the currently known information about the senders.
-    sender_info: FxHashMap<SenderId, SenderInfo>,
+    sender_info: SenderSlotMap<SenderInfo>,
     /// Tracks the number of transactions by sender that are currently in the pool.
-    tx_counter: FxHashMap<SenderId, usize>,
+    tx_counter: SenderSlotMap<usize>,
     /// The current block number the pool keeps track of.
     last_seen_block_number: u64,
     /// The current block hash the pool keeps track of.
@@ -1405,7 +1404,7 @@ pub(crate) struct AllTransactions<T: PoolTransaction> {
     /// How to handle [`TransactionOrigin::Local`](crate::TransactionOrigin) transactions.
     local_transactions_config: LocalTransactionConfig,
     /// All accounts with a pooled authorization
-    auths: FxHashMap<SenderId, HashSet<TxHash>>,
+    auths: SenderSlotMap<HashSet<TxHash>>,
     /// All Transactions metrics
     metrics: AllTransactionsMetrics,
 }
@@ -1448,17 +1447,15 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
     /// Increments the transaction counter for the sender
     pub(crate) fn tx_inc(&mut self, sender: SenderId) {
-        let count = self.tx_counter.entry(sender).or_default();
-        *count += 1;
+        *self.tx_counter.get_or_insert_default(sender) += 1;
         self.metrics.all_transactions_by_all_senders.increment(1.0);
     }
 
     /// Decrements the transaction counter for the sender
     pub(crate) fn tx_decr(&mut self, sender: SenderId) {
-        if let hash_map::Entry::Occupied(mut entry) = self.tx_counter.entry(sender) {
-            let count = entry.get_mut();
+        if let Some(count) = self.tx_counter.get_mut(&sender) {
             if *count == 1 {
-                entry.remove();
+                self.tx_counter.remove(&sender);
                 self.sender_info.remove(&sender);
                 self.metrics.all_transactions_by_all_senders.decrement(1.0);
                 return
@@ -1822,11 +1819,14 @@ impl<T: PoolTransaction> AllTransactions<T> {
 
         let tx_hash = tx.transaction.hash();
         for auth in auths {
-            if let Some(list) = self.auths.get_mut(auth) {
+            let should_remove = if let Some(list) = self.auths.get_mut(auth) {
                 list.remove(tx_hash);
-                if list.is_empty() {
-                    self.auths.remove(auth);
-                }
+                list.is_empty()
+            } else {
+                false
+            };
+            if should_remove {
+                self.auths.remove(auth);
             }
         }
     }
@@ -2080,7 +2080,7 @@ impl<T: PoolTransaction> AllTransactions<T> {
         if let Some(auths) = &transaction.authority_ids {
             let tx_hash = transaction.hash();
             for auth in auths {
-                self.auths.entry(*auth).or_default().insert(*tx_hash);
+                self.auths.get_or_insert_default(*auth).insert(*tx_hash);
             }
         }
 


### PR DESCRIPTION
SenderId is a monotonically-assigned u64 starting from 0, but all sender-keyed maps use FxHashMap. This replaces them with `SenderSlotMap<T>`, a dense `Vec<Option<T>>` indexed directly by sender id — zero hashing, O(1) access, better cache locality.

Replaced maps:
- `SenderIdentifiers::sender_to_address`
- `AllTransactions::sender_info`, `tx_counter`, `auths`
- `PendingPool::highest_nonces`, `independent_transactions`
- `ParkedPool::sender_transaction_count`

Co-Authored-By: YK <46377366+yongkangc@users.noreply.github.com>

Prompted by: yk