### PR TITLE
perf(storage): defer static file `sync_all()` until batch finalize [autoopt]

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3832,7 +3832,8 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
 
             self.static_file_provider.commit()?;
         } else {
-            // Normal path: finalize() will call sync_all() if not already synced
+            // Normal path: finalize() first syncs all dirty static file writers, then publishes
+            // their configs and indices.
             let mut timings = metrics::CommitTimings::default();
 
             let start = Instant::now();

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -656,8 +656,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
     /// Writes to a static file segment using the provided closure.
     ///
-    /// The closure receives a mutable reference to the segment writer. After the closure completes,
-    /// `sync_all()` is called to flush writes to disk.
+    /// The closure receives a mutable reference to the segment writer. Durability is deferred to
+    /// the batch finalization pass so that segment writes can be synced together.
     #[instrument(level = "debug", target = "providers::static_file", skip_all, fields(?segment))]
     fn write_segment<F>(
         &self,
@@ -669,14 +669,13 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         F: FnOnce(&mut StaticFileProviderRWRefMut<'_, N>) -> ProviderResult<()>,
     {
         let mut w = self.get_writer(first_block_number, segment)?;
-        f(&mut w)?;
-        w.sync_all()
+        f(&mut w)
     }
 
     /// Writes all static file data for multiple blocks in parallel per-segment.
     ///
-    /// This spawns tasks on the storage thread pool for each segment type and each task calls
-    /// `sync_all()` on its writer when done.
+    /// This spawns tasks on the storage thread pool for each segment type. The tasks only append
+    /// data; durability is handled by the shared finalization step at commit time.
     #[instrument(level = "debug", target = "providers::static_file", skip_all)]
     pub fn write_blocks_data(
         &self,

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -163,8 +163,9 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
 
     /// Finalizes all writers by committing their configuration to disk and updating indices.
     ///
-    /// Must be called after `sync_all` was called on individual writers.
-    /// Returns an error if any writer has prune queued.
+    /// This keeps all segment write locks held while it first syncs every dirty writer and then
+    /// finalizes them. That preserves the changeset sidecar-before-header ordering across the
+    /// whole batch and prevents new writes from slipping in between the two phases.
     #[instrument(
         name = "StaticFileWriters::finalize",
         level = "debug",
@@ -174,16 +175,25 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
     pub(crate) fn finalize(&self) -> ProviderResult<()> {
         debug!(target: "providers::static_file", "Finalizing all static file segments into disk");
 
-        for writer_lock in [
-            &self.headers,
-            &self.transactions,
-            &self.receipts,
-            &self.transaction_senders,
-            &self.account_change_sets,
-            &self.storage_change_sets,
-        ] {
-            let mut writer = writer_lock.write();
-            if let Some(writer) = writer.as_mut() {
+        let mut writers = [
+            self.headers.write(),
+            self.transactions.write(),
+            self.receipts.write(),
+            self.transaction_senders.write(),
+            self.account_change_sets.write(),
+            self.storage_change_sets.write(),
+        ];
+
+        for writer in &mut writers {
+            let Some(writer) = writer.as_mut() else { continue };
+            if writer.is_dirty() {
+                writer.sync_all()?;
+            }
+        }
+
+        for writer in &mut writers {
+            let Some(writer) = writer.as_mut() else { continue };
+            if writer.is_dirty() {
                 writer.finalize()?;
             }
         }
@@ -365,6 +375,11 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// Returns `true` if the writer will prune on commit.
     pub const fn will_prune_on_commit(&self) -> bool {
         self.prune_on_commit.is_some()
+    }
+
+    /// Returns `true` if the inner writer has uncommitted changes.
+    const fn is_dirty(&self) -> bool {
+        self.writer.is_dirty()
     }
 
     /// Heals the changeset offset sidecar after `NippyJar` healing.


### PR DESCRIPTION
Branch: `auto-opt/20260331-defer-static-file-sync`

## Verdict: **NO_WIN**

## Benchmark Results

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-defer-static-file-sync`](https://github.com/paradigmxyz/reth/commit/c254ba7f487d6bdca41a30c78f3c5d6693137c6e) | Change |
|--------|------|--------|--------|
| Mean | 27.65ms | 27.69ms | +0.15% ⚪ (±0.33%) |
| StdDev | 24.28ms | 24.24ms | |
| P50 | 19.92ms | 20.05ms | +0.66% ⚪ (±2.00%) |
| P90 | 51.05ms | 50.70ms | -0.67% ⚪ (±7.54%) |
| P99 | 114.62ms | 113.86ms | -0.66% ⚪ (±3.53%) |
| Mgas/s | 1315.39 | 1312.03 | -0.26% ⚪ (±0.43%) |
| Wall Clock | 28.33s | 28.38s | +0.16% ⚪ (±0.33%) |

*500 blocks*

<details>
<summary>Wait Time Breakdown</summary>

### Persistence Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-defer-static-file-sync`](https://github.com/paradigmxyz/reth/commit/c254ba7f487d6bdca41a30c78f3c5d6693137c6e) |
|--------|------|--------|
| Mean | 67.30ms | 68.02ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 254.20ms | 265.56ms |

### Trie Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-defer-static-file-sync`](https://github.com/paradigmxyz/reth/commit/c254ba7f487d6bdca41a30c78f3c5d6693137c6e) |
|--------|------|--------|
| Mean | 0.10ms | 0.09ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.52ms | 0.49ms |

### Execution Cache Update Wait

| Metric | [`main`](https://github.com/paradigmxyz/reth/commit/f0d07c38be40c173abab5879b49a20dc4126c427) | [`auto-opt/20260331-defer-static-file-sync`](https://github.com/paradigmxyz/reth/commit/c254ba7f487d6bdca41a30c78f3c5d6693137c6e) |
|--------|------|--------|
| Mean | 0.00ms | 0.00ms |
| P50 | 0.00ms | 0.00ms |
| P95 | 0.00ms | 0.00ms |

</details>

**[Grafana Dashboard](https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=1774946153000&to=1774946246000&timezone=browser&var-datasource=ef57fux92e9z4e&var-job=reth-bench&var-benchmark_id=ci-23788092104&var-benchmark_run=$__all)**

[GH Actions Run](https://github.com/paradigmxyz/reth/actions/runs/23788092104)

<details>
<summary>Hypothesis</summary>

## Evidence
`combined_latency.csv` shows `persistence_wait` is still the only meaningful wait bucket: ~64.5ms mean and ~238.6ms p95, while 66.8% of blocks have zero persistence wait and 33.2% pay the full batch cost, matching the fixed 3-block persistence cadence in the logs.

The baseline log contains 200 `on_save_blocks{block_count=3}` windows for 500 blocks. Parsing those windows shows mean persistence time of ~201.6ms, and the pre-commit portion before `providers::db: Appended block data` already costs ~108.2ms mean / ~144.6ms p95.

In code, [`StaticFileProvider::write_segment`](file:///home/ubuntu/reth/crates/storage/provider/src/providers/static_file/manager.rs#L664-L676) always calls `w.sync_all()` after each per-segment write task, and [`write_blocks_data`](file:///home/ubuntu/reth/crates/storage/provider/src/providers/static_file/manager.rs#L681-L772) spawns one such task per static-file segment. `sync_all()` in [`StaticFileProviderRW`](file:///home/ubuntu/reth/crates/storage/provider/src/providers/static_file/writer.rs#L533-L550) flushes the changeset sidecar and calls `File::sync_all` for dirty writers.

The samply profile backs this up: filtering on `ChangesetOffsetWriter::sync` lands in `fsync -> ChangesetOffsetWriter::sync -> StaticFileProviderRW::sync_all -> write_segment -> write_blocks_data`, so static-file durability work is happening inside the hot persistence window before `DatabaseProvider::commit` even starts.

## Hypothesis
If we stop forcing each static-file segment task to call `sync_all()` immediately and instead batch static-file durability at the end of the `save_blocks` batch, gas_per_second improves by ~0.8-1.5% because we amortize ext4 journal/fsync work across segments and shrink the ~108ms pre-append portion of the persistence critical path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.8%
- mgas_s.sig should be "good" (statistically significant at 95% CI)

## Plan
Change [`crates/storage/provider/src/providers/static_file/manager.rs`](file:///home/ubuntu/reth/crates/storage/provider/src/providers/static_file/manager.rs) so segment tasks only write data and mark writers dirty, then perform one coordinated sync/finalize pass after all segment tasks complete instead of per-task `sync_all()`.

Adjust [`crates/storage/provider/src/providers/static_file/writer.rs`](file:///home/ubuntu/reth/crates/storage/provider/src/providers/static_file/writer.rs) so batched finalization preserves the current crash-safety rule for changeset sidecars before header/index publication.

Touch [`crates/storage/provider/src/providers/database/provider.rs`](file:///home/ubuntu/reth/crates/storage/provider/src/providers/database/provider.rs) only as needed for metrics/plumbing. Estimated size: ~150-220 lines.

## Results

</details>