### PR TITLE
perf(trie): sort sparse-trie leaf batches by raw key before unpacking nibble paths [autoopt]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10544,6 +10544,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "auto_impl",
+ "codspeed-criterion-compat",
  "itertools 0.14.0",
  "metrics",
  "pretty_assertions",

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -46,6 +46,7 @@ reth-tracing.workspace = true
 
 arbitrary.workspace = true
 assert_matches.workspace = true
+criterion.workspace = true
 itertools.workspace = true
 pretty_assertions.workspace = true
 proptest-arbitrary-interop.workspace = true
@@ -88,3 +89,7 @@ arbitrary = [
     "reth-trie-common/arbitrary",
     "smallvec/arbitrary",
 ]
+
+[[bench]]
+name = "update_leaves"
+harness = false

--- a/crates/trie/sparse/benches/update_leaves.rs
+++ b/crates/trie/sparse/benches/update_leaves.rs
@@ -1,0 +1,132 @@
+#![allow(missing_docs, unreachable_pub)]
+
+use alloy_primitives::{keccak256, map::B256Map, B256};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use reth_trie_sparse::{ArenaParallelSparseTrie, LeafUpdate, SparseTrie};
+use std::time::Duration;
+
+const ACCOUNT_BATCH_SIZE: usize = 4_096;
+const STORAGE_BATCH_SIZE: usize = 4_096;
+const ACCOUNT_VALUE_LEN: usize = 96;
+const STORAGE_VALUE_LEN: usize = 32;
+const STORAGE_PREFIX: u8 = 0x42;
+
+#[derive(Clone)]
+struct UpdateLeavesBenchCase {
+    trie: ArenaParallelSparseTrie,
+    updates: B256Map<LeafUpdate>,
+}
+
+fn update_leaves_large_account_batch(c: &mut Criterion) {
+    let case = build_case(*b"acct", ACCOUNT_BATCH_SIZE, ACCOUNT_VALUE_LEN, None);
+    c.bench_function("update_leaves_large_account_batch", |b| {
+        b.iter_batched(
+            || case.clone(),
+            |mut case| {
+                case.trie
+                    .update_leaves(&mut case.updates, |_, _| {
+                        panic!("benchmarked account updates should not require proofs")
+                    })
+                    .expect("account update_leaves should succeed");
+                black_box(case.trie);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn update_leaves_large_storage_batch(c: &mut Criterion) {
+    // Keep every update under a single upper-trie child so the benchmark stresses the large
+    // single-subtrie batch shape that makes prefix scanning and per-entry path unpacking hot.
+    let case = build_case(*b"stor", STORAGE_BATCH_SIZE, STORAGE_VALUE_LEN, Some(STORAGE_PREFIX));
+    c.bench_function("update_leaves_large_storage_batch", |b| {
+        b.iter_batched(
+            || case.clone(),
+            |mut case| {
+                case.trie
+                    .update_leaves(&mut case.updates, |_, _| {
+                        panic!("benchmarked storage updates should not require proofs")
+                    })
+                    .expect("storage update_leaves should succeed");
+                black_box(case.trie);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn build_case(
+    domain: [u8; 4],
+    batch_size: usize,
+    value_len: usize,
+    fixed_first_byte: Option<u8>,
+) -> UpdateLeavesBenchCase {
+    let keys: Vec<_> =
+        (0..batch_size).map(|idx| make_key(&domain, idx as u64, fixed_first_byte)).collect();
+
+    let mut trie = ArenaParallelSparseTrie::default();
+    let mut bootstrap_updates: B256Map<_> = keys
+        .iter()
+        .enumerate()
+        .map(|(idx, key)| {
+            (*key, LeafUpdate::Changed(make_value(&domain, idx as u64, value_len, 0)))
+        })
+        .collect();
+    trie.update_leaves(&mut bootstrap_updates, |_, _| {
+        panic!("benchmark bootstrap should not require proofs")
+    })
+    .expect("benchmark bootstrap update_leaves should succeed");
+    debug_assert!(bootstrap_updates.is_empty());
+
+    let updates = keys
+        .iter()
+        .enumerate()
+        .map(|(idx, key)| {
+            (*key, LeafUpdate::Changed(make_value(&domain, idx as u64, value_len, 1)))
+        })
+        .collect();
+
+    UpdateLeavesBenchCase { trie, updates }
+}
+
+fn make_key(domain: &[u8; 4], idx: u64, fixed_first_byte: Option<u8>) -> B256 {
+    let mut seed = [0u8; 16];
+    seed[..4].copy_from_slice(domain);
+    seed[8..].copy_from_slice(&idx.to_be_bytes());
+
+    let mut key = keccak256(seed);
+    if let Some(first_byte) = fixed_first_byte {
+        key.0[0] = first_byte;
+    }
+    key
+}
+
+fn make_value(domain: &[u8; 4], idx: u64, len: usize, version: u8) -> Vec<u8> {
+    let mut value = Vec::with_capacity(len);
+    let mut chunk = 0u8;
+
+    while value.len() < len {
+        let mut seed = [0u8; 16];
+        seed[..4].copy_from_slice(domain);
+        seed[4..12].copy_from_slice(&idx.to_be_bytes());
+        seed[12] = version;
+        seed[13] = chunk;
+
+        let hash = keccak256(seed);
+        let remaining = len - value.len();
+        value.extend_from_slice(&hash[..remaining.min(hash.len())]);
+        chunk = chunk.wrapping_add(1);
+    }
+
+    value
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    targets = update_leaves_large_account_batch, update_leaves_large_storage_batch
+}
+criterion_main!(benches);

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -60,6 +60,20 @@ fn prefix_range(
     begin..end
 }
 
+/// Returns `true` if the fixed-width raw key begins with the given nibble prefix.
+///
+/// Sparse trie leaf keys are always 32-byte hashes, so lexicographic `B256` order matches the
+/// fully unpacked nibble-path order. This lets the hot `update_leaves` path sort and group raw
+/// keys first, and only materialize [`Nibbles`] when a walker actually consumes an item.
+fn key_starts_with_prefix(key: B256, prefix: &Nibbles) -> bool {
+    let key = key.as_slice();
+    prefix.iter().enumerate().all(|(idx, nibble)| {
+        let byte = key[idx / 2];
+        let key_nibble = if idx % 2 == 0 { byte >> 4 } else { byte & 0x0f };
+        key_nibble == nibble
+    })
+}
+
 /// Returns the per-slot byte size used by `SlotMap<_, T>`. `SlotMap` wraps each value in a
 /// `Slot<T>` containing the value union + a 4-byte version field, with struct alignment.
 const fn slotmap_slot_size<T>() -> usize {
@@ -337,7 +351,9 @@ impl ArenaSparseSubtrie {
     /// Applies leaf updates within this subtrie. Uses the same walk-down-with-cursor pattern as
     /// [`Self::reveal_nodes`], but checks accessibility for [`LeafUpdate::Touched`] entries.
     ///
-    /// `sorted_updates` must be sorted lexicographically by their nibbles path (index 1).
+    /// `sorted_updates` must be sorted lexicographically by their raw `B256` key.
+    /// Because trie leaf keys are always 32 bytes wide, this is equivalent to full nibble-path
+    /// ordering while letting the caller defer `Nibbles::unpack` until the update is consumed.
     ///
     /// Any required proofs are appended to `self.required_proofs` and should be drained by the
     /// caller after this method returns.
@@ -350,7 +366,7 @@ impl ArenaSparseSubtrie {
             num_updates = sorted_updates.len(),
         ),
     )]
-    fn update_leaves(&mut self, sorted_updates: &[(B256, Nibbles, LeafUpdate)]) {
+    fn update_leaves(&mut self, sorted_updates: &[(B256, LeafUpdate)]) {
         if sorted_updates.is_empty() {
             return;
         }
@@ -363,8 +379,9 @@ impl ArenaSparseSubtrie {
 
         self.buffers.cursor.reset(&self.arena, self.root, self.path);
 
-        for (idx, &(key, ref full_path, ref update)) in sorted_updates.iter().enumerate() {
-            let find_result = self.buffers.cursor.seek(&mut self.arena, full_path);
+        for (idx, &(key, ref update)) in sorted_updates.iter().enumerate() {
+            let full_path = Nibbles::unpack(key);
+            let find_result = self.buffers.cursor.seek(&mut self.arena, &full_path);
 
             // If the path hits a blinded node, request a proof regardless of update type.
             if matches!(find_result, SeekResult::Blinded) {
@@ -383,7 +400,7 @@ impl ArenaSparseSubtrie {
                         &mut self.arena,
                         &mut self.buffers.cursor,
                         &mut self.root,
-                        full_path,
+                        &full_path,
                         value,
                         find_result,
                     );
@@ -397,7 +414,7 @@ impl ArenaSparseSubtrie {
                         &mut self.buffers.cursor,
                         &mut self.root,
                         key,
-                        full_path,
+                        &full_path,
                         find_result,
                         &mut self.buffers.updates,
                     );
@@ -1780,11 +1797,11 @@ impl ArenaParallelSparseTrie {
     fn check_subtrie_collapse_needs_proof(
         arena: &NodeArena,
         cursor: &ArenaCursor,
-        subtrie_updates: &[(B256, Nibbles, LeafUpdate)],
+        subtrie_updates: &[(B256, LeafUpdate)],
     ) -> Option<ArenaRequiredProof> {
         let num_removals = subtrie_updates
             .iter()
-            .filter(|(_, _, u)| matches!(u, LeafUpdate::Changed(v) if v.is_empty()))
+            .filter(|(_, u)| matches!(u, LeafUpdate::Changed(v) if v.is_empty()))
             .count() as u64;
 
         // Touched is a no-op that doesn't alter trie structure, so it must be
@@ -1795,7 +1812,7 @@ impl ArenaParallelSparseTrie {
         // request for the blinded sibling, and later panic in
         // `maybe_collapse_or_remove_branch` when the subtrie empties inline.
         let num_changed =
-            subtrie_updates.iter().filter(|(_, _, u)| matches!(u, LeafUpdate::Changed(_))).count()
+            subtrie_updates.iter().filter(|(_, u)| matches!(u, LeafUpdate::Changed(_))).count()
                 as u64;
 
         if num_removals == 0 || num_removals != num_changed {
@@ -2821,10 +2838,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
         #[cfg(feature = "trie-debug")]
         let mut recorded_proof_targets: Vec<(B256, u8)> = Vec::new();
 
-        // Drain and sort updates lexicographically by nibbles path.
-        let mut sorted: Vec<_> =
-            updates.drain().map(|(key, update)| (key, Nibbles::unpack(key), update)).collect();
-        sorted.sort_unstable_by_key(|entry| entry.1);
+        // Sort the raw fixed-width keys. For 32-byte trie keys, lexicographic `B256` order is
+        // the same as the unpacked nibble-path order, so we can defer `Nibbles::unpack` until a
+        // walker actually consumes an entry.
+        let mut sorted: Vec<_> = updates.drain().collect();
+        sorted.sort_unstable_by_key(|entry| entry.0);
 
         let threshold = self.parallelism_thresholds.min_updates;
 
@@ -2836,9 +2854,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
         let mut update_idx = 0;
         while update_idx < sorted.len() {
-            let (key, ref full_path, ref update) = sorted[update_idx];
+            let (key, ref update) = sorted[update_idx];
+            let full_path = Nibbles::unpack(key);
 
-            let find_result = cursor.seek(&mut self.upper_arena, full_path);
+            let find_result = cursor.seek(&mut self.upper_arena, &full_path);
 
             match find_result {
                 // Blinded — request a proof regardless of update type.
@@ -2859,7 +2878,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
                     let subtrie_start = update_idx;
                     while update_idx < sorted.len() &&
-                        sorted[update_idx].1.starts_with(&subtrie_root_path)
+                        key_starts_with_prefix(sorted[update_idx].0, &subtrie_root_path)
                     {
                         update_idx += 1;
                     }
@@ -2878,7 +2897,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         proof_required_fn(proof.key, proof.min_len);
                         #[cfg(feature = "trie-debug")]
                         recorded_proof_targets.push((proof.key, proof.min_len));
-                        for &(key, _, ref update) in subtrie_updates {
+                        for &(key, ref update) in subtrie_updates {
                             updates.insert(key, update.clone());
                         }
                         // Pop the subtrie entry before continuing.
@@ -2895,8 +2914,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         // Filter out Touched, as they don't affect the structure of the trie. So an
                         // update set with 2 removals and one Touched could still result in an empty
                         // sub trie.
-                        .filter(|(_, _, u)| matches!(u, LeafUpdate::Changed(_)))
-                        .all(|(_, _, u)| matches!(u, LeafUpdate::Changed(v) if v.is_empty()));
+                        .filter(|(_, u)| matches!(u, LeafUpdate::Changed(_)))
+                        .all(|(_, u)| matches!(u, LeafUpdate::Changed(v) if v.is_empty()));
                     let subtrie_num_leaves = match &self.upper_arena[child_idx] {
                         ArenaSparseNode::Subtrie(s) => s.num_leaves,
                         _ => 0,
@@ -2928,7 +2947,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             proof_required_fn(proof.key, proof.min_len);
                             #[cfg(feature = "trie-debug")]
                             recorded_proof_targets.push((proof.key, proof.min_len));
-                            let (key, _, ref update) = subtrie_updates[target_idx];
+                            let (key, ref update) = subtrie_updates[target_idx];
                             updates.insert(key, update.clone());
                         }
 
@@ -2949,7 +2968,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             &mut self.upper_arena,
                             &mut cursor,
                             &mut self.root,
-                            full_path,
+                            &full_path,
                             v,
                             find_result,
                         );
@@ -2981,7 +3000,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             &mut cursor,
                             &mut self.root,
                             key,
-                            full_path,
+                            &full_path,
                             find_result,
                             &mut self.buffers.updates,
                         );
@@ -2991,7 +3010,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                                 #[cfg(feature = "trie-debug")]
                                 recorded_proof_targets.push((proof_key, min_len));
                                 let update =
-                                    mem::replace(&mut sorted[update_idx].2, LeafUpdate::Touched);
+                                    mem::replace(&mut sorted[update_idx].1, LeafUpdate::Touched);
                                 updates.insert(key, update);
                             }
                             RemoveLeafResult::Removed => {
@@ -3056,7 +3075,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 proof_required_fn(proof.key, proof.min_len);
                 #[cfg(feature = "trie-debug")]
                 recorded_proof_targets.push((proof.key, proof.min_len));
-                let (key, _, ref update) = subtrie_updates[target_idx];
+                let (key, ref update) = subtrie_updates[target_idx];
                 updates.insert(key, update.clone());
             }
 


### PR DESCRIPTION
Branch: `auto-opt/20260331-sparse-leaf-sort-by-key`

## Verdict: **WIN**

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-leaf-sort-by-key`](https://github.com/paradigmxyz/reth/commit/23aef944cb7b2a420c29183bc4ae839bdf520fca) | Change |
|--------|------|--------|--------|
| Mean | 28.01ms | 27.92ms | -0.33% ✅ (±0.31%) |
| StdDev | 23.50ms | 23.56ms | |
| P50 | 20.79ms | 20.46ms | -1.58% ✅ (±1.51%) |
| P90 | 52.06ms | 51.46ms | -1.16% ⚪ (±5.30%) |
| P99 | 110.72ms | 110.38ms | -0.31% ⚪ (±2.48%) |
| Mgas/s | 1273.97 | 1280.76 | +0.53% ✅ (±0.40%) |
| Wall Clock | 28.70s | 28.60s | -0.35% ✅ (±0.32%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-leaf-sort-by-key`](https://github.com/paradigmxyz/reth/commit/23aef944cb7b2a420c29183bc4ae839bdf520fca) |
|--------|------|--------|
| Mean | 66.92ms | 66.67ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 253.04ms | 255.85ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-leaf-sort-by-key`](https://github.com/paradigmxyz/reth/commit/23aef944cb7b2a420c29183bc4ae839bdf520fca) |
|--------|------|--------|
| Mean | 0.13ms | 0.13ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.58ms | 0.62ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-leaf-sort-by-key`](https://github.com/paradigmxyz/reth/commit/23aef944cb7b2a420c29183bc4ae839bdf520fca) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774938566000&to=1774938660000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23783649371&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23783649371)

<details>
<summary>Hypothesis</summary>

## Evidence
- Target crate/function: `reth-trie-sparse`, `ArenaParallelSparseTrie::update_leaves` in `crates/trie/sparse/src/arena/mod.rs`.
- The hot path currently drains `updates` into `Vec<(B256, Nibbles, LeafUpdate)>` and eagerly calls `Nibbles::unpack(key)` for every entry before `sorted.sort_unstable_by_key(|entry| entry.1)`.
- Samply stacks filtered on `update_leaves` land in `SparseTrieCacheTask::process_account_leaf_updates` / `process_leaf_updates` and show `nybbles::nibbles::byte_len`, `Nibbles::cmp`, `sort_unstable_by_key`, and `ArenaCursor::push` / `Vec::push` under this function.
- The keys being sorted here are fixed-width 32-byte hashes, so lexicographic `B256` order is equivalent to full-path nibble order; the unpacked `Nibbles` value is needed for tree walking, but not necessarily as the sort key itself.

## Hypothesis
If we sort sparse-trie leaf batches by raw `B256` first and only unpack nibble paths when the walker actually consumes an item, cargo bench improves by ~15-25% because we remove one eager nibble materialization and a more expensive comparator from the hottest leaf-update path, while also reducing cursor scratch growth pressure in large batches.

## Success Metric
- cargo bench shows >15% improvement in targeted benchmark
- Benchmark to create/use: `cargo bench -p reth-trie-sparse --bench update_leaves` with `update_leaves_large_account_batch` and `update_leaves_large_storage_batch`

## Plan
- Change `crates/trie/sparse/src/arena/mod.rs` and, if scratch reuse is needed, `crates/trie/sparse/src/arena/cursor.rs`.
- Keep trie ordering identical by sorting on raw keys or cached inline bytes and unpacking `Nibbles` lazily at the consume sites.
- Reuse or pre-size cursor scratch for deep batches so the walk stops paying repeated `Vec` growth on the hot path.
- Add the benchmark in `crates/trie/sparse/benches/update_leaves.rs`.
- Estimated diff size: 120-220 lines.

## Results

</details>