### PR TITLE
chore(cli): suppress unused tracy_client dependency warning

### DIFF
--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -10,6 +10,8 @@
 
 #[cfg(feature = "tracy-allocator")]
 use reth_tracing as _;
+#[cfg(feature = "tracy-allocator")]
+use tracy_client as _;
 
 pub mod allocator;
 pub mod cancellation;


### PR DESCRIPTION
Adds `use tracy_client as _;` behind the `tracy-allocator` feature gate in `reth-cli-util`, matching the existing `reth_tracing` suppression.

Prompted by: DaniPopes