### PR TITLE
chore(cli): add more WARN logging before we retry a download

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -1328,7 +1328,17 @@ fn streaming_download_and_extract(
         let response = match client.get(url).send().and_then(|r| r.error_for_status()) {
             Ok(r) => r,
             Err(e) => {
-                last_error = Some(e.into());
+                let err = eyre::Error::from(e);
+                if attempt < MAX_DOWNLOAD_RETRIES {
+                    warn!(target: "reth::cli",
+                        url = %url,
+                        attempt,
+                        max = MAX_DOWNLOAD_RETRIES,
+                        err = %err,
+                        "Streaming request failed, retrying"
+                    );
+                }
+                last_error = Some(err);
                 if attempt < MAX_DOWNLOAD_RETRIES {
                     std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
                 }
@@ -1355,6 +1365,15 @@ fn streaming_download_and_extract(
         match result {
             Ok(()) => return Ok(()),
             Err(e) => {
+                if attempt < MAX_DOWNLOAD_RETRIES {
+                    warn!(target: "reth::cli",
+                        url = %url,
+                        attempt,
+                        max = MAX_DOWNLOAD_RETRIES,
+                        err = %e,
+                        "Streaming extraction failed, retrying"
+                    );
+                }
                 last_error = Some(e);
                 if attempt < MAX_DOWNLOAD_RETRIES {
                     std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));


### PR DESCRIPTION
Previously this would just have an info log that we were retrying download:
```
2026-03-27T17:29:58.107080Z  INFO Retrying streaming download from scratch url=https://snapshots-r2.reth.rs/reth-1-archive-stable-24742788-1774545318/state.tar.zst attempt=10 max=10
```

now this also adds a WARN for the exact error