### PR TITLE
chore: enable all dependency patches pointing at main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -705,46 +705,44 @@ vergen-git2 = "9.1.0"
 ipnet = "2.11"
 
 [patch.crates-io]
-# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-# alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
 
-# op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-# op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", rev = "a79d6fc" }
-#
-# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1207e33" }
-#
-# jsonrpsee = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-core = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-server = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
-# jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
+op-alloy-consensus = { git = "https://github.com/alloy-rs/op-alloy", branch = "main" }
+op-alloy-rpc-types = { git = "https://github.com/alloy-rs/op-alloy", branch = "main" }
+op-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/op-alloy", branch = "main" }
 
-# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "9bc2dba" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", branch = "main" }
 
-# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }
+jsonrpsee = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "main" }
+jsonrpsee-core = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "main" }
+jsonrpsee-server = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "main" }
+jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "main" }
+jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "main" }
+
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "main" }


### PR DESCRIPTION
Enables all `[patch.crates-io]` entries pointing at the `main` branch of each dependency repo (alloy, op-alloy, revm-inspectors, jsonrpsee, alloy-evm).

Co-Authored-By: Matthias Seitz <19890894+mattsse@users.noreply.github.com>

Prompted by: mattsse