### PR TITLE
fix(net): avoid itertools Format panic in tracing log

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1,7 +1,6 @@
 //! Transactions management for the p2p network.
 
 use alloy_consensus::transaction::TxHashRef;
-use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 /// Aggregation on configurable parameters for [`TransactionsManager`].
@@ -785,7 +784,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         trace!(target: "net::tx::propagation",
             peer_id=format!("{peer_id:#}"),
             hashes_len=valid_announcement_data.len(),
-            hashes=%valid_announcement_data.keys().format(", "),
+            hashes=?valid_announcement_data.keys(),
             msg_version=%valid_announcement_data.msg_version(),
             client_version=%client,
             "received previously unseen and pending hashes in announcement from peer"


### PR DESCRIPTION
The itertools `Format` adapter can only be consumed once. When used with tracing's `%` sigil, the subscriber may evaluate it multiple times, causing a `Format: was already formatted once` panic. Switches to `?` (Debug) formatting instead and removes the now-unused itertools import.