### PR TITLE
perf: disable readahead on slot-preimage MDBX environment

### DIFF
--- a/crates/stages/stages/src/stages/execution/slot_preimages.rs
+++ b/crates/stages/stages/src/stages/execution/slot_preimages.rs
@@ -48,6 +48,7 @@ impl SlotPreimages {
         builder.write_map();
         builder.set_flags(EnvironmentFlags {
             no_sub_dir: false,
+            no_rdahead: true,
             mode: Mode::ReadWrite { sync_mode: SyncMode::Durable },
             ..Default::default()
         });


### PR DESCRIPTION
The slot-preimage MDBX environment (used for pre-Cancun selfdestruct handling in `--storage.v2`) is missing `no_rdahead: true`, which the main database sets at `crates/storage/db/src/implementation/mdbx/mod.rs:451`.

The preimage DB does random B-tree seeks across a 92 GB database. Without `MDBX_NORDAHEAD`, every 4 KB page fault triggers 256 KB of kernel readahead — **44x I/O amplification**. Traced on `reth-revm-0` (ethereum-mainnet-dev) during pipeline sync at block 18.1M:

| Phase | Faults/s | Useful I/O | Actual I/O | Waste |
|-------|----------|-----------|------------|-------|
| Preimage (no NORDAHEAD) | 4,294/s | 17 MB/s | 743 MB/s | 98% |
| write_hashed_state (NORDAHEAD) | 11,824/s | 46 MB/s | 46 MB/s | 0% |

The preimage phase takes ~121s per batch (55% of the write phase). The node is entirely I/O-bound at 0.41 CPU cores.

Prompted by: joshie