### PR TITLE
refactor(evm): use TransactionEnvMut from alloy-evm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,21 +290,17 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6ba2dafd6327f78f2b59ae539bd5c39c57a01dc76763e92942619d934a7bb"
+source = "git+https://github.com/alloy-rs/evm?rev=a5a756b#a5a756b3fdb4033bf2a80ae2973384a7db4d6b65"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks 0.4.7",
- "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
  "tracing",
@@ -438,18 +434,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-op-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6472c610150c4c4c15be9e1b964c9b78068f933bda25fb9cdf09b9ac2bb66f36"
-dependencies = [
- "alloy-chains",
- "alloy-hardforks 0.4.7",
- "alloy-primitives",
- "auto_impl",
 ]
 
 [[package]]
@@ -6318,19 +6302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "op-alloy"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
-dependencies = [
- "op-alloy-consensus",
- "op-alloy-network",
- "op-alloy-provider",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
 name = "op-alloy-consensus"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6347,37 +6318,6 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-network"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
-]
-
-[[package]]
-name = "op-alloy-provider"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
-dependencies = [
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-transport",
- "async-trait",
- "op-alloy-rpc-types-engine",
 ]
 
 [[package]]
@@ -6419,17 +6359,6 @@ dependencies = [
  "sha2",
  "snap",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a98f3a512a7e02a1dcf1242b57302d83657b265a665d50ad98d0b158efaf2c"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -745,6 +745,6 @@ ipnet = "2.11"
 # jsonrpsee-http-client = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 # jsonrpsee-types = { git = "https://github.com/paradigmxyz/jsonrpsee", branch = "matt/make-rpc-service-pub" }
 
-# alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "9bc2dba" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "a5a756b" }
 
 # revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3020ea8" }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -28,7 +28,7 @@ use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
 use reth_ethereum_primitives::{Block, EthPrimitives, TransactionSigned};
 use reth_evm::{
     eth::NextEvmEnvAttributes, precompiles::PrecompilesMap, ConfigureEvm, EvmEnv, EvmFactory,
-    NextBlockEnvAttributes, TransactionEnv,
+    NextBlockEnvAttributes, TransactionEnvMut,
 };
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use revm::{context::BlockEnv, primitives::hardfork::SpecId};
@@ -127,7 +127,7 @@ impl<ChainSpec, EvmF> ConfigureEvm for EthEvmConfig<ChainSpec, EvmF>
 where
     ChainSpec: EthExecutorSpec + EthChainSpec<Header = Header> + Hardforks + 'static,
     EvmF: EvmFactory<
-            Tx: TransactionEnv
+            Tx: TransactionEnvMut
                     + FromRecoveredTx<TransactionSigned>
                     + FromTxWithEncoded<TransactionSigned>,
             Spec = SpecId,
@@ -218,7 +218,7 @@ impl<ChainSpec, EvmF> ConfigureEngineEvm<ExecutionData> for EthEvmConfig<ChainSp
 where
     ChainSpec: EthExecutorSpec + EthChainSpec<Header = Header> + Hardforks + 'static,
     EvmF: EvmFactory<
-            Tx: TransactionEnv
+            Tx: TransactionEnvMut
                     + FromRecoveredTx<TransactionSigned>
                     + FromTxWithEncoded<TransactionSigned>,
             Spec = SpecId,

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -62,4 +62,4 @@ test-utils = [
     "reth-trie-common/test-utils",
     "reth-ethereum-primitives/test-utils",
 ]
-op = []
+

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -62,4 +62,3 @@ test-utils = [
     "reth-trie-common/test-utils",
     "reth-ethereum-primitives/test-utils",
 ]
-

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -62,4 +62,4 @@ test-utils = [
     "reth-trie-common/test-utils",
     "reth-ethereum-primitives/test-utils",
 ]
-op = ["alloy-evm/op"]
+op = []

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -502,18 +502,3 @@ pub struct NextBlockEnvAttributes {
     /// Optional extra data.
     pub extra_data: Bytes,
 }
-
-#[cfg(feature = "op")]
-impl<T: TransactionEnvMut> TransactionEnvMut for op_revm::OpTransaction<T> {
-    fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.base.set_gas_limit(gas_limit);
-    }
-
-    fn set_nonce(&mut self, nonce: u64) {
-        self.base.set_nonce(nonce);
-    }
-
-    fn set_access_list(&mut self, access_list: alloy_eips::eip2930::AccessList) {
-        self.base.set_access_list(access_list);
-    }
-}

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -19,11 +19,7 @@ extern crate alloc;
 
 use crate::execute::{BasicBlockBuilder, Executor};
 use alloc::vec::Vec;
-use alloy_eips::{
-    eip2718::{EIP2930_TX_TYPE_ID, LEGACY_TX_TYPE_ID},
-    eip2930::AccessList,
-    eip4895::Withdrawals,
-};
+use alloy_eips::eip4895::Withdrawals;
 use alloy_evm::{
     block::{BlockExecutorFactory, BlockExecutorFor},
     precompiles::PrecompilesMap,
@@ -35,7 +31,7 @@ use reth_execution_errors::BlockExecutionError;
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, ReceiptTy, SealedBlock, SealedHeader, TxTy,
 };
