### PR TITLE
perf(engine): pre-merge persistence trie bundles before the blocking `save_blocks` flush [autoopt]

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -3,7 +3,7 @@ use parking_lot::Mutex;
 use reth_metrics::{metrics::Counter, Metrics};
 use reth_trie::{
     updates::{TrieUpdates, TrieUpdatesSorted},
-    HashedPostState, HashedPostStateSorted, TrieInputSorted,
+    HashedPostState, HashedPostStateSorted, SortedTrieData, TrieInputSorted,
 };
 use std::{
     fmt,
@@ -135,6 +135,17 @@ impl DeferredTrieData {
     /// [`Self::wait_cloned`] will return without any computation.
     pub fn ready(bundle: ComputedTrieData) -> Self {
         Self { state: Arc::new(Mutex::new(DeferredState::Ready(bundle))) }
+    }
+
+    /// Returns cached trie data only if the deferred task has already completed.
+    ///
+    /// This never blocks and never triggers synchronous fallback computation.
+    pub fn try_ready_cloned(&self) -> Option<ComputedTrieData> {
+        let state = self.state.try_lock()?;
+        match &*state {
+            DeferredState::Ready(bundle) => Some(bundle.clone()),
+            DeferredState::Pending(_) => None,
+        }
     }
 
     /// Sort block execution outputs and build a [`TrieInputSorted`] overlay.
@@ -393,6 +404,17 @@ impl ComputedTrieData {
     pub fn trie_input(&self) -> Option<&Arc<TrieInputSorted>> {
         self.anchored_trie_input.as_ref().map(|anchored| &anchored.trie_input)
     }
+
+    /// Returns the cumulative persistence bundle when it still matches the expected anchor.
+    pub fn persistence_bundle(&self, expected_anchor: B256) -> Option<SortedTrieData> {
+        let anchored = self.anchored_trie_input.as_ref()?;
+        (anchored.anchor_hash == expected_anchor).then(|| {
+            SortedTrieData::new(
+                Arc::clone(&anchored.trie_input.state),
+                Arc::clone(&anchored.trie_input.nodes),
+            )
+        })
+    }
 }
 
 #[cfg(test)]
@@ -426,6 +448,15 @@ mod tests {
             anchor,
             Vec::new(),
         )
+    }
+
+    #[test]
+    fn try_ready_cloned_only_returns_cached_data() {
+        let pending = empty_pending();
+        assert!(pending.try_ready_cloned().is_none());
+
+        let ready = DeferredTrieData::ready(empty_bundle());
+        assert!(ready.try_ready_cloned().is_some());
     }
 
     /// Verifies that a ready handle returns immediately without computation.

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -852,6 +852,12 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         self.trie_data.wait_cloned()
     }
 
+    /// Returns cached trie data only if deferred computation has already completed.
+    #[inline]
+    pub fn try_ready_trie_data(&self) -> Option<ComputedTrieData> {
+        self.trie_data.try_ready_cloned()
+    }
+
     /// Returns a clone of the deferred trie data handle.
     ///
     /// A handle is a lightweight reference that can be passed to descendants without
@@ -890,6 +896,13 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     #[inline]
     pub fn anchor_hash(&self) -> Option<B256> {
         self.trie_data().anchor_hash()
+    }
+
+    /// Returns the cumulative persistence bundle if the cached overlay already matches the
+    /// expected persisted parent for a flush batch.
+    #[inline]
+    pub fn try_persistence_bundle(&self, expected_anchor: B256) -> Option<SortedTrieData> {
+        self.try_ready_trie_data()?.persistence_bundle(expected_anchor)
     }
 
     /// Returns a [`BlockNumber`] of the block.

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -1,4 +1,5 @@
 use crate::metrics::PersistenceMetrics;
+use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumHash;
 use crossbeam_channel::Sender as CrossbeamSender;
 use reth_chain_state::ExecutedBlock;
