### PR TITLE
ci: add affected-crate detection to skip unchanged tests

### DIFF
--- a/.affected.toml
+++ b/.affected.toml
@@ -1,0 +1,4 @@
+ignore = ["*.md", "docs/**", ".github/**", "LICENSE*", "*.txt", "*.yml", "*.yaml", "rustfmt.toml", "clippy.toml", "typos.toml", "deny.toml"]
+
+[test]
+cargo = "cargo nextest run -p {package} --no-fail-fast --no-tests=warn"

--- a/.github/workflows/affected-test.yml
+++ b/.github/workflows/affected-test.yml
@@ -1,0 +1,92 @@
+# Experimental: run tests only for crates affected by the PR.
+# Runs alongside existing unit.yml — does not replace it.
+
+name: affected-test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect affected crates
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.affected.outputs.matrix }}
+      has_affected: ${{ steps.affected.outputs.has_affected }}
+      count: ${{ steps.affected.outputs.count }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Rani367/setup-affected@750ce2e1ff1be73b511666ea7ddc9a76b4dd80f2 # v1
+
+      - name: Detect affected crates
+        id: affected
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: affected ci --merge-base "origin/${BASE_REF:-main}"
+
+      - name: Summary
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          AFFECTED_COUNT: ${{ steps.affected.outputs.count }}
+        run: |
+          {
+            echo "### Affected Crates (${AFFECTED_COUNT} / 143)"
+            echo ""
+            affected list --merge-base "origin/${BASE_REF:-main}" --explain
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    name: "test / ${{ matrix.package }}"
+    needs: detect
+    if: needs.detect.outputs.has_affected == 'true'
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-4' || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    strategy:
+      matrix: ${{ fromJson(needs.detect.outputs.matrix) }}
+      fail-fast: false
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6 # v2
+        with:
+          tool: cargo-nextest
+
+      - name: "Test ${{ matrix.package }}"
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          cargo nextest run \
+            -p "$PACKAGE" \
+            --no-fail-fast \
+            --features "asm-keccak ethereum" \
+            --locked \
+            --no-tests=warn


### PR DESCRIPTION
## Problem

This repo has **143 crates** in its Cargo workspace. On every PR, `unit.yml` runs `cargo nextest run --workspace`, which compiles and tests all 143 crates regardless of what changed.

I analyzed the last 15 commits on `main`. Most PRs only need to test a subset:

| # | Commit | Message | Affected | Total | Reduction |
|---|--------|---------|----------|-------|-----------|
| 1 | `c82d435` | feat(bench): upload nightly regression results | 0 | 143 | **100%** |
| 2 | `4a6f9cd` | fix(provider): cap storage_v2 unwind history | 95 | 143 | **34%** |
| 3 | `7ecbea5` | feat: add bal rpc methods | 95 | 143 | **34%** |
| 4 | `aa5effb` | perf(rpc): pre-allocate vectors in eth_feeHistory | 95 | 143 | **34%** |
| 5 | `abab678` | fix(rpc): apply count only after is consumed | 95 | 143 | **34%** |
| 6 | `079d496` | chore(deps): bump actions/configure-pages | 95 | 143 | **34%** |
| 7 | `00336b3` | chore(deps): bump the cargo-weekly group | 95 | 143 | **34%** |
| 8 | `8b8430a` | docs(libmdbx): fix typo writeable -> writable | 95 | 143 | **34%** |
| 11 | `08a33da` | chore: migrate allow(clippy::) to expect(clippy::) | 121 | 143 | **15%** |

**Even in the worst case (a broad refactor touching clippy lints), 15% of crates are still skippable. Typical PRs skip 34-100%.**

Related: #459 (Investigate slow tests), #20238 (Use sccache in CI)

## Proposal

[`affected`](https://github.com/Rani367/affected) is a zero-config CLI that:
1. Reads your `Cargo.toml` workspace via `cargo metadata`
2. Diffs changed files against the base branch
3. Walks the dependency graph to find transitively affected crates
4. Outputs a GitHub Actions matrix of only those crates

Example from this repo (`affected list --base HEAD~2 --explain`):

```
95 affected package(s) (base: HEAD~2, 13 files changed):

  ● reth-db-api        (directly changed: crates/storage/db-api/src/...)
  ● reth-provider       (depends on: reth-provider → reth-db-api)
  ● reth-stages         (depends on: reth-stages → reth-provider → reth-db-api)
  ● reth-ethereum       (depends on: reth-ethereum → reth-db)
  ...
  (48 crates NOT affected — no test needed)
```

## What this PR adds

- **`.affected.toml`** — config file (ignores docs/markdown/CI files, uses nextest)
- **`.github/workflows/affected-test.yml`** — experimental workflow that:
  1. Detects affected crates via `affected ci`
  2. Creates a dynamic GitHub Actions matrix
  3. Runs `cargo nextest run -p <crate>` per affected crate in parallel

**This runs alongside the existing `unit.yml` — it does NOT replace anything.** You can compare runtimes over a few PRs and decide whether to keep it.

## What it is

- Single 5MB Rust binary, MIT licensed
- Zero config — auto-detects Cargo workspaces
- [GitHub Action](https://github.com/Rani367/setup-affected) for easy CI setup
- [PR comment bot](https://github.com/Rani367/affected-pr-comment) that shows affected crates on each PR

## Not proposing

- Removing or modifying the existing CI
- Any lock-in (it's `cargo install affected-cli` or a single binary download)
- Changes to the build system or project structure