### PR TITLE
bench: add release regression mode

### DIFF
--- a/.github/scripts/bench-scheduled-refs.sh
+++ b/.github/scripts/bench-scheduled-refs.sh
@@ -2,17 +2,20 @@
 #
 # Resolves baseline and feature refs for scheduled benchmark runs.
 #
-# Supports two modes:
+# Supports three modes:
 #   nightly — Queries the latest successful scheduled docker.yml run via
 #             GitHub API to find the nightly Docker image commit. Compares
 #             with the last successful feature ref to detect staleness.
 #   hourly  — Compares origin/main HEAD against the last successfully
 #             benchmarked commit (falls back to HEAD~1 on first run).
 #             Checks for in-progress sibling runs to avoid overlap.
+#   release — Compares the latest GitHub release tag against the current
+#             nightly Docker build. Baseline is the release tag commit,
+#             feature is the nightly commit.
 #
 # Usage: bench-scheduled-refs.sh <force> <mode>
 #   force — "true" to run even if no new commit (bypass skip logic)
-#   mode  — "nightly" or "hourly"
+#   mode  — "nightly", "hourly", or "release"
 #
 # Outputs (via GITHUB_OUTPUT):
 #   baseline-ref    — commit SHA for baseline
@@ -21,10 +24,12 @@
 #   is-stale        — "true" if latest nightly build is >24h old (nightly only)
 #   stale-age-hours — age of the nightly build in hours (nightly only)
 #   nightly-created — ISO timestamp of the nightly build (nightly only)
+#   release-tag     — release tag name (release mode only, e.g. "v2.0.0")
 #
 # Reads:
 #   state/nightly-last-feature-ref  (nightly, from decofe/reth-bench-charts repo)
 #   state/hourly-last-feature-ref   (hourly, from decofe/reth-bench-charts repo)
+#   state/release-last-feature-ref  (release, from decofe/reth-bench-charts repo)
 #
 # Requires: gh (GitHub CLI), jq, date, git (hourly mode), curl, DEREK_TOKEN env
 set -euo pipefail
@@ -117,6 +122,106 @@ if [ "$MODE" = "hourly" ]; then
     echo "is-stale=false"
     echo "stale-age-hours=0"
     echo "nightly-created="
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# ==========================================================================
+# Release mode: compare latest GitHub release tag vs current nightly build
+# ==========================================================================
+if [ "$MODE" = "release" ]; then
+
+  # --- Step 1: Resolve feature ref from latest nightly Docker build ---
+  echo "::group::Querying latest nightly docker build"
+  RUNS_JSON=$(gh run list \
+    -R "$REPO" \
+    --workflow=docker.yml \
+    --event=schedule \
+    --status=completed \
+    --limit 5 \
+    --json headSha,createdAt,conclusion)
+
+  LATEST=$(echo "$RUNS_JSON" | jq -r '[.[] | select(.conclusion == "success")] | first // empty')
+  if [ -z "$LATEST" ]; then
+    echo "::error::No successful scheduled docker.yml run found in the last 5 runs"
+    exit 1
+  fi
+
+  FEATURE_REF=$(echo "$LATEST" | jq -r '.headSha')
+  echo "Nightly commit (feature): $FEATURE_REF"
+  echo "::endgroup::"
+
+  # --- Step 2: Resolve baseline ref from latest GitHub release ---
+  echo "::group::Resolving latest release tag"
+  RELEASE_JSON=$(gh release view --repo "$REPO" --json tagName,targetCommitish,publishedAt 2>/dev/null || echo "{}")
+  RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -r '.tagName // empty')
+
+  if [ -z "$RELEASE_TAG" ]; then
+    echo "::error::No release found on $REPO"
+    exit 1
+  fi
+
+  # Resolve the tag to a commit SHA
+  BASELINE_REF=$(gh api "repos/$REPO/git/ref/tags/$RELEASE_TAG" --jq '.object.sha' 2>/dev/null || true)
+
+  # If tag points to an annotated tag object, dereference to the commit
+  if [ -n "$BASELINE_REF" ]; then
+    OBJ_TYPE=$(gh api "repos/$REPO/git/tags/$BASELINE_REF" --jq '.object.type' 2>/dev/null || echo "commit")
+    if [ "$OBJ_TYPE" = "commit" ]; then
+      BASELINE_REF=$(gh api "repos/$REPO/git/tags/$BASELINE_REF" --jq '.object.sha' 2>/dev/null || echo "$BASELINE_REF")
+    fi
+  fi
+
+  if [ -z "$BASELINE_REF" ]; then
+    echo "::error::Could not resolve release tag $RELEASE_TAG to a commit"
+    exit 1
+  fi
+
+  echo "Release tag: $RELEASE_TAG"
+  echo "Release commit (baseline): $BASELINE_REF"
+  echo "::endgroup::"
+
+  # --- Step 3: Read last successful feature ref from charts repo ---
+  echo "::group::Reading persisted state"
+  LAST_FEATURE_REF=""
+  STATE_URL="https://raw.githubusercontent.com/decofe/reth-bench-charts/state/state/release-last-feature-ref"
+  if RAW=$(curl -sfL -H "Authorization: token ${DEREK_TOKEN}" "$STATE_URL"); then
+    LAST_FEATURE_REF=$(echo "$RAW" | tr -d '[:space:]')
+    echo "Previous feature ref: $LAST_FEATURE_REF"
+  else
+    echo "No persisted state found (first run)"
+  fi
+  echo "::endgroup::"
+
+  # --- Step 4: Skip logic ---
+  echo "::group::Resolving skip logic"
+  SHOULD_SKIP="false"
+  if [ -n "$LAST_FEATURE_REF" ] && [ "$LAST_FEATURE_REF" = "$FEATURE_REF" ]; then
+    if [ "$FORCE" = "true" ] || [ "$FORCE" = "--force" ]; then
+      echo "No new nightly, but force=true — running anyway"
+    else
+      SHOULD_SKIP="true"
+      echo "No new nightly since last release regression run — will skip"
+    fi
+  else
+    echo "New nightly detected or first run"
+  fi
+
+  echo "Baseline: $BASELINE_REF ($RELEASE_TAG)"
+  echo "Feature:  $FEATURE_REF"
+  echo "Skip:     $SHOULD_SKIP"
+  echo "::endgroup::"
+
+  # --- Step 5: Write outputs ---
+  {
+    echo "baseline-ref=$BASELINE_REF"
+    echo "feature-ref=$FEATURE_REF"
+    echo "should-skip=$SHOULD_SKIP"
+    echo "is-stale=false"
+    echo "stale-age-hours=0"
+    echo "nightly-created="
+    echo "long-running=false"
+    echo "release-tag=$RELEASE_TAG"
   } >> "$GITHUB_OUTPUT"
   exit 0
 fi

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -1,11 +1,13 @@
-# Scheduled regression benchmarks (nightly + hourly).
+# Scheduled regression benchmarks (nightly + hourly + release).
 #
