### PR TITLE
perf(storage): use mdbx_cache_get for DB reads

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -295,7 +295,7 @@ impl<K: TransactionKind> DbTx for Tx<K> {
         key: &<T::Key as Encode>::Encoded,
     ) -> Result<Option<T::Value>, DatabaseError> {
         self.execute_with_operation_metric::<T, _>(Operation::Get, None, |tx| {
-            tx.get(self.get_dbi::<T>()?, key.as_ref())
+            tx.get_cached(self.get_dbi::<T>()?, key.as_ref())
                 .map_err(|e| DatabaseError::Read(e.into()))?
                 .map(decode_one::<T>)
                 .transpose()

--- a/crates/storage/libmdbx-rs/Cargo.toml
+++ b/crates/storage/libmdbx-rs/Cargo.toml
@@ -23,12 +23,12 @@ smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-dashmap = { workspace = true, features = ["inline"], optional = true }
+dashmap = { workspace = true, features = ["inline"] }
 
 [features]
 default = []
 return-borrowed = []
-read-tx-timeouts = ["dep:dashmap"]
+read-tx-timeouts = []
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/storage/libmdbx-rs/src/cache.rs
+++ b/crates/storage/libmdbx-rs/src/cache.rs
@@ -1,0 +1,37 @@
+use dashmap::DashMap;
+use ffi::MDBX_cache_entry_t;
+use smallvec::SmallVec;
+
+/// Key type for the B-tree traversal cache: `(dbi, key_bytes)`.
+///
+/// Uses `SmallVec` to avoid heap allocation for keys up to 64 bytes.
+type CacheKey = (ffi::MDBX_dbi, SmallVec<[u8; 64]>);
+
+/// Per-environment store of [`MDBX_cache_entry_t`] entries, keyed by `(dbi, key)`.
+///
+/// Each entry stores B-tree page offsets and version metadata that lets
+/// [`ffi::mdbx_cache_get`] skip the root-to-leaf tree walk when the target
+/// page hasn't been modified since the last lookup.
+#[derive(Debug)]
+pub struct CacheStore {
+    inner: DashMap<CacheKey, MDBX_cache_entry_t>,
+}
+
+impl CacheStore {
+    /// Creates a new, empty cache store.
+    pub fn new() -> Self {
+        Self { inner: DashMap::new() }
+    }
+
+    /// Returns a reference to the inner map.
+    #[inline]
+    pub(crate) const fn map(&self) -> &DashMap<CacheKey, MDBX_cache_entry_t> {
+        &self.inner
+    }
+}
+
+impl Default for CacheStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -1,4 +1,5 @@
 use crate::{
+    cache::CacheStore,
     database::Database,
     error::{mdbx_result, Error, Result},
     flags::EnvironmentFlags,
@@ -87,6 +88,12 @@ impl Environment {
     #[inline]
     pub(crate) fn txn_manager(&self) -> &TxnManager {
         &self.inner.txn_manager
+    }
+
+    /// Returns the B-tree traversal cache store.
+    #[inline]
+    pub fn cache_store(&self) -> &CacheStore {
+        &self.inner.cache_store
     }
 
     /// Returns the number of timed out transactions that were not aborted by the user yet.
@@ -254,6 +261,8 @@ struct EnvironmentInner {
     txn_manager: TxnManager,
     /// Pool of reset read-only transaction handles for reuse.
     ro_txn_pool: ReadTxnPool,
+    /// B-tree traversal cache for `mdbx_cache_get`.
+    cache_store: CacheStore,
 }
 
 impl Drop for EnvironmentInner {
@@ -779,6 +788,7 @@ impl EnvironmentBuilder {
             txn_manager,
             env_kind: self.kind,
             ro_txn_pool: ReadTxnPool::new(),
+            cache_store: CacheStore::new(),
         };
 
         Ok(Environment { inner: Arc::new(env) })

--- a/crates/storage/libmdbx-rs/src/lib.rs
+++ b/crates/storage/libmdbx-rs/src/lib.rs
@@ -12,6 +12,7 @@
 pub extern crate reth_mdbx_sys as ffi;
 
 pub use crate::{
+    cache::CacheStore,
     codec::*,
     cursor::{Cursor, Iter, IterDup},
     database::Database,
@@ -27,6 +28,7 @@ pub use crate::{
 #[cfg(feature = "read-tx-timeouts")]
 pub use crate::environment::read_transactions::MaxReadTransactionDuration;
 
+mod cache;
 mod codec;
 mod cursor;
 mod database;

--- a/crates/storage/libmdbx-rs/src/transaction.rs
+++ b/crates/storage/libmdbx-rs/src/transaction.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use ffi::{MDBX_txn_flags_t, MDBX_TXN_RDONLY, MDBX_TXN_READWRITE};
 use parking_lot::{Mutex, MutexGuard};
+use smallvec::SmallVec;
 use std::{
     ffi::{c_uint, c_void},
     fmt::{self, Debug},
@@ -160,6 +161,37 @@ where
 
         self.txn_execute(|txn| unsafe {
             match ffi::mdbx_get(txn, dbi, &key_val, &mut data_val) {
+                ffi::MDBX_SUCCESS => Key::decode_val::<K>(txn, data_val).map(Some),
+                ffi::MDBX_NOTFOUND => Ok(None),
+                err_code => Err(Error::from_err_code(err_code)),
+            }
+        })?
+    }
+
+    /// Gets an item from a database using the B-tree traversal cache.
+    ///
+    /// Like [`get`](Self::get), but uses [`ffi::mdbx_cache_get`] with a per-key
+    /// [`ffi::MDBX_cache_entry_t`] stored in the environment's [`CacheStore`](crate::CacheStore).
+    /// On repeated lookups of the same key, this can skip B-tree traversal entirely when the
+    /// target page hasn't been modified since the last access.
+    pub fn get_cached<Key>(&self, dbi: ffi::MDBX_dbi, key: &[u8]) -> Result<Option<Key>>
+    where
+        Key: TableObject,
+    {
+        let key_val: ffi::MDBX_val =
+            ffi::MDBX_val { iov_len: key.len(), iov_base: key.as_ptr() as *mut c_void };
+        let mut data_val: ffi::MDBX_val = ffi::MDBX_val { iov_len: 0, iov_base: ptr::null_mut() };
+
+        let cache_key = (dbi, SmallVec::from_slice(key));
+        let cache_store = self.env().cache_store();
+
+        // Get or insert a zeroed cache entry (equivalent to mdbx_cache_init).
+        let mut entry =
+            cache_store.map().entry(cache_key).or_insert_with(|| unsafe { std::mem::zeroed() });
+
+        self.txn_execute(|txn| unsafe {
+            let result = ffi::mdbx_cache_get(txn, dbi, &key_val, &mut data_val, entry.value_mut());
+            match result.errcode {
                 ffi::MDBX_SUCCESS => Key::decode_val::<K>(txn, data_val).map(Some),
                 ffi::MDBX_NOTFOUND => Ok(None),
                 err_code => Err(Error::from_err_code(err_code)),


### PR DESCRIPTION
Stacked on #23375 (libmdbx 0.14 bump).

Uses `mdbx_cache_get` for all `DbTx::get()` calls. Stores per-key `MDBX_cache_entry_t` entries in a `DashMap` on the environment. On repeated lookups libmdbx can skip the full B-tree traversal when the target page hasn't changed — best case is a few pointer checks instead of root-to-leaf walk.

`Transaction::get()` is kept as-is for callers that don't want caching. `Transaction::get_cached()` is the new method, wired into `Tx::get_by_encoded_key()`.

Co-Authored-By: DaniPopes <57450786+DaniPopes@users.noreply.github.com>

Prompted by: DaniPopes