### PR TITLE
chore: allow "writeable" in typos config

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -41,3 +41,4 @@ Pn = "Pn" # Part of UPnP (Universal Plug and Play)
 BA = "BA" # Part of BAL - Block Access List (EIP-7928)
 consts = "consts" # std::env::consts is a valid Rust module
 Consts = "Consts" # Valid identifier suffix (e.g., RethCliVersionConsts)
+writeable = "writeable"


### PR DESCRIPTION
Adds "writeable" to the allowed words list in `typos.toml` to suppress the false positive suggesting it should be "writable".