### PR TITLE
chore: validate bal at last

### DIFF
--- a/.github/scripts/hive/build_simulators.sh
+++ b/.github/scripts/hive/build_simulators.sh
@@ -13,11 +13,11 @@ go build .
 echo "Building images"
 # TODO: test code has been moved from https://github.com/ethereum/execution-spec-tests to https://github.com/ethereum/execution-specs  we need to pin eels branch with `--sim.buildarg branch=<release-branch-name>` once we have the fusaka release tagged on the new repo
 ./hive -client reth --sim "ethereum/eels/consume-engine" \
-    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.0/fixtures_bal.tar.gz \
+    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz \
     --sim.buildarg branch=devnets/bal/3 \
     --sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/eels/consume-rlp" \
-    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.0/fixtures_bal.tar.gz \
+    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz \
     --sim.buildarg branch=devnets/bal/3 \
     --sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/engine" -sim.timelimit 1s || true &

--- a/.github/scripts/hive/build_simulators.sh
+++ b/.github/scripts/hive/build_simulators.sh
@@ -13,11 +13,11 @@ go build .
 echo "Building images"
 # TODO: test code has been moved from https://github.com/ethereum/execution-spec-tests to https://github.com/ethereum/execution-specs  we need to pin eels branch with `--sim.buildarg branch=<release-branch-name>` once we have the fusaka release tagged on the new repo
 ./hive -client reth --sim "ethereum/eels/consume-engine" \
-    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.5.1/fixtures_bal.tar.gz \
+    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.0/fixtures_bal.tar.gz \
     --sim.buildarg branch=devnets/bal/3 \
     --sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/eels/consume-rlp" \
-    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.5.1/fixtures_bal.tar.gz \
+    --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.0/fixtures_bal.tar.gz \
     --sim.buildarg branch=devnets/bal/3 \
     --sim.timelimit 1s || true &
 ./hive -client reth --sim "ethereum/engine" -sim.timelimit 1s || true &

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/Soubhik-10/evm?branch=bal-devnet3#cda27d49f46ceea67c5e30bfb259ba6e5204f9c5"
+source = "git+https://github.com/alloy-rs/evm?branch=bal-devnet3#2a00efbd5345540490e5a06c6eaa2960e714e0a9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/Soubhik-10/evm?branch=precompile-fix#8e9ff3fdbd9e07704b3aaecce8bf9033ec0cb240"
+source = "git+https://github.com/Soubhik-10/evm?branch=bal-devnet3#cda27d49f46ceea67c5e30bfb259ba6e5204f9c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/alloy-rs/evm?branch=bal-devnet3#2a00efbd5345540490e5a06c6eaa2960e714e0a9"
+source = "git+https://github.com/Soubhik-10/evm?branch=bal-revm#fd2e52b16a834512e304d41c4a79eb25b8a3d020"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "36.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10491,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "bitvec",
  "phf",
@@ -10502,7 +10502,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10518,7 +10518,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "16.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "12.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10546,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "auto_impl",
  "either",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "17.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "17.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "auto_impl",
  "either",
@@ -10613,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "34.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.1.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.1.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0abb42b23#0abb42b23afd0a055a9cbe94e1d5be17300e4cab"
+source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/Soubhik-10/evm?branch=bal-revm#fd2e52b16a834512e304d41c4a79eb25b8a3d020"
+source = "git+https://github.com/alloy-rs/evm?branch=bal-devnet3#36b9e8c0a929799f5d82345e84cb760cfaf973f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/Soubhik-10/evm?branch=s%2Frevm#4a8ab904e829fb88f3133f8575bd3c7cf2d3ab5b"
+source = "git+https://github.com/alloy-rs/evm?branch=bal-devnet3#3cd42e7b37854e3f94c4da0f334d085f38bbcb16"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/alloy-rs/evm?branch=bal-devnet3#36b9e8c0a929799f5d82345e84cb760cfaf973f2"
+source = "git+https://github.com/Soubhik-10/evm?branch=s%2Frevm#4a8ab904e829fb88f3133f8575bd3c7cf2d3ab5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -443,7 +443,7 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -789,7 +789,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1706,7 +1706,7 @@ dependencies = [
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "num-bigint",
  "rustc-hash",
 ]
@@ -1738,7 +1738,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "hashbrown 0.16.1",
  "icu_normalizer",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "intrusive-collections",
  "itertools 0.14.0",
  "num-bigint",
@@ -1784,7 +1784,7 @@ dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -4384,7 +4384,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4968,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "arbitrary",
  "equivalent",
@@ -5835,7 +5835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "metrics",
  "metrics-util",
  "quanta",
@@ -5867,7 +5867,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "metrics",
  "ordered-float",
  "quanta",
@@ -10473,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "36.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10491,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "bitvec",
  "phf",
@@ -10502,7 +10502,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "15.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10518,7 +10518,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "16.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "12.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10546,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "auto_impl",
  "either",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "17.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "17.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "auto_impl",
  "either",
