### PR TITLE
fix(rpc): apply count only after after is consumed

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -454,14 +454,16 @@ where
                 after = None;
             }
 
-            // Return at most `count` of traces
-            if let Some(count) = count {
+            // Return at most `count` traces after `after` has been consumed.
+            if after.is_none() &&
+                let Some(count) = count
+            {
                 let count = count as usize;
                 if count < all_traces.len() {
                     all_traces.truncate(count);
                     return Ok(all_traces)
                 }
-            };
+            }
         }
 
         // If `after` is greater than or equal to the number of matched traces, it returns an

--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -94,7 +94,7 @@ These include general information about the node itself, as well as what protoco
     "id": 1,
     "result": {
         "enode": "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@[::]:30303",
-            "id": "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
+            "id": "8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
             "ip": "::",
             "listenAddr": "[::]:30303",
             "name": "reth/v0.0.1/x86_64-unknown-linux-gnu",
@@ -128,7 +128,7 @@ Returns information about peers currently known to the node.
 // > {"jsonrpc":"2.0","id":1,"method":"admin_peers","params":[]}
 {"jsonrpc":"2.0","id":1,"result":[
   {
-    "id":"44826a5d6a55f88a18298bca4773fca...",
+    "id":"8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
     "name":"reth/v0.0.1/x86_64-unknown-linux-gnu",
     "enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303",
     "enr":"enr:-IS4QHCYr...",
@@ -190,7 +190,7 @@ The subscription emits events with the following structure:
         "result": {
             "type": "add", // or "drop", "error"
             "peer": {
-                "id": "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
+                "id": "8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
                 "enode": "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303",
                 "addr": "192.168.1.1:30303"
             },
@@ -208,7 +208,7 @@ The subscription emits events with the following structure:
 {"jsonrpc": "2.0", "id": 1, "result": "0xcd0c3e8af590364c09d0fa6a1210faf5"}
 
 // Example event when a peer connects
-{"jsonrpc":"2.0","method":"admin_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"type":"add","peer":{"id":"44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d","enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303","addr":"192.168.1.1:30303"}}}}
+{"jsonrpc":"2.0","method":"admin_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"type":"add","peer":{"id":"8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a","enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303","addr":"192.168.1.1:30303"}}}}
 
 // Unsubscribe
 // > {"jsonrpc":"2.0","id":2,"method":"admin_peerEvents_unsubscribe","params":["0xcd0c3e8af590364c09d0fa6a1210faf5"]}

--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -94,7 +94,7 @@ These include general information about the node itself, as well as what protoco
     "id": 1,
     "result": {
         "enode": "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@[::]:30303",
-            "id": "8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
+            "id": "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
             "ip": "::",
             "listenAddr": "[::]:30303",
             "name": "reth/v0.0.1/x86_64-unknown-linux-gnu",
@@ -128,7 +128,7 @@ Returns information about peers currently known to the node.
 // > {"jsonrpc":"2.0","id":1,"method":"admin_peers","params":[]}
 {"jsonrpc":"2.0","id":1,"result":[
   {
-    "id":"8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
+    "id":"44826a5d6a55f88a18298bca4773fca...",
     "name":"reth/v0.0.1/x86_64-unknown-linux-gnu",
     "enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303",
     "enr":"enr:-IS4QHCYr...",
@@ -190,7 +190,7 @@ The subscription emits events with the following structure:
         "result": {
             "type": "add", // or "drop", "error"
             "peer": {
-                "id": "8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
+                "id": "44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d",
                 "enode": "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303",
                 "addr": "192.168.1.1:30303"
             },
@@ -208,7 +208,7 @@ The subscription emits events with the following structure:
 {"jsonrpc": "2.0", "id": 1, "result": "0xcd0c3e8af590364c09d0fa6a1210faf5"}
 
 // Example event when a peer connects
-{"jsonrpc":"2.0","method":"admin_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"type":"add","peer":{"id":"8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a","enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303","addr":"192.168.1.1:30303"}}}}
+{"jsonrpc":"2.0","method":"admin_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"type":"add","peer":{"id":"44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d","enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303","addr":"192.168.1.1:30303"}}}}
 
 // Unsubscribe
 // > {"jsonrpc":"2.0","id":2,"method":"admin_peerEvents_unsubscribe","params":["0xcd0c3e8af590364c09d0fa6a1210faf5"]}


### PR DESCRIPTION
Apply count only after after has been consumed in trace_filter to preserve pagination semantics.