### PR TITLE
fix(test): prevent temp directory leak in test utilities

### DIFF
--- a/crates/exex/test-utils/src/lib.rs
+++ b/crates/exex/test-utils/src/lib.rs
@@ -20,9 +20,7 @@ use futures_util::FutureExt;
 use reth_chainspec::{ChainSpec, MAINNET};
 use reth_consensus::test_utils::TestConsensus;
 use reth_db::{
-    test_utils::{
-        create_test_rocksdb_dir, create_test_rw_db, create_test_static_files_dir, TempDatabase,
-    },
+    test_utils::{create_test_rw_db_with_datadir, tempdir_path, TempDatabase},
     DatabaseEnv,
 };
 use reth_db_common::init::init_genesis;
@@ -52,7 +50,7 @@ use reth_node_ethereum::{
 use reth_payload_builder::noop::NoopPayloadBuilderService;
 use reth_primitives_traits::{Block as _, RecoveredBlock};
 use reth_provider::{
-    providers::{BlockchainProvider, RocksDBProvider, StaticFileProvider},
+    providers::{BlockchainProvider, RocksDBBuilder, StaticFileProvider},
     BlockReader, EthStorage, ProviderFactory,
 };
 use reth_tasks::Runtime;
@@ -244,14 +242,17 @@ pub async fn test_exex_context_with_chain_spec(
     let evm_config = MockEvmConfig::default();
     let consensus = Arc::new(TestConsensus::default());
 
-    let (static_dir, _) = create_test_static_files_dir();
-    let (rocksdb_dir, _) = create_test_rocksdb_dir();
-    let db = create_test_rw_db();
+    // Use a single temp directory for all data dirs so TempDatabase cleans up everything
+    let datadir_path = tempdir_path();
+    let static_files_path = datadir_path.join("static_files");
+    let rocksdb_path = datadir_path.join("rocksdb");
+    std::fs::create_dir_all(&static_files_path).expect("failed to create static_files dir");
+
     let provider_factory = ProviderFactory::<NodeTypesWithDBAdapter<TestNode, _>>::new(
-        db,
+        create_test_rw_db_with_datadir(&datadir_path),
         chain_spec.clone(),
-        StaticFileProvider::read_write(static_dir.keep()).expect("static file provider"),
-        RocksDBProvider::builder(rocksdb_dir.keep()).with_default_tables().build().unwrap(),
+        StaticFileProvider::read_write(&static_files_path).expect("static file provider"),
+        RocksDBBuilder::new(&rocksdb_path).with_default_tables().build().unwrap(),
         reth_tasks::Runtime::test(),
     )?;
 

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -324,12 +324,10 @@ impl<Provider, S: Stage<Provider> + ?Sized> StageExt<Provider> for S {}
 #[cfg(test)]
 mod tests {
     use reth_chainspec::MAINNET;
-    use reth_db::test_utils::{
-        create_test_rocksdb_dir, create_test_rw_db, create_test_static_files_dir,
-    };
+    use reth_db::test_utils::{create_test_rw_db_with_datadir, tempdir_path};
     use reth_db_api::{models::StoredBlockBodyIndices, tables, transaction::DbTxMut};
     use reth_provider::{
-        providers::RocksDBProvider, test_utils::MockNodeTypesWithDB, ProviderFactory,
+        providers::RocksDBBuilder, test_utils::MockNodeTypesWithDB, ProviderFactory,
         StaticFileProviderBuilder, StaticFileProviderFactory, StaticFileSegment,
     };
     use reth_stages_types::StageCheckpoint;
@@ -340,14 +338,21 @@ mod tests {
     #[test]
     fn test_exec_input_next_block_range_with_transaction_threshold() {
         let mut rng = generators::rng();
+
+        // Use a single temp directory for all data dirs so TempDatabase cleans up everything
+        let datadir_path = tempdir_path();
+        let static_files_path = datadir_path.join("static_files");
+        let rocksdb_path = datadir_path.join("rocksdb");
+        std::fs::create_dir_all(&static_files_path).expect("failed to create static_files dir");
+
         let provider_factory = ProviderFactory::<MockNodeTypesWithDB>::new(
-            create_test_rw_db(),
+            create_test_rw_db_with_datadir(&datadir_path),
             MAINNET.clone(),
-            StaticFileProviderBuilder::read_write(create_test_static_files_dir().0.keep())
+            StaticFileProviderBuilder::read_write(&static_files_path)
                 .with_blocks_per_file(1)
                 .build()
-                .unwrap(),
-            RocksDBProvider::builder(create_test_rocksdb_dir().0.keep()).build().unwrap(),
+                .expect("static file provider"),
+            RocksDBBuilder::new(&rocksdb_path).build().unwrap(),
             reth_tasks::Runtime::test(),
         )
         .unwrap();


### PR DESCRIPTION
Calling `.keep()` on `TempDir` abandons ownership and prevents cleanup. Tests were leaving behind `reth-test-static-*` and `reth-test-rocksdb-*` directories in `/tmp`. Now using a single parent temp directory with `create_test_rw_db_with_datadir()` so `TempDatabase` cleans up everything on drop—same pattern already used in `crates/storage/provider/src/test_utils/mod.rs`.