### PR TITLE
fix: use named systemd scope for reliable reth cleanup in benchmarks

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -399,6 +399,8 @@ upload_tracy() {
 # ── Step 6: Pre-flight cleanup ───────────────────────────────────────
 echo "▸ Pre-flight cleanup..."
 pkill -f bench-metrics-proxy 2>/dev/null || true
+sudo systemctl stop "${RETH_SCOPE:-reth-bench.scope}" 2>/dev/null || true
+sudo systemctl reset-failed "${RETH_SCOPE:-reth-bench.scope}" 2>/dev/null || true
 sudo pkill -9 reth 2>/dev/null || true
 sleep 1
 if mountpoint -q "$SCHELK_MOUNT" 2>/dev/null; then

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -26,6 +26,8 @@ DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
 mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
+RETH_SCOPE="reth-bench.scope"
+
 cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
   # Stop tracy-capture first (SIGINT makes it disconnect and flush to disk)
@@ -46,7 +48,7 @@ cleanup() {
     fi
     wait "$TRACY_PID" 2>/dev/null || true
   fi
-  if [ -n "${RETH_PID:-}" ] && sudo kill -0 "$RETH_PID" 2>/dev/null; then
+  if sudo systemctl is-active "$RETH_SCOPE" >/dev/null 2>&1; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
       # Send SIGINT to the inner reth process by exact name (not -f which
       # would also match samply's cmdline containing "reth"). Samply will
@@ -64,16 +66,13 @@ cleanup() {
         echo "Samply still running after 120s, sending SIGTERM..."
         sudo pkill -x samply 2>/dev/null || true
       fi
-    else
-      sudo kill "$RETH_PID"
-      for i in $(seq 1 30); do
-        sudo kill -0 "$RETH_PID" 2>/dev/null || break
-        sleep 1
-      done
     fi
-    sudo kill -9 "$RETH_PID" 2>/dev/null || true
+    # Stop the entire systemd scope — kills all processes in the cgroup.
+    # This is reliable regardless of process reparenting or PID wrapper issues.
+    sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
     sleep 1
   fi
+  sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
   # Fix ownership of reth-created files (reth runs as root)
   sudo chown -R "$(id -un):$(id -gn)" "$OUTPUT_DIR" 2>/dev/null || true
   if mountpoint -q "$SCHELK_MOUNT"; then
@@ -85,9 +84,10 @@ TAIL_PID=
 TRACY_PID=
 trap cleanup EXIT
 
-# Clean up stale schelk state from a previous cancelled run.
-# If schelk thinks it's still mounted (e.g. a cancelled run skipped cleanup),
-# recover first to reset state.
+# Clean up stale state from a previous cancelled run.
+# Stop any leftover reth process in the scope, then recover schelk state.
+sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
 sudo schelk recover -y -k || true
 
 # Mount
@@ -182,19 +182,19 @@ echo "Memory limit: $(( MEM_LIMIT / 1024 / 1024 ))MB (95% of $(( TOTAL_MEM_KB / 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   RETH_ARGS+=(--log.samply)
   SAMPLY="$(which samply)"
-  sudo systemd-run --scope -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+    -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 \
     "$SAMPLY" record --save-only --presymbolicate --rate 10000 \
     --output "$OUTPUT_DIR/samply-profile.json.gz" \
     -- "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &
 else
-  sudo systemd-run --scope -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+    -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &
 fi
-
-RETH_PID=$!
 stdbuf -oL tail -f "$LOG" | sed -u "s/^/[reth] /" &
 TAIL_PID=$!
 

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -26,7 +26,7 @@ DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
 mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
-RETH_SCOPE="reth-bench.scope"
+RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
 
 cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -233,6 +233,7 @@ jobs:
     env:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc
       SCHELK_MOUNT: /reth-bench
+      RETH_SCOPE: reth-bench.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_PR: ""
       BENCH_MODE: ${{ needs.resolve-refs.outputs.mode }}
@@ -446,8 +447,8 @@ jobs:
 
       - name: Pre-flight cleanup
         run: |
-          sudo systemctl stop reth-bench.scope 2>/dev/null || true
-          sudo systemctl reset-failed reth-bench.scope 2>/dev/null || true
+          sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+          sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
           sudo pkill -9 reth || true
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -446,6 +446,8 @@ jobs:
 
       - name: Pre-flight cleanup
         run: |
+          sudo systemctl stop reth-bench.scope 2>/dev/null || true
+          sudo systemctl reset-failed reth-bench.scope 2>/dev/null || true
           sudo pkill -9 reth || true
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -850,6 +850,8 @@ jobs:
       # Clean up any leftover state
       - name: Pre-flight cleanup
         run: |
+          sudo systemctl stop reth-bench.scope 2>/dev/null || true
+          sudo systemctl reset-failed reth-bench.scope 2>/dev/null || true
           sudo pkill -9 reth || true
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -474,6 +474,7 @@ jobs:
     env:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc
       SCHELK_MOUNT: /reth-bench
+      RETH_SCOPE: reth-bench.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_PR: ${{ needs.reth-bench-ack.outputs.pr }}
       BENCH_ACTOR: ${{ needs.reth-bench-ack.outputs.actor }}
@@ -850,8 +851,8 @@ jobs:
       # Clean up any leftover state
       - name: Pre-flight cleanup
         run: |
-          sudo systemctl stop reth-bench.scope 2>/dev/null || true
-          sudo systemctl reset-failed reth-bench.scope 2>/dev/null || true
+          sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+          sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
           sudo pkill -9 reth || true
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then


### PR DESCRIPTION
Fixes stale reth processes surviving benchmark cleanup and blocking
subsequent runs with `Volume is already mounted` errors.

**Root cause:** `bench-reth-run.sh` launches reth via
`sudo systemd-run --scope ... &` but captures `$!` as `RETH_PID` — which
is the PID of the `sudo` wrapper, not reth inside the scope's cgroup. Cleanup
kills the wrapper; reth keeps running, holds FDs on the schelk volume, and
blocks the next mount.

**Fix:** give the scope a fixed name (`--unit=reth-bench.scope --collect`)
and use `systemctl stop reth-bench.scope` in cleanup instead of PID-based
killing. This terminates the entire cgroup atomically regardless of process
reparenting.

Changes:
- `bench-reth-run.sh`: replace PID-based kill with scope-based stop, add
  stale-scope cleanup before `schelk recover`
- `bench.yml`, `bench-scheduled.yml`: add scope stop to pre-flight cleanup

Prompted by: pep

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>