### PR TITLE
fix: add --kill to all schelk recover calls

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -405,7 +405,7 @@ sudo pkill -9 reth 2>/dev/null || true
 sleep 1
 if mountpoint -q "$SCHELK_MOUNT" 2>/dev/null; then
   sudo umount -l "$SCHELK_MOUNT" 2>/dev/null || true
-  sudo schelk recover -y 2>/dev/null || true
+  sudo schelk recover -y --kill 2>/dev/null || true
 fi
 echo
 

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -77,7 +77,7 @@ cleanup() {
   sudo chown -R "$(id -un):$(id -gn)" "$OUTPUT_DIR" 2>/dev/null || true
   # Let schelk recover the mounted volume in place so dm-era can restore only
   # the changed blocks and clean up its own state.
-  mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+  mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y --kill || true
 }
 TAIL_PID=
 TRACY_PID=
@@ -87,7 +87,7 @@ trap cleanup EXIT
 # Stop any leftover reth process in the scope, then recover schelk state.
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
 sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
-sudo schelk recover -y -k || true
+sudo schelk recover -y --kill || true
 
 # Mount
 sudo schelk mount -y

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -79,7 +79,7 @@ echo "$MANIFEST_CONTENT" \
 
 # Prepare mount. If a previous run left the volume mounted, let schelk recover
 # it in place so dm-era can restore only the changed blocks.
-mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y || true
+mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y --kill || true
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -453,7 +453,7 @@ jobs:
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then
             sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y || true
+            sudo schelk recover -y --kill || true
           fi
           rm -rf "$BENCH_WORK_DIR"
           mkdir -p "$BENCH_WORK_DIR"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -876,7 +876,7 @@ jobs:
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then
             sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y || true
+            sudo schelk recover -y --kill || true
           fi
           rm -rf "$BENCH_WORK_DIR"
           mkdir -p "$BENCH_WORK_DIR"

--- a/.github/workflows/pgo-profile.yml
+++ b/.github/workflows/pgo-profile.yml
@@ -62,7 +62,7 @@ jobs:
           sleep 1
           if mountpoint -q "$SCHELK_MOUNT"; then
             sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y || true
+            sudo schelk recover -y --kill || true
           fi
           sudo schelk mount -y
           sync
@@ -103,5 +103,5 @@ jobs:
         run: |
           if mountpoint -q "$SCHELK_MOUNT"; then
             sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y || true
+            sudo schelk recover -y --kill || true
           fi


### PR DESCRIPTION
All `schelk recover` calls are in cleanup/teardown paths where any
process still blocking the volume is a stale leftover from a previous run.
Without `-k`, recover fails silently on EBUSY and leaves the volume stuck.

Adds `-k` to the 7 calls that were missing it (1 already had it).

Prompted by: pep

Co-Authored-By: Sergei Shulepov <2205845+pepyakin@users.noreply.github.com>