### PR TITLE
refactor: simplify compact impls for scale types

### DIFF
--- a/crates/storage/db-api/src/scale.rs
+++ b/crates/storage/db-api/src/scale.rs
@@ -2,54 +2,33 @@ use crate::{
     table::{Compress, Decompress},
     DatabaseError,
 };
-use alloy_primitives::U256;
-
-mod sealed {
-    pub trait Sealed {}
-}
-
-/// Marker trait type to restrict the [`Compress`] and [`Decompress`] with scale to chosen types.
-pub trait ScaleValue: sealed::Sealed {}
-
-impl<T> Compress for T
-where
-    T: ScaleValue + parity_scale_codec::Encode + Sync + Send + std::fmt::Debug,
-{
-    type Compressed = Vec<u8>;
-
-    fn compress(self) -> Self::Compressed {
-        parity_scale_codec::Encode::encode(&self)
-    }
-
-    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
-        parity_scale_codec::Encode::encode_to(&self, OutputCompat::wrap_mut(buf));
-    }
-}
-
-impl<T> Decompress for T
-where
-    T: ScaleValue + parity_scale_codec::Decode + Sync + Send + std::fmt::Debug,
-{
-    fn decompress(mut value: &[u8]) -> Result<T, DatabaseError> {
-        parity_scale_codec::Decode::decode(&mut value).map_err(|_| DatabaseError::Decode)
-    }
-}
 
 /// Implements compression for SCALE type.
 macro_rules! impl_compression_for_scale {
-    ($($name:tt),+) => {
+    ($($name:ty),+) => {
         $(
-            impl ScaleValue for $name {}
-            impl sealed::Sealed for $name {}
+            impl Compress for $name {
+                type Compressed = Vec<u8>;
+
+                fn compress(self) -> Self::Compressed {
+                    parity_scale_codec::Encode::encode(&self)
+                }
+
+                fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
+                    parity_scale_codec::Encode::encode_to(&self, OutputCompat::wrap_mut(buf));
+                }
+            }
+
+            impl Decompress for $name {
+                fn decompress(mut value: &[u8]) -> Result<Self, DatabaseError> {
+                    parity_scale_codec::Decode::decode(&mut value).map_err(|_| DatabaseError::Decode)
+                }
+            }
         )+
     };
 }
 
-impl ScaleValue for Vec<u8> {}
-impl sealed::Sealed for Vec<u8> {}
-
-impl_compression_for_scale!(U256);
-impl_compression_for_scale!(u8, u32, u16, u64);
+impl_compression_for_scale!(u8, u32, u16, u64, Vec<u8>);
 
 #[repr(transparent)]
 struct OutputCompat<B>(B);


### PR DESCRIPTION
Removed `Sealed` and `ScaleValue` trait in favor of directly implementing compression traits for types we're interested in within the macro
