### PR TITLE
feat(rpc): add paginated block tracing endpoints

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -84,6 +84,32 @@ pub trait DebugApi<TxReq: RpcObject> {
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
 
+    /// Returns traces for a range of transactions within a block by block hash.
+    ///
+    /// Transactions before `start` are replayed without tracing to build up state.
+    /// Transactions from `start` to `end` (exclusive) are traced.
+    #[method(name = "traceBlockByHashRange")]
+    async fn debug_trace_block_by_hash_range(
+        &self,
+        block: B256,
+        start: u64,
+        end: u64,
+        opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<Vec<TraceResult>>;
+
+    /// Returns traces for a range of transactions within a block by block number.
+    ///
+    /// Transactions before `start` are replayed without tracing to build up state.
+    /// Transactions from `start` to `end` (exclusive) are traced.
+    #[method(name = "traceBlockByNumberRange")]
+    async fn debug_trace_block_by_number_range(
+        &self,
+        block: BlockNumberOrTag,
+        start: u64,
+        end: u64,
+        opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<Vec<TraceResult>>;
+
     /// The `debug_traceTransaction` debugging method will attempt to run the transaction in the
     /// exact same manner as it was executed on the network. It will replay any transaction that
     /// may have been executed prior to this one before it will finally attempt to execute the

--- a/crates/rpc/rpc-api/src/trace.rs
+++ b/crates/rpc/rpc-api/src/trace.rs
@@ -106,4 +106,16 @@ pub trait TraceApi<TxReq> {
     /// This is the same as `trace_transactionOpcodeGas` but for all transactions in a block.
     #[method(name = "blockOpcodeGas")]
     async fn trace_block_opcode_gas(&self, block_id: BlockId) -> RpcResult<Option<BlockOpcodeGas>>;
+
+    /// Returns traces for a range of transactions within a block.
+    ///
+    /// Transactions before `start` are replayed without tracing to build up state.
+    /// Transactions from `start` to `end` (exclusive) are traced.
+    #[method(name = "blockRange")]
+    async fn trace_block_range(
+        &self,
+        block_id: BlockId,
+        start: u64,
+        end: u64,
+    ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>>;
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -5,7 +5,7 @@ use crate::{FromEthApiError, FromEvmError};
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
-use futures::Future;
+use futures::{future::ready, Future, FutureExt};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, evm::EvmFactoryExt, tracing::TracingCtx, ConfigureEvm, Database, Evm,
@@ -230,6 +230,47 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         )
     }
 
+    /// Executes a range of transactions within a block.
+    ///
+    /// Transactions before `start_index` are replayed without tracing to build up state.
+    /// Transactions from `start_index` to `end_index` (exclusive) are traced.
+    fn trace_block_range<F, R>(
+        &self,
+        block_id: BlockId,
+        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
+        start_index: u64,
+        end_index: u64,
+        config: TracingInspectorConfig,
+        f: F,
+    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<
+                    '_,
+                    Recovered<&ProviderTx<Self::Provider>>,
+                    EvmFor<Self::Evm, &mut StateCacheDb, TracingInspector>,
+                >,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        R: Send + 'static,
+    {
+        if end_index == 0 || start_index >= end_index {
+            return ready(Ok(Some(Vec::new()))).right_future()
+        }
+        self.trace_block_range_with_inspector(
+            block_id,
+            block,
+            Some(start_index),
+            Some(end_index - 1),
+            move || TracingInspector::new(config),
+            f,
+        )
+        .left_future()
+    }
+
     /// Executes all transactions of a block.
     ///
     /// If a `highest_index` is given, this will only execute the first `highest_index`
@@ -244,6 +285,47 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         &self,
         block_id: BlockId,
         block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
+        highest_index: Option<u64>,
+        inspector_setup: Setup,
+        f: F,
+    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<
+                    '_,
+                    Recovered<&ProviderTx<Self::Provider>>,
+                    EvmFor<Self::Evm, &mut StateCacheDb, Insp>,
+                >,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        Setup: FnMut() -> Insp + Send + 'static,
+        Insp: Clone + for<'a> InspectorFor<Self::Evm, &'a mut StateCacheDb>,
+        R: Send + 'static,
+    {
+        self.trace_block_range_with_inspector(
+            block_id,
+            block,
+            None,
+            highest_index,
+            inspector_setup,
+            f,
+        )
+    }
+
+    /// Core method for tracing a range of transactions within a block.
+    ///
+    /// If `lowest_index` is set, transactions before it are replayed without tracing to build up
+    /// state. If `highest_index` is set, tracing stops after that index (inclusive, 0-based).
+    ///
+    /// Both `trace_block_until_with_inspector` and `trace_block_range` delegate to this.
+    fn trace_block_range_with_inspector<Setup, Insp, F, R>(
+        &self,
+        block_id: BlockId,
+        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
+        lowest_index: Option<u64>,
         highest_index: Option<u64>,
         mut inspector_setup: Setup,
         f: F,
@@ -272,38 +354,43 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
 
             if block.body().transactions().is_empty() {
-                // nothing to trace
                 return Ok(Some(Vec::new()))
             }
 
-            // replay all transactions of the block
-            // we need to get the state of the parent block because we're replaying this block
-            // on top of its parent block's state
             self.spawn_with_state_at_block(block.parent_hash(), move |this, mut db| {
                 let block_hash = block.hash();
-
                 let block_number = evm_env.block_env.number().saturating_to();
                 let base_fee = evm_env.block_env.basefee();
 
                 this.apply_pre_execution_changes(&block, &mut db)?;
 
-                // prepare transactions, we do everything upfront to reduce time spent with open
-                // state
-                let max_transactions = highest_index.map_or_else(
-                    || block.body().transaction_count(),
-                    |highest| {
-                        // we need + 1 because the index is 0-based
-                        highest as usize + 1
-                    },
-                );
+                let tx_count = block.body().transaction_count();
+                let start = lowest_index.unwrap_or(0) as usize;
+                let end = highest_index.map_or(tx_count, |h| (h as usize + 1).min(tx_count));
 
-                let mut idx = 0;
+                if start >= end {
+                    return Ok(Some(Vec::new()))
+                }
+
+                let transactions: Vec<_> = block.transactions_recovered().collect();
+
+                // Replay transactions before start without tracing to build up state
+                if start > 0 {
+                    let mut evm = this.evm_config().evm_with_env(&mut db, evm_env.clone());
+                    for tx in transactions.iter().take(start) {
+                        let tx_env = this.evm_config().tx_env(*tx);
+                        evm.transact_commit(tx_env).map_err(Self::Error::from_evm_err)?;
+                    }
+                }
+
+                // Trace transactions in [start, end)
+                let mut idx = start as u64;
 
                 let results = this
                     .evm_config()
                     .evm_factory()
                     .create_tracer(&mut db, evm_env, inspector_setup())
-                    .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
+                    .try_trace_many(transactions[start..end].iter().copied(), |ctx| {
                         #[allow(clippy::needless_update)]
                         let tx_info = TransactionInfo {
                             hash: Some(*ctx.tx.tx_hash()),
@@ -314,7 +401,6 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                             ..Default::default()
                         };
                         idx += 1;
-
                         f(tx_info, ctx)
                     })
                     .collect::<Result<_, _>>()?;
@@ -400,7 +486,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Insp: Clone + for<'a> InspectorFor<Self::Evm, &'a mut StateCacheDb>,
         R: Send + 'static,
     {
-        self.trace_block_until_with_inspector(block_id, block, None, insp_setup, f)
+        self.trace_block_range_with_inspector(block_id, block, None, None, insp_setup, f)
     }
 
     /// Applies chain-specific state transitions required before executing a block.

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,6 +12,7 @@ use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use async_trait::async_trait;
+use core::ops::Range;
 use futures::Stream;
 use jsonrpsee::core::RpcResult;
 use parking_lot::RwLock;
@@ -106,24 +107,51 @@ where
         self.inner.blocking_task_guard.clone().acquire_owned().await
     }
 
-    /// Trace the entire block asynchronously
+    /// Trace transactions in a block, optionally limiting to a specific range.
+    ///
+    /// If `tx_range` is `None`, all transactions are traced. If set, transactions before the
+    /// range start are replayed without tracing to build up state, and only transactions
+    /// within the range are traced.
     async fn trace_block(
         &self,
         block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
         evm_env: EvmEnvFor<Eth::Evm>,
         opts: GethDebugTracingOptions,
+        tx_range: Option<Range<usize>>,
     ) -> Result<Vec<TraceResult>, Eth::Error> {
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
-                let mut results = Vec::with_capacity(block.body().transactions().len());
-
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
-                let mut transactions = block.transactions_recovered().enumerate().peekable();
+                let tx_count = block.body().transactions().len();
+                let range = tx_range.unwrap_or(0..tx_count);
+                let start = range.start.min(tx_count);
+                let end = range.end.min(tx_count);
+
+                if start >= end {
+                    return Ok(Vec::new())
+                }
+
+                let transactions: Vec<_> = block.transactions_recovered().collect();
+
+                // Replay transactions before start without tracing to build up state
+                if start > 0 {
+                    let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
+                    for tx in transactions.iter().take(start) {
+                        let tx_env = eth_api.evm_config().tx_env(*tx);
+                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+                    }
+                }
+
+                // Trace transactions in [start, end)
+                let mut results = Vec::with_capacity(end - start);
                 let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                while let Some((index, tx)) = transactions.next() {
+
+                let mut trace_txs = transactions[start..end].iter().enumerate().peekable();
+                while let Some((relative_idx, tx)) = trace_txs.next() {
+                    let index = start + relative_idx;
                     let tx_hash = *tx.tx_hash();
-                    let tx_env = eth_api.evm_config().tx_env(tx);
+                    let tx_env = eth_api.evm_config().tx_env(*tx);
 
                     let res = eth_api.inspect(
                         &mut db,
@@ -146,10 +174,10 @@ where
                         .map_err(Eth::Error::from_eth_err)?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
-                    if transactions.peek().is_some() {
+                    if trace_txs.peek().is_some() {
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
-                        // need to apply the state changes of this transaction before executing the
-                        // next transaction
+                        // need to apply the state changes of this transaction before executing
+                        // the next transaction
                         db.commit(res.state)
                     }
                 }
@@ -189,7 +217,8 @@ where
             }
             .map_err(Eth::Error::from_eth_err)?;
 
-        self.trace_block(Arc::new(block.into_recovered_with_signers(senders)), evm_env, opts).await
+        self.trace_block(Arc::new(block.into_recovered_with_signers(senders)), evm_env, opts, None)
+            .await
     }
 
     /// Replays a block and returns the trace of each transaction.
@@ -205,7 +234,27 @@ where
             .ok_or(EthApiError::HeaderNotFound(block_id))?;
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
 
-        self.trace_block(block, evm_env, opts).await
+        self.trace_block(block, evm_env, opts, None).await
+    }
+
+    /// Replays a range of transactions within a block and returns their traces.
+    ///
+    /// Transactions before `start` are replayed without tracing to build up state.
+    pub async fn debug_trace_block_range(
+        &self,
+        block_id: BlockId,
+        start: u64,
+        end: u64,
+        opts: GethDebugTracingOptions,
+    ) -> Result<Vec<TraceResult>, Eth::Error> {
+        let block = self
+            .eth_api()
+            .recovered_block(block_id)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
+
+        self.trace_block(block, evm_env, opts, Some(start as usize..end as usize)).await
     }
 
     /// Trace the transaction according to the provided options.
@@ -807,6 +856,34 @@ where
             .map_err(Into::into)
     }
 
+    /// Handler for `debug_traceBlockByHashRange`
+    async fn debug_trace_block_by_hash_range(
+        &self,
+        block: B256,
+        start: u64,
+        end: u64,
+        opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<Vec<TraceResult>> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_block_range(self, block.into(), start, end, opts.unwrap_or_default())
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Handler for `debug_traceBlockByNumberRange`
+    async fn debug_trace_block_by_number_range(
+        &self,
+        block: BlockNumberOrTag,
+        start: u64,
+        end: u64,
+        opts: Option<GethDebugTracingOptions>,
+    ) -> RpcResult<Vec<TraceResult>> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_block_range(self, block.into(), start, end, opts.unwrap_or_default())
+            .await
+            .map_err(Into::into)
+    }
+
     /// Handler for `debug_traceTransaction`
     async fn debug_trace_transaction(
         &self,
@@ -1118,7 +1195,7 @@ where
             .to_rpc_result()?;
 
         let opts = opts.map(|o| o.tracing_options).unwrap_or_default();
-        self.trace_block(block, evm_env, opts).await.map_err(Into::into)
+        self.trace_block(block, evm_env, opts, None).await.map_err(Into::into)
     }
 
     async fn debug_verbosity(&self, level: usize) -> RpcResult<()> {

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -515,6 +515,36 @@ where
         Ok(traces)
     }
 
+    /// Returns traces for a range of transactions within a block.
+    ///
+    /// Transactions before `start` are replayed without tracing to build up state.
+    pub async fn trace_block_range(
+        &self,
+        block_id: BlockId,
+        start: u64,
+        end: u64,
+    ) -> Result<Option<Vec<LocalizedTransactionTrace>>, Eth::Error> {
+        let traces = self
+            .eth_api()
+            .trace_block_range(
+                block_id,
+                None,
+                start,
+                end,
+                TracingInspectorConfig::default_parity(),
+                |tx_info, mut ctx| {
+                    let traces = ctx
+                        .take_inspector()
+                        .into_parity_builder()
+                        .into_localized_transaction_traces(tx_info);
+                    Ok(traces)
+                },
+            )
+            .await?;
+
+        Ok(traces.map(|traces| traces.into_iter().flatten().collect::<Vec<_>>()))
+    }
+
     /// Replays all transactions in a block
     pub async fn replay_block_transactions(
         &self,
@@ -750,6 +780,17 @@ where
     async fn trace_block_opcode_gas(&self, block_id: BlockId) -> RpcResult<Option<BlockOpcodeGas>> {
         let _permit = self.acquire_trace_permit().await;
         Ok(Self::trace_block_opcode_gas(self, block_id).await.map_err(Into::into)?)
+    }
+
+    /// Handler for `trace_blockRange`
+    async fn trace_block_range(
+        &self,
+        block_id: BlockId,
+        start: u64,
+        end: u64,
+    ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>> {
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_block_range(self, block_id, start, end).await.map_err(Into::into)?)
     }
 }
 


### PR DESCRIPTION
Adds range-based block tracing for large blocks where full traces are too expensive in memory, CPU, and response size.

New endpoints:
- `trace_blockRange(block_id, start, end)`
- `debug_traceBlockByHashRange(hash, start, end, opts)`
- `debug_traceBlockByNumberRange(number, start, end, opts)`

Transactions in `[0, start)` are replayed without tracing to build state. Transactions in `[start, end)` are traced and returned. Response types are identical to the existing non-paginated endpoints.

Extends `trace_block_until_with_inspector` into a shared `trace_block_range_with_inspector` core that both the existing "trace until" and the new "trace range" delegate to.

Supersedes #21307