### PR TITLE
fix: ignore SIGPIPE for graceful shutdown with piped output

### DIFF
--- a/bin/reth-bb/src/main.rs
+++ b/bin/reth-bb/src/main.rs
@@ -354,7 +354,7 @@ where
 // ---------------------------------------------------------------------------
 
 fn main() {
-    reth_cli_util::sigsegv_handler::install();
+    reth_cli_util::init();
 
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         unsafe { std::env::set_var("RUST_BACKTRACE", "1") };

--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -18,7 +18,7 @@ use reth_node_ethereum::EthereumNode;
 use tracing::info;
 
 fn main() {
-    reth_cli_util::sigsegv_handler::install();
+    reth_cli_util::init();
 
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var_os("RUST_BACKTRACE").is_none() {

--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -38,3 +38,30 @@ pub mod sigsegv_handler {
     /// No-op function.
     pub fn install() {}
 }
+
+/// Installs process-wide signal handlers and other one-time setup.
+///
+/// Currently this:
+/// - Installs a SIGSEGV handler that prints a backtrace on stack overflow.
+/// - Ignores SIGPIPE so broken pipes (e.g. `reth | tee`) result in `EPIPE` errors instead of
+///   killing the process, allowing graceful shutdown to run.
+pub fn init() {
+    sigsegv_handler::install();
+
+    #[cfg(unix)]
+    ignore_sigpipe();
+}
+
+/// Ignores SIGPIPE so that writes to broken pipes return `EPIPE` instead of killing the process.
+///
+/// Without this, piping reth output through another program (e.g. `reth node | tee log`) can
+/// cause an ungraceful shutdown: when the pipe reader is killed, the next write to stdout
+/// delivers SIGPIPE which terminates reth immediately, skipping cleanup and leaving static files
+/// inconsistent with database checkpoints.
+#[cfg(unix)]
+fn ignore_sigpipe() {
+    // SAFETY: `signal()` with `SIG_IGN` is async-signal-safe and has no preconditions.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
+}


### PR DESCRIPTION
When reth output is piped (e.g. `reth node | tee log`), C-c kills the pipe reader first. The next stdout write delivers SIGPIPE which terminates reth immediately, skipping graceful shutdown. This leaves static files inconsistent with database checkpoints, requiring lengthy consistency healing on next startup.

Ignores SIGPIPE at process start so broken-pipe writes return `EPIPE` instead of killing the process. Also consolidates process-wide setup into `reth_cli_util::init()` (SIGSEGV handler + SIGPIPE ignore).