### PR TITLE
chore: remove unused return value from dispatch_with_chunking

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -65,8 +65,7 @@ pub(crate) fn dispatch_with_chunking<T, I>(
     has_multiple_idle_storage_workers: bool,
     chunker: impl FnOnce(T, usize) -> I,
     mut dispatch: impl FnMut(T),
-) -> usize
-where
+) where
     I: IntoIterator<Item = T>,
 {
     let should_chunk = chunking_len > max_targets_for_chunking ||
@@ -74,14 +73,11 @@ where
         has_multiple_idle_storage_workers;
 
     if should_chunk && chunking_len > chunk_size {
-        let mut num_chunks = 0usize;
         for chunk in chunker(items, chunk_size) {
             dispatch(chunk);
-            num_chunks += 1;
         }
-        return num_chunks;
+        return;
     }
 
     dispatch(items);
-    1
 }


### PR DESCRIPTION
`dispatch_with_chunking` returned a `usize` chunk count that no caller used. Changed to return `()` and removed the counter tracking.

Prompted by: pep