### PR TITLE
fix(tracing): default log output to stderr when no file writer is set

### DIFF
--- a/crates/tracing/src/formatter.rs
+++ b/crates/tracing/src/formatter.rs
@@ -32,7 +32,7 @@ impl LogFormat {
     /// * `color` - An optional string that enables or disables ANSI color codes in the logs.
     /// * `show_target` - Whether to show the target module path in log output.
     /// * `file_writer` - An optional [`NonBlocking`] writer for directing logs to a file. When
-    ///   `None`, logs are written to stdout.
+    ///   `None`, logs are written to stderr.
     ///
     /// # Returns
     /// A `BoxedLayer<Registry>` that can be added to a tracing subscriber.
@@ -61,7 +61,7 @@ impl LogFormat {
                 if let Some(writer) = file_writer {
                     layer.with_writer(writer).with_filter(filter).boxed()
                 } else {
-                    layer.with_filter(filter).boxed()
+                    layer.with_writer(std::io::stderr).with_filter(filter).boxed()
                 }
             }
             Self::LogFmt => {
@@ -69,7 +69,7 @@ impl LogFormat {
                 if let Some(writer) = file_writer {
                     layer.with_writer(writer).with_filter(filter).boxed()
                 } else {
-                    layer.with_filter(filter).boxed()
+                    layer.with_writer(std::io::stderr).with_filter(filter).boxed()
                 }
             }
             Self::Terminal => {
@@ -77,7 +77,7 @@ impl LogFormat {
                 if let Some(writer) = file_writer {
                     layer.with_writer(writer).with_filter(filter).boxed()
                 } else {
-                    layer.with_filter(filter).boxed()
+                    layer.with_writer(std::io::stderr).with_filter(filter).boxed()
                 }
             }
         }


### PR DESCRIPTION
reth's log output was going to stdout when running without `--log.file.directory`, which meant piping `reth node` output to other tools was mixing structured data with log noise. saw stuff like `2026-03-27T14:32:11.483Z  INFO reth::node: Starting reth v1.x.x` showing up in stdout alongside JSON-RPC responses when testing locally.

the fix is small — when no file writer is configured, `LogFormat::layer()` now explicitly passes `std::io::stderr` to `.with_writer()` for all three format variants (`Terminal`, `LogFmt`, default). the doc comment on the function was also wrong (said stdout), fixed that too.
