### PR TITLE
perf: enable revm p256-aws-lc-rs feature by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10801,6 +10801,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,7 +431,7 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { version = "0.1.0", default-features = false }
 
 # revm
-revm = { version = "36.0.0", default-features = false }
+revm = { version = "36.0.0", default-features = false, features = ["secp256k1", "blst", "c-kzg", "p256-aws-lc-rs"] }
 revm-bytecode = { version = "9.0.0", default-features = false }
 revm-database = { version = "12.0.0", default-features = false }
 revm-state = { version = "10.0.0", default-features = false }

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -49,7 +49,7 @@ tokio.workspace = true
 
 # revm with required ethereum features
 # Note: this must be kept to ensure all features are properly enabled/forwarded
-revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }
+revm = { workspace = true, features = ["memory_limit"] }
 
 # misc
 eyre.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -31,7 +31,7 @@ reth-revm.workspace = true
 reth-tracing.workspace = true
 reth-trie.workspace = true
 reth-trie-db.workspace = true
-revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit"] }
+revm = { workspace = true, features = ["memory_limit"] }
 
 alloy-rlp.workspace = true
 alloy-primitives.workspace = true


### PR DESCRIPTION
Enables the revm `p256-aws-lc-rs` feature flag so secp256r1 (RIP-7212) signature verification uses `aws-lc-rs` instead of the pure-Rust `p256` crate. Faster for the P256 precompile.

Context: https://github.com/tempoxyz/tempo/pull/3339

Prompted by: DaniPopes