### PR TITLE
chore: make EvmConfig generic in examples

### DIFF
--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -30,6 +30,7 @@ use alloy_rpc_types::{
 use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadBuilder, PayloadConfig};
 use reth_ethereum::{
     chainspec::{Chain, ChainSpec, ChainSpecProvider},
+    evm::primitives::{ConfigureEvm, NextBlockEnvAttributes},
     node::{
         api::{
             payload::{EngineApiMessageVersion, EngineObjectValidationError, PayloadOrAttributes},
@@ -47,7 +48,7 @@ use reth_ethereum::{
             EthereumConsensusBuilder, EthereumExecutorBuilder, EthereumNetworkBuilder,
             EthereumPoolBuilder,
         },
-        EthEvmConfig, EthereumEthApiBuilder,
+        EthereumEthApiBuilder,
     },
     pool::{PoolTransaction, TransactionPool},
     primitives::{Block, SealedBlock},
@@ -208,7 +209,7 @@ pub struct CustomEngineValidatorBuilder;
 
 impl<N> PayloadValidatorBuilder<N> for CustomEngineValidatorBuilder
 where
-    N: FullNodeComponents<Types = MyCustomNode, Evm = EthEvmConfig>,
+    N: FullNodeComponents<Types = MyCustomNode>,
 {
     type Validator = CustomEngineValidator;
 
@@ -269,7 +270,7 @@ where
 #[non_exhaustive]
 pub struct CustomPayloadBuilderBuilder;
 
-impl<Node, Pool> PayloadBuilderBuilder<Node, Pool, EthEvmConfig> for CustomPayloadBuilderBuilder
+impl<Node, Pool, Evm> PayloadBuilderBuilder<Node, Pool, Evm> for CustomPayloadBuilderBuilder
 where
     Node: FullNodeTypes<
         Types: NodeTypes<
@@ -281,14 +282,16 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
         + Unpin
         + 'static,
+    Evm: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>
+        + 'static,
 {
-    type PayloadBuilder = CustomPayloadBuilder<Pool, Node::Provider>;
+    type PayloadBuilder = CustomPayloadBuilder<Pool, Node::Provider, Evm>;
 
     async fn build_payload_builder(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-        evm_config: EthEvmConfig,
+        evm_config: Evm,
     ) -> eyre::Result<Self::PayloadBuilder> {
         let payload_builder = CustomPayloadBuilder {
             inner: reth_ethereum_payload_builder::EthereumPayloadBuilder::new(
@@ -306,14 +309,15 @@ where
 /// The type responsible for building custom payloads
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct CustomPayloadBuilder<Pool, Client> {
-    inner: reth_ethereum_payload_builder::EthereumPayloadBuilder<Pool, Client>,
+pub struct CustomPayloadBuilder<Pool, Client, Evm> {
+    inner: reth_ethereum_payload_builder::EthereumPayloadBuilder<Pool, Client, Evm>,
 }
 
-impl<Pool, Client> PayloadBuilder for CustomPayloadBuilder<Pool, Client>
+impl<Pool, Client, Evm> PayloadBuilder for CustomPayloadBuilder<Pool, Client, Evm>
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec = ChainSpec> + Clone,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>,
+    Evm: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
 {
     type Attributes = CustomPayloadAttributes;
     type BuiltPayload = EthBuiltPayload;

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -5,7 +5,7 @@
 use reth_ethereum::{
     chainspec::ChainSpec,
     cli::interface::Cli,
-    evm::EthEvmConfig,
+    evm::primitives::ConfigureEvm,
     node::{
         api::{FullNodeTypes, NodeTypes},
         builder::{components::PoolBuilder, BuilderContext},
@@ -50,16 +50,17 @@ pub struct CustomPoolBuilder {
 /// Implement the [`PoolBuilder`] trait for the custom pool builder
 ///
 /// This will be used to build the transaction pool and its maintenance tasks during launch.
-impl<Node> PoolBuilder<Node, EthEvmConfig> for CustomPoolBuilder
+impl<Node, Evm> PoolBuilder<Node, Evm> for CustomPoolBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec = ChainSpec, Primitives = EthPrimitives>>,
+    Evm: ConfigureEvm<Primitives = EthPrimitives> + Clone + 'static,
 {
-    type Pool = EthTransactionPool<Node::Provider, InMemoryBlobStore>;
+    type Pool = EthTransactionPool<Node::Provider, InMemoryBlobStore, Evm>;
 
     async fn build_pool(
         self,
         ctx: &BuilderContext<Node>,
-        evm_config: EthEvmConfig,
+        evm_config: Evm,
     ) -> eyre::Result<Self::Pool> {
         let data_dir = ctx.config().datadir();
         let blob_store = InMemoryBlobStore::default();

--- a/examples/custom-payload-builder/src/main.rs
+++ b/examples/custom-payload-builder/src/main.rs
@@ -16,12 +16,13 @@ use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_ethereum::{
     chainspec::ChainSpec,
     cli::interface::Cli,
+    evm::primitives::{ConfigureEvm, NextBlockEnvAttributes},
     node::{
         api::{node::FullNodeTypes, NodeTypes},
         builder::{components::PayloadServiceBuilder, BuilderContext},
         core::cli::config::PayloadBuilderConfig,
         node::EthereumAddOns,
-        EthEngineTypes, EthEvmConfig, EthereumNode,
+        EthEngineTypes, EthereumNode,
     },
     pool::{PoolTransaction, TransactionPool},
     provider::CanonStateSubscriptions,
@@ -37,7 +38,7 @@ pub mod job;
 #[non_exhaustive]
 pub struct CustomPayloadBuilder;
 
-impl<Node, Pool> PayloadServiceBuilder<Node, Pool, EthEvmConfig> for CustomPayloadBuilder
+impl<Node, Pool, Evm> PayloadServiceBuilder<Node, Pool, Evm> for CustomPayloadBuilder
 where
     Node: FullNodeTypes<
         Types: NodeTypes<
@@ -49,12 +50,14 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TransactionSigned>>
         + Unpin
         + 'static,
+    Evm: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>
+        + 'static,
 {
     async fn spawn_payload_builder_service(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
-        evm_config: EthEvmConfig,
+        evm_config: Evm,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
         tracing::info!("Spawning a custom payload builder");
 


### PR DESCRIPTION
Encountered in https://github.com/paradigmxyz/reth/pull/23230, which changes the reth evm config and factory away from the default.