### PR TITLE
perf(engine): move pruning out of the persistence reply path [autoopt]

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -60,6 +60,12 @@ where
     /// Pending safe block number to be committed with the next block save.
     /// This avoids triggering a separate fsync for each safe block update.
     pending_safe_block: Option<u64>,
+    /// Highest persisted tip that still needs a pruning pass.
+    ///
+    /// Save results are sent as soon as their durability commit lands. Pruning then runs only once
+    /// the action queue goes idle, and this watermark is clamped on reorgs so deferred pruning
+    /// never runs ahead of persisted history.
+    pending_prune_tip: Option<u64>,
 }
 
 impl<N> PersistenceService<N>
@@ -81,6 +87,7 @@ where
             sync_metrics_tx,
             pending_finalized_block: None,
             pending_safe_block: None,
+            pending_prune_tip: None,
         }
     }
 }
@@ -92,37 +99,86 @@ where
     /// This is the main loop, that will listen to database events and perform the requested
     /// database actions
     pub fn run(mut self) -> Result<(), PersistenceError> {
-        // If the receiver errors then senders have disconnected, so the loop should then end.
-        while let Ok(action) = self.incoming.recv() {
-            match action {
-                PersistenceAction::RemoveBlocksAbove(new_tip_num, sender) => {
-                    let last_block = self.on_remove_blocks_above(new_tip_num)?;
-                    // send new sync metrics based on removed blocks
+        loop {
+            let action = match self.incoming.recv() {
+                Ok(action) => action,
+                Err(_) => {
+                    self.run_pending_prune()?;
+                    return Ok(())
+                }
+            };
+
+            self.on_action(action)?;
+
+            while let Ok(action) = self.incoming.try_recv() {
+                self.on_action(action)?;
+            }
+
+            self.run_pending_prune()?;
+        }
+    }
+
+    fn on_action(
+        &mut self,
+        action: PersistenceAction<N::Primitives>,
+    ) -> Result<(), PersistenceError> {
+        match action {
+            PersistenceAction::RemoveBlocksAbove(new_tip_num, sender) => {
+                let last_block = self.on_remove_blocks_above(new_tip_num)?;
+                self.pending_prune_tip = self.pending_prune_tip.map(|tip| tip.min(new_tip_num));
+
+                // send new sync metrics based on removed blocks
+                let _ = self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
+                let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
+            }
+            PersistenceAction::SaveBlocks(blocks, sender) => {
+                let result = self.on_save_blocks(blocks)?;
+                let result_number = result.last_block.map(|b| b.number);
+
+                let _ = sender.send(result);
+
+                if let Some(block_number) = result_number {
+                    // send new sync metrics based on saved blocks
                     let _ =
-                        self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
-                    let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
-                }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
-                    let result_number = result.last_block.map(|b| b.number);
-
-                    let _ = sender.send(result);
-
-                    if let Some(block_number) = result_number {
-                        // send new sync metrics based on saved blocks
-                        let _ = self
-                            .sync_metrics_tx
-                            .send(MetricEvent::SyncHeight { height: block_number });
-                    }
-                }
-                PersistenceAction::SaveFinalizedBlock(finalized_block) => {
-                    self.pending_finalized_block = Some(finalized_block);
-                }
-                PersistenceAction::SaveSafeBlock(safe_block) => {
-                    self.pending_safe_block = Some(safe_block);
+                        self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: block_number });
                 }
             }
+            PersistenceAction::SaveFinalizedBlock(finalized_block) => {
+                self.pending_finalized_block = Some(finalized_block);
+            }
+            PersistenceAction::SaveSafeBlock(safe_block) => {
+                self.pending_safe_block = Some(safe_block);
+            }
         }
+
+        Ok(())
+    }
+
+    fn run_pending_prune(&mut self) -> Result<(), PersistenceError> {
+        let Some(tip_block_number) = self.pending_prune_tip.take() else { return Ok(()) };
+
+        if !self.pruner.is_pruning_needed(tip_block_number) {
+            return Ok(())
+        }
+
+        debug!(
+            target: "engine::persistence",
+            tip = tip_block_number,
+            "Running deferred pruner after durability reply"
+        );
+
+        let prune_start = Instant::now();
+        let provider_rw = self.provider.database_provider_rw()?;
+        let _ = self.pruner.run_with_provider(&provider_rw, tip_block_number)?;
+        provider_rw.commit()?;
+
+        debug!(
+            target: "engine::persistence",
+            tip = tip_block_number,
+            "Finished deferred pruning"
+        );
+        self.metrics.prune_before_duration_seconds.record(prune_start.elapsed());
+
         Ok(())
     }
 
@@ -180,20 +236,8 @@ where
             provider_rw.commit()?;
             debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");
 
-            // Run the pruner in a separate provider so it reads committed RocksDB state
-            // that includes the history entries written by save_blocks above.
-            //
-            // The pruner reads the indices from rocksdb, filters it, and writes to indices, so it
-            // must be able to read anything written by save_blocks.
-            if self.pruner.is_pruning_needed(last.number) {
-                debug!(target: "engine::persistence", block_num=?last.number, "Running pruner");
-                let prune_start = Instant::now();
-                let provider_rw = self.provider.database_provider_rw()?;
-                let _ = self.pruner.run_with_provider(&provider_rw, last.number)?;
-                provider_rw.commit()?;
-                debug!(target: "engine::persistence", tip=?last.number, "Finished pruning after saving blocks");
-                self.metrics.prune_before_duration_seconds.record(prune_start.elapsed());
-            }
+            self.pending_prune_tip =
+                Some(self.pending_prune_tip.map_or(last.number, |tip| tip.max(last.number)));
         }
 
         let elapsed = start_time.elapsed();
@@ -378,8 +422,42 @@ mod tests {
     use reth_chain_state::test_utils::TestBlockBuilder;
     use reth_exex_types::FinishedExExHeight;
     use reth_provider::test_utils::create_test_provider_factory;
-    use reth_prune::Pruner;
+    use reth_prune::{
+        segments::{PruneInput, Segment},
+        Pruner,
+    };
+    use reth_prune_types::{PruneMode, PrunePurpose, PruneSegment, SegmentOutput};
     use tokio::sync::mpsc::unbounded_channel;
+
+    #[derive(Debug)]
+    struct BlockingSegment {
+        started: crossbeam_channel::Sender<()>,
+        release: crossbeam_channel::Receiver<()>,
+    }
+
+    impl<Provider> Segment<Provider> for BlockingSegment {
+        fn segment(&self) -> PruneSegment {
+            PruneSegment::TransactionLookup
+        }
+
+        fn mode(&self) -> Option<PruneMode> {
+            Some(PruneMode::Full)
+        }
+
+        fn purpose(&self) -> PrunePurpose {
+            PrunePurpose::User
+        }
+
+        fn prune(
+            &self,
+            _provider: &Provider,
+            _input: PruneInput,
+        ) -> Result<SegmentOutput, PrunerError> {
+            let _ = self.started.send(());
+            let _ = self.release.recv();
+            Ok(SegmentOutput::done())
+        }
+    }
 
     fn default_persistence_handle() -> PersistenceHandle<EthPrimitives> {
         let provider = create_test_provider_factory();
@@ -460,6 +538,50 @@ mod tests {
             let result = rx.recv().unwrap();
             assert_eq!(last_hash, result.last_block.unwrap().hash);
         }
+    }
+
+    #[test]
+    fn test_save_blocks_replies_before_deferred_prune_finishes() {
+        reth_tracing::init_test_tracing();
+
+        let provider = create_test_provider_factory();
+        let (_finished_exex_height_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let (prune_started_tx, prune_started_rx) = crossbeam_channel::bounded(1);
+        let (release_prune_tx, release_prune_rx) = crossbeam_channel::bounded(1);
+
+        let pruner = Pruner::new_with_factory(
+            provider.clone(),
+            vec![Box::new(BlockingSegment {
+                started: prune_started_tx,
+                release: release_prune_rx,
+            })],
+            1,
+            1,
+            None,
+            finished_exex_height_rx,
+        );
+
+        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+        let handle =
+            PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx);
+
+        let mut test_block_builder = TestBlockBuilder::eth();
+        let blocks = test_block_builder.get_executed_blocks(0..2).collect::<Vec<_>>();
+        let last_hash = blocks.last().unwrap().recovered_block().hash();
+        let (tx, rx) = crossbeam_channel::bounded(1);
+
+        handle.save_blocks(blocks, tx).unwrap();
+
+        let result = rx.recv_timeout(Duration::from_secs(10)).expect("save result should arrive");
+        assert_eq!(last_hash, result.last_block.unwrap().hash);
+
+        prune_started_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("deferred prune should start after the reply is sent");
+
+        release_prune_tx.send(()).unwrap();
+        drop(handle);
     }
 
     /// Verifies that committing `save_blocks` history before running the pruner


### PR DESCRIPTION
Branch: `auto-opt/20260330-async-pruner-after-save`

## Verdict: **REGRESSION**

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-async-pruner-after-save`](https://github.com/paradigmxyz/reth/commit/751edbeedf47f9c7969ada9f50a049941a3defc1) | Change |
|--------|------|--------|--------|
| Mean | 21.52ms | 21.77ms | +1.19% ❌ (±0.47%) |
| StdDev | 14.75ms | 14.79ms | |
| P50 | 18.53ms | 18.97ms | +2.39% ❌ (±1.62%) |
| P90 | 33.40ms | 33.32ms | -0.24% ⚪ (±3.67%) |
| P99 | 87.59ms | 89.14ms | +1.77% ⚪ (±3.33%) |
| Mgas/s | 1491.35 | 1467.84 | -1.58% ❌ (±0.52%) |
| Wall Clock | 22.19s | 22.45s | +1.19% ❌ (±0.47%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-async-pruner-after-save`](https://github.com/paradigmxyz/reth/commit/751edbeedf47f9c7969ada9f50a049941a3defc1) |
|--------|------|--------|
| Mean | 59.66ms | 49.59ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 221.13ms | 181.44ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-async-pruner-after-save`](https://github.com/paradigmxyz/reth/commit/751edbeedf47f9c7969ada9f50a049941a3defc1) |
|--------|------|--------|
| Mean | 0.10ms | 0.10ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.53ms | 0.56ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/930f2a6eb257854138bb9e291c7013586fcd0223) | [`auto-opt/20260330-async-pruner-after-save`](https://github.com/paradigmxyz/reth/commit/751edbeedf47f9c7969ada9f50a049941a3defc1) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774889573000&to=1774889655000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23756219875&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23756219875)

<details>
<summary>Hypothesis</summary>

## Evidence
- `baseline-1` and `baseline-2` `combined_latency.csv` show that `persistence_wait` is the only material wait bucket: mean ~64.5ms, p95 ~238ms, max ~290ms, and it appears on 166/500 blocks as isolated single-block spikes. Its correlation with `gas_used` is effectively zero (~-0.02), so the spikes look like a periodic background tail rather than per-gas execution work.
- `TreeConfig` defaults to `persistence_threshold=2` and `memory_block_buffer_target=0`, and `EngineApiTreeHandler::should_persist()` / `get_canonical_blocks_to_persist()` flush the full buffered canonical window once the tip is more than two blocks ahead of disk. In this run the log shows a steady stream of 3-block persistence batches.
- `PersistenceService::on_save_blocks()` in `crates/engine/tree/src/persistence.rs` does `provider_rw.save_blocks(...); provider_rw.commit();` and then, when pruning is needed, opens a second provider, runs `pruner.run_with_provider(...)`, commits again, and only then returns the persistence result to the tree.
- Parsed timestamps from `baseline-1/reth.log` show 200 `save_blocks` batches averaging ~173ms total, while the inline pruner adds another ~56ms on average when it runs (100 pruner runs across those 200 batches). That extra tail is currently part of the `wait_for_persistence` critical path even though the blocks are already durable.

## Hypothesis
If we decouple pruning from the persistence reply path and let `reth_newPayload(wait_for_persistence)` wait only for durability, gas_per_second improves by ~1.5-3% because the dominant persistence spikes no longer include the extra 40-70ms prune tail on already hot batches.

## Success Metric
For macro:
- gas_per_second (mgas_s.pct in summary.json) improves by >1.5%
- mgas_s.sig should be "good" (statistically significant at 95% CI)

## Plan
- Change `crates/engine/tree/src/persistence.rs` so `on_save_blocks()` only performs block durability and records a prune watermark instead of running `pruner.run_with_provider()` inline.
- Add a small background prune action/state machine in `crates/engine/tree/src/persistence.rs` plus any required tracking in `crates/engine/tree/src/tree/persistence_state.rs` or metrics so pruning can lag behind durability safely.
- Keep the current crash-safety boundary: `save_blocks` must still commit before the save result is sent, and prune checkpoints/watermarks must make restart recovery deterministic.
- Verify that finalization/safe-block updates and pruning never outrun persisted history; estimated diff ~150-250 lines.

## Results

</details>