### PR TITLE
ci(bench): always send Slack notification for nightly bench runs

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -762,7 +762,6 @@ jobs:
             const changes = summary.changes || {};
             const mode = process.env.BENCH_MODE || 'nightly';
             const hasRegression = Object.values(changes).some(c => c.sig === 'bad');
-            const hasSignificant = Object.values(changes).some(c => c.sig === 'good' || c.sig === 'bad');
 
             // Hourly mode: only notify on regressions
             if (mode === 'hourly' && !hasRegression) {
@@ -770,11 +769,7 @@ jobs:
               return;
             }
 
-            // Nightly mode: notify on any significant change (regression or improvement)
-            if (!hasSignificant) {
-              core.info('No significant changes detected, skipping nightly Slack notification');
-              return;
-            }
+            // Nightly mode: always notify (report every run regardless of significance)
 
             const SLACK_VERDICT = {
               '⚠️': ':warning:',


### PR DESCRIPTION
Removes the significance filter so nightly bench results are always
reported to Slack, even when no regression or improvement is detected.
Hourly mode is unchanged (still only notifies on regressions).

Note: manual `workflow_dispatch` runs still default to `no_slack: true`,
so Slack is only always-on for scheduled nightly runs.

Co-Authored-By: Alexey Shekhirin <5773434+shekhirin@users.noreply.github.com>

Prompted by: alexey