### PR TITLE
fix(nat): resolve DNS for ExternalAddr in external_addr_with

### DIFF
--- a/crates/net/nat/src/lib.rs
+++ b/crates/net/nat/src/lib.rs
@@ -231,9 +231,13 @@ pub async fn external_addr_with(resolver: NatResolver) -> Option<IpAddr> {
                 );
             })
             .ok(),
-        NatResolver::ExternalAddr(domain) => {
-            domain.to_socket_addrs().ok().and_then(|mut addrs| addrs.next().map(|addr| addr.ip()))
-        }
+        NatResolver::ExternalAddr(domain) => tokio::net::lookup_host(format!("{domain}:0"))
+            .await
+            .inspect_err(|err| {
+                debug!(target: "net::nat", %err, %domain, "Failed to resolve external address");
+            })
+            .ok()
+            .and_then(|mut addrs| addrs.next().map(|addr| addr.ip())),
         NatResolver::None => None,
     }
 }


### PR DESCRIPTION
every bare domain fails with `invalid socket address`, and `.ok()` silently converts it to `None`. 
Reproduced locally — bare domains always fail while the same domain with `:port` resolves fine:

    === domain.to_socket_addrs() (no port) ===
      localhost   -> Err(invalid socket address)
      example.com -> Err(invalid socket address)

    === format!("{domain}:0").to_socket_addrs() ===
      localhost:0   -> Ok([::1, 127.0.0.1])
      example.com:0 -> Ok([104.18.26.120, 104.18.27.120])

    === Docker scenario: bare domain 'my-reth-node' ===
      'my-reth-node'.to_socket_addrs() -> Err -> .ok() = None (silent failure)