### PR TITLE
fix(engine): log warnings on failed persistence and tree channel sends

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -196,7 +196,9 @@ where
 
     fn on_event(&mut self, event: FromEngine<Self::Request, Self::Block>) {
         // delegate to the tree
-        let _ = self.to_tree.send(event);
+        if let Err(err) = self.to_tree.send(event) {
+            tracing::warn!(target: "engine::handler", %err, "Failed to send event to engine tree");
+        }
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1342,7 +1342,9 @@ where
         if new_tip_num < self.persistence_state.last_persisted_block.number {
             debug!(target: "engine::tree", ?new_tip_num, "Starting remove blocks job");
             let (tx, rx) = crossbeam_channel::bounded(1);
-            let _ = self.persistence.remove_blocks_above(new_tip_num, tx);
+            if let Err(err) = self.persistence.remove_blocks_above(new_tip_num, tx) {
+                warn!(target: "engine::tree", %err, ?new_tip_num, "Failed to send remove_blocks_above to persistence");
+            }
             self.persistence_state.start_remove(new_tip_num, rx);
         }
     }
@@ -1364,7 +1366,9 @@ where
 
         debug!(target: "engine::tree", count=blocks_to_persist.len(), blocks = ?blocks_to_persist.iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
         let (tx, rx) = crossbeam_channel::bounded(1);
-        let _ = self.persistence.save_blocks(blocks_to_persist, tx);
+        if let Err(err) = self.persistence.save_blocks(blocks_to_persist, tx) {
+            warn!(target: "engine::tree", %err, "Failed to send save_blocks to persistence");
+        }
 
         self.persistence_state.start_save(highest_num_hash, rx);
     }


### PR DESCRIPTION
## Summary

- Replaces `let _ = self.persistence.save_blocks(...)` and `remove_blocks_above(...)` in `engine::tree` with `if let Err` + `warn!` logging
- Replaces `let _ = self.to_tree.send(event)` in `EngineApiRequestHandler::on_event` with logged error handling

## Motivation

These three call sites silently discard `SendError` when the persistence service or engine tree task has shut down. During production incidents, this creates an observability blind spot — the engine appears to hang with no indication of why. Adding `warn!` logs makes channel drops immediately visible to operators.

## Test plan

- [x] `cargo +nightly check -p reth-engine-tree` — compiles clean
- [x] No logic change, only logging added on error paths