### PR TITLE
refactor(bench): decouple block prefetch from consumption in new-payload-fcu

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -18,7 +18,7 @@ use alloy_provider::{ext::DebugApi, Provider};
 use alloy_rpc_types_engine::ForkchoiceState;
 use clap::Parser;
 use eyre::{Context, OptionExt};
-use futures::{stream, StreamExt, TryStreamExt};
+use futures::{stream, StreamExt};
 use reth_cli_runner::CliContext;
 use reth_engine_primitives::config::DEFAULT_PERSISTENCE_THRESHOLD;
 use reth_node_core::args::BenchmarkArgs;
@@ -111,83 +111,95 @@ impl Command {
 
         let buffer_size = self.rpc_block_buffer_size;
 
-        let mut blocks = Box::pin(
-            stream::iter((next_block..)
-                .take_while(|next_block| {
-                    benchmark_mode.contains(*next_block)
-                }))
-                .map(|next_block| {
-                    let block_provider = block_provider.clone();
-                    async move {
-                        let block_res = block_provider
-                            .get_block_by_number(next_block.into())
-                            .full()
+        // Spawn a task that drives a `.buffered()` stream and sends fetched blocks
+        // through a channel. This decouples fetching from consumption: up to
+        // `buffer_size` block fetches run concurrently, and the channel keeps
+        // completed blocks ready for the consumer even while it is busy processing
+        // the previous block (calling newPayload + FCU).
+        let (block_tx, mut block_rx) = tokio::sync::mpsc::channel(buffer_size);
+        tokio::task::spawn(async move {
+            let mut blocks = stream::iter(
+                (next_block..).take_while(|n| benchmark_mode.contains(*n)),
+            )
+            .map(|next_block| {
+                let block_provider = block_provider.clone();
+                async move {
+                    let block_res = block_provider
+                        .get_block_by_number(next_block.into())
+                        .full()
+                        .await
+                        .wrap_err_with(|| {
+                            format!("Failed to fetch block by number {next_block}")
+                        });
+                    let block =
+                        match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
+                            Ok(block) => block,
+                            Err(e) => {
+                                tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
+                                return Err(e)
+                            }
+                        };
+
+                    let rlp = if rlp_blocks {
+                        let rlp = match block_provider
+                            .debug_get_raw_block(next_block.into())
                             .await
-                            .wrap_err_with(|| {
-                                format!("Failed to fetch block by number {next_block}")
-                            });
-                        let block =
-                            match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
-                                Ok(block) => block,
-                                Err(e) => {
-                                    tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
-                                    return Err(e)
-                                }
-                            };
-
-                        let rlp = if rlp_blocks {
-                            let rlp = match block_provider
-                                .debug_get_raw_block(next_block.into())
-                                .await
-                            {
-                                Ok(rlp) => rlp,
-                                Err(e) => {
-                                    tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
-                                    return Err(e.into())
-                                }
-                            };
-                            Some(rlp)
-                        } else {
-                            None
+                        {
+                            Ok(rlp) => rlp,
+                            Err(e) => {
+                                tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
+                                return Err(e.into())
+                            }
                         };
+                        Some(rlp)
+                    } else {
+                        None
+                    };
 
-                        let head_block_hash = block.header.hash;
-                        let safe_block_hash = block_provider
-                            .get_block_by_number(block.header.number.saturating_sub(32).into());
+                    let head_block_hash = block.header.hash;
+                    let safe_block_hash = block_provider
+                        .get_block_by_number(block.header.number.saturating_sub(32).into());
 
-                        let finalized_block_hash = block_provider
-                            .get_block_by_number(block.header.number.saturating_sub(64).into());
+                    let finalized_block_hash = block_provider
+                        .get_block_by_number(block.header.number.saturating_sub(64).into());
 
-                        let (safe, finalized) =
-                            tokio::join!(safe_block_hash, finalized_block_hash);
+                    let (safe, finalized) =
+                        tokio::join!(safe_block_hash, finalized_block_hash);
 
-                        let safe_block_hash = match safe {
-                            Ok(Some(block)) => block.header.hash,
-                            Ok(None) | Err(_) => head_block_hash,
-                        };
+                    let safe_block_hash = match safe {
+                        Ok(Some(block)) => block.header.hash,
+                        Ok(None) | Err(_) => head_block_hash,
+                    };
 
-                        let finalized_block_hash = match finalized {
-                            Ok(Some(block)) => block.header.hash,
-                            Ok(None) | Err(_) => head_block_hash,
-                        };
+                    let finalized_block_hash = match finalized {
+                        Ok(Some(block)) => block.header.hash,
+                        Ok(None) | Err(_) => head_block_hash,
+                    };
 
-                        Ok((block, head_block_hash, safe_block_hash, finalized_block_hash, rlp))
-                    }
-                })
-                .buffered(buffer_size),
-        );
+                    Ok((block, head_block_hash, safe_block_hash, finalized_block_hash, rlp))
+                }
+            })
+            .buffered(buffer_size);
+
+            while let Some(result) = blocks.next().await {
+                if block_tx.send(result).await.is_err() {
+                    break;
+                }
+            }
+        });
 
         let mut results = Vec::new();
         let mut blocks_processed = 0u64;
         let total_benchmark_duration = Instant::now();
         let mut total_wait_time = Duration::ZERO;
 
