### PR TITLE
fix(engine): downgrade emit_event send failure to debug

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1912,7 +1912,7 @@ where
         }
 
         let _ = self.outgoing.send(event).inspect_err(
-            |err| error!(target: "engine::tree", "Failed to send internal event: {err:?}"),
+            |err| debug!(target: "engine::tree", "Failed to send internal event: {err:?}"),
         );
     }
 


### PR DESCRIPTION
Downgrades the `error!` log in `emit_event` to `debug!` when the outgoing channel send fails. This happens during shutdown when the receiver is already dropped — a benign race condition, especially visible with `--debug.terminate`.

Prompted by: DaniPopes