### PR TITLE
refactor: remove `StateProviderBuilder`

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types_engine::{
 use error::{InsertBlockError, InsertBlockFatalError};
 use reth_chain_state::{
     CanonicalInMemoryState, ComputedTrieData, ExecutedBlock, ExecutionTimingStats,
-    MemoryOverlayStateProvider, NewCanonicalChain,
+    NewCanonicalChain,
 };
 use reth_consensus::{Consensus, FullConsensus};
 use reth_engine_primitives::{
@@ -33,8 +33,8 @@ use reth_primitives_traits::{
 use reth_provider::{
     BlockExecutionOutput, BlockExecutionResult, BlockReader, ChangeSetReader,
     DatabaseProviderFactory, HashedPostStateProvider, ProviderError, StageCheckpointReader,
-    StateProviderBox, StateProviderFactory, StateReader, StorageChangeSetReader,
-    StorageSettingsCache, TransactionVariant,
+    StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
+    TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
@@ -93,43 +93,6 @@ pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
 /// This ensures that recent trie changesets are kept in memory for potential reorgs,
 /// even when the finalized block is not set (e.g., on L2s like Optimism).
 const CHANGESET_CACHE_RETENTION_BLOCKS: u64 = 64;
-
-/// A builder for creating state providers that can be used across threads.
-#[derive(Clone, Debug)]
-pub struct StateProviderBuilder<N: NodePrimitives, P> {
-    /// The provider factory used to create providers.
-    provider_factory: P,
-    /// The historical block hash to fetch state from.
-    historical: B256,
-    /// The blocks that form the chain from historical to target and are in memory.
-    overlay: Option<Vec<ExecutedBlock<N>>>,
-}
-
-impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
-    /// Creates a new state provider from the provider factory, historical block hash and optional
-    /// overlaid blocks.
-    pub const fn new(
-        provider_factory: P,
-        historical: B256,
-        overlay: Option<Vec<ExecutedBlock<N>>>,
-    ) -> Self {
-        Self { provider_factory, historical, overlay }
-    }
-}
-
-impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
-where
-    P: BlockReader + StateProviderFactory + StateReader + Clone,
-{
-    /// Creates a new state provider from this builder.
-    pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        let mut provider = self.provider_factory.state_by_block_hash(self.historical)?;
-        if let Some(overlay) = self.overlay.clone() {
-            provider = Box::new(MemoryOverlayStateProvider::new(provider, overlay))
-        }
-        Ok(provider)
-    }
-}
 
 /// Tracks the state of the engine api internals.
 ///
@@ -2794,12 +2757,12 @@ where
         }
 
         // Ensure that the parent state is available.
-        match self.state_provider_builder(block_id.parent) {
+        match self.find_canonical_state_for(block_id.parent) {
             Err(err) => {
                 let block = convert_to_block(self, input)?;
                 return Err(InsertBlockError::new(block, err.into()).into());
             }
-            Ok(None) => {
+            Ok(false) => {
                 let block = convert_to_block(self, input)?;
 
                 // we don't have the state required to execute this block, buffering it and find the
@@ -2818,7 +2781,7 @@ where
                     missing_ancestor,
                 }))
             }
-            Ok(Some(_)) => {}
+            Ok(true) => {}
         }
 
         // determine whether we are on a fork chain by comparing the block number with the
@@ -3123,25 +3086,17 @@ where
         Ok(())
     }
 
-    /// Returns a builder for creating state providers for the given hash.
+    /// Method that checks if we have canonical state for the given block hash.
     ///
-    /// This is an optimization for parallel execution contexts where we want to avoid
-    /// creating state providers in the critical path.
-    pub fn state_provider_builder(
-        &self,
-        hash: B256,
-    ) -> ProviderResult<Option<StateProviderBuilder<N, P>>>
+    /// Returns whether the canonical state was found.
+    pub fn find_canonical_state_for(&self, hash: B256) -> ProviderResult<bool>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone,
     {
-        if let Some((historical, blocks)) = self.state.tree_state.blocks_by_hash(hash) {
+        if let Some((historical, _)) = self.state.tree_state.blocks_by_hash(hash) {
             debug!(target: "engine::tree", %hash, %historical, "found canonical state for block in memory, creating provider builder");
             // the block leads back to the canonical chain
-            return Ok(Some(StateProviderBuilder::new(
-                self.provider.clone(),
-                historical,
-                Some(blocks),
-            )))
+            return Ok(true)
         }
 
         // Check if the block is persisted
@@ -3149,11 +3104,11 @@ where
             debug!(target: "engine::tree", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(true);
         }
 
         debug!(target: "engine::tree", %hash, "no canonical state found for block");
-        Ok(None)
+        Ok(false)
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -8,7 +8,7 @@ use crate::tree::{
         sparse_trie::StateRootComputeOutcome,
     },
     sparse_trie::SparseTrieCacheTask,
-    CacheWaitDurations, StateProviderBuilder, TreeConfig, WaitForCaches,
+    CacheWaitDurations, TreeConfig, WaitForCaches,
 };
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal};
@@ -256,7 +256,7 @@ where
         &mut self,
         env: ExecutionEnv<Evm>,
         transactions: I,
