### PR TITLE
fix: add full recover fallback

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -401,12 +401,7 @@ echo "▸ Pre-flight cleanup..."
 pkill -f bench-metrics-proxy 2>/dev/null || true
 sudo systemctl stop "${RETH_SCOPE:-reth-bench.scope}" 2>/dev/null || true
 sudo systemctl reset-failed "${RETH_SCOPE:-reth-bench.scope}" 2>/dev/null || true
-sudo pkill -9 reth 2>/dev/null || true
-sleep 1
-if mountpoint -q "$SCHELK_MOUNT" 2>/dev/null; then
-  sudo umount -l "$SCHELK_MOUNT" 2>/dev/null || true
-  sudo schelk recover -y --kill 2>/dev/null || true
-fi
+sudo schelk recover -y --kill || sudo schelk full-recover -y || true
 echo
 
 # ── Step 7: Interleaved benchmark runs (B-F-F-B) ────────────────────

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -87,7 +87,7 @@ trap cleanup EXIT
 # Stop any leftover reth process in the scope, then recover schelk state.
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
 sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
-sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+sudo schelk recover -y --kill || true
 
 # Mount
 sudo schelk mount -y

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -77,7 +77,7 @@ cleanup() {
   sudo chown -R "$(id -un):$(id -gn)" "$OUTPUT_DIR" 2>/dev/null || true
   # Let schelk recover the mounted volume in place so dm-era can restore only
   # the changed blocks and clean up its own state.
-  mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y --kill || true
+  sudo schelk recover -y --kill || true
 }
 TAIL_PID=
 TRACY_PID=
@@ -87,7 +87,7 @@ trap cleanup EXIT
 # Stop any leftover reth process in the scope, then recover schelk state.
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
 sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
-sudo schelk recover -y --kill || true
+sudo schelk recover -y --kill || sudo schelk full-recover -y || true
 
 # Mount
 sudo schelk mount -y

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -78,7 +78,7 @@ echo "$MANIFEST_CONTENT" \
   | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 
 # Prepare mount. If a previous run left the volume mounted, recover first.
-sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+sudo schelk recover -y --kill || true
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -77,9 +77,8 @@ trap 'rm -f -- "$MANIFEST_TMP"' EXIT
 echo "$MANIFEST_CONTENT" \
   | jq --arg base "$BASE_URL" '.base_url = $base' > "$MANIFEST_TMP"
 
-# Prepare mount. If a previous run left the volume mounted, let schelk recover
-# it in place so dm-era can restore only the changed blocks.
-mountpoint -q "$SCHELK_MOUNT" && sudo schelk recover -y --kill || true
+# Prepare mount. If a previous run left the volume mounted, recover first.
+sudo schelk recover -y --kill || sudo schelk full-recover -y || true
 sudo schelk mount -y
 sudo rm -rf "$DATADIR"
 sudo mkdir -p "$DATADIR"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -449,12 +449,7 @@ jobs:
         run: |
           sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
           sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
-          sudo pkill -9 reth || true
-          sleep 1
-          if mountpoint -q "$SCHELK_MOUNT"; then
-            sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y --kill || true
-          fi
+          sudo schelk recover -y --kill || sudo schelk full-recover -y || true
           rm -rf "$BENCH_WORK_DIR"
           mkdir -p "$BENCH_WORK_DIR"
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -872,12 +872,7 @@ jobs:
         run: |
           sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
           sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
-          sudo pkill -9 reth || true
-          sleep 1
-          if mountpoint -q "$SCHELK_MOUNT"; then
-            sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y --kill || true
-          fi
+          sudo schelk recover -y --kill || sudo schelk full-recover -y || true
           rm -rf "$BENCH_WORK_DIR"
           mkdir -p "$BENCH_WORK_DIR"
 

--- a/.github/workflows/pgo-profile.yml
+++ b/.github/workflows/pgo-profile.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Mount snapshot
         run: |
-          sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+          sudo schelk recover -y --kill || true
           sudo schelk mount -y
           sync
           sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'

--- a/.github/workflows/pgo-profile.yml
+++ b/.github/workflows/pgo-profile.yml
@@ -58,12 +58,7 @@ jobs:
 
       - name: Mount snapshot
         run: |
-          sudo pkill -9 reth || true
-          sleep 1
-          if mountpoint -q "$SCHELK_MOUNT"; then
-            sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y --kill || true
-          fi
+          sudo schelk recover -y --kill || sudo schelk full-recover -y || true
           sudo schelk mount -y
           sync
           sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
@@ -101,7 +96,4 @@ jobs:
       - name: Recover snapshot
         if: always()
         run: |
-          if mountpoint -q "$SCHELK_MOUNT"; then
-            sudo umount -l "$SCHELK_MOUNT" || true
-            sudo schelk recover -y --kill || true
-          fi
+          sudo schelk recover -y --kill || true


### PR DESCRIPTION
Simplify schelk recovery to handle host reboots. Remove `mountpoint -q guards` — schelk already handles not-actually-mounted internally. 

Remove redundant `pkill/umount` — schelk recover --kill does this. 

Add full-recover fallback to pre-flight sites so the pipeline self-heals after a reboot instead of getting stuck.