### PR TITLE
fix(rpc): enforce non-zero max tracing requests

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -28,6 +28,14 @@ use super::types::MaxOr;
 /// Global static RPC server defaults
 static RPC_SERVER_DEFAULTS: OnceLock<DefaultRpcServerArgs> = OnceLock::new();
 
+fn parse_non_zero_usize(value: &str) -> Result<usize, String> {
+    let parsed = value.parse::<usize>().map_err(|err| err.to_string())?;
+    if parsed == 0 {
+        return Err("value must be at least 1".to_string())
+    }
+    Ok(parsed)
+}
+
 /// Default max number of subscriptions per connection.
 pub(crate) const RPC_DEFAULT_MAX_SUBS_PER_CONN: u32 = 1024;
 
@@ -533,7 +541,13 @@ pub struct RpcServerArgs {
     /// Tracing requests are generally CPU bound.
     /// Choosing a value that is higher than the available CPU cores can have a negative impact on
     /// the performance of the node and affect the node's ability to maintain sync.
-    #[arg(long = "rpc.max-tracing-requests", alias = "rpc-max-tracing-requests", value_name = "COUNT", default_value_t = DefaultRpcServerArgs::get_global().rpc_max_tracing_requests)]
+    #[arg(
+        long = "rpc.max-tracing-requests",
+        alias = "rpc-max-tracing-requests",
+        value_name = "COUNT",
+        value_parser = parse_non_zero_usize,
+        default_value_t = DefaultRpcServerArgs::get_global().rpc_max_tracing_requests
+    )]
     pub rpc_max_tracing_requests: usize,
 
     /// Maximum number of concurrent blocking IO requests.
@@ -1007,6 +1021,16 @@ mod tests {
         let args = CommandParser::<RpcServerArgs>::parse_from(["reth"]).args;
         let expected = 1_000_000_000_000_000_000u128;
         assert_eq!(args.rpc_tx_fee_cap, expected); // 1 ETH default cap
+    }
+
+    #[test]
+    fn test_rpc_max_tracing_requests_reject_zero() {
+        let result = CommandParser::<RpcServerArgs>::try_parse_from([
+            "reth",
+            "--rpc.max-tracing-requests",
+            "0",
+        ]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -543,9 +543,12 @@ where
     where
         EvmConfig: ConfigureEvm<Primitives = N>,
     {
-        let blocking_pool_guard = BlockingTaskGuard::new(config.eth.max_tracing_requests);
+        let mut eth_config = config.eth;
+        eth_config.max_tracing_requests = eth_config.max_tracing_requests.max(1);
 
-        let eth = EthHandlers::bootstrap(config.eth.clone(), executor.clone(), eth_api);
+        let blocking_pool_guard = BlockingTaskGuard::new(eth_config.max_tracing_requests);
+
+        let eth = EthHandlers::bootstrap(eth_config.clone(), executor.clone(), eth_api);
 
         Self {
             provider,
@@ -556,7 +559,7 @@ where
             consensus,
             modules: Default::default(),
             blocking_pool_guard,
-            eth_config: config.eth,
+            eth_config,
             evm_config,
             engine_events,
         }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -377,13 +377,11 @@ where
             .into())
         }
 
+        let max_tracing_requests = self.inner.eth_config.max_tracing_requests.max(1);
         let mut all_traces = Vec::new();
-        let mut block_traces = Vec::with_capacity(self.inner.eth_config.max_tracing_requests);
-        for chunk_start in (start..=end).step_by(self.inner.eth_config.max_tracing_requests) {
-            let chunk_end = std::cmp::min(
-                chunk_start + self.inner.eth_config.max_tracing_requests as u64 - 1,
-                end,
-            );
+        let mut block_traces = Vec::with_capacity(max_tracing_requests);
+        for chunk_start in (start..=end).step_by(max_tracing_requests) {
+            let chunk_end = std::cmp::min(chunk_start + max_tracing_requests as u64 - 1, end);
 
             // fetch all blocks in that chunk
             let blocks = self


### PR DESCRIPTION
Refs #22477

Reject zero for rpc.max-tracing-requests and clamp runtime fallback to 1, preventing trace_filter step_by(0) panics while keeping behavior aligned with configurable tracing limits.