### PR TITLE
txpool: enforce non-zero max-batch-size for RPC insertion batching

### DIFF
--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -20,6 +20,14 @@ use std::{path::PathBuf, sync::OnceLock, time::Duration};
 /// Global static transaction pool defaults
 static TXPOOL_DEFAULTS: OnceLock<DefaultTxPoolValues> = OnceLock::new();
 
+fn parse_non_zero_usize(value: &str) -> Result<usize, String> {
+    let parsed = value.parse::<usize>().map_err(|err| err.to_string())?;
+    if parsed == 0 {
+        return Err("value must be at least 1".to_string())
+    }
+    Ok(parsed)
+}
+
 /// Default values for transaction pool that can be customized
 ///
 /// Global defaults can be set via [`DefaultTxPoolValues::try_init`].
@@ -409,7 +417,11 @@ pub struct TxPoolArgs {
     pub disable_transactions_backup: bool,
 
     /// Max batch size for transaction pool insertions
-    #[arg(long = "txpool.max-batch-size", default_value_t = DefaultTxPoolValues::get_global().max_batch_size)]
+    #[arg(
+        long = "txpool.max-batch-size",
+        default_value_t = DefaultTxPoolValues::get_global().max_batch_size,
+        value_parser = parse_non_zero_usize
+    )]
     pub max_batch_size: usize,
 }
 
@@ -545,7 +557,7 @@ impl RethTransactionPoolConfig for TxPoolArgs {
 
     /// Returns max batch size for transaction batch insertion.
     fn max_batch_size(&self) -> usize {
-        self.max_batch_size
+        self.max_batch_size.max(1)
     }
 }
 
@@ -587,6 +599,19 @@ mod tests {
             CommandParser::<TxPoolArgs>::try_parse_from(["reth", "--txpool.lifetime", "invalid"]);
 
         assert!(result.is_err(), "Expected an error for invalid duration");
+    }
+
+    #[test]
+    fn txpool_parse_zero_max_batch_size_is_invalid() {
+        let result =
+            CommandParser::<TxPoolArgs>::try_parse_from(["reth", "--txpool.max-batch-size", "0"]);
+        assert!(result.is_err(), "Expected an error for zero max batch size");
+    }
+
+    #[test]
+    fn txpool_max_batch_size_config_is_defensively_non_zero() {
+        let args = TxPoolArgs { max_batch_size: 0, ..Default::default() };
+        assert_eq!(RethTransactionPoolConfig::max_batch_size(&args), 1);
     }
 
     #[test]

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -61,6 +61,8 @@ where
     ) -> (Self, mpsc::UnboundedSender<BatchTxRequest<Pool::Transaction>>) {
         let (request_tx, request_rx) = mpsc::unbounded_channel();
 
+        let max_batch_size = max_batch_size.max(1);
+
         let processor = Self { pool, max_batch_size, buf: Vec::with_capacity(1), request_rx };
 
         (processor, request_tx)
@@ -242,6 +244,35 @@ mod tests {
             .await
             .expect("Timeout waiting for transaction result")
         {
+            assert!(result.is_ok());
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_zero_max_batch_size_is_clamped_and_completes() {
+        let pool = testing_pool();
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 0);
+        assert_eq!(processor.max_batch_size, 1);
+
+        // Spawn the processor
+        let handle = tokio::spawn(processor);
+
+        let mut responses = Vec::new();
+        for i in 0..10 {
+            let tx = MockTransaction::legacy().with_nonce(i).with_gas_price(100);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            let request = BatchTxRequest::new(TransactionOrigin::Local, tx, response_tx);
+            request_tx.send(request).expect("Could not send batch tx");
+            responses.push(response_rx);
+        }
+
+        for response_rx in responses {
+            let result = timeout(Duration::from_millis(10), response_rx)
+                .await
+                .expect("Timeout waiting for response")
+                .expect("Response channel was closed unexpectedly");
             assert!(result.is_ok());
         }
 


### PR DESCRIPTION
## Summary
- clamp `BatchTxProcessor` batch size to at least `1` at construction time
- reject `--txpool.max-batch-size 0` at CLI parse time
- defensively clamp `RethTransactionPoolConfig::max_batch_size()` to at least `1`
- add zero-case regression tests for both batcher completion and txpool arg parsing/config behavior

## Why
`txpool.max-batch-size` is user configurable and currently reaches the tx insertion batcher unchanged.
When it is set to `0`, `poll_recv_many` can return without making progress, which can leave RPC insertion oneshot responses unresolved.
This directly impacts transaction submission reliability and latency for `eth_sendRawTransaction` and related insertion paths.

## Testing
- `cargo build -p reth-transaction-pool -p reth-node-core`
- `cargo test -p reth-transaction-pool`
- `cargo test -p reth-node-core`
- `cargo test -p reth-transaction-pool batcher::tests::test_zero_max_batch_size_is_clamped_and_completes`
- `cargo test -p reth-node-core txpool_parse_zero_max_batch_size_is_invalid`
- `cargo test -p reth-node-core txpool_max_batch_size_config_is_defensively_non_zero`
- `cargo +nightly fmt --check`

Note: `cargo clippy -p reth-transaction-pool -p reth-node-core --tests -- -D warnings` currently fails on clean `origin/main` due a pre-existing `unused_crate_dependencies` error in `crates/evm/execution-types`.