### PR TITLE
feat(revm): add `ExecutionWitnessRecord::into_execution_witness` helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9723,6 +9723,8 @@ version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
  "reth-ethereum-forks",
  "reth-primitives-traits",
  "reth-storage-api",

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -20,6 +20,8 @@ reth-trie = { workspace = true, optional = true }
 
 # alloy
 alloy-primitives.workspace = true
+alloy-rlp = { workspace = true, optional = true }
+alloy-rpc-types-debug = { workspace = true, optional = true }
 
 # revm
 revm.workspace = true
@@ -34,13 +36,14 @@ default = ["std"]
 std = [
     "reth-primitives-traits/std",
     "alloy-primitives/std",
+    "alloy-rlp?/std",
     "revm/std",
     "alloy-consensus/std",
     "reth-ethereum-forks/std",
     "reth-storage-api/std",
     "reth-storage-errors/std",
 ]
-witness = ["dep:reth-trie"]
+witness = ["dep:reth-trie", "dep:alloy-rlp", "dep:alloy-rpc-types-debug"]
 test-utils = [
     "dep:reth-trie",
     "reth-primitives-traits/test-utils",

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -80,4 +80,44 @@ impl ExecutionWitnessRecord {
         record.record_executed_state(state);
         record
     }
+
+    /// Converts this record into a complete [`alloy_rpc_types_debug::ExecutionWitness`] by
+    /// generating state proofs and fetching ancestor block headers.
+    ///
+    /// The `block_number` is the number of the block being witnessed. Ancestor headers are
+    /// included based on the lowest block number referenced by BLOCKHASH opcodes during
+    /// execution, or just the parent header if BLOCKHASH was not called.
+    #[cfg(feature = "witness")]
+    pub fn into_execution_witness<SP, HP>(
+        self,
+        state_provider: &SP,
+        headers_provider: &HP,
+        block_number: u64,
+    ) -> reth_storage_errors::provider::ProviderResult<alloy_rpc_types_debug::ExecutionWitness>
+    where
+        SP: reth_storage_api::StateProofProvider + ?Sized,
+        HP: reth_storage_api::HeaderProvider + ?Sized,
+        HP::Header: alloy_rlp::Encodable,
+    {
+        let Self { hashed_state, codes, keys, lowest_block_number } = self;
+
+        let state = state_provider.witness(Default::default(), hashed_state)?;
+        let mut exec_witness =
+            alloy_rpc_types_debug::ExecutionWitness { state, codes, keys, ..Default::default() };
+
+        let smallest = lowest_block_number.unwrap_or_else(|| block_number.saturating_sub(1));
+        let range = smallest..block_number;
+
+        exec_witness.headers = headers_provider
+            .headers_range(range)?
+            .into_iter()
+            .map(|header| {
+                let mut buf = Vec::new();
+                alloy_rlp::Encodable::encode(&header, &mut buf);
+                buf.into()
+            })
+            .collect();
+
+        Ok(exec_witness)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `into_execution_witness` method to `ExecutionWitnessRecord` behind the `witness` feature
- Generates state proofs and serializes ancestor headers into a complete `ExecutionWitness`
- Adds `alloy-rlp` and `alloy-rpc-types-debug` as optional deps gated behind `witness`

## Motivation
The witness assembly pattern (destructure record → generate state proofs → resolve BLOCKHASH headers → build `ExecutionWitness`) is duplicated in reth's `debug_execution_witness_for_block` and downstream in [`paradigmxyz/stateless`](https://github.com/paradigmxyz/stateless/blob/main/testing/ef-tests/src/cases/blockchain_test.rs#L338). This extracts it into a reusable method on `ExecutionWitnessRecord`.