### PR TITLE
chore(ci): add `set -x` to all GHA bash scripts

### DIFF
--- a/.github/scripts/bench-reth-build.sh
+++ b/.github/scripts/bench-reth-build.sh
@@ -16,7 +16,7 @@
 #
 # Required: mc (MinIO client) with a configured alias
 # Optional env: BENCH_BIG_BLOCKS (true/false) — build reth-bb instead of reth
-set -euo pipefail
+set -euxo pipefail
 
 MC="mc"
 MODE="$1"

--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -26,7 +26,7 @@
 #
 # The script delegates to the existing bench-reth-*.sh scripts in the reth
 # repo for the actual build, snapshot, and run steps.
-set -euo pipefail
+set -euxo pipefail
 
 # ── PATH ──────────────────────────────────────────────────────────────
 # Ensure cargo and user-local bins (mc, uv) are visible

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -13,7 +13,7 @@
 #               BENCH_OTLP_TRACES_ENDPOINT (OTLP HTTP endpoint for traces, e.g. https://host/insert/opentelemetry/v1/traces)
 #               BENCH_OTLP_LOGS_ENDPOINT (OTLP HTTP endpoint for logs, e.g. https://host/insert/opentelemetry/v1/logs)
 #               BENCH_OTLP_DISABLED (true to skip OTLP export even if endpoints are set)
-set -euo pipefail
+set -euxo pipefail
 
 LABEL="$1"
 BINARY="$2"

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -18,7 +18,7 @@
 #   BENCH_JOB_URL      – link to the Actions job
 #   BENCH_ACTOR        – user who triggered the benchmark
 #   BENCH_CONFIG       – config summary line
-set -euo pipefail
+set -euxo pipefail
 
 MC="mc"
 BUCKET="minio/reth-snapshots"

--- a/.github/scripts/bench-scheduled-refs.sh
+++ b/.github/scripts/bench-scheduled-refs.sh
@@ -27,7 +27,7 @@
 #   state/hourly-last-feature-ref   (hourly, from decofe/reth-bench-charts repo)
 #
 # Requires: gh (GitHub CLI), jq, date, git (hourly mode), curl, DEREK_TOKEN env
-set -euo pipefail
+set -euxo pipefail
 
 FORCE="${1:-false}"
 MODE="${2:-nightly}"

--- a/.github/scripts/build_pgo_bolt.sh
+++ b/.github/scripts/build_pgo_bolt.sh
@@ -25,7 +25,7 @@
 #
 # Output:
 #   target/$PROFILE_DIR/reth  — final optimized binary
-set -euo pipefail
+set -euxo pipefail
 
 gha_section_start() {
     local title="$1"

--- a/.github/scripts/check_rv32imac.sh
+++ b/.github/scripts/check_rv32imac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -uxo pipefail
 
 crates_to_check=(
     reth-network-peers

--- a/.github/scripts/check_wasm.sh
+++ b/.github/scripts/check_wasm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -uxo pipefail
 
 readarray -t crates < <(
   cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name' | grep '^reth' | sort

--- a/.github/scripts/install_geth.sh
+++ b/.github/scripts/install_geth.sh
@@ -2,7 +2,7 @@
 
 # Installs Geth (https://geth.ethereum.org) in $HOME/bin for x86_64 Linux.
 
-set -eo pipefail
+set -exo pipefail
 
 GETH_BUILD=${GETH_BUILD:-"1.13.4-3f907d6a"}
 

--- a/.github/scripts/verify_image_arch.sh
+++ b/.github/scripts/verify_image_arch.sh
@@ -7,7 +7,7 @@
 # Environment:
 #   DRY_RUN=true  - Skip actual verification, just print what would be checked.
 
-set -euo pipefail
+set -euxo pipefail
 
 TARGETS="${1:-}"
 REGISTRY="${2:-}"


### PR DESCRIPTION
`bench-reth-run.sh` (and other scripts) are called from `bench.yml` workflows, but without `set -x` the logs only show the script output — not which command produced it.

**Example:** [run 24178299041, baseline (1/2)](https://github.com/paradigmxyz/reth/actions/runs/24178299041) fails with:

```
Error:
   0: Volume is not mounted.

Location:
```

The script does `schelk recover`, `schelk mount`, then starts reth — but the log shows none of these commands, so you have to guess which one failed.

**After this PR**, the log would show:

```
+ sudo schelk recover -y --kill
+ sudo schelk mount -y
Error:
   0: Volume is not mounted.
```

Now it is immediately obvious `schelk mount` returned the error.

Prompted by: pep