### PR TITLE
perf(provider): make static-file changeset counts O(files)

### DIFF
--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -227,6 +227,21 @@ impl ChangesetOffsetReader {
     pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
+
+    /// Returns the total number of changeset entries across all blocks in this sidecar.
+    ///
+    /// This is O(1) — it reads only the last record and computes `offset + num_changes`,
+    /// rather than scanning every record.
+    pub fn total_changes(&mut self) -> io::Result<u64> {
+        if self.len == 0 {
+            return Ok(0);
+        }
+
+        match self.get(self.len - 1)? {
+            Some(last) => Ok(last.offset() + last.num_changes()),
+            None => Err(io::Error::new(io::ErrorKind::UnexpectedEof, "missing last csoff record")),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -433,5 +448,52 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_total_changes_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+        std::fs::File::create(&path).unwrap();
+
+        let mut reader = ChangesetOffsetReader::new(&path, 0).unwrap();
+        assert_eq!(reader.total_changes().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_total_changes_multiple_records() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+
+        {
+            let mut writer = ChangesetOffsetWriter::new(&path, 0).unwrap();
+            writer.append(&ChangesetOffset::new(0, 5)).unwrap();
+            writer.append(&ChangesetOffset::new(5, 3)).unwrap();
+            writer.append(&ChangesetOffset::new(8, 10)).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let mut reader = ChangesetOffsetReader::new(&path, 3).unwrap();
+        // total = last.offset (8) + last.num_changes (10) = 18
+        assert_eq!(reader.total_changes().unwrap(), 18);
+    }
+
+    #[test]
+    fn test_total_changes_respects_committed_len() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+
+        {
+            let mut writer = ChangesetOffsetWriter::new(&path, 0).unwrap();
+            writer.append(&ChangesetOffset::new(0, 5)).unwrap();
+            writer.append(&ChangesetOffset::new(5, 3)).unwrap();
+            writer.append(&ChangesetOffset::new(8, 10)).unwrap();
+            writer.sync().unwrap();
+        }
+
+        // Only 2 records committed — should ignore the third
+        let mut reader = ChangesetOffsetReader::new(&path, 2).unwrap();
+        // total = record[1].offset (5) + record[1].num_changes (3) = 8
+        assert_eq!(reader.total_changes().unwrap(), 8);
     }
 }

--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -234,10 +234,13 @@ impl ChangesetOffsetReader {
             return Ok(0);
         }
 
-        match self.get(self.len - 1)? {
-            Some(last) => Ok(last.offset() + last.num_changes()),
-            None => Err(io::Error::new(io::ErrorKind::UnexpectedEof, "missing last csoff record")),
-        }
+        let last = self.get(self.len - 1)?.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::UnexpectedEof, "missing last csoff record")
+        })?;
+
+        last.offset().checked_add(last.num_changes()).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "csoff total_changes overflow")
+        })
     }
 }
 
