### PR TITLE
fix: properly validate authorities in the pool

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -951,8 +951,8 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///    of the standard limit. This is due to the possibility of the account being sweeped by an
     ///    unrelated account.
     /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
-    ///    most one in-flight transaction is allowed; any additional delegated transactions from
-    ///    that account will be rejected.
+    ///    most the configured inflight delegation slot limit of in-flight transactions is allowed;
+    ///    any additional delegated transactions from that account will be rejected.
     fn validate_auth(
         &self,
         transaction: &ValidPoolTransaction<T::Transaction>,
@@ -964,8 +964,8 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         if let Some(authority_list) = &transaction.authority_ids {
             for sender_id in authority_list {
-                // Ensure authority has at most 1 inflight transaction.
-                if self.all_transactions.txs_iter(*sender_id).nth(1).is_some() {
+                // Ensure authority does not exceed the configured inflight delegation slot limit.
+                if self.all_transactions.txs_iter(*sender_id).nth(self.config.max_inflight_delegated_slot_limit).is_some() {
                     return Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -965,7 +965,12 @@ impl<T: TransactionOrdering> TxPool<T> {
         if let Some(authority_list) = &transaction.authority_ids {
             for sender_id in authority_list {
                 // Ensure authority does not exceed the configured inflight delegation slot limit.
-                if self.all_transactions.txs_iter(*sender_id).nth(self.config.max_inflight_delegated_slot_limit).is_some() {
+                if self
+                    .all_transactions
+                    .txs_iter(*sender_id)
+                    .nth(self.config.max_inflight_delegated_slot_limit)
+                    .is_some()
+                {
                     return Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Eip7702(


### PR DESCRIPTION
This check still enforces at most 1 transaction per authority while we have this limit configurable