### PR TITLE
fix(trie): use Entry API in `MultiProofTargets::extend_inner`

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -79,7 +79,14 @@ impl MultiProofTargets {
 
     fn extend_inner(&mut self, other: Cow<'_, Self>) {
         for (hashed_address, hashed_slots) in other.iter() {
-            self.entry(*hashed_address).or_default().extend(hashed_slots);
+            match self.entry(*hashed_address) {
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(hashed_slots.clone());
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().extend(hashed_slots);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Spotted that `MultiProofTargets::extend_inner()` was still using `.or_default().extend()` while `MultiProof::extend`, `DecodedMultiProof::extend`, and `DecodedMultiProofV2::extend` in the same file already got the Entry API treatment. The old pattern allocates an empty `B256Set` when a key is missing, only to immediately extend into it. Swapped it to `match entry { Vacant => insert(clone), Occupied => extend }` for consistency and to skip the throwaway allocation.