### PR TITLE
feat(txpool): add TransactionValidationTaskExecutor::spawn

### DIFF
--- a/.changelog/warm-slugs-crawl.md
+++ b/.changelog/warm-slugs-crawl.md
@@ -1,0 +1,5 @@
+---
+reth-transaction-pool: minor
+---
+
+Added `TransactionValidationTaskExecutor::spawn` as a dedicated constructor that encapsulates spawning validation tasks on a runtime, and refactored `EthTransactionValidatorBuilder::build_with_tasks` to use it.

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     metrics::TxPoolValidationMetrics,
     traits::TransactionOrigin,
-    validate::{ValidTransaction, ValidationTask},
+    validate::ValidTransaction,
     Address, BlobTransactionSidecarVariant, EthBlobTransactionSidecar, EthPoolTransaction,
     LocalTransactionConfig, TransactionValidationOutcome, TransactionValidationTaskExecutor,
     TransactionValidator,
@@ -44,7 +44,6 @@ use std::{
     },
     time::{Instant, SystemTime},
 };
-use tokio::sync::Mutex;
 
 /// Additional stateless validation function signature.
 ///
@@ -1324,26 +1323,7 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
     {
         let additional_tasks = self.additional_tasks;
         let validator = self.build::<Tx, S>(blob_store);
-
-        let (tx, task) = ValidationTask::new();
-
-        // Spawn validation tasks, they are blocking because they perform db lookups
-        for _ in 0..additional_tasks {
-            let task = task.clone();
-            tasks.spawn_blocking_task(async move {
-                task.run().await;
-            });
-        }
-
-        // we spawn them on critical tasks because validation, especially for EIP-4844 can be quite
-        // heavy
-        tasks.spawn_critical_blocking_task("transaction-validation-service", async move {
-            task.run().await;
-        });
-
-        let to_validation_task = Arc::new(Mutex::new(tx));
-
-        TransactionValidationTaskExecutor { validator: Arc::new(validator), to_validation_task }
+        TransactionValidationTaskExecutor::spawn(validator, &tasks, additional_tasks)
     }
 }
 

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -206,6 +206,27 @@ impl<V> TransactionValidationTaskExecutor<V> {
             task,
         )
     }
+
+    /// Creates a new executor and spawns the validation tasks on the given runtime.
+    ///
+    /// This spawns `additional_tasks` extra blocking tasks plus one critical blocking task
+    /// for the validation service.
+    pub fn spawn(validator: V, tasks: &Runtime, additional_tasks: usize) -> Self {
+        let (tx, task) = ValidationTask::new();
+
+        for _ in 0..additional_tasks {
+            let task = task.clone();
+            tasks.spawn_blocking_task(async move {
+                task.run().await;
+            });
+        }
+
+        tasks.spawn_critical_blocking_task("transaction-validation-service", async move {
+            task.run().await;
+        });
+
+        Self { validator: Arc::new(validator), to_validation_task: Arc::new(sync::Mutex::new(tx)) }
+    }
 }
 
 impl<V> TransactionValidator for TransactionValidationTaskExecutor<V>


### PR DESCRIPTION
Extracts the task spawning logic from `EthTransactionValidatorBuilder::build_with_tasks` into a standalone `TransactionValidationTaskExecutor::spawn` method. This allows any validator to be wrapped with task-based validation without going through the Eth builder, making it easier to set up custom validators with the full spawning infrastructure.