@@ -12,6 +13,7 @@ use reth_provider::{
 use reth_prune::{PrunerError, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
 use reth_tasks::spawn_os_thread;
+use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted, SortedTrieData};
 use std::{
     sync::{
         mpsc::{Receiver, SendError, Sender},
@@ -102,8 +104,8 @@ where
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
                     let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
                 }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
+                PersistenceAction::SaveBlocks { blocks, trie_bundle, sender } => {
+                    let result = self.on_save_blocks(blocks, trie_bundle)?;
                     let result_number = result.last_block.map(|b| b.number);
 
                     let _ = sender.send(result);
@@ -148,6 +150,7 @@ where
     fn on_save_blocks(
         &mut self,
         blocks: Vec<ExecutedBlock<N::Primitives>>,
+        trie_bundle: Option<SortedTrieData>,
     ) -> Result<PersistenceResult, PersistenceError> {
         let first_block = blocks.first().map(|b| b.recovered_block.num_hash());
         let last_block = blocks.last().map(|b| b.recovered_block.num_hash());
@@ -162,7 +165,7 @@ where
 
         if let Some(last) = last_block {
             let provider_rw = self.provider.database_provider_rw()?;
-            provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
+            provider_rw.save_blocks_with_trie_bundle(blocks, trie_bundle, SaveBlocksMode::Full)?;
 
             if let Some(finalized) = pending_finalized {
                 provider_rw.save_finalized_block_number(finalized.min(last.number))?;
@@ -216,6 +219,31 @@ pub enum PersistenceError {
     ProviderError(#[from] ProviderError),
 }
 
+fn prepare_persistence_trie_bundle<N: NodePrimitives>(
+    blocks: &[ExecutedBlock<N>],
+) -> Option<SortedTrieData> {
+    let (first, last) = blocks.first().zip(blocks.last())?;
+    let expected_anchor = first.recovered_block().parent_hash();
+
+    if let Some(bundle) = last.try_persistence_bundle(expected_anchor) {
+        return Some(bundle)
+    }
+
+    let trie_data = blocks
+        .iter()
+        .rev()
+        .map(ExecutedBlock::try_ready_trie_data)
+        .collect::<Option<Vec<_>>>()
+        .unwrap_or_else(|| blocks.iter().rev().map(ExecutedBlock::trie_data).collect());
+
+    Some(SortedTrieData::new(
+        HashedPostStateSorted::merge_batch(
+            trie_data.iter().map(|data| Arc::clone(&data.hashed_state)),
+        ),
+        TrieUpdatesSorted::merge_batch(trie_data.iter().map(|data| Arc::clone(&data.trie_updates))),
+    ))
+}
+
 /// A signal to the persistence service that part of the tree state can be persisted.
 #[derive(Debug)]
 pub enum PersistenceAction<N: NodePrimitives = EthPrimitives> {
@@ -224,7 +252,15 @@ pub enum PersistenceAction<N: NodePrimitives = EthPrimitives> {
     ///
     /// First, header, transaction, and receipt-related data should be written to static files.
     /// Then the execution history-related data will be written to the database.
-    SaveBlocks(Vec<ExecutedBlock<N>>, CrossbeamSender<PersistenceResult>),
+    SaveBlocks {
+        /// The blocks to persist, in increasing block number order.
+        blocks: Vec<ExecutedBlock<N>>,
+        /// Pre-merged trie data for this batch, prepared before the persistence thread enters the
+        /// blocking flush path.
+        trie_bundle: Option<SortedTrieData>,
+        /// Channel used to report the persistence result.
+        sender: CrossbeamSender<PersistenceResult>,
+    },
 
     /// Removes block data above the given block number from the database.
     ///
@@ -311,7 +347,8 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
         blocks: Vec<ExecutedBlock<T>>,
         tx: CrossbeamSender<PersistenceResult>,
     ) -> Result<(), SendError<PersistenceAction<T>>> {
-        self.send_action(PersistenceAction::SaveBlocks(blocks, tx))
+        let trie_bundle = prepare_persistence_trie_bundle(&blocks);
+        self.send_action(PersistenceAction::SaveBlocks { blocks, trie_bundle, sender: tx })
     }
 
     /// Queues the finalized block number to be persisted on disk.
@@ -375,10 +412,11 @@ impl Drop for ServiceGuard {
 mod tests {
     use super::*;
     use alloy_primitives::B256;
-    use reth_chain_state::test_utils::TestBlockBuilder;
+    use reth_chain_state::{test_utils::TestBlockBuilder, ComputedTrieData};
     use reth_exex_types::FinishedExExHeight;
     use reth_provider::test_utils::create_test_provider_factory;
     use reth_prune::Pruner;
+    use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted, TrieInputSorted};
     use tokio::sync::mpsc::unbounded_channel;
 
     fn default_persistence_handle() -> PersistenceHandle<EthPrimitives> {
@@ -406,6 +444,39 @@ mod tests {
 
         let result = rx.recv().unwrap();
         assert!(result.last_block.is_none());
+    }
+
+    #[test]
+    fn test_prepare_persistence_trie_bundle_reuses_ready_overlay() {
+        let mut test_block_builder = TestBlockBuilder::eth();
+        let anchor = B256::random();
+
+        let first = test_block_builder.get_executed_block_with_number(1, anchor);
+        let second =
+            test_block_builder.get_executed_block_with_number(2, first.recovered_block().hash());
+
+        let cumulative_state = Arc::new(HashedPostStateSorted::default());
+        let cumulative_updates = Arc::new(TrieUpdatesSorted::default());
+        let cumulative_input = Arc::new(TrieInputSorted::new(
+            Arc::clone(&cumulative_updates),
+            Arc::clone(&cumulative_state),
+            Default::default(),
+        ));
+
+        let second = reth_chain_state::ExecutedBlock::new(
+            Arc::clone(&second.recovered_block),
+            Arc::clone(&second.execution_output),
+            ComputedTrieData::with_trie_input(
+                Arc::default(),
+                Arc::default(),
+                anchor,
+                cumulative_input,
+            ),
+        );
+
+        let bundle = prepare_persistence_trie_bundle(&[first, second]).unwrap();
+        assert!(Arc::ptr_eq(&bundle.hashed_state, &cumulative_state));
+        assert!(Arc::ptr_eq(&bundle.trie_updates, &cumulative_updates));
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -548,7 +548,7 @@ async fn test_tree_persist_blocks() {
 
     let received_action =
         test_harness.action_rx.recv().expect("Failed to receive save blocks action");
-    if let PersistenceAction::SaveBlocks(saved_blocks, _) = received_action {
+    if let PersistenceAction::SaveBlocks { blocks: saved_blocks, .. } = received_action {
         // only blocks.len() - tree_config.memory_block_buffer_target() will be
         // persisted
         let expected_persist_len = blocks.len() - tree_config.memory_block_buffer_target() as usize;
@@ -818,7 +818,7 @@ async fn test_tree_state_on_new_head_reorg() {
 
     // get rid of the prev action
     let received_action = test_harness.action_rx.recv().unwrap();
-    let PersistenceAction::SaveBlocks(saved_blocks, sender) = received_action else {
+    let PersistenceAction::SaveBlocks { blocks: saved_blocks, sender, .. } = received_action else {
         panic!("received wrong action");
     };
     assert_eq!(saved_blocks, vec![blocks[0].clone(), blocks[1].clone()]);
@@ -2106,7 +2106,7 @@ mod forkchoice_updated_tests {
                 break;
             }
 
-            if let Ok(PersistenceAction::SaveBlocks(saved_blocks, sender)) =
+            if let Ok(PersistenceAction::SaveBlocks { blocks: saved_blocks, sender, .. }) =
                 action_rx.recv_timeout(std::time::Duration::from_millis(100))
             {
                 if let Some(last) = saved_blocks.last() {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -67,7 +67,7 @@ use reth_storage_api::{
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
 use reth_trie::{
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
-    HashedPostStateSorted,
+    HashedPostStateSorted, SortedTrieData,
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
 use revm_database::states::{
@@ -518,10 +518,29 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ///
     /// Use [`SaveBlocksMode::Full`] for production (includes receipts, state, trie).
     /// Use [`SaveBlocksMode::BlocksOnly`] for block structure only (used by `insert_block`).
-    #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = blocks.len()))]
     pub fn save_blocks(
         &self,
         blocks: Vec<ExecutedBlock<N::Primitives>>,
+        save_mode: SaveBlocksMode,
+    ) -> ProviderResult<()> {
+        self.save_blocks_inner(blocks, None, save_mode)
+    }
+
+    /// Writes executed blocks and state to storage using a pre-merged trie bundle when available.
+    pub fn save_blocks_with_trie_bundle(
+        &self,
+        blocks: Vec<ExecutedBlock<N::Primitives>>,
+        trie_bundle: Option<SortedTrieData>,
+        save_mode: SaveBlocksMode,
+    ) -> ProviderResult<()> {
+        self.save_blocks_inner(blocks, trie_bundle, save_mode)
+    }
+
+    #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = blocks.len()))]
+    fn save_blocks_inner(
+        &self,
+        blocks: Vec<ExecutedBlock<N::Primitives>>,
+        trie_bundle: Option<SortedTrieData>,
         save_mode: SaveBlocksMode,
     ) -> ProviderResult<()> {
         if blocks.is_empty() {
@@ -569,6 +588,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
         // Write to all backends in parallel.
         let runtime = &self.runtime;
+        let trie_bundle = trie_bundle.as_ref();
         // Propagate tracing context into rayon-spawned threads so that static file
         // and RocksDB write spans appear as children of save_blocks in traces.
         let span = tracing::Span::current();
@@ -667,21 +687,34 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Write all hashed state and trie updates in single batches.
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() {
-                // Blocks are oldest-to-newest, merge_batch expects newest-to-oldest.
                 let start = Instant::now();
-                let merged_hashed_state = HashedPostStateSorted::merge_batch(
-                    blocks.iter().rev().map(|b| b.trie_data().hashed_state),
-                );
-                if !merged_hashed_state.is_empty() {
-                    self.write_hashed_state(&merged_hashed_state)?;
+                if let Some(trie_bundle) = trie_bundle {
+                    if !trie_bundle.hashed_state.is_empty() {
+                        self.write_hashed_state(trie_bundle.hashed_state.as_ref())?;
+                    }
+                } else {
+                    // Blocks are oldest-to-newest, merge_batch expects newest-to-oldest.
+                    let merged_hashed_state = HashedPostStateSorted::merge_batch(
+                        blocks.iter().rev().map(|b| b.trie_data().hashed_state),
+                    );
+                    if !merged_hashed_state.is_empty() {
+                        self.write_hashed_state(&merged_hashed_state)?;
+                    }
                 }
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                let merged_trie =
-                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
-                if !merged_trie.is_empty() {
-                    self.write_trie_updates_sorted(&merged_trie)?;
+                if let Some(trie_bundle) = trie_bundle {
+                    if !trie_bundle.trie_updates.is_empty() {
+                        self.write_trie_updates_sorted(trie_bundle.trie_updates.as_ref())?;
+                    }
+                } else {
+                    let merged_trie = TrieUpdatesSorted::merge_batch(
+                        blocks.iter().rev().map(|b| b.trie_updates()),
+                    );
+                    if !merged_trie.is_empty() {
+                        self.write_trie_updates_sorted(&merged_trie)?;
+                    }
                 }
                 timings.write_trie_updates += start.elapsed();
             }


### PR DESCRIPTION
Branch: `auto-opt/20260331-premerge-persistence-bundles`

## Verdict: **REGRESSION**

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-premerge-persistence-bundles`](https://github.com/paradigmxyz/reth/commit/bfe0db7d82e2cf3b861027ea76c16f937f0ac09c) | Change |
|--------|------|--------|--------|
| Mean | 27.57ms | 27.74ms | +0.62% ❌ (±0.43%) |
| StdDev | 24.26ms | 24.56ms | |
| P50 | 19.78ms | 19.85ms | +0.35% ⚪ (±1.71%) |
| P90 | 50.71ms | 51.94ms | +2.42% ⚪ (±3.96%) |
| P99 | 113.10ms | 114.41ms | +1.16% ⚪ (±5.39%) |
| Mgas/s | 1320.98 | 1313.62 | -0.56% ❌ (±0.42%) |
| Wall Clock | 28.25s | 28.43s | +0.62% ❌ (±0.43%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-premerge-persistence-bundles`](https://github.com/paradigmxyz/reth/commit/bfe0db7d82e2cf3b861027ea76c16f937f0ac09c) |
|--------|------|--------|
| Mean | 69.17ms | 67.76ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 265.10ms | 260.30ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-premerge-persistence-bundles`](https://github.com/paradigmxyz/reth/commit/bfe0db7d82e2cf3b861027ea76c16f937f0ac09c) |
|--------|------|--------|
| Mean | 0.09ms | 0.08ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.47ms | 0.48ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-premerge-persistence-bundles`](https://github.com/paradigmxyz/reth/commit/bfe0db7d82e2cf3b861027ea76c16f937f0ac09c) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774942236000&to=1774942329000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23785661324&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23785661324)

<details>
<summary>Hypothesis</summary>

## Evidence
- `summary.json` shows the only material wait bucket in this run is still persistence: `persistence_wait` averages 64.5ms with a 238.6ms p95, while `sparse_trie_wait` averages 0.14ms and `execution_cache_wait` is 0.
- The baseline `combined_latency.csv` confirms that `persistence_wait` is bursty rather than gas-scaled: mean is about 64.5ms in both baseline runs, and its correlation with `gas_used` is effectively zero (`-0.021` in `baseline-1`).
- `DatabaseProvider::save_blocks` in `crates/storage/provider/src/providers/database/provider.rs` merges sorted state for every flushed batch on the persistence thread via `HashedPostStateSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_data().hashed_state))` and `TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()))` before it writes anything.
- Samply stacks filtered on `HashedPostStateSorted::merge_batch` and `TrieUpdatesSorted::merge_batch` show clone-heavy work in the persistence thread: `HashedStorageSorted::clone`, `HashedPostStateSorted::clone`, `StorageTrieUpdatesSorted::clone`, `TrieUpdatesSorted::clone`, `extend_sorted_vec`, hash map updates, and allocator/page-fault samples. `ExecutedBlock::trie_data()` also falls back to synchronous `wait_cloned()` if the background deferred-trie task has not finished, so the blocking flush can become the first consumer of this merge/sort work.

## Hypothesis
If we maintain an incrementally merged persistence bundle as executed blocks enter the in-memory queue (or when their deferred trie task completes) so `save_blocks` can write one ready bundle instead of recomputing `merge_batch` across the whole batch, gas_per_second improves by ~1.5-3% because we move clone-and-allocation-heavy merge work off the only wait bucket that materially shows up in end-to-end latency.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >1.5%
- mgas_s.sig should be "good" (statistically significant at 95% CI)

## Plan
- Change `crates/storage/provider/src/providers/database/provider.rs`, `crates/engine/tree/src/persistence.rs`, and the buffered block types in `crates/chain-state/src/in_memory.rs` (with `crates/chain-state/src/deferred_trie.rs` likely involved if bundle assembly hooks into deferred completion).
- Add an aggregated persistence bundle that is updated when executed blocks are appended or evicted, so the flush path reuses pre-merged `HashedPostStateSorted` / `TrieUpdatesSorted` instead of rebuilding them from per-block pieces.
- Keep DB write order and crash-safety identical: this optimization should only change when merge/sort CPU runs, not what gets committed, and it should fall back to the existing per-batch merge when the cached bundle is absent or invalidated by reorg handling.
- This is intentionally different from the earlier rejected `save_blocks` batching/smoothing ideas: table write order stays the same, and the target is the clone-heavy pre-write merge work that profiling shows inside the persistence critical path.
- Estimated diff size: 220-350 lines.

## Results

</details>