### PR TITLE
refactor: remove `PayloadBuilderAttributes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,7 +3620,6 @@ dependencies = [
 name = "example-custom-engine-types"
 version = "0.0.0"
 dependencies = [
- "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types",
@@ -9478,6 +9477,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
+ "serde_json",
  "sha2",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7584,6 +7584,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
+ "serde",
  "tokio",
  "tracing",
 ]
@@ -8599,7 +8600,6 @@ version = "1.11.3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
  "reth-ethereum-primitives",
@@ -8607,7 +8607,6 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "serde_json",
- "sha2",
  "thiserror 2.0.18",
 ]
 
@@ -9466,6 +9465,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "assert_matches",
  "auto_impl",
@@ -9478,6 +9478,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -1,8 +1,7 @@
 use alloy_consensus::Sealable;
 use alloy_primitives::B256;
 use reth_node_api::{
-    BuiltPayload, ConsensusEngineHandle, ExecutionPayload, NodePrimitives,
-    PayloadTypes,
+    BuiltPayload, ConsensusEngineHandle, ExecutionPayload, NodePrimitives, PayloadTypes,
 };
 use reth_primitives_traits::{Block, SealedBlock};
 use reth_tracing::tracing::warn;
@@ -131,10 +130,7 @@ where
                 safe_block_hash,
                 finalized_block_hash,
             };
-            let _ = self
-                .engine_handle
-                .fork_choice_updated(state, None)
-                .await;
+            let _ = self.engine_handle.fork_choice_updated(state, None).await;
         }
     }
 }

--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::Sealable;
 use alloy_primitives::B256;
 use reth_node_api::{
-    BuiltPayload, ConsensusEngineHandle, EngineApiMessageVersion, ExecutionPayload, NodePrimitives,
+    BuiltPayload, ConsensusEngineHandle, ExecutionPayload, NodePrimitives,
     PayloadTypes,
 };
 use reth_primitives_traits::{Block, SealedBlock};
@@ -133,7 +133,7 @@ where
             };
             let _ = self
                 .engine_handle
-                .fork_choice_updated(state, None, EngineApiMessageVersion::V3)
+                .fork_choice_updated(state, None)
                 .await;
         }
     }

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -48,7 +48,11 @@ pub async fn setup<N>(
     num_nodes: usize,
     chain_spec: Arc<N::ChainSpec>,
     is_dev: bool,
-    attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes
+        + Send
+        + Sync
+        + Copy
+        + 'static,
 ) -> eyre::Result<(Vec<NodeHelperType<N>>, Wallet)>
 where
     N: NodeBuilderHelper,
@@ -65,7 +69,11 @@ pub async fn setup_engine<N>(
     chain_spec: Arc<N::ChainSpec>,
     is_dev: bool,
     tree_config: reth_node_api::TreeConfig,
-    attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes
+        + Send
+        + Sync
+        + Copy
+        + 'static,
 ) -> eyre::Result<(
     Vec<NodeHelperType<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>,
     Wallet,
@@ -90,7 +98,11 @@ pub async fn setup_engine_with_connection<N>(
     chain_spec: Arc<N::ChainSpec>,
     is_dev: bool,
     tree_config: reth_node_api::TreeConfig,
-    attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes
+        + Send
+        + Sync
+        + Copy
+        + 'static,
     connect_nodes: bool,
 ) -> eyre::Result<(
     Vec<NodeHelperType<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>,

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! Utilities for end-to-end tests.
 
+use alloy_rpc_types_engine::PayloadAttributes;
 use node::NodeTestContext;
 use reth_chainspec::ChainSpec;
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
@@ -145,11 +146,8 @@ pub type NodeHelperType<N, Provider = BlockchainProvider<NodeTypesWithDBAdapter<
 pub trait NodeBuilderHelper
 where
     Self: Default
-        + NodeTypesForProvider<
-            Payload: PayloadTypes<
-                PayloadBuilderAttributes: From<reth_payload_builder::EthPayloadBuilderAttributes>,
-            >,
-        > + Node<
+        + NodeTypesForProvider<Payload: PayloadTypes<PayloadAttributes: From<PayloadAttributes>>>
+        + Node<
             TmpNodeAdapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             ComponentsBuilder: NodeComponentsBuilder<
                 TmpNodeAdapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
@@ -170,11 +168,8 @@ where
 
 impl<T> NodeBuilderHelper for T where
     Self: Default
-        + NodeTypesForProvider<
-            Payload: PayloadTypes<
-                PayloadBuilderAttributes: From<reth_payload_builder::EthPayloadBuilderAttributes>,
-            >,
-        > + Node<
+        + NodeTypesForProvider<Payload: PayloadTypes<PayloadAttributes: From<PayloadAttributes>>>
+        + Node<
             TmpNodeAdapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,
             ComponentsBuilder: NodeComponentsBuilder<
                 TmpNodeAdapter<Self, BlockchainProvider<NodeTypesWithDBAdapter<Self, TmpDB>>>,

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -58,7 +58,7 @@ where
     /// Creates a new test node
     pub async fn new(
         node: FullNode<Node, AddOns>,
-        attributes_generator: impl Fn(u64) -> Payload::PayloadBuilderAttributes + Send + Sync + 'static,
+        attributes_generator: impl Fn(u64) -> Payload::PayloadAttributes + Send + Sync + 'static,
     ) -> eyre::Result<Self> {
         Ok(Self {
             inner: node.clone(),

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -9,10 +9,7 @@ use futures_util::Future;
 use jsonrpsee::{core::client::ClientT, http_client::HttpClient};
 use reth_chainspec::EthereumHardforks;
 use reth_network_api::test_utils::PeersHandleProvider;
-use reth_node_api::{
-    Block, BlockBody, BlockTy, FullNodeComponents, PayloadTypes,
-    PrimitivesTy,
-};
+use reth_node_api::{Block, BlockBody, BlockTy, FullNodeComponents, PayloadTypes, PrimitivesTy};
 use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeTypes};
 
 use reth_payload_primitives::BuiltPayload;

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -10,7 +10,7 @@ use jsonrpsee::{core::client::ClientT, http_client::HttpClient};
 use reth_chainspec::EthereumHardforks;
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_api::{
-    Block, BlockBody, BlockTy, EngineApiMessageVersion, FullNodeComponents, PayloadTypes,
+    Block, BlockBody, BlockTy, FullNodeComponents, PayloadTypes,
     PrimitivesTy,
 };
 use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeTypes};
@@ -265,7 +265,6 @@ where
                     finalized_block_hash: current_head,
                 },
                 None,
-                EngineApiMessageVersion::default(),
             )
             .await?;
 

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -15,7 +15,7 @@ use reth_node_api::{
 };
 use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeTypes};
 
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
+use reth_payload_primitives::BuiltPayload;
 use reth_provider::{
     BlockReader, BlockReaderIdExt, CanonStateNotificationStream, CanonStateSubscriptions,
     HeaderProvider, StageCheckpointReader,
@@ -112,11 +112,11 @@ where
     /// It triggers the resolve payload via engine api and expects the built payload event.
     pub async fn new_payload(&mut self) -> eyre::Result<Payload::BuiltPayload> {
         // trigger new payload building draining the pool
-        let eth_attr = self.payload.new_payload().await.unwrap();
+        let (eth_attr, payload_id) = self.payload.new_payload().await.unwrap();
         // first event is the payload attributes
-        self.payload.expect_attr_event(eth_attr.clone()).await?;
+        self.payload.expect_attr_event(eth_attr).await?;
         // wait for the payload builder to have finished building
-        self.payload.wait_for_built_payload(eth_attr.payload_id()).await;
+        self.payload.wait_for_built_payload(payload_id).await;
         // ensure we're also receiving the built payload as event
         Ok(self.payload.expect_built_payload().await?)
     }

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -12,14 +12,14 @@ pub struct PayloadTestContext<T: PayloadTypes> {
     payload_builder: PayloadBuilderHandle<T>,
     pub timestamp: u64,
     #[debug(skip)]
-    attributes_generator: Box<dyn Fn(u64) -> T::PayloadBuilderAttributes + Send + Sync>,
+    attributes_generator: Box<dyn Fn(u64) -> T::PayloadAttributes + Send + Sync>,
 }
 
 impl<T: PayloadTypes> PayloadTestContext<T> {
     /// Creates a new payload helper
     pub async fn new(
         payload_builder: PayloadBuilderHandle<T>,
-        attributes_generator: impl Fn(u64) -> T::PayloadBuilderAttributes + Send + Sync + 'static,
+        attributes_generator: impl Fn(u64) -> T::PayloadAttributes + Send + Sync + 'static,
     ) -> eyre::Result<Self> {
         let payload_events = payload_builder.subscribe().await?;
         let payload_event_stream = payload_events.into_stream();
@@ -33,7 +33,7 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
     }
 
     /// Creates a new payload job from static attributes
-    pub async fn new_payload(&mut self) -> eyre::Result<T::PayloadBuilderAttributes> {
+    pub async fn new_payload(&mut self) -> eyre::Result<T::PayloadAttributes> {
         self.timestamp += 1;
         let attributes = (self.attributes_generator)(self.timestamp);
         self.payload_builder.send_new_payload(attributes.clone()).await.unwrap()?;
@@ -41,10 +41,7 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
     }
 
     /// Asserts that the next event is a payload attributes event
-    pub async fn expect_attr_event(
-        &mut self,
-        attrs: T::PayloadBuilderAttributes,
-    ) -> eyre::Result<()> {
+    pub async fn expect_attr_event(&mut self, attrs: T::PayloadAttributes) -> eyre::Result<()> {
         let first_event = self.payload_event_stream.next().await.unwrap()?;
         if let Events::Attributes(attr) = first_event {
             assert_eq!(attrs.timestamp(), attr.timestamp());

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -1,8 +1,9 @@
+use alloy_primitives::B256;
 use futures_util::StreamExt;
-use reth_node_api::{BlockBody, PayloadKind};
+use reth_node_api::{BlockBody, PayloadAttributes, PayloadKind};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadId};
 use reth_payload_builder_primitives::Events;
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadTypes};
+use reth_payload_primitives::{BuiltPayload, PayloadTypes};
 use tokio_stream::wrappers::BroadcastStream;
 
 /// Helper for payload operations
@@ -33,11 +34,16 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
     }
 
     /// Creates a new payload job from static attributes
-    pub async fn new_payload(&mut self) -> eyre::Result<T::PayloadAttributes> {
+    pub async fn new_payload(&mut self) -> eyre::Result<(T::PayloadAttributes, PayloadId)> {
         self.timestamp += 1;
         let attributes = (self.attributes_generator)(self.timestamp);
-        self.payload_builder.send_new_payload(attributes.clone()).await.unwrap()?;
-        Ok(attributes)
+        let parent_hash = B256::ZERO;
+        let payload_id = self
+            .payload_builder
+            .send_new_payload(parent_hash, attributes.clone())
+            .await
+            .unwrap()?;
+        Ok((attributes, payload_id))
     }
 
     /// Asserts that the next event is a payload attributes event

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -33,7 +33,7 @@ type NodeConfigModifier<C> = Box<dyn Fn(NodeConfig<C>) -> NodeConfig<C> + Send +
 pub struct E2ETestSetupBuilder<N, F>
 where
     N: NodeBuilderHelper,
-    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
+    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes
         + Send
         + Sync
         + Copy
@@ -50,7 +50,7 @@ where
 impl<N, F> E2ETestSetupBuilder<N, F>
 where
     N: NodeBuilderHelper,
-    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
+    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes
         + Send
         + Sync
         + Copy
@@ -207,7 +207,7 @@ where
 impl<N, F> std::fmt::Debug for E2ETestSetupBuilder<N, F>
 where
     N: NodeBuilderHelper,
-    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
+    F: Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes
         + Send
         + Sync
         + Copy

--- a/crates/e2e-test-utils/src/setup_import.rs
+++ b/crates/e2e-test-utils/src/setup_import.rs
@@ -1,6 +1,7 @@
 //! Setup utilities for importing RLP chain data before starting nodes.
 
 use crate::{node::NodeTestContext, NodeHelperType, Wallet};
+use alloy_rpc_types_engine::PayloadAttributes;
 use reth_chainspec::ChainSpec;
 use reth_cli_commands::import_core::{import_blocks_from_file, ImportConfig};
 use reth_config::Config;
@@ -59,11 +60,7 @@ pub async fn setup_engine_with_chain_import(
     is_dev: bool,
     tree_config: TreeConfig,
     rlp_path: &Path,
-    attributes_generator: impl Fn(u64) -> reth_payload_builder::EthPayloadBuilderAttributes
-        + Send
-        + Sync
-        + Copy
-        + 'static,
+    attributes_generator: impl Fn(u64) -> PayloadAttributes + Send + Sync + Copy + 'static,
 ) -> eyre::Result<ChainImportResult> {
     let runtime = reth_tasks::Runtime::test();
 
@@ -273,10 +270,10 @@ pub fn load_forkchoice_state(path: &Path) -> eyre::Result<alloy_rpc_types_engine
 mod tests {
     use super::*;
     use crate::test_rlp_utils::{create_fcu_json, generate_test_blocks, write_blocks_to_rlp};
+    use alloy_rpc_types_engine::PayloadAttributes;
     use reth_chainspec::{ChainSpecBuilder, MAINNET};
     use reth_db::mdbx::DatabaseArguments;
     use reth_ethereum_primitives::Block;
-    use reth_payload_builder::EthPayloadBuilderAttributes;
     use reth_primitives_traits::SealedBlock;
     use reth_provider::{
         test_utils::MockNodeTypesWithDB, BlockHashReader, BlockNumReader, BlockReaderIdExt,
@@ -569,7 +566,7 @@ mod tests {
             false,
             TreeConfig::default(),
             &rlp_path,
-            |_| EthPayloadBuilderAttributes::default(),
+            |_| PayloadAttributes::default(),
         )
         .await
         .expect("Failed to setup nodes with chain import");

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -288,9 +288,7 @@ where
 
     /// Create a static attributes generator that doesn't capture any instance data
     fn create_static_attributes_generator<N>(
-    ) -> impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes
-           + Copy
-           + use<N, I>
+    ) -> impl Fn(u64) -> <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes + Copy + use<N, I>
     where
         N: NodeBuilderHelper<Payload = I>,
     {
@@ -302,7 +300,7 @@ where
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
             };
-            <<N as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes::from(
+            <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes::from(
                 EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
             )
         }

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -10,7 +10,6 @@ use reth_ethereum_primitives::Block;
 use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState};
 use reth_node_api::{EngineTypes, NodeTypes, PayloadTypes, TreeConfig};
 use reth_node_core::primitives::RecoveredBlock;
-use reth_payload_builder::EthPayloadBuilderAttributes;
 use revm::state::EvmState;
 use std::{marker::PhantomData, path::Path, sync::Arc};
 use tokio::{
@@ -264,15 +263,12 @@ where
         let chain_spec =
             self.chain_spec.clone().ok_or_else(|| eyre!("Chain specification is required"))?;
 
-        let attributes_generator = move |timestamp| {
-            let attributes = PayloadAttributes {
-                timestamp,
-                prev_randao: B256::ZERO,
-                suggested_fee_recipient: alloy_primitives::Address::ZERO,
-                withdrawals: Some(vec![]),
-                parent_beacon_block_root: Some(B256::ZERO),
-            };
-            EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+        let attributes_generator = move |timestamp| PayloadAttributes {
+            timestamp,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: alloy_primitives::Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
         };
 
         crate::setup_import::setup_engine_with_chain_import(
@@ -293,16 +289,14 @@ where
         N: NodeBuilderHelper<Payload = I>,
     {
         move |timestamp| {
-            let attributes = PayloadAttributes {
+            PayloadAttributes {
                 timestamp,
                 prev_randao: B256::ZERO,
                 suggested_fee_recipient: alloy_primitives::Address::ZERO,
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
-            };
-            <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes::from(
-                EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
-            )
+            }
+            .into()
         }
     }
 

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -19,7 +19,6 @@ use reth_e2e_test_utils::{
 };
 use reth_node_api::TreeConfig;
 use reth_node_ethereum::{EthEngineTypes, EthereumNode};
-use reth_payload_builder::EthPayloadBuilderAttributes;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tracing::debug;
@@ -371,7 +370,7 @@ async fn test_setup_builder_with_custom_tree_config() -> Result<()> {
     );
 
     let (nodes, _wallet) = E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, |_| {
-        EthPayloadBuilderAttributes::default()
+        PayloadAttributes::default()
     })
     .with_tree_config_modifier(|config| {
         config.with_persistence_threshold(0).with_memory_block_buffer_target(5)

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -3,6 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+use alloy_rpc_types_engine::PayloadAttributes;
 use alloy_rpc_types_eth::{Transaction, TransactionInput, TransactionReceipt, TransactionRequest};
 use eyre::Result;
 use jsonrpsee::core::client::ClientT;
@@ -10,7 +11,6 @@ use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
 use reth_db::tables;
 use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet, E2ETestSetupBuilder};
 use reth_node_ethereum::EthereumNode;
-use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_provider::RocksDBProviderFactory;
 use std::{sync::Arc, time::Duration};
 
@@ -83,15 +83,14 @@ fn test_chain_spec() -> Arc<ChainSpec> {
 }
 
 /// Returns test payload attributes for the given timestamp.
-fn test_attributes_generator(timestamp: u64) -> EthPayloadBuilderAttributes {
-    let attributes = alloy_rpc_types_engine::PayloadAttributes {
+const fn test_attributes_generator(timestamp: u64) -> PayloadAttributes {
+    PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
         suggested_fee_recipient: alloy_primitives::Address::ZERO,
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
-    };
-    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    }
 }
 
 /// Smoke test: node boots with `RocksDB` routing enabled.

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -7,7 +7,7 @@ use futures_util::{stream::Fuse, Stream, StreamExt};
 use reth_engine_primitives::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
-    BuiltPayload, EngineApiMessageVersion, PayloadAttributesBuilder, PayloadKind, PayloadTypes,
+    BuiltPayload, PayloadAttributesBuilder, PayloadKind, PayloadTypes,
 };
 use reth_primitives_traits::{HeaderTy, SealedHeaderFor};
 use reth_storage_api::BlockReader;
@@ -216,7 +216,7 @@ where
         let state = self.forkchoice_state();
         let res = self
             .to_engine
-            .fork_choice_updated(state, None, EngineApiMessageVersion::default())
+            .fork_choice_updated(state, None)
             .await?;
 
         if !res.is_valid() {
@@ -234,7 +234,6 @@ where
             .fork_choice_updated(
                 self.forkchoice_state(),
                 Some(self.payload_attributes_builder.build(&self.last_header)),
-                EngineApiMessageVersion::default(),
             )
             .await?;
 

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -6,9 +6,7 @@ use eyre::OptionExt;
 use futures_util::{stream::Fuse, Stream, StreamExt};
 use reth_engine_primitives::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_payload_primitives::{
-    BuiltPayload, PayloadAttributesBuilder, PayloadKind, PayloadTypes,
-};
+use reth_payload_primitives::{BuiltPayload, PayloadAttributesBuilder, PayloadKind, PayloadTypes};
 use reth_primitives_traits::{HeaderTy, SealedHeaderFor};
 use reth_storage_api::BlockReader;
 use reth_transaction_pool::TransactionPool;
@@ -214,10 +212,7 @@ where
     /// Sends a FCU to the engine.
     async fn update_forkchoice_state(&self) -> eyre::Result<()> {
         let state = self.forkchoice_state();
-        let res = self
-            .to_engine
-            .fork_choice_updated(state, None)
-            .await?;
+        let res = self.to_engine.fork_choice_updated(state, None).await?;
 
         if !res.is_valid() {
             eyre::bail!("Invalid fork choice update {state:?}: {res:?}")

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -14,7 +14,7 @@ use core::{
 use futures::{future::Either, FutureExt, TryFutureExt};
 use reth_errors::RethResult;
 use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::{PayloadTypes};
+use reth_payload_primitives::PayloadTypes;
 use std::time::Duration;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -14,7 +14,7 @@ use core::{
 use futures::{future::Either, FutureExt, TryFutureExt};
 use reth_errors::RethResult;
 use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::{EngineApiMessageVersion, PayloadTypes};
+use reth_payload_primitives::{PayloadTypes};
 use std::time::Duration;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
@@ -195,8 +195,6 @@ pub enum BeaconEngineMessage<Payload: PayloadTypes> {
         state: ForkchoiceState,
         /// The payload attributes for block building.
         payload_attrs: Option<Payload::PayloadAttributes>,
-        /// The Engine API Version.
-        version: EngineApiMessageVersion,
         /// The sender for returning forkchoice updated result.
         tx: oneshot::Sender<RethResult<OnForkChoiceUpdated>>,
     },
@@ -297,10 +295,9 @@ where
         &self,
         state: ForkchoiceState,
         payload_attrs: Option<Payload::PayloadAttributes>,
-        version: EngineApiMessageVersion,
     ) -> Result<ForkchoiceUpdated, BeaconForkChoiceUpdateError> {
         Ok(self
-            .send_fork_choice_updated(state, payload_attrs, version)
+            .send_fork_choice_updated(state, payload_attrs)
             .map_err(|_| BeaconForkChoiceUpdateError::EngineUnavailable)
             .await?
             .map_err(BeaconForkChoiceUpdateError::internal)?
@@ -313,14 +310,12 @@ where
         &self,
         state: ForkchoiceState,
         payload_attrs: Option<Payload::PayloadAttributes>,
-        version: EngineApiMessageVersion,
     ) -> oneshot::Receiver<RethResult<OnForkChoiceUpdated>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.to_engine.send(BeaconEngineMessage::ForkchoiceUpdated {
             state,
             payload_attrs,
             tx,
-            version,
         });
         rx
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -24,9 +24,7 @@ use reth_engine_primitives::{
 use reth_errors::{ConsensusError, ProviderResult};
 use reth_evm::ConfigureEvm;
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_payload_primitives::{
-    BuiltPayload, NewPayloadError, PayloadTypes,
-};
+use reth_payload_primitives::{BuiltPayload, NewPayloadError, PayloadTypes};
 use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
@@ -1144,11 +1142,8 @@ where
                 if let Some(attr) = attrs {
                     debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
                     // Clone only when we actually need to process the attributes
-                    let updated = self.process_payload_attributes(
-                        attr.clone(),
-                        &canonical_header,
-                        state,
-                    );
+                    let updated =
+                        self.process_payload_attributes(attr.clone(), &canonical_header, state);
                     return Ok(Some(TreeOutcome::new(updated)));
                 }
             }
@@ -1452,16 +1447,11 @@ where
                     }
                     EngineApiRequest::Beacon(request) => {
                         match request {
-                            BeaconEngineMessage::ForkchoiceUpdated {
-                                state,
-                                payload_attrs,
-                                tx,
-                            } => {
+                            BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx } => {
                                 let has_attrs = payload_attrs.is_some();
 
                                 let start = Instant::now();
-                                let mut output =
-                                    self.on_forkchoice_updated(state, payload_attrs);
+                                let mut output = self.on_forkchoice_updated(state, payload_attrs);
 
                                 if let Ok(res) = &mut output {
                                     // track last received forkchoice state

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -25,7 +25,7 @@ use reth_errors::{ConsensusError, ProviderResult};
 use reth_evm::ConfigureEvm;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
-    BuiltPayload, EngineApiMessageVersion, NewPayloadError, PayloadTypes,
+    BuiltPayload, NewPayloadError, PayloadTypes,
 };
 use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
@@ -993,7 +993,6 @@ where
         &mut self,
         state: ForkchoiceState,
         attrs: Option<T::PayloadAttributes>,
-        version: EngineApiMessageVersion,
     ) -> ProviderResult<TreeOutcome<OnForkChoiceUpdated>> {
         trace!(target: "engine::tree", ?attrs, "invoked forkchoice update");
 
@@ -1006,13 +1005,13 @@ where
         }
 
         // Return early if we are on the correct fork
-        if let Some(result) = self.handle_canonical_head(state, &attrs, version)? {
+        if let Some(result) = self.handle_canonical_head(state, &attrs)? {
             return Ok(result);
         }
 
         // Attempt to apply a chain update when the head differs from our canonical chain.
         // This handles reorgs and chain extensions by making the specified head canonical.
-        if let Some(result) = self.apply_chain_update(state, &attrs, version)? {
+        if let Some(result) = self.apply_chain_update(state, &attrs)? {
             return Ok(result);
         }
 
@@ -1063,7 +1062,6 @@ where
         &self,
         state: ForkchoiceState,
         attrs: &Option<T::PayloadAttributes>, // Changed to reference
-        version: EngineApiMessageVersion,
     ) -> ProviderResult<Option<TreeOutcome<OnForkChoiceUpdated>>> {
         // Process the forkchoice update by trying to make the head block canonical
         //
@@ -1101,7 +1099,7 @@ where
                     ProviderError::HeaderNotFound(state.head_block_hash.into())
                 })?;
             // Clone only when we actually need to process the attributes
-            let updated = self.process_payload_attributes(attr.clone(), &tip, state, version);
+            let updated = self.process_payload_attributes(attr.clone(), &tip, state);
             return Ok(Some(TreeOutcome::new(updated)));
         }
 
@@ -1124,7 +1122,6 @@ where
         &mut self,
         state: ForkchoiceState,
         attrs: &Option<T::PayloadAttributes>,
-        version: EngineApiMessageVersion,
     ) -> ProviderResult<Option<TreeOutcome<OnForkChoiceUpdated>>> {
         // Check if the head is already part of the canonical chain
         if let Ok(Some(canonical_header)) = self.find_canonical_header(state.head_block_hash) {
@@ -1151,7 +1148,6 @@ where
                         attr.clone(),
                         &canonical_header,
                         state,
-                        version,
                     );
                     return Ok(Some(TreeOutcome::new(updated)));
                 }
@@ -1183,7 +1179,7 @@ where
 
             if let Some(attr) = attrs {
                 // Clone only when we actually need to process the attributes
-                let updated = self.process_payload_attributes(attr.clone(), &tip, state, version);
+                let updated = self.process_payload_attributes(attr.clone(), &tip, state);
                 return Ok(Some(TreeOutcome::new(updated)));
             }
 
@@ -1460,13 +1456,12 @@ where
                                 state,
                                 payload_attrs,
                                 tx,
-                                version,
                             } => {
                                 let has_attrs = payload_attrs.is_some();
 
                                 let start = Instant::now();
                                 let mut output =
-                                    self.on_forkchoice_updated(state, payload_attrs, version);
+                                    self.on_forkchoice_updated(state, payload_attrs);
 
                                 if let Ok(res) = &mut output {
                                     // track last received forkchoice state
@@ -3053,7 +3048,6 @@ where
         attrs: T::PayloadAttributes,
         head: &N::BlockHeader,
         state: ForkchoiceState,
-        _version: EngineApiMessageVersion,
     ) -> OnForkChoiceUpdated {
         if let Err(err) =
             self.payload_validator.validate_payload_attributes_against_header(&attrs, head)

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -25,7 +25,7 @@ use reth_errors::{ConsensusError, ProviderResult};
 use reth_evm::ConfigureEvm;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{
-    BuiltPayload, EngineApiMessageVersion, NewPayloadError, PayloadBuilderAttributes, PayloadTypes,
+    BuiltPayload, EngineApiMessageVersion, NewPayloadError, PayloadTypes,
 };
 use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
@@ -3053,7 +3053,7 @@ where
         attrs: T::PayloadAttributes,
         head: &N::BlockHeader,
         state: ForkchoiceState,
-        version: EngineApiMessageVersion,
+        _version: EngineApiMessageVersion,
     ) -> OnForkChoiceUpdated {
         if let Err(err) =
             self.payload_validator.validate_payload_attributes_against_header(&attrs, head)
@@ -3066,34 +3066,27 @@ where
         //    forkchoiceState.headBlockHash and identified via buildProcessId value if
         //    payloadAttributes is not null and the forkchoice state has been updated successfully.
         //    The build process is specified in the Payload building section.
-        match <T::PayloadBuilderAttributes as PayloadBuilderAttributes>::try_new(
-            state.head_block_hash,
-            attrs,
-            version as u8,
-        ) {
-            Ok(attributes) => {
-                // send the payload to the builder and return the receiver for the pending payload
-                // id, initiating payload job is handled asynchronously
-                let pending_payload_id = self.payload_builder.send_new_payload(attributes);
 
-                // Client software MUST respond to this method call in the following way:
-                // {
-                //      payloadStatus: {
-                //          status: VALID,
-                //          latestValidHash: forkchoiceState.headBlockHash,
-                //          validationError: null
-                //      },
-                //      payloadId: buildProcessId
-                // }
-                //
-                // if the payload is deemed VALID and the build process has begun.
-                OnForkChoiceUpdated::updated_with_pending_payload_id(
-                    PayloadStatus::new(PayloadStatusEnum::Valid, Some(state.head_block_hash)),
-                    pending_payload_id,
-                )
-            }
-            Err(_) => OnForkChoiceUpdated::invalid_payload_attributes(),
-        }
+        // send the payload to the builder and return the receiver for the pending payload
+        // id, initiating payload job is handled asynchronously
+        let pending_payload_id =
+            self.payload_builder.send_new_payload(state.head_block_hash, attrs);
+
+        // Client software MUST respond to this method call in the following way:
+        // {
+        //      payloadStatus: {
+        //          status: VALID,
+        //          latestValidHash: forkchoiceState.headBlockHash,
+        //          validationError: null
+        //      },
+        //      payloadId: buildProcessId
+        // }
+        //
+        // if the payload is deemed VALID and the build process has begun.
+        OnForkChoiceUpdated::updated_with_pending_payload_id(
+            PayloadStatus::new(PayloadStatusEnum::Valid, Some(state.head_block_hash)),
+            pending_payload_id,
+        )
     }
 
     /// Remove all blocks up to __and including__ the given block number.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1804,10 +1804,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .handle_canonical_head(state, &None)
-            .unwrap();
+        let result = test_harness.tree.handle_canonical_head(state, &None).unwrap();
         assert!(result.is_some(), "Should return outcome for canonical head");
         let outcome = result.unwrap();
         let fcu_result = outcome.outcome.await.unwrap();
@@ -1820,10 +1817,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .handle_canonical_head(non_canonical_state, &None)
-            .unwrap();
+        let result = test_harness.tree.handle_canonical_head(non_canonical_state, &None).unwrap();
         assert!(result.is_none(), "Non-canonical head should return None");
     }
 
@@ -1846,10 +1840,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .apply_chain_update(state, &None)
-            .unwrap();
+        let result = test_harness.tree.apply_chain_update(state, &None).unwrap();
         assert!(result.is_some(), "Should apply chain update for new head");
         let outcome = result.unwrap();
         let fcu_result = outcome.outcome.await.unwrap();
@@ -1862,10 +1853,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .apply_chain_update(missing_state, &None)
-            .unwrap();
+        let result = test_harness.tree.apply_chain_update(missing_state, &None).unwrap();
         assert!(result.is_none(), "Missing block should return None");
     }
 
@@ -1919,10 +1907,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: canonical_head,
         };
 
-        let result = test_harness
-            .tree
-            .on_forkchoice_updated(state, None)
-            .unwrap();
+        let result = test_harness.tree.on_forkchoice_updated(state, None).unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_valid());
 
@@ -1933,10 +1918,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .on_forkchoice_updated(missing_state, None)
-            .unwrap();
+        let result = test_harness.tree.on_forkchoice_updated(missing_state, None).unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_syncing());
         assert!(result.event.is_some(), "Should trigger download event for missing block");
@@ -1949,10 +1931,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .on_forkchoice_updated(state, None)
-            .unwrap();
+        let result = test_harness.tree.on_forkchoice_updated(state, None).unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_syncing(), "Should return syncing during backfill");
     }
@@ -2000,10 +1979,7 @@ mod forkchoice_updated_tests {
             finalized_block_hash: B256::ZERO,
         };
 
-        let result = test_harness
-            .tree
-            .handle_canonical_head(state, &None)
-            .unwrap();
+        let result = test_harness.tree.handle_canonical_head(state, &None).unwrap();
         assert!(result.is_some(), "OpStack should handle canonical head");
     }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -305,7 +305,6 @@ impl TestHarness {
                     state: fcu_state,
                     payload_attrs: None,
                     tx,
-                    version: EngineApiMessageVersion::default(),
                 }
                 .into(),
             ))
@@ -605,7 +604,6 @@ async fn test_engine_request_during_backfill() {
                 },
                 payload_attrs: None,
                 tx,
-                version: EngineApiMessageVersion::default(),
             }
             .into(),
         ))
@@ -1091,7 +1089,6 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
                 },
                 payload_attrs: None,
                 tx,
-                version: EngineApiMessageVersion::default(),
             }
             .into(),
         ))
@@ -1809,7 +1806,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .handle_canonical_head(state, &None, EngineApiMessageVersion::default())
+            .handle_canonical_head(state, &None)
             .unwrap();
         assert!(result.is_some(), "Should return outcome for canonical head");
         let outcome = result.unwrap();
@@ -1825,7 +1822,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .handle_canonical_head(non_canonical_state, &None, EngineApiMessageVersion::default())
+            .handle_canonical_head(non_canonical_state, &None)
             .unwrap();
         assert!(result.is_none(), "Non-canonical head should return None");
     }
@@ -1851,7 +1848,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .apply_chain_update(state, &None, EngineApiMessageVersion::default())
+            .apply_chain_update(state, &None)
             .unwrap();
         assert!(result.is_some(), "Should apply chain update for new head");
         let outcome = result.unwrap();
@@ -1867,7 +1864,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .apply_chain_update(missing_state, &None, EngineApiMessageVersion::default())
+            .apply_chain_update(missing_state, &None)
             .unwrap();
         assert!(result.is_none(), "Missing block should return None");
     }
@@ -1924,7 +1921,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .on_forkchoice_updated(state, None, EngineApiMessageVersion::default())
+            .on_forkchoice_updated(state, None)
             .unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_valid());
@@ -1938,7 +1935,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .on_forkchoice_updated(missing_state, None, EngineApiMessageVersion::default())
+            .on_forkchoice_updated(missing_state, None)
             .unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_syncing());
@@ -1954,7 +1951,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .on_forkchoice_updated(state, None, EngineApiMessageVersion::default())
+            .on_forkchoice_updated(state, None)
             .unwrap();
         let fcu_result = result.outcome.await.unwrap();
         assert!(fcu_result.payload_status.is_syncing(), "Should return syncing during backfill");
@@ -2005,7 +2002,7 @@ mod forkchoice_updated_tests {
 
         let result = test_harness
             .tree
-            .handle_canonical_head(state, &None, EngineApiMessageVersion::default())
+            .handle_canonical_head(state, &None)
             .unwrap();
         assert!(result.is_some(), "OpStack should handle canonical head");
     }

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -66,7 +66,6 @@ impl EngineMessageStore {
                 state,
                 payload_attrs,
                 tx: _tx,
-                version: _version,
             } => {
                 let filename = format!("{}-fcu-{}.json", timestamp, state.head_block_hash);
                 fs::write(

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -62,11 +62,7 @@ impl EngineMessageStore {
         fs::create_dir_all(&self.path)?; // ensure that store path had been created
         let timestamp = received_at.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis();
         match msg {
-            BeaconEngineMessage::ForkchoiceUpdated {
-                state,
-                payload_attrs,
-                tx: _tx,
-            } => {
+            BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx: _tx } => {
                 let filename = format!("{}-fcu-{}.json", timestamp, state.head_block_hash);
                 fs::write(
                     self.path.join(filename),

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -207,24 +207,13 @@ where
                     *this.state = EngineReorgState::Reorg { queue };
                     continue
                 }
-                (
-                    Some(BeaconEngineMessage::ForkchoiceUpdated {
-                        state,
-                        payload_attrs,
-                        tx,
-                    }),
-                    _,
-                ) => {
+                (Some(BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx }), _) => {
                     // Record last forkchoice state forwarded to the engine.
                     // We do not care if it's valid since engine should be able to handle
                     // reorgs that rely on invalid forkchoice state.
                     *this.last_forkchoice_state = Some(state);
                     *this.forkchoice_states_forwarded += 1;
-                    Some(BeaconEngineMessage::ForkchoiceUpdated {
-                        state,
-                        payload_attrs,
-                        tx,
-                    })
+                    Some(BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx })
                 }
                 (item, _) => item,
             };

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -14,7 +14,7 @@ use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm,
 };
-use reth_payload_primitives::{BuiltPayload, EngineApiMessageVersion, PayloadTypes};
+use reth_payload_primitives::{BuiltPayload, PayloadTypes};
 use reth_primitives_traits::{
     block::Block as _, BlockBody as _, BlockTy, HeaderTy, SealedBlock, SignedTransaction,
 };
@@ -202,7 +202,6 @@ where
                             state: reorg_forkchoice_state,
                             payload_attrs: None,
                             tx: reorg_fcu_tx,
-                            version: EngineApiMessageVersion::default(),
                         },
                     ]);
                     *this.state = EngineReorgState::Reorg { queue };
@@ -213,7 +212,6 @@ where
                         state,
                         payload_attrs,
                         tx,
-                        version,
                     }),
                     _,
                 ) => {
@@ -226,7 +224,6 @@ where
                         state,
                         payload_attrs,
                         tx,
-                        version,
                     })
                 }
                 (item, _) => item,

--- a/crates/engine/util/src/skip_fcu.rs
+++ b/crates/engine/util/src/skip_fcu.rs
@@ -49,7 +49,6 @@ where
                     state,
                     payload_attrs,
                     tx,
-                    version,
                 }) => {
                     if this.skipped < this.threshold {
                         *this.skipped += 1;
@@ -62,7 +61,6 @@ where
                         state,
                         payload_attrs,
                         tx,
-                        version,
                     })
                 }
                 next => next,

--- a/crates/engine/util/src/skip_fcu.rs
+++ b/crates/engine/util/src/skip_fcu.rs
@@ -45,11 +45,7 @@ where
         loop {
             let next = ready!(this.stream.poll_next_unpin(cx));
             let item = match next {
-                Some(BeaconEngineMessage::ForkchoiceUpdated {
-                    state,
-                    payload_attrs,
-                    tx,
-                }) => {
+                Some(BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx }) => {
                     if this.skipped < this.threshold {
                         *this.skipped += 1;
                         tracing::warn!(target: "engine::stream::skip_fcu", ?state, ?payload_attrs, threshold=this.threshold, skipped=this.skipped, "Skipping FCU");
@@ -57,11 +53,7 @@ where
                         continue
                     }
                     *this.skipped = 0;
-                    Some(BeaconEngineMessage::ForkchoiceUpdated {
-                        state,
-                        payload_attrs,
-                        tx,
-                    })
+                    Some(BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx })
                 }
                 next => next,
             };

--- a/crates/ethereum/engine-primitives/Cargo.toml
+++ b/crates/ethereum/engine-primitives/Cargo.toml
@@ -21,11 +21,9 @@ reth-payload-primitives.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-rpc-types-engine.workspace = true
-alloy-rlp.workspace = true
 
 # misc
 serde.workspace = true
-sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
@@ -38,9 +36,7 @@ std = [
     "alloy-primitives/std",
     "alloy-eips/std",
     "alloy-rpc-types-engine/std",
-    "alloy-rlp/std",
     "serde/std",
-    "sha2/std",
     "serde_json/std",
     "thiserror/std",
     "reth-engine-primitives/std",

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 mod payload;
-pub use payload::{payload_id, BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
+pub use payload::{BlobSidecars, EthBuiltPayload};
 
 mod error;
 pub use error::*;
@@ -46,7 +46,6 @@ impl<
     type ExecutionData = T::ExecutionData;
     type BuiltPayload = T::BuiltPayload;
     type PayloadAttributes = T::PayloadAttributes;
-    type PayloadBuilderAttributes = T::PayloadBuilderAttributes;
 
     fn block_to_payload(
         block: SealedBlock<
@@ -84,7 +83,6 @@ pub struct EthPayloadTypes;
 impl PayloadTypes for EthPayloadTypes {
     type BuiltPayload = EthBuiltPayload;
     type PayloadAttributes = EthPayloadAttributes;
-    type PayloadBuilderAttributes = EthPayloadBuilderAttributes;
     type ExecutionData = ExecutionData;
 
     fn block_to_payload(

--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -3,20 +3,17 @@
 use alloc::{sync::Arc, vec::Vec};
 use alloy_eips::{
     eip4844::BlobTransactionSidecar,
-    eip4895::Withdrawals,
     eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant},
     eip7685::Requests,
 };
-use alloy_primitives::{Address, B256, U256};
-use alloy_rlp::Encodable;
+use alloy_primitives::U256;
 use alloy_rpc_types_engine::{
     BlobsBundleV1, BlobsBundleV2, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
     ExecutionPayloadEnvelopeV4, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
-    ExecutionPayloadFieldV2, ExecutionPayloadV1, ExecutionPayloadV3, PayloadAttributes, PayloadId,
+    ExecutionPayloadFieldV2, ExecutionPayloadV1, ExecutionPayloadV3,
 };
-use core::convert::Infallible;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
+use reth_payload_primitives::BuiltPayload;
 use reth_primitives_traits::{NodePrimitives, SealedBlock};
 
 use crate::BuiltPayloadConversionError;
@@ -30,8 +27,6 @@ use crate::BuiltPayloadConversionError;
 /// more transactions.
 #[derive(Debug, Clone)]
 pub struct EthBuiltPayload<N: NodePrimitives = EthPrimitives> {
-    /// Identifier of the payload
-    pub(crate) id: PayloadId,
     /// The built block
     pub(crate) block: Arc<SealedBlock<N::Block>>,
     /// The fees of the block
@@ -50,17 +45,11 @@ impl<N: NodePrimitives> EthBuiltPayload<N> {
     ///
     /// Caution: This does not set any [`BlobSidecars`].
     pub const fn new(
-        id: PayloadId,
         block: Arc<SealedBlock<N::Block>>,
         fees: U256,
         requests: Option<Requests>,
     ) -> Self {
-        Self { id, block, fees, requests, sidecars: BlobSidecars::Empty }
-    }
-
-    /// Returns the identifier of the payload.
-    pub const fn id(&self) -> PayloadId {
-        self.id
+        Self { block, fees, requests, sidecars: BlobSidecars::Empty }
     }
 
     /// Returns the built block(sealed)
@@ -326,232 +315,5 @@ impl From<alloc::vec::IntoIter<BlobTransactionSidecar>> for BlobSidecars {
 impl From<alloc::vec::IntoIter<BlobTransactionSidecarEip7594>> for BlobSidecars {
     fn from(value: alloc::vec::IntoIter<BlobTransactionSidecarEip7594>) -> Self {
         value.collect::<Vec<_>>().into()
-    }
-}
-
-/// Container type for all components required to build a payload.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct EthPayloadBuilderAttributes {
-    /// Id of the payload
-    pub id: PayloadId,
-    /// Parent block to build the payload on top
-    pub parent: B256,
-    /// Unix timestamp for the generated payload
-    ///
-    /// Number of seconds since the Unix epoch.
-    pub timestamp: u64,
-    /// Address of the recipient for collecting transaction fee
-    pub suggested_fee_recipient: Address,
-    /// Randomness value for the generated payload
-    pub prev_randao: B256,
-    /// Withdrawals for the generated payload
-    pub withdrawals: Withdrawals,
-    /// Root of the parent beacon block
-    pub parent_beacon_block_root: Option<B256>,
-}
-
-// === impl EthPayloadBuilderAttributes ===
-
-impl EthPayloadBuilderAttributes {
-    /// Returns the identifier of the payload.
-    pub const fn payload_id(&self) -> PayloadId {
-        self.id
-    }
-
-    /// Creates a new payload builder for the given parent block and the attributes.
-    ///
-    /// Derives the unique [`PayloadId`] for the given parent and attributes
-    pub fn new(parent: B256, attributes: PayloadAttributes) -> Self {
-        let id = payload_id(&parent, &attributes);
-
-        Self {
-            id,
-            parent,
-            timestamp: attributes.timestamp,
-            suggested_fee_recipient: attributes.suggested_fee_recipient,
-            prev_randao: attributes.prev_randao,
-            withdrawals: attributes.withdrawals.unwrap_or_default().into(),
-            parent_beacon_block_root: attributes.parent_beacon_block_root,
-        }
-    }
-}
-
-impl PayloadBuilderAttributes for EthPayloadBuilderAttributes {
-    type RpcPayloadAttributes = PayloadAttributes;
-    type Error = Infallible;
-
-    /// Creates a new payload builder for the given parent block and the attributes.
-    ///
-    /// Derives the unique [`PayloadId`] for the given parent and attributes
-    fn try_new(
-        parent: B256,
-        attributes: PayloadAttributes,
-        _version: u8,
-    ) -> Result<Self, Infallible> {
-        Ok(Self::new(parent, attributes))
-    }
-
-    fn payload_id(&self) -> PayloadId {
-        self.id
-    }
-
-    fn parent(&self) -> B256 {
-        self.parent
-    }
-
-    fn timestamp(&self) -> u64 {
-        self.timestamp
-    }
-
-    fn parent_beacon_block_root(&self) -> Option<B256> {
-        self.parent_beacon_block_root
-    }
-
-    fn suggested_fee_recipient(&self) -> Address {
-        self.suggested_fee_recipient
-    }
-
-    fn prev_randao(&self) -> B256 {
-        self.prev_randao
-    }
-
-    fn withdrawals(&self) -> &Withdrawals {
-        &self.withdrawals
-    }
-}
-
-/// Generates the payload id for the configured payload from the [`PayloadAttributes`].
-///
-/// Returns an 8-byte identifier by hashing the payload components with sha256 hash.
-pub fn payload_id(parent: &B256, attributes: &PayloadAttributes) -> PayloadId {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(parent.as_slice());
-    hasher.update(&attributes.timestamp.to_be_bytes()[..]);
-    hasher.update(attributes.prev_randao.as_slice());
-    hasher.update(attributes.suggested_fee_recipient.as_slice());
-    if let Some(withdrawals) = &attributes.withdrawals {
-        let mut buf = Vec::new();
-        withdrawals.encode(&mut buf);
-        hasher.update(buf);
-    }
-
-    if let Some(parent_beacon_block) = attributes.parent_beacon_block_root {
-        hasher.update(parent_beacon_block);
-    }
-
-    let out = hasher.finalize();
-
-    #[allow(deprecated)] // generic-array 0.14 deprecated
-    PayloadId::new(out.as_slice()[..8].try_into().expect("sufficient length"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_eips::eip4895::Withdrawal;
-    use alloy_primitives::B64;
-    use core::str::FromStr;
-
-    #[test]
-    fn attributes_serde() {
-        let attributes = r#"{"timestamp":"0x1235","prevRandao":"0xf343b00e02dc34ec0124241f74f32191be28fb370bb48060f5fa4df99bda774c","suggestedFeeRecipient":"0x0000000000000000000000000000000000000000","withdrawals":null,"parentBeaconBlockRoot":null}"#;
-        let _attributes: PayloadAttributes = serde_json::from_str(attributes).unwrap();
-    }
-
-    #[test]
-    fn test_payload_id_basic() {
-        // Create a parent block and payload attributes
-        let parent =
-            B256::from_str("0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a")
-                .unwrap();
-        let attributes = PayloadAttributes {
-            timestamp: 0x5,
-            prev_randao: B256::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            suggested_fee_recipient: Address::from_str(
-                "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-            )
-            .unwrap(),
-            withdrawals: None,
-            parent_beacon_block_root: None,
-        };
-
-        // Verify that the generated payload ID matches the expected value
-        assert_eq!(
-            payload_id(&parent, &attributes),
-            PayloadId(B64::from_str("0xa247243752eb10b4").unwrap())
-        );
-    }
-
-    #[test]
-    fn test_payload_id_with_withdrawals() {
-        // Set up the parent and attributes with withdrawals
-        let parent =
-            B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
-                .unwrap();
-        let attributes = PayloadAttributes {
-            timestamp: 1622553200,
-            prev_randao: B256::from_slice(&[1; 32]),
-            suggested_fee_recipient: Address::from_str(
-                "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-            )
-            .unwrap(),
-            withdrawals: Some(vec![
-                Withdrawal {
-                    index: 1,
-                    validator_index: 123,
-                    address: Address::from([0xAA; 20]),
-                    amount: 10,
-                },
-                Withdrawal {
-                    index: 2,
-                    validator_index: 456,
-                    address: Address::from([0xBB; 20]),
-                    amount: 20,
-                },
-            ]),
-            parent_beacon_block_root: None,
-        };
-
-        // Verify that the generated payload ID matches the expected value
-        assert_eq!(
-            payload_id(&parent, &attributes),
-            PayloadId(B64::from_str("0xedddc2f84ba59865").unwrap())
-        );
-    }
-
-    #[test]
-    fn test_payload_id_with_parent_beacon_block_root() {
-        // Set up the parent and attributes with a parent beacon block root
-        let parent =
-            B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
-                .unwrap();
-        let attributes = PayloadAttributes {
-            timestamp: 1622553200,
-            prev_randao: B256::from_str(
-                "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",
-            )
-            .unwrap(),
-            suggested_fee_recipient: Address::from_str(
-                "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-            )
-            .unwrap(),
-            withdrawals: None,
-            parent_beacon_block_root: Some(
-                B256::from_str(
-                    "0x2222222222222222222222222222222222222222222222222222222222222222",
-                )
-                .unwrap(),
-            ),
-        };
-
-        // Verify that the generated payload ID matches the expected value
-        assert_eq!(
-            payload_id(&parent, &attributes),
-            PayloadId(B64::from_str("0x0fc49cd532094cce").unwrap())
-        );
     }
 }

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -9,9 +9,7 @@ use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_engine_primitives::EngineTypes;
 use reth_ethereum_consensus::EthBeaconConsensus;
-use reth_ethereum_engine_primitives::{
-    EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
-};
+use reth_ethereum_engine_primitives::{EthBuiltPayload, EthPayloadAttributes};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
     eth::spec::EthExecutorSpec, ConfigureEvm, EvmFactory, EvmFactoryFor, NextBlockEnvAttributes,
@@ -81,11 +79,8 @@ impl EthereumNode {
                 Primitives = EthPrimitives,
             >,
         >,
-        <Node::Types as NodeTypes>::Payload: PayloadTypes<
-            BuiltPayload = EthBuiltPayload,
-            PayloadAttributes = EthPayloadAttributes,
-            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-        >,
+        <Node::Types as NodeTypes>::Payload:
+            PayloadTypes<BuiltPayload = EthBuiltPayload, PayloadAttributes = EthPayloadAttributes>,
     {
         ComponentsBuilder::default()
             .node_types::<Node>()

--- a/crates/ethereum/node/src/payload.rs
+++ b/crates/ethereum/node/src/payload.rs
@@ -1,9 +1,7 @@
 //! Payload component configuration for the Ethereum node.
 
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_ethereum_engine_primitives::{
-    EthBuiltPayload, EthPayloadAttributes, EthPayloadBuilderAttributes,
-};
+use reth_ethereum_engine_primitives::{EthBuiltPayload, EthPayloadAttributes};
 use reth_ethereum_payload_builder::EthereumBuilderConfig;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::ConfigureEvm;
@@ -29,11 +27,8 @@ where
             Primitives = PrimitivesTy<Types>,
             NextBlockEnvCtx = reth_evm::NextBlockEnvAttributes,
         > + 'static,
-    Types::Payload: PayloadTypes<
-        BuiltPayload = EthBuiltPayload,
-        PayloadAttributes = EthPayloadAttributes,
-        PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-    >,
+    Types::Payload:
+        PayloadTypes<BuiltPayload = EthBuiltPayload, PayloadAttributes = EthPayloadAttributes>,
 {
     type PayloadBuilder =
         reth_ethereum_payload_builder::EthereumPayloadBuilder<Pool, Node::Provider, Evm>;

--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -11,35 +11,32 @@ use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer::SignerSync;
 use rand::{seq::IndexedRandom, Rng};
 use reth_e2e_test_utils::{wallet::Wallet, NodeHelperType, TmpDB};
-use reth_ethereum_engine_primitives::EthPayloadBuilderAttributes;
 use reth_ethereum_primitives::TxType;
 use reth_node_api::NodeTypesWithDBAdapter;
 use reth_node_ethereum::EthereumNode;
 use reth_provider::FullProvider;
 
 /// Helper function to create a new eth payload attributes
-pub(crate) fn eth_payload_attributes(timestamp: u64) -> EthPayloadBuilderAttributes {
-    let attributes = PayloadAttributes {
+pub(crate) const fn eth_payload_attributes(timestamp: u64) -> PayloadAttributes {
+    PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
         suggested_fee_recipient: Address::ZERO,
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
-    };
-    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    }
 }
 
 /// Helper function to create pre-Cancun (Shanghai) payload attributes.
 /// No `parent_beacon_block_root` field.
-pub(crate) fn eth_payload_attributes_shanghai(timestamp: u64) -> EthPayloadBuilderAttributes {
-    let attributes = PayloadAttributes {
+pub(crate) const fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAttributes {
+    PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
         suggested_fee_recipient: Address::ZERO,
         withdrawals: Some(vec![]),
         parent_beacon_block_root: None,
-    };
-    EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    }
 }
 
 /// Advances node by producing blocks with random transactions.

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -12,6 +12,7 @@
 use alloy_consensus::Transaction;
 use alloy_primitives::U256;
 use alloy_rlp::Encodable;
+use alloy_rpc_types_engine::PayloadAttributes as EthPayloadAttributes;
 use reth_basic_payload_builder::{
     is_better_payload, BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder,
     PayloadConfig,
@@ -25,9 +26,9 @@ use reth_evm::{
     ConfigureEvm, Evm, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::EthEvmConfig;
-use reth_payload_builder::{BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
+use reth_payload_builder::{BlobSidecars, EthBuiltPayload};
 use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_payload_primitives::PayloadAttributes;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_storage_api::StateProviderFactory;
@@ -82,12 +83,12 @@ where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthereumHardforks> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
-    type Attributes = EthPayloadBuilderAttributes;
+    type Attributes = EthPayloadAttributes;
     type BuiltPayload = EthBuiltPayload;
 
     fn try_build(
         &self,
-        args: BuildArguments<EthPayloadBuilderAttributes, EthBuiltPayload>,
+        args: BuildArguments<EthPayloadAttributes, EthBuiltPayload>,
     ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError> {
         default_ethereum_payload(
             self.evm_config.clone(),
@@ -140,7 +141,7 @@ pub fn default_ethereum_payload<EvmConfig, Client, Pool, F>(
     client: Client,
     pool: Pool,
     builder_config: EthereumBuilderConfig,
-    args: BuildArguments<EthPayloadBuilderAttributes, EthBuiltPayload>,
+    args: BuildArguments<EthPayloadAttributes, EthBuiltPayload>,
     best_txs: F,
 ) -> Result<BuildOutcome<EthBuiltPayload>, PayloadBuilderError>
 where
@@ -150,7 +151,7 @@ where
     F: FnOnce(BestTransactionsAttributes) -> BestTransactionsIter<Pool>,
 {
     let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
-    let PayloadConfig { parent_header, attributes } = config;
+    let PayloadConfig { parent_header, attributes, payload_id } = config;
 
     let state_provider = client.state_by_block_hash(parent_header.hash())?;
     let state = StateProviderDatabase::new(state_provider.as_ref());
@@ -163,11 +164,11 @@ where
             &parent_header,
             NextBlockEnvAttributes {
                 timestamp: attributes.timestamp(),
-                suggested_fee_recipient: attributes.suggested_fee_recipient(),
-                prev_randao: attributes.prev_randao(),
+                suggested_fee_recipient: attributes.suggested_fee_recipient,
+                prev_randao: attributes.prev_randao,
                 gas_limit: builder_config.gas_limit(parent_header.gas_limit),
                 parent_beacon_block_root: attributes.parent_beacon_block_root(),
-                withdrawals: Some(attributes.withdrawals().clone()),
+                withdrawals: attributes.withdrawals.clone().map(Into::into),
                 extra_data: builder_config.extra_data,
             },
         )
@@ -175,7 +176,7 @@ where
 
     let chain_spec = client.chain_spec();
 
-    debug!(target: "payload_builder", id=%attributes.id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
+    debug!(target: "payload_builder", id=%payload_id, parent_header = ?parent_header.hash(), parent_number = parent_header.number, "building new payload");
     let mut cumulative_gas_used = 0;
     let block_gas_limit: u64 = builder.evm_mut().block().gas_limit();
     let base_fee = builder.evm_mut().block().basefee();
@@ -211,7 +212,8 @@ where
 
     let is_osaka = chain_spec.is_osaka_active_at_timestamp(attributes.timestamp);
 
-    let withdrawals_rlp_length = attributes.withdrawals().length();
+    let withdrawals_rlp_length =
+        attributes.withdrawals.as_ref().map(|withdrawals| withdrawals.length()).unwrap_or(0);
 
     while let Some(pool_tx) = best_txs.next() {
         // ensure we still have capacity for this transaction
@@ -368,7 +370,7 @@ where
         .then_some(execution_result.requests);
 
     let sealed_block = Arc::new(block.into_sealed_block());
-    debug!(target: "payload_builder", id=%attributes.id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
+    debug!(target: "payload_builder", id=%payload_id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
 
     if is_osaka && sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {
         return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
@@ -377,7 +379,7 @@ where
         }));
     }
 
-    let payload = EthBuiltPayload::new(attributes.id, sealed_block, total_fees, requests)
+    let payload = EthBuiltPayload::new(sealed_block, total_fees, requests)
         // add blob sidecars from the executed txs
         .with_sidecars(blob_sidecars);
 

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -48,7 +48,7 @@ where
 /// Helper trait to bound [`PayloadBuilder`] to the node's engine types.
 pub trait PayloadBuilderFor<N: NodeTypes>:
     PayloadBuilder<
-    Attributes = <N::Payload as PayloadTypes>::PayloadBuilderAttributes,
+    Attributes = <N::Payload as PayloadTypes>::PayloadAttributes,
     BuiltPayload = <N::Payload as PayloadTypes>::BuiltPayload,
 >
 {
@@ -56,7 +56,7 @@ pub trait PayloadBuilderFor<N: NodeTypes>:
 
 impl<T, N: NodeTypes> PayloadBuilderFor<N> for T where
     T: PayloadBuilder<
-        Attributes = <N::Payload as PayloadTypes>::PayloadBuilderAttributes,
+        Attributes = <N::Payload as PayloadTypes>::PayloadAttributes,
         BuiltPayload = <N::Payload as PayloadTypes>::BuiltPayload,
     >
 {

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -38,3 +38,4 @@ metrics.workspace = true
 
 # misc
 tracing.workspace = true
+serde.workspace = true

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -16,7 +16,7 @@ use futures_util::FutureExt;
 use reth_chain_state::CanonStateNotification;
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadId, PayloadJob, PayloadJobGenerator};
 use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind};
+use reth_payload_primitives::{BuiltPayload, PayloadAttributes, PayloadKind};
 use reth_primitives_traits::{HeaderTy, NodePrimitives, SealedHeader};
 use reth_revm::{cached::CachedReads, cancelled::CancelOnDrop};
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
@@ -140,9 +140,11 @@ where
 
     fn new_payload_job(
         &self,
+        parent: B256,
         attributes: <Self::Job as PayloadJob>::PayloadAttributes,
+        id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
-        let parent_header = if attributes.parent().is_zero() {
+        let parent_header = if parent.is_zero() {
             // Use latest header for genesis block case
             self.client
                 .latest_header()
@@ -151,14 +153,14 @@ where
         } else {
             // Fetch specific header by hash
             self.client
-                .sealed_header_by_hash(attributes.parent())
+                .sealed_header_by_hash(parent)
                 .map_err(PayloadBuilderError::from)?
-                .ok_or_else(|| PayloadBuilderError::MissingParentHeader(attributes.parent()))?
+                .ok_or_else(|| PayloadBuilderError::MissingParentHeader(parent))?
         };
 
         let cached_reads = self.maybe_pre_cached(parent_header.hash());
 
-        let config = PayloadConfig::new(Arc::new(parent_header), attributes);
+        let config = PayloadConfig::new(Arc::new(parent_header), attributes, id);
 
         let until = self.job_deadline(config.attributes.timestamp());
         let deadline = Box::pin(tokio::time::sleep_until(until));
@@ -667,20 +669,26 @@ pub struct PayloadConfig<Attributes, Header = alloy_consensus::Header> {
     pub parent_header: Arc<SealedHeader<Header>>,
     /// Requested attributes for the payload.
     pub attributes: Attributes,
+    /// The payload id.
+    pub payload_id: PayloadId,
 }
 
 impl<Attributes, Header> PayloadConfig<Attributes, Header>
 where
-    Attributes: PayloadBuilderAttributes,
+    Attributes: PayloadAttributes,
 {
     /// Create new payload config.
-    pub const fn new(parent_header: Arc<SealedHeader<Header>>, attributes: Attributes) -> Self {
-        Self { parent_header, attributes }
+    pub const fn new(
+        parent_header: Arc<SealedHeader<Header>>,
+        attributes: Attributes,
+        payload_id: PayloadId,
+    ) -> Self {
+        Self { parent_header, attributes, payload_id }
     }
 
     /// Returns the payload id.
-    pub fn payload_id(&self) -> PayloadId {
-        self.attributes.payload_id()
+    pub const fn payload_id(&self) -> PayloadId {
+        self.payload_id
     }
 }
 
@@ -831,7 +839,7 @@ impl<Attributes, Payload: BuiltPayload> BuildArguments<Attributes, Payload> {
 /// Ethereum client types.
 pub trait PayloadBuilder: Send + Sync + Clone {
     /// The payload attributes type to accept for building.
-    type Attributes: PayloadBuilderAttributes;
+    type Attributes: PayloadAttributes;
     /// The type of the built payload.
     type BuiltPayload: BuiltPayload;
 

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -1,19 +1,19 @@
 use crate::{
-    BuildArguments, BuildOutcome, HeaderForPayload, PayloadBuilder, PayloadBuilderAttributes,
-    PayloadBuilderError, PayloadConfig,
+    BuildArguments, BuildOutcome, HeaderForPayload, PayloadBuilder, PayloadBuilderError,
+    PayloadConfig,
 };
 
-use alloy_eips::eip4895::Withdrawals;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{B256, U256};
 use reth_payload_builder::PayloadId;
-use reth_payload_primitives::BuiltPayload;
+use reth_payload_primitives::{BuiltPayload, PayloadAttributes};
 use reth_primitives_traits::{NodePrimitives, SealedBlock};
 
 use alloy_eips::eip7685::Requests;
 use std::{error::Error, fmt};
 
 /// hand rolled Either enum to handle two builder types
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
 pub enum Either<L, R> {
     /// left variant
     Left(L),
@@ -47,42 +47,15 @@ where
     }
 }
 
-impl<L, R> PayloadBuilderAttributes for Either<L, R>
+impl<L, R> PayloadAttributes for Either<L, R>
 where
-    L: PayloadBuilderAttributes,
-    R: PayloadBuilderAttributes,
-    L::Error: Error + 'static,
-    R::Error: Error + 'static,
+    L: PayloadAttributes,
+    R: PayloadAttributes,
 {
-    type RpcPayloadAttributes = Either<L::RpcPayloadAttributes, R::RpcPayloadAttributes>;
-    type Error = Either<L::Error, R::Error>;
-
-    fn try_new(
-        parent: B256,
-        rpc_payload_attributes: Self::RpcPayloadAttributes,
-        version: u8,
-    ) -> Result<Self, Self::Error> {
-        match rpc_payload_attributes {
-            Either::Left(attr) => {
-                L::try_new(parent, attr, version).map(Either::Left).map_err(Either::Left)
-            }
-            Either::Right(attr) => {
-                R::try_new(parent, attr, version).map(Either::Right).map_err(Either::Right)
-            }
-        }
-    }
-
-    fn payload_id(&self) -> PayloadId {
+    fn payload_id(&self, parent_hash: &B256) -> PayloadId {
         match self {
-            Self::Left(l) => l.payload_id(),
-            Self::Right(r) => r.payload_id(),
-        }
-    }
-
-    fn parent(&self) -> B256 {
-        match self {
-            Self::Left(l) => l.parent(),
-            Self::Right(r) => r.parent(),
+            Self::Left(l) => l.payload_id(parent_hash),
+            Self::Right(r) => r.payload_id(parent_hash),
         }
     }
 
@@ -100,21 +73,7 @@ where
         }
     }
 
-    fn suggested_fee_recipient(&self) -> Address {
-        match self {
-            Self::Left(l) => l.suggested_fee_recipient(),
-            Self::Right(r) => r.suggested_fee_recipient(),
-        }
-    }
-
-    fn prev_randao(&self) -> B256 {
-        match self {
-            Self::Left(l) => l.prev_randao(),
-            Self::Right(r) => r.prev_randao(),
-        }
-    }
-
-    fn withdrawals(&self) -> &Withdrawals {
+    fn withdrawals(&self) -> Option<&Vec<alloy_eips::eip4895::Withdrawal>> {
         match self {
             Self::Left(l) => l.withdrawals(),
             Self::Right(r) => r.withdrawals(),
@@ -195,13 +154,13 @@ where
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         let BuildArguments { cached_reads, config, cancel, best_payload } = args;
-        let PayloadConfig { parent_header, attributes } = config;
+        let PayloadConfig { parent_header, attributes, payload_id } = config;
 
         match attributes {
             Either::Left(left_attr) => {
                 let left_args: BuildArguments<L::Attributes, L::BuiltPayload> = BuildArguments {
                     cached_reads,
-                    config: PayloadConfig { parent_header, attributes: left_attr },
+                    config: PayloadConfig { parent_header, attributes: left_attr, payload_id },
                     cancel,
                     best_payload: best_payload.and_then(|payload| {
                         if let Either::Left(p) = payload {
@@ -216,7 +175,7 @@ where
             Either::Right(right_attr) => {
                 let right_args = BuildArguments {
                     cached_reads,
-                    config: PayloadConfig { parent_header, attributes: right_attr },
+                    config: PayloadConfig { parent_header, attributes: right_attr, payload_id },
                     cancel,
                     best_payload: best_payload.and_then(|payload| {
                         if let Either::Right(p) = payload {
@@ -236,12 +195,14 @@ where
         config: PayloadConfig<Self::Attributes, HeaderForPayload<Self::BuiltPayload>>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         match config {
-            PayloadConfig { parent_header, attributes: Either::Left(left_attr) } => {
-                let left_config = PayloadConfig { parent_header, attributes: left_attr };
+            PayloadConfig { parent_header, attributes: Either::Left(left_attr), payload_id } => {
+                let left_config =
+                    PayloadConfig { parent_header, attributes: left_attr, payload_id };
                 self.left.build_empty_payload(left_config).map(Either::Left)
             }
-            PayloadConfig { parent_header, attributes: Either::Right(right_attr) } => {
-                let right_config = PayloadConfig { parent_header, attributes: right_attr };
+            PayloadConfig { parent_header, attributes: Either::Right(right_attr), payload_id } => {
+                let right_config =
+                    PayloadConfig { parent_header, attributes: right_attr, payload_id };
                 self.right.build_empty_payload(right_config).map(Either::Right)
             }
         }

--- a/crates/payload/builder-primitives/src/events.rs
+++ b/crates/payload/builder-primitives/src/events.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 pub enum Events<T: PayloadTypes> {
     /// The payload attributes as
     /// they are received from the CL through the engine api.
-    Attributes(T::PayloadBuilderAttributes),
+    Attributes(T::PayloadAttributes),
     /// The built payload that has been just built.
     /// Triggered by the CL whenever it asks for an execution payload.
     /// This event is only thrown if the CL is a validator.
@@ -91,7 +91,7 @@ pub struct PayloadAttributeStream<T: PayloadTypes> {
 }
 
 impl<T: PayloadTypes> Stream for PayloadAttributeStream<T> {
-    type Item = T::PayloadBuilderAttributes;
+    type Item = T::PayloadAttributes;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -30,8 +30,9 @@
 //! use std::task::{Context, Poll};
 //! use alloy_consensus::{Header, Block};
 //! use alloy_primitives::U256;
-//! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, PayloadAttributes, PayloadJob, PayloadJobGenerator, PayloadKind};
+//! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, PayloadJob, PayloadJobGenerator, PayloadKind};
 //! use reth_primitives_traits::SealedBlock;
+//! use alloy_rpc_types::engine::PayloadAttributes;
 //!
 //! /// The generator type that creates new jobs that builds empty blocks.
 //! pub struct EmptyBlockPayloadJobGenerator;
@@ -40,7 +41,7 @@
 //!     type Job = EmptyBlockPayloadJob;
 //!
 //! /// This is invoked when the node receives payload attributes from the beacon node via `engine_forkchoiceUpdatedV1`
-//! fn new_payload_job(&self, attr: PayloadAttributes) -> Result<Self::Job, PayloadBuilderError> {
+//! fn new_payload_job(&self, _parent: B256, attr: PayloadAttributes, _id: PayloadId) -> Result<Self::Job, PayloadBuilderError> {
 //!         Ok(EmptyBlockPayloadJob{ attributes: attr,})
 //!     }
 //!
@@ -67,7 +68,7 @@
 //!         },
 //!         ..Default::default()
 //!     };
-//!     let payload = EthBuiltPayload::new(self.attributes.id, Arc::new(SealedBlock::seal_slow(block)), U256::ZERO, None);
+//!     let payload = EthBuiltPayload::new(Arc::new(SealedBlock::seal_slow(block)), U256::ZERO, None);
 //!     Ok(payload)
 //! }
 //!

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -30,7 +30,7 @@
 //! use std::task::{Context, Poll};
 //! use alloy_consensus::{Header, Block};
 //! use alloy_primitives::U256;
-//! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, EthPayloadBuilderAttributes, PayloadJob, PayloadJobGenerator, PayloadKind};
+//! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, PayloadAttributes, PayloadJob, PayloadJobGenerator, PayloadKind};
 //! use reth_primitives_traits::SealedBlock;
 //!
 //! /// The generator type that creates new jobs that builds empty blocks.
@@ -40,7 +40,7 @@
 //!     type Job = EmptyBlockPayloadJob;
 //!
 //! /// This is invoked when the node receives payload attributes from the beacon node via `engine_forkchoiceUpdatedV1`
-//! fn new_payload_job(&self, attr: EthPayloadBuilderAttributes) -> Result<Self::Job, PayloadBuilderError> {
+//! fn new_payload_job(&self, attr: PayloadAttributes) -> Result<Self::Job, PayloadBuilderError> {
 //!         Ok(EmptyBlockPayloadJob{ attributes: attr,})
 //!     }
 //!
@@ -48,11 +48,11 @@
 //!
 //! /// A [PayloadJob] that builds empty blocks.
 //! pub struct EmptyBlockPayloadJob {
-//!   attributes: EthPayloadBuilderAttributes,
+//!   attributes: PayloadAttributes,
 //! }
 //!
 //! impl PayloadJob for EmptyBlockPayloadJob {
-//!    type PayloadAttributes = EthPayloadBuilderAttributes;
+//!    type PayloadAttributes = PayloadAttributes;
 //!    type ResolvePayloadFuture = futures_util::future::Ready<Result<EthBuiltPayload, PayloadBuilderError>>;
 //!    type BuiltPayload = EthBuiltPayload;
 //!
@@ -71,7 +71,7 @@
 //!     Ok(payload)
 //! }
 //!
-//! fn payload_attributes(&self) -> Result<EthPayloadBuilderAttributes, PayloadBuilderError> {
+//! fn payload_attributes(&self) -> Result<PayloadAttributes, PayloadBuilderError> {
 //!     Ok(self.attributes.clone())
 //! }
 //!

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -126,6 +126,4 @@ pub use traits::{KeepPayloadJobAlive, PayloadJob, PayloadJobGenerator};
 
 // re-export the Ethereum engine primitives for convenience
 #[doc(inline)]
-pub use reth_ethereum_engine_primitives::{
-    BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes,
-};
+pub use reth_ethereum_engine_primitives::{BlobSidecars, EthBuiltPayload};

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -29,6 +29,8 @@
 //! use std::sync::Arc;
 //! use std::task::{Context, Poll};
 //! use alloy_consensus::{Header, Block};
+//! use alloy_primitives::B256;
+//! use reth_payload_builder::PayloadId;
 //! use alloy_primitives::U256;
 //! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, PayloadJob, PayloadJobGenerator, PayloadKind};
 //! use reth_primitives_traits::SealedBlock;
@@ -42,7 +44,7 @@
 //!
 //! /// This is invoked when the node receives payload attributes from the beacon node via `engine_forkchoiceUpdatedV1`
 //! fn new_payload_job(&self, _parent: B256, attr: PayloadAttributes, _id: PayloadId) -> Result<Self::Job, PayloadBuilderError> {
-//!         Ok(EmptyBlockPayloadJob{ attributes: attr,})
+//!         Ok(EmptyBlockPayloadJob{ attributes: attr, parent })
 //!     }
 //!
 //! }
@@ -50,6 +52,7 @@
 //! /// A [PayloadJob] that builds empty blocks.
 //! pub struct EmptyBlockPayloadJob {
 //!   attributes: PayloadAttributes,
+//!   parent: B256,
 //! }
 //!
 //! impl PayloadJob for EmptyBlockPayloadJob {
@@ -61,7 +64,7 @@
 //!     // NOTE: some fields are omitted here for brevity
 //!     let block = Block {
 //!         header: Header {
-//!             parent_hash: self.attributes.parent,
+//!             parent_hash: self.parent,
 //!             timestamp: self.attributes.timestamp,
 //!             beneficiary: self.attributes.suggested_fee_recipient,
 //!             ..Default::default()

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -43,7 +43,7 @@
 //!     type Job = EmptyBlockPayloadJob;
 //!
 //! /// This is invoked when the node receives payload attributes from the beacon node via `engine_forkchoiceUpdatedV1`
-//! fn new_payload_job(&self, _parent: B256, attr: PayloadAttributes, _id: PayloadId) -> Result<Self::Job, PayloadBuilderError> {
+//! fn new_payload_job(&self, parent: B256, attr: PayloadAttributes, _id: PayloadId) -> Result<Self::Job, PayloadBuilderError> {
 //!         Ok(EmptyBlockPayloadJob{ attributes: attr, parent })
 //!     }
 //!

--- a/crates/payload/builder/src/noop.rs
+++ b/crates/payload/builder/src/noop.rs
@@ -2,7 +2,7 @@
 
 use crate::{service::PayloadServiceCommand, PayloadBuilderHandle};
 use futures_util::{ready, StreamExt};
-use reth_payload_primitives::{PayloadBuilderAttributes, PayloadTypes};
+use reth_payload_primitives::{PayloadAttributes, PayloadTypes};
 use std::{
     future::Future,
     pin::Pin,
@@ -45,8 +45,8 @@ where
                 return Poll::Ready(())
             };
             match cmd {
-                PayloadServiceCommand::BuildNewPayload(attr, _, tx) => {
-                    let id = attr.payload_id();
+                PayloadServiceCommand::BuildNewPayload(parent_hash, attr, _, tx) => {
+                    let id = attr.payload_id(&parent_hash);
                     tx.send(Ok(id)).ok()
                 }
                 PayloadServiceCommand::BestPayload(_, tx) => tx.send(None).ok(),

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -8,12 +8,12 @@ use crate::{
     PayloadJob,
 };
 use alloy_consensus::BlockHeader;
-use alloy_primitives::BlockTimestamp;
+use alloy_primitives::{BlockTimestamp, B256};
 use alloy_rpc_types::engine::PayloadId;
 use futures_util::{future::FutureExt, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;
 use reth_payload_builder_primitives::{Events, PayloadBuilderError, PayloadEvents};
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind, PayloadTypes};
+use reth_payload_primitives::{BuiltPayload, PayloadAttributes, PayloadKind, PayloadTypes};
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use std::{
     fmt,
@@ -123,11 +123,14 @@ impl<T: PayloadTypes> PayloadBuilderHandle<T> {
     /// Returns a receiver that will receive the payload id.
     pub fn send_new_payload(
         &self,
-        attr: T::PayloadBuilderAttributes,
+        parent: B256,
+        attr: T::PayloadAttributes,
     ) -> Receiver<Result<PayloadId, PayloadBuilderError>> {
         let (tx, rx) = oneshot::channel();
         let job_span = debug_span!(parent: Span::current(), "payload_job");
-        let _ = self.to_service.send(PayloadServiceCommand::BuildNewPayload(attr, job_span, tx));
+        let _ = self
+            .to_service
+            .send(PayloadServiceCommand::BuildNewPayload(parent, attr, job_span, tx));
         rx
     }
 
@@ -200,7 +203,7 @@ pub struct PayloadBuilderService<Gen, St, T>
 where
     T: PayloadTypes,
     Gen: PayloadJobGenerator,
-    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
+    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadAttributes>,
 {
     /// The type that knows how to create new payloads.
     generator: Gen,
@@ -233,7 +236,7 @@ impl<Gen, St, T> PayloadBuilderService<Gen, St, T>
 where
     T: PayloadTypes,
     Gen: PayloadJobGenerator,
-    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
+    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadAttributes>,
     <Gen::Job as PayloadJob>::BuiltPayload: Into<T::BuiltPayload>,
 {
     /// Creates a new payload builder service and returns the [`PayloadBuilderHandle`] to interact
@@ -376,7 +379,7 @@ where
     Gen: PayloadJobGenerator + Unpin + 'static,
     <Gen as PayloadJobGenerator>::Job: Unpin + 'static,
     St: Stream<Item = CanonStateNotification<N>> + Send + Unpin + 'static,
-    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadBuilderAttributes>,
+    Gen::Job: PayloadJob<PayloadAttributes = T::PayloadAttributes>,
     <Gen::Job as PayloadJob>::BuiltPayload: Into<T::BuiltPayload>,
 {
     type Output = ();
@@ -422,18 +425,17 @@ where
             // drain all requests
             while let Poll::Ready(Some(cmd)) = this.command_rx.poll_next_unpin(cx) {
                 match cmd {
-                    PayloadServiceCommand::BuildNewPayload(attr, job_span, tx) => {
-                        let id = attr.payload_id();
+                    PayloadServiceCommand::BuildNewPayload(parent, attr, job_span, tx) => {
+                        let id = attr.payload_id(&parent);
                         let mut res = Ok(id);
 
                         if this.contains_payload(id) {
-                            debug!(target: "payload_builder",%id, parent = %attr.parent(), "Payload job already in progress, ignoring.");
+                            debug!(target: "payload_builder", %id, %parent, "Payload job already in progress, ignoring.");
                         } else {
-                            let parent = attr.parent();
                             let start = Instant::now();
                             let job_result = {
                                 let _entered = job_span.enter();
-                                this.generator.new_payload_job(attr.clone())
+                                this.generator.new_payload_job(parent, attr.clone(), id)
                             };
 
                             match job_result {
@@ -500,7 +502,8 @@ pub enum PayloadServiceCommand<T: PayloadTypes> {
     /// Carries the caller's [`Span`] so the service can parent payload-building work under the
     /// originating Engine API trace.
     BuildNewPayload(
-        T::PayloadBuilderAttributes,
+        B256,
+        T::PayloadAttributes,
         Span,
         oneshot::Sender<Result<PayloadId, PayloadBuilderError>>,
     ),
@@ -524,8 +527,8 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::BuildNewPayload(f0, _, f1) => {
-                f.debug_tuple("BuildNewPayload").field(&f0).field(&f1).finish()
+            Self::BuildNewPayload(f0, f1, _, f2) => {
+                f.debug_tuple("BuildNewPayload").field(&f0).field(&f1).field(&f2).finish()
             }
             Self::BestPayload(f0, f1) => {
                 f.debug_tuple("BestPayload").field(&f0).field(&f1).finish()

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -1,13 +1,15 @@
 //! Utils for testing purposes.
 
 use crate::{
-    traits::KeepPayloadJobAlive, EthBuiltPayload, EthPayloadBuilderAttributes,
-    PayloadBuilderHandle, PayloadBuilderService, PayloadJob, PayloadJobGenerator,
+    traits::KeepPayloadJobAlive, EthBuiltPayload, PayloadBuilderHandle, PayloadBuilderService,
+    PayloadJob, PayloadJobGenerator,
 };
 
 use alloy_consensus::Block;
-use alloy_primitives::U256;
+use alloy_primitives::{B256, U256};
+use alloy_rpc_types::engine::PayloadId;
 use reth_chain_state::CanonStateNotification;
+use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::{PayloadKind, PayloadTypes};
 use reth_primitives_traits::Block as _;
@@ -28,10 +30,8 @@ pub fn test_payload_service<T>() -> (
     PayloadBuilderHandle<T>,
 )
 where
-    T: PayloadTypes<
-            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-            BuiltPayload = EthBuiltPayload,
-        > + 'static,
+    T: PayloadTypes<PayloadAttributes = EthPayloadAttributes, BuiltPayload = EthBuiltPayload>
+        + 'static,
 {
     PayloadBuilderService::new(Default::default(), futures_util::stream::empty())
 }
@@ -39,10 +39,8 @@ where
 /// Creates a new [`PayloadBuilderService`] for testing purposes and spawns it in the background.
 pub fn spawn_test_payload_service<T>() -> PayloadBuilderHandle<T>
 where
-    T: PayloadTypes<
-            PayloadBuilderAttributes = EthPayloadBuilderAttributes,
-            BuiltPayload = EthBuiltPayload,
-        > + 'static,
+    T: PayloadTypes<PayloadAttributes = EthPayloadAttributes, BuiltPayload = EthBuiltPayload>
+        + 'static,
 {
     let (service, handle) = test_payload_service();
     tokio::spawn(service);
@@ -59,7 +57,9 @@ impl PayloadJobGenerator for TestPayloadJobGenerator {
 
     fn new_payload_job(
         &self,
-        attr: EthPayloadBuilderAttributes,
+        _parent: B256,
+        attr: EthPayloadAttributes,
+        _id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
         Ok(TestPayloadJob { attr })
     }
@@ -68,7 +68,7 @@ impl PayloadJobGenerator for TestPayloadJobGenerator {
 /// A [`PayloadJob`] for testing purposes
 #[derive(Debug)]
 pub struct TestPayloadJob {
-    attr: EthPayloadBuilderAttributes,
+    attr: EthPayloadAttributes,
 }
 
 impl Future for TestPayloadJob {
@@ -80,26 +80,25 @@ impl Future for TestPayloadJob {
 }
 
 impl PayloadJob for TestPayloadJob {
-    type PayloadAttributes = EthPayloadBuilderAttributes;
+    type PayloadAttributes = EthPayloadAttributes;
     type ResolvePayloadFuture =
         futures_util::future::Ready<Result<EthBuiltPayload, PayloadBuilderError>>;
     type BuiltPayload = EthBuiltPayload;
 
     fn best_payload(&self) -> Result<EthBuiltPayload, PayloadBuilderError> {
         Ok(EthBuiltPayload::new(
-            self.attr.payload_id(),
             Arc::new(Block::<_>::default().seal_slow()),
             U256::ZERO,
             Some(Default::default()),
         ))
     }
 
-    fn payload_attributes(&self) -> Result<EthPayloadBuilderAttributes, PayloadBuilderError> {
+    fn payload_attributes(&self) -> Result<EthPayloadAttributes, PayloadBuilderError> {
         Ok(self.attr.clone())
     }
 
     fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
-        Ok(self.attr.inner.timestamp)
+        Ok(self.attr.timestamp)
     }
 
     fn resolve_kind(

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -99,7 +99,7 @@ impl PayloadJob for TestPayloadJob {
     }
 
     fn payload_timestamp(&self) -> Result<u64, PayloadBuilderError> {
-        Ok(self.attr.timestamp)
+        Ok(self.attr.inner.timestamp)
     }
 
     fn resolve_kind(

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -1,8 +1,10 @@
 //! Trait abstractions used by the payload crate.
 
+use alloy_primitives::B256;
+use alloy_rpc_types::engine::PayloadId;
 use reth_chain_state::CanonStateNotification;
 use reth_payload_builder_primitives::PayloadBuilderError;
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes, PayloadKind};
+use reth_payload_primitives::{BuiltPayload, PayloadAttributes, PayloadKind};
 use reth_primitives_traits::NodePrimitives;
 use std::future::Future;
 
@@ -19,7 +21,7 @@ use std::future::Future;
 /// Note: A `PayloadJob` need to be cancel safe because it might be dropped after the CL has requested the payload via `engine_getPayloadV1` (see also [engine API docs](https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_getpayloadv1))
 pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> {
     /// Represents the payload attributes type that is used to spawn this payload job.
-    type PayloadAttributes: PayloadBuilderAttributes + std::fmt::Debug;
+    type PayloadAttributes: PayloadAttributes + std::fmt::Debug;
     /// Represents the future that resolves the block that's returned to the CL.
     type ResolvePayloadFuture: Future<Output = Result<Self::BuiltPayload, PayloadBuilderError>>
         + Send
@@ -108,7 +110,9 @@ pub trait PayloadJobGenerator {
     /// returned directly.
     fn new_payload_job(
         &self,
+        parent: B256,
         attr: <Self::Job as PayloadJob>::PayloadAttributes,
+        id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError>;
 
     /// Handles new chain state events

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 assert_matches.workspace = true
+serde_json.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -24,6 +24,7 @@ reth-trie-common.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 op-alloy-rpc-types-engine = { workspace = true, optional = true, features = ["serde"] }
 
@@ -31,6 +32,7 @@ op-alloy-rpc-types-engine = { workspace = true, optional = true, features = ["se
 auto_impl.workspace = true
 either.workspace = true
 serde.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -55,6 +55,9 @@ std = [
     "reth-primitives-traits/std",
     "either/std",
     "alloy-consensus/std",
+    "alloy-rlp/std",
+    "serde_json/std",
+    "sha2/std",
 ]
 op = [
     "dep:op-alloy-rpc-types-engine",

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -25,8 +25,8 @@ pub use error::{
 
 mod traits;
 pub use traits::{
-    BuildNextEnv, BuiltPayload, BuiltPayloadExecutedBlock, PayloadAttributes,
-    PayloadAttributesBuilder, PayloadBuilderAttributes,
+    payload_id, BuildNextEnv, BuiltPayload, BuiltPayloadExecutedBlock, PayloadAttributes,
+    PayloadAttributesBuilder,
 };
 
 mod payload;
@@ -47,15 +47,6 @@ pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone + 'static
     /// These attributes typically come from external sources (e.g., consensus layer over RPC such
     /// as the Engine API) and contain parameters like timestamp, fee recipient, and randomness.
     type PayloadAttributes: PayloadAttributes + Unpin;
-
-    /// Extended attributes used internally during payload building.
-    ///
-    /// This type augments the basic payload attributes with additional information
-    /// needed during the building process, such as unique identifiers and parent
-    /// block references.
-    type PayloadBuilderAttributes: PayloadBuilderAttributes<RpcPayloadAttributes = Self::PayloadAttributes>
-        + Clone
-        + Unpin;
 
     /// Converts a sealed block into the execution payload format.
     fn block_to_payload(

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -2,11 +2,9 @@
 
 use crate::PayloadBuilderError;
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use alloy_eips::{
-    eip4895::{Withdrawal, Withdrawals},
-    eip7685::Requests,
-};
-use alloy_primitives::{Address, B256, U256};
+use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
+use alloy_primitives::{B256, U256};
+use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadId};
 use core::fmt;
 use either::Either;
@@ -97,52 +95,6 @@ pub trait BuiltPayload: Send + Sync + fmt::Debug {
     fn requests(&self) -> Option<Requests>;
 }
 
-/// Attributes used to guide the construction of a new execution payload.
-///
-/// Extends basic payload attributes with additional context needed during the
-/// building process, tracking in-progress payload jobs and their parameters.
-pub trait PayloadBuilderAttributes: Send + Sync + Unpin + fmt::Debug + 'static {
-    /// The external payload attributes format this type can be constructed from.
-    type RpcPayloadAttributes: Send + Sync + 'static;
-    /// The error type used in [`PayloadBuilderAttributes::try_new`].
-    type Error: core::error::Error + Send + Sync + 'static;
-
-    /// Constructs new builder attributes from external payload attributes.
-    ///
-    /// Validates attributes and generates a unique [`PayloadId`] based on the
-    /// parent block, attributes, and version.
-    fn try_new(
-        parent: B256,
-        rpc_payload_attributes: Self::RpcPayloadAttributes,
-        version: u8,
-    ) -> Result<Self, Self::Error>
-    where
-        Self: Sized;
-
-    /// Returns the unique identifier for this payload build job.
-    fn payload_id(&self) -> PayloadId;
-
-    /// Returns the hash of the parent block this payload builds on.
-    fn parent(&self) -> B256;
-
-    /// Returns the timestamp to be used in the payload's header.
-    fn timestamp(&self) -> u64;
-
-    /// Returns the beacon chain block root from the parent block.
-    ///
-    /// Returns `None` for pre-merge blocks or non-beacon contexts.
-    fn parent_beacon_block_root(&self) -> Option<B256>;
-
-    /// Returns the address that should receive transaction fees.
-    fn suggested_fee_recipient(&self) -> Address;
-
-    /// Returns the randomness value for this block.
-    fn prev_randao(&self) -> B256;
-
-    /// Returns the list of withdrawals to be processed in this block.
-    fn withdrawals(&self) -> &Withdrawals;
-}
-
 /// Basic attributes required to initiate payload construction.
 ///
 /// Defines minimal parameters needed to build a new execution payload.
@@ -150,6 +102,9 @@ pub trait PayloadBuilderAttributes: Send + Sync + Unpin + fmt::Debug + 'static {
 pub trait PayloadAttributes:
     serde::de::DeserializeOwned + serde::Serialize + fmt::Debug + Clone + Send + Sync + 'static
 {
+    /// Computes the unique identifier for this payload build job.
+    fn payload_id(&self, parent_hash: &B256) -> PayloadId;
+
     /// Returns the timestamp for the new payload.
     fn timestamp(&self) -> u64;
 
@@ -165,6 +120,10 @@ pub trait PayloadAttributes:
 }
 
 impl PayloadAttributes for EthPayloadAttributes {
+    fn payload_id(&self, parent_hash: &B256) -> PayloadId {
+        payload_id(parent_hash, self)
+    }
+
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
@@ -248,4 +207,143 @@ pub trait BuildNextEnv<Attributes, Header, Ctx>: Sized {
         parent: &SealedHeader<Header>,
         ctx: &Ctx,
     ) -> Result<Self, PayloadBuilderError>;
+}
+
+/// Generates the payload id for the configured payload from the [`PayloadAttributes`].
+///
+/// Returns an 8-byte identifier by hashing the payload components with sha256 hash.
+pub fn payload_id(
+    parent: &B256,
+    attributes: &alloy_rpc_types_engine::PayloadAttributes,
+) -> PayloadId {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(parent.as_slice());
+    hasher.update(&attributes.timestamp.to_be_bytes()[..]);
+    hasher.update(attributes.prev_randao.as_slice());
+    hasher.update(attributes.suggested_fee_recipient.as_slice());
+    if let Some(withdrawals) = &attributes.withdrawals {
+        let mut buf = Vec::new();
+        withdrawals.encode(&mut buf);
+        hasher.update(buf);
+    }
+
+    if let Some(parent_beacon_block) = attributes.parent_beacon_block_root {
+        hasher.update(parent_beacon_block);
+    }
+
+    let out = hasher.finalize();
+
+    #[allow(deprecated)] // generic-array 0.14 deprecated
+    PayloadId::new(out.as_slice()[..8].try_into().expect("sufficient length"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eips::eip4895::Withdrawal;
+    use alloy_primitives::B64;
+    use core::str::FromStr;
+
+    #[test]
+    fn attributes_serde() {
+        let attributes = r#"{"timestamp":"0x1235","prevRandao":"0xf343b00e02dc34ec0124241f74f32191be28fb370bb48060f5fa4df99bda774c","suggestedFeeRecipient":"0x0000000000000000000000000000000000000000","withdrawals":null,"parentBeaconBlockRoot":null}"#;
+        let _attributes: PayloadAttributes = serde_json::from_str(attributes).unwrap();
+    }
+
+    #[test]
+    fn test_payload_id_basic() {
+        // Create a parent block and payload attributes
+        let parent =
+            B256::from_str("0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a")
+                .unwrap();
+        let attributes = PayloadAttributes {
+            timestamp: 0x5,
+            prev_randao: B256::from_str(
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            suggested_fee_recipient: Address::from_str(
+                "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            )
+            .unwrap(),
+            withdrawals: None,
+            parent_beacon_block_root: None,
+        };
+
+        // Verify that the generated payload ID matches the expected value
+        assert_eq!(
+            payload_id(&parent, &attributes),
+            PayloadId(B64::from_str("0xa247243752eb10b4").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_payload_id_with_withdrawals() {
+        // Set up the parent and attributes with withdrawals
+        let parent =
+            B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
+                .unwrap();
+        let attributes = PayloadAttributes {
+            timestamp: 1622553200,
+            prev_randao: B256::from_slice(&[1; 32]),
+            suggested_fee_recipient: Address::from_str(
+                "0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            )
+            .unwrap(),
+            withdrawals: Some(vec![
+                Withdrawal {
+                    index: 1,
+                    validator_index: 123,
+                    address: Address::from([0xAA; 20]),
+                    amount: 10,
+                },
+                Withdrawal {
+                    index: 2,
+                    validator_index: 456,
+                    address: Address::from([0xBB; 20]),
+                    amount: 20,
+                },
+            ]),
+            parent_beacon_block_root: None,
+        };
+
+        // Verify that the generated payload ID matches the expected value
+        assert_eq!(
+            payload_id(&parent, &attributes),
+            PayloadId(B64::from_str("0xedddc2f84ba59865").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_payload_id_with_parent_beacon_block_root() {
+        // Set up the parent and attributes with a parent beacon block root
+        let parent =
+            B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
+                .unwrap();
+        let attributes = PayloadAttributes {
+            timestamp: 1622553200,
+            prev_randao: B256::from_str(
+                "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",
+            )
+            .unwrap(),
+            suggested_fee_recipient: Address::from_str(
+                "0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            )
+            .unwrap(),
+            withdrawals: None,
+            parent_beacon_block_root: Some(
+                B256::from_str(
+                    "0x2222222222222222222222222222222222222222222222222222222222222222",
+                )
+                .unwrap(),
+            ),
+        };
+
+        // Verify that the generated payload ID matches the expected value
+        assert_eq!(
+            payload_id(&parent, &attributes),
+            PayloadId(B64::from_str("0x0fc49cd532094cce").unwrap())
+        );
+    }
 }

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -137,21 +137,6 @@ impl PayloadAttributes for EthPayloadAttributes {
     }
 }
 
-#[cfg(feature = "op")]
-impl PayloadAttributes for op_alloy_rpc_types_engine::OpPayloadAttributes {
-    fn timestamp(&self) -> u64 {
-        self.payload_attributes.timestamp
-    }
-
-    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
-        self.payload_attributes.withdrawals.as_ref()
-    }
-
-    fn parent_beacon_block_root(&self) -> Option<B256> {
-        self.payload_attributes.parent_beacon_block_root
-    }
-}
-
 /// Factory trait for creating payload attributes.
 ///
 /// Enables different strategies for generating payload attributes based on
@@ -242,13 +227,13 @@ pub fn payload_id(
 mod tests {
     use super::*;
     use alloy_eips::eip4895::Withdrawal;
-    use alloy_primitives::B64;
+    use alloy_primitives::{Address, B64};
     use core::str::FromStr;
 
     #[test]
     fn attributes_serde() {
         let attributes = r#"{"timestamp":"0x1235","prevRandao":"0xf343b00e02dc34ec0124241f74f32191be28fb370bb48060f5fa4df99bda774c","suggestedFeeRecipient":"0x0000000000000000000000000000000000000000","withdrawals":null,"parentBeaconBlockRoot":null}"#;
-        let _attributes: PayloadAttributes = serde_json::from_str(attributes).unwrap();
+        let _attributes: EthPayloadAttributes = serde_json::from_str(attributes).unwrap();
     }
 
     #[test]
@@ -257,7 +242,7 @@ mod tests {
         let parent =
             B256::from_str("0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a")
                 .unwrap();
-        let attributes = PayloadAttributes {
+        let attributes = EthPayloadAttributes {
             timestamp: 0x5,
             prev_randao: B256::from_str(
                 "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -284,7 +269,7 @@ mod tests {
         let parent =
             B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
                 .unwrap();
-        let attributes = PayloadAttributes {
+        let attributes = EthPayloadAttributes {
             timestamp: 1622553200,
             prev_randao: B256::from_slice(&[1; 32]),
             suggested_fee_recipient: Address::from_str(
@@ -321,7 +306,7 @@ mod tests {
         let parent =
             B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
                 .unwrap();
-        let attributes = PayloadAttributes {
+        let attributes = EthPayloadAttributes {
             timestamp: 1622553200,
             prev_randao: B256::from_str(
                 "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234",

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -761,8 +761,7 @@ where
             //
             // NOTE: This also applies to cancun/shanghai-specific payload attributes.
             if let Err(err) = attr_validation_res {
-                let fcu_res =
-                    self.inner.beacon_consensus.fork_choice_updated(state, None).await?;
+                let fcu_res = self.inner.beacon_consensus.fork_choice_updated(state, None).await?;
                 if fcu_res.is_invalid() || fcu_res.payload_status.is_syncing() {
                     return Ok(fcu_res)
                 }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -762,7 +762,7 @@ where
             // NOTE: This also applies to cancun/shanghai-specific payload attributes.
             if let Err(err) = attr_validation_res {
                 let fcu_res =
-                    self.inner.beacon_consensus.fork_choice_updated(state, None, version).await?;
+                    self.inner.beacon_consensus.fork_choice_updated(state, None).await?;
                 if fcu_res.is_invalid() || fcu_res.payload_status.is_syncing() {
                     return Ok(fcu_res)
                 }
@@ -770,7 +770,7 @@ where
             }
         }
 
-        Ok(self.inner.beacon_consensus.fork_choice_updated(state, payload_attrs, version).await?)
+        Ok(self.inner.beacon_consensus.fork_choice_updated(state, payload_attrs).await?)
     }
 
     /// Returns reference to supported capabilities.

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated};
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_payload_primitives::{PayloadTypes};
+use reth_payload_primitives::PayloadTypes;
 use reth_primitives_traits::SealedBlock;
 use reth_rpc_api::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus};
 use tracing::trace;

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -4,7 +4,7 @@ use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated};
 use async_trait::async_trait;
 use jsonrpsee_core::RpcResult;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_payload_primitives::{EngineApiMessageVersion, PayloadTypes};
+use reth_payload_primitives::{PayloadTypes};
 use reth_primitives_traits::SealedBlock;
 use reth_rpc_api::{RethEngineApiServer, RethNewPayloadInput, RethPayloadStatus};
 use tracing::trace;
@@ -67,7 +67,7 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
     ) -> RpcResult<ForkchoiceUpdated> {
         trace!(target: "rpc::engine", "Serving reth_forkchoiceUpdated");
         self.beacon_engine_handle
-            .fork_choice_updated(forkchoice_state, None, EngineApiMessageVersion::V3)
+            .fork_choice_updated(forkchoice_state, None)
             .await
             .map_err(|e| EngineApiError::from(e).into())
     }

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -212,15 +212,10 @@ where
 
                 let requests = has_requests.then_some(outcome.execution_result.requests);
 
-                EthBuiltPayload::new(
-                    alloy_rpc_types_engine::PayloadId::default(),
-                    sealed_block,
-                    total_fees,
-                    requests,
-                )
-                .try_into_v5()
-                .map_err(RethError::other)
-                .map_err(Eth::Error::from_eth_err)
+                EthBuiltPayload::new(sealed_block, total_fees, requests)
+                    .try_into_v5()
+                    .map_err(RethError::other)
+                    .map_err(Eth::Error::from_eth_err)
             })
             .await
     }

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -154,7 +154,7 @@ where
                 finalized_block_hash: head_block_hash,
             };
 
-            match engine.fork_choice_updated(state, None, EngineApiMessageVersion::default()).await
+            match engine.fork_choice_updated(state, None).await
             {
                 Ok(response) => match response.payload_status.status {
                     PayloadStatusEnum::Valid => Outcome::<T> {
@@ -421,7 +421,6 @@ mod tests {
                     BeaconEngineMessage::ForkchoiceUpdated {
                         state: _,
                         payload_attrs: _,
-                        version: _,
                         tx,
                     } => {
                         tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -154,8 +154,7 @@ where
                 finalized_block_hash: head_block_hash,
             };
 
-            match engine.fork_choice_updated(state, None).await
-            {
+            match engine.fork_choice_updated(state, None).await {
                 Ok(response) => match response.payload_status.status {
                     PayloadStatusEnum::Valid => Outcome::<T> {
                         peer: peer_id,
@@ -418,11 +417,7 @@ mod tests {
                         tx.send(Ok(PayloadStatus::new(responses.new_payload.clone(), None)))
                             .unwrap();
                     }
-                    BeaconEngineMessage::ForkchoiceUpdated {
-                        state: _,
-                        payload_attrs: _,
-                        tx,
-                    } => {
+                    BeaconEngineMessage::ForkchoiceUpdated { state: _, payload_attrs: _, tx } => {
                         tx.send(Ok(OnForkChoiceUpdated::valid(PayloadStatus::new(
                             responses.fcu.clone(),
                             None,

--- a/examples/custom-engine-types/Cargo.toml
+++ b/examples/custom-engine-types/Cargo.toml
@@ -14,7 +14,6 @@ reth-tracing.workspace = true
 alloy-genesis.workspace = true
 alloy-rpc-types = { workspace = true, features = ["engine"] }
 alloy-primitives.workspace = true
-alloy-eips.workspace = true
 
 eyre.workspace = true
 tokio.workspace = true

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -9,7 +9,7 @@
 //! arguments to the `engine_forkchoiceUpdated` method. This type should be used to define and
 //! _spawn_ payload jobs.
 //!
-//! [PayloadBuilderAttributes] can be implemented for payload attributes types that _describe_
+//! [PayloadAttributes] can be implemented for payload attributes types that _describe_
 //! running payload jobs.
 //!
 //! Once traits are implemented and custom types are defined, the [EngineTypes] trait can be
@@ -17,9 +17,8 @@
 
 #![warn(unused_crate_dependencies)]
 
-use alloy_eips::eip4895::Withdrawals;
 use alloy_genesis::Genesis;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::B256;
 use alloy_rpc_types::{
     engine::{
         ExecutionData, ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3,
@@ -36,7 +35,7 @@ use reth_ethereum::{
             payload::{EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes},
             validate_version_specific_fields, AddOnsContext, EngineApiValidator, EngineTypes,
             FullNodeComponents, FullNodeTypes, InvalidPayloadAttributesError, NewPayloadError,
-            NodeTypes, PayloadAttributes, PayloadBuilderAttributes, PayloadTypes, PayloadValidator,
+            NodeTypes, PayloadAttributes, PayloadTypes, PayloadValidator,
         },
         builder::{
             components::{BasicPayloadServiceBuilder, ComponentsBuilder, PayloadBuilderBuilder},
@@ -58,10 +57,10 @@ use reth_ethereum::{
     EthPrimitives, TransactionSigned,
 };
 use reth_ethereum_payload_builder::{EthereumBuilderConfig, EthereumExecutionPayloadValidator};
-use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderError};
+use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
 use reth_tracing::{RethTracer, Tracer};
 use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, sync::Arc};
+use std::sync::Arc;
 use thiserror::Error;
 
 /// A custom payload attributes type.
@@ -82,6 +81,10 @@ pub enum CustomError {
 }
 
 impl PayloadAttributes for CustomPayloadAttributes {
+    fn payload_id(&self, parent_hash: &B256) -> PayloadId {
+        self.inner.payload_id(parent_hash)
+    }
+
     fn timestamp(&self) -> u64 {
         self.inner.timestamp()
     }
@@ -95,51 +98,6 @@ impl PayloadAttributes for CustomPayloadAttributes {
     }
 }
 
-/// New type around the payload builder attributes type
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CustomPayloadBuilderAttributes(EthPayloadBuilderAttributes);
-
-impl PayloadBuilderAttributes for CustomPayloadBuilderAttributes {
-    type RpcPayloadAttributes = CustomPayloadAttributes;
-    type Error = Infallible;
-
-    fn try_new(
-        parent: B256,
-        attributes: CustomPayloadAttributes,
-        _version: u8,
-    ) -> Result<Self, Infallible> {
-        Ok(Self(EthPayloadBuilderAttributes::new(parent, attributes.inner)))
-    }
-
-    fn payload_id(&self) -> PayloadId {
-        self.0.id
-    }
-
-    fn parent(&self) -> B256 {
-        self.0.parent
-    }
-
-    fn timestamp(&self) -> u64 {
-        self.0.timestamp
-    }
-
-    fn parent_beacon_block_root(&self) -> Option<B256> {
-        self.0.parent_beacon_block_root
-    }
-
-    fn suggested_fee_recipient(&self) -> Address {
-        self.0.suggested_fee_recipient
-    }
-
-    fn prev_randao(&self) -> B256 {
-        self.0.prev_randao
-    }
-
-    fn withdrawals(&self) -> &Withdrawals {
-        &self.0.withdrawals
-    }
-}
-
 /// Custom engine types - uses a custom payload attributes RPC type, but uses the default
 /// payload builder attributes type.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -150,7 +108,6 @@ impl PayloadTypes for CustomEngineTypes {
     type ExecutionData = ExecutionData;
     type BuiltPayload = EthBuiltPayload;
     type PayloadAttributes = CustomPayloadAttributes;
-    type PayloadBuilderAttributes = CustomPayloadBuilderAttributes;
 
     fn block_to_payload(
         block: SealedBlock<
@@ -358,7 +315,7 @@ where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
 {
-    type Attributes = CustomPayloadBuilderAttributes;
+    type Attributes = CustomPayloadAttributes;
     type BuiltPayload = EthBuiltPayload;
 
     fn try_build(
@@ -366,13 +323,13 @@ where
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
         let BuildArguments { cached_reads, config, cancel, best_payload } = args;
-        let PayloadConfig { parent_header, attributes } = config;
+        let PayloadConfig { parent_header, attributes, payload_id } = config;
 
         // This reuses the default EthereumPayloadBuilder to build the payload
         // but any custom logic can be implemented here
         self.inner.try_build(BuildArguments {
             cached_reads,
-            config: PayloadConfig { parent_header, attributes: attributes.0 },
+            config: PayloadConfig { parent_header, attributes: attributes.inner, payload_id },
             cancel,
             best_payload,
         })
@@ -382,8 +339,12 @@ where
         &self,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        let PayloadConfig { parent_header, attributes } = config;
-        self.inner.build_empty_payload(PayloadConfig { parent_header, attributes: attributes.0 })
+        let PayloadConfig { parent_header, attributes, payload_id } = config;
+        self.inner.build_empty_payload(PayloadConfig {
+            parent_header,
+            attributes: attributes.inner,
+            payload_id,
+        })
     }
 }
 

--- a/examples/custom-payload-builder/src/generator.rs
+++ b/examples/custom-payload-builder/src/generator.rs
@@ -4,12 +4,13 @@ use reth_basic_payload_builder::{
     BasicPayloadJobGeneratorConfig, HeaderForPayload, PayloadBuilder, PayloadConfig,
 };
 use reth_ethereum::{
-    node::api::{Block, PayloadBuilderAttributes},
+    evm::revm::primitives::B256,
+    node::api::Block,
     primitives::SealedHeader,
     provider::{BlockReaderIdExt, BlockSource, StateProviderFactory},
     tasks::Runtime,
 };
-use reth_payload_builder::{PayloadBuilderError, PayloadJobGenerator};
+use reth_payload_builder::{PayloadBuilderError, PayloadId, PayloadJobGenerator};
 use std::sync::Arc;
 
 /// The generator type that creates new jobs that builds empty blocks.
@@ -59,27 +60,29 @@ where
     /// `engine_forkchoiceUpdatedV1`
     fn new_payload_job(
         &self,
+        parent: B256,
         attributes: Builder::Attributes,
+        id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
-        let parent_block = if attributes.parent().is_zero() {
+        let parent_block = if parent.is_zero() {
             // use latest block if parent is zero: genesis block
             self.client
                 .block_by_number_or_tag(BlockNumberOrTag::Latest)?
-                .ok_or_else(|| PayloadBuilderError::MissingParentBlock(attributes.parent()))?
+                .ok_or_else(|| PayloadBuilderError::MissingParentBlock(parent))?
                 .seal_slow()
         } else {
             let block = self
                 .client
-                .find_block_by_hash(attributes.parent(), BlockSource::Any)?
-                .ok_or_else(|| PayloadBuilderError::MissingParentBlock(attributes.parent()))?;
+                .find_block_by_hash(parent, BlockSource::Any)?
+                .ok_or_else(|| PayloadBuilderError::MissingParentBlock(parent))?;
 
             // we already know the hash, so we can seal it
-            block.seal_unchecked(attributes.parent())
+            block.seal_unchecked(parent)
         };
         let hash = parent_block.hash();
         let header = SealedHeader::new(parent_block.header().clone(), hash);
 
-        let config = PayloadConfig::new(Arc::new(header), attributes);
+        let config = PayloadConfig::new(Arc::new(header), attributes, id);
         Ok(EmptyBlockPayloadJob {
             _executor: self.executor.clone(),
             builder: self.builder.clone(),

--- a/examples/custom-payload-builder/src/job.rs
+++ b/examples/custom-payload-builder/src/job.rs
@@ -1,7 +1,7 @@
 use futures_util::Future;
 use reth_basic_payload_builder::{HeaderForPayload, PayloadBuilder, PayloadConfig};
 use reth_ethereum::{
-    node::api::{PayloadBuilderAttributes, PayloadKind},
+    node::api::{PayloadAttributes, PayloadKind},
     tasks::Runtime,
 };
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadBuilderError, PayloadJob};


### PR DESCRIPTION
Unifies `PayloadBuilderAttributes` and `PayloadAttributes` so that payload builder and engine API operate on the same type.

This is done by extending `PayloadAttributes` trait with `payload_id` method that is responsible for computing payload ID given parent hash.
https://github.com/paradigmxyz/reth/blob/958b738a42d0734c14fdbdfefe4e60c2bb4bd7ed/crates/payload/primitives/src/traits.rs#L105-L106

This allows to remove `PayloadBuilderAttributes` type which purpose was essentially to combine RPC attributes with a parent hash and payload ID.