### PR TITLE
fix(engine): use caller's gas state on precompile cache hits

### DIFF
--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -9,7 +9,7 @@ use reth_evm::precompiles::{
     DynPrecompile, Precompile, PrecompileInput, PrecompileOutputExt, PrecompileResultExt,
 };
 use reth_primitives_traits::dashmap::DashMap;
-use revm::precompile::PrecompileId;
+use revm::{interpreter::gas::GasTracker, precompile::PrecompileId};
 use revm_primitives::Address;
 use std::{hash::Hash, sync::Arc};
 
@@ -87,8 +87,16 @@ impl<S> CacheEntry<S> {
         self.output.gas.limit() - self.output.gas.remaining()
     }
 
-    fn to_precompile_result(&self) -> PrecompileResultExt {
-        Ok(self.output.clone())
+    /// Construct a result using the cached output bytes and regular gas cost,
+    /// but with the *caller's current* gas limit and reservoir so we don't
+    /// overwrite live state-gas accounting (`reservoir`, `state_gas_spent`).
+    fn to_precompile_result(&self, gas_limit: u64, reservoir: u64) -> PrecompileResultExt {
+        let gas_used = self.regular_gas_used();
+        Ok(PrecompileOutputExt {
+            gas: GasTracker::new(gas_limit, gas_limit - gas_used, reservoir),
+            bytes: self.output.bytes.clone(),
+            reverted: self.output.reverted,
+        })
     }
 }
 
@@ -175,7 +183,7 @@ where
             input.gas >= entry.regular_gas_used()
         {
             self.increment_by_one_precompile_cache_hits();
-            return entry.to_precompile_result();
+            return entry.to_precompile_result(input.gas, input.reservoir);
         }
 
         let calldata = input.data;
@@ -365,5 +373,35 @@ mod tests {
             .into_output()
             .unwrap();
         assert_eq!(result3.as_ref(), b"output_from_precompile_1");
+    }
+
+    /// Cache hits must return the *caller's current* gas_limit and reservoir,
+    /// not the stale values captured during the original (miss) execution.
+    #[test]
+    fn test_cache_hit_preserves_caller_reservoir() {
+        let precompile_gas_cost = 5000u64;
+
+        let cache_entry = CacheEntry {
+            output: PrecompileOutputExt {
+                // Original call had gas_limit=100_000, reservoir=800
+                gas: GasTracker::new(100_000, 100_000 - precompile_gas_cost, 800),
+                bytes: Bytes::copy_from_slice(b"result"),
+                reverted: false,
+            },
+            spec: SpecId::PRAGUE,
+        };
+
+        assert_eq!(cache_entry.regular_gas_used(), precompile_gas_cost);
+
+        // Simulate a cache hit where caller has different gas_limit and reservoir.
+        let caller_gas = 50_000u64;
+        let caller_reservoir = 200u64;
+        let result = cache_entry.to_precompile_result(caller_gas, caller_reservoir).unwrap();
+
+        // The returned GasTracker must reflect the *caller's* values.
+        assert_eq!(result.gas.limit(), caller_gas);
+        assert_eq!(result.gas.remaining(), caller_gas - precompile_gas_cost);
+        assert_eq!(result.gas.reservoir(), caller_reservoir);
+        assert_eq!(result.gas.state_gas_spent(), 0);
     }
 }

--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -5,9 +5,10 @@
 use alloy_evm::{
     eth::EthEvmContext,
     precompiles::{
-        DynPrecompile, Precompile, PrecompileInput, PrecompileResultExt, PrecompilesMap,
+        DynPrecompile, Precompile, PrecompileInput, PrecompileOutputExt, PrecompileResultExt,
+        PrecompilesMap,
     },
-    revm::{handler::EthPrecompiles, precompile::PrecompileId},
+    revm::{handler::EthPrecompiles, interpreter::gas::GasTracker, precompile::PrecompileId},
     Evm, EvmFactory,
 };
 use alloy_genesis::Genesis;
@@ -41,14 +42,26 @@ use reth_tracing::{RethTracer, Tracer};
 use schnellru::{ByLength, LruMap};
 use std::sync::Arc;
 
