### PR TITLE
fix(engine): refresh executed_blocks on InsertExecutedBlock

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1472,6 +1472,10 @@ where
                         }
 
                         self.state.tree_state.insert_executed(block.clone());
+                        self.metrics
+                            .engine
+                            .executed_blocks
+                            .set(self.state.tree_state.block_count() as f64);
                         self.payload_validator.on_inserted_executed_block(block.clone());
                         self.metrics.engine.inserted_already_executed_blocks.increment(1);
                         self.emit_event(EngineApiEvent::BeaconConsensus(

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -613,6 +613,32 @@ async fn test_engine_request_during_backfill() {
     assert!(resp.payload_status.is_syncing());
 }
 
+#[tokio::test]
+async fn test_insert_executed_block_updates_tree_state_and_emits_event() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    let block = test_harness
+        .block_builder
+        .get_executed_blocks(1..2)
+        .next()
+        .expect("expected one executed block");
+    let block_hash = block.recovered_block().hash();
+
+    let _ = test_harness
+        .tree
+        .on_engine_message(FromEngine::Request(EngineApiRequest::InsertExecutedBlock(block)))
+        .unwrap();
+
+    assert_eq!(test_harness.tree.state.tree_state.block_count(), 1);
+
+    let event = test_harness.from_tree_rx.recv().await.unwrap();
+    match event {
+        EngineApiEvent::BeaconConsensus(ConsensusEngineEvent::CanonicalBlockAdded(added, _)) => {
+            assert_eq!(added.recovered_block().hash(), block_hash);
+        }
+        _ => panic!("Unexpected event: {event:#?}"),
+    }
+}
+
 #[test]
 fn test_disconnected_payload() {
     let s = include_str!("../../test-data/holesky/2.rlp");

--- a/pr_body_insert_executed_block_gauge.md
+++ b/pr_body_insert_executed_block_gauge.md
@@ -1,0 +1,11 @@
+Fixes stale `consensus.engine.beacon.executed_blocks` reporting on the `InsertExecutedBlock` path.
+
+`EngineApiRequest::InsertExecutedBlock` inserts into `tree_state`, but previously did not refresh the `executed_blocks` gauge. This change updates the gauge immediately after insertion so observability stays aligned with in-memory state.
+
+Adds a focused tree test that exercises `InsertExecutedBlock` handling and verifies insertion plus emitted canonical-add event behavior.
+
+## How to test
+
+- `cargo test -p reth-engine-tree test_insert_executed_block_updates_tree_state_and_emits_event`
+- `cargo clippy -p reth-engine-tree --tests --no-deps -- -D warnings`
+- `cargo +nightly fmt --check`


### PR DESCRIPTION
Fixes stale `consensus.engine.beacon.executed_blocks` reporting on the `InsertExecutedBlock` path.

`EngineApiRequest::InsertExecutedBlock` inserts into `tree_state`, but previously did not refresh the `executed_blocks` gauge. This change updates the gauge immediately after insertion so observability stays aligned with in-memory state.

Adds a focused tree test that exercises `InsertExecutedBlock` handling and verifies insertion plus emitted canonical-add event behavior.

## How to test

- `cargo test -p reth-engine-tree test_insert_executed_block_updates_tree_state_and_emits_event`
- `cargo clippy -p reth-engine-tree --tests --no-deps -- -D warnings`
- `cargo +nightly fmt --check`
