### PR TITLE
perf(trie): stop rebuilding sparse-trie prune hotsets from scratch every reuse cycle [autoopt]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10544,6 +10544,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "auto_impl",
+ "codspeed-criterion-compat",
  "itertools 0.14.0",
  "metrics",
  "pretty_assertions",

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -46,6 +46,7 @@ reth-tracing.workspace = true
 
 arbitrary.workspace = true
 assert_matches.workspace = true
+criterion.workspace = true
 itertools.workspace = true
 pretty_assertions.workspace = true
 proptest-arbitrary-interop.workspace = true
@@ -88,3 +89,7 @@ arbitrary = [
     "reth-trie-common/arbitrary",
     "smallvec/arbitrary",
 ]
+
+[[bench]]
+name = "prune_hotset"
+harness = false

--- a/crates/trie/sparse/benches/prune_hotset.rs
+++ b/crates/trie/sparse/benches/prune_hotset.rs
@@ -1,0 +1,56 @@
+#![allow(missing_docs, unreachable_pub)]
+
+use alloy_primitives::B256;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use reth_trie_sparse::SparseStateTrie;
+
+const HOT_ACCOUNTS: usize = 512;
+const SLOTS_PER_ACCOUNT: usize = 16;
+const HOT_SLOTS: usize = HOT_ACCOUNTS * SLOTS_PER_ACCOUNT;
+
+fn benchmark_key(prefix: u64, suffix: u64) -> B256 {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&prefix.to_be_bytes());
+    bytes[24..].copy_from_slice(&suffix.to_be_bytes());
+    B256::from(bytes)
+}
+
+fn sparse_hotset(include_accounts: bool) -> SparseStateTrie {
+    let mut sparse = SparseStateTrie::default();
+    sparse
+        .set_hot_cache_capacities(HOT_SLOTS, include_accounts.then_some(HOT_ACCOUNTS).unwrap_or(0));
+
+    for account_idx in 0..HOT_ACCOUNTS as u64 {
+        let account = benchmark_key(0xA11CE, account_idx);
+
+        if include_accounts {
+            sparse.record_account_touch(account);
+        }
+
+        for slot_idx in 0..SLOTS_PER_ACCOUNT as u64 {
+            sparse.record_slot_touch(account, benchmark_key(account_idx + 1, slot_idx));
+        }
+    }
+
+    sparse
+}
+
+fn bench_prune_hotset(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prune_hotset");
+    group.sample_size(30);
+
+    group.bench_function("retained_slots_by_address_hotset", |b| {
+        let mut sparse = sparse_hotset(false);
+        b.iter(|| black_box(&mut sparse).prune(HOT_SLOTS, 0));
+    });
+
+    group.bench_function("sparse_state_trie_prune_retained_hotset", |b| {
+        let mut sparse = sparse_hotset(true);
+        b.iter(|| black_box(&mut sparse).prune(HOT_SLOTS, HOT_ACCOUNTS));
+    });
+
+    group.finish();
+}
+
+criterion_group!(prune_hotset, bench_prune_hotset);
+criterion_main!(prune_hotset);

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -50,6 +50,10 @@ pub struct SparseStateTrie<
     hot_slots_lfu: BucketedLfu<HotSlotKey>,
     /// Global LFU tracker for hot account entries.
     hot_accounts_lfu: BucketedLfu<B256>,
+    /// Scratch buffer reused to group retained slots by address across prune cycles.
+    retained_slot_paths: B256Map<Vec<Nibbles>>,
+    /// Scratch buffer reused to unpack retained account paths across prune cycles.
+    retained_account_paths: Vec<Nibbles>,
     /// Metrics for the sparse state trie.
     #[cfg(feature = "metrics")]
     metrics: crate::metrics::SparseStateTrieMetrics,
@@ -69,6 +73,8 @@ where
             deferred_drops: DeferredDrops::default(),
             hot_slots_lfu: BucketedLfu::default(),
             hot_accounts_lfu: BucketedLfu::default(),
+            retained_slot_paths: Default::default(),
+            retained_account_paths: Default::default(),
             #[cfg(feature = "metrics")]
             metrics: Default::default(),
         }
