### PR TITLE
fix(net): drain satellite out_buffer in Sink::poll_ready to prevent starvation

### DIFF
--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -651,9 +651,26 @@ where
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
-        if let Err(err) = ready!(this.inner.conn.poll_ready_unpin(cx)) {
-            return Poll::Ready(Err(err.into()))
+
+        // Drain buffered outgoing messages (FCFS) to prevent satellite starvation.
+        // Check readiness BEFORE popping to avoid losing messages on Pending.
+        loop {
+            match this.inner.conn.poll_ready_unpin(cx) {
+                Poll::Ready(Ok(())) => {
+                    if let Some(msg) = this.inner.out_buffer.pop_front() {
+                        if let Err(err) = this.inner.conn.start_send_unpin(msg) {
+                            return Poll::Ready(Err(err.into()))
+                        }
+                    } else {
+                        break
+                    }
+                }
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err.into())),
+                Poll::Pending => return Poll::Pending,
+            }
         }
+
+        // conn is already Ready(Ok(())) from the last drain iteration (buffer was empty).
         if let Err(err) = ready!(this.primary.st.poll_ready_unpin(cx)) {
             return Poll::Ready(Err(err))
         }


### PR DESCRIPTION
Closes #13856

Drains `out_buffer` in `RlpxSatelliteStream`'s `Sink::poll_ready` before reporting readiness, so that buffered satellite messages are flushed to the wire before new primary messages are accepted.

Previously, `out_buffer` was only drained inside `Stream::poll_next`. The `Sink::poll_ready` checked connection and primary readiness but never touched `out_buffer`, meaning callers could continuously send primary messages via the sink path while satellite messages sat in the buffer waiting for the stream to be polled.

The drain logic checks `conn.poll_ready` before popping from the buffer to avoid losing messages if the connection returns `Pending`. The existing `poll_ready` call on `conn` after the drain loop was removed since `conn` is already known to be `Ready(Ok(()))` from the last drain iteration.