@@ -10613,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "34.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.1.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.1.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=d537a3b3b3896ceb2c17937acfbda0c09b52ea25#d537a3b3b3896ceb2c17937acfbda0c09b52ea25"
+source = "git+https://github.com/bluealloy/revm?rev=30e1c40#30e1c404a00c4770695f02fa14593d0e2b434b23"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
@@ -11255,7 +11255,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
@@ -11305,7 +11305,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -12019,9 +12019,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -12036,9 +12036,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12120,7 +12120,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -12153,7 +12153,7 @@ version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -12220,7 +12220,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -12922,7 +12922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -12948,7 +12948,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver 1.0.27",
 ]
 
@@ -13546,7 +13546,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -13577,7 +13577,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -13596,7 +13596,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver 1.0.27",
  "serde",
@@ -13614,9 +13614,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.29.2"
-source = "git+https://github.com/alloy-rs/evm?branch=bal-devnet3#cda27d49f46ceea67c5e30bfb259ba6e5204f9c5"
+source = "git+https://github.com/Soubhik-10/evm?branch=precompile-fix#8e9ff3fdbd9e07704b3aaecce8bf9033ec0cb240"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1654,16 +1654,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
  "bitflags 2.11.0",
  "boa_interner",
@@ -1713,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
 dependencies = [
  "boa_macros",
  "boa_string",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9626505d33dc63d349662437297df1d3afd9d5fc4a2b3ad34e5e1ce879a78848"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
 dependencies = [
  "boa_gc",
  "boa_macros",
@@ -1793,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36418a46544b152632c141b0a0b7a453cd69ca150caeef83aee9e2f4b48b7d"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
  "bitflags 2.11.0",
  "boa_ast",
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce9d7aa5563a2e14eab111e2ae1a06a69a812f6c0c3d843196c9d03fbef440"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -2470,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2558,6 +2558,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2738,7 +2747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -3413,7 +3422,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring",
  "sha2",
 ]
@@ -4670,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4685,7 +4694,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4785,9 +4793,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4844,9 +4852,9 @@ checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -5018,9 +5026,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.0"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f40e41efb5f592d3a0764f818e2f08e5e21c4f368126f74f37c81bd4af7a0c6"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console 0.16.3",
  "once_cell",
@@ -5095,9 +5103,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -5226,10 +5234,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -5453,7 +5463,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -5500,9 +5510,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
@@ -5604,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5635,9 +5645,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -6412,9 +6422,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0218004a4aae742209bee9c3cef05672f6b2708be36a50add8eb613b1f2a4008"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -6699,7 +6709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -6725,9 +6735,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -10843,9 +10853,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -11266,9 +11276,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -11333,7 +11343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -11344,7 +11354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -11946,7 +11956,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -11974,9 +11983,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -12131,39 +12140,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -12843,9 +12852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12856,23 +12865,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12880,9 +12885,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12893,9 +12898,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -12963,9 +12968,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13506,9 +13511,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -13665,9 +13670,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13676,9 +13681,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13688,18 +13693,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13708,18 +13713,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13749,20 +13754,21 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -13772,9 +13778,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -765,23 +765,23 @@ ipnet = "2.11"
 # =============================================================================
 
 # revm staging patches
-revm = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
 # op-revm = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "bal-devnet3" }
+alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "s/revm" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -781,7 +781,7 @@ revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "precompile-fix" }
+alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "bal-devnet3" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -781,7 +781,7 @@ revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b38
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "bal-revm" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "bal-devnet3" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -781,7 +781,7 @@ revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "bal-devnet3" }
+alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "precompile-fix" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -765,23 +765,23 @@ ipnet = "2.11"
 # =============================================================================
 
 # revm staging patches
-revm = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
 # op-revm = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "d537a3b3b3896ceb2c17937acfbda0c09b52ea25" }
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "bal-devnet3" }
+alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "bal-revm" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -781,7 +781,7 @@ revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0abb42b23" 
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "bal-devnet3" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "bal-devnet3" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -781,7 +781,7 @@ revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e1c40" }
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "24becc3" }
 
 # alloy-evm bal-devnet2 patches
-alloy-evm = { git = "https://github.com/Soubhik-10/evm", branch = "s/revm" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "bal-devnet3" }
 
 # alloy bal-devnet2 patches
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "bal-devnet2" }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -528,7 +528,7 @@ where
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
-        let (output, senders, receipt_root_rx) =
+        let (output, senders, receipt_root_rx, built_bal) =
             match self.execute_block(state_provider, env, &input, &mut handle) {
                 Ok(output) => output,
                 Err(err) => return self.handle_execution_error(input, err, &parent_block),
@@ -609,6 +609,7 @@ where
                 &mut ctx,
                 transaction_root,
                 receipt_root_bloom,
+                built_bal,
                 hashed_state,
             ),
             block
@@ -858,6 +859,7 @@ where
             BlockExecutionOutput<N::Receipt>,
             Vec<Address>,
             tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>,
