### PR TITLE
perf: use FastInstant for remaining metrics timing

### DIFF
--- a/crates/cli/commands/src/db/checksum/rocksdb.rs
+++ b/crates/cli/commands/src/db/checksum/rocksdb.rs
@@ -8,8 +8,9 @@ use reth_db::{tables, DatabaseEnv};
 use reth_db_api::table::Table;
 use reth_db_common::DbTool;
 use reth_node_builder::NodeTypesWithDBAdapter;
+use reth_primitives_traits::FastInstant as Instant;
 use reth_provider::RocksDBProviderFactory;
-use std::{hash::Hasher, time::Instant};
+use std::hash::Hasher;
 use tracing::info;
 
 /// RocksDB tables that can be checksummed.

--- a/crates/cli/commands/src/download/manifest_cmd.rs
+++ b/crates/cli/commands/src/download/manifest_cmd.rs
@@ -3,9 +3,10 @@ use clap::Parser;
 use eyre::{Result, WrapErr};
 use reth_db::{mdbx::DatabaseArguments, open_db_read_only, tables, Database};
 use reth_db_api::transaction::DbTx;
+use reth_primitives_traits::FastInstant as Instant;
 use reth_stages_types::StageId;
 use reth_static_file_types::DEFAULT_BLOCKS_PER_STATIC_FILE;
-use std::{path::PathBuf, time::Instant};
+use std::path::PathBuf;
 use tracing::{info, warn};
 
 /// Generate modular chunk archives and a snapshot manifest from a source datadir.

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -28,6 +28,7 @@ use reth_node_metrics::{
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
 };
+use reth_primitives_traits::FastInstant as Instant;
 use reth_provider::{
     ChainSpecProvider, DBProvider, DatabaseProviderFactory, StageCheckpointReader,
     StageCheckpointWriter,
@@ -40,7 +41,7 @@ use reth_stages::{
     },
     ExecInput, ExecOutput, ExecutionStageThresholds, Stage, StageExt, UnwindInput, UnwindOutput,
 };
-use std::{any::Any, net::SocketAddr, sync::Arc, time::Instant};
+use std::{any::Any, net::SocketAddr, sync::Arc};
 use tokio::sync::watch;
 use tracing::*;
 

--- a/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
@@ -2,8 +2,9 @@
 
 use alloy_primitives::B256;
 use parking_lot::Mutex;
+use reth_primitives_traits::FastInstant as Instant;
 use reth_trie_sparse::{ConfigurableSparseTrie, SparseStateTrie};
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 use tracing::debug;
 
 /// Type alias for the sparse trie type used in preservation.

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -293,7 +293,7 @@ pub struct TransactionFetcherMetrics {
 #[macro_export]
 macro_rules! duration_metered_exec {
     ($code:expr, $acc:expr) => {{
-        let start = std::time::Instant::now();
+        let start = reth_primitives_traits::FastInstant::now();
 
         let res = $code;
 

--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -8,13 +8,13 @@ use reth_metrics::{
     metrics::{Counter, Histogram},
     Metrics,
 };
+use reth_primitives_traits::FastInstant as Instant;
 use std::{
     collections::HashMap,
     future::Future,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::Instant,
 };
 use tower::Layer;
 


### PR DESCRIPTION
Replace `std::time::Instant` with `quanta`-based `FastInstant` (TSC on x86) in metrics and timing code that was still using the slower `clock_gettime` syscall.

Files changed:
- `crates/rpc/rpc-builder/src/metrics.rs` — RPC call duration tracking
- `crates/net/network/src/metrics.rs` — `duration_metered_exec!` macro
- `crates/cli/commands/src/stage/run.rs` — stage run timing
- `crates/cli/commands/src/db/checksum/rocksdb.rs` — checksum timing
- `crates/cli/commands/src/download/manifest_cmd.rs` — download timing
- `crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs` — trie wait timing