### PR TITLE
perf(storage): precompute save-blocks history indices from execution reverts [autoopt]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9619,6 +9619,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "assert_matches",
+ "codspeed-criterion-compat",
  "eyre",
  "itertools 0.14.0",
  "metrics",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -81,9 +81,15 @@ revm-state.workspace = true
 
 tempfile.workspace = true
 assert_matches.workspace = true
+criterion.workspace = true
 rand.workspace = true
 
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
+
+[[bench]]
+name = "history_indices"
+required-features = ["test-utils"]
+harness = false
 
 [features]
 jemalloc = ["rocksdb/jemalloc"]

--- a/crates/storage/provider/benches/history_indices.rs
+++ b/crates/storage/provider/benches/history_indices.rs
@@ -1,0 +1,139 @@
+#![allow(missing_docs, unreachable_pub)]
+
+use alloy_consensus::Header;
+use alloy_primitives::{
+    map::{FbBuildHasher, HashMap},
+    Address, B256, U256,
+};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use reth_chain_state::{ComputedTrieData, ExecutedBlock};
+use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
+use reth_primitives_traits::{SealedBlock, SealedHeader};
+use reth_provider::{
+    test_utils::create_test_provider_factory, SaveBlocksMode, StorageSettings, StorageSettingsCache,
+};
+use revm_database::BundleState;
+use revm_state::AccountInfo;
+use std::sync::Arc;
+
+const NUM_BLOCKS: u64 = 24;
+const ACCOUNTS_PER_BLOCK: usize = 128;
+const SLOTS_PER_ACCOUNT: u64 = 8;
+
+fn build_bench_blocks() -> Vec<ExecutedBlock> {
+    let mut blocks = Vec::with_capacity(NUM_BLOCKS as usize);
+    let mut parent_hash = B256::ZERO;
+
+    for block_num in 1..=NUM_BLOCKS {
+        let mut builder = BundleState::builder(block_num..=block_num);
+
+        for acct_idx in 0..ACCOUNTS_PER_BLOCK {
+            let address = bench_address(block_num, acct_idx);
+            let info = AccountInfo {
+                nonce: block_num,
+                balance: U256::from(block_num * 1_000 + acct_idx as u64),
+                ..Default::default()
+            };
+
+            let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (0..SLOTS_PER_ACCOUNT)
+                .map(|slot| {
+                    let key = U256::from(slot + acct_idx as u64 * 1_000);
+                    (key, (U256::ZERO, U256::from(block_num * 10_000 + slot)))
+                })
+                .collect();
+
+            let revert_storage: Vec<(U256, U256)> = (0..SLOTS_PER_ACCOUNT)
+                .map(|slot| (U256::from(slot + acct_idx as u64 * 1_000), U256::ZERO))
+                .collect();
+
+            builder = builder
+                .state_present_account_info(address, info)
+                .revert_account_info(block_num, address, Some(None))
+                .state_storage(address, storage)
+                .revert_storage(block_num, address, revert_storage);
+        }
+
+        let bundle = builder.build();
+        let header = Header {
+            number: block_num,
+            parent_hash,
+            difficulty: U256::from(1),
+            ..Default::default()
+        };
+        let block =
+            SealedBlock::<reth_ethereum_primitives::Block>::seal_parts(header, Default::default());
+        parent_hash = block.hash();
+
+        blocks.push(ExecutedBlock::new(
+            Arc::new(block.try_recover().unwrap()),
+            Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: vec![],
+                    requests: Default::default(),
+                    gas_used: 0,
+                    blob_gas_used: 0,
+                },
+                state: bundle,
+            }),
+            ComputedTrieData::default(),
+        ));
+    }
+
+    blocks
+}
+
+fn bench_address(block_num: u64, acct_idx: usize) -> Address {
+    let mut bytes = [0u8; 20];
+    bytes[17] = (block_num & 0xff) as u8;
+    bytes[18] = ((acct_idx >> 8) & 0xff) as u8;
+    bytes[19] = (acct_idx & 0xff) as u8;
+    Address::from(bytes)
+}
+
+fn bench_save_blocks_history_indices(c: &mut Criterion) {
+    let blocks = build_bench_blocks();
+
+    c.bench_function("save_blocks_history_indices", |b| {
+        b.iter_batched(
+            || {
+                let factory = create_test_provider_factory();
+                factory.set_storage_settings_cache(StorageSettings::v1());
+
+                let genesis = SealedBlock::<reth_ethereum_primitives::Block>::from_sealed_parts(
+                    SealedHeader::new(
+                        Header { number: 0, difficulty: U256::from(1), ..Default::default() },
+                        B256::ZERO,
+                    ),
+                    Default::default(),
+                );
+
+                let genesis_executed = ExecutedBlock::new(
+                    Arc::new(genesis.try_recover().unwrap()),
+                    Arc::new(BlockExecutionOutput {
+                        result: BlockExecutionResult {
+                            receipts: vec![],
+                            requests: Default::default(),
+                            gas_used: 0,
+                            blob_gas_used: 0,
+                        },
+                        state: Default::default(),
+                    }),
+                    ComputedTrieData::default(),
+                );
+
+                let provider_rw = factory.provider_rw().unwrap();
+                provider_rw.save_blocks(vec![genesis_executed], SaveBlocksMode::Full).unwrap();
+                provider_rw.commit().unwrap();
+
+                (factory.provider_rw().unwrap(), blocks.clone())
+            },
+            |(provider_rw, blocks)| {
+                provider_rw.save_blocks(blocks, SaveBlocksMode::Full).unwrap();
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(history_indices, bench_save_blocks_history_indices);
+criterion_main!(history_indices);

--- a/crates/storage/provider/benches/history_indices.rs
+++ b/crates/storage/provider/benches/history_indices.rs
@@ -10,8 +10,10 @@ use reth_chain_state::{ComputedTrieData, ExecutedBlock};
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use reth_provider::{
-    test_utils::create_test_provider_factory, SaveBlocksMode, StorageSettings, StorageSettingsCache,
+    test_utils::create_test_provider_factory, OriginalValuesKnown, SaveBlocksMode,
+    StateWriteConfig, StateWriter, StorageSettings, StorageSettingsCache,
 };
+use reth_storage_api::WriteStateInput;
 use revm_database::BundleState;
 use revm_state::AccountInfo;
 use std::sync::Arc;
@@ -98,6 +100,7 @@ fn bench_save_blocks_history_indices(c: &mut Criterion) {
             || {
                 let factory = create_test_provider_factory();
                 factory.set_storage_settings_cache(StorageSettings::v1());
+                let blocks = blocks.clone();
 
                 let genesis = SealedBlock::<reth_ethereum_primitives::Block>::from_sealed_parts(
                     SealedHeader::new(
@@ -125,10 +128,30 @@ fn bench_save_blocks_history_indices(c: &mut Criterion) {
                 provider_rw.save_blocks(vec![genesis_executed], SaveBlocksMode::Full).unwrap();
                 provider_rw.commit().unwrap();
 
-                (factory.provider_rw().unwrap(), blocks.clone())
+                let provider_rw = factory.provider_rw().unwrap();
+                provider_rw.save_blocks(blocks.clone(), SaveBlocksMode::BlocksOnly).unwrap();
+
+                for block in &blocks {
+                    provider_rw
+                        .write_state(
+                            WriteStateInput::Single {
+                                outcome: block.execution_outcome(),
+                                block: block.recovered_block().number,
+                            },
+                            OriginalValuesKnown::No,
+                            StateWriteConfig {
+                                write_receipts: false,
+                                write_account_changesets: true,
+                                write_storage_changesets: true,
+                            },
+                        )
+                        .unwrap();
+                }
+
+                (provider_rw, blocks)
             },
             |(provider_rw, blocks)| {
-                provider_rw.save_blocks(blocks, SaveBlocksMode::Full).unwrap();
+                provider_rw.benchmark_history_indices(&blocks).unwrap();
             },
             BatchSize::LargeInput,
         );

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -595,7 +595,25 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             return Ok(())
         };
         let last_block_number = blocks.last().expect("checked above").recovered_block().number();
-        self.update_history_indices(first_number..=last_block_number)
+
+        let mut history_transitions = HistoryTransitions::default();
+        for block in blocks {
+            for (block_idx, block_reverts) in
+                block.execution_outcome().state.reverts.iter().enumerate()
+            {
+                let block_number = block.recovered_block().number() + block_idx as u64;
+                if !history_transitions
+                    .extend_from_block_reverts(block_number, block_reverts)
+                    .is_empty()
+                {
+                    // The benchmark harness writes state before calling this helper, so the old
+                    // changeset reread path remains the only correct option for storage wipes.
+                    return self.update_history_indices(first_number..=last_block_number)
+                }
+            }
+        }
+
+        self.write_history_indices_from_transitions(history_transitions)
     }
 
     fn extend_wiped_storage_history_transitions(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -584,6 +584,20 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         Ok(())
     }
 
+    /// Bench-only helper for measuring history-index generation in isolation.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn benchmark_history_indices(
+        &self,
+        blocks: &[ExecutedBlock<N::Primitives>],
+    ) -> ProviderResult<()> {
+        let Some(first_number) = blocks.first().map(|block| block.recovered_block().number())
+        else {
+            return Ok(())
+        };
+        let last_block_number = blocks.last().expect("checked above").recovered_block().number();
+        self.update_history_indices(first_number..=last_block_number)
+    }
+
     fn extend_wiped_storage_history_transitions(
         &self,
         block_number: BlockNumber,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -71,7 +71,8 @@ use reth_trie::{
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
 use revm_database::states::{
-    PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
+    reverts::AccountInfoRevert, AccountRevert, PlainStateReverts, PlainStorageChangeset,
+    PlainStorageRevert, StateChangeset,
 };
 use std::{
     cmp::Ordering,
@@ -212,6 +213,51 @@ pub struct DatabaseProvider<TX, N: NodeTypes> {
     minimum_pruning_distance: u64,
     /// Database provider metrics
     metrics: metrics::DatabaseProviderMetrics,
+}
+
+#[derive(Default)]
+struct HistoryTransitions {
+    accounts: BTreeMap<Address, Vec<BlockNumber>>,
+    storages: BTreeMap<(Address, B256), Vec<BlockNumber>>,
+}
+
+impl HistoryTransitions {
+    fn extend_from_block_reverts(
+        &mut self,
+        block_number: BlockNumber,
+        block_reverts: &[(Address, AccountRevert)],
+    ) -> BTreeMap<Address, BTreeSet<B256>> {
+        let mut wiped_storage = BTreeMap::default();
+
+        for (address, account_revert) in block_reverts {
+            if !matches!(account_revert.account, AccountInfoRevert::DoNothing) {
+                self.accounts.entry(*address).or_default().push(block_number);
+            }
+
+            let mut reverted_storage_keys = BTreeSet::new();
+            for storage_key in account_revert.storage.keys() {
+                let key = B256::from(storage_key.to_be_bytes());
+                self.storages.entry((*address, key)).or_default().push(block_number);
+                reverted_storage_keys.insert(key);
+            }
+
+            if account_revert.wipe_storage {
+                wiped_storage.insert(*address, reverted_storage_keys);
+            }
+        }
+
+        wiped_storage
+    }
+
+    fn extend_from_reverts(
+        &mut self,
+        first_block_number: BlockNumber,
+        block_reverts: &[Vec<(Address, AccountRevert)>],
+    ) {
+        for (block_idx, block_reverts) in block_reverts.iter().enumerate() {
+            self.extend_from_block_reverts(first_block_number + block_idx as u64, block_reverts);
+        }
+    }
 }
 
 impl<TX: Debug, N: NodeTypes> Debug for DatabaseProvider<TX, N> {
@@ -510,6 +556,70 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         }
     }
 
+    fn write_history_indices_from_transitions(
+        &self,
+        history_transitions: HistoryTransitions,
+    ) -> ProviderResult<()> {
+        let HistoryTransitions { accounts, storages } = history_transitions;
+        let storage_settings = self.cached_storage_settings();
+        if storage_settings.storage_v2 {
+            self.with_rocksdb_batch(|mut batch| {
+                for (address, blocks) in accounts {
+                    batch.append_account_history_shard(address, blocks)?;
+                }
+                Ok(((), Some(batch.into_inner())))
+            })?;
+
+            self.with_rocksdb_batch(|mut batch| {
+                for ((address, key), blocks) in storages {
+                    batch.append_storage_history_shard(address, key, blocks)?;
+                }
+                Ok(((), Some(batch.into_inner())))
+            })?;
+        } else {
+            self.insert_account_history_index(accounts)?;
+            self.insert_storage_history_index(storages)?;
+        }
+
+        Ok(())
+    }
+
+    fn extend_wiped_storage_history_transitions(
+        &self,
+        block_number: BlockNumber,
+        wiped_storage: BTreeMap<Address, BTreeSet<B256>>,
+        history_transitions: &mut HistoryTransitions,
+    ) -> ProviderResult<()> {
+        if wiped_storage.is_empty() {
+            return Ok(())
+        }
+
+        let mut plain_storage = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
+        for (address, mut reverted_storage_keys) in wiped_storage {
+            let Some((_, entry)) = plain_storage.seek_exact(address)? else { continue };
+
+            if reverted_storage_keys.insert(entry.key) {
+                history_transitions
+                    .storages
+                    .entry((address, entry.key))
+                    .or_default()
+                    .push(block_number);
+            }
+
+            while let Some(entry) = plain_storage.next_dup_val()? {
+                if reverted_storage_keys.insert(entry.key) {
+                    history_transitions
+                        .storages
+                        .entry((address, entry.key))
+                        .or_default()
+                        .push(block_number);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Writes executed blocks and state to storage.
     ///
     /// This method parallelizes static file (SF) writes with MDBX writes.
@@ -563,6 +673,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         let rocksdb_provider = self.rocksdb_provider.clone();
         let rocksdb_ctx = self.rocksdb_write_ctx(first_number);
         let rocksdb_enabled = rocksdb_ctx.storage_settings.storage_v2;
+        let precompute_history_indices = save_mode.with_state() && !rocksdb_enabled;
 
         let mut sf_result = None;
         let mut rocksdb_result = None;
@@ -634,6 +745,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 );
             }
 
+            let mut history_transitions =
+                precompute_history_indices.then(HistoryTransitions::default);
+
             for (i, block) in blocks.iter().enumerate() {
                 let recovered_block = block.recovered_block();
 
@@ -643,6 +757,23 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                 if save_mode.with_state() {
                     let execution_output = block.execution_outcome();
+
+                    if let Some(history_transitions) = history_transitions.as_mut() {
+                        // Reuse the execution reverts while the previous plain-state view is still
+                        // visible, avoiding a second changeset read after write_state().
+                        for (block_idx, block_reverts) in
+                            execution_output.state.reverts.iter().enumerate()
+                        {
+                            let block_number = recovered_block.number() + block_idx as u64;
+                            let wiped_storage = history_transitions
+                                .extend_from_block_reverts(block_number, block_reverts);
+                            self.extend_wiped_storage_history_transitions(
+                                block_number,
+                                wiped_storage,
+                                history_transitions,
+                            )?;
+                        }
+                    }
 
                     // Write state and changesets to the database.
                     // Must be written after blocks because of the receipt lookup.
@@ -689,7 +820,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Full mode: update history indices
             if save_mode.with_state() {
                 let start = Instant::now();
-                self.update_history_indices(first_number..=last_block_number)?;
+                if let Some(history_transitions) = history_transitions {
+                    self.write_history_indices_from_transitions(history_transitions)?;
+                } else {
+                    self.update_history_indices(first_number..=last_block_number)?;
+                }
                 timings.update_history_indices = start.elapsed();
             }
 
@@ -3374,16 +3509,17 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HistoryWriter for DatabaseProvi
 
     #[instrument(level = "debug", target = "providers::db", skip_all)]
     fn update_history_indices(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<()> {
-        let storage_settings = self.cached_storage_settings();
-        if !storage_settings.storage_v2 {
-            let indices = self.changed_accounts_and_blocks_with_range(range.clone())?;
-            self.insert_account_history_index(indices)?;
+        if self.cached_storage_settings().storage_v2 {
+            return Ok(())
         }
 
-        if !storage_settings.storage_v2 {
-            let indices = self.changed_storages_and_blocks_with_range(range)?;
-            self.insert_storage_history_index(indices)?;
-        }
+        let history_transitions = HistoryTransitions {
+            accounts: self.changed_accounts_and_blocks_with_range(range.clone())?,
+            storages: self.changed_storages_and_blocks_with_range(range)?,
+        };
+
+        self.insert_account_history_index(history_transitions.accounts)?;
+        self.insert_storage_history_index(history_transitions.storages)?;
 
         Ok(())
     }
@@ -3644,21 +3780,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
         // This is necessary because with edge storage, changesets are written to static files
         // whose index isn't updated until commit, making them invisible to subsequent reads
         // within the same transaction.
-        let (account_transitions, storage_transitions) = {
-            let mut account_transitions: BTreeMap<Address, Vec<u64>> = BTreeMap::new();
-            let mut storage_transitions: BTreeMap<(Address, B256), Vec<u64>> = BTreeMap::new();
-            for (block_idx, block_reverts) in execution_outcome.bundle.reverts.iter().enumerate() {
-                let block_number = first_number + block_idx as u64;
-                for (address, account_revert) in block_reverts {
-                    account_transitions.entry(*address).or_default().push(block_number);
-                    for storage_key in account_revert.storage.keys() {
-                        let key = B256::from(storage_key.to_be_bytes());
-                        storage_transitions.entry((*address, key)).or_default().push(block_number);
-                    }
-                }
-            }
-            (account_transitions, storage_transitions)
-        };
+        let mut history_transitions = HistoryTransitions::default();
+        history_transitions.extend_from_reverts(first_number, &execution_outcome.bundle.reverts);
 
         // Insert the blocks
         for block in blocks {
@@ -3675,29 +3798,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
 
         // Use pre-computed transitions for history indices since static file
         // writes aren't visible until commit.
-        // Note: For MDBX we use insert_*_history_index. For RocksDB we use
-        // append_*_history_shard which handles read-merge-write internally.
-        let storage_settings = self.cached_storage_settings();
-        if storage_settings.storage_v2 {
-            self.with_rocksdb_batch(|mut batch| {
-                for (address, blocks) in account_transitions {
-                    batch.append_account_history_shard(address, blocks)?;
-                }
-                Ok(((), Some(batch.into_inner())))
-            })?;
-        } else {
-            self.insert_account_history_index(account_transitions)?;
-        }
-        if storage_settings.storage_v2 {
-            self.with_rocksdb_batch(|mut batch| {
-                for ((address, key), blocks) in storage_transitions {
-                    batch.append_storage_history_shard(address, key, blocks)?;
-                }
-                Ok(((), Some(batch.into_inner())))
-            })?;
-        } else {
-            self.insert_storage_history_index(storage_transitions)?;
-        }
+        self.write_history_indices_from_transitions(history_transitions)?;
         durations_recorder.record_relative(metrics::Action::InsertHistoryIndices);
 
         // Update pipeline progress


### PR DESCRIPTION
Branch: `auto-opt/20260330-precompute-save-blocks-history`

## Verdict: **NO_WIN**

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-precompute-save-blocks-history`](https://github.com/paradigmxyz/reth/commit/c8c71f347e52fd441aa8b7ebf448e3879ad1d044) | Change |
|--------|------|--------|--------|
| Mean | 22.21ms | 22.21ms | +0.01% ⚪ (±0.35%) |
| StdDev | 14.41ms | 14.37ms | |
| P50 | 19.72ms | 19.61ms | -0.56% ⚪ (±1.46%) |
| P90 | 33.38ms | 33.38ms | -0.01% ⚪ (±2.27%) |
| P99 | 88.15ms | 87.50ms | -0.74% ⚪ (±1.72%) |
| Mgas/s | 1420.90 | 1419.66 | -0.09% ⚪ (±0.43%) |
| Wall Clock | 22.87s | 22.84s | -0.11% ⚪ (±0.35%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-precompute-save-blocks-history`](https://github.com/paradigmxyz/reth/commit/c8c71f347e52fd441aa8b7ebf448e3879ad1d044) |
|--------|------|--------|
| Mean | 63.66ms | 62.73ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 233.76ms | 233.89ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-precompute-save-blocks-history`](https://github.com/paradigmxyz/reth/commit/c8c71f347e52fd441aa8b7ebf448e3879ad1d044) |
|--------|------|--------|
| Mean | 0.15ms | 0.15ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.73ms | 0.71ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-precompute-save-blocks-history`](https://github.com/paradigmxyz/reth/commit/c8c71f347e52fd441aa8b7ebf448e3879ad1d044) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774887157000&to=1774887246000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23754787572&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23754787572)

<details>
<summary>Hypothesis</summary>

## Evidence
- `DatabaseProvider::save_blocks()` in `crates/storage/provider/src/providers/database/provider.rs` writes state, hashed state, and trie updates, then always calls `update_history_indices()` inline before the provider commit completes.
- For storage-v2, `update_history_indices()` reconstructs `(address -> blocks)` and `(address, slot -> blocks)` by rereading the just-written account/storage changesets through `account_block_changeset()` / `storage_changesets_range()`, building fresh `BTreeMap<_, Vec<u64>>` collections on the persistence path.
- The same file already contains a faster pattern in `append_blocks_with_state()`: it extracts account/storage transitions directly from `execution_outcome.bundle.reverts` before writing state because static-file writes are not visible until commit. `ExecutedBlock` already carries that execution output, so the data needed by `save_blocks()` is available without rereading changesets.
- The samply profile shows history/index style work in the same run: `reth_stages::stages::utils::collect_storage_history_indices`, `roaring::bitmap::push_unchecked`, `roaring::treemap::...::push_unchecked`, `HashMap::insert`, and `Vec::push_mut` all appear in the hot set. That is consistent with avoidable map/bitmap churn in history-index generation.

## Hypothesis
If we derive history index transitions directly from each `ExecutedBlock.execution_output.state.reverts` during `save_blocks()` and batch-insert them, `cargo bench` improves by ~20-30% on the history-index portion because we eliminate the second full pass over freshly written changesets and cut a large amount of `Map<Vec<u64>>`/bitmap churn.

## Success Metric
For micro:
- cargo bench shows >20% improvement in targeted benchmark
- Add or use a benchmark in `crates/storage/provider/benches/history_indices.rs` that compares current `save_blocks` history-index generation against a revert-derived path on synthetic multi-block, revert-heavy workloads

## Plan
- Extract the transition-building logic already used in `append_blocks_with_state()` into a helper that can consume a batch of `ExecutedBlock`s.
- Thread the precomputed account/storage transition maps through `save_blocks()` so `update_history_indices()` can skip rereading changesets when the data is already available.
- Keep backend behavior identical for MDBX vs RocksDB history storage by reusing the existing `insert_*_history_index` / `append_*_history_shard` writers.
- Touch `crates/storage/provider/src/providers/database/provider.rs` and add a focused bench under `crates/storage/provider/benches/`; estimated diff ~180-260 lines.

## Results

</details>