### PR TITLE
bench(ci): reuse cached big-block fixtures and select snapshot from manifest

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -252,7 +252,7 @@ fi
 
 if [ "$BIG_BLOCKS" = "true" ]; then
   # Big blocks mode: replay pre-generated payloads
-  BIG_BLOCKS_DIR="${BENCH_WORK_DIR}/big-blocks"
+  BIG_BLOCKS_DIR="${BENCH_BIG_BLOCKS_DIR:-${BENCH_WORK_DIR}/big-blocks}"
 
   # Start tracy-capture so profile only covers the benchmark
   if [ "${BENCH_TRACY:-off}" != "off" ]; then

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -18,7 +18,11 @@ set -euo pipefail
 LABEL="$1"
 BINARY="$2"
 OUTPUT_DIR="$3"
-DATADIR="$SCHELK_MOUNT/datadir"
+DATADIR_NAME="datadir"
+if [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
+  DATADIR_NAME="datadir-big-blocks"
+fi
+DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
 mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -26,8 +26,14 @@ BUCKET="minio/reth-snapshots"
 # big-blocks manifest specifies which base snapshot to use).
 SNAPSHOT_NAME="${BENCH_SNAPSHOT_NAME:-reth-1-minimal-stable}"
 MANIFEST_PATH="${SNAPSHOT_NAME}/manifest.json"
-DATADIR="$SCHELK_MOUNT/datadir"
-HASH_FILE="$HOME/.reth-bench-snapshot-hash"
+DATADIR_NAME="datadir"
+HASH_MODE_SUFFIX=""
+if [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
+  DATADIR_NAME="datadir-big-blocks"
+  HASH_MODE_SUFFIX="-big-blocks"
+fi
+DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
+HASH_FILE="$HOME/.reth-bench-snapshot-hash${HASH_MODE_SUFFIX}"
 
 # Fetch manifest and compute content hash for reliable freshness check
 MANIFEST_CONTENT=$($MC cat "${BUCKET}/${MANIFEST_PATH}" 2>/dev/null) || {

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -22,7 +22,10 @@ set -euo pipefail
 
 MC="mc"
 BUCKET="minio/reth-snapshots"
-MANIFEST_PATH="reth-1-minimal-stable/manifest.json"
+# Allow overriding the snapshot name (e.g. for big-blocks mode where the
+# big-blocks manifest specifies which base snapshot to use).
+SNAPSHOT_NAME="${BENCH_SNAPSHOT_NAME:-reth-1-minimal-stable}"
+MANIFEST_PATH="${SNAPSHOT_NAME}/manifest.json"
 DATADIR="$SCHELK_MOUNT/datadir"
 HASH_FILE="$HOME/.reth-bench-snapshot-hash"
 
@@ -60,7 +63,7 @@ if [ -z "$MINIO_ENDPOINT" ]; then
   echo "::error::Failed to resolve MinIO endpoint from mc alias 'minio'"
   exit 1
 fi
-BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/reth-1-minimal-stable"
+BASE_URL="${MINIO_ENDPOINT}/reth-snapshots/${SNAPSHOT_NAME}"
 
 # Rewrite manifest's base_url with the runner-reachable endpoint
 MANIFEST_TMP=$(mktemp --suffix=.json)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -729,7 +729,7 @@ jobs:
         run: |
           set -euo pipefail
           MC="mc --config-dir /home/ubuntu/.mc"
-          MANIFEST="minio/reth-snapshots/brian-test-big-blocks.json"
+          MANIFEST="minio/reth-snapshots/reth-1-minimal-stable-big-blocks.json"
           HASH_FILE="$HOME/.reth-bench-big-blocks-hash"
           echo "Fetching big-blocks manifest from $MANIFEST..."
           BB_MANIFEST=$($MC cat "$MANIFEST" 2>/dev/null) || {

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -723,6 +723,39 @@ jobs:
             core.setOutput('feature-ref', featureRef);
             core.setOutput('feature-name', featureName);
 
+      - name: Check big-blocks freshness
+        if: env.BENCH_BIG_BLOCKS == 'true'
+        id: big-blocks-check
+        run: |
+          set -euo pipefail
+          MC="mc --config-dir /home/ubuntu/.mc"
+          MANIFEST="minio/reth-snapshots/brian-test-big-blocks.json"
+          HASH_FILE="$HOME/.reth-bench-big-blocks-hash"
+          echo "Fetching big-blocks manifest from $MANIFEST..."
+          BB_MANIFEST=$($MC cat "$MANIFEST" 2>/dev/null) || {
+            echo "::error::Failed to fetch big-blocks manifest from $MANIFEST"
+            exit 1
+          }
+          BASE_SNAPSHOT=$(echo "$BB_MANIFEST" | jq -r '.base_snapshot // empty')
+          if [ -z "$BASE_SNAPSHOT" ]; then
+            echo "::error::Big-blocks manifest missing base_snapshot field"
+            exit 1
+          fi
+          echo "Big-blocks base snapshot: $BASE_SNAPSHOT"
+          echo "BENCH_SNAPSHOT_NAME=${BASE_SNAPSHOT}" >> "$GITHUB_ENV"
+
+          REMOTE_HASH=$(echo "$BB_MANIFEST" | sha256sum | awk '{print $1}')
+          LOCAL_HASH=""
+          [ -f "$HASH_FILE" ] && LOCAL_HASH=$(cat "$HASH_FILE")
+          if [ "$REMOTE_HASH" = "$LOCAL_HASH" ]; then
+            echo "Big blocks up-to-date (hash: ${REMOTE_HASH:0:16}…)"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Big blocks need update (local: ${LOCAL_HASH:+${LOCAL_HASH:0:16}…}${LOCAL_HASH:-<none>}, remote: ${REMOTE_HASH:0:16}…)"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "remote-hash=${REMOTE_HASH}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check if snapshot needs update
         id: snapshot-check
         run: |
@@ -850,9 +883,15 @@ jobs:
         if: env.BENCH_BIG_BLOCKS == 'true'
         run: |
           set -euo pipefail
+          BIG_BLOCKS_DIR="$HOME/.reth-bench-big-blocks"
+          echo "BENCH_BIG_BLOCKS_DIR=${BIG_BLOCKS_DIR}" >> "$GITHUB_ENV"
+          if [ "${{ steps.big-blocks-check.outputs.needed }}" = "false" ]; then
+            echo "Big blocks cached at $BIG_BLOCKS_DIR, skipping download"
+            echo "Payload files: $(find "$BIG_BLOCKS_DIR/payloads" -name '*.json' | wc -l)"
+            exit 0
+          fi
           MC="mc --config-dir /home/ubuntu/.mc"
           BUCKET="minio/reth-snapshots/reth-1-minimal-stable-big-blocks.tar.zst"
-          BIG_BLOCKS_DIR="${BENCH_WORK_DIR}/big-blocks"
           rm -rf "$BIG_BLOCKS_DIR"; mkdir -p "$BIG_BLOCKS_DIR"
           echo "Downloading big blocks from $BUCKET..."
           $MC cat "$BUCKET" | pzstd -d -p 6 | tar -xf - -C "$BIG_BLOCKS_DIR"
@@ -864,6 +903,8 @@ jobs:
             exit 1
           fi
           echo "Payload files: $(find "$BIG_BLOCKS_DIR/payloads" -name '*.json' | wc -l)"
+          # Save manifest hash for freshness check on next run
+          echo "${{ steps.big-blocks-check.outputs.remote-hash }}" > "$HOME/.reth-bench-big-blocks-hash"
 
       - name: Start metrics proxy
         run: |


### PR DESCRIPTION
Bench workflow now checks a big-blocks manifest hash to skip re-downloading payload fixtures when unchanged. Bench scripts now support env-driven paths by honoring BENCH_BIG_BLOCKS_DIR and BENCH_SNAPSHOT_NAME so big-block runs use the manifest-selected base snapshot.