### PR TITLE
chore(ci): ping AI agent on nightly Docker build failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -183,6 +183,8 @@ jobs:
             *Run:* <https://github.com/paradigmxyz/reth/actions/runs/${{ github.run_id }}|View logs>
 
             *Action required:* Re-run the workflow or investigate the build failure.
+
+            <@U0AAA8F0JEM> investigate and re-run if flaky
           SLACK_FOOTER: "paradigmxyz/reth · docker.yml"
           MSG_MINIMAL: true
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Adds an @ai mention to the Slack notification when the scheduled nightly Docker build fails, so the agent can investigate the logs and re-run if the failure is flaky.