### PR TITLE
fix(rpc): prevent u64 underflow in binary_search when mid is 0

### DIFF
--- a/crates/rpc/rpc-eth-types/src/utils.rs
+++ b/crates/rpc/rpc-eth-types/src/utils.rs
@@ -68,8 +68,12 @@ where
     let mut num = high;
 
     while low <= high {
-        let mid = (low + high) / 2;
+        let mid = low + (high - low) / 2;
         if check(mid).await? {
+            if mid == 0 {
+                num = mid;
+                break;
+            }
             high = mid - 1;
             num = mid;
         } else {
@@ -118,6 +122,21 @@ mod tests {
         let num: Result<_, ()> =
             binary_search(1, 10, |mid| Box::pin(async move { Ok(mid >= 11) })).await;
         assert_eq!(num, Ok(10));
+
+        // low == 0: previously caused underflow on `high = mid - 1` when mid == 0
+        let num: Result<_, ()> =
+            binary_search(0, 10, |_mid| Box::pin(async move { Ok(true) })).await;
+        assert_eq!(num, Ok(0));
+
+        // low == 0 with target in the middle
+        let num: Result<_, ()> =
+            binary_search(0, 10, |mid| Box::pin(async move { Ok(mid >= 5) })).await;
+        assert_eq!(num, Ok(5));
+
+        // low == high == 0
+        let num: Result<_, ()> =
+            binary_search(0, 0, |_mid| Box::pin(async move { Ok(true) })).await;
+        assert_eq!(num, Ok(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Changes midpoint calculation from `(low + high) / 2` to `low + (high - low) / 2` to avoid potential overflow
- Adds a guard for `mid == 0` to prevent `high = mid - 1` from wrapping a `u64`
- Adds three new test cases covering `low == 0` scenarios

## Motivation

The `binary_search` utility in `reth-rpc-eth-types` is used by `eth_getTransactionByBlockNumberAndIndex` (otterscan) and transaction helpers. Current callers hardcode `low = 1`, so the bug is latent — but any future caller passing `low = 0` where the check function returns `true` at `mid = 0` would trigger a u64 underflow panic in debug or wrap to `u64::MAX` in release, causing an infinite loop.

## Test plan

- [x] `cargo +nightly nextest run -p reth-rpc-eth-types -- test_binary_search` — all tests pass including 3 new `low=0` cases
- [x] Existing tests unchanged and still pass