### PR TITLE
fix: unmount schelk volume before recover in snapshot script

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -76,10 +76,9 @@ cleanup() {
   fi
   # Fix ownership of reth-created files (reth runs as root)
   sudo chown -R "$(id -un):$(id -gn)" "$OUTPUT_DIR" 2>/dev/null || true
-  if mountpoint -q "$SCHELK_MOUNT"; then
-    sudo umount -l "$SCHELK_MOUNT" || true
-    sudo schelk recover -y || true
-  fi
+  # Let schelk recover the mounted volume in place so dm-era can restore only
+  # the changed blocks and clean up its own state.
+  mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
 }
 TAIL_PID=
 TRACY_PID=

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -77,8 +77,11 @@ trap 'rm -f -- "$MANIFEST_TMP"' EXIT
 echo "$MANIFEST_CONTENT" \
   | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 
-# Prepare mount
-mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+# Prepare mount – unmount first if a previous run left the volume mounted
+if mountpoint -q "$SCHELK_MOUNT"; then
+  sudo umount -l "$SCHELK_MOUNT" || true
+  sudo schelk recover -y || true
+fi
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -77,11 +77,9 @@ trap 'rm -f -- "$MANIFEST_TMP"' EXIT
 echo "$MANIFEST_CONTENT" \
   | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 
-# Prepare mount – unmount first if a previous run left the volume mounted
-if mountpoint -q "$SCHELK_MOUNT"; then
-  sudo umount -l "$SCHELK_MOUNT" || true
-  sudo schelk recover -y || true
-fi
+# Prepare mount. If a previous run left the volume mounted, let schelk recover
+# it in place so dm-era can restore only the changed blocks.
+mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"


### PR DESCRIPTION
 Fixes "Volume is already mounted" failures when a previous run left the volume mounted on the same runner.