### PR TITLE
fix(net): prefer peer-reported block number in session activation

### DIFF
--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -155,9 +155,11 @@ impl<N: NetworkPrimitives> NetworkState<N> {
     ) {
         debug_assert!(!self.active_peers.contains_key(&peer), "Already connected; not possible");
 
-        // find the corresponding block number
-        let block_number =
-            self.client.block_number(status.blockhash).ok().flatten().unwrap_or_default();
+        // Use the block number from the peer's status (eth/69+) if available,
+        // otherwise fall back to a local lookup by hash.
+        let block_number = status.latest_block.unwrap_or_else(|| {
+            self.client.block_number(status.blockhash).ok().flatten().unwrap_or_default()
+        });
         self.state_fetcher.new_active_peer(
             peer,
             status.blockhash,


### PR DESCRIPTION
`on_session_activated` always does a local DB lookup for the peer's block number via `blockhash`, even when `UnifiedStatus.latest_block` already carries it from the wire. Worse, if the hash isn't in local chain, `unwrap_or_default()` silently drops it to 0 

uses `status.latest_block` directly when available (eth/69+), falls back to the hash lookup for older protocol versions. Related to eth/69 support work.
