### PR TITLE
perf(trie): cache proof-v2 range bounds in next_uncached_key_range [autoopt]

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -928,7 +928,7 @@ where
 
         // If the trie cursor is seeked to a branch whose leaves have already been processed
         // then we can't use it, instead we seek forward and try again.
-        if trie_cursor_path < uncalculated_lower_bound {
+        if PathPrefixRelation::new(trie_cursor_path, uncalculated_lower_bound).is_before_prefix() {
             *trie_cursor_state =
                 TrieCursorState::seeked(self.trie_cursor_seek(*uncalculated_lower_bound)?);
 
@@ -962,7 +962,9 @@ where
         // If the next cached branch's path is all zeros then we can skip this catch-up step,
         // because there cannot be any keys prior to that range.
         let cached_path = &cached.0;
-        if uncalculated_lower_bound < cached_path && !cached_path.is_zeroes() {
+        if PathPrefixRelation::new(uncalculated_lower_bound, cached_path).is_before_prefix() &&
+            !cached_path.is_zeroes()
+        {
             let range = (*uncalculated_lower_bound, Some(*cached_path));
             trace!(target: TRACE_TARGET, ?range, "Returning key range to calculate in order to catch up to cached branch");
 
@@ -1078,6 +1080,11 @@ where
                 self.push_cached_branch(targets, cached_path, &cached_branch)?;
             }
 
+            let branch_path = self.branch_path;
+            let branch_path_len = branch_path.len();
+            let lower_bound_relation =
+                PathPrefixRelation::new(uncalculated_lower_bound_ref, &branch_path);
+
             // At this point the top of the branch stack is the same branch which was found in the
             // cache.
             let curr_branch =
@@ -1094,9 +1101,8 @@ where
             // indicate children that need recalculation from leaves (e.g. new keys inserted
             // under this branch). Skip nibbles already set in `curr_state_mask` since those
             // children have already been constructed.
-            if self.prefix_set.contains(&self.branch_path) {
-                let branch_path_len = self.branch_path.len();
-                let mut child_path = self.branch_path;
+            if self.prefix_set.contains(&branch_path) {
+                let mut child_path = branch_path;
                 for nibble in 0u8..16 {
                     if !curr_state_mask.is_bit_set(nibble) {
                         child_path.truncate(branch_path_len);
@@ -1114,35 +1120,33 @@ where
             // This can happen when `calculate_key_range` finds no keys for a child's range,
             // leaving the child's bit unset in `state_mask`. Without this, re-entering this
             // function would select the same child again.
-            if uncalculated_lower_bound_ref.starts_with(&self.branch_path) &&
-                uncalculated_lower_bound_ref.len() > self.branch_path.len()
-            {
-                let lower_nibble =
-                    uncalculated_lower_bound_ref.get_unchecked(self.branch_path.len());
-                // Clear all nibbles strictly below `lower_nibble` since they've been processed.
-                let already_processed_mask = TrieMask::new((1u16 << lower_nibble) - 1);
-                next_child_nibbles &= !already_processed_mask;
-                trace!(
-                    target: TRACE_TARGET,
-                    branch_path = ?self.branch_path,
-                    ?_orig_next_child_nibbles,
-                    ?already_processed_mask,
-                    ?next_child_nibbles,
-                    "Unset already processed key nibbles from next_child_nibbles",
-                );
-            } else if !uncalculated_lower_bound_ref.starts_with(&self.branch_path) &&
-                uncalculated_lower_bound_ref > &self.branch_path
-            {
-                // The lower bound has moved entirely past this branch (e.g. branch is 0x6 but
-                // lower is 0x7). All remaining children have been processed.
-                next_child_nibbles = TrieMask::default();
-                trace!(
-                    target: TRACE_TARGET,
-                    branch_path = ?self.branch_path,
-                    ?_orig_next_child_nibbles,
-                    ?next_child_nibbles,
-                    "Unset all nibbles from next_child_nibbles due to branch_path being outside this subtrie",
-                );
+            match lower_bound_relation {
+                PathPrefixRelation::WithinPrefix { next_nibble } => {
+                    // Clear all nibbles strictly below `next_nibble` since they've been processed.
+                    let already_processed_mask = TrieMask::new((1u16 << next_nibble) - 1);
+                    next_child_nibbles &= !already_processed_mask;
+                    trace!(
+                        target: TRACE_TARGET,
+                        branch_path = ?branch_path,
+                        ?_orig_next_child_nibbles,
+                        ?already_processed_mask,
+                        ?next_child_nibbles,
+                        "Unset already processed key nibbles from next_child_nibbles",
+                    );
+                }
+                PathPrefixRelation::AfterPrefix => {
+                    // The lower bound has moved entirely past this branch (e.g. branch is 0x6 but
+                    // lower is 0x7). All remaining children have been processed.
+                    next_child_nibbles = TrieMask::default();
+                    trace!(
+                        target: TRACE_TARGET,
+                        branch_path = ?branch_path,
+                        ?_orig_next_child_nibbles,
+                        ?next_child_nibbles,
+                        "Unset all nibbles from next_child_nibbles due to branch_path being outside this subtrie",
+                    );
+                }
+                PathPrefixRelation::BeforePrefix | PathPrefixRelation::AtPrefix => {}
             }
 
             // If there are no further children to construct for this branch then pop it off both
@@ -1178,7 +1182,7 @@ where
             // any dirty leaves between that path and this child, it indicates there may be leaves
             // which would split that extension node. In that case we return the range to process
             // the leaves.
-            if uncalculated_lower_bound_ref < &child_path &&
+            if lower_bound_relation.is_before_child(child_nibble) &&
                 self.prefix_set.contains_range(uncalculated_lower_bound_ref..&child_path)
             {
                 self.cached_branch_stack.push((cached_path, cached_branch));
@@ -1244,7 +1248,10 @@ where
 
             // All trie nodes prior to `child_path` will not be modified further, so we can seek the
             // trie cursor to the next cached node at-or-after `child_path`.
-            if trie_cursor_state.path().is_some_and(|path| path < &child_path) {
+            if trie_cursor_state
+                .path()
+                .is_some_and(|path| PathPrefixRelation::new(path, &child_path).is_before_prefix())
+            {
                 trace!(target: TRACE_TARGET, ?child_path, "Seeking trie cursor to child path");
                 *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(child_path)?);
             }
@@ -1728,6 +1735,57 @@ impl<'a> TargetsCursor<'a> {
     /// current.
     fn rev_iter(&self) -> impl Iterator<Item = &'a ProofV2Target> {
         self.targets[..self.i].iter().rev()
+    }
+}
+
+/// Caches how a path sits relative to a prefix so hot proof-v2 loops can avoid repeated full
+/// `Nibbles::cmp` calls for the same pair of paths.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PathPrefixRelation {
+    BeforePrefix,
+    AtPrefix,
+    WithinPrefix { next_nibble: u8 },
+    AfterPrefix,
+}
+
+impl PathPrefixRelation {
+    #[inline]
+    fn new(path: &Nibbles, prefix: &Nibbles) -> Self {
+        let prefix_len = prefix.len();
+        if path.starts_with(prefix) {
+            return if path.len() == prefix_len {
+                Self::AtPrefix
+            } else {
+                Self::WithinPrefix { next_nibble: path.get_unchecked(prefix_len) }
+            }
+        }
+
+        let common_prefix_len = path.common_prefix_length(prefix);
+        if common_prefix_len == path.len() {
+            debug_assert!(path.len() < prefix_len);
+            return Self::BeforePrefix
+        }
+
+        debug_assert!(common_prefix_len < prefix_len);
+        if path.get_unchecked(common_prefix_len) < prefix.get_unchecked(common_prefix_len) {
+            Self::BeforePrefix
+        } else {
+            Self::AfterPrefix
+        }
+    }
+
+    #[inline]
+    const fn is_before_prefix(self) -> bool {
+        matches!(self, Self::BeforePrefix)
+    }
+
+    #[inline]
+    const fn is_before_child(self, child_nibble: u8) -> bool {
+        match self {
+            Self::BeforePrefix | Self::AtPrefix => true,
+            Self::WithinPrefix { next_nibble } => next_nibble < child_nibble,
+            Self::AfterPrefix => false,
+        }
     }
 }
 


### PR DESCRIPTION
Branch: `auto-opt/20260330-proof-v2-range-bounds`

## Verdict: **NO_WIN**

**Micro bench:** -47.7% on `cargo bench -p reth-trie --bench proof_v2` (targeted function improvement does not translate to e2e throughput)

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/69bde3a5ccf0045acd1b5e701f1e285e06fc75b4) | [`auto-opt/20260330-proof-v2-range-bounds`](https://github.com/paradigmxyz/reth/commit/6edbe2215c8e50edcccdd470e66f8b901cb22c18) | Change |
|--------|------|--------|--------|
| Mean | 22.30ms | 22.32ms | +0.11% ⚪ (±0.37%) |
| StdDev | 14.41ms | 14.43ms | |
| P50 | 19.88ms | 19.84ms | -0.17% ⚪ (±1.40%) |
| P90 | 33.50ms | 33.74ms | +0.74% ⚪ (±2.36%) |
| P99 | 85.20ms | 86.28ms | +1.27% ⚪ (±4.07%) |
| Mgas/s | 1414.77 | 1412.06 | -0.19% ⚪ (±0.42%) |
| Wall Clock | 22.94s | 22.98s | +0.15% ⚪ (±0.38%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/69bde3a5ccf0045acd1b5e701f1e285e06fc75b4) | [`auto-opt/20260330-proof-v2-range-bounds`](https://github.com/paradigmxyz/reth/commit/6edbe2215c8e50edcccdd470e66f8b901cb22c18) |
|--------|------|--------|
| Mean | 62.83ms | 63.55ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 232.92ms | 235.09ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/69bde3a5ccf0045acd1b5e701f1e285e06fc75b4) | [`auto-opt/20260330-proof-v2-range-bounds`](https://github.com/paradigmxyz/reth/commit/6edbe2215c8e50edcccdd470e66f8b901cb22c18) |
|--------|------|--------|
| Mean | 0.15ms | 0.15ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.68ms | 0.69ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/69bde3a5ccf0045acd1b5e701f1e285e06fc75b4) | [`auto-opt/20260330-proof-v2-range-bounds`](https://github.com/paradigmxyz/reth/commit/6edbe2215c8e50edcccdd470e66f8b901cb22c18) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774876543000&to=1774876631000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23746438591&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23746438591)

<details>
<summary>Hypothesis</summary>

## Evidence
- Target crate/function: `crates/trie/trie/src/proof_v2/mod.rs`, especially `ProofCalculator::next_uncached_key_range`.
- Samply stacks filtered on `nybbles::nibbles::byte_len` and `Nibbles::cmp` land in `ProofCalculator::next_uncached_key_range` / `proof_subtrie` under `StorageProofWorker::process_storage_proof` on the `proof-strg-00` thread, which is direct evidence that path comparison and bound bookkeeping are hot in V2 storage proof generation.
- Across all runs, `new_payload_latency` averages only ~23.6-23.9ms but reaches ~100-111ms on the heaviest blocks while `sparse_trie_wait` is effectively zero, so CPU inside the proof calculation path matters more than waiting on the sparse trie lock.
- Reading the code shows `next_uncached_key_range` repeatedly compares `Nibbles` and re-derives lower/upper-bound relationships (`uncalculated_lower_bound < cached_path`, `starts_with`, repeated range construction) inside a tight loop that runs for every cached branch and sub-trie segment.
- There is already a focused benchmark in `crates/trie/trie/benches/proof_v2.rs` covering large `targets_512` and `targets_2048` storage-proof cases, so this hot loop is easy to validate locally.

## Hypothesis
If we cache compact comparable bounds or prefix-length metadata inside the V2 traversal and avoid repeated full-`Nibbles` compare/`byte_len` work in `next_uncached_key_range`, `cargo bench` improves by ~10-15% on large-target V2 storage proofs because the cursor loop does less per-range path bookkeeping.

## Success Metric
- `cargo bench -p reth-trie --bench proof_v2` shows >10% improvement in the V2 `dataset_10240/targets_512` and `dataset_10240/targets_2048` cases
- The benchmark shows no regression worse than 5% in the small-target V2 cases

## Plan
- Change `crates/trie/trie/src/proof_v2/mod.rs`, especially `next_uncached_key_range` and its nearby helpers, to retain precomputed range metadata instead of re-deriving it from `Nibbles` on every loop iteration.
- Keep the external proof API unchanged and confine the optimization to traversal internals plus, at most, one small helper struct in `proof_v2/mod.rs`.
- Reuse `crates/trie/trie/benches/proof_v2.rs` for validation; est. 60-120 lines.

</details>