### PR TITLE
fix(pruning): avoid unused import warning in checkpoint

### DIFF
--- a/crates/prune/types/src/checkpoint.rs
+++ b/crates/prune/types/src/checkpoint.rs
@@ -1,5 +1,7 @@
 use crate::PruneMode;
-use alloy_primitives::{bytes, BlockNumber, TxNumber};
+#[cfg(any(test, feature = "reth-codec"))]
+use alloy_primitives::bytes;
+use alloy_primitives::{BlockNumber, TxNumber};
 
 /// Saves the pruning progress of a stage.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
Fixes an unused import warning in `PruneCheckpoint` when `reth-prune-types` is built without `reth-codec`.

Replace the `impl_compression_for_compact!` macro usage with explicit codec impls so the code can use `alloy_primitives::bytes::BufMut` directly without carrying an otherwise unused import.

Validation:
- cargo check -p reth-prune-types
- cargo check -p reth-prune-types --features reth-codec
- cargo +nightly fmt --all --check