### PR TITLE
feat(engine): log in-flight persistence action in persist_until_complete

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1297,7 +1297,8 @@ where
     fn persist_until_complete(&mut self) -> Result<(), AdvancePersistenceError> {
         loop {
             // Wait for any in-progress persistence to complete (blocking)
-            if let Some((rx, start_time, _action)) = self.persistence_state.rx.take() {
+            if let Some((rx, start_time, action)) = self.persistence_state.rx.take() {
+                debug!(target: "engine::tree", ?action, "waiting for in-flight persistence");
                 let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
                 self.on_persistence_complete(result, start_time)?;
             }


### PR DESCRIPTION
Adds a `debug!` log before the blocking `rx.recv()` in `persist_until_complete`, printing the current `CurrentPersistenceAction` (saving blocks up to which height, or removing blocks above which tip). Makes it obvious in logs when shutdown is blocking on persistence instead of being completely silent.

Prompted by: DaniPopes