### PR TITLE
fix(rpc): guard gas_used_ratio against division by zero

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -10,7 +10,8 @@ use futures::{Future, StreamExt};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives_traits::BlockBody;
 use reth_rpc_eth_types::{
-    fee_history::calculate_reward_percentiles_for_block, utils::checked_blob_gas_used_ratio,
+    fee_history::calculate_reward_percentiles_for_block,
+    utils::{checked_blob_gas_used_ratio, checked_gas_used_ratio},
     EthApiError, FeeHistoryCache, FeeHistoryEntry, GasPriceOracle, RpcInvalidTransactionError,
 };
 use reth_storage_api::{
@@ -197,7 +198,10 @@ pub trait EthFees:
                 let chain_spec = self.provider().chain_spec();
                 for header in &headers {
                     base_fee_per_gas.push(header.base_fee_per_gas().unwrap_or_default() as u128);
-                    gas_used_ratio.push(header.gas_used() as f64 / header.gas_limit() as f64);
+                    gas_used_ratio.push(checked_gas_used_ratio(
+                        header.gas_used(),
+                        header.gas_limit(),
+                    ));
 
                     let blob_params = chain_spec
                         .blob_params_at_timestamp(header.timestamp())

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -374,7 +374,10 @@ where
         let header = block.header();
         Self {
             header: block.header().clone(),
-            gas_used_ratio: header.gas_used() as f64 / header.gas_limit() as f64,
+            gas_used_ratio: crate::utils::checked_gas_used_ratio(
+                header.gas_used(),
+                header.gas_limit(),
+            ),
             base_fee_per_blob_gas: header
                 .excess_blob_gas()
                 .and_then(|excess_blob_gas| Some(blob_params?.calc_blob_fee(excess_blob_gas))),

--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -80,6 +80,18 @@ where
     Ok(num)
 }
 
+/// Calculates the gas used ratio for a block, accounting for the case where
+/// `gas_limit` is zero.
+///
+/// Returns `0.0` if `gas_limit` is `0`, otherwise returns the ratio `gas_used / gas_limit`.
+pub fn checked_gas_used_ratio(gas_used: u64, gas_limit: u64) -> f64 {
+    if gas_limit == 0 {
+        0.0
+    } else {
+        gas_used as f64 / gas_limit as f64
+    }
+}
+
 /// Calculates the blob gas used ratio for a block, accounting for the case where
 /// `max_blob_gas_per_block` is zero.
 ///
@@ -118,6 +130,19 @@ mod tests {
         let num: Result<_, ()> =
             binary_search(1, 10, |mid| Box::pin(async move { Ok(mid >= 11) })).await;
         assert_eq!(num, Ok(10));
+    }
+
+    #[test]
+    fn test_checked_gas_used_ratio() {
+        // gas_limit is 0 — division by zero protection
+        assert_eq!(checked_gas_used_ratio(0, 0), 0.0);
+        assert_eq!(checked_gas_used_ratio(100, 0), 0.0);
+        // gas_used is 0, gas_limit is non-zero
+        assert_eq!(checked_gas_used_ratio(0, 1_000_000), 0.0);
+        // partial usage
+        assert_eq!(checked_gas_used_ratio(500_000, 1_000_000), 0.5);
+        // full usage
+        assert_eq!(checked_gas_used_ratio(1_000_000, 1_000_000), 1.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `checked_gas_used_ratio` helper to safely compute `gas_used / gas_limit`, returning `0.0` when `gas_limit` is zero instead of producing `NaN`
- Applies the helper in `FeeHistoryEntry::new` and the `fee_history` fallback path where the ratio was previously computed with raw division
- Adds unit tests covering the zero, partial, and full usage cases

## Motivation

Unguarded `gas_used as f64 / gas_limit as f64` produces `NaN` when `gas_limit` is `0`. `NaN` is not valid JSON per RFC 8259 and would cause serialization failures in `eth_feeHistory` responses. This mirrors the existing `checked_blob_gas_used_ratio` pattern already used for blob gas.

## Test plan

- [x] `cargo +nightly nextest run -p reth-rpc-eth-types -- test_checked_gas_used_ratio` — new test passes
- [x] `cargo +nightly check -p reth-rpc-eth-types` — compiles clean
- [x] `cargo +nightly check -p reth-rpc-eth-api` — downstream consumer compiles clean