### PR TITLE
fix: remove apt-get upgrade from hive Dockerfile

### DIFF
--- a/.github/scripts/hive/Dockerfile
+++ b/.github/scripts/hive/Dockerfile
@@ -7,7 +7,7 @@ FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN apt-get update && apt-get install -y libclang-dev pkg-config
 
 # 
 # We prepare the build plan


### PR DESCRIPTION
**Remove `apt-get -y upgrade` from `.github/scripts/hive/Dockerfile` to align with the main Dockerfile and ensure reproducible builds, consistent with the change made in commit d8729a9d2c (#19080).**

slow hive CI build, noticed `apt-get upgrade` sitting in the Dockerfile. Checked the build logs and saw lines like `2026-03-24T14:22:08Z debconf: delaying package configuration, since apt-utils is not installed` followed by a bunch of upgrades we don't need — pulling in new versions of base packages on every single build.

Spotted this in the logs: `Unpacking libc6 (2.36-9+deb12u9) over (2.36-9+deb12u4) ...` — the base image already has everything we need, upgrading just adds time and nondeterminism.

Removed the `apt-get -y upgrade` from `.github/scripts/hive/Dockerfile`, kept the `apt-get update` and `apt-get install` for the packages we actually need (`libclang-dev`, `pkg-config`).
