### PR TITLE
fix(test): fix flaky bincode roundtrip tests

### DIFF
--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -30,10 +30,9 @@ serde_with = { workspace = true, optional = true }
 derive_more.workspace = true
 
 [dev-dependencies]
-reth-primitives-traits = { workspace = true, features = ["test-utils", "arbitrary"] }
-reth-ethereum-primitives = { workspace = true, features = ["arbitrary"] }
-alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
-arbitrary.workspace = true
+reth-primitives-traits = { workspace = true, features = ["test-utils"] }
+reth-ethereum-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["rand"] }
 bincode.workspace = true
 rand.workspace = true
 

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -618,9 +618,6 @@ pub(super) mod serde_bincode_compat {
     #[cfg(test)]
     mod tests {
         use super::super::{serde_bincode_compat, Chain};
-        use arbitrary::Arbitrary;
-        use rand::Rng;
-        use reth_primitives_traits::RecoveredBlock;
         use serde::{Deserialize, Serialize};
         use serde_with::serde_as;
 
@@ -635,15 +632,8 @@ pub(super) mod serde_bincode_compat {
                 chain: Chain,
             }
 
-            let mut bytes = [0u8; 1024];
-            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
-                chain: Chain::new(
-                    vec![RecoveredBlock::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
-                        .unwrap()],
-                    Default::default(),
-                    BTreeMap::new(),
-                ),
+                chain: Chain::new(vec![Default::default()], Default::default(), BTreeMap::new()),
             };
 
             let encoded = bincode::serialize(&data).unwrap();

--- a/crates/exex/types/Cargo.toml
+++ b/crates/exex/types/Cargo.toml
@@ -26,11 +26,8 @@ serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 
 [dev-dependencies]
-reth-primitives-traits = { workspace = true, features = ["arbitrary"] }
-reth-ethereum-primitives = { workspace = true, features = ["arbitrary", "std"] }
-arbitrary.workspace = true
+reth-ethereum-primitives = { workspace = true, features = ["std"] }
 bincode.workspace = true
-rand.workspace = true
 
 [features]
 default = []
@@ -39,7 +36,6 @@ serde = [
     "reth-execution-types/serde",
     "alloy-eips/serde",
     "alloy-primitives/serde",
-    "rand/serde",
     "reth-primitives-traits/serde",
     "reth-ethereum-primitives/serde",
     "reth-chain-state/serde",

--- a/crates/exex/types/src/notification.rs
+++ b/crates/exex/types/src/notification.rs
@@ -195,10 +195,7 @@ pub(super) mod serde_bincode_compat {
     #[cfg(test)]
     mod tests {
         use super::super::{serde_bincode_compat, ExExNotification};
-        use arbitrary::Arbitrary;
-        use rand::Rng;
         use reth_execution_types::Chain;
-        use reth_primitives_traits::RecoveredBlock;
         use serde::{Deserialize, Serialize};
         use serde_with::serde_as;
         use std::{collections::BTreeMap, sync::Arc};
@@ -214,19 +211,15 @@ pub(super) mod serde_bincode_compat {
                 notification: ExExNotification,
             }
 
-            let mut bytes = [0u8; 1024];
-            rand::rng().fill(bytes.as_mut_slice());
             let data = Data {
                 notification: ExExNotification::ChainReorged {
                     old: Arc::new(Chain::new(
-                        vec![RecoveredBlock::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
-                            .unwrap()],
+                        vec![Default::default()],
                         Default::default(),
                         BTreeMap::new(),
                     )),
                     new: Arc::new(Chain::new(
-                        vec![RecoveredBlock::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
-                            .unwrap()],
+                        vec![Default::default()],
                         Default::default(),
                         BTreeMap::new(),
                     )),


### PR DESCRIPTION
Replace `Arbitrary`-generated `RecoveredBlock`s with `Default::default()` in `test_exex_notification_bincode_roundtrip` and `test_chain_bincode_roundtrip`.

The tests were flaky because `Arbitrary` with a 1024-byte random buffer can either run out of bytes (panic on `.unwrap()`) or produce blocks whose RLP doesn't roundtrip cleanly (`UnexpectedLength` on decode). Since these tests verify the bincode serde compat layer, not block generation, default blocks are sufficient.

Also removes now-unused `arbitrary`/`rand` dev-dependencies.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes