### PR TITLE
refactor(rpc): use reth-core rpc-convert for trait definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,7 +3440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4253,8 +4253,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4806,7 +4806,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5159,7 +5159,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7567,7 +7567,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
- "reth-rpc-convert",
+ "reth-rpc-convert 1.11.3",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tasks",
@@ -9286,7 +9286,7 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives-traits",
  "reth-prune-types",
- "reth-rpc-convert",
+ "reth-rpc-convert 1.11.3",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-stages-types",
@@ -9745,7 +9745,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
- "reth-rpc-convert",
+ "reth-rpc-convert 1.11.3",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
@@ -9878,6 +9878,19 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
+version = "0.1.0"
+source = "git+https://github.com/theochap/reth-core?branch=feat%2Frpc-convert-traits#04dfb9aabdb4f382336f20a2738807221909c886"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-rpc-convert"
 version = "1.11.3"
 dependencies = [
  "alloy-consensus",
@@ -9894,6 +9907,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "reth-evm",
  "reth-primitives-traits",
+ "reth-rpc-convert 0.1.0",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -9984,7 +9998,7 @@ dependencies = [
  "reth-node-api",
  "reth-primitives-traits",
  "reth-revm",
- "reth-rpc-convert",
+ "reth-rpc-convert 1.11.3",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-storage-api",
@@ -10027,7 +10041,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
- "reth-rpc-convert",
+ "reth-rpc-convert 1.11.3",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
@@ -11012,7 +11026,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11860,7 +11874,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13164,7 +13178,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,6 +412,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
+reth-rpc-convert-traits = { package = "reth-rpc-convert", git = "https://github.com/theochap/reth-core", branch = "feat/rpc-convert-traits", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -14,12 +14,13 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives-traits.workspace = true
+reth-rpc-convert-traits.workspace = true
 reth-evm.workspace = true
 
 # ethereum
 alloy-primitives.workspace = true
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
-alloy-signer.workspace = true
+alloy-signer = { workspace = true, optional = true }
 alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-json-rpc.workspace = true
@@ -46,6 +47,7 @@ default = []
 op = [
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",
+    "dep:alloy-signer",
     "reth-evm/op",
     "alloy-evm/op",
 ]

--- a/crates/rpc/rpc-convert/src/lib.rs
+++ b/crates/rpc/rpc-convert/src/lib.rs
@@ -15,7 +15,8 @@ pub mod transaction;
 
 pub use rpc::*;
 pub use transaction::{
-    RpcConvert, RpcConverter, TransactionConversionError, TryIntoSimTx, TxInfoMapper,
+    FromConsensusTx, IntoRpcTx, RpcConvert, RpcConverter, TransactionConversionError, TryIntoSimTx,
+    TxInfoMapper,
 };
 
 pub use alloy_evm::rpc::{CallFees, CallFeesError, EthTxEnvError, TryIntoTxEnv};

--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -1,12 +1,10 @@
-use std::{fmt::Debug, future::Future};
+use std::fmt::Debug;
 
-use alloy_consensus::{EthereumTxEnvelope, SignableTransaction, TxEip4844};
 use alloy_json_rpc::RpcObject;
-use alloy_network::{
-    primitives::HeaderResponse, Network, ReceiptResponse, TransactionResponse, TxSigner,
-};
-use alloy_primitives::Signature;
+use alloy_network::{primitives::HeaderResponse, Network, ReceiptResponse, TransactionResponse};
 use alloy_rpc_types_eth::TransactionRequest;
+
+pub use reth_rpc_convert_traits::{SignTxRequestError, SignableTxRequest};
 
 /// RPC types used by the `eth_` RPC API.
 ///
@@ -47,47 +45,16 @@ pub type RpcBlock<T> = alloy_rpc_types_eth::Block<RpcTransaction<T>, RpcHeader<T
 /// Adapter for network specific transaction request.
 pub type RpcTxReq<T> = <T as RpcTypes>::TransactionRequest;
 
-/// Error for [`SignableTxRequest`] trait.
-#[derive(Debug, thiserror::Error)]
-pub enum SignTxRequestError {
-    /// The transaction request is invalid.
-    #[error("invalid transaction request")]
-    InvalidTransactionRequest,
-
-    /// The signer is not supported.
-    #[error(transparent)]
-    SignerNotSupported(#[from] alloy_signer::Error),
-}
-
-/// An abstraction over transaction requests that can be signed.
-pub trait SignableTxRequest<T>: Send + Sync + 'static {
-    /// Attempts to build a transaction request and sign it with the given signer.
-    fn try_build_and_sign(
-        self,
-        signer: impl TxSigner<Signature> + Send,
-    ) -> impl Future<Output = Result<T, SignTxRequestError>> + Send;
-}
-
-impl SignableTxRequest<EthereumTxEnvelope<TxEip4844>> for TransactionRequest {
-    async fn try_build_and_sign(
-        self,
-        signer: impl TxSigner<Signature> + Send,
-    ) -> Result<EthereumTxEnvelope<TxEip4844>, SignTxRequestError> {
-        let mut tx =
-            self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
-        let signature = signer.sign_transaction(&mut tx).await?;
-        Ok(tx.into_signed(signature).into())
-    }
-}
-
 #[cfg(feature = "op")]
 impl SignableTxRequest<op_alloy_consensus::OpTxEnvelope>
     for op_alloy_rpc_types::OpTransactionRequest
 {
     async fn try_build_and_sign(
         self,
-        signer: impl TxSigner<Signature> + Send,
+        signer: impl alloy_network::TxSigner<alloy_primitives::Signature> + Send,
     ) -> Result<op_alloy_consensus::OpTxEnvelope, SignTxRequestError> {
+        use alloy_consensus::SignableTransaction;
+
         let mut tx =
             self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
 

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -1,12 +1,12 @@
 //! Compatibility functions for rpc `Transaction` type.
+pub use reth_rpc_convert_traits::{FromConsensusTx, IntoRpcTx, TryIntoSimTx};
+
 use crate::{
     RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes, SignableTxRequest, TryIntoTxEnv,
 };
-use alloy_consensus::{
-    error::ValueError, transaction::Recovered, EthereumTxEnvelope, Sealable, TxEip4844,
-};
+use alloy_consensus::{error::ValueError, transaction::Recovered, Sealable};
 use alloy_primitives::{Address, U256};
-use alloy_rpc_types_eth::{request::TransactionRequest, Transaction, TransactionInfo};
+use alloy_rpc_types_eth::TransactionInfo;
 use core::error;
 use dyn_clone::DynClone;
 use reth_evm::{BlockEnvFor, ConfigureEvm, EvmEnvFor, SpecFor, TxEnvFor};
@@ -188,81 +188,6 @@ dyn_clone::clone_trait_object!(
     RpcConvert<Primitives = Primitives, Network = Network, Error = Error, Evm = Evm>
 );
 
-/// Converts `self` into `T`. The opposite of [`FromConsensusTx`].
-///
-/// Should create an RPC transaction response object based on a consensus transaction, its signer
-/// [`Address`] and an additional context [`IntoRpcTx::TxInfo`].
-///
-/// Avoid implementing [`IntoRpcTx`] and use [`FromConsensusTx`] instead. Implementing it
-/// automatically provides an implementation of [`IntoRpcTx`] thanks to the blanket implementation
-/// in this crate.
-///
-/// Prefer using [`IntoRpcTx`] over [`FromConsensusTx`] when specifying trait bounds on a generic
-/// function to ensure that types that only implement [`IntoRpcTx`] can be used as well.
-pub trait IntoRpcTx<T> {
-    /// An additional context, usually [`TransactionInfo`] in a wrapper that carries some
-    /// implementation specific extra information.
-    type TxInfo;
-    /// An associated RPC conversion error.
-    type Err: error::Error;
-
-    /// Performs the conversion consuming `self` with `signer` and `tx_info`. See [`IntoRpcTx`]
-    /// for details.
-    fn into_rpc_tx(self, signer: Address, tx_info: Self::TxInfo) -> Result<T, Self::Err>;
-}
-
-/// Converts `T` into `self`. It is reciprocal of [`IntoRpcTx`].
-///
-/// Should create an RPC transaction response object based on a consensus transaction, its signer
-/// [`Address`] and an additional context [`FromConsensusTx::TxInfo`].
-///
-/// Prefer implementing [`FromConsensusTx`] over [`IntoRpcTx`] because it automatically provides an
-/// implementation of [`IntoRpcTx`] thanks to the blanket implementation in this crate.
-///
-/// Prefer using [`IntoRpcTx`] over using [`FromConsensusTx`] when specifying trait bounds on a
-/// generic function. This way, types that directly implement [`IntoRpcTx`] can be used as arguments
-/// as well.
-pub trait FromConsensusTx<T>: Sized {
-    /// An additional context, usually [`TransactionInfo`] in a wrapper that carries some
-    /// implementation specific extra information.
-    type TxInfo;
-    /// An associated RPC conversion error.
-    type Err: error::Error;
-
-    /// Performs the conversion consuming `tx` with `signer` and `tx_info`. See [`FromConsensusTx`]
-    /// for details.
-    fn from_consensus_tx(tx: T, signer: Address, tx_info: Self::TxInfo) -> Result<Self, Self::Err>;
-}
-
-impl<TxIn: alloy_consensus::Transaction, T: alloy_consensus::Transaction + From<TxIn>>
-    FromConsensusTx<TxIn> for Transaction<T>
-{
-    type TxInfo = TransactionInfo;
-    type Err = Infallible;
-
-    fn from_consensus_tx(
-        tx: TxIn,
-        signer: Address,
-        tx_info: Self::TxInfo,
-    ) -> Result<Self, Self::Err> {
-        Ok(Self::from_transaction(Recovered::new_unchecked(tx.into(), signer), tx_info))
-    }
-}
-
-impl<ConsensusTx, RpcTx> IntoRpcTx<RpcTx> for ConsensusTx
-where
-    ConsensusTx: alloy_consensus::Transaction,
-    RpcTx: FromConsensusTx<Self>,
-    <RpcTx as FromConsensusTx<ConsensusTx>>::Err: Debug,
-{
-    type TxInfo = RpcTx::TxInfo;
-    type Err = <RpcTx as FromConsensusTx<ConsensusTx>>::Err;
-
-    fn into_rpc_tx(self, signer: Address, tx_info: Self::TxInfo) -> Result<RpcTx, Self::Err> {
-        RpcTx::from_consensus_tx(self, signer, tx_info)
-    }
-}
-
 /// Converts `Tx` into `RpcTx`
 ///
 /// Where:
@@ -366,23 +291,6 @@ where
     }
 }
 
-/// Converts `self` into `T`.
-///
-/// Should create a fake transaction for simulation using [`TransactionRequest`].
-pub trait TryIntoSimTx<T>
-where
-    Self: Sized,
-{
-    /// Performs the conversion.
-    ///
-    /// Should return a signed typed transaction envelope for the [`eth_simulateV1`] endpoint with a
-    /// dummy signature or an error if [required fields] are missing.
-    ///
-    /// [`eth_simulateV1`]: <https://github.com/ethereum/execution-apis/pull/484>
-    /// [required fields]: TransactionRequest::buildable_type
-    fn try_into_sim_tx(self) -> Result<T, ValueError<Self>>;
-}
-
 /// Adds extra context to [`TransactionInfo`].
 pub trait TxInfoMapper<T> {
     /// An associated output type that carries [`TransactionInfo`] with some extra context.
@@ -400,12 +308,6 @@ impl<T> TxInfoMapper<T> for () {
 
     fn try_map(&self, _tx: &T, tx_info: TransactionInfo) -> Result<Self::Out, Self::Err> {
         Ok(tx_info)
-    }
-}
-
-impl TryIntoSimTx<EthereumTxEnvelope<TxEip4844>> for TransactionRequest {
-    fn try_into_sim_tx(self) -> Result<EthereumTxEnvelope<TxEip4844>, ValueError<Self>> {
-        Self::build_typed_simulate_transaction(self)
     }
 }
 


### PR DESCRIPTION
## Summary

Depends on paradigmxyz/reth-core#7

- Moves `SignableTxRequest`, `FromConsensusTx`, `IntoRpcTx`, and `TryIntoSimTx` trait definitions (and their Ethereum impls) to reth-core's new `reth-rpc-convert` crate
- Re-exports them from reth's `reth-rpc-convert` to preserve the public API
- OP-specific impls remain in reth
- Makes `alloy-signer` optional (only needed for `op` feature)

## Test plan
- [x] `cargo check -p reth-rpc-convert` passes
- [x] `cargo check -p reth-rpc` passes (downstream consumer)
- [x] `cargo check -p reth-rpc-eth-api` passes (downstream consumer)
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)