### PR TITLE
feat(client): add era type override functionality to EraClient

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -52,9 +52,18 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     const CHECKSUMS: &'static str = "checksums.txt";
 
     /// Constructs [`EraClient`] using `client` to download from `url` into `folder`.
+    ///
+    /// The file type is auto-detected from the URL. Use
+    /// [`with_era_type`](Self::with_era_type) to override.
     pub fn new(client: Http, url: Url, folder: impl Into<Box<Path>>) -> Self {
         let era_type = EraFileType::from_url(url.as_str());
         Self { client, url, folder: folder.into(), era_type }
+    }
+
+    /// Override the auto-detected [`EraFileType`].
+    pub const fn with_era_type(mut self, era_type: EraFileType) -> Self {
+        self.era_type = era_type;
+        self
     }
 
     /// Performs a GET request on `url` and stores the response body into a file located within
@@ -366,5 +375,20 @@ mod tests {
         let actual_number = client.file_name_to_number(file_name);
 
         assert_eq!(actual_number, expected_number);
+    }
+
+    #[test]
+    fn test_with_era_type_overrides_auto_detection() {
+        // URL without "era1" auto-detects as Era
+        let client = EraClient::new(
+            Client::new(),
+            Url::from_str("https://example.com/").unwrap(),
+            PathBuf::new(),
+        );
+        assert_eq!(client.era_type, EraFileType::Era);
+
+        // with_era_type overrides to Era1
+        let client = client.with_era_type(EraFileType::Era1);
+        assert_eq!(client.era_type, EraFileType::Era1);
     }
 }


### PR DESCRIPTION
`EraClient::new` auto-detects the file type from the URL via `EraFileType::from_url`, which checks whether the URL string contains "era1". When the hosting URL does not contain "era1" (e.g. `https://gc-era.gnosiscoredevs.io/`), the client incorrectly defaults to `EraFileType::Era` even though the server hosts ERA1 files. This causes it to look for `.era` extensions instead of `.era1`, construct wrong download URLs, and silently save HTTP 403 error pages as ERA files — which then fail with "Reserved field in header not zero" when parsed.

This PR adds a `with_era_type` builder method so callers can explicitly set the file type when the URL-based heuristic is insufficient.