### PR TITLE
perf(rpc): pre-allocate vectors in `eth_feeHistory`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -137,13 +137,14 @@ pub trait EthFees:
             let start_block = end_block_plus - block_count;
 
             // Collect base fees, gas usage ratios and (optionally) reward percentile data
-            let mut base_fee_per_gas: Vec<u128> = Vec::new();
-            let mut gas_used_ratio: Vec<f64> = Vec::new();
+            // Pre-allocate capacity: base_fee and blob_fee need +1 for the next block's fee
+            let mut base_fee_per_gas: Vec<u128> = Vec::with_capacity(block_count as usize + 1);
+            let mut gas_used_ratio: Vec<f64> = Vec::with_capacity(block_count as usize);
 
-            let mut base_fee_per_blob_gas: Vec<u128> = Vec::new();
-            let mut blob_gas_used_ratio: Vec<f64> = Vec::new();
+            let mut base_fee_per_blob_gas: Vec<u128> = Vec::with_capacity(block_count as usize + 1);
+            let mut blob_gas_used_ratio: Vec<f64> = Vec::with_capacity(block_count as usize);
 
-            let mut rewards: Vec<Vec<u128>> = Vec::new();
+            let mut rewards: Vec<Vec<u128>> = Vec::with_capacity(block_count as usize);
 
             // Check if the requested range is within the cache bounds
             let fee_entries = self.fee_history_cache().get_history(start_block, end_block).await;

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -144,7 +144,11 @@ pub trait EthFees:
             let mut base_fee_per_blob_gas: Vec<u128> = Vec::with_capacity(block_count as usize + 1);
             let mut blob_gas_used_ratio: Vec<f64> = Vec::with_capacity(block_count as usize);
 
-            let mut rewards: Vec<Vec<u128>> = Vec::with_capacity(block_count as usize);
+            let mut rewards: Vec<Vec<u128>> = if reward_percentiles.is_some() {
+                Vec::with_capacity(block_count as usize)
+            } else {
+                Vec::new()
+            };
 
             // Check if the requested range is within the cache bounds
             let fee_entries = self.fee_history_cache().get_history(start_block, end_block).await;


### PR DESCRIPTION
Vectors in `eth_feeHistory` were growing dynamically despite `block_count` being known upfront. Switched from `Vec::new()` to `Vec::with_capacity()` for all five vectors, eliminating ~10 reallocations per vector on large requests (block_count=1024).