### PR TITLE
revert: perf(trie): call update_subtrie_hashes after every update

### DIFF
--- a/.changelog/nice-whales-buzz.md
+++ b/.changelog/nice-whales-buzz.md
@@ -1,5 +1,0 @@
----
-reth-engine-tree: patch
----
-
-Added idle-time pre-computation of account trie upper hashes in the sparse trie payload processor when no pending proof results are available.

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -335,12 +335,6 @@ where
                 }
 
                 self.dispatch_pending_targets();
-
-                // If there's still no pending updates spend some time pre-computing the account
-                // trie upper hashes
-                if self.proof_result_rx.is_empty() {
-                    self.trie.calculate_subtries();
-                }
             } else if self.updates.is_empty() || self.pending_updates > MAX_PENDING_UPDATES {
                 // If we don't have any pending updates OR we've accumulated a lot already, apply
                 // them to the trie,


### PR DESCRIPTION
Reverts #23052 (commit 35dc30561f512eb2f31419d0a1a672f26db6f2a4) to investigate a potential regression in trie performance observed between 03/15 and 03/18.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: brian