@@ -455,6 +458,38 @@ mod tests {
 
         let mut reader = ChangesetOffsetReader::new(&path, 0).unwrap();
         assert_eq!(reader.total_changes().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_total_changes_single_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+
+        {
+            let mut writer = ChangesetOffsetWriter::new(&path, 0).unwrap();
+            writer.append(&ChangesetOffset::new(0, 7)).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let mut reader = ChangesetOffsetReader::new(&path, 1).unwrap();
+        assert_eq!(reader.total_changes().unwrap(), 7);
+    }
+
+    #[test]
+    fn test_total_changes_last_block_zero_changes() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+
+        {
+            let mut writer = ChangesetOffsetWriter::new(&path, 0).unwrap();
+            writer.append(&ChangesetOffset::new(0, 5)).unwrap();
+            writer.append(&ChangesetOffset::new(5, 0)).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let mut reader = ChangesetOffsetReader::new(&path, 2).unwrap();
+        // last record is (offset=5, num_changes=0), total = 5
+        assert_eq!(reader.total_changes().unwrap(), 5);
     }
 
     #[test]

--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -478,6 +478,27 @@ mod tests {
     }
 
     #[test]
+    fn test_total_changes_reads_only_last_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.csoff");
+        let len = 1_024u64;
+        let last = ChangesetOffset::new(65_535, 7);
+
+        {
+            let mut file = std::fs::File::create(&path).unwrap();
+            // Leave the earlier records as sparse holes so only the last record contains data.
+            file.seek(SeekFrom::Start((len - 1) * ChangesetOffsetReader::RECORD_SIZE as u64))
+                .unwrap();
+            file.write_all(&last.offset().to_le_bytes()).unwrap();
+            file.write_all(&last.num_changes().to_le_bytes()).unwrap();
+            file.sync_all().unwrap();
+        }
+
+        let mut reader = ChangesetOffsetReader::new(&path, len).unwrap();
+        assert_eq!(reader.total_changes().unwrap(), last.offset() + last.num_changes());
+    }
+
+    #[test]
     fn test_total_changes_respects_committed_len() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.csoff");

--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -228,9 +228,7 @@ impl ChangesetOffsetReader {
         self.len == 0
     }
 
-    /// Returns the total number of changeset entries across all blocks in this sidecar.
-    ///
-    /// O(1): reads the last record and returns `offset + num_changes`.
+    /// Returns the total number of changeset entries by reading the last sidecar record.
     pub fn total_changes(&mut self) -> io::Result<u64> {
         if self.len == 0 {
             return Ok(0);

--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -230,8 +230,7 @@ impl ChangesetOffsetReader {
 
     /// Returns the total number of changeset entries across all blocks in this sidecar.
     ///
-    /// This is O(1) — it reads only the last record and computes `offset + num_changes`,
-    /// rather than scanning every record.
+    /// O(1): reads the last record and returns `offset + num_changes`.
     pub fn total_changes(&mut self) -> io::Result<u64> {
         if self.len == 0 {
             return Ok(0);

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2514,10 +2514,7 @@ impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
                     let len = header.changeset_offsets_len();
                     let mut reader = ChangesetOffsetReader::new(&csoff_path, len)
                         .map_err(ProviderError::other)?;
-                    let offsets = reader.get_range(0, len).map_err(ProviderError::other)?;
-                    for offset in offsets {
-                        count += offset.num_changes() as usize;
-                    }
+                    count += reader.total_changes().map_err(ProviderError::other)? as usize;
                 }
             }
         }
@@ -2640,10 +2637,7 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
                     let len = header.changeset_offsets_len();
                     let mut reader = ChangesetOffsetReader::new(&csoff_path, len)
                         .map_err(ProviderError::other)?;
-                    let offsets = reader.get_range(0, len).map_err(ProviderError::other)?;
-                    for offset in offsets {
-                        count += offset.num_changes() as usize;
-                    }
+                    count += reader.total_changes().map_err(ProviderError::other)? as usize;
                 }
             }
         }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2501,25 +2501,7 @@ impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
     }
 
     fn account_changeset_count(&self) -> ProviderResult<usize> {
-        let mut count = 0;
-
-        let static_files = iter_static_files(&self.path).map_err(ProviderError::other)?;
-        if let Some(changeset_segments) = static_files.get(StaticFileSegment::AccountChangeSets) {
-            for (block_range, header) in changeset_segments {
-                let csoff_path = self
-                    .path
-                    .join(StaticFileSegment::AccountChangeSets.filename(block_range))
-                    .with_extension("csoff");
-                if csoff_path.exists() {
-                    let len = header.changeset_offsets_len();
-                    let mut reader = ChangesetOffsetReader::new(&csoff_path, len)
-                        .map_err(ProviderError::other)?;
-                    count += reader.total_changes().map_err(ProviderError::other)? as usize;
-                }
-            }
-        }
-
-        Ok(count)
+        self.changeset_count_for_segment(StaticFileSegment::AccountChangeSets)
     }
 }
 
