### PR TITLE
rpc: propagate EIP-2718 decode error in FailedToDecodeSignedTransaction

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation specific Errors for the `eth_` namespace.
 
 pub mod api;
-use alloy_eips::BlockId;
+use alloy_eips::{eip2718::Eip2718Error, BlockId};
 use alloy_evm::{call::CallError, overrides::StateOverrideError};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{error::EthRpcErrorCode, request::TransactionInputError, BlockError};
@@ -65,8 +65,8 @@ pub enum EthApiError {
     #[error("empty transaction data")]
     EmptyRawTransactionData,
     /// When decoding a signed transaction fails
-    #[error("failed to decode signed transaction")]
-    FailedToDecodeSignedTransaction,
+    #[error("failed to decode signed transaction: {0}")]
+    FailedToDecodeSignedTransaction(Eip2718Error),
     /// When the transaction signature is invalid
     #[error("invalid transaction signature")]
     InvalidTransactionSignature,
@@ -276,7 +276,7 @@ impl EthApiError {
 impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     fn from(error: EthApiError) -> Self {
         match error {
-            EthApiError::FailedToDecodeSignedTransaction |
+            EthApiError::FailedToDecodeSignedTransaction(_) |
             EthApiError::InvalidTransactionSignature |
             EthApiError::EmptyRawTransactionData |
             EthApiError::InvalidBlockRange |

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -38,7 +38,7 @@ pub fn recover_raw_transaction<T: SignedTransaction>(data: &[u8]) -> EthResult<R
     }
 
     let transaction =
-        T::decode_2718_exact(data).map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+        T::decode_2718_exact(data).map_err(EthApiError::FailedToDecodeSignedTransaction)?;
 
     SignedTransaction::try_into_recovered(transaction)
         .or(Err(EthApiError::InvalidTransactionSignature))


### PR DESCRIPTION
## Motivation

`recover_raw_transaction` silently discards the `Eip2718Error` from `decode_2718_exact` via `map_err(|_|)`. The `FailedToDecodeSignedTransaction` variant is a unit struct, so callers always get the static message `"failed to decode signed transaction"` with no detail about why decoding failed.

When `eth_sendRawTransaction` receives malformed input, operators and SDK authors cannot distinguish between an unknown tx type byte, truncated data, or trailing bytes. All three produce the same error response.

## Changes

- `FailedToDecodeSignedTransaction` unit variant now wraps `Eip2718Error`
- `map_err(|_| EthApiError::FailedToDecodeSignedTransaction)` becomes `map_err(EthApiError::FailedToDecodeSignedTransaction)` so the inner error is passed through
- match arm in `From<EthApiError> for ErrorObject` updated to `FailedToDecodeSignedTransaction(_)`
- error message is now `"failed to decode signed transaction: <reason>"`, e.g. `"failed to decode signed transaction: Unexpected type flag. Got 153."`

follows the same pattern as `PoolError`, `InvalidTransaction`, `Signing`, `TransactionConversionError`, `MuxTracerError` and other variants that already wrap inner errors.

## Testing

```
cargo test -p reth-rpc-eth-types
cargo clippy -p reth-rpc-eth-types -- -D warnings
cargo +nightly fmt --check
```
