### PR TITLE
feat(engine): add --engine.disable-bal-tracking flag

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -162,6 +162,11 @@ pub struct TreeConfig {
     /// When disabled, falls back to individual per-slot storage reads instead of
     /// batched cursor reads via `storage_range`.
     disable_bal_batch_io: bool,
+    /// Whether to disable BAL (Block Access List) tracking during block execution.
+    /// When disabled, the BAL builder is not attached to the state, `bump_bal_index` is skipped,
+    /// and BAL hash validation is bypassed. This isolates the pure BAL execution overhead for
+    /// benchmarking purposes.
+    disable_bal_tracking: bool,
     /// Maximum random jitter applied before each proof computation (trie-debug only).
     /// When set, each proof worker sleeps for a random duration up to this value
     /// before starting a proof calculation.
@@ -200,6 +205,7 @@ impl Default for TreeConfig {
             disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
+            disable_bal_tracking: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -264,6 +270,7 @@ impl TreeConfig {
             disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
+            disable_bal_tracking: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -625,6 +632,17 @@ impl TreeConfig {
     /// Setter for whether to disable BAL batched IO.
     pub const fn without_bal_batch_io(mut self, disable_bal_batch_io: bool) -> Self {
         self.disable_bal_batch_io = disable_bal_batch_io;
+        self
+    }
+
+    /// Returns whether BAL tracking during execution is disabled.
+    pub const fn disable_bal_tracking(&self) -> bool {
+        self.disable_bal_tracking
+    }
+
+    /// Setter for whether to disable BAL tracking during execution.
+    pub const fn without_bal_tracking(mut self, disable_bal_tracking: bool) -> Self {
+        self.disable_bal_tracking = disable_bal_tracking;
         self
     }
 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -873,7 +873,7 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        let has_bal = input.block_access_list().is_some();
+        let has_bal = input.block_access_list().is_some() && !self.config.disable_bal_tracking();
 
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -427,6 +427,11 @@ pub struct EngineArgs {
     /// to individual per-slot storage reads instead of batched cursor reads.
     #[arg(long = "engine.disable-bal-batch-io", default_value_t = false)]
     pub disable_bal_batch_io: bool,
+    /// Disable BAL (Block Access List) tracking during block execution. When set, the BAL
+    /// builder is not attached to the execution state, index bumps are skipped, and BAL hash
+    /// validation is bypassed. Useful for isolating BAL execution overhead in benchmarks.
+    #[arg(long = "engine.disable-bal-tracking", default_value_t = false)]
+    pub disable_bal_tracking: bool,
     /// Add random jitter before each proof computation (trie-debug only).
     /// Each proof worker sleeps for a random duration up to this value before
     /// starting work. Useful for stress-testing timing-sensitive proof logic.
@@ -506,6 +511,7 @@ impl Default for EngineArgs {
             bal_parallel_execution_disabled,
             bal_parallel_state_root_disabled,
             disable_bal_batch_io: false,
+            disable_bal_tracking: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -541,7 +547,8 @@ impl EngineArgs {
             .without_bal_parallel_execution(self.bal_parallel_execution_disabled)
             .without_bal_parallel_state_root(self.bal_parallel_state_root_disabled)
             .without_bal_parallel_state_root(self.bal_parallel_state_root_disabled)
-            .without_bal_batch_io(self.disable_bal_batch_io);
+            .without_bal_batch_io(self.disable_bal_batch_io)
+            .without_bal_tracking(self.disable_bal_tracking);
         #[cfg(feature = "trie-debug")]
         let config = config.with_proof_jitter(self.proof_jitter);
         config
@@ -602,6 +609,7 @@ mod tests {
             bal_parallel_execution_disabled: true,
             bal_parallel_state_root_disabled: true,
             disable_bal_batch_io: true,
+            disable_bal_tracking: true,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         };
@@ -645,6 +653,7 @@ mod tests {
             "--engine.disable-bal-parallel-execution",
             "--engine.disable-bal-parallel-state-root",
             "--engine.disable-bal-batch-io",
+            "--engine.disable-bal-tracking",
         ])
         .args;
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1029,6 +1029,9 @@ Engine:
       --engine.disable-bal-batch-io
           Disable BAL (Block Access List) batched IO during prewarming. When set, falls back to individual per-slot storage reads instead of batched cursor reads
 
+      --engine.disable-bal-tracking
+          Disable BAL (Block Access List) tracking during block execution. When set, the BAL builder is not attached to the execution state, index bumps are skipped, and BAL hash validation is bypassed. Useful for isolating BAL execution overhead in benchmarks
+
 ERA:
       --era.enable
           Enable import from ERA1 files


### PR DESCRIPTION
Adds a flag to disable BAL tracking during block execution. The existing `--engine.disable-bal-*` flags only control the prewarming/prefetching strategy, but the following BAL overhead during execution is always-on:

- `with_bal_builder_if` — attaching the BAL builder to execution state
- `bump_bal_index()` — called after pre-execution and after each transaction
- BAL hash validation — computing and comparing BAL hashes post-execution

When `--engine.disable-bal-tracking` is set, all of the above are bypassed, allowing clean A/B benchmarking of the pure BAL execution overhead.