### PR TITLE
refactor: support modifying `next_available_nonce_for`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -12,9 +12,10 @@ use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::SealedHeaderFor;
-use reth_rpc_convert::RpcConvert;
+use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
-    error::FromEvmError, EthApiError, PendingBlockEnv, RpcInvalidTransactionError,
+    error::{FromEvmError, IntoEthApiError},
+    EthApiError, PendingBlockEnv, RpcInvalidTransactionError, SignError,
 };
 use reth_rpc_server_types::constants::DEFAULT_MAX_STORAGE_VALUES_SLOTS;
 use reth_storage_api::{
@@ -350,14 +351,22 @@ pub trait LoadState:
     /// Returns the next available nonce without gaps for the given address
     /// Next available nonce is either the on chain nonce of the account or the highest consecutive
     /// nonce in the pool + 1
-    fn next_available_nonce(
+    ///
+    /// The provided request must have a from address set.
+    fn next_available_nonce_for(
         &self,
-        address: Address,
+        request: &RpcTxReq<Self::NetworkTypes>,
     ) -> impl Future<Output = Result<u64, Self::Error>> + Send
     where
         Self: SpawnBlocking,
     {
+        let address = request.as_ref().from;
         self.spawn_blocking_io(move |this| {
+            let address = match address {
+                Some(address) => address,
+                None => return Err(SignError::NoAccount.into_eth_err()),
+            };
+
             // first fetch the on chain nonce of the account
             let mut next_nonce = this
                 .latest_state()?

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -463,7 +463,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
 
             // set nonce if not already set before
             if request.as_ref().nonce().is_none() {
-                let nonce = self.next_available_nonce(from).await?;
+                let nonce = self.next_available_nonce_for(&request).await?;
                 request.as_mut().set_nonce(nonce);
             }
 
@@ -505,17 +505,12 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         Self: EthApiSpec + LoadBlock + EstimateCall + LoadFee,
     {
         async move {
-            let from = match request.as_ref().from() {
-                Some(from) => from,
-                None => return Err(SignError::NoAccount.into_eth_err()),
-            };
-
             if request.as_ref().value().is_none() {
                 request.as_mut().set_value(U256::ZERO);
             }
 
             if request.as_ref().nonce().is_none() {
-                let nonce = self.next_available_nonce(from).await?;
+                let nonce = self.next_available_nonce_for(&request).await?;
                 request.as_mut().set_nonce(nonce);
             }
 


### PR DESCRIPTION
changes `next_available_nonce_for` to take a transaction request, allowing for shared logic for nonce filling