### PR TITLE
fix(trie): before prune call root

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2051,35 +2051,29 @@ impl ArenaParallelSparseTrie {
         }
     }
 
-    /// Removes a pruned node from the arena and blinds the parent's child slot with `cached_rlp`.
-    ///
-    /// Callers must only invoke this for nodes whose cached RLP is available.
+    /// Removes a pruned node from the arena and blinds the parent's child slot with the node's
+    /// cached RLP. If the node has no cached RLP (e.g. it was never hashed), the parent slot
+    /// is left dangling — this is safe because the parent will also be removed during pruning.
     fn remove_pruned_node(
         arena: &mut NodeArena,
         cursor: &ArenaCursor,
         idx: Index,
         nibble: Option<u8>,
-        cached_rlp: RlpNode,
     ) -> ArenaSparseNode {
         trace!(target: TRACE_TARGET, path = ?cursor.head().unwrap().path, "pruning node");
+        let node = arena.remove(idx).expect("node must exist to be pruned");
+        let rlp_node = node.state_ref().and_then(|s| s.cached_rlp_node()).cloned();
 
-        {
+        if let Some(rlp_node) = rlp_node {
             let parent_idx = cursor.parent().expect("pruned child has parent").index;
             let child_nibble = nibble.expect("non-root child");
             let parent_branch = arena[parent_idx].branch_mut();
             let child_idx = BranchChildIdx::new(parent_branch.state_mask, child_nibble)
                 .expect("child nibble not found in parent state_mask");
-            debug_assert!(
-                matches!(
-                    parent_branch.children[child_idx],
-                    ArenaSparseNodeBranchChild::Revealed(revealed_idx) if revealed_idx == idx
-                ),
-                "parent child slot at nibble {child_nibble} does not point to pruned node"
-            );
-            parent_branch.children[child_idx] = ArenaSparseNodeBranchChild::Blinded(cached_rlp);
+            parent_branch.children[child_idx] = ArenaSparseNodeBranchChild::Blinded(rlp_node);
         }
 
-        arena.remove(idx).expect("node must exist to be pruned")
+        node
     }
 
     /// Reveals a single proof node using a pre-computed [`SeekResult`] from
@@ -2726,22 +2720,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         continue;
                     }
 
-                    // Pruning requires replacing the parent edge with a blinded hash. If this
-                    // node has no cached RLP yet (dirty), skip pruning it in this pass.
-                    let Some(cached_rlp) = self.upper_arena[head_idx]
-                        .state_ref()
-                        .and_then(|state| state.cached_rlp_node())
-                        .cloned()
-                    else {
-                        continue;
-                    };
-
                     Self::remove_pruned_node(
                         &mut self.upper_arena,
                         &cursor,
                         head_idx,
                         head_path.last(),
-                        cached_rlp,
                     );
                     pruned += 1;
                 }
@@ -2750,22 +2733,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     retained_idx = subtrie_range.end;
 
                     if subtrie_range.is_empty() {
-                        // A subtrie can only be removed if its root has a cached RLP to install
-                        // as a blinded child in the parent branch.
-                        let Some(cached_rlp) = self.upper_arena[head_idx]
-                            .state_ref()
-                            .and_then(|state| state.cached_rlp_node())
-                            .cloned()
-                        else {
-                            continue;
-                        };
-
                         let removed = Self::remove_pruned_node(
                             &mut self.upper_arena,
                             &cursor,
                             head_idx,
                             head_path.last(),
-                            cached_rlp,
                         );
                         let ArenaSparseNode::Subtrie(s) = &removed else { unreachable!() };
                         pruned += s.num_leaves as usize;

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -820,8 +820,9 @@ where
     ///
     /// # Preconditions
     ///
-    /// Node hashes must be computed via `root()` before calling this method. Otherwise, nodes
-    /// cannot be converted to hash stubs and pruning will have no effect.
+    /// All revealed account and storage tries must already have computed hashes via `root()`
+    /// / `storage_root()` for their current state. Pruning a dirty revealed trie is a hard
+    /// error and may panic.
     #[cfg(feature = "std")]
     #[instrument(
         level = "debug",

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -302,8 +302,8 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     ///
     /// # Preconditions
     ///
-    /// Must be called after `root()` to ensure all nodes have computed hashes.
-    /// Calling on a trie without computed hashes will result in limited or no pruning.
+    /// Must be called only after `root()` has computed hashes for the current trie state.
+    /// Calling `prune` on a dirty trie is a hard error and may panic.
     ///
     /// # Returns
     ///

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -304,7 +304,6 @@ sparse_trie_tests! {
     test_prune_then_update_no_panic,
     test_prune_only_descends_into_branch_root,
     test_prune_handles_small_subtrie_root_nodes,
-    test_prune_after_dirty_update_keeps_root_stable,
 
     // wipe / clear
     test_wipe_resets_to_empty_root,

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -348,37 +348,3 @@ pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie>(new_tri
     let root_after = trie.root();
     assert_eq!(root_after, root_before, "root must not change after prune");
 }
-
-/// Pruning after a dirty update should preserve correctness and not panic during root recompute.
-///
-/// This reproduces a case where a lower-subtrie root can be removed by prune while the trie still
-/// has pending dirty prefixes from a prior update.
-pub(super) fn test_prune_after_dirty_update_keeps_root_stable<T: SparseTrie>(new_trie: fn() -> T) {
-    let mut key_1 = B256::ZERO;
-    key_1.0[0] = 0x5d;
-    key_1.0[1] = 0xa0;
-
-    let mut key_2 = B256::ZERO;
-    key_2.0[0] = 0x5e;
-
-    let storage: BTreeMap<B256, U256> =
-        BTreeMap::from([(key_1, U256::from(1)), (key_2, U256::from(2))]);
-    let harness = SuiteTestHarness::new(storage);
-    let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
-
-    // Cache initial hashes so prune can convert nodes to blinded hashes.
-    let _ = trie.root();
-
-    // Mark the 0x5d subtree dirty without recomputing root afterwards.
-    let mut leaf_updates =
-        SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_1, U256::from(3))]));
-    harness.reveal_and_update(&mut trie, &mut leaf_updates);
-
-    // Prune while retaining only the sibling subtree.
-    trie.prune(&[Nibbles::unpack(key_2)]);
-
-    // Recompute root: this used to panic for one implementation.
-    let root_after = trie.root();
-    let root_after_second = trie.root();
-    assert_eq!(root_after, root_after_second, "root should be stable after dirty update + prune");
-}


### PR DESCRIPTION
Remove tolerant prune behavior from 50ce26f since we discovered more cases. It's better just to embrace the tight requirement of calling prune after `root()`.