### PR TITLE
fix(engine): handle stream termination in MiningMode::Trigger

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -119,7 +119,7 @@ impl<Pool: TransactionPool + Unpin> Future for MiningMode<Pool> {
                 Poll::Pending
             }
             Self::Trigger(trigger) => {
-                if trigger.poll_next_unpin(cx).is_ready() {
+                if let Poll::Ready(Some(_)) = trigger.poll_next_unpin(cx) {
                     return Poll::Ready(())
                 }
                 Poll::Pending


### PR DESCRIPTION
`MiningMode::Trigger` uses `is_ready()` to check if the stream yielded a value, but this also returns true when the stream terminates (`Ready(None)`). 

Match the pattern used in `MiningMode::Instant` which correctly checks `Poll::Ready(Some(_))` to only trigger on actual stream items.