### PR TITLE
refactor(tests): use FCU for requesting new payloads

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -103,13 +103,46 @@ where
         Ok(chain)
     }
 
+    /// Returns the current forkchoice state of the node.
+    pub fn current_forkchoice_state(&self) -> eyre::Result<ForkchoiceState> {
+        let latest_header =
+            self.inner.provider.sealed_header_by_number_or_tag(BlockNumberOrTag::Latest)?.unwrap();
+
+        if latest_header.number() == 0 {
+            return Ok(ForkchoiceState::same_hash(latest_header.hash()));
+        }
+
+        Ok(ForkchoiceState {
+            head_block_hash: latest_header.hash(),
+            safe_block_hash: self
+                .inner
+                .provider
+                .sealed_header_by_number_or_tag(BlockNumberOrTag::Safe)?
+                .unwrap()
+                .hash(),
+            finalized_block_hash: self
+                .inner
+                .provider
+                .sealed_header_by_number_or_tag(BlockNumberOrTag::Finalized)?
+                .unwrap()
+                .hash(),
+        })
+    }
+
     /// Creates a new payload from given attributes generator
     /// expects a payload attribute event and waits until the payload is built.
     ///
     /// It triggers the resolve payload via engine api and expects the built payload event.
     pub async fn new_payload(&mut self) -> eyre::Result<Payload::BuiltPayload> {
-        // trigger new payload building draining the pool
-        let (eth_attr, payload_id) = self.payload.new_payload().await.unwrap();
+        let eth_attr = self.payload.next_attributes();
+        let payload_id = self
+            .inner
+            .add_ons_handle
+            .beacon_engine_handle
+            .fork_choice_updated(self.current_forkchoice_state()?, Some(eth_attr.clone()))
+            .await?
+            .payload_id
+            .unwrap();
         // first event is the payload attributes
         self.payload.expect_attr_event(eth_attr).await?;
         // wait for the payload builder to have finished building

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -1,4 +1,3 @@
-use alloy_primitives::B256;
 use futures_util::StreamExt;
 use reth_node_api::{BlockBody, PayloadAttributes, PayloadKind};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadId};
@@ -33,17 +32,10 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
         })
     }
 
-    /// Creates a new payload job from static attributes
-    pub async fn new_payload(&mut self) -> eyre::Result<(T::PayloadAttributes, PayloadId)> {
+    /// Generates the next payload attributes
+    pub fn next_attributes(&mut self) -> T::PayloadAttributes {
         self.timestamp += 1;
-        let attributes = (self.attributes_generator)(self.timestamp);
-        let parent_hash = B256::ZERO;
-        let payload_id = self
-            .payload_builder
-            .send_new_payload(parent_hash, attributes.clone())
-            .await
-            .unwrap()?;
-        Ok((attributes, payload_id))
+        (self.attributes_generator)(self.timestamp)
     }
 
     /// Asserts that the next event is a payload attributes event


### PR DESCRIPTION
Changes our e2e tests to use FCU with payload attributes to build new payloads. Given that we're going to be optimizing for that codepath ideally we also use it in our tests