### PR TITLE
docs(libmdbx): fix typo writeable -> writable

### DIFF
--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -282,7 +282,7 @@ pub enum EnvironmentKind {
     #[default]
     Default,
     /// Open the environment as mdbx-WRITEMAP.
-    /// Use a writeable memory map unless the environment is opened as `MDBX_RDONLY`
+    /// Use a writable memory map unless the environment is opened as `MDBX_RDONLY`
     /// ([`crate::Mode::ReadOnly`]).
     ///
     /// All data will be mapped into memory in the read-write mode [`crate::Mode::ReadWrite`]. This


### PR DESCRIPTION
## Description

This PR fixes a minor typo in the documentation of `EnvironmentKind::WriteMap` in `crates/storage/libmdbx-rs/src/environment.rs`.

- `writeable` -> `writable`