### PR TITLE
Fix: Use repository to track hourly reth-bench runs instead of github actions cache

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -13,6 +13,7 @@
 #               BENCH_FEATURE_ARGS (extra reth node args for feature runs)
 #               BENCH_OTLP_TRACES_ENDPOINT (OTLP HTTP endpoint for traces, e.g. https://host/insert/opentelemetry/v1/traces)
 #               BENCH_OTLP_LOGS_ENDPOINT (OTLP HTTP endpoint for logs, e.g. https://host/insert/opentelemetry/v1/logs)
+#               BENCH_OTLP_DISABLED (true to skip OTLP export even if endpoints are set)
 set -euo pipefail
 
 LABEL="$1"
@@ -149,11 +150,13 @@ if [ -n "${BENCH_METRICS_ADDR:-}" ]; then
 fi
 
 # OTLP traces and logs export
-if [ -n "${BENCH_OTLP_TRACES_ENDPOINT:-}" ]; then
-  RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench)
-fi
-if [ -n "${BENCH_OTLP_LOGS_ENDPOINT:-}" ]; then
-  RETH_ARGS+=(--logs-otlp="${BENCH_OTLP_LOGS_ENDPOINT}" --logs-otlp.filter=debug)
+if [ "${BENCH_OTLP_DISABLED:-false}" != "true" ]; then
+  if [ -n "${BENCH_OTLP_TRACES_ENDPOINT:-}" ]; then
+    RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench)
+  fi
+  if [ -n "${BENCH_OTLP_LOGS_ENDPOINT:-}" ]; then
+    RETH_ARGS+=(--logs-otlp="${BENCH_OTLP_LOGS_ENDPOINT}" --logs-otlp.filter=debug)
+  fi
 fi
 
 # Tracy profiling: add --log.tracy flags and set environment

--- a/.github/scripts/bench-scheduled-refs.sh
+++ b/.github/scripts/bench-scheduled-refs.sh
@@ -23,10 +23,10 @@
 #   nightly-created — ISO timestamp of the nightly build (nightly only)
 #
 # Reads:
-#   .nightly-state/last-feature-ref  (nightly, from GH Actions cache)
-#   .hourly-state/last-feature-ref   (hourly, from GH Actions cache)
+#   state/nightly-last-feature-ref  (nightly, from decofe/reth-bench-charts repo)
+#   state/hourly-last-feature-ref   (hourly, from decofe/reth-bench-charts repo)
 #
-# Requires: gh (GitHub CLI), jq, date, git (hourly mode)
+# Requires: gh (GitHub CLI), jq, date, git (hourly mode), curl, DEREK_TOKEN env
 set -euo pipefail
 
 FORCE="${1:-false}"
@@ -69,15 +69,15 @@ if [ "$MODE" = "hourly" ]; then
   fi
   echo "::endgroup::"
 
-  # --- Step 3: Read last successful feature ref from cache ---
-  echo "::group::Reading cached state"
+  # --- Step 3: Read last successful feature ref from charts repo ---
+  echo "::group::Reading persisted state"
   LAST_FEATURE_REF=""
-  STATE_FILE=".hourly-state/last-feature-ref"
-  if [ -f "$STATE_FILE" ]; then
-    LAST_FEATURE_REF=$(tr -d '[:space:]' < "$STATE_FILE")
+  STATE_URL="https://raw.githubusercontent.com/decofe/reth-bench-charts/state/state/hourly-last-feature-ref"
+  if RAW=$(curl -sfL -H "Authorization: token ${DEREK_TOKEN}" "$STATE_URL"); then
+    LAST_FEATURE_REF=$(echo "$RAW" | tr -d '[:space:]')
     echo "Previous feature ref: $LAST_FEATURE_REF"
   else
-    echo "No cached state found (first run)"
+    echo "No persisted state found (first run)"
   fi
   echo "::endgroup::"
 
@@ -173,15 +173,15 @@ else
 fi
 echo "::endgroup::"
 
-# --- Step 3: Read last successful feature ref from cache ---
-echo "::group::Reading cached state"
+# --- Step 3: Read last successful feature ref from charts repo ---
+echo "::group::Reading persisted state"
 LAST_FEATURE_REF=""
-STATE_FILE=".nightly-state/last-feature-ref"
-if [ -f "$STATE_FILE" ]; then
-  LAST_FEATURE_REF=$(tr -d '[:space:]' < "$STATE_FILE")
+STATE_URL="https://raw.githubusercontent.com/decofe/reth-bench-charts/state/state/nightly-last-feature-ref"
+if RAW=$(curl -sfL -H "Authorization: token ${DEREK_TOKEN}" "$STATE_URL"); then
+  LAST_FEATURE_REF=$(echo "$RAW" | tr -d '[:space:]')
   echo "Previous feature ref: $LAST_FEATURE_REF"
 else
