### PR TITLE
chore(bench): tag tim and alexey on nightly bench failures

### DIFF
--- a/.github/scripts/bench-slack-users.json
+++ b/.github/scripts/bench-slack-users.json
@@ -20,5 +20,6 @@
   "SuperFluffy": "U095BKHB2Q4",
   "kamsz": "U0A2563UBRD",
   "zerosnacks": "U09FARPMN74",
-  "samczsun": "U096R14E4H3"
+  "samczsun": "U096R14E4H3",
+  "laibe": "U09FARE0B9Q"
 }

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -819,7 +819,7 @@ jobs:
               },
               {
                 type: 'section',
-                text: { type: 'mrkdwn', text: `*Nightly regression* failed while *${failedStep}*` },
+                text: { type: 'mrkdwn', text: `*Nightly regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>` },
               },
               {
                 type: 'actions',


### PR DESCRIPTION
Adds Tim and Alexey mentions to the nightly bench failure Slack notification so they get pinged when it breaks. Also adds `laibe` (Tim) to `bench-slack-users.json`.

Prompted by: Emma