### PR TITLE
fix(engine): emit slow block log immediately after execution

### DIFF
--- a/crates/engine/primitives/src/event.rs
+++ b/crates/engine/primitives/src/event.rs
@@ -86,13 +86,14 @@ where
     }
 }
 
-/// Information about a slow block detected after persistence.
+/// Information about a slow block detected after execution or persistence.
 #[derive(Clone, Debug)]
 pub struct SlowBlockInfo {
     /// The timing statistics for the slow block.
     pub stats: Box<ExecutionTimingStats>,
     /// The commit duration for the batch containing this block.
-    pub commit_duration: Duration,
+    /// `None` when emitted immediately after execution (before persistence).
+    pub commit_duration: Option<Duration>,
     /// The total duration (execution + `state_root` + commit).
     /// Note: `state_read` is a subset of execution and is not added separately.
     pub total_duration: Duration,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2822,7 +2822,6 @@ where
 
         // Emit slow block event immediately after execution so it appears even when
         // persistence hasn't completed yet (e.g. blocks arriving faster than persistence).
-        // The commit_duration is unknown at this point so we use Duration::ZERO.
         if let Some(stats) = timing_stats {
             if let Some(threshold) = self.config.slow_block_threshold() {
                 let total_duration = stats.execution_duration + stats.state_hash_duration;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1849,7 +1849,7 @@ where
                 if total_duration > threshold.expect("checked above") {
                     self.emit_event(ConsensusEngineEvent::SlowBlock(SlowBlockInfo {
                         stats,
-                        commit_duration: commit_dur,
+                        commit_duration: Some(commit_dur),
                         total_duration,
                     }));
                 }
@@ -2820,8 +2820,20 @@ where
 
         let (executed, timing_stats) = execute(&mut self.payload_validator, input, ctx)?;
 
-        // Store timing stats for detailed block logging after persistence
+        // Emit slow block event immediately after execution so it appears even when
+        // persistence hasn't completed yet (e.g. blocks arriving faster than persistence).
+        // The commit_duration is unknown at this point so we use Duration::ZERO.
         if let Some(stats) = timing_stats {
+            if let Some(threshold) = self.config.slow_block_threshold() {
+                let total_duration = stats.execution_duration + stats.state_hash_duration;
+                if total_duration > threshold {
+                    self.emit_event(ConsensusEngineEvent::SlowBlock(SlowBlockInfo {
+                        stats: stats.clone(),
+                        commit_duration: None,
+                        total_duration,
+                    }));
+                }
+            }
             self.execution_timing_stats.insert(executed.recovered_block().hash(), stats);
         }
 

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -309,7 +309,7 @@ impl NodeState {
             timing.execution_ms = stats.execution_duration.as_millis(),
             timing.state_read_ms = stats.state_read_duration.as_millis(),
             timing.state_hash_ms = stats.state_hash_duration.as_millis(),
-            timing.commit_ms = info.commit_duration.as_millis(),
+            timing.commit_ms = info.commit_duration.map(|d| d.as_millis()),
             timing.total_ms = info.total_duration.as_millis(),
             throughput.mgas_per_sec = format!("{:.2}", mgas_per_sec),
             state_reads.accounts = stats.accounts_read,

--- a/crates/node/events/src/node.rs
+++ b/crates/node/events/src/node.rs
@@ -299,41 +299,53 @@ impl NodeState {
             0.0
         };
 
-        warn!(
-            target: "reth::slow_block",
-            message = "Slow block",
-            block.number = stats.block_number,
-            block.hash = ?stats.block_hash,
-            block.gas_used = stats.gas_used,
-            block.tx_count = stats.tx_count,
-            timing.execution_ms = stats.execution_duration.as_millis(),
-            timing.state_read_ms = stats.state_read_duration.as_millis(),
-            timing.state_hash_ms = stats.state_hash_duration.as_millis(),
-            timing.commit_ms = info.commit_duration.map(|d| d.as_millis()),
-            timing.total_ms = info.total_duration.as_millis(),
-            throughput.mgas_per_sec = format!("{:.2}", mgas_per_sec),
-            state_reads.accounts = stats.accounts_read,
-            state_reads.storage_slots = stats.storage_read,
-            state_reads.code = stats.code_read,
-            state_reads.code_bytes = stats.code_bytes_read,
-            state_writes.accounts = stats.accounts_changed,
-            state_writes.accounts_deleted = stats.accounts_deleted,
-            state_writes.storage_slots = stats.storage_slots_changed,
-            state_writes.storage_slots_deleted = stats.storage_slots_deleted,
-            state_writes.code = stats.bytecodes_changed,
-            state_writes.code_bytes = stats.code_bytes_written,
-            state_writes.eip7702_delegations_set = stats.eip7702_delegations_set,
-            state_writes.eip7702_delegations_cleared = stats.eip7702_delegations_cleared,
-            cache.account.hits = stats.account_cache_hits,
-            cache.account.misses = stats.account_cache_misses,
-            cache.account.hit_rate = format!("{:.2}", hit_rate(stats.account_cache_hits, stats.account_cache_misses)),
-            cache.storage.hits = stats.storage_cache_hits,
-            cache.storage.misses = stats.storage_cache_misses,
-            cache.storage.hit_rate = format!("{:.2}", hit_rate(stats.storage_cache_hits, stats.storage_cache_misses)),
-            cache.code.hits = stats.code_cache_hits,
-            cache.code.misses = stats.code_cache_misses,
-            cache.code.hit_rate = format!("{:.2}", hit_rate(stats.code_cache_hits, stats.code_cache_misses)),
-        );
+        // Macro for the shared fields — commit_ms is only included when known
+        // (after persistence), omitted entirely for the immediate post-execution emit.
+        macro_rules! log_slow_block_fields {
+            ($($commit_field:tt)*) => {
+                warn!(
+                    target: "reth::slow_block",
+                    message = "Slow block",
+                    block.number = stats.block_number,
+                    block.hash = ?stats.block_hash,
+                    block.gas_used = stats.gas_used,
+                    block.tx_count = stats.tx_count,
+                    timing.execution_ms = stats.execution_duration.as_millis(),
+                    timing.state_read_ms = stats.state_read_duration.as_millis(),
+                    timing.state_hash_ms = stats.state_hash_duration.as_millis(),
+                    $($commit_field)*
+                    timing.total_ms = info.total_duration.as_millis(),
+                    throughput.mgas_per_sec = format!("{:.2}", mgas_per_sec),
+                    state_reads.accounts = stats.accounts_read,
+                    state_reads.storage_slots = stats.storage_read,
+                    state_reads.code = stats.code_read,
+                    state_reads.code_bytes = stats.code_bytes_read,
+                    state_writes.accounts = stats.accounts_changed,
+                    state_writes.accounts_deleted = stats.accounts_deleted,
+                    state_writes.storage_slots = stats.storage_slots_changed,
+                    state_writes.storage_slots_deleted = stats.storage_slots_deleted,
+                    state_writes.code = stats.bytecodes_changed,
+                    state_writes.code_bytes = stats.code_bytes_written,
+                    state_writes.eip7702_delegations_set = stats.eip7702_delegations_set,
+                    state_writes.eip7702_delegations_cleared = stats.eip7702_delegations_cleared,
+                    cache.account.hits = stats.account_cache_hits,
+                    cache.account.misses = stats.account_cache_misses,
+                    cache.account.hit_rate = format!("{:.2}", hit_rate(stats.account_cache_hits, stats.account_cache_misses)),
+                    cache.storage.hits = stats.storage_cache_hits,
+                    cache.storage.misses = stats.storage_cache_misses,
+                    cache.storage.hit_rate = format!("{:.2}", hit_rate(stats.storage_cache_hits, stats.storage_cache_misses)),
+                    cache.code.hits = stats.code_cache_hits,
+                    cache.code.misses = stats.code_cache_misses,
+                    cache.code.hit_rate = format!("{:.2}", hit_rate(stats.code_cache_hits, stats.code_cache_misses)),
+                );
+            }
+        }
+
+        if let Some(commit_dur) = info.commit_duration {
+            log_slow_block_fields!(timing.commit_ms = commit_dur.as_millis(),);
+        } else {
+            log_slow_block_fields!();
+        }
     }
 
     fn handle_consensus_layer_health_event(&self, event: ConsensusLayerHealthEvent) {


### PR DESCRIPTION
Closes the gap where slow block logs never appear when blocks arrive faster than persistence.

`purge_timing_stats` only runs on persistence completion. During benchmarking or high-throughput scenarios, blocks can arrive faster than persistence completes, so the timing stats accumulate in memory but never get flushed — meaning slow block logs never appear even with `--engine.slow-block-threshold=0`.

This emits the `SlowBlock` event right after execution with `commit_duration=0`, so the log appears immediately. The stats are still stored for the existing persistence-based check.