-# Two modes:
+# Three modes:
 #   nightly — Compares the previous nightly Docker build against the current one.
 #             Runs daily after docker.yml produces a new nightly image.
 #   hourly  — Compares main HEAD against the last benchmarked commit to catch
 #             regressions quickly. Falls back to HEAD~1 on first run.
 #             Skips if no new commits or if a previous run is still in progress.
+#   release — Compares the latest GitHub release tag against the current nightly
+#             Docker build. Runs daily to track nightly vs release performance.
 #
 # State is persisted between runs via the decofe/reth-bench-charts repo: each
 # successful run saves the feature commit SHA so the next run knows what to
@@ -17,6 +19,8 @@ on:
     - cron: "30 5 * * *"
     # Hourly: compares main HEAD vs last benchmarked commit, skips if no new commits
     - cron: "0 * * * *"
+    # Release: compares latest GitHub release tag vs current nightly Docker build
+    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -37,6 +41,7 @@ on:
         options:
           - nightly
           - hourly
+          - release
 
 env:
   CARGO_TERM_COLOR: always
@@ -64,6 +69,7 @@ jobs:
       stale-age-hours: ${{ steps.refs.outputs.stale-age-hours }}
       nightly-created: ${{ steps.refs.outputs.nightly-created }}
       long-running: ${{ steps.refs.outputs.long-running }}
