### PR TITLE
fix(engine): do not report metrics for already seen payloads

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -448,11 +448,17 @@ impl NewPayloadStatusMetrics {
             Ok(outcome) => match outcome.outcome.status {
                 PayloadStatusEnum::Valid => {
                     self.new_payload_valid.increment(1);
-                    self.new_payload_total_gas.record(gas_used as f64);
-                    self.new_payload_total_gas_last.set(gas_used as f64);
-                    let gas_per_second = gas_used as f64 / elapsed.as_secs_f64();
-                    self.new_payload_gas_per_second.record(gas_per_second);
-                    self.new_payload_gas_per_second_last.set(gas_per_second);
+                    if !outcome.already_seen {
+                        self.new_payload_total_gas.record(gas_used as f64);
+                        self.new_payload_total_gas_last.set(gas_used as f64);
+                        let gas_per_second = gas_used as f64 / elapsed.as_secs_f64();
+                        self.new_payload_gas_per_second.record(gas_per_second);
+                        self.new_payload_gas_per_second_last.set(gas_per_second);
+
+                        self.new_payload_latency.record(elapsed);
+                        self.new_payload_last.set(elapsed);
+                        self.gas_bucket.record(gas_used, elapsed);
+                    }
                 }
                 PayloadStatusEnum::Syncing => self.new_payload_syncing.increment(1),
                 PayloadStatusEnum::Accepted => self.new_payload_accepted.increment(1),
@@ -461,9 +467,6 @@ impl NewPayloadStatusMetrics {
             Err(_) => self.new_payload_error.increment(1),
         }
         self.new_payload_messages.increment(1);
-        self.new_payload_latency.record(elapsed);
-        self.new_payload_last.set(elapsed);
-        self.gas_bucket.record(gas_used, elapsed);
         if let Some(latest_forkchoice_updated_at) = latest_forkchoice_updated_at.take() {
             self.forkchoice_updated_new_payload_time_diff
                 .record(start - latest_forkchoice_updated_at);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -204,6 +204,25 @@ impl<T> TreeOutcome<T> {
     }
 }
 
+/// Result of trying to insert a new payload in [`EngineApiTreeHandler`].
+#[derive(Debug)]
+pub struct TryInsertPayloadResult {
+    /// - `Valid`: Payload successfully validated and inserted
+    /// - `Syncing`: Parent missing, payload buffered for later
+    /// - Error status: Payload is invalid
+    pub status: PayloadStatus,
+    /// Whether the block was already seen
+    pub already_seen: bool,
+}
+
+impl TryInsertPayloadResult {
+    /// Convert the result into a [`TreeOutcome`].
+    #[inline]
+    pub fn into_outcome(self) -> TreeOutcome<PayloadStatus> {
+        TreeOutcome::new(self.status).with_already_seen(self.already_seen)
+    }
+}
+
 /// Events that are triggered by Tree Chain
 #[derive(Debug)]
 pub enum TreeEvent {
@@ -648,13 +667,12 @@ where
         // record pre-execution phase duration
         self.metrics.block_validation.record_payload_validation(start.elapsed().as_secs_f64());
 
-        let (status, already_seen) = if self.backfill_sync_state.is_idle() {
-            self.try_insert_payload(payload)?
+        let mut outcome = if self.backfill_sync_state.is_idle() {
+            self.try_insert_payload(payload)?.into_outcome()
         } else {
-            (self.try_buffer_payload(payload)?, false)
+            TreeOutcome::new(self.try_buffer_payload(payload)?)
         };
 
-        let mut outcome = TreeOutcome::new(status).with_already_seen(already_seen);
         // if the block is valid and it is the current sync target head, make it canonical
         if outcome.outcome.is_valid() && self.is_sync_target_head(block_hash) {
             // Only create the canonical event if this block isn't already the canonical head
@@ -672,18 +690,11 @@ where
     }
 
     /// Processes a payload during normal sync operation.
-    ///
-    /// Returns:
-    /// - Status:
-    ///   - `Valid`: Payload successfully validated and inserted
-    ///   - `Syncing`: Parent missing, payload buffered for later
-    ///   - Error status: Payload is invalid
-    /// - Whether the block was already seen
     #[instrument(level = "debug", target = "engine::tree", skip_all)]
     fn try_insert_payload(
         &mut self,
         payload: T::ExecutionData,
-    ) -> Result<(PayloadStatus, bool), InsertBlockFatalError> {
+    ) -> Result<TryInsertPayloadResult, InsertBlockFatalError> {
         let block_hash = payload.block_hash();
         let num_hash = payload.num_hash();
         let parent_hash = payload.parent_hash();
@@ -710,14 +721,21 @@ where
                     }
                 };
 
-                Ok((PayloadStatus::new(status, latest_valid_hash), already_seen))
+                Ok(TryInsertPayloadResult {
+                    status: PayloadStatus::new(status, latest_valid_hash),
+                    already_seen,
+                })
             }
-            Err(error) => match error {
-                InsertPayloadError::Block(error) => Ok((self.on_insert_block_error(error)?, false)),
-                InsertPayloadError::Payload(error) => {
-                    Ok((self.on_new_payload_error(error, num_hash, parent_hash)?, false))
-                }
-            },
+            Err(error) => {
+                let status = match error {
+                    InsertPayloadError::Block(error) => self.on_insert_block_error(error)?,
+                    InsertPayloadError::Payload(error) => {
+                        self.on_new_payload_error(error, num_hash, parent_hash)?
+                    }
+                };
+
+                Ok(TryInsertPayloadResult { status, already_seen: false })
+            }
         }
     }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -180,17 +180,26 @@ pub struct TreeOutcome<T> {
     pub outcome: T,
     /// An optional event to tell the caller to do something.
     pub event: Option<TreeEvent>,
+    /// Whether the block was already seen, meaning no real execution happened during this
+    /// `newPayload` call.
+    pub already_seen: bool,
 }
 
 impl<T> TreeOutcome<T> {
     /// Create new tree outcome.
     pub const fn new(outcome: T) -> Self {
-        Self { outcome, event: None }
+        Self { outcome, event: None, already_seen: false }
     }
 
     /// Set event on the outcome.
     pub fn with_event(mut self, event: TreeEvent) -> Self {
         self.event = Some(event);
+        self
+    }
+
+    /// Set the `already_seen` flag on the outcome.
+    pub const fn with_already_seen(mut self, value: bool) -> Self {
+        self.already_seen = value;
         self
     }
 }
