### PR TITLE
perf(stages): parallelize hash_state_slow and write_state in execution stage

### DIFF
--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -58,6 +58,7 @@ serde-bincode-compat = [
     "alloy-consensus/serde-bincode-compat",
     "reth-ethereum-primitives/serde-bincode-compat",
 ]
+rayon = ["reth-trie-common/rayon", "reth-primitives-traits/rayon"]
 std = [
     "alloy-eips/std",
     "alloy-primitives/std",

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -213,6 +213,13 @@ impl<T> ExecutionOutcome<T> {
         HashedPostState::from_bundle_state::<KH>(&self.bundle.state)
     }
 
+    /// Returns [`HashedPostState`] for this execution outcome using parallel hashing.
+    /// See [`HashedPostState::from_bundle_state_parallel`] for more info.
+    #[cfg(feature = "rayon")]
+    pub fn par_hash_state_slow<KH: KeyHasher>(&self) -> HashedPostState {
+        HashedPostState::from_bundle_state_parallel::<KH>(&self.bundle.state)
+    }
+
     /// Transform block number to the index of block.
     pub const fn block_number_to_index(&self, block_number: BlockNumber) -> Option<usize> {
         if self.first_block > block_number {

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -30,7 +30,7 @@ reth-fs-util.workspace = true
 reth-network-p2p.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
-reth-execution-types.workspace = true
+reth-execution-types = { workspace = true, features = ["rayon"] }
 reth-ethereum-primitives = { workspace = true, optional = true }
 reth-prune.workspace = true
 reth-prune-types.workspace = true

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -492,7 +492,8 @@ where
         // state is then written separately below.
         if provider.cached_storage_settings().use_hashed_state() {
             let (hashed_state, write_result) = std::thread::scope(|s| {
-                let handle = s.spawn(|| state.hash_state_slow::<KeccakKeyHasher>().into_sorted());
+                let handle =
+                    s.spawn(|| state.par_hash_state_slow::<KeccakKeyHasher>().into_sorted());
                 let write_result = provider.write_state(
                     &state,
                     OriginalValuesKnown::Yes,

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -273,8 +273,7 @@ where
         + StateWriter<Receipt = <E::Primitives as NodePrimitives>::Receipt>
         + StorageSettingsCache
         + StoragePath
-        + ChainSpecProvider<ChainSpec: EthereumHardforks>
-        + Sync,
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -492,18 +491,17 @@ where
         // plain account/storage tables and only writes bytecodes and changesets. The hashed
         // state is then written separately below.
         if provider.cached_storage_settings().use_hashed_state() {
-            let (hashed_state, write_result) = rayon::join(
-                || state.hash_state_slow::<KeccakKeyHasher>().into_sorted(),
-                || {
-                    provider.write_state(
-                        &state,
-                        OriginalValuesKnown::Yes,
-                        StateWriteConfig::default(),
-                    )
-                },
-            );
-            write_result?;
-            provider.write_hashed_state(&hashed_state)?;
+            let hashed_state = std::thread::scope(|s| {
+                let handle = s.spawn(|| state.hash_state_slow::<KeccakKeyHasher>().into_sorted());
+                let write_result = provider.write_state(
+                    &state,
+                    OriginalValuesKnown::Yes,
+                    StateWriteConfig::default(),
+                );
+                (handle.join().expect("hash_state_slow panicked"), write_result)
+            });
+            hashed_state.1?;
+            provider.write_hashed_state(&hashed_state.0)?;
         } else {
             provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
         }

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -273,7 +273,8 @@ where
         + StateWriter<Receipt = <E::Primitives as NodePrimitives>::Receipt>
         + StorageSettingsCache
         + StoragePath
-        + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+        + ChainSpecProvider<ChainSpec: EthereumHardforks>
+        + Sync,
 {
     /// Return the id of the stage
     fn id(&self) -> StageId {
@@ -490,11 +491,24 @@ where
         // Write output. When `use_hashed_state` is enabled, `write_state` skips writing to
         // plain account/storage tables and only writes bytecodes and changesets. The hashed
         // state is then written separately below.
-        provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
-
+        //
+        // `hash_state_slow` is CPU-bound and independent of `write_state` (IO-bound), so we
+        // run them in parallel when hashed state is enabled.
         if provider.cached_storage_settings().use_hashed_state() {
-            let hashed_state = state.hash_state_slow::<KeccakKeyHasher>();
+            let (hashed_state, write_result) = rayon::join(
+                || state.hash_state_slow::<KeccakKeyHasher>(),
+                || {
+                    provider.write_state(
+                        &state,
+                        OriginalValuesKnown::Yes,
+                        StateWriteConfig::default(),
+                    )
+                },
+            );
+            write_result?;
             provider.write_hashed_state(&hashed_state.into_sorted())?;
+        } else {
+            provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
         }
 
         let db_write_duration = time.elapsed();

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -491,7 +491,7 @@ where
         // plain account/storage tables and only writes bytecodes and changesets. The hashed
         // state is then written separately below.
         if provider.cached_storage_settings().use_hashed_state() {
-            let hashed_state = std::thread::scope(|s| {
+            let (hashed_state, write_result) = std::thread::scope(|s| {
                 let handle = s.spawn(|| state.hash_state_slow::<KeccakKeyHasher>().into_sorted());
                 let write_result = provider.write_state(
                     &state,
@@ -500,8 +500,8 @@ where
                 );
                 (handle.join().expect("hash_state_slow panicked"), write_result)
             });
-            hashed_state.1?;
-            provider.write_hashed_state(&hashed_state.0)?;
+            write_result?;
+            provider.write_hashed_state(&hashed_state)?;
         } else {
             provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
         }

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -496,7 +496,7 @@ where
         // run them in parallel when hashed state is enabled.
         if provider.cached_storage_settings().use_hashed_state() {
             let (hashed_state, write_result) = rayon::join(
-                || state.hash_state_slow::<KeccakKeyHasher>(),
+                || state.hash_state_slow::<KeccakKeyHasher>().into_sorted(),
                 || {
                     provider.write_state(
                         &state,
@@ -506,7 +506,7 @@ where
                 },
             );
             write_result?;
-            provider.write_hashed_state(&hashed_state.into_sorted())?;
+            provider.write_hashed_state(&hashed_state)?;
         } else {
             provider.write_state(&state, OriginalValuesKnown::Yes, StateWriteConfig::default())?;
         }

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -491,9 +491,6 @@ where
         // Write output. When `use_hashed_state` is enabled, `write_state` skips writing to
         // plain account/storage tables and only writes bytecodes and changesets. The hashed
         // state is then written separately below.
-        //
-        // `hash_state_slow` is CPU-bound and independent of `write_state` (IO-bound), so we
-        // run them in parallel when hashed state is enabled.
         if provider.cached_storage_settings().use_hashed_state() {
             let (hashed_state, write_result) = rayon::join(
                 || state.hash_state_slow::<KeccakKeyHasher>().into_sorted(),

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -18,7 +18,9 @@ pub use rayon::*;
 use reth_primitives_traits::Account;
 
 #[cfg(feature = "rayon")]
-use rayon::prelude::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
+use rayon::prelude::{
+    FromParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 use revm_database::{AccountStatus, BundleAccount};
 
@@ -51,6 +53,32 @@ impl HashedPostState {
     ) -> Self {
         state
             .into_iter()
+            .map(|(address, account)| {
+                let hashed_address = KH::hash_key(address);
+                let hashed_account = account.info.as_ref().map(Into::into);
+                let hashed_storage = HashedStorage::from_plain_storage(
+                    account.status,
+                    account.storage.iter().map(|(slot, value)| (slot, &value.present_value)),
+                );
+
+                (
+                    hashed_address,
+                    hashed_account,
+                    (!hashed_storage.is_empty()).then_some(hashed_storage),
+                )
+            })
+            .collect()
+    }
+
+    /// Initialize [`HashedPostState`] from bundle state in parallel.
+    /// Hashes all changed accounts and storage entries using rayon for parallelism.
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn from_bundle_state_parallel<KH: KeyHasher>(
+        state: &alloy_primitives::map::AddressHashMap<BundleAccount>,
+    ) -> Self {
+        state
+            .par_iter()
             .map(|(address, account)| {
                 let hashed_address = KH::hash_key(address);
                 let hashed_account = account.info.as_ref().map(Into::into);


### PR DESCRIPTION
When `use_hashed_state` is enabled, `hash_state_slow` (CPU-bound key hashing) and `write_state` (IO-bound DB writes) are independent — run them concurrently via `rayon::join`.

Co-Authored-By: joshieDo <93316087+joshieDo@users.noreply.github.com>

Prompted by: joshie