### PR TITLE
refactor(payload): remove op ExecutionPayload impl and op feature from payload-primitives

### DIFF
--- a/.changelog/rich-pigs-shake.md
+++ b/.changelog/rich-pigs-shake.md
@@ -1,0 +1,6 @@
+---
+reth-payload-primitives: patch
+reth-engine-local: patch
+---
+
+Removed the `op` feature and `op-alloy-rpc-types-engine` dependency from `reth-payload-primitives`, along with the `ExecutionPayload` impl for `OpExecutionData`. Updated `reth-engine-local` to drop the corresponding feature flag dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9531,7 +9531,6 @@ dependencies = [
  "assert_matches",
  "auto_impl",
  "either",
- "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",

--- a/crates/engine/local/Cargo.toml
+++ b/crates/engine/local/Cargo.toml
@@ -40,5 +40,4 @@ workspace = true
 [features]
 op = [
     "dep:op-alloy-rpc-types-engine",
-    "reth-payload-primitives/op",
 ]

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -26,7 +26,6 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
-op-alloy-rpc-types-engine = { workspace = true, optional = true, features = ["serde"] }
 
 # misc
 auto_impl.workspace = true
@@ -49,7 +48,6 @@ std = [
     "alloy-eips/std",
     "alloy-primitives/std",
     "alloy-rpc-types-engine/std",
-    "op-alloy-rpc-types-engine?/std",
     "serde/std",
     "thiserror/std",
     "reth-primitives-traits/std",
@@ -58,7 +56,4 @@ std = [
     "alloy-rlp/std",
     "serde_json/std",
     "sha2/std",
-]
-op = [
-    "dep:op-alloy-rpc-types-engine",
 ]

--- a/crates/payload/primitives/src/payload.rs
+++ b/crates/payload/primitives/src/payload.rs
@@ -169,46 +169,6 @@ where
         Self::PayloadAttributes(attributes)
     }
 }
-
-#[cfg(feature = "op")]
-impl ExecutionPayload for op_alloy_rpc_types_engine::OpExecutionData {
-    fn parent_hash(&self) -> B256 {
-        self.parent_hash()
-    }
-
-    fn block_hash(&self) -> B256 {
-        self.block_hash()
-    }
-
-    fn block_number(&self) -> u64 {
-        self.block_number()
-    }
-
-    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
-        self.payload.as_v2().map(|p| &p.withdrawals)
-    }
-
-    fn block_access_list(&self) -> Option<&Bytes> {
-        None
-    }
-
-    fn parent_beacon_block_root(&self) -> Option<B256> {
-        self.sidecar.parent_beacon_block_root()
-    }
-
-    fn timestamp(&self) -> u64 {
-        self.payload.as_v1().timestamp
-    }
-
-    fn gas_used(&self) -> u64 {
-        self.payload.as_v1().gas_used
-    }
-
-    fn transaction_count(&self) -> usize {
-        self.payload.as_v1().transactions.len()
-    }
-}
-
 /// Extended functionality for Ethereum execution payloads
 impl<Attributes> PayloadOrAttributes<'_, ExecutionData, Attributes>
 where


### PR DESCRIPTION
Removes the `ExecutionPayload` impl for `OpExecutionData` and the `op` feature + `op-alloy-rpc-types-engine` dep from `reth-payload-primitives`. Also removes the downstream `reth-payload-primitives/op` propagation from `reth-engine-local`.

Prompted by: mattsse