+            Option<BlockAccessList>,
         ),
         InsertBlockErrorKind,
     >
@@ -969,31 +971,8 @@ where
         debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
-        // Validate BAL hash if we executed with BAL tracking
-        if has_bal {
-            // Get the expected BAL from input and the built BAL from execution
-            let expected_bal =
-                input.block_access_list().transpose().map_err(BlockExecutionError::other)?;
-
-            let built_bal = db.take_built_alloy_bal();
-
-            // Compute hashes and compare
-            let expected_hash = expected_bal
-                .as_ref()
-                .map(|bal| alloy_eips::eip7928::compute_block_access_list_hash(bal));
-
-            let built_hash = built_bal
-                .as_ref()
-                .map(|bal| alloy_eips::eip7928::compute_block_access_list_hash(bal));
-
-            if let (Some(expected), Some(got)) = (expected_hash, built_hash) &&
-                expected != got
-            {
-                return Err(InsertBlockErrorKind::Consensus(
-                    ConsensusError::BlockAccessListHashMismatch((got, expected).into()),
-                ));
-            }
-        }
+        // Extract the built bal is payload has bal
+        let built_bal = if has_bal { db.take_built_alloy_bal() } else { None };
 
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
@@ -1002,7 +981,7 @@ where
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
 
-        Ok((output, senders, result_rx))
+        Ok((output, senders, result_rx, built_bal))
     }
 
     /// Executes transactions and collects senders, streaming receipts to a background task.
@@ -1376,6 +1355,7 @@ where
         ctx: &mut TreeCtx<'_, N>,
         transaction_root: Option<B256>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        built_bal: Option<BlockAccessList>,
         hashed_state: LazyHashedPostState,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
@@ -1407,8 +1387,8 @@ where
             block,
             output,
             receipt_root_bloom,
-            None,
-            false,
+            built_bal,
+            true,
         ) {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -9,7 +9,7 @@ use reth_evm::precompiles::{
     DynPrecompile, Precompile, PrecompileInput, PrecompileOutputExt, PrecompileResultExt,
 };
 use reth_primitives_traits::dashmap::DashMap;
-use revm::precompile::PrecompileId;
+use revm::{interpreter::gas::GasTracker, precompile::PrecompileId};
 use revm_primitives::Address;
 use std::{hash::Hash, sync::Arc};
 
@@ -87,8 +87,13 @@ impl<S> CacheEntry<S> {
         self.output.gas.limit() - self.output.gas.remaining()
     }
 
-    fn to_precompile_result(&self) -> PrecompileResultExt {
-        Ok(self.output.clone())
+    fn to_precompile_result(&self, gas_limit: u64, reservoir: u64) -> PrecompileResultExt {
+        let gas_used = self.regular_gas_used();
+        Ok(PrecompileOutputExt {
+            gas: GasTracker::new(gas_limit, gas_limit - gas_used, reservoir),
+            bytes: self.output.bytes.clone(),
+            reverted: self.output.reverted,
+        })
     }
 }
 
@@ -175,7 +180,7 @@ where
             input.gas >= entry.regular_gas_used()
         {
             self.increment_by_one_precompile_cache_hits();
-            return entry.to_precompile_result();
+            return entry.to_precompile_result(input.gas, input.reservoir);
         }
 
         let calldata = input.data;

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -57,18 +57,6 @@ where
             gas_spent_by_tx: gas_spent_by_transactions(receipts),
         })
     }
-    // Validate that the block access list hash matches the calculated block access list hash
-    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) && allow_bal_check {
-        let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
-        let default_bal = BlockAccessList::default();
-        let block_access_list_hash =
-            compute_block_access_list_hash(block_access_list.as_ref().unwrap_or(&default_bal));
-        if block_access_list_hash != block_bal_hash {
-            return Err(ConsensusError::BlockAccessListHashMismatch(
-                (block_access_list_hash, block_bal_hash).into(),
-            ))
-        }
-    }
 
     // Before Byzantium, receipts contained state root that would mean that expensive
     // operation as hashing that is required for state root got calculated in every
@@ -105,6 +93,19 @@ where
         if requests_hash != header_requests_hash {
             return Err(ConsensusError::BodyRequestsHashDiff(
                 GotExpected::new(requests_hash, header_requests_hash).into(),
+            ))
+        }
+    }
+
+    // Validate that the block access list hash matches the calculated block access list hash
+    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) && allow_bal_check {
+        let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
+        let default_bal = BlockAccessList::default();
+        let block_access_list_hash =
+            compute_block_access_list_hash(block_access_list.as_ref().unwrap_or(&default_bal));
+        if block_access_list_hash != block_bal_hash {
+            return Err(ConsensusError::BlockAccessListHashMismatch(
+                (block_access_list_hash, block_bal_hash).into(),
             ))
         }
     }


### PR DESCRIPTION
Previously bal_hash checking was done at first, this was correct as per logic but to match specs, we moved it to the end so that we get correct error mappings.
Also bumps the fixture to bal@5.6.1 and fixes the precompile cache gas 