@@ -2624,29 +2606,38 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
     }
 
     fn storage_changeset_count(&self) -> ProviderResult<usize> {
-        let mut count = 0;
-
-        let static_files = iter_static_files(&self.path).map_err(ProviderError::other)?;
-        if let Some(changeset_segments) = static_files.get(StaticFileSegment::StorageChangeSets) {
-            for (block_range, header) in changeset_segments {
-                let csoff_path = self
-                    .path
-                    .join(StaticFileSegment::StorageChangeSets.filename(block_range))
-                    .with_extension("csoff");
-                if csoff_path.exists() {
-                    let len = header.changeset_offsets_len();
-                    let mut reader = ChangesetOffsetReader::new(&csoff_path, len)
-                        .map_err(ProviderError::other)?;
-                    count += reader.total_changes().map_err(ProviderError::other)? as usize;
-                }
-            }
-        }
-
-        Ok(count)
+        self.changeset_count_for_segment(StaticFileSegment::StorageChangeSets)
     }
 }
 
 impl<N: NodePrimitives> StaticFileProvider<N> {
+    fn changeset_count_for_segment(&self, segment: StaticFileSegment) -> ProviderResult<usize> {
+        let Some(block_ranges) = self.expected_block_index(segment) else {
+            return Ok(0);
+        };
+
+        let mut count = 0;
+        for block_range in block_ranges.into_values() {
+            let provider =
+                self.get_segment_provider_for_block(segment, block_range.start(), None)?;
+            let len = provider.user_header().changeset_offsets_len();
+            if len == 0 {
+                continue;
+            }
+
+            let csoff_path = provider.data_path().with_extension("csoff");
+            if !csoff_path.exists() {
+                continue;
+            }
+
+            let mut reader =
+                ChangesetOffsetReader::new(&csoff_path, len).map_err(ProviderError::other)?;
+            count += reader.total_changes().map_err(ProviderError::other)? as usize;
+        }
+
+        Ok(count)
+    }
+
     /// Creates an iterator for walking through account changesets in the specified block range.
     ///
     /// This returns a lazy iterator that fetches changesets block by block to avoid loading

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2612,7 +2612,12 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
 
 impl<N: NodePrimitives> StaticFileProvider<N> {
     fn changeset_count_for_segment(&self, segment: StaticFileSegment) -> ProviderResult<usize> {
-        let Some(block_ranges) = self.expected_block_index(segment) else {
+        let Some(block_ranges) = self
+            .indexes
+            .read()
+            .get(segment)
+            .map(|index| index.expected_block_ranges_by_max_block.clone())
+        else {
             return Ok(0);
         };
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -761,6 +761,69 @@ mod tests {
     }
 
     #[test]
+    fn test_account_changeset_count_across_files() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let blocks_per_file = 2;
+        let start_block = 10u64;
+        let counts = [1u64, 3, 2, 4, 1];
+        let end_block = start_block + counts.len() as u64 - 1;
+
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(blocks_per_file)
+                    .build()
+                    .unwrap();
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+
+            for block_number in 0..=end_block {
+                let count = if block_number >= start_block {
+                    counts[(block_number - start_block) as usize]
+                } else {
+                    0
+                };
+                let changeset = (0..count)
+                    .map(|i| {
+                        let mut address = Address::ZERO;
+                        address.0[0] = block_number as u8;
+                        address.0[1] = i as u8;
+
+                        AccountBeforeTx {
+                            address,
+                            info: Some(Account {
+                                nonce: block_number,
+                                balance: U256::from((block_number * 100) + i),
+                                bytecode_hash: None,
+                            }),
+                        }
+                    })
+                    .collect();
+
+                writer.append_account_changeset(changeset, block_number).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        let sf_rw: StaticFileProvider<EthPrimitives> =
+            StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(blocks_per_file)
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            sf_rw.expected_block_index(StaticFileSegment::AccountChangeSets).unwrap().len(),
+            8
+        );
+        let expected_total = sf_rw
+            .walk_account_changeset_range(0..=end_block)
+            .collect::<ProviderResult<Vec<_>>>()
+            .unwrap()
+            .len();
+        assert_eq!(sf_rw.account_changeset_count().unwrap(), expected_total);
+    }
+
+    #[test]
     fn test_get_account_before_block() {
         let (static_dir, _) = create_test_static_files_dir();
 
@@ -1104,6 +1167,66 @@ mod tests {
                 assert_eq!(offset.num_changes(), 5, "Block {} should have 5 changes", i);
             }
         }
+    }
+
+    #[test]
+    fn test_storage_changeset_count_across_files() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let blocks_per_file = 2;
+        let start_block = 10u64;
+        let counts = [2u64, 1, 4, 3, 2];
+        let end_block = start_block + counts.len() as u64 - 1;
+
+        {
+            let sf_rw: StaticFileProvider<EthPrimitives> =
+                StaticFileProviderBuilder::read_write(&static_dir)
+                    .with_blocks_per_file(blocks_per_file)
+                    .build()
+                    .unwrap();
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::StorageChangeSets).unwrap();
+
+            for block_number in 0..=end_block {
+                let count = if block_number >= start_block {
+                    counts[(block_number - start_block) as usize]
+                } else {
+                    0
+                };
+                let changeset = (0..count)
+                    .map(|i| {
+                        let mut address = Address::ZERO;
+                        address.0[0] = block_number as u8;
+                        address.0[1] = i as u8;
+
+                        StorageBeforeTx {
+                            address,
+                            key: B256::with_last_byte(i as u8),
+                            value: U256::from((block_number * 100) + i),
+                        }
+                    })
+                    .collect();
+
+                writer.append_storage_changeset(changeset, block_number).unwrap();
+            }
+
+            writer.commit().unwrap();
+        }
+
+        let sf_rw: StaticFileProvider<EthPrimitives> =
+            StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(blocks_per_file)
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            sf_rw.expected_block_index(StaticFileSegment::StorageChangeSets).unwrap().len(),
+            8
+        );
+        let expected_total = sf_rw
+            .walk_storage_changeset_range(0..=end_block)
+            .collect::<ProviderResult<Vec<_>>>()
+            .unwrap()
+            .len();
+        assert_eq!(sf_rw.storage_changeset_count().unwrap(), expected_total);
     }
 
     #[test]


### PR DESCRIPTION
Closes RETH-694

`changeset_count()` scans every `.csoff` record to compute a progress-bar denominator for the history indexing stages.

- At block 10.7M, that's ~10.7M 16-byte reads per call, taking ~9s
- Both account and storage counts run every pipeline cycle → ~20s total
- This is longer than the batch being processed, so after a restart the pipeline can never catch up

Since `.csoff` records are cumulative `[offset, num_changes]`, the total is just `last.offset + last.num_changes`.

- Reads one record per file instead of all records
- O(files) instead of O(blocks) → 22 reads instead of 10.7M

Before: 502ms (2.2M blocks), ~9s (10.7M blocks)
After:  0.2ms (2.2M blocks), ~0.3ms (10.7M blocks)

Repro and timings: https://gist.github.com/yongkangc/06d1da54a32b4a1818c9432483fef7a6