### PR TITLE
perf(provider): avoid full receipt clone on tx-range reads

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -21,7 +21,7 @@ use reth_trie::{
     updates::TrieUpdatesSorted, HashedPostStateSorted, LazyTrieData, SortedTrieData,
     TrieInputSorted,
 };
-use std::{collections::BTreeMap, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc, time::Instant};
 use tokio::sync::{broadcast, watch};
 
 /// Size of the broadcast channel used to notify canonical state events.
@@ -671,6 +671,16 @@ impl<N: NodePrimitives> BlockState<N> {
     /// the state.
     pub fn executed_block_receipts_ref(&self) -> &[N::Receipt] {
         self.receipts()
+    }
+
+    /// Returns receipts in the given range for the executed block.
+    ///
+    /// This avoids cloning all block receipts when only a sub-range is needed.
+    pub fn executed_block_receipts_in_range(
+        &self,
+        range: RangeInclusive<usize>,
+    ) -> Vec<N::Receipt> {
+        self.executed_block_receipts_ref()[range].to_vec()
     }
 
     /// Returns an iterator over __parent__ `BlockStates`.

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1098,9 +1098,7 @@ impl<N: ProviderNodeTypes> ReceiptProvider for ConsistentProvider<N> {
         self.get_in_memory_or_storage_by_tx_range(
             range,
             |db_provider, db_range| db_provider.receipts_by_tx_range(db_range),
-            |index_range, block_state| {
-                Ok(block_state.executed_block_receipts().drain(index_range).collect())
-            },
+            |index_range, block_state| Ok(block_state.executed_block_receipts_in_range(index_range)),
         )
     }
 


### PR DESCRIPTION
Clone only the requested in-memory receipt subrange for tx-range queries.