-        while let Some((block, head, safe, finalized, rlp)) = {
+        while let Some(block_result) = {
             let wait_start = Instant::now();
-            let result = blocks.try_next().await?;
+            let result = block_rx.recv().await;
             total_wait_time += wait_start.elapsed();
             result
         } {
+            let (block, head, safe, finalized, rlp) = block_result?;
             let gas_used = block.header.gas_used;
             let gas_limit = block.header.gas_limit;
             let block_number = block.header.number;

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -65,8 +65,10 @@ pub struct Command {
     )]
     persistence_timeout: Duration,
 
-    /// The size of the block buffer (channel capacity) for prefetching blocks from the RPC
-    /// endpoint.
+    /// The number of blocks to fetch concurrently from the RPC endpoint.
+    ///
+    /// Up to this many block fetches will be in-flight at once, and results are
+    /// yielded in order.
     #[arg(
         long = "rpc-block-buffer-size",
         value_name = "RPC_BLOCK_BUFFER_SIZE",

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -15,7 +15,6 @@ use alloy_provider::{ext::DebugApi, Provider};
 use clap::Parser;
 use csv::Writer;
 use eyre::{Context, OptionExt};
-use futures::{stream, StreamExt, TryStreamExt};
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
 use std::time::{Duration, Instant};
@@ -28,10 +27,8 @@ pub struct Command {
     #[arg(long, value_name = "RPC_URL", verbatim_doc_comment)]
     rpc_url: String,
 
-    /// The number of blocks to fetch concurrently from the RPC endpoint.
-    ///
-    /// Up to this many block fetches will be in-flight at once, and results are
-    /// yielded in order.
+    /// The size of the block buffer (channel capacity) for prefetching blocks from the RPC
+    /// endpoint.
     #[arg(
         long = "rpc-block-buffer-size",
         value_name = "RPC_BLOCK_BUFFER_SIZE",
@@ -51,7 +48,7 @@ impl Command {
             benchmark_mode,
             block_provider,
             auth_provider,
-            next_block,
+            mut next_block,
             is_optimism,
             use_reth_namespace,
             rlp_blocks,
@@ -69,50 +66,46 @@ impl Command {
 
         let buffer_size = self.rpc_block_buffer_size;
 
-        let mut blocks = Box::pin(
-            stream::iter(
-                (next_block..).take_while(|next_block| benchmark_mode.contains(*next_block)),
-            )
-            .map(|next_block| {
-                let block_provider = block_provider.clone();
-                async move {
-                    let block_res = block_provider
-                        .get_block_by_number(next_block.into())
-                        .full()
-                        .await
-                        .wrap_err_with(|| {
-                            format!("Failed to fetch block by number {next_block}")
-                        });
-                    let block =
-                        match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
-                            Ok(block) => block,
-                            Err(e) => {
-                                tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
-                                return Err(e)
-                            }
-                        };
+        // Use a oneshot channel to propagate errors from the spawned task
+        let (error_sender, mut error_receiver) = tokio::sync::oneshot::channel();
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(buffer_size);
 
-                    let rlp = if rlp_blocks {
-                        let rlp = match block_provider
-                            .debug_get_raw_block(next_block.into())
-                            .await
-                        {
-                            Ok(rlp) => rlp,
-                            Err(e) => {
-                                tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
-                                return Err(e.into())
-                            }
-                        };
-                        Some(rlp)
-                    } else {
-                        None
+        tokio::task::spawn(async move {
+            while benchmark_mode.contains(next_block) {
+                let block_res = block_provider
+                    .get_block_by_number(next_block.into())
+                    .full()
+                    .await
+                    .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"));
+                let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
+                    Ok(block) => block,
+                    Err(e) => {
+                        tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
+                        let _ = error_sender.send(e);
+                        break;
+                    }
+                };
+
+                let rlp = if rlp_blocks {
+                    let Ok(rlp) = block_provider.debug_get_raw_block(next_block.into()).await
+                    else {
+                        tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}");
+                        let _ = error_sender
+                            .send(eyre::eyre!("Failed to fetch raw block {next_block}"));
+                        break;
                     };
+                    Some(rlp)
+                } else {
+                    None
+                };
 
-                    Ok((block, rlp))
+                next_block += 1;
+                if let Err(e) = sender.send((block, rlp)).await {
+                    tracing::error!(target: "reth-bench", "Failed to send block data: {e}");
+                    break;
                 }
-            })
-            .buffered(buffer_size),
-        );
+            }
+        });
 
         let mut results = Vec::new();
         let mut blocks_processed = 0u64;
@@ -121,7 +114,7 @@ impl Command {
 
         while let Some((block, rlp)) = {
             let wait_start = Instant::now();
-            let result = blocks.try_next().await?;
+            let result = receiver.recv().await;
             total_wait_time += wait_start.elapsed();
             result
         } {
@@ -180,6 +173,11 @@ impl Command {
             {
                 tracing::warn!(target: "reth-bench", %err, block_number, "Failed to scrape metrics");
             }
+        }
+
+        // Check if the spawned task encountered an error
+        if let Ok(error) = error_receiver.try_recv() {
+            return Err(error);
         }
 
         let (gas_output_results, new_payload_results): (_, Vec<NewPayloadResult>) =

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -15,6 +15,7 @@ use alloy_provider::{ext::DebugApi, Provider};
 use clap::Parser;
 use csv::Writer;
 use eyre::{Context, OptionExt};
+use futures::{stream, StreamExt, TryStreamExt};
 use reth_cli_runner::CliContext;
 use reth_node_core::args::BenchmarkArgs;
 use std::time::{Duration, Instant};
@@ -27,8 +28,10 @@ pub struct Command {
     #[arg(long, value_name = "RPC_URL", verbatim_doc_comment)]
     rpc_url: String,
 
-    /// The size of the block buffer (channel capacity) for prefetching blocks from the RPC
-    /// endpoint.
+    /// The number of blocks to fetch concurrently from the RPC endpoint.
+    ///
+    /// Up to this many block fetches will be in-flight at once, and results are
+    /// yielded in order.
     #[arg(
         long = "rpc-block-buffer-size",
         value_name = "RPC_BLOCK_BUFFER_SIZE",
@@ -48,7 +51,7 @@ impl Command {
             benchmark_mode,
             block_provider,
             auth_provider,
-            mut next_block,
+            next_block,
             is_optimism,
             use_reth_namespace,
             rlp_blocks,
@@ -66,46 +69,50 @@ impl Command {
 
         let buffer_size = self.rpc_block_buffer_size;
 
-        // Use a oneshot channel to propagate errors from the spawned task
-        let (error_sender, mut error_receiver) = tokio::sync::oneshot::channel();
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(buffer_size);
+        let mut blocks = Box::pin(
+            stream::iter(
+                (next_block..).take_while(|next_block| benchmark_mode.contains(*next_block)),
+            )
+            .map(|next_block| {
+                let block_provider = block_provider.clone();
+                async move {
+                    let block_res = block_provider
+                        .get_block_by_number(next_block.into())
+                        .full()
+                        .await
+                        .wrap_err_with(|| {
+                            format!("Failed to fetch block by number {next_block}")
+                        });
+                    let block =
+                        match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
+                            Ok(block) => block,
+                            Err(e) => {
+                                tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
+                                return Err(e)
+                            }
+                        };
 
-        tokio::task::spawn(async move {
-            while benchmark_mode.contains(next_block) {
-                let block_res = block_provider
-                    .get_block_by_number(next_block.into())
-                    .full()
-                    .await
-                    .wrap_err_with(|| format!("Failed to fetch block by number {next_block}"));
-                let block = match block_res.and_then(|opt| opt.ok_or_eyre("Block not found")) {
-                    Ok(block) => block,
-                    Err(e) => {
-                        tracing::error!(target: "reth-bench", "Failed to fetch block {next_block}: {e}");
-                        let _ = error_sender.send(e);
-                        break;
-                    }
-                };
-
-                let rlp = if rlp_blocks {
-                    let Ok(rlp) = block_provider.debug_get_raw_block(next_block.into()).await
-                    else {
-                        tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}");
-                        let _ = error_sender
-                            .send(eyre::eyre!("Failed to fetch raw block {next_block}"));
-                        break;
+                    let rlp = if rlp_blocks {
+                        let rlp = match block_provider
+                            .debug_get_raw_block(next_block.into())
+                            .await
+                        {
+                            Ok(rlp) => rlp,
+                            Err(e) => {
+                                tracing::error!(target: "reth-bench", "Failed to fetch raw block {next_block}: {e}");
+                                return Err(e.into())
+                            }
+                        };
+                        Some(rlp)
+                    } else {
+                        None
                     };
-                    Some(rlp)
-                } else {
-                    None
-                };
 
-                next_block += 1;
-                if let Err(e) = sender.send((block, rlp)).await {
-                    tracing::error!(target: "reth-bench", "Failed to send block data: {e}");
-                    break;
+                    Ok((block, rlp))
                 }
-            }
-        });
+            })
+            .buffered(buffer_size),
+        );
 
         let mut results = Vec::new();
         let mut blocks_processed = 0u64;
@@ -114,7 +121,7 @@ impl Command {
 
         while let Some((block, rlp)) = {
             let wait_start = Instant::now();
-            let result = receiver.recv().await;
+            let result = blocks.try_next().await?;
             total_wait_time += wait_start.elapsed();
             result
         } {
@@ -173,11 +180,6 @@ impl Command {
             {
                 tracing::warn!(target: "reth-bench", %err, block_number, "Failed to scrape metrics");
             }
-        }
-
-        // Check if the spawned task encountered an error
-        if let Ok(error) = error_receiver.try_recv() {
-            return Err(error);
         }
 
         let (gas_output_results, new_payload_results): (_, Vec<NewPayloadResult>) =


### PR DESCRIPTION
The `.buffered()` stream in `new-payload-fcu` was consumed inline — block fetches only made progress when the consumer polled `try_next()`, so while `newPayload` + `FCU` were executing no new fetches started.

Now the `.buffered()` stream is driven by a dedicated spawned task that sends completed blocks through an mpsc channel. This keeps up to `--rpc-block-buffer-size` block fetches in-flight concurrently and buffers results independently of how fast the consumer processes them.

Prompted by: Alexey