### PR TITLE
chore: move alloy-rlp to dev-dependencies in reth-execution-types

### DIFF
--- a/crates/evm/execution-types/Cargo.toml
+++ b/crates/evm/execution-types/Cargo.toml
@@ -22,8 +22,6 @@ alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-eips.workspace = true
-alloy-rlp.workspace = true
-
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 
@@ -36,6 +34,7 @@ alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 arbitrary.workspace = true
 bincode.workspace = true
 rand.workspace = true
+alloy-rlp.workspace = true
 
 [features]
 default = ["std"]
@@ -69,5 +68,4 @@ std = [
     "reth-ethereum-primitives/std",
     "reth-trie-common/std",
     "alloy-evm/std",
-    "alloy-rlp/std",
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -41,3 +41,4 @@ Pn = "Pn" # Part of UPnP (Universal Plug and Play)
 BA = "BA" # Part of BAL - Block Access List (EIP-7928)
 consts = "consts" # std::env::consts is a valid Rust module
 Consts = "Consts" # Valid identifier suffix (e.g., RethCliVersionConsts)
+writeable = "writeable"


### PR DESCRIPTION
`alloy-rlp` is only used in test code, so it belongs in `[dev-dependencies]`. Also removes its `std` feature from the `std` feature list.