### PR TITLE
feat(docker): enable jemalloc-prof in nightly images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,7 +126,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.build_type }}" == "nightly" ]]; then
             echo "targets=nightly" >> "$GITHUB_OUTPUT"
             echo "ethereum_tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
-            echo "ethereum_set=ethereum.tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
+            echo "ethereum_set=" >> "$GITHUB_OUTPUT"
 
           else
             # git-sha build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,8 +125,6 @@ jobs:
 
           elif [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.build_type }}" == "nightly" ]]; then
             echo "targets=nightly" >> "$GITHUB_OUTPUT"
-            echo "ethereum_tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
-            echo "ethereum_set=" >> "$GITHUB_OUTPUT"
 
           else
             # git-sha build

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -9,7 +9,7 @@ use reth_cli_util::allocator::tikv_jemalloc_sys as _;
 
 #[cfg(all(feature = "jemalloc-prof", unix))]
 #[unsafe(export_name = "malloc_conf")]
-static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
 use clap::Parser;
 use reth::cli::Cli;

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -61,7 +61,7 @@ use reth_node_metrics::{
     chain::ChainSpecInfo,
     hooks::Hooks,
     recorder::install_prometheus_recorder,
-    server::{MetricServer, MetricServerConfig},
+    server::{activate_jemalloc_heap_profiling, MetricServer, MetricServerConfig},
     version::VersionInfo,
 };
 use reth_provider::{
@@ -626,6 +626,10 @@ where
 
     /// Starts the prometheus endpoint.
     pub async fn start_prometheus_endpoint(&self) -> eyre::Result<()> {
+        if self.node_config().debug.heap_profile {
+            Self::activate_heap_profiling();
+        }
+
         // ensure recorder runs upkeep periodically
         install_prometheus_recorder().spawn_upkeep();
 
@@ -655,6 +659,15 @@ where
         }
 
         Ok(())
+    }
+
+    /// Activates jemalloc heap profiling if the binary was compiled with `jemalloc-prof`.
+    fn activate_heap_profiling() {
+        if activate_jemalloc_heap_profiling() {
+            info!(target: "reth::cli", "Jemalloc heap profiling activated");
+        } else {
+            warn!(target: "reth::cli", "--debug.heap-profile: failed to activate jemalloc profiling (binary may not be compiled with jemalloc-prof)");
+        }
     }
 
     /// Convenience function to [`Self::init_genesis`]

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -108,6 +108,14 @@ pub struct DebugArgs {
     /// the backfill, but did not yet receive any new blocks.
     #[arg(long = "debug.startup-sync-state-idle", help_heading = "Debug")]
     pub startup_sync_state_idle: bool,
+
+    /// Enable jemalloc heap profiling.
+    ///
+    /// Requires the binary to be compiled with the `jemalloc-prof` feature.
+    /// When enabled, heap profiles become available via the `/debug/pprof/heap` endpoint
+    /// on the metrics server.
+    #[arg(long = "debug.heap-profile", help_heading = "Debug")]
+    pub heap_profile: bool,
 }
 
 impl Default for DebugArgs {
@@ -127,6 +135,7 @@ impl Default for DebugArgs {
             healthy_node_rpc_url: None,
             ethstats: None,
             startup_sync_state_idle: false,
+            heap_profile: false,
         }
     }
 }

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -412,6 +412,31 @@ fn handle_pprof_heap(_pprof_dump_dir: &PathBuf) -> Response<Full<Bytes>> {
     response
 }
 
+/// Activates jemalloc heap profiling at runtime.
+///
+/// Requires the binary to be compiled with `jemalloc-prof` and initialized with
+/// `prof:true` in `MALLOC_CONF`. When `prof_active` is initially `false`, calling this
+/// enables sampling with zero overhead until activation.
+#[cfg(all(feature = "jemalloc-prof", unix))]
+pub fn activate_jemalloc_heap_profiling() -> bool {
+    match jemalloc_pprof::PROF_CTL.as_ref() {
+        Some(prof_ctl) => match prof_ctl.try_lock() {
+            Ok(mut ctl) => match ctl.activate() {
+                Ok(()) => true,
+                Err(_) => false,
+            },
+            Err(_) => false,
+        },
+        None => false,
+    }
+}
+
+/// No-op when `jemalloc-prof` is not compiled in.
+#[cfg(not(all(feature = "jemalloc-prof", unix)))]
+pub fn activate_jemalloc_heap_profiling() -> bool {
+    false
+}
+
 #[cfg(tokio_unstable)]
 async fn handle_tokio_dump() -> Response<Full<Bytes>> {
     let handle = tokio::runtime::Handle::current();

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -50,7 +50,7 @@ group "default" {
 }
 
 group "nightly" {
-  targets = ["ethereum", "ethereum-profiling"]
+  targets = ["ethereum-nightly", "ethereum-profiling"]
 }
 
 // Base target with shared configuration
@@ -87,6 +87,15 @@ target "ethereum" {
     MANIFEST_PATH = "bin/reth"
   }
   tags = ["${REGISTRY}/reth:${TAG}"]
+}
+
+// Nightly ethereum with jemalloc heap profiling support
+target "ethereum-nightly" {
+  inherits = ["ethereum"]
+  args = {
+    FEATURES = "jemalloc-prof"
+  }
+  tags = ["${REGISTRY}/reth:nightly"]
 }
 
 target "ethereum-profiling" {


### PR DESCRIPTION
Adds `jemalloc-prof` feature to the main nightly Docker image (`reth:nightly`), enabling the `/debug/pprof/heap` endpoint for jemalloc heap profiling.

Previously only the `reth:nightly-profiling` image (built with the `profiling` Cargo profile) had this. The main nightly image is built with `maxperf-symbols` and is what we actually run in production/dev, so heap profiles were unavailable where they matter most.

Introduces a new `ethereum-nightly` bake target that inherits from `ethereum` but overrides `FEATURES=jemalloc-prof` and tags as `reth:nightly`. Release/tag builds are unaffected.

Prompted by: alexey