-  echo "No cached state found (first run)"
+  echo "No persisted state found (first run)"
 fi
 echo "::endgroup::"
 

--- a/.github/scripts/bench-scheduled-refs.sh
+++ b/.github/scripts/bench-scheduled-refs.sh
@@ -42,7 +42,7 @@ if [ "$MODE" = "hourly" ]; then
 
   # --- Step 1: Resolve feature ref from git ---
   echo "::group::Resolving hourly refs from git"
-  git fetch origin main --quiet
+  git fetch origin main --depth=2 --quiet
   FEATURE_REF=$(git rev-parse origin/main)
   echo "Feature (HEAD): $FEATURE_REF"
   echo "::endgroup::"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -250,8 +250,7 @@ jobs:
       BENCH_COMMENT_ID: ""
       BENCH_NO_SLACK: ${{ github.event_name == 'workflow_dispatch' && inputs.no_slack == true && 'true' || 'false' }}
       BENCH_METRICS_ADDR: "127.0.0.1:9100"
-      BENCH_OTLP_TRACES_ENDPOINT: ${{ secrets.BENCH_OTLP_TRACES_ENDPOINT }}
-      BENCH_OTLP_LOGS_ENDPOINT: ${{ secrets.BENCH_OTLP_LOGS_ENDPOINT }}
+      BENCH_OTLP_DISABLED: "true"
       BASELINE_REF: ${{ needs.resolve-refs.outputs.baseline-ref }}
       FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
     steps:

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -7,8 +7,9 @@
 #             regressions quickly. Falls back to HEAD~1 on first run.
 #             Skips if no new commits or if a previous run is still in progress.
 #
-# State is persisted between runs via GitHub Actions cache: each successful
-# run saves the feature commit SHA so the next run knows what to compare against.
+# State is persisted between runs via the decofe/reth-bench-charts repo: each
+# successful run saves the feature commit SHA so the next run knows what to
+# compare against.
 
 on:
   schedule:
@@ -84,19 +85,11 @@ jobs:
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "Detected mode: $MODE"
 
-      - name: Restore state cache
-        id: state-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .${{ steps.mode.outputs.mode == 'hourly' && 'hourly' || 'nightly' }}-state
-          key: bench-${{ steps.mode.outputs.mode }}-state-dummy
-          restore-keys: |
-            bench-${{ steps.mode.outputs.mode }}-state-
-
       - name: Resolve refs
         id: refs
         env:
           GH_TOKEN: ${{ github.token }}
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
@@ -952,15 +945,27 @@ jobs:
     name: save-state
     runs-on: ubuntu-latest
     steps:
-      - name: Write state file
+      - name: Push state to charts repo
+        env:
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
         run: |
           MODE="${{ needs.resolve-refs.outputs.mode }}"
-          STATE_DIR=".${MODE}-state"
-          mkdir -p "$STATE_DIR"
-          echo "${{ needs.resolve-refs.outputs.feature-ref }}" > "$STATE_DIR/last-feature-ref"
+          FEATURE_REF="${{ needs.resolve-refs.outputs.feature-ref }}"
+          CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/reth-bench-charts.git"
 
-      - name: Save state
-        uses: actions/cache/save@v4
-        with:
-          path: .${{ needs.resolve-refs.outputs.mode }}-state
-          key: bench-${{ needs.resolve-refs.outputs.mode }}-state-${{ needs.resolve-refs.outputs.feature-ref }}
+          TMP_DIR=$(mktemp -d)
+          if git clone --depth 1 --branch state "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+            true
+          else
+            git init "${TMP_DIR}"
+            git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
+          fi
+
+          mkdir -p "${TMP_DIR}/state"
+          echo "${FEATURE_REF}" > "${TMP_DIR}/state/${MODE}-last-feature-ref"
+          git -C "${TMP_DIR}" add state/
+          git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
+          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
+            commit -m "bench: update ${MODE} state to ${FEATURE_REF}"
+          git -C "${TMP_DIR}" push origin HEAD:state
+          rm -rf "${TMP_DIR}"


### PR DESCRIPTION
* use https://github.com/decofe/reth-bench-charts/ repository to store state since github action cache is not long lived enough. Same repo already used by reth-bench to store charts
* test runs:
  * https://github.com/paradigmxyz/reth/actions/runs/23787288989
  * https://github.com/paradigmxyz/reth/actions/runs/23798533195