-        provider_builder: StateProviderBuilder<N, P>,
+        provider_builder: P,
         multiproof_provider_factory: F,
         config: &TreeConfig,
         bal: Option<Arc<BlockAccessList>>,
@@ -300,7 +300,7 @@ where
         &self,
         env: ExecutionEnv<Evm>,
         transactions: I,
-        provider_builder: StateProviderBuilder<N, P>,
+        provider: P,
         bal: Option<Arc<BlockAccessList>>,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
@@ -308,7 +308,7 @@ where
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count);
-        let prewarm_handle = self.spawn_caching_with(env, prewarm_rx, provider_builder, None, bal);
+        let prewarm_handle = self.spawn_caching_with(env, prewarm_rx, provider, None, bal);
         PayloadHandle {
             state_root_handle: None,
             prewarm_handle,
@@ -468,7 +468,7 @@ where
         &self,
         env: ExecutionEnv<Evm>,
         transactions: mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
-        provider_builder: StateProviderBuilder<N, P>,
+        provider: P,
         to_multi_proof: Option<CrossbeamSender<MultiProofMessage>>,
         bal: Option<Arc<BlockAccessList>>,
     ) -> CacheTaskHandle<N::Receipt>
@@ -487,7 +487,7 @@ where
             env,
             evm_config: self.evm_config.clone(),
             saved_cache: saved_cache.clone(),
