### PR TITLE
feat(bench): add --wait-for-persistence flag

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -244,7 +244,7 @@ BENCH_NICE="sudo nice -n -20 sudo -u $(id -un)"
 # Build optional flags
 EXTRA_BENCH_ARGS=()
 if [ "${BENCH_RETH_NEW_PAYLOAD:-true}" != "false" ]; then
-  EXTRA_BENCH_ARGS+=(--reth-new-payload)
+  EXTRA_BENCH_ARGS+=(--reth-new-payload --wait-for-persistence)
 fi
 if [ -n "${BENCH_WAIT_TIME:-}" ]; then
   EXTRA_BENCH_ARGS+=(--wait-time "$BENCH_WAIT_TIME")

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -38,7 +38,7 @@ pub(crate) struct BenchContext {
     /// Whether to skip waiting for caches (pass `wait_for_caches: false`).
     pub(crate) no_wait_for_caches: bool,
     /// When set, wait for persistence every N blocks (pass `wait_for_persistence: true` on those).
-    pub(crate) force_persistence_every_n_blocks: Option<u64>,
+    pub(crate) wait_for_persistence_every: Option<u64>,
 }
 
 impl BenchContext {
@@ -168,9 +168,9 @@ impl BenchContext {
 
         let next_block = first_block.header.number + 1;
         let rlp_blocks = bench_args.rlp_blocks;
-        let force_persistence_every_n_blocks = bench_args.force_persistence_every_n_blocks;
+        let wait_for_persistence_every = bench_args.wait_for_persistence_every;
         let use_reth_namespace =
-            bench_args.reth_new_payload || rlp_blocks || force_persistence_every_n_blocks.is_some();
+            bench_args.reth_new_payload || rlp_blocks || wait_for_persistence_every.is_some();
         let no_wait_for_persistence = bench_args.no_wait_for_persistence;
         let no_wait_for_caches = bench_args.no_wait_for_caches;
         Ok(Self {
@@ -183,7 +183,7 @@ impl BenchContext {
             rlp_blocks,
             no_wait_for_persistence,
             no_wait_for_caches,
-            force_persistence_every_n_blocks,
+            wait_for_persistence_every,
         })
     }
 }

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -167,7 +167,7 @@ impl BenchContext {
         let next_block = first_block.header.number + 1;
         let rlp_blocks = bench_args.rlp_blocks;
         let wait_for_persistence =
-            bench_args.wait_for_persistence.unwrap_or(WaitForPersistence::Always);
+            bench_args.wait_for_persistence.unwrap_or(WaitForPersistence::Never);
         let use_reth_namespace =
             bench_args.reth_new_payload || rlp_blocks || bench_args.wait_for_persistence.is_some();
         let no_wait_for_caches = bench_args.no_wait_for_caches;

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -168,8 +168,7 @@ impl BenchContext {
         let rlp_blocks = bench_args.rlp_blocks;
         let wait_for_persistence =
             bench_args.wait_for_persistence.unwrap_or(WaitForPersistence::Never);
-        let use_reth_namespace =
-            bench_args.reth_new_payload || rlp_blocks || bench_args.wait_for_persistence.is_some();
+        let use_reth_namespace = bench_args.reth_new_payload || rlp_blocks;
         let no_wait_for_caches = bench_args.no_wait_for_caches;
         Ok(Self {
             auth_provider,

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -37,6 +37,8 @@ pub(crate) struct BenchContext {
     pub(crate) no_wait_for_persistence: bool,
     /// Whether to skip waiting for caches (pass `wait_for_caches: false`).
     pub(crate) no_wait_for_caches: bool,
+    /// When set, wait for persistence every N blocks (pass `wait_for_persistence: true` on those).
+    pub(crate) force_persistence_every_n_blocks: Option<u64>,
 }
 
 impl BenchContext {
@@ -166,7 +168,9 @@ impl BenchContext {
 
         let next_block = first_block.header.number + 1;
         let rlp_blocks = bench_args.rlp_blocks;
-        let use_reth_namespace = bench_args.reth_new_payload || rlp_blocks;
+        let force_persistence_every_n_blocks = bench_args.force_persistence_every_n_blocks;
+        let use_reth_namespace =
+            bench_args.reth_new_payload || rlp_blocks || force_persistence_every_n_blocks.is_some();
         let no_wait_for_persistence = bench_args.no_wait_for_persistence;
         let no_wait_for_caches = bench_args.no_wait_for_caches;
         Ok(Self {
@@ -179,6 +183,7 @@ impl BenchContext {
             rlp_blocks,
             no_wait_for_persistence,
             no_wait_for_caches,
+            force_persistence_every_n_blocks,
         })
     }
 }

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -9,7 +9,7 @@ use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::JwtSecret;
 use alloy_transport::layers::{RateLimitRetryPolicy, RetryBackoffLayer};
 use reqwest::Url;
-use reth_node_core::args::BenchmarkArgs;
+use reth_node_core::args::{BenchmarkArgs, WaitForPersistence};
 use tracing::info;
 
 /// This is intended to be used by benchmarks that replay blocks from an RPC.
@@ -33,12 +33,10 @@ pub(crate) struct BenchContext {
     pub(crate) use_reth_namespace: bool,
     /// Whether to fetch and replay RLP-encoded blocks.
     pub(crate) rlp_blocks: bool,
-    /// Whether to skip waiting for persistence (pass `wait_for_persistence: false`).
-    pub(crate) no_wait_for_persistence: bool,
+    /// Controls when `reth_newPayload` waits for persistence.
+    pub(crate) wait_for_persistence: WaitForPersistence,
     /// Whether to skip waiting for caches (pass `wait_for_caches: false`).
     pub(crate) no_wait_for_caches: bool,
-    /// When set, wait for persistence every N blocks (pass `wait_for_persistence: true` on those).
-    pub(crate) wait_for_persistence_every: Option<u64>,
 }
 
 impl BenchContext {
@@ -168,10 +166,10 @@ impl BenchContext {
 
         let next_block = first_block.header.number + 1;
         let rlp_blocks = bench_args.rlp_blocks;
-        let wait_for_persistence_every = bench_args.wait_for_persistence_every;
+        let wait_for_persistence =
+            bench_args.wait_for_persistence.unwrap_or(WaitForPersistence::Always);
         let use_reth_namespace =
-            bench_args.reth_new_payload || rlp_blocks || wait_for_persistence_every.is_some();
-        let no_wait_for_persistence = bench_args.no_wait_for_persistence;
+            bench_args.reth_new_payload || rlp_blocks || bench_args.wait_for_persistence.is_some();
         let no_wait_for_caches = bench_args.no_wait_for_caches;
         Ok(Self {
             auth_provider,
@@ -181,9 +179,8 @@ impl BenchContext {
             is_optimism,
             use_reth_namespace,
             rlp_blocks,
-            no_wait_for_persistence,
+            wait_for_persistence,
             no_wait_for_caches,
-            wait_for_persistence_every,
         })
     }
 }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     valid_payload::{
         block_to_new_payload, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
-        PersistenceWaitMode,
     },
 };
 use alloy_provider::{ext::DebugApi, Provider};
@@ -96,9 +95,8 @@ impl Command {
             is_optimism,
             use_reth_namespace,
             rlp_blocks,
-            no_wait_for_persistence,
+            wait_for_persistence,
             no_wait_for_caches,
-            wait_for_persistence_every,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -201,19 +199,12 @@ impl Command {
                 finalized_block_hash: finalized,
             };
 
-            let persistence_mode = if let Some(n) = wait_for_persistence_every {
-                PersistenceWaitMode::EveryNBlocks(n)
-            } else if no_wait_for_persistence {
-                PersistenceWaitMode::Never
-            } else {
-                PersistenceWaitMode::Always
-            };
             let (version, params) = block_to_new_payload(
                 block,
                 is_optimism,
                 rlp,
                 use_reth_namespace,
-                persistence_mode,
+                wait_for_persistence,
                 no_wait_for_caches,
             )?;
             let start = Instant::now();

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -98,7 +98,7 @@ impl Command {
             rlp_blocks,
             no_wait_for_persistence,
             no_wait_for_caches,
-            force_persistence_every_n_blocks,
+            wait_for_persistence_every,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -201,7 +201,7 @@ impl Command {
                 finalized_block_hash: finalized,
             };
 
-            let persistence_mode = if let Some(n) = force_persistence_every_n_blocks {
+            let persistence_mode = if let Some(n) = wait_for_persistence_every {
                 PersistenceWaitMode::EveryNBlocks(n)
             } else if no_wait_for_persistence {
                 PersistenceWaitMode::Never

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     valid_payload::{
         block_to_new_payload, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
+        PersistenceWaitMode,
     },
 };
 use alloy_provider::{ext::DebugApi, Provider};
@@ -97,6 +98,7 @@ impl Command {
             rlp_blocks,
             no_wait_for_persistence,
             no_wait_for_caches,
+            force_persistence_every_n_blocks,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -199,12 +201,19 @@ impl Command {
                 finalized_block_hash: finalized,
             };
 
+            let persistence_mode = if let Some(n) = force_persistence_every_n_blocks {
+                PersistenceWaitMode::EveryNBlocks(n)
+            } else if no_wait_for_persistence {
+                PersistenceWaitMode::Never
+            } else {
+                PersistenceWaitMode::Always
+            };
             let (version, params) = block_to_new_payload(
                 block,
                 is_optimism,
                 rlp,
                 use_reth_namespace,
-                no_wait_for_persistence,
+                persistence_mode,
                 no_wait_for_caches,
             )?;
             let start = Instant::now();

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -54,7 +54,7 @@ impl Command {
             rlp_blocks,
             no_wait_for_persistence,
             no_wait_for_caches,
-            force_persistence_every_n_blocks,
+            wait_for_persistence_every,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -125,7 +125,7 @@ impl Command {
 
             debug!(target: "reth-bench", number=?block.header.number, "Sending payload to engine");
 
-            let persistence_mode = if let Some(n) = force_persistence_every_n_blocks {
+            let persistence_mode = if let Some(n) = wait_for_persistence_every {
                 PersistenceWaitMode::EveryNBlocks(n)
             } else if no_wait_for_persistence {
                 PersistenceWaitMode::Never

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -9,7 +9,7 @@ use crate::{
             NEW_PAYLOAD_OUTPUT_SUFFIX,
         },
     },
-    valid_payload::{block_to_new_payload, call_new_payload_with_reth, PersistenceWaitMode},
+    valid_payload::{block_to_new_payload, call_new_payload_with_reth},
 };
 use alloy_provider::{ext::DebugApi, Provider};
 use clap::Parser;
@@ -52,9 +52,8 @@ impl Command {
             is_optimism,
             use_reth_namespace,
             rlp_blocks,
-            no_wait_for_persistence,
+            wait_for_persistence,
             no_wait_for_caches,
-            wait_for_persistence_every,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -125,19 +124,12 @@ impl Command {
 
             debug!(target: "reth-bench", number=?block.header.number, "Sending payload to engine");
 
-            let persistence_mode = if let Some(n) = wait_for_persistence_every {
-                PersistenceWaitMode::EveryNBlocks(n)
-            } else if no_wait_for_persistence {
-                PersistenceWaitMode::Never
-            } else {
-                PersistenceWaitMode::Always
-            };
             let (version, params) = block_to_new_payload(
                 block,
                 is_optimism,
                 rlp,
                 use_reth_namespace,
-                persistence_mode,
+                wait_for_persistence,
                 no_wait_for_caches,
             )?;
 

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -9,7 +9,7 @@ use crate::{
             NEW_PAYLOAD_OUTPUT_SUFFIX,
         },
     },
-    valid_payload::{block_to_new_payload, call_new_payload_with_reth},
+    valid_payload::{block_to_new_payload, call_new_payload_with_reth, PersistenceWaitMode},
 };
 use alloy_provider::{ext::DebugApi, Provider};
 use clap::Parser;
@@ -54,6 +54,7 @@ impl Command {
             rlp_blocks,
             no_wait_for_persistence,
             no_wait_for_caches,
+            force_persistence_every_n_blocks,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -124,12 +125,19 @@ impl Command {
 
             debug!(target: "reth-bench", number=?block.header.number, "Sending payload to engine");
 
+            let persistence_mode = if let Some(n) = force_persistence_every_n_blocks {
+                PersistenceWaitMode::EveryNBlocks(n)
+            } else if no_wait_for_persistence {
+                PersistenceWaitMode::Never
+            } else {
+                PersistenceWaitMode::Always
+            };
             let (version, params) = block_to_new_payload(
                 block,
                 is_optimism,
                 rlp,
                 use_reth_namespace,
-                no_wait_for_persistence,
+                persistence_mode,
                 no_wait_for_caches,
             )?;
 

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -220,18 +220,10 @@ impl Command {
 
             let use_reth = self.reth_new_payload;
             let (version, params) = if use_reth {
-                let mode = self.wait_for_persistence.unwrap_or(WaitForPersistence::Never);
-                let wait_for_persistence = match mode {
-                    WaitForPersistence::Always => None,
-                    WaitForPersistence::Never => Some(false),
-                    WaitForPersistence::EveryN(n) => {
-                        if block_number % n == 0 {
-                            Some(true)
-                        } else {
-                            Some(false)
-                        }
-                    }
-                };
+                let wait_for_persistence = self
+                    .wait_for_persistence
+                    .unwrap_or(WaitForPersistence::Never)
+                    .rpc_value(block_number);
                 let reth_data = ExecutionData {
                     payload: execution_payload.clone().into(),
                     sidecar: ExecutionPayloadSidecar::v4(

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -95,6 +95,16 @@ pub struct Command {
     #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
     no_wait_for_caches: bool,
 
+    /// Force waiting for persistence every N blocks during replay.
+    ///
+    /// When set, passes `wait_for_persistence: true` to `reth_newPayload` every N blocks
+    /// and `wait_for_persistence: false` for all other blocks. This applies back-pressure
+    /// to prevent OOM during long-running benchmark runs.
+    ///
+    /// Implies `--reth-new-payload`.
+    #[arg(long, value_name = "N", verbatim_doc_comment)]
+    force_persistence_every_n_blocks: Option<u64>,
+
     /// Optional Prometheus metrics endpoint to scrape after each block.
     ///
     /// When provided, reth-bench will fetch metrics from this URL after each
@@ -207,7 +217,19 @@ impl Command {
                 "Sending newPayload"
             );
 
-            let (version, params) = if self.reth_new_payload {
+            let use_reth = self.reth_new_payload || self.force_persistence_every_n_blocks.is_some();
+            let (version, params) = if use_reth {
+                let wait_for_persistence = if let Some(n) = self.force_persistence_every_n_blocks {
+                    if n > 0 && block_number % n == 0 {
+                        Some(true)
+                    } else {
+                        Some(false)
+                    }
+                } else if self.no_wait_for_persistence {
+                    Some(false)
+                } else {
+                    None
+                };
                 let reth_data = ExecutionData {
                     payload: execution_payload.clone().into(),
                     sidecar: ExecutionPayloadSidecar::v4(
@@ -224,7 +246,7 @@ impl Command {
                     None,
                     serde_json::to_value((
                         RethNewPayloadInput::ExecutionData(reth_data),
-                        self.no_wait_for_persistence.then_some(false),
+                        wait_for_persistence,
                         self.no_wait_for_caches.then_some(false),
                     ))?,
                 )

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -95,15 +95,15 @@ pub struct Command {
     #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
     no_wait_for_caches: bool,
 
-    /// Force waiting for persistence every N blocks during replay.
+    /// Wait for persistence every N blocks during replay.
     ///
     /// When set, passes `wait_for_persistence: true` to `reth_newPayload` every N blocks
     /// and `wait_for_persistence: false` for all other blocks. This applies back-pressure
     /// to prevent OOM during long-running benchmark runs.
     ///
     /// Implies `--reth-new-payload`.
-    #[arg(long, value_name = "N", verbatim_doc_comment)]
-    force_persistence_every_n_blocks: Option<u64>,
+    #[arg(long = "wait-for-persistence-every", value_name = "N", verbatim_doc_comment)]
+    wait_for_persistence_every: Option<u64>,
 
     /// Optional Prometheus metrics endpoint to scrape after each block.
     ///
@@ -217,9 +217,9 @@ impl Command {
                 "Sending newPayload"
             );
 
-            let use_reth = self.reth_new_payload || self.force_persistence_every_n_blocks.is_some();
+            let use_reth = self.reth_new_payload || self.wait_for_persistence_every.is_some();
             let (version, params) = if use_reth {
-                let wait_for_persistence = if let Some(n) = self.force_persistence_every_n_blocks {
+                let wait_for_persistence = if let Some(n) = self.wait_for_persistence_every {
                     if n > 0 && block_number % n == 0 {
                         Some(true)
                     } else {

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -22,6 +22,7 @@ use clap::Parser;
 use eyre::Context;
 use reth_cli_runner::CliContext;
 use reth_node_api::EngineApiMessageVersion;
+use reth_node_core::args::WaitForPersistence;
 use reth_rpc_api::RethNewPayloadInput;
 use std::{
     path::PathBuf,
@@ -81,12 +82,19 @@ pub struct Command {
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     reth_new_payload: bool,
 
-    /// Skip waiting for in-flight persistence before processing.
+    /// Control when `reth_newPayload` waits for in-flight persistence.
     ///
-    /// Only works with `--reth-new-payload`. When set, passes `wait_for_persistence: false`
-    /// to the `reth_newPayload` endpoint.
-    #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
-    no_wait_for_persistence: bool,
+    /// Accepts `always` (default — wait on every block), `never`, or a number N
+    /// to wait every N blocks and skip the rest.
+    ///
+    /// Implies `--reth-new-payload`.
+    #[arg(
+        long = "wait-for-persistence",
+        value_name = "MODE",
+        value_parser = reth_node_core::args::benchmark_args::parse_wait_for_persistence,
+        verbatim_doc_comment
+    )]
+    wait_for_persistence: Option<WaitForPersistence>,
 
     /// Skip waiting for execution cache and sparse trie locks before processing.
     ///
@@ -94,16 +102,6 @@ pub struct Command {
     /// to the `reth_newPayload` endpoint.
     #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
     no_wait_for_caches: bool,
-
-    /// Wait for persistence every N blocks during replay.
-    ///
-    /// When set, passes `wait_for_persistence: true` to `reth_newPayload` every N blocks
-    /// and `wait_for_persistence: false` for all other blocks. This applies back-pressure
-    /// to prevent OOM during long-running benchmark runs.
-    ///
-    /// Implies `--reth-new-payload`.
-    #[arg(long = "wait-for-persistence-every", value_name = "N", verbatim_doc_comment)]
-    wait_for_persistence_every: Option<u64>,
 
     /// Optional Prometheus metrics endpoint to scrape after each block.
     ///
@@ -217,18 +215,19 @@ impl Command {
                 "Sending newPayload"
             );
 
-            let use_reth = self.reth_new_payload || self.wait_for_persistence_every.is_some();
+            let use_reth = self.reth_new_payload || self.wait_for_persistence.is_some();
             let (version, params) = if use_reth {
-                let wait_for_persistence = if let Some(n) = self.wait_for_persistence_every {
-                    if n > 0 && block_number % n == 0 {
-                        Some(true)
-                    } else {
-                        Some(false)
+                let mode = self.wait_for_persistence.unwrap_or(WaitForPersistence::Always);
+                let wait_for_persistence = match mode {
+                    WaitForPersistence::Always => None,
+                    WaitForPersistence::Never => Some(false),
+                    WaitForPersistence::EveryN(n) => {
+                        if block_number % n == 0 {
+                            Some(true)
+                        } else {
+                            Some(false)
+                        }
                     }
-                } else if self.no_wait_for_persistence {
-                    Some(false)
-                } else {
-                    None
                 };
                 let reth_data = ExecutionData {
                     payload: execution_payload.clone().into(),

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -91,6 +91,8 @@ pub struct Command {
     #[arg(
         long = "wait-for-persistence",
         value_name = "MODE",
+        num_args = 0..=1,
+        default_missing_value = "always",
         value_parser = reth_node_core::args::benchmark_args::parse_wait_for_persistence,
         requires = "reth_new_payload",
         verbatim_doc_comment

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -93,7 +93,7 @@ pub struct Command {
         value_name = "MODE",
         num_args = 0..=1,
         default_missing_value = "always",
-        value_parser = reth_node_core::args::benchmark_args::parse_wait_for_persistence,
+        value_parser = clap::value_parser!(WaitForPersistence),
         requires = "reth_new_payload",
         verbatim_doc_comment
     )]

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -217,7 +217,7 @@ impl Command {
 
             let use_reth = self.reth_new_payload || self.wait_for_persistence.is_some();
             let (version, params) = if use_reth {
-                let mode = self.wait_for_persistence.unwrap_or(WaitForPersistence::Always);
+                let mode = self.wait_for_persistence.unwrap_or(WaitForPersistence::Never);
                 let wait_for_persistence = match mode {
                     WaitForPersistence::Always => None,
                     WaitForPersistence::Never => Some(false),

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -87,11 +87,12 @@ pub struct Command {
     /// Accepts `always` (default — wait on every block), `never`, or a number N
     /// to wait every N blocks and skip the rest.
     ///
-    /// Implies `--reth-new-payload`.
+    /// Requires `--reth-new-payload`.
     #[arg(
         long = "wait-for-persistence",
         value_name = "MODE",
         value_parser = reth_node_core::args::benchmark_args::parse_wait_for_persistence,
+        requires = "reth_new_payload",
         verbatim_doc_comment
     )]
     wait_for_persistence: Option<WaitForPersistence>,
@@ -215,7 +216,7 @@ impl Command {
                 "Sending newPayload"
             );
 
-            let use_reth = self.reth_new_payload || self.wait_for_persistence.is_some();
+            let use_reth = self.reth_new_payload;
             let (version, params) = if use_reth {
                 let mode = self.wait_for_persistence.unwrap_or(WaitForPersistence::Never);
                 let wait_for_persistence = match mode {

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -180,7 +180,7 @@ pub(crate) fn block_to_new_payload(
     no_wait_for_caches: bool,
 ) -> eyre::Result<(Option<EngineApiMessageVersion>, serde_json::Value)> {
     let block_number = block.header.number;
-    let wait_for_persistence = persistence_wait_value(wait_for_persistence, block_number);
+    let wait_for_persistence = wait_for_persistence.rpc_value(block_number);
 
     if let Some(rlp) = rlp {
         return Ok((
@@ -217,21 +217,6 @@ pub(crate) fn block_to_new_payload(
         ))
     } else {
         Ok((Some(version), params))
-    }
-}
-
-/// Returns the `wait_for_persistence` parameter value for the given block number.
-fn persistence_wait_value(mode: WaitForPersistence, block_number: u64) -> Option<bool> {
-    match mode {
-        WaitForPersistence::Always => None, // server default (true)
-        WaitForPersistence::Never => Some(false),
-        WaitForPersistence::EveryN(n) => {
-            if block_number % n == 0 {
-                Some(true)
-            } else {
-                Some(false)
-            }
-        }
     }
 }
 

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -12,6 +12,7 @@ use alloy_rpc_types_engine::{
 use alloy_transport::TransportResult;
 use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
 use reth_node_api::EngineApiMessageVersion;
+use reth_node_core::args::WaitForPersistence;
 use reth_rpc_api::RethNewPayloadInput;
 use serde::Deserialize;
 use std::time::Duration;
@@ -164,33 +165,22 @@ where
     }
 }
 
-/// Options controlling the `wait_for_persistence` parameter sent with `reth_newPayload`.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum PersistenceWaitMode {
-    /// Always wait for persistence (default `reth_newPayload` behavior).
-    Always,
-    /// Never wait for persistence (`--no-wait-for-persistence`).
-    Never,
-    /// Wait for persistence every N blocks, skip for the rest.
-    EveryNBlocks(u64),
-}
-
 /// Converts an RPC block into versioned engine API params and an [`ExecutionData`].
 ///
 /// Returns `(version, versioned_params, execution_data)`.
 ///
-/// When `persistence_mode` is `Never` or `EveryNBlocks` (on non-matching blocks), passes
-/// `wait_for_persistence: false` to the `reth_newPayload` endpoint.
+/// `wait_for_persistence` controls how `wait_for_persistence` is passed to
+/// `reth_newPayload` on a per-block basis.
 pub(crate) fn block_to_new_payload(
     block: AnyRpcBlock,
     is_optimism: bool,
     rlp: Option<Bytes>,
     reth_new_payload: bool,
-    persistence_mode: PersistenceWaitMode,
+    wait_for_persistence: WaitForPersistence,
     no_wait_for_caches: bool,
 ) -> eyre::Result<(Option<EngineApiMessageVersion>, serde_json::Value)> {
     let block_number = block.header.number;
-    let wait_for_persistence = persistence_wait_value(persistence_mode, block_number);
+    let wait_for_persistence = persistence_wait_value(wait_for_persistence, block_number);
 
     if let Some(rlp) = rlp {
         return Ok((
@@ -231,12 +221,12 @@ pub(crate) fn block_to_new_payload(
 }
 
 /// Returns the `wait_for_persistence` parameter value for the given block number.
-fn persistence_wait_value(mode: PersistenceWaitMode, block_number: u64) -> Option<bool> {
+fn persistence_wait_value(mode: WaitForPersistence, block_number: u64) -> Option<bool> {
     match mode {
-        PersistenceWaitMode::Always => None, // server default (true)
-        PersistenceWaitMode::Never => Some(false),
-        PersistenceWaitMode::EveryNBlocks(n) => {
-            if n > 0 && block_number % n == 0 {
+        WaitForPersistence::Always => None, // server default (true)
+        WaitForPersistence::Never => Some(false),
+        WaitForPersistence::EveryN(n) => {
+            if block_number % n == 0 {
                 Some(true)
             } else {
                 Some(false)

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -164,26 +164,40 @@ where
     }
 }
 
+/// Options controlling the `wait_for_persistence` parameter sent with `reth_newPayload`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum PersistenceWaitMode {
+    /// Always wait for persistence (default `reth_newPayload` behavior).
+    Always,
+    /// Never wait for persistence (`--no-wait-for-persistence`).
+    Never,
+    /// Wait for persistence every N blocks, skip for the rest.
+    EveryNBlocks(u64),
+}
+
 /// Converts an RPC block into versioned engine API params and an [`ExecutionData`].
 ///
 /// Returns `(version, versioned_params, execution_data)`.
 ///
-/// When `no_wait_for_persistence` or `no_wait_for_caches` is `true` and using `reth_newPayload`,
-/// passes the corresponding `wait_for_*: false` to skip that wait.
+/// When `persistence_mode` is `Never` or `EveryNBlocks` (on non-matching blocks), passes
+/// `wait_for_persistence: false` to the `reth_newPayload` endpoint.
 pub(crate) fn block_to_new_payload(
     block: AnyRpcBlock,
     is_optimism: bool,
     rlp: Option<Bytes>,
     reth_new_payload: bool,
-    no_wait_for_persistence: bool,
+    persistence_mode: PersistenceWaitMode,
     no_wait_for_caches: bool,
 ) -> eyre::Result<(Option<EngineApiMessageVersion>, serde_json::Value)> {
+    let block_number = block.header.number;
+    let wait_for_persistence = persistence_wait_value(persistence_mode, block_number);
+
     if let Some(rlp) = rlp {
         return Ok((
             None,
             serde_json::to_value((
                 RethNewPayloadInput::<ExecutionData>::BlockRlp(rlp),
-                no_wait_for_persistence.then_some(false),
+                wait_for_persistence,
                 no_wait_for_caches.then_some(false),
             ))?,
         ));
@@ -207,12 +221,27 @@ pub(crate) fn block_to_new_payload(
             None,
             serde_json::to_value((
                 RethNewPayloadInput::ExecutionData(execution_data),
-                no_wait_for_persistence.then_some(false),
+                wait_for_persistence,
                 no_wait_for_caches.then_some(false),
             ))?,
         ))
     } else {
         Ok((Some(version), params))
+    }
+}
+
+/// Returns the `wait_for_persistence` parameter value for the given block number.
+fn persistence_wait_value(mode: PersistenceWaitMode, block_number: u64) -> Option<bool> {
+    match mode {
+        PersistenceWaitMode::Always => None, // server default (true)
+        PersistenceWaitMode::Never => Some(false),
+        PersistenceWaitMode::EveryNBlocks(n) => {
+            if n > 0 && block_number % n == 0 {
+                Some(true)
+            } else {
+                Some(false)
+            }
+        }
     }
 }
 

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -172,20 +172,15 @@ fn parse_rpc_block_fetch_retries(value: &str) -> Result<RpcBlockFetchRetries, St
 }
 
 /// Controls when `reth_newPayload` waits for in-flight persistence to complete.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WaitForPersistence {
     /// Wait for persistence on every block (default `reth_newPayload` behavior).
+    #[default]
     Always,
     /// Never wait for persistence.
     Never,
     /// Wait for persistence every N blocks, skip for the rest.
     EveryN(u64),
-}
-
-impl Default for WaitForPersistence {
-    fn default() -> Self {
-        Self::Always
-    }
 }
 
 impl WaitForPersistence {
@@ -199,7 +194,7 @@ impl WaitForPersistence {
             Self::Always => None,
             Self::Never => Some(false),
             Self::EveryN(n) => {
-                if block_number % n == 0 {
+                if block_number.is_multiple_of(n) {
                     Some(true)
                 } else {
                     Some(false)

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -94,12 +94,19 @@ pub struct BenchmarkArgs {
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub reth_new_payload: bool,
 
-    /// Skip waiting for in-flight persistence before processing.
+    /// Control when `reth_newPayload` waits for in-flight persistence.
     ///
-    /// Only works with `--reth-new-payload`. When set, passes `wait_for_persistence: false`
-    /// to the `reth_newPayload` endpoint.
-    #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
-    pub no_wait_for_persistence: bool,
+    /// Accepts `always` (default — wait on every block), `never`, or a number N
+    /// to wait every N blocks and skip the rest.
+    ///
+    /// Implies `--reth-new-payload`.
+    #[arg(
+        long = "wait-for-persistence",
+        value_name = "MODE",
+        value_parser = parse_wait_for_persistence,
+        verbatim_doc_comment
+    )]
+    pub wait_for_persistence: Option<WaitForPersistence>,
 
     /// Skip waiting for execution cache and sparse trie locks before processing.
     ///
@@ -107,17 +114,6 @@ pub struct BenchmarkArgs {
     /// to the `reth_newPayload` endpoint.
     #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
     pub no_wait_for_caches: bool,
-
-    /// Wait for persistence every N blocks during benchmarking.
-    ///
-    /// When set, passes `wait_for_persistence: true` to `reth_newPayload` every N blocks
-    /// and `wait_for_persistence: false` for all other blocks. This applies back-pressure
-    /// to prevent OOM during long-running back-to-back block benchmarks.
-    ///
-    /// Implies `--reth-new-payload`. When not set, persistence behavior is controlled by
-    /// `--no-wait-for-persistence` (default: wait for all blocks).
-    #[arg(long = "wait-for-persistence-every", value_name = "N", verbatim_doc_comment)]
-    pub wait_for_persistence_every: Option<u64>,
 
     /// Fetch and replay RLP-encoded blocks. Implies `reth_new_payload`.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
@@ -172,6 +168,49 @@ fn parse_rpc_block_fetch_retries(value: &str) -> Result<RpcBlockFetchRetries, St
     value.parse()
 }
 
+/// Controls when `reth_newPayload` waits for in-flight persistence to complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitForPersistence {
+    /// Wait for persistence on every block (default `reth_newPayload` behavior).
+    Always,
+    /// Never wait for persistence.
+    Never,
+    /// Wait for persistence every N blocks, skip for the rest.
+    EveryN(u64),
+}
+
+impl Default for WaitForPersistence {
+    fn default() -> Self {
+        Self::Always
+    }
+}
+
+impl FromStr for WaitForPersistence {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.eq_ignore_ascii_case("always") {
+            return Ok(Self::Always)
+        }
+        if s.eq_ignore_ascii_case("never") {
+            return Ok(Self::Never)
+        }
+        let n = s.parse::<u64>().map_err(|_| {
+            format!("invalid value {s:?}, expected 'always', 'never', or a block interval number")
+        })?;
+        if n == 0 {
+            return Err("block interval must be > 0, use 'never' to disable".to_string())
+        }
+        Ok(Self::EveryN(n))
+    }
+}
+
+/// Parses a [`WaitForPersistence`] value from a CLI string.
+pub fn parse_wait_for_persistence(value: &str) -> Result<WaitForPersistence, String> {
+    value.parse()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,5 +253,36 @@ mod tests {
         ])
         .args;
         assert_eq!(args.rpc_block_fetch_retries, RpcBlockFetchRetries::Finite(7));
+    }
+
+    #[test]
+    fn test_parse_wait_for_persistence() {
+        let args = CommandParser::<BenchmarkArgs>::parse_from([
+            "reth-bench",
+            "--wait-for-persistence",
+            "always",
+        ])
+        .args;
+        assert_eq!(args.wait_for_persistence, Some(WaitForPersistence::Always));
+
+        let args = CommandParser::<BenchmarkArgs>::parse_from([
+            "reth-bench",
+            "--wait-for-persistence",
+            "never",
+        ])
+        .args;
+        assert_eq!(args.wait_for_persistence, Some(WaitForPersistence::Never));
+
+        let args = CommandParser::<BenchmarkArgs>::parse_from([
+            "reth-bench",
+            "--wait-for-persistence",
+            "10",
+        ])
+        .args;
+        assert_eq!(args.wait_for_persistence, Some(WaitForPersistence::EveryN(10)));
+
+        // default is None
+        let args = CommandParser::<BenchmarkArgs>::parse_from(["reth-bench"]).args;
+        assert_eq!(args.wait_for_persistence, None);
     }
 }

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -96,7 +96,7 @@ pub struct BenchmarkArgs {
 
     /// Control when `reth_newPayload` waits for in-flight persistence.
     ///
-    /// Accepts `always` (default — wait on every block), `never`, or a number N
+    /// Accepts `always` (wait on every block), `never` (default), or a number N
     /// to wait every N blocks and skip the rest.
     ///
     /// Implies `--reth-new-payload`.

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -188,6 +188,27 @@ impl Default for WaitForPersistence {
     }
 }
 
+impl WaitForPersistence {
+    /// Returns the `wait_for_persistence` RPC parameter value for a given block number.
+    ///
+    /// - `None` → use the server default (true)
+    /// - `Some(false)` → skip waiting
+    /// - `Some(true)` → explicitly wait
+    pub const fn rpc_value(self, block_number: u64) -> Option<bool> {
+        match self {
+            Self::Always => None,
+            Self::Never => Some(false),
+            Self::EveryN(n) => {
+                if block_number % n == 0 {
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+        }
+    }
+}
+
 impl FromStr for WaitForPersistence {
     type Err = String;
 

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -105,7 +105,7 @@ pub struct BenchmarkArgs {
         value_name = "MODE",
         num_args = 0..=1,
         default_missing_value = "always",
-        value_parser = parse_wait_for_persistence,
+        value_parser = clap::value_parser!(WaitForPersistence),
         requires = "reth_new_payload",
         verbatim_doc_comment
     )]
@@ -228,11 +228,6 @@ impl FromStr for WaitForPersistence {
         }
         Ok(Self::EveryN(n))
     }
-}
-
-/// Parses a [`WaitForPersistence`] value from a CLI string.
-pub fn parse_wait_for_persistence(value: &str) -> Result<WaitForPersistence, String> {
-    value.parse()
 }
 
 #[cfg(test)]

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -99,11 +99,12 @@ pub struct BenchmarkArgs {
     /// Accepts `always` (wait on every block), `never` (default), or a number N
     /// to wait every N blocks and skip the rest.
     ///
-    /// Implies `--reth-new-payload`.
+    /// Requires `--reth-new-payload`.
     #[arg(
         long = "wait-for-persistence",
         value_name = "MODE",
         value_parser = parse_wait_for_persistence,
+        requires = "reth_new_payload",
         verbatim_doc_comment
     )]
     pub wait_for_persistence: Option<WaitForPersistence>,
@@ -259,6 +260,7 @@ mod tests {
     fn test_parse_wait_for_persistence() {
         let args = CommandParser::<BenchmarkArgs>::parse_from([
             "reth-bench",
+            "--reth-new-payload",
             "--wait-for-persistence",
             "always",
         ])
@@ -267,6 +269,7 @@ mod tests {
 
         let args = CommandParser::<BenchmarkArgs>::parse_from([
             "reth-bench",
+            "--reth-new-payload",
             "--wait-for-persistence",
             "never",
         ])
@@ -275,6 +278,7 @@ mod tests {
 
         let args = CommandParser::<BenchmarkArgs>::parse_from([
             "reth-bench",
+            "--reth-new-payload",
             "--wait-for-persistence",
             "10",
         ])

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -108,7 +108,7 @@ pub struct BenchmarkArgs {
     #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
     pub no_wait_for_caches: bool,
 
-    /// Force waiting for persistence every N blocks during benchmarking.
+    /// Wait for persistence every N blocks during benchmarking.
     ///
     /// When set, passes `wait_for_persistence: true` to `reth_newPayload` every N blocks
     /// and `wait_for_persistence: false` for all other blocks. This applies back-pressure
@@ -116,8 +116,8 @@ pub struct BenchmarkArgs {
     ///
     /// Implies `--reth-new-payload`. When not set, persistence behavior is controlled by
     /// `--no-wait-for-persistence` (default: wait for all blocks).
-    #[arg(long, value_name = "N", verbatim_doc_comment)]
-    pub force_persistence_every_n_blocks: Option<u64>,
+    #[arg(long = "wait-for-persistence-every", value_name = "N", verbatim_doc_comment)]
+    pub wait_for_persistence_every: Option<u64>,
 
     /// Fetch and replay RLP-encoded blocks. Implies `reth_new_payload`.
     #[arg(long, default_value = "false", verbatim_doc_comment)]

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -103,6 +103,8 @@ pub struct BenchmarkArgs {
     #[arg(
         long = "wait-for-persistence",
         value_name = "MODE",
+        num_args = 0..=1,
+        default_missing_value = "always",
         value_parser = parse_wait_for_persistence,
         requires = "reth_new_payload",
         verbatim_doc_comment
@@ -284,6 +286,15 @@ mod tests {
         ])
         .args;
         assert_eq!(args.wait_for_persistence, Some(WaitForPersistence::EveryN(10)));
+
+        // bare --wait-for-persistence (no value) defaults to Always
+        let args = CommandParser::<BenchmarkArgs>::parse_from([
+            "reth-bench",
+            "--reth-new-payload",
+            "--wait-for-persistence",
+        ])
+        .args;
+        assert_eq!(args.wait_for_persistence, Some(WaitForPersistence::Always));
 
         // default is None
         let args = CommandParser::<BenchmarkArgs>::parse_from(["reth-bench"]).args;

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -108,6 +108,17 @@ pub struct BenchmarkArgs {
     #[arg(long, default_value = "false", verbatim_doc_comment, requires = "reth_new_payload")]
     pub no_wait_for_caches: bool,
 
+    /// Force waiting for persistence every N blocks during benchmarking.
+    ///
+    /// When set, passes `wait_for_persistence: true` to `reth_newPayload` every N blocks
+    /// and `wait_for_persistence: false` for all other blocks. This applies back-pressure
+    /// to prevent OOM during long-running back-to-back block benchmarks.
+    ///
+    /// Implies `--reth-new-payload`. When not set, persistence behavior is controlled by
+    /// `--no-wait-for-persistence` (default: wait for all blocks).
+    #[arg(long, value_name = "N", verbatim_doc_comment)]
+    pub force_persistence_every_n_blocks: Option<u64>,
+
     /// Fetch and replay RLP-encoded blocks. Implies `reth_new_payload`.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub rlp_blocks: bool,

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -61,7 +61,7 @@ mod datadir_args;
 pub use datadir_args::DatadirArgs;
 
 /// BenchmarkArgs struct for configuring the benchmark to run
-pub mod benchmark_args;
+mod benchmark_args;
 pub use benchmark_args::{BenchmarkArgs, RpcBlockFetchRetries, WaitForPersistence};
 
 /// EngineArgs for configuring the engine

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -61,8 +61,8 @@ mod datadir_args;
 pub use datadir_args::DatadirArgs;
 
 /// BenchmarkArgs struct for configuring the benchmark to run
-mod benchmark_args;
-pub use benchmark_args::{BenchmarkArgs, RpcBlockFetchRetries};
+pub mod benchmark_args;
+pub use benchmark_args::{BenchmarkArgs, RpcBlockFetchRetries, WaitForPersistence};
 
 /// EngineArgs for configuring the engine
 mod engine;


### PR DESCRIPTION
Adds a `--wait-for-persistence` flag to reth-bench that controls how `wait_for_persistence` is passed to `reth_newPayload` on a per-block basis.

- `--wait-for-persistence` (bare) or `--wait-for-persistence always` — wait on every block
- `--wait-for-persistence never` — never wait
- `--wait-for-persistence N` — wait every N blocks, skip the rest

Default (when flag is omitted): `never`. Requires `--reth-new-payload`.

`bench.yml` passes `--wait-for-persistence` to preserve the previous always-wait behavior in CI.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey