### PR TITLE
chore: migrate `allow(clippy::` to `expect(clippy::`

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -275,7 +275,7 @@ pub fn create_chain_config(
     // Check if DAO fork is supported (it has an activation block)
     let dao_fork_support = hardforks.fork(EthereumHardfork::Dao) != ForkCondition::Never;
 
-    #[allow(clippy::needless_update)]
+    #[expect(clippy::needless_update)]
     ChainConfig {
         chain_id: chain.map(|c| c.id()).unwrap_or(0),
         homestead_block: block_num(EthereumHardfork::Homestead),

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -55,7 +55,7 @@ pub(crate) struct MultiProofTaskMetrics {
 
 /// Dispatches work items as a single unit or in chunks based on target size and worker
 /// availability.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn dispatch_with_chunking<T, I>(
     items: T,
     chunking_len: usize,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -220,7 +220,7 @@ where
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Creates a new `TreePayloadValidator`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         provider: P,
         consensus: Arc<dyn FullConsensus<N>>,
@@ -1426,7 +1426,6 @@ where
     ///
     /// * `overlay_factory` - Pre-computed overlay factory for multiproof generation
     ///   (`StateRootTask`)
-    #[allow(clippy::too_many_arguments)]
     #[instrument(
         level = "debug",
         target = "engine::tree::payload_validator",

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -7,7 +7,6 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(clippy::useless_let_if_seq)]
 
 use alloy_consensus::Transaction;
 use alloy_primitives::U256;

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -161,7 +161,7 @@ impl<N: NodePrimitives> Chain<N> {
     /// 1. The blocks contained in the chain.
     /// 2. The execution outcome representing the final state.
     /// 3. The trie data map.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn into_inner(
         self,
     ) -> (

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -114,7 +114,7 @@ impl SessionError for EthStreamError {
                 P2PHandshakeError::NonHelloMessageInHandshake,
             )) => true,
             Self::EthHandshakeError(err) => {
-                #[allow(clippy::match_same_arms)]
+                #[expect(clippy::match_same_arms)]
                 match err {
                     EthHandshakeError::NoResponse => {
                         // this happens when the conn simply stalled
@@ -160,7 +160,7 @@ impl SessionError for EthStreamError {
                 )
             }
             Self::EthHandshakeError(err) => {
-                #[allow(clippy::match_same_arms)]
+                #[expect(clippy::match_same_arms)]
                 match err {
                     EthHandshakeError::NoResponse => {
                         // this happens when the conn simply stalled

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -447,7 +447,7 @@ impl Peer {
                 let self_covers = self_r.contains(range.start()) && self_r.contains(range.end());
                 let other_covers = other_r.contains(range.start()) && other_r.contains(range.end());
 
-                #[allow(clippy::match_same_arms)]
+                #[expect(clippy::match_same_arms)]
                 match (self_covers, other_covers) {
                     (true, false) => true,  // Only self covers the range
                     (false, true) => false, // Only other covers the range
@@ -531,7 +531,7 @@ struct Request<Req, Resp> {
 
 /// Requests that can be sent to the Syncer from a [`FetchClient`]
 #[derive(Debug)]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub(crate) enum DownloadRequest<N: NetworkPrimitives> {
     /// Download the requested headers and send response through channel
     GetBlockHeaders {

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -125,7 +125,6 @@ pub enum AnyNode {
 
 impl AnyNode {
     /// Returns the peer id of the node.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn peer_id(&self) -> PeerId {
         match self {
             Self::NodeRecord(record) => record.id,
@@ -136,7 +135,6 @@ impl AnyNode {
     }
 
     /// Returns the full node record if available.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -1,6 +1,7 @@
 //! Customizable node builder.
 
-#![allow(clippy::type_complexity, missing_debug_implementations)]
+#![expect(clippy::type_complexity)]
+#![allow(missing_debug_implementations)]
 
 use crate::{
     common::WithConfigs,

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -134,7 +134,7 @@ where
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         ctx.task_executor().spawn_critical_task("payload builder", async move {
-            #[allow(clippy::collection_is_never_read)]
+            #[expect(clippy::collection_is_never_read)]
             let mut subscriptions = Vec::new();
 
             while let Some(message) = rx.recv().await {

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1012,7 +1012,7 @@ where
     }
 
     /// Launches ExEx (Execution Extensions) and returns the ExEx manager handle.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub async fn launch_exex(
         &self,
         installed_exex: Vec<(
@@ -1034,7 +1034,7 @@ where
     ///     .launch()
     ///     .await
     /// ```
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn exex_launcher(
         &self,
         installed_exex: Vec<(

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -247,7 +247,7 @@ impl EngineNodeLauncher {
 
         info!(target: "reth::cli", "Consensus engine initialized");
 
-        #[allow(clippy::needless_continue)]
+        #[expect(clippy::needless_continue)]
         let events = stream_select!(
             event_sender.new_listener().map(Into::into),
             pipeline_events.map(Into::into),

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -18,7 +18,7 @@ pub enum PruneMode {
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-#[allow(clippy::derivable_impls)]
+#[expect(clippy::derivable_impls)]
 impl Default for PruneMode {
     fn default() -> Self {
         Self::Full

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -46,7 +46,7 @@ pub enum PruneSegment {
 }
 
 #[cfg(test)]
-#[allow(clippy::derivable_impls)]
+#[expect(clippy::derivable_impls)]
 impl Default for PruneSegment {
     fn default() -> Self {
         Self::SenderRecovery

--- a/crates/rpc/ipc/src/server/rpc_service.rs
+++ b/crates/rpc/ipc/src/server/rpc_service.rs
@@ -132,7 +132,7 @@ impl RpcServiceT for RpcService {
         }
     }
 
-    #[allow(clippy::manual_async_fn)]
+    #[expect(clippy::manual_async_fn)]
     fn notification<'a>(
         &self,
         _n: jsonrpsee::core::middleware::Notification<'a>,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -304,7 +304,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                     .evm_factory()
                     .create_tracer(&mut db, evm_env, inspector_setup())
                     .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
-                        #[allow(clippy::needless_update)]
+                        #[expect(clippy::needless_update)]
                         let tx_info = TransactionInfo {
                             hash: Some(*ctx.tx.tx_hash()),
                             index: Some(idx),

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -327,7 +327,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 let block_number = block.number();
                 let base_fee_per_gas = block.base_fee_per_gas();
                 if let Some((signer, tx)) = block.transactions_with_sender().nth(index) {
-                    #[allow(clippy::needless_update)]
+                    #[expect(clippy::needless_update)]
                     let tx_info = TransactionInfo {
                         hash: Some(*tx.tx_hash()),
                         block_hash: Some(block_hash),
@@ -403,7 +403,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                         .enumerate()
                         .find(|(_, (signer, tx))| **signer == sender && (*tx).nonce() == nonce)
                         .map(|(index, (signer, tx))| {
-                            #[allow(clippy::needless_update)]
+                            #[expect(clippy::needless_update)]
                             let tx_info = TransactionInfo {
                                 hash: Some(*tx.tx_hash()),
                                 block_hash: Some(block_hash),

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -203,7 +203,7 @@ impl<N: NodePrimitives> EthStateCache<N> {
     }
 
     /// Streams cached receipts and blocks for a list of block hashes, preserving input order.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn get_receipts_and_maybe_block_stream<'a>(
         &'a self,
         hashes: Vec<B256>,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -306,7 +306,7 @@ where
         let call = match result {
             ExecutionResult::Halt { reason, gas, .. } => {
                 let error = Err::from_evm_halt(reason, tx.gas_limit());
-                #[allow(clippy::needless_update)]
+                #[expect(clippy::needless_update)]
                 SimCallResult {
                     return_data: Bytes::new(),
                     error: Some(SimulateError {
@@ -322,7 +322,7 @@ where
             }
             ExecutionResult::Revert { output, gas, .. } => {
                 let error = Err::from_revert(output.clone());
-                #[allow(clippy::needless_update)]
+                #[expect(clippy::needless_update)]
                 SimCallResult {
                     return_data: output,
                     error: Some(SimulateError {
@@ -338,7 +338,7 @@ where
             }
             ExecutionResult::Success { output, gas, logs, .. } =>
             {
-                #[allow(clippy::needless_update)]
+                #[expect(clippy::needless_update)]
                 SimCallResult {
                     return_data: output.into_data(),
                     error: None,

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -49,7 +49,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
         match self {
             Self::Pool(tx) => resp_builder.fill_pending(tx),
             Self::Block { transaction, index, block_hash, block_number, base_fee } => {
-                #[allow(clippy::needless_update)]
+                #[expect(clippy::needless_update)]
                 let tx_info = TransactionInfo {
                     hash: Some(transaction.trie_hash()),
                     index: Some(index),
@@ -71,7 +71,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
                 let hash = tx.trie_hash();
                 (tx, TransactionInfo { hash: Some(hash), ..Default::default() })
             }
-            #[allow(clippy::needless_update)]
+            #[expect(clippy::needless_update)]
             Self::Block { transaction, index, block_hash, block_number, base_fee } => {
                 let hash = transaction.trie_hash();
                 (

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -419,7 +419,7 @@ where
                 block_traces.push(traces);
             }
 
-            #[allow(clippy::iter_with_drain)]
+            #[expect(clippy::iter_with_drain)]
             let block_traces = futures::future::try_join_all(block_traces.drain(..)).await?;
             all_traces.extend(block_traces.into_iter().flatten().flat_map(|traces| {
                 traces.into_iter().flatten().flat_map(|traces| traces.into_iter())

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![allow(missing_docs, clippy::needless_pass_by_ref_mut)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(clippy::borrow_as_ptr)]
+#![expect(clippy::borrow_as_ptr)]
 
 pub extern crate reth_mdbx_sys as ffi;
 

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -232,7 +232,7 @@ where
         }
 
         // The types are not the same on Windows. Great!
-        #[cfg_attr(not(windows), allow(clippy::useless_conversion))]
+        #[cfg_attr(not(windows), expect(clippy::useless_conversion))]
         Ok(DatabaseFlags::from_bits_truncate(flags.try_into().unwrap()))
     }
 
@@ -426,7 +426,7 @@ impl Transaction<RW> {
     /// The caller must ensure that the returned buffer is not used after the transaction is
     /// committed or aborted, or if another value is inserted. To be clear: the second call to
     /// this function is not permitted while the returned slice is reachable.
-    #[allow(clippy::mut_from_ref)]
+    #[expect(clippy::mut_from_ref)]
     pub unsafe fn reserve(
         &self,
         dbi: ffi::MDBX_dbi,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -353,7 +353,7 @@ impl<TX: Debug + Send, N: NodeTypes<ChainSpec: EthChainSpec + 'static>> ChainSpe
 
 impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
     /// Creates a provider with an inner read-write transaction.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new_rw_inner(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
@@ -386,7 +386,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
     }
 
     /// Creates a provider with an inner read-write transaction using normal commit order.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_rw(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
@@ -415,7 +415,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
     }
 
     /// Creates a provider with an inner read-write transaction using unwind commit order.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_unwind_rw(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,
@@ -979,7 +979,7 @@ where
 
 impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
     /// Creates a provider with an inner read-only transaction.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         tx: TX,
         chain_spec: Arc<N::ChainSpec>,

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1916,7 +1916,7 @@ impl<'a> RocksDBBatch<'a> {
     /// Generic implementation for both account and storage history pruning.
     /// Mirrors MDBX `prune_shard` semantics. After pruning, the last remaining shard
     /// (if any) will have the sentinel key (`u64::MAX`).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn prune_history_shards_inner<K>(
         &mut self,
         shards: Vec<(K, BlockNumberList)>,
@@ -3905,7 +3905,7 @@ mod tests {
         let storage_key = B256::from([0x01; 32]);
 
         // Test cases that exercise invariants
-        #[allow(clippy::type_complexity)]
+        #[expect(clippy::type_complexity)]
         let invariant_cases: &[(&[(u64, &[u64])], u64)] = &[
             // Account: shards where middle becomes empty
             (&[(10, &[5, 10]), (20, &[15, 20]), (u64::MAX, &[25, 30])], 20),

--- a/crates/tasks/src/utils.rs
+++ b/crates/tasks/src/utils.rs
@@ -45,7 +45,6 @@ pub fn increase_thread_priority() {
 /// Should be called once after tracing is initialized.
 ///
 /// No-op on non-Linux platforms.
-#[allow(clippy::missing_const_for_fn)]
 pub fn deprioritize_background_threads() {
     #[cfg(target_os = "linux")]
     _deprioritize_background_threads();

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -190,7 +190,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
     }
 
     /// Returns the next best transaction and its priority value.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn next_tx_and_priority(
         &mut self,
     ) -> Option<(Arc<ValidPoolTransaction<T::Transaction>>, Priority<T::PriorityValue>)> {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -905,7 +905,6 @@ where
     /// [`TransactionEvents`] receivers when manually implementing the
     /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
     /// [`TransactionPool::transaction_event_listener`](crate::TransactionPool).
-    #[allow(clippy::type_complexity)]
     pub fn notify_on_transaction_updates(
         &self,
         promoted: Vec<Arc<ValidPoolTransaction<T::Transaction>>>,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -960,7 +960,7 @@ where
     Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>,
 {
     /// Creates a new account proof worker.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     const fn new(
         task_ctx: ProofTaskCtx<Factory>,
         work_rx: CrossbeamReceiver<AccountWorkerJob>,

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1936,7 +1936,7 @@ impl ParallelSparseTrie {
         // upper trie then apply them to the top-level set.
         if let Some(mut update_actions_buf) = update_actions_buf {
             self.apply_subtrie_update_actions(
-                #[allow(clippy::iter_with_drain)]
+                #[expect(clippy::iter_with_drain)]
                 update_actions_buf.drain(..),
             );
             self.update_actions_buffers.push(update_actions_buf);
@@ -2177,7 +2177,7 @@ impl ParallelSparseTrie {
         for ChangedSubtrie { index, subtrie, update_actions_buf, .. } in changed_subtries {
             if let Some(mut update_actions_buf) = update_actions_buf {
                 self.apply_subtrie_update_actions(
-                    #[allow(clippy::iter_with_drain)]
+                    #[expect(clippy::iter_with_drain)]
                     update_actions_buf.drain(..),
                 );
                 self.update_actions_buffers.push(update_actions_buf);

--- a/examples/exex-test/src/main.rs
+++ b/examples/exex-test/src/main.rs
@@ -57,7 +57,7 @@ async fn test_assertion_exex<
             println!("Received committed chain: {range:?}");
 
             // Increment blocks count
-            #[allow(clippy::unnecessary_cast)]
+            #[expect(clippy::unnecessary_cast)]
             state_clone.received_blocks.fetch_add(blocks_count as u64, Ordering::SeqCst);
 
             // Send event that we've processed this height

--- a/examples/txpool-tracing/src/submit.rs
+++ b/examples/txpool-tracing/src/submit.rs
@@ -1,6 +1,6 @@
 //! Transaction submission functionality for the txpool tracing example
 #![allow(unused)]
-#![allow(clippy::too_many_arguments)]
+#![expect(clippy::too_many_arguments)]
 
 use alloy_network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
 use alloy_primitives::{Address, TxHash, U256};


### PR DESCRIPTION
Replaces all `#[allow(clippy::...)]` with `#[expect(clippy::...)]` across 32 files. `expect` warns when the suppressed lint no longer fires, keeping annotations from going stale.

Removed 6 annotations where the lint was already gone (unfulfilled expectations):
- `clippy::too_many_arguments` in `engine/tree`
- `clippy::useless_let_if_seq` in `ethereum/payload`
- `clippy::missing_const_for_fn` in `net/peers` (×2) and `tasks`
- `clippy::type_complexity` in `transaction-pool`

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>

Prompted by: pep