+/// Cached output of a successful precompile call.
+///
+/// Only the output bytes, regular gas cost, and reverted flag are stored.
+/// The gas tracker is reconstructed on cache hit using the caller's current
+/// gas limit and reservoir to avoid returning stale EIP-8037 state gas values.
+#[derive(Debug, Clone)]
+pub struct CachedOutput {
+    bytes: Bytes,
+    gas_used: u64,
+    reverted: bool,
+}
+
 /// Type alias for the LRU cache used within the [`PrecompileCache`].
-type PrecompileLRUCache = LruMap<(Bytes, u64), PrecompileResultExt>;
+type PrecompileLRUCache = LruMap<Bytes, CachedOutput>;
 
 /// A cache for precompile inputs / outputs.
 ///
-/// This cache works with standard precompiles that take input data and gas limit as parameters.
-/// The cache key is composed of the input bytes and gas limit, and the cached value is the
-/// precompile execution result.
+/// The cache key is the input bytes. On cache hit, a fresh `GasTracker` is built
+/// from the caller's current gas limit and reservoir so that EIP-8037 state gas
+/// accounting is never corrupted by stale cached values.
 #[derive(Debug)]
 pub struct PrecompileCache {
     /// Caches for each precompile input / output.
@@ -86,7 +99,7 @@ impl EvmFactory for MyEvmFactory {
 
         let mut evm = EthEvm::new(evm, false);
 
-        evm.precompiles_mut().map_precompiles(|_, precompile| {
+        evm.precompiles_mut().map_cacheable_precompiles(|_, precompile| {
             WrappedPrecompile::wrap(precompile, new_cache.clone())
         });
 
@@ -136,20 +149,33 @@ impl Precompile for WrappedPrecompile {
 
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResultExt {
         let mut cache = self.cache.write();
-        let key = (Bytes::copy_from_slice(input.data), input.gas);
+        let key = Bytes::copy_from_slice(input.data);
 
-        // get the result if it exists
-        if let Some(result) = cache.cache.get(&key) {
-            return result.clone()
+        // On cache hit, rebuild the GasTracker from the *caller's current* gas
+        // limit and reservoir so we never return stale EIP-8037 state gas values.
+        if let Some(cached) = cache.cache.get(&key) &&
+            input.gas >= cached.gas_used
+        {
+            return Ok(PrecompileOutputExt {
+                gas: GasTracker::new(input.gas, input.gas - cached.gas_used, input.reservoir),
+                bytes: cached.bytes.clone(),
+                reverted: cached.reverted,
+            });
         }
 
-        // call the precompile if cache miss
-        let output = self.precompile.call(input);
+        // Call the precompile on cache miss.
+        let result = self.precompile.call(input);
 
-        // insert the result into the cache
-        cache.cache.insert(key, output.clone());
+        // Cache successful results.
+        if let Ok(output) = &result {
+            let gas_used = output.gas.limit() - output.gas.remaining();
+            cache.cache.insert(
+                key,
+                CachedOutput { bytes: output.bytes.clone(), gas_used, reverted: output.reverted },
+            );
+        }
 
-        output
+        result
     }
 }
 
@@ -163,9 +189,8 @@ pub struct MyExecutorBuilder {
 
 impl Default for MyExecutorBuilder {
     fn default() -> Self {
-        let precompile_cache = PrecompileCache {
-            cache: LruMap::<(Bytes, u64), PrecompileResultExt>::new(ByLength::new(100)),
-        };
+        let precompile_cache =
+            PrecompileCache { cache: LruMap::<Bytes, CachedOutput>::new(ByLength::new(100)) };
         Self { precompile_cache: Arc::new(RwLock::new(precompile_cache)) }
     }
 }


### PR DESCRIPTION
Cached precompile results stored the full `GasTracker` from the original
execution, including `reservoir` and `state_gas_spent`. On cache hits, returning
that stale tracker overwrote the caller's live gas state — corrupting EIP-8037
reservoir accounting by restoring already-spent reservoir gas and zeroing
`state_gas_spent`.

Builds a fresh `GasTracker` from the caller's current `gas_limit` and
`reservoir` on cache hits, replaying only the cached regular gas cost.
Also preserves the `reverted` flag from the cached output instead of
hardcoding `false`.

Prompted by: Dragan