-use revm::{context::TxEnv, database::State, primitives::hardfork::SpecId};
+use revm::{database::State, primitives::hardfork::SpecId};
 
 pub mod either;
 /// EVM environment configuration.
@@ -199,7 +195,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         Receipt = ReceiptTy<Self::Primitives>,
         ExecutionCtx<'a>: Debug + Send,
         EvmFactory: EvmFactory<
-            Tx: TransactionEnv
+            Tx: TransactionEnvMut
                     + FromRecoveredTx<TxTy<Self::Primitives>>
                     + FromTxWithEncoded<TxTy<Self::Primitives>>,
             Precompiles = PrecompilesMap,
@@ -507,80 +503,17 @@ pub struct NextBlockEnvAttributes {
     pub extra_data: Bytes,
 }
 
-/// Abstraction over transaction environment.
-pub trait TransactionEnv:
-    revm::context_interface::Transaction + Debug + Clone + Send + Sync + 'static
-{
-    /// Set the gas limit.
-    fn set_gas_limit(&mut self, gas_limit: u64);
-
-    /// Set the gas limit.
-    fn with_gas_limit(mut self, gas_limit: u64) -> Self {
-        self.set_gas_limit(gas_limit);
-        self
-    }
-
-    /// Returns the configured nonce.
-    fn nonce(&self) -> u64;
-
-    /// Sets the nonce.
-    fn set_nonce(&mut self, nonce: u64);
-
-    /// Sets the nonce.
-    fn with_nonce(mut self, nonce: u64) -> Self {
-        self.set_nonce(nonce);
-        self
-    }
-
-    /// Set access list.
-    fn set_access_list(&mut self, access_list: AccessList);
-
-    /// Set access list.
-    fn with_access_list(mut self, access_list: AccessList) -> Self {
-        self.set_access_list(access_list);
-        self
-    }
-}
-
-impl TransactionEnv for TxEnv {
-    fn set_gas_limit(&mut self, gas_limit: u64) {
-        self.gas_limit = gas_limit;
-    }
-
-    fn nonce(&self) -> u64 {
-        self.nonce
-    }
-
-    fn set_nonce(&mut self, nonce: u64) {
-        self.nonce = nonce;
-    }
-
-    fn set_access_list(&mut self, access_list: AccessList) {
-        self.access_list = access_list;
-
-        if self.tx_type == LEGACY_TX_TYPE_ID {
-            // if this was previously marked as legacy tx, this must be upgraded to eip2930 with an
-            // accesslist
-            self.tx_type = EIP2930_TX_TYPE_ID;
-        }
-    }
-}
-
 #[cfg(feature = "op")]
-impl<T: TransactionEnv> TransactionEnv for op_revm::OpTransaction<T> {
+impl<T: TransactionEnvMut> TransactionEnvMut for op_revm::OpTransaction<T> {
     fn set_gas_limit(&mut self, gas_limit: u64) {
         self.base.set_gas_limit(gas_limit);
-    }
-
-    fn nonce(&self) -> u64 {
-        TransactionEnv::nonce(&self.base)
     }
 
     fn set_nonce(&mut self, nonce: u64) {
         self.base.set_nonce(nonce);
     }
 
-    fn set_access_list(&mut self, access_list: AccessList) {
+    fn set_access_list(&mut self, access_list: alloy_eips::eip2930::AccessList) {
         self.base.set_access_list(access_list);
     }
 }

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -124,5 +124,4 @@ test-utils = [
 trie-debug = ["reth-engine-tree/trie-debug"]
 op = [
     "reth-engine-local/op",
-    "reth-evm/op",
 ]

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -46,6 +46,5 @@ default = []
 op = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",
-    "reth-evm/op",
     
 ]

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -46,5 +46,4 @@ default = []
 op = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",
-    
 ]

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -47,5 +47,5 @@ op = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",
     "reth-evm/op",
-    "alloy-evm/op",
+    
 ]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -63,7 +63,6 @@ tracing.workspace = true
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]
 op = [
-    "reth-evm/op",
     "reth-rpc-convert/op",
     
 ]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -64,5 +64,4 @@ js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]
 op = [
     "reth-rpc-convert/op",
-    
 ]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -65,5 +65,5 @@ client = ["jsonrpsee/client", "jsonrpsee/async-client"]
 op = [
     "reth-evm/op",
     "reth-rpc-convert/op",
-    "alloy-evm/op",
+    
 ]

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -21,7 +21,7 @@ use futures::Future;
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
-    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnv, TxEnvFor,
+    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_eth::{state::StateOverride, BlockId};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_errors::ProviderError;
-use reth_evm::{ConfigureEvm, Database, Evm, EvmEnvFor, EvmFor, TransactionEnv, TxEnvFor};
+use reth_evm::{ConfigureEvm, Database, Evm, EvmEnvFor, EvmFor, TransactionEnvMut, TxEnvFor};
 use reth_revm::{
     database::{EvmStateProvider, StateProviderDatabase},
     db::{bal::EvmDatabaseError, State},


### PR DESCRIPTION
Replaces reth's `TransactionEnv` trait with `TransactionEnvMut` from alloy-evm (alloy-rs/evm#320). Drops the redundant `nonce()` getter (already on the `Transaction` supertrait). Keeps the `OpTransaction` blanket impl in reth.

Depends on https://github.com/alloy-rs/evm/pull/320

Prompted by: klkvr