### PR TITLE
fix(rpc): remove 0x prefix from admin_peers id to match go-ethereum format

### DIFF
--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -76,7 +76,7 @@ where
 
         for peer in peers {
             infos.push(PeerInfo {
-                id: keccak256(peer.remote_id.as_slice()).to_string(),
+                id: alloy_primitives::hex::encode(keccak256(peer.remote_id.as_slice())),
                 name: peer.client_version.to_string(),
                 enode: peer.enode,
                 enr: peer.enr,


### PR DESCRIPTION
## Summary

Removes the spurious `0x` prefix from `admin_peers[].id`, making it consistent with go-ethereum which returns bare hex without any prefix.

## Root Cause

`keccak256(...).to_string()` uses alloy-primitives `B256::Display`, which always prepends `0x` (via `fmt_hex` with `prefix = true`). Replacing it with `alloy_primitives::hex::encode(...)` produces a bare 64-character hex string.

As a bonus, the `node_info` handler in the same file already uses `hex::encode` at line 160 — so this change makes both handlers consistent.

## Change

**File:** `crates/rpc/rpc/src/admin.rs`

```diff
-id: keccak256(peer.remote_id.as_slice()).to_string(),
+id: alloy_primitives::hex::encode(keccak256(peer.remote_id.as_slice())),
```

## Before / After

| | Value | Length | Has `0x`? |
|---|---|---|---|
| Before | `0x6b36f791352f15eb3ec4f67787074ab8ad9d487e37c4401d383f0561a0a20507` | 66 chars | Yes ❌ |
| After | `6b36f791352f15eb3ec4f67787074ab8ad9d487e37c4401d383f0561a0a20507` | 64 chars | No ✅ |

Closes #23316

## Related

- #19245 fixed the hash algorithm (raw pubkey → keccak256) but left the `0x` prefix issue
- go-ethereum reference: https://github.com/ethereum/go-ethereum/blob/master/p2p/server.go