+      release-tag: ${{ steps.refs.outputs.release-tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -79,6 +85,8 @@ jobs:
             MODE="${{ inputs.mode || 'nightly' }}"
           elif [ "${{ github.event.schedule }}" = "30 5 * * *" ]; then
             MODE="nightly"
+          elif [ "${{ github.event.schedule }}" = "0 9 * * *" ]; then
+            MODE="release"
           else
             MODE="hourly"
           fi
@@ -338,12 +346,19 @@ jobs:
 
       - name: Resolve display names
         id: refs
+        env:
+          RELEASE_TAG: ${{ needs.resolve-refs.outputs.release-tag }}
         run: |
-          BASELINE_SHORT=$(echo "$BASELINE_REF" | cut -c1-8)
           FEATURE_SHORT=$(echo "$FEATURE_REF" | cut -c1-8)
-          echo "baseline-name=${BENCH_MODE}-${BASELINE_SHORT}" >> "$GITHUB_OUTPUT"
+          if [ "$BENCH_MODE" = "release" ] && [ -n "$RELEASE_TAG" ]; then
+            echo "baseline-name=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "baseline-ref=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            BASELINE_SHORT=$(echo "$BASELINE_REF" | cut -c1-8)
+            echo "baseline-name=${BENCH_MODE}-${BASELINE_SHORT}" >> "$GITHUB_OUTPUT"
+            echo "baseline-ref=$BASELINE_REF" >> "$GITHUB_OUTPUT"
+          fi
           echo "feature-name=${BENCH_MODE}-${FEATURE_SHORT}" >> "$GITHUB_OUTPUT"
-          echo "baseline-ref=$BASELINE_REF" >> "$GITHUB_OUTPUT"
           echo "feature-ref=$FEATURE_REF" >> "$GITHUB_OUTPUT"
 
       - name: Check if snapshot needs update
@@ -559,11 +574,12 @@ jobs:
         env:
           BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
+          BASELINE_REF_DISPLAY: ${{ steps.refs.outputs.baseline-ref }}
         run: |
           SUMMARY_ARGS="--output-summary $BENCH_WORK_DIR/summary.json"
           SUMMARY_ARGS="$SUMMARY_ARGS --output-markdown $BENCH_WORK_DIR/comment.md"
           SUMMARY_ARGS="$SUMMARY_ARGS --repo ${{ github.repository }}"
-          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-ref ${BASELINE_REF}"
+          SUMMARY_ARGS="$SUMMARY_ARGS --baseline-ref ${BASELINE_REF_DISPLAY}"
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-name ${BASELINE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-name ${FEATURE_NAME}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-ref ${FEATURE_REF}"
@@ -590,7 +606,11 @@ jobs:
           CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
         run: |
-          WORKFLOW_NAME="workflows-nightly-regression-${{ github.run_id }}"
+          if [ "$BENCH_MODE" = "release" ]; then
+            WORKFLOW_NAME="workflows-release-regression-${{ github.run_id }}"
+          else
+            WORKFLOW_NAME="workflows-nightly-regression-${{ github.run_id }}"
+          fi
           DIFF_URL="https://github.com/${{ github.repository }}/compare/${BASELINE_REF}...${FEATURE_REF}"
           GRAFANA_URL='${{ steps.metrics.outputs.grafana-url }}'
           JOB_URL="${BENCH_JOB_URL:-${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}}"
@@ -633,7 +653,7 @@ jobs:
         if: success() && env.BENCH_MODE != 'hourly'
         run: |
           RUN_ID=${{ github.run_id }}
-          CHART_DIR="nightly/${RUN_ID}"
+          CHART_DIR="${BENCH_MODE}/${RUN_ID}"
           CHARTS_REPO="https://x-access-token:${{ secrets.DEREK_TOKEN }}@github.com/decofe/reth-bench-charts.git"
 
           TMP_DIR=$(mktemp -d)
@@ -794,7 +814,7 @@ jobs:
 
             function cell(text) { return { type: 'raw_text', text: String(text) || ' ' }; }
 
-            const modeLabel = mode === 'hourly' ? 'Hourly Regression' : 'Nightly Regression';
+            const modeLabel = mode === 'release' ? 'Release Regression' : mode === 'hourly' ? 'Hourly Regression' : 'Nightly Regression';
             const sectionText = [
               `*${modeLabel}*`,
               '',
@@ -911,7 +931,7 @@ jobs:
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${repo}/actions/runs/${context.runId}`;
 
             const mode = process.env.BENCH_MODE || 'nightly';
-            const modeLabel = mode === 'hourly' ? 'Hourly' : 'Nightly';
+            const modeLabel = mode === 'release' ? 'Release' : mode === 'hourly' ? 'Hourly' : 'Nightly';
 
             const blocks = [
               {


### PR DESCRIPTION
## Summary

Add a third scheduled benchmark mode (`release`) that compares the **latest GitHub release tag** against the **current nightly Docker build**. This populates the "Nightly Build vs Last Release" panel on the PM dashboard, which has been stale for ~48 days.

## Changes

### `.github/scripts/bench-scheduled-refs.sh`
- Add `release` mode that:
  - Resolves **feature ref** from the latest successful nightly `docker.yml` build (same as nightly mode)
  - Resolves **baseline ref** from `gh release view --repo paradigmxyz/reth` → latest release tag, dereferenced to commit SHA
  - Persists state in `decofe/reth-bench-charts` at `state/release-last-feature-ref`
  - Skips if the nightly commit hasn't changed since last successful run
  - Outputs `release-tag` (e.g. `v2.0.0`) for display/ClickHouse

### `.github/workflows/bench-scheduled.yml`
- Add `release` cron schedule: `0 9 * * *` (09:00 UTC daily)
- Add `release` to `workflow_dispatch` mode options
- Map `0 9 * * *` → `release` in mode detection
- For release mode, use the tag name (e.g. `v2.0.0`) as `baseline-ref` in summary/ClickHouse so the PM dashboard query `baseline_ref LIKE 'v%'` matches
- Use `workflows-release-regression-*` as ClickHouse workflow name
- Update Slack notification labels for release mode
- Charts pushed under `release/` directory (not `nightly/`)

## How it works

```
09:00 UTC daily
  → resolve-refs: baseline = latest release tag SHA, feature = nightly commit
  → bench-scheduled: build both, run B-F-F-B interleaved benchmark
  → upload to ClickHouse with baseline_ref = tag name (e.g. v2.0.0)
  → PM dashboard picks up rows where baseline_ref LIKE 'v%'
```

## Testing

Can be triggered manually via `workflow_dispatch` with `mode: release`.