### PR TITLE
fix(engine): make persistence threshold relative to memory buffer target

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -87,13 +87,15 @@ pub fn has_enough_parallelism() -> bool {
 /// The configuration of the engine tree.
 #[derive(Debug, Clone)]
 pub struct TreeConfig {
-    /// Maximum number of blocks to be kept only in memory without triggering
-    /// persistence.
+    /// Number of blocks that must accumulate past the
+    /// [`memory_block_buffer_target`] before triggering persistence.
     persistence_threshold: u64,
-    /// How close to the canonical head we persist blocks. Represents the ideal
+    /// How close to the canonical head we persist blocks. Represents the
     /// number of most recent blocks to keep in memory for quick access and reorgs.
+    /// Blocks within this distance from the canonical head are never persisted.
     ///
-    /// Note: this should be less than or equal to `persistence_threshold`.
+    /// This can be set independently of `persistence_threshold` — any combination
+    /// of values is valid.
     memory_block_buffer_target: u64,
     /// Maximum canonical-minus-persisted gap before engine API processing is stalled.
     persistence_backpressure_threshold: u64,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2000,18 +2000,29 @@ where
         );
     }
 
-    /// Returns true if the canonical chain length minus the last persisted
-    /// block is greater than or equal to the persistence threshold and
-    /// backfill is not running.
+    /// Returns true if there are enough blocks ready to persist beyond the
+    /// [`memory_block_buffer_target`](TreeConfig::memory_block_buffer_target) and backfill is not
+    /// running.
+    ///
+    /// The number of blocks ready to persist is the gap between the persist target
+    /// (`canonical_head - memory_block_buffer_target`) and the last persisted block. Persistence
+    /// triggers when this gap exceeds
+    /// [`persistence_threshold`](TreeConfig::persistence_threshold).
     pub const fn should_persist(&self) -> bool {
         if !self.backfill_sync_state.is_idle() {
             // can't persist if backfill is running
             return false
         }
 
-        let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
-            self.config.persistence_threshold()
+        let last_persisted = self.persistence_state.last_persisted_block.number;
+        let canonical_head = self.state.tree_state.canonical_block_number();
+
+        // The persist target is how far back from the head we persist, respecting the
+        // memory buffer. Blocks between the target and the head stay in memory.
+        let persist_target =
+            canonical_head.saturating_sub(self.config.memory_block_buffer_target());
+
+        persist_target.saturating_sub(last_persisted) > self.config.persistence_threshold()
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range


### PR DESCRIPTION
The `should_persist()` check compared `canonical_head - last_persisted` against `persistence_threshold`. With a non-zero `memory_block_buffer_target`, the total unpersisted count always exceeded the threshold once the buffer filled, causing 1-block-at-a-time persistence every engine loop iteration.

Now the threshold is measured against the persist target (`canonical_head - memory_block_buffer_target - last_persisted > persistence_threshold`), so it correctly controls batching regardless of buffer size.

Also removes the stale constraint that `memory_block_buffer_target` must be `<= persistence_threshold` — any combination of values now works correctly.