### PR TITLE
fix(net): warn on persisted peers parse failure instead of silent fallback

### DIFF
--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -317,14 +317,23 @@ impl PeersConfig {
         tracing::info!(target: "net::peers", file = %file_path.as_ref().display(), "Loading saved peers");
 
         // Try the new format first, fall back to legacy Vec<NodeRecord>
-        let peers: Vec<PersistedPeerInfo> = serde_json::from_str(&raw)
-            .or_else(|_| {
-                let nodes: HashSet<NodeRecord> = serde_json::from_str(&raw)?;
-                Ok::<_, serde_json::Error>(
-                    nodes.into_iter().map(PersistedPeerInfo::from_node_record).collect(),
-                )
-            })
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let peers: Vec<PersistedPeerInfo> = match serde_json::from_str(&raw).or_else(|_| {
+            let nodes: HashSet<NodeRecord> = serde_json::from_str(&raw)?;
+            Ok::<_, serde_json::Error>(
+                nodes.into_iter().map(PersistedPeerInfo::from_node_record).collect(),
+            )
+        }) {
+            Ok(peers) => peers,
+            Err(err) => {
+                tracing::warn!(
+                    target: "net::peers",
+                    file = %file_path.as_ref().display(),
+                    %err,
+                    "Failed to parse persisted peers file, starting without persisted peers"
+                );
+                return Ok(self);
+            }
+        };
 
         tracing::info!(target: "net::peers", count = peers.len(), "Loaded persisted peers");
         self.persisted_peers = peers;


### PR DESCRIPTION
there's no log output at all when the persisted peers file is corrupted or has an unexpected format `with_basic_nodes_from_file` would return an error, but the caller in `peers_config_with_basic_nodes_from_file` silently swallows it with `unwrap_or_else` and falls back to default config. 

A node could cold-start without any of its saved peers and you'd have zero indication why connectivity dropped.

now the parse failure is caught inside `with_basic_nodes_from_file` itself, logs a warning with the file path and error, and gracefully returns without persisted peers. Same behavior as before, just no longer invisible.