@@ -873,24 +879,24 @@ where
     pub fn prune(&mut self, max_hot_slots: usize, max_hot_accounts: usize) {
         self.hot_slots_lfu.decay_and_evict(max_hot_slots);
         self.hot_accounts_lfu.decay_and_evict(max_hot_accounts);
-        let retained = self.hot_slots_lfu.retained_slots_by_address();
+        self.hot_slots_lfu.retained_slots_by_address_into(&mut self.retained_slot_paths);
+        self.retained_account_paths.clear();
+        self.retained_account_paths
+            .extend(self.hot_accounts_lfu.keys().map(|key| Nibbles::unpack(*key)));
 
-        let retained_account_paths: Vec<Nibbles> =
-            self.hot_accounts_lfu.keys().map(|k| Nibbles::unpack(*k)).collect();
-
-        let retained_accounts = retained_account_paths.len();
-        let retained_storage_tries = retained.len();
+        let retained_accounts = self.retained_account_paths.len();
+        let retained_storage_tries = self.retained_slot_paths.len();
         let total_storage_tries_before = self.storage.tries.len();
+
+        let state = &mut self.state;
+        let storage = &mut self.storage;
+        let retained_account_paths = &self.retained_account_paths;
+        let retained_slot_paths = &self.retained_slot_paths;
 
         // Prune account and storage tries in parallel using the same LFU-selected set.
         let (account_nodes_pruned, storage_tries_evicted) = rayon::join(
-            || {
-                self.state
-                    .as_revealed_mut()
-                    .map(|trie| trie.prune(&retained_account_paths))
-                    .unwrap_or(0)
-            },
-            || self.storage.prune_by_retained_slots(retained),
+            || state.as_revealed_mut().map(|trie| trie.prune(&retained_account_paths)).unwrap_or(0),
+            || storage.prune_by_retained_slots(retained_slot_paths),
         );
 
         debug!(
@@ -929,6 +935,8 @@ struct StorageTries<S = ParallelSparseTrie> {
     cleared_tries: Vec<RevealableSparseTrie<S>>,
     /// A default cleared trie instance, which will be cloned when creating new tries.
     default_trie: RevealableSparseTrie<S>,
+    /// Scratch buffer reused to collect evicted trie addresses after the parallel prune pass.
+    evicted_addresses: Vec<B256>,
 }
 
 #[cfg(feature = "std")]
@@ -937,7 +945,7 @@ impl<S: SparseTrieTrait> StorageTries<S> {
     ///
     /// Tries without retained slots are evicted entirely. Tries with retained slots are pruned to
     /// those slots.
-    fn prune_by_retained_slots(&mut self, retained_slots: B256Map<Vec<Nibbles>>) -> usize {
+    fn prune_by_retained_slots(&mut self, retained_slots: &B256Map<Vec<Nibbles>>) -> usize {
         // Parallel pass: prune retained tries and clear evicted ones in place.
         {
             use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
@@ -953,20 +961,21 @@ impl<S: SparseTrieTrait> StorageTries<S> {
         }
 
         // Cheap sequential drain: move already-cleared tries into the reuse pool.
-        let addresses_to_evict: Vec<B256> = self
-            .tries
-            .keys()
-            .filter(|address| !retained_slots.contains_key(*address))
-            .copied()
-            .collect();
+        let mut evicted_addresses = core::mem::take(&mut self.evicted_addresses);
+        evicted_addresses.clear();
+        evicted_addresses.extend(
+            self.tries.keys().filter(|address| !retained_slots.contains_key(*address)).copied(),
+        );
 
-        let evicted = addresses_to_evict.len();
+        let evicted = evicted_addresses.len();
         self.cleared_tries.reserve(evicted);
-        for address in &addresses_to_evict {
+        for address in &evicted_addresses {
             if let Some(trie) = self.tries.remove(address) {
                 self.cleared_tries.push(trie);
             }
         }
+
+        self.evicted_addresses = evicted_addresses;
 
         evicted
     }
@@ -1037,20 +1046,21 @@ struct HotSlotKey {
 /// Slot-specific helpers for the `BucketedLfu<HotSlotKey>`.
 #[cfg(feature = "std")]
 impl BucketedLfu<HotSlotKey> {
-    /// Returns retained slots grouped by address.
-    fn retained_slots_by_address(&self) -> B256Map<Vec<Nibbles>> {
-        let mut grouped =
-            B256Map::<Vec<Nibbles>>::with_capacity_and_hasher(self.len(), Default::default());
+    /// Writes retained slots grouped by address into a caller-owned scratch map.
+    fn retained_slots_by_address_into(&self, grouped: &mut B256Map<Vec<Nibbles>>) {
+        grouped.reserve(self.len().saturating_sub(grouped.len()));
+
+        for slots in grouped.values_mut() {
+            slots.clear();
+        }
+
+        // LFU entries are unique `(address, slot)` pairs, and trie-level prune sorts the retained
+        // leaves it receives, so we only need to rebuild the grouping here.
         for key in self.keys() {
             grouped.entry(key.address).or_default().push(Nibbles::unpack(key.slot));
         }
 
-        for slots in grouped.values_mut() {
-            slots.sort_unstable();
-            slots.dedup();
-        }
-
-        grouped
+        grouped.retain(|_, slots| !slots.is_empty());
     }
 }
 
@@ -1240,6 +1250,35 @@ mod tests {
             sparse.hot_slots_lfu.keys().copied().collect::<Vec<_>>(),
             vec![HotSlotKey { address: account, slot }]
         );
+    }
+
+    #[test]
+    fn prune_reuses_hotset_scratch_without_stale_entries() {
+        let account_a = b256!("0x1000000000000000000000000000000000000000000000000000000000000000");
+        let account_b = b256!("0x2000000000000000000000000000000000000000000000000000000000000000");
+        let slot_a = b256!("0x3000000000000000000000000000000000000000000000000000000000000000");
+        let slot_b = b256!("0x4000000000000000000000000000000000000000000000000000000000000000");
+        let mut sparse = SparseStateTrie::<ParallelSparseTrie>::default();
+
+        sparse.set_hot_cache_capacities(2, 2);
+        sparse.record_account_touch(account_a);
+        sparse.record_account_touch(account_b);
+        sparse.record_slot_touch(account_a, slot_a);
+        sparse.record_slot_touch(account_b, slot_b);
+
+        sparse.prune(2, 2);
+        assert_eq!(sparse.retained_slot_paths.len(), 2);
+        assert_eq!(sparse.retained_account_paths.len(), 2);
+
+        sparse.prune(1, 1);
+
+        assert_eq!(sparse.retained_slot_paths.len(), 1);
+        assert_eq!(
+            sparse.retained_slot_paths.get(&account_a),
+            Some(&vec![Nibbles::unpack(slot_a)])
+        );
+        assert!(!sparse.retained_slot_paths.contains_key(&account_b));
+        assert_eq!(sparse.retained_account_paths, vec![Nibbles::unpack(account_a)]);
     }
 
     #[test]


### PR DESCRIPTION
Branch: `auto-opt/20260331-sparse-prune-hotset-reuse`

## Verdict: **REGRESSION**

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-prune-hotset-reuse`](https://github.com/paradigmxyz/reth/commit/f5daa4a38007453b8a44508e83d853f0d83b3621) | Change |
|--------|------|--------|--------|
| Mean | 27.91ms | 28.10ms | +0.67% ❌ (±0.33%) |
| StdDev | 23.52ms | 23.38ms | |
| P50 | 20.48ms | 20.87ms | +1.87% ❌ (±1.63%) |
| P90 | 52.13ms | 51.84ms | -0.54% ⚪ (±4.26%) |
| P99 | 109.38ms | 109.64ms | +0.23% ⚪ (±5.25%) |
| Mgas/s | 1280.46 | 1265.40 | -1.18% ❌ (±0.40%) |
| Wall Clock | 28.57s | 28.76s | +0.67% ❌ (±0.33%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-prune-hotset-reuse`](https://github.com/paradigmxyz/reth/commit/f5daa4a38007453b8a44508e83d853f0d83b3621) |
|--------|------|--------|
| Mean | 67.02ms | 66.36ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 254.50ms | 250.57ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-prune-hotset-reuse`](https://github.com/paradigmxyz/reth/commit/f5daa4a38007453b8a44508e83d853f0d83b3621) |
|--------|------|--------|
| Mean | 0.11ms | 0.11ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.57ms | 0.57ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-sparse-prune-hotset-reuse`](https://github.com/paradigmxyz/reth/commit/f5daa4a38007453b8a44508e83d853f0d83b3621) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774938821000&to=1774938914000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23783778517&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23783778517)

<details>
<summary>Hypothesis</summary>

## Evidence
- Target crate/function: `reth-trie-sparse`, `SparseStateTrie::prune` and `BucketedLfu<HotSlotKey>::retained_slots_by_address` in `crates/trie/sparse/src/state.rs`.
- `SparseTrieCacheTask::into_trie_for_reuse` in `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs` always calls `trie.prune(max_hot_slots, max_hot_accounts)` before reusing the cached trie.
- `SparseStateTrie::prune` currently builds `retained = self.hot_slots_lfu.retained_slots_by_address()` and `retained_account_paths: Vec<Nibbles> = self.hot_accounts_lfu.keys().map(|k| Nibbles::unpack(*k)).collect()` on every prune.
- `retained_slots_by_address()` allocates a fresh `B256Map<Vec<Nibbles>>`, unpacks every retained slot into a new `Nibbles`, then sorts and dedups each address bucket. Samply stacks filtered on `ArenaSparseSubtrie::prune` / `into_trie_for_reuse` show `SparseStateTrie::prune` and `BucketedLfu<HotSlotKey>::retained_slots_by_address` with hashbrown hashing, vector growth, and collection overhead in this reuse path.

## Hypothesis
If we maintain the retained hot-slot grouping incrementally or add allocation-reusing APIs that build the retained slot/account paths into caller-owned scratch buffers, cargo bench improves by ~15-30% because sparse-trie pruning stops rebuilding the same grouped hotset and nibble vectors from scratch on every reuse cycle.

## Success Metric
- cargo bench shows >15% improvement in targeted benchmark
- Benchmark to create/use: `cargo bench -p reth-trie-sparse --bench prune_hotset` with `sparse_state_trie_prune_retained_hotset` and `retained_slots_by_address_hotset`

## Plan
- Change `crates/trie/sparse/src/state.rs` and keep the reuse call sites in `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs` compatible.
- Add an allocation-aware `retained_slots_by_address_into` / iterator-style API, or store grouped hot-slot state alongside the LFU so prune can reuse it after `decay_and_evict`.
- Reuse account-path scratch too, so `hot_accounts_lfu.keys().map(Nibbles::unpack)` is not rebuilding a fresh vector every cycle.
- Add the benchmark in `crates/trie/sparse/benches/prune_hotset.rs`.
- Estimated diff size: 140-260 lines.

## Results

</details>