@@ -639,13 +648,13 @@ where
         // record pre-execution phase duration
         self.metrics.block_validation.record_payload_validation(start.elapsed().as_secs_f64());
 
-        let status = if self.backfill_sync_state.is_idle() {
+        let (status, already_seen) = if self.backfill_sync_state.is_idle() {
             self.try_insert_payload(payload)?
         } else {
-            self.try_buffer_payload(payload)?
+            (self.try_buffer_payload(payload)?, false)
         };
 
-        let mut outcome = TreeOutcome::new(status);
+        let mut outcome = TreeOutcome::new(status).with_already_seen(already_seen);
         // if the block is valid and it is the current sync target head, make it canonical
         if outcome.outcome.is_valid() && self.is_sync_target_head(block_hash) {
             // Only create the canonical event if this block isn't already the canonical head
@@ -665,14 +674,16 @@ where
     /// Processes a payload during normal sync operation.
     ///
     /// Returns:
-    /// - `Valid`: Payload successfully validated and inserted
-    /// - `Syncing`: Parent missing, payload buffered for later
-    /// - Error status: Payload is invalid
+    /// - Status:
+    ///   - `Valid`: Payload successfully validated and inserted
+    ///   - `Syncing`: Parent missing, payload buffered for later
+    ///   - Error status: Payload is invalid
+    /// - Whether the block was already seen
     #[instrument(level = "debug", target = "engine::tree", skip_all)]
     fn try_insert_payload(
         &mut self,
         payload: T::ExecutionData,
-    ) -> Result<PayloadStatus, InsertBlockFatalError> {
+    ) -> Result<(PayloadStatus, bool), InsertBlockFatalError> {
         let block_hash = payload.block_hash();
         let num_hash = payload.num_hash();
         let parent_hash = payload.parent_hash();
@@ -680,29 +691,31 @@ where
 
         match self.insert_payload(payload) {
             Ok(status) => {
-                let status = match status {
+                let (status, already_seen) = match status {
                     InsertPayloadOk::Inserted(BlockStatus::Valid) => {
                         latest_valid_hash = Some(block_hash);
                         self.try_connect_buffered_blocks(num_hash)?;
-                        PayloadStatusEnum::Valid
+                        (PayloadStatusEnum::Valid, false)
                     }
                     InsertPayloadOk::AlreadySeen(BlockStatus::Valid) => {
                         latest_valid_hash = Some(block_hash);
-                        PayloadStatusEnum::Valid
+                        (PayloadStatusEnum::Valid, true)
                     }
-                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) |
+                    InsertPayloadOk::Inserted(BlockStatus::Disconnected { .. }) => {
+                        (PayloadStatusEnum::Syncing, false)
+                    }
                     InsertPayloadOk::AlreadySeen(BlockStatus::Disconnected { .. }) => {
                         // not known to be invalid, but we don't know anything else
-                        PayloadStatusEnum::Syncing
+                        (PayloadStatusEnum::Syncing, true)
                     }
                 };
 
-                Ok(PayloadStatus::new(status, latest_valid_hash))
+                Ok((PayloadStatus::new(status, latest_valid_hash), already_seen))
             }
             Err(error) => match error {
-                InsertPayloadError::Block(error) => Ok(self.on_insert_block_error(error)?),
+                InsertPayloadError::Block(error) => Ok((self.on_insert_block_error(error)?, false)),
                 InsertPayloadError::Payload(error) => {
-                    Ok(self.on_new_payload_error(error, num_hash, parent_hash)?)
+                    Ok((self.on_new_payload_error(error, num_hash, parent_hash)?, false))
                 }
             },
         }


### PR DESCRIPTION
Previously, we've emitted metrics for newPayload gas and latencies even if the payload was already seen and immediately inserted without execution. This skewed the metrics.