-            provider: provider_builder,
+            provider,
             metrics: PrewarmMetrics::default(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
             executed_tx_index: Arc::clone(&executed_tx_index),
@@ -1154,7 +1154,7 @@ mod tests {
         cached_state::{CachedStateMetrics, ExecutionCache, SavedCache},
         payload_processor::{evm_state_to_hashed_post_state, ExecutionEnv, PayloadProcessor},
         precompile_cache::PrecompileCacheMap,
-        StateProviderBuilder, TreeConfig,
+        TreeConfig,
     };
     use alloy_eips::eip1898::{BlockNumHash, BlockWithParent};
     use alloy_evm::block::StateChangeSource;
@@ -1378,7 +1378,6 @@ mod tests {
         reth_tracing::init_test_tracing();
 
         let factory = create_test_provider_factory_with_chain_spec(Arc::new(ChainSpec::default()));
-        let genesis_hash = init_genesis(&factory).unwrap();
 
         let state_updates = create_mock_state_updates(10, 10);
         let mut hashed_state = HashedPostState::default();
@@ -1440,7 +1439,7 @@ mod tests {
                 Vec::<Result<Recovered<TransactionSigned>, core::convert::Infallible>>::new(),
                 std::convert::identity,
             ),
-            StateProviderBuilder::new(provider_factory.clone(), genesis_hash, None),
+            provider_factory.clone(),
             OverlayStateProviderFactory::new(provider_factory, ChangesetCache::new()),
             &TreeConfig::default(),
             None, // No BAL for test

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -15,7 +15,7 @@ use crate::tree::{
     cached_state::{CachedStateProvider, SavedCache},
     payload_processor::{bal, multiproof::MultiProofMessage, PayloadExecutionCache},
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
-    ExecutionEnv, StateProviderBuilder,
+    ExecutionEnv,
 };
 use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::BlockAccessList;
@@ -383,7 +383,7 @@ where
     fn send_bal_hashed_state(&self, bal: &BlockAccessList) {
         let Some(to_multi_proof) = &self.to_multi_proof else { return };
 
-        let provider = match self.ctx.provider.build() {
+        let provider = match self.ctx.provider.history_by_block_hash(self.ctx.env.parent_hash) {
             Ok(provider) => provider,
             Err(err) => {
                 warn!(
@@ -502,7 +502,7 @@ where
     /// The saved cache.
     pub saved_cache: Option<SavedCache>,
     /// Provider to obtain the state
-    pub provider: StateProviderBuilder<N, P>,
+    pub provider: P,
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
@@ -531,7 +531,7 @@ where
     /// Creates a per-thread EVM for prewarming.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(&self) -> PrewarmEvmState<Evm> {
-        let mut state_provider = match self.provider.build() {
+        let mut state_provider = match self.provider.history_by_block_hash(self.env.parent_hash) {
             Ok(provider) => provider,
             Err(err) => {
                 trace!(
@@ -606,7 +606,7 @@ where
         let state_provider = match provider {
             Some(p) => p,
             slot @ None => {
-                let built = match self.provider.build() {
+                let built = match self.provider.history_by_block_hash(self.env.parent_hash) {
                     Ok(p) => p,
                     Err(err) => {
                         trace!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -46,7 +46,7 @@ use crate::tree::{
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     sparse_trie::StateRootComputeOutcome,
     CacheWaitDurations, EngineApiMetrics, EngineApiTreeState, ExecutionEnv, PayloadHandle,
-    StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
+    StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::BlockAccessList;
@@ -459,17 +459,13 @@ where
         trace!(target: "engine::tree::payload_validator", "Fetching block state provider");
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "state_provider").entered();
-        let Some(provider_builder) =
-            ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
-        else {
-            // this is pre-validated in the tree
-            return Err(InsertBlockError::new(
-                convert_to_block(input)?,
-                ProviderError::HeaderNotFound(parent_hash.into()).into(),
-            )
-            .into())
+        let mut state_provider = match self.provider.history_by_block_hash(parent_hash) {
+            Ok(p) => p,
+            Err(err) => {
+                // this is pre-validated in the tree
+                return Err(InsertBlockError::new(convert_to_block(input)?, err.into()).into())
+            }
         };
-        let mut state_provider = ensure_ok!(provider_builder.build());
         drop(_enter);
 
         // Fetch parent block. This goes to memory most of the time unless the parent block is
@@ -532,7 +528,6 @@ where
         let mut handle = ensure_ok!(self.spawn_payload_processor(
             env.clone(),
             txs,
-            provider_builder,
             overlay_factory.clone(),
             strategy,
             block_access_list,
@@ -1437,7 +1432,6 @@ where
         &mut self,
         env: ExecutionEnv<Evm>,
         txs: T,
-        provider_builder: StateProviderBuilder<N, P>,
         overlay_factory: OverlayStateProviderFactory<P>,
         strategy: StateRootStrategy,
         block_access_list: Option<Arc<BlockAccessList>>,
@@ -1457,7 +1451,7 @@ where
                 let handle = self.payload_processor.spawn(
                     env,
                     txs,
-                    provider_builder,
+                    self.provider.clone(),
                     overlay_factory,
                     &self.config,
                     block_access_list,
@@ -1476,7 +1470,7 @@ where
                 let handle = self.payload_processor.spawn_cache_exclusive(
                     env,
                     txs,
-                    provider_builder,
+                    self.provider.clone(),
                     block_access_list,
                 );
 
@@ -1489,37 +1483,6 @@ where
                 Ok(handle)
             }
         }
-    }
-
-    /// Creates a `StateProviderBuilder` for the given parent hash.
-    ///
-    /// This method checks if the parent is in the tree state (in-memory) or persisted to disk,
-    /// and creates the appropriate provider builder.
-    fn state_provider_builder(
-        &self,
-        hash: B256,
-        state: &EngineApiTreeState<N>,
-    ) -> ProviderResult<Option<StateProviderBuilder<N, P>>> {
-        if let Some((historical, blocks)) = state.tree_state.blocks_by_hash(hash) {
-            debug!(target: "engine::tree::payload_validator", %hash, %historical, "found canonical state for block in memory, creating provider builder");
-            // the block leads back to the canonical chain
-            return Ok(Some(StateProviderBuilder::new(
-                self.provider.clone(),
-                historical,
-                Some(blocks),
-            )))
-        }
-
-        // Check if the block is persisted
-        if let Some(header) = self.provider.header(hash)? {
-            debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
-            // For persisted blocks, we create a builder that will fetch state directly from the
-            // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
-        }
-
-        debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");
-        Ok(None)
     }
 
     /// Determines the state root computation strategy based on configuration.


### PR DESCRIPTION
For sharing prewarm/trie components with payload builder ideally we stop using as much of engine-specific provider wrappers as possible