### PR TITLE
fix(rpc): admin_nodeInfo.id now returns keccak256 node ID matching go-ethereum format

### DIFF
--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_network_api::{NetworkInfo, Peers};
-use reth_network_peers::{id2pk, AnyNode, NodeRecord};
+use reth_network_peers::{AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
 use reth_rpc_api::AdminApiServer;
 use reth_rpc_server_types::ToRpcResult;
@@ -155,9 +155,7 @@ where
         ]);
 
         Ok(NodeInfo {
-            id: id2pk(enode.id)
-                .map(|pk| pk.to_string())
-                .unwrap_or_else(|_| alloy_primitives::hex::encode(enode.id.as_slice())),
+            id: alloy_primitives::hex::encode(keccak256(enode.id.as_slice())),
             name: status.client_version,
             enode: enode.to_string(),
             enr: self.network.local_enr().to_string(),


### PR DESCRIPTION
## Summary

Fixes `admin_nodeInfo.id` to return the correct node ID format matching go-ethereum: `keccak256(X||Y)` of the public key as a 64-character hex string without `0x` prefix.

Previously, `id2pk(enode.id).map(|pk| pk.to_string())` was used, which calls the secp256k1 crate's `LowerHex` implementation that returns the **compressed** public key (33 bytes, 66 hex chars, `02`/`03` prefix). This is not the node ID format used by go-ethereum or the Ethereum devp2p spec.

This also makes `admin_nodeInfo` **consistent** with `admin_peers`, which already correctly uses `keccak256(peer.remote_id.as_slice())`.

## Changes

- `crates/rpc/rpc/src/admin.rs`: Replace `id2pk(enode.id).map(|pk| pk.to_string()).unwrap_or_else(...)` with `alloy_primitives::hex::encode(keccak256(enode.id.as_slice()))`
- Remove now-unused `id2pk` import from `reth_network_peers`

## Before / After

| | Value | Length | Format |
|---|---|---|---|
| Before | `02a1b2c3...` | 66 chars | compressed secp256k1 pubkey |
| After | `6b36f791...` | 64 chars | `keccak256(X\|\|Y)` — go-ethereum compatible |

## Why this works

`enode.id` is a `PeerId` (`B512`), which already holds the raw 64-byte uncompressed public key coordinates `X||Y`. Calling `keccak256` on those bytes directly produces the correct 32-byte node ID — exactly what go-ethereum does:

```go
// go-ethereum: p2p/enode/idscheme.go
math.ReadBits(pubkey.X, buf[:32])
math.ReadBits(pubkey.Y, buf[32:])
return crypto.Keccak256(buf)
```

`keccak256` is already imported in this file (used by `admin_peers`), so no new dependencies are added.

Closes #23317

## Related

- Attempted fix in #9448 (did not fully resolve the format)
- go-ethereum reference: https://github.com/ethereum/go-ethereum/blob/master/p2p/enode/idscheme.go