### PR TITLE
perf: enable revm p256-aws-lc-rs feature for faster RIP-7212 precompile

### DIFF
--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -49,7 +49,7 @@ tokio.workspace = true
 
 # revm with required ethereum features
 # Note: this must be kept to ensure all features are properly enabled/forwarded
-revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }
+revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit", "p256-aws-lc-rs"] }
 
 # misc
 eyre.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -31,7 +31,7 @@ reth-revm.workspace = true
 reth-tracing.workspace = true
 reth-trie.workspace = true
 reth-trie-db.workspace = true
-revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }
+revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit", "p256-aws-lc-rs"] }
 
 alloy-rlp.workspace = true
 alloy-primitives.workspace = true


### PR DESCRIPTION
Enables `revm/p256-aws-lc-rs` feature in `reth-node-ethereum` and `ef-tests`, switching the P256 (secp256r1) signature verification precompile to use the aws-lc-rs backend instead of the default `p256` crate.

Co-Authored-By: Arsenii Kulikov <62447812+klkvr@users.noreply.github.com>

Prompted by: klkvr