### PR TITLE
refactor(reth-bench): remove op-alloy dependencies via PayloadConverter trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7638,6 +7638,7 @@ dependencies = [
 name = "reth-bench"
 version = "1.11.3"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -7656,8 +7657,6 @@ dependencies = [
  "eyre",
  "futures",
  "humantime",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
  "reqwest 0.13.2",
  "reth-cli-runner",
  "reth-cli-util",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -26,6 +26,7 @@ reth-rpc-api.workspace = true
 reth-tracing.workspace = true
 
 # alloy
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-json-rpc.workspace = true
 
@@ -38,8 +39,6 @@ alloy-transport-http.workspace = true
 alloy-transport-ipc.workspace = true
 alloy-transport-ws.workspace = true
 alloy-transport.workspace = true
-op-alloy-consensus = { workspace = true, features = ["alloy-compat"] }
-op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # reqwest
 reqwest.workspace = true

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -3,7 +3,6 @@
 
 use crate::{authenticated_transport::AuthenticatedTransportConnect, bench_mode::BenchMode};
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::address;
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
 use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::JwtSecret;
@@ -27,8 +26,6 @@ pub(crate) struct BenchContext {
     pub(crate) benchmark_mode: BenchMode,
     /// The next block to fetch.
     pub(crate) next_block: u64,
-    /// Whether the chain is an OP rollup.
-    pub(crate) is_optimism: bool,
     /// Whether to use `reth_newPayload` endpoint instead of `engine_newPayload*`.
     pub(crate) use_reth_namespace: bool,
     /// Whether to fetch and replay RLP-encoded blocks.
@@ -69,12 +66,6 @@ impl BenchContext {
             .layer(RetryBackoffLayer::new_with_policy(max_retries, 800, u64::MAX, retry_policy))
             .http(rpc_url.parse()?);
         let block_provider = RootProvider::<AnyNetwork>::new(client);
-
-        // Check if this is an OP chain by checking code at a predeploy address.
-        let is_optimism = !block_provider
-            .get_code_at(address!("0x420000000000000000000000000000000000000F"))
-            .await?
-            .is_empty();
 
         // construct the authenticated provider
         let auth_jwt = bench_args
@@ -175,7 +166,6 @@ impl BenchContext {
             block_provider,
             benchmark_mode,
             next_block,
-            is_optimism,
             use_reth_namespace,
             rlp_blocks,
             wait_for_persistence,

--- a/bin/reth-bench/src/bench/mod.rs
+++ b/bin/reth-bench/src/bench/mod.rs
@@ -1,5 +1,6 @@
 //! `reth benchmark` command. Collection of various benchmarking routines.
 
+use crate::payload_converter::PayloadConverter;
 use clap::{Parser, Subcommand};
 use reth_cli_runner::CliContext;
 use reth_node_core::args::LogArgs;
@@ -88,17 +89,21 @@ pub enum Subcommands {
 
 impl BenchmarkCommand {
     /// Execute `benchmark` command
-    pub async fn execute(self, ctx: CliContext) -> eyre::Result<()> {
+    pub async fn execute<C: PayloadConverter>(
+        self,
+        ctx: CliContext,
+        converter: C,
+    ) -> eyre::Result<()> {
         // Initialize tracing
         let _guard = self.init_tracing()?;
 
         match self.command {
-            Subcommands::NewPayloadFcu(command) => command.execute(ctx).await,
-            Subcommands::NewPayloadOnly(command) => command.execute(ctx).await,
-            Subcommands::SendPayload(command) => command.execute(ctx).await,
+            Subcommands::NewPayloadFcu(command) => command.execute(ctx, &converter).await,
+            Subcommands::NewPayloadOnly(command) => command.execute(ctx, &converter).await,
+            Subcommands::SendPayload(command) => command.execute(ctx, &converter).await,
             Subcommands::GenerateBigBlock(command) => command.execute(ctx).await,
             Subcommands::ReplayPayloads(command) => command.execute(ctx).await,
-            Subcommands::SendInvalidPayload(command) => (*command).execute(ctx).await,
+            Subcommands::SendInvalidPayload(command) => (*command).execute(ctx, &converter).await,
         }
     }
 

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -10,6 +10,7 @@ use crate::{
             write_benchmark_results, CombinedResult, NewPayloadResult, TotalGasOutput, TotalGasRow,
         },
     },
+    payload_converter::PayloadConverter,
     valid_payload::{
         block_to_new_payload, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
     },
@@ -81,7 +82,11 @@ pub struct Command {
 
 impl Command {
     /// Execute `benchmark new-payload-fcu` command
-    pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
+    pub async fn execute<C: PayloadConverter>(
+        self,
+        _ctx: CliContext,
+        converter: &C,
+    ) -> eyre::Result<()> {
         // Log mode configuration
         if let Some(duration) = self.wait_time {
             info!(target: "reth-bench", "Using wait-time mode with {}ms delay between blocks", duration.as_millis());
@@ -92,7 +97,6 @@ impl Command {
             block_provider,
             auth_provider,
             next_block,
-            is_optimism,
             use_reth_namespace,
             rlp_blocks,
             wait_for_persistence,
@@ -200,8 +204,8 @@ impl Command {
             };
 
             let (version, params) = block_to_new_payload(
+                converter,
                 block,
-                is_optimism,
                 rlp,
                 use_reth_namespace,
                 wait_for_persistence,

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -9,6 +9,7 @@ use crate::{
             NEW_PAYLOAD_OUTPUT_SUFFIX,
         },
     },
+    payload_converter::PayloadConverter,
     valid_payload::{block_to_new_payload, call_new_payload_with_reth},
 };
 use alloy_provider::{ext::DebugApi, Provider};
@@ -43,13 +44,16 @@ pub struct Command {
 
 impl Command {
     /// Execute `benchmark new-payload-only` command
-    pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
+    pub async fn execute<C: PayloadConverter>(
+        self,
+        _ctx: CliContext,
+        converter: &C,
+    ) -> eyre::Result<()> {
         let BenchContext {
             benchmark_mode,
             block_provider,
             auth_provider,
             mut next_block,
-            is_optimism,
             use_reth_namespace,
             rlp_blocks,
             wait_for_persistence,
@@ -125,8 +129,8 @@ impl Command {
             debug!(target: "reth-bench", number=?block.header.number, "Sending payload to engine");
 
             let (version, params) = block_to_new_payload(
+                converter,
                 block,
-                is_optimism,
                 rlp,
                 use_reth_namespace,
                 wait_for_persistence,

--- a/bin/reth-bench/src/bench/send_invalid_payload/mod.rs
+++ b/bin/reth-bench/src/bench/send_invalid_payload/mod.rs
@@ -4,12 +4,12 @@ mod invalidation;
 use invalidation::InvalidationConfig;
 
 use super::helpers::{load_jwt_secret, read_input};
+use crate::payload_converter::PayloadConverter;
 use alloy_primitives::{Address, B256};
 use alloy_provider::network::AnyRpcBlock;
 use alloy_rpc_types_engine::ExecutionPayload;
 use clap::Parser;
 use eyre::{OptionExt, Result};
-use op_alloy_consensus::OpTxEnvelope;
 use reth_cli_runner::CliContext;
 use std::io::Write;
 
@@ -215,26 +215,23 @@ impl Command {
     }
 
     /// Execute the command
-    pub async fn execute(self, _ctx: CliContext) -> Result<()> {
+    pub async fn execute<C: PayloadConverter>(self, _ctx: CliContext, converter: &C) -> Result<()> {
         let block_json = read_input(self.path.as_deref())?;
         let jwt_secret = load_jwt_secret(self.jwt_secret.as_deref())?;
 
-        let block = serde_json::from_str::<AnyRpcBlock>(&block_json)?
-            .into_inner()
-            .map_header(|header| header.map(|h| h.into_header_with_defaults()))
-            .try_map_transactions(|tx| tx.try_into_either::<OpTxEnvelope>())?
-            .into_consensus();
+        let block = serde_json::from_str::<AnyRpcBlock>(&block_json)?;
+
+        let (mut execution_payload, sidecar) = converter.block_to_payload(block)?;
 
         let config = self.build_invalidation_config();
 
+        let cancun = sidecar.cancun();
         let parent_beacon_block_root =
-            self.parent_beacon_block_root.or(block.header.parent_beacon_block_root);
-        let blob_versioned_hashes =
-            block.body.blob_versioned_hashes_iter().copied().collect::<Vec<_>>();
-        let use_v4 = block.header.requests_hash.is_some();
-        let requests_hash = self.requests_hash.or(block.header.requests_hash);
-
-        let mut execution_payload = ExecutionPayload::from_block_slow(&block).0;
+            self.parent_beacon_block_root.or_else(|| cancun.map(|c| c.parent_beacon_block_root));
+        let blob_versioned_hashes = cancun.map(|c| c.versioned_hashes.clone()).unwrap_or_default();
+        let use_v4 = sidecar.prague().is_some();
+        let requests_hash =
+            self.requests_hash.or_else(|| sidecar.prague().map(|p| p.requests.requests_hash()));
 
         let changes = match &mut execution_payload {
             ExecutionPayload::V1(p) => config.apply_to_payload_v1(p),

--- a/bin/reth-bench/src/bench/send_payload.rs
+++ b/bin/reth-bench/src/bench/send_payload.rs
@@ -1,9 +1,8 @@
 use super::helpers::{load_jwt_secret, read_input};
+use crate::payload_converter::PayloadConverter;
 use alloy_provider::network::AnyRpcBlock;
-use alloy_rpc_types_engine::ExecutionPayload;
 use clap::Parser;
 use eyre::{OptionExt, Result};
-use op_alloy_consensus::OpTxEnvelope;
 use reth_cli_runner::CliContext;
 use std::io::Write;
 
@@ -53,7 +52,7 @@ enum Mode {
 
 impl Command {
     /// Execute the generate payload command
-    pub async fn execute(self, _ctx: CliContext) -> Result<()> {
+    pub async fn execute<C: PayloadConverter>(self, _ctx: CliContext, converter: &C) -> Result<()> {
         // Load block
         let block_json = read_input(self.path.as_deref())?;
 
@@ -61,49 +60,20 @@ impl Command {
         let jwt_secret = load_jwt_secret(self.jwt_secret.as_deref())?;
 
         // Parse the block
-        let block = serde_json::from_str::<AnyRpcBlock>(&block_json)?
-            .into_inner()
-            .map_header(|header| header.map(|h| h.into_header_with_defaults()))
-            .try_map_transactions(|tx| {
-                // try to convert unknowns into op type so that we can also support optimism
-                tx.try_into_either::<OpTxEnvelope>()
-            })?
-            .into_consensus();
+        let block = serde_json::from_str::<AnyRpcBlock>(&block_json)?;
 
-        // Extract parent beacon block root
-        let parent_beacon_block_root = block.header.parent_beacon_block_root;
+        let (payload, sidecar) = converter.block_to_payload(block)?;
+        let (version, params, _execution_data) =
+            converter.payload_to_new_payload(payload, sidecar, None)?;
 
-        // Extract blob versioned hashes
-        let blob_versioned_hashes =
-            block.body.blob_versioned_hashes_iter().copied().collect::<Vec<_>>();
-
-        // Convert to execution payload
-        let execution_payload = ExecutionPayload::from_block_slow(&block).0;
-
-        let use_v4 = block.header.requests_hash.is_some();
-
-        // Create JSON request data
-        let json_request = if use_v4 {
-            serde_json::to_string(&(
-                execution_payload,
-                blob_versioned_hashes,
-                parent_beacon_block_root,
-                block.header.requests_hash.unwrap_or_default(),
-            ))?
-        } else {
-            serde_json::to_string(&(
-                execution_payload,
-                blob_versioned_hashes,
-                parent_beacon_block_root,
-            ))?
-        };
+        let json_request = serde_json::to_string(&params)?;
+        let method = version.method_name();
 
         // Print output or execute command
         match self.mode {
             Mode::Execute => {
                 // Create cast command
                 let mut command = std::process::Command::new("cast");
-                let method = if use_v4 { "engine_newPayloadV4" } else { "engine_newPayloadV3" };
                 command.arg("rpc").arg(method).arg("--raw");
                 if let Some(rpc_url) = self.rpc_url {
                     command.arg("--rpc-url").arg(rpc_url);
@@ -126,10 +96,7 @@ impl Command {
                 process.wait()?;
             }
             Mode::Cast => {
-                let mut cmd = format!(
-                    "cast rpc engine_newPayloadV{} --raw '{}'",
-                    self.new_payload_version, json_request
-                );
+                let mut cmd = format!("cast rpc {} --raw '{}'", method, json_request);
 
                 if let Some(rpc_url) = self.rpc_url {
                     cmd += &format!(" --rpc-url {rpc_url}");

--- a/bin/reth-bench/src/main.rs
+++ b/bin/reth-bench/src/main.rs
@@ -20,10 +20,12 @@ use reth_cli_util::allocator::tikv_jemalloc_sys as _;
 pub mod authenticated_transport;
 pub mod bench;
 pub mod bench_mode;
+pub mod payload_converter;
 pub mod valid_payload;
 
 use bench::BenchmarkCommand;
 use clap::Parser;
+use payload_converter::EthereumPayloadConverter;
 use reth_cli_runner::CliRunner;
 
 fn main() -> eyre::Result<()> {
@@ -38,7 +40,9 @@ fn main() -> eyre::Result<()> {
 
     // Run until either exit or sigint or sigterm
     let runner = CliRunner::try_default_runtime()?;
-    runner.run_command_until_exit(|ctx| BenchmarkCommand::parse().execute(ctx))?;
+    runner.run_command_until_exit(|ctx| {
+        BenchmarkCommand::parse().execute(ctx, EthereumPayloadConverter)
+    })?;
 
     Ok(())
 }

--- a/bin/reth-bench/src/payload_converter.rs
+++ b/bin/reth-bench/src/payload_converter.rs
@@ -1,0 +1,106 @@
+//! Trait abstraction for chain-specific payload conversions in benchmarks.
+
+use alloy_consensus::TxEnvelope;
+use alloy_provider::network::AnyRpcBlock;
+use alloy_rpc_types_engine::{
+    ExecutionData, ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadSidecar,
+};
+use reth_node_api::EngineApiMessageVersion;
+
+/// Converts RPC blocks into engine API payloads.
+///
+/// Different chains (Ethereum, Optimism, …) need different transaction/payload
+/// encoding when talking to `engine_newPayload*`. Implement this trait once per
+/// chain and pass it into the benchmark commands.
+pub trait PayloadConverter: Send + Sync + 'static {
+    /// Convert an [`AnyRpcBlock`] into an [`ExecutionPayload`] and its
+    /// [`ExecutionPayloadSidecar`].
+    fn block_to_payload(
+        &self,
+        block: AnyRpcBlock,
+    ) -> eyre::Result<(ExecutionPayload, ExecutionPayloadSidecar)>;
+
+    /// Serialize an [`ExecutionPayload`] + [`ExecutionPayloadSidecar`] into the
+    /// versioned JSON params expected by the corresponding `engine_newPayload*`
+    /// method, together with the assembled [`ExecutionData`].
+    fn payload_to_new_payload(
+        &self,
+        payload: ExecutionPayload,
+        sidecar: ExecutionPayloadSidecar,
+        target_version: Option<EngineApiMessageVersion>,
+    ) -> eyre::Result<(EngineApiMessageVersion, serde_json::Value, ExecutionData)>;
+}
+
+/// Ethereum-specific [`PayloadConverter`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EthereumPayloadConverter;
+
+impl PayloadConverter for EthereumPayloadConverter {
+    fn block_to_payload(
+        &self,
+        block: AnyRpcBlock,
+    ) -> eyre::Result<(ExecutionPayload, ExecutionPayloadSidecar)> {
+        let block = block
+            .into_inner()
+            .map_header(|header| header.map(|h| h.into_header_with_defaults()))
+            .try_map_transactions(|tx| -> eyre::Result<TxEnvelope> {
+                tx.try_into().map_err(|_| eyre::eyre!("unsupported tx type"))
+            })?
+            .into_consensus();
+
+        Ok(ExecutionPayload::from_block_slow(&block))
+    }
+
+    fn payload_to_new_payload(
+        &self,
+        payload: ExecutionPayload,
+        sidecar: ExecutionPayloadSidecar,
+        target_version: Option<EngineApiMessageVersion>,
+    ) -> eyre::Result<(EngineApiMessageVersion, serde_json::Value, ExecutionData)> {
+        let execution_data = ExecutionData { payload: payload.clone(), sidecar: sidecar.clone() };
+
+        let (version, params) = match payload {
+            ExecutionPayload::V3(payload) => {
+                let cancun = sidecar
+                    .cancun()
+                    .ok_or_else(|| eyre::eyre!("missing cancun sidecar for V3 payload"))?;
+
+                if let Some(prague) = sidecar.prague() {
+                    let version = target_version.unwrap_or(EngineApiMessageVersion::V4);
+                    let requests = prague.requests.clone();
+                    (
+                        version,
+                        serde_json::to_value((
+                            payload,
+                            cancun.versioned_hashes.clone(),
+                            cancun.parent_beacon_block_root,
+                            requests,
+                        ))?,
+                    )
+                } else {
+                    (
+                        EngineApiMessageVersion::V3,
+                        serde_json::to_value((
+                            payload,
+                            cancun.versioned_hashes.clone(),
+                            cancun.parent_beacon_block_root,
+                        ))?,
+                    )
+                }
+            }
+            ExecutionPayload::V2(payload) => {
+                let input = ExecutionPayloadInputV2 {
+                    execution_payload: payload.payload_inner,
+                    withdrawals: Some(payload.withdrawals),
+                };
+
+                (EngineApiMessageVersion::V2, serde_json::to_value((input,))?)
+            }
+            ExecutionPayload::V1(payload) => {
+                (EngineApiMessageVersion::V1, serde_json::to_value((payload,))?)
+            }
+        };
+
+        Ok((version, params, execution_data))
+    }
+}

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -2,15 +2,13 @@
 //! response. This is useful for benchmarking, as it allows us to wait for a payload to be valid
 //! before sending additional calls.
 
-use alloy_eips::eip7685::Requests;
-use alloy_primitives::{Bytes, B256};
+use crate::payload_converter::PayloadConverter;
+use alloy_primitives::Bytes;
 use alloy_provider::{ext::EngineApi, network::AnyRpcBlock, Network, Provider};
 use alloy_rpc_types_engine::{
-    ExecutionData, ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadSidecar,
-    ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
+    ExecutionData, ForkchoiceState, ForkchoiceUpdated, PayloadAttributes, PayloadStatus,
 };
 use alloy_transport::TransportResult;
-use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
 use reth_node_api::EngineApiMessageVersion;
 use reth_node_core::args::WaitForPersistence;
 use reth_rpc_api::RethNewPayloadInput;
@@ -171,9 +169,9 @@ where
 ///
 /// `wait_for_persistence` controls how `wait_for_persistence` is passed to
 /// `reth_newPayload` on a per-block basis.
-pub(crate) fn block_to_new_payload(
+pub(crate) fn block_to_new_payload<C: PayloadConverter>(
+    converter: &C,
     block: AnyRpcBlock,
-    is_optimism: bool,
     rlp: Option<Bytes>,
     reth_new_payload: bool,
     wait_for_persistence: WaitForPersistence,
@@ -192,19 +190,10 @@ pub(crate) fn block_to_new_payload(
             ))?,
         ));
     }
-    let block = block
-        .into_inner()
-        .map_header(|header| header.map(|h| h.into_header_with_defaults()))
-        .try_map_transactions(|tx| {
-            // try to convert unknowns into op type so that we can also support optimism
-            tx.try_into_either::<op_alloy_consensus::OpTxEnvelope>()
-        })?
-        .into_consensus();
 
-    // Convert to execution payload
-    let (payload, sidecar) = ExecutionPayload::from_block_slow(&block);
+    let (payload, sidecar) = converter.block_to_payload(block)?;
     let (version, params, execution_data) =
-        payload_to_new_payload(payload, sidecar, is_optimism, block.withdrawals_root, None)?;
+        converter.payload_to_new_payload(payload, sidecar, None)?;
 
     if reth_new_payload {
         Ok((
@@ -218,80 +207,6 @@ pub(crate) fn block_to_new_payload(
     } else {
         Ok((Some(version), params))
     }
-}
-
-/// Converts an execution payload and sidecar into versioned engine API params and an
-/// [`ExecutionData`].
-///
-/// Returns `(version, versioned_params, execution_data)`.
-pub(crate) fn payload_to_new_payload(
-    payload: ExecutionPayload,
-    sidecar: ExecutionPayloadSidecar,
-    is_optimism: bool,
-    withdrawals_root: Option<B256>,
-    target_version: Option<EngineApiMessageVersion>,
-) -> eyre::Result<(EngineApiMessageVersion, serde_json::Value, ExecutionData)> {
-    let execution_data = ExecutionData { payload: payload.clone(), sidecar: sidecar.clone() };
-
-    let (version, params) = match payload {
-        ExecutionPayload::V3(payload) => {
-            let cancun = sidecar.cancun().unwrap();
-
-            if let Some(prague) = sidecar.prague() {
-                // Use target version if provided (for Osaka), otherwise default to V4
-                let version = target_version.unwrap_or(EngineApiMessageVersion::V4);
-
-                if is_optimism {
-                    let withdrawals_root = withdrawals_root.ok_or_else(|| {
-                        eyre::eyre!("Missing withdrawals root for Optimism payload")
-                    })?;
-                    (
-                        version,
-                        serde_json::to_value((
-                            OpExecutionPayloadV4 { payload_inner: payload, withdrawals_root },
-                            cancun.versioned_hashes.clone(),
-                            cancun.parent_beacon_block_root,
-                            Requests::default(),
-                        ))?,
-                    )
-                } else {
-                    // Preserve the original RequestsOrHash payload for engine_newPayloadV4.
-                    let requests = prague.requests.clone();
-                    (
-                        version,
-                        serde_json::to_value((
-                            payload,
-                            cancun.versioned_hashes.clone(),
-                            cancun.parent_beacon_block_root,
-                            requests,
-                        ))?,
-                    )
-                }
-            } else {
-                (
-                    EngineApiMessageVersion::V3,
-                    serde_json::to_value((
-                        payload,
-                        cancun.versioned_hashes.clone(),
-                        cancun.parent_beacon_block_root,
-                    ))?,
-                )
-            }
-        }
-        ExecutionPayload::V2(payload) => {
-            let input = ExecutionPayloadInputV2 {
-                execution_payload: payload.payload_inner,
-                withdrawals: Some(payload.withdrawals),
-            };
-
-            (EngineApiMessageVersion::V2, serde_json::to_value((input,))?)
-        }
-        ExecutionPayload::V1(payload) => {
-            (EngineApiMessageVersion::V1, serde_json::to_value((payload,))?)
-        }
-    };
-
-    Ok((version, params, execution_data))
 }
 
 /// Calls the correct `engine_newPayload` method depending on the given [`ExecutionPayload`] and its

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -209,7 +209,7 @@ pub(crate) fn block_to_new_payload<C: PayloadConverter>(
     }
 }
 
-/// Calls the correct `engine_newPayload` method depending on the given [`ExecutionPayload`] and its
+/// Calls the correct `engine_newPayload` method depending on the given execution payload and its
 /// versioned variant. Returns the [`EngineApiMessageVersion`] depending on the payload's version.
 ///
 /// # Panics


### PR DESCRIPTION
Removes `op-alloy-consensus` and `op-alloy-rpc-types-engine` from reth-bench to phase out the optimism dependency.

Introduces a `PayloadConverter` trait with two methods:
- `block_to_payload`: converts `AnyRpcBlock` → `(ExecutionPayload, ExecutionPayloadSidecar)`
- `payload_to_new_payload`: serializes payload+sidecar into versioned `engine_newPayload*` params

`EthereumPayloadConverter` is the sole implementation, wired in via `main.rs`. No optimism implementation is included — that can be added downstream by implementing the trait.

Prompted by: Matthias