### PR TITLE
fix(consensus): retry block subscription on initial connection failure

### DIFF
--- a/crates/consensus/debug-client/src/providers/rpc.rs
+++ b/crates/consensus/debug-client/src/providers/rpc.rs
@@ -79,10 +79,16 @@ where
                     target: "consensus::debug-client",
                     %err,
                     url=%self.url,
-                    "Failed to subscribe to blocks",
+                    "Failed to subscribe to blocks, retrying in 5s",
                 );
             }) else {
-                return
+                // Exit if the receiver has been dropped (e.g. during shutdown) so we
+                // don't keep retrying after the consumer is gone.
+                if tx.is_closed() {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue
             };
 
             while let Some(res) = stream.next().await {


### PR DESCRIPTION
## Summary

Retry the block subscription in `RpcBlockProvider::subscribe_blocks()` when the initial `full_block_stream()` call fails, instead of exiting permanently.

Closes #23232

## Problem

When `full_block_stream()` fails (e.g. the target RPC endpoint is not yet available), `subscribe_blocks()` returns permanently:

```rust
let Ok(mut stream) = self.full_block_stream().await.inspect_err(|err| {
    warn!("Failed to subscribe to blocks");
}) else {
    return  // exits forever — no retry
};
```

The outer `loop` already handles stream disconnection correctly (re-establishes the subscription), but initial connection failure causes an early `return` that bypasses this retry logic entirely.

Since `subscribe_blocks` is called from `DebugConsensusClient::run()` via a spawned task, the permanent exit means the follow/debug consensus feature silently stops working with no way to recover.

This is the complementary case to #20772, which fixed an infinite reconnection loop when the *receiver* closes. Here the problem is the opposite: *no* retry when the provider can't connect.

## Solution

Replace `return` with `sleep(5s) + continue` so the subscription is retried on the next loop iteration — consistent with how stream termination is already handled:

```rust
} else {
    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
    continue
};
```

## How it was tested

Reproduced the issue in a local consensus network (4 validators + 1 full node):

**Before (current behavior):**
- Start full node with `--debug.rpc-consensus-ws http://localhost:8545` before the target validator is running
- Validator starts and reaches block 234
- Full node stays at block 0 forever — the follow task exited on first failure

**After (this fix):**
- Same setup — full node starts 15s before validators
- Full node logs: `"Failed to subscribe to blocks, retrying in 5s"` (3 times)
- Once validator is up, full node connects and syncs blocks