### PR TITLE
[autoopt] 20260410-1-deferred-overlay-reuse

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -72,7 +72,7 @@ enum DeferredState {
     /// Wrapped in `Option` to allow taking ownership during computation.
     Pending(Option<PendingInputs>),
     /// Data has been computed and is ready.
-    Ready(ComputedTrieData),
+    Ready(Arc<ComputedTrieData>),
 }
 
 /// Inputs kept while a deferred trie computation is pending.
@@ -134,7 +134,7 @@ impl DeferredTrieData {
     /// Useful when trie data is available immediately.
     /// [`Self::wait_cloned`] will return without any computation.
     pub fn ready(bundle: ComputedTrieData) -> Self {
-        Self { state: Arc::new(Mutex::new(DeferredState::Ready(bundle))) }
+        Self { state: Arc::new(Mutex::new(DeferredState::Ready(Arc::new(bundle)))) }
     }
 
     /// Sort block execution outputs and build a [`TrieInputSorted`] overlay.
@@ -198,9 +198,9 @@ impl DeferredTrieData {
         // persisted anchor. If the anchor has changed (e.g., due to persistence),
         // the parent's overlay is relative to an old state and cannot be used.
         let overlay = if let Some(parent) = ancestors.last() {
-            let parent_data = parent.wait_cloned();
+            let parent_data = parent.wait_arc();
 
-            match &parent_data.anchored_trie_input {
+            match parent_data.anchored_trie_input.as_ref() {
                 // Case 1: Parent has cached overlay AND anchors match.
                 Some(AnchoredTrieInput { anchor_hash: parent_anchor, trie_input })
                     if *parent_anchor == anchor_hash =>
@@ -288,7 +288,7 @@ impl DeferredTrieData {
         let nodes_mut = Arc::make_mut(&mut overlay.nodes);
 
         for ancestor in ancestors {
-            let ancestor_data = ancestor.wait_cloned();
+            let ancestor_data = ancestor.wait_arc();
             state_mut.extend_ref_and_sort(ancestor_data.hashed_state.as_ref());
             nodes_mut.extend_ref_and_sort(ancestor_data.trie_updates.as_ref());
         }
@@ -321,13 +321,13 @@ impl DeferredTrieData {
     ///
     /// Given that invariant, circular wait dependencies are impossible.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
-    pub fn wait_cloned(&self) -> ComputedTrieData {
+    pub fn wait_arc(&self) -> Arc<ComputedTrieData> {
         let mut state = self.state.lock();
         match &mut *state {
             // If the deferred trie data is ready, return the cached result.
             DeferredState::Ready(bundle) => {
                 DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
-                bundle.clone()
+                Arc::clone(bundle)
             }
             // If the deferred trie data is pending, compute the trie data synchronously and return
             // the result. This is the fallback path if the async task hasn't completed.
@@ -342,7 +342,8 @@ impl DeferredTrieData {
                     inputs.anchor_hash,
                     &inputs.ancestors,
                 );
-                *state = DeferredState::Ready(computed.clone());
+                let computed = Arc::new(computed);
+                *state = DeferredState::Ready(Arc::clone(&computed));
 
                 // Release lock before inputs (and its ancestors) drop to avoid holding it
                 // while their potential last Arc refs drop (which could trigger recursive locking)
@@ -351,6 +352,16 @@ impl DeferredTrieData {
                 computed
             }
         }
+    }
+
+    /// Returns trie data, cloning the cached fields if the async task already completed.
+    ///
+    /// This preserves the existing by-value API for callers that need an owned
+    /// [`ComputedTrieData`] while letting hot read-only paths reuse the shared `Arc` via
+    /// [`Self::wait_arc`].
+    #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
+    pub fn wait_cloned(&self) -> ComputedTrieData {
+        self.wait_arc().as_ref().clone()
     }
 }
 

--- a/crates/chain-state/src/lazy_overlay.rs
+++ b/crates/chain-state/src/lazy_overlay.rs
@@ -33,7 +33,7 @@ struct LazyOverlayInputs {
 #[derive(Clone)]
 pub struct LazyOverlay {
     /// Computed result, cached after first access.
-    inner: Arc<OnceLock<TrieInputSorted>>,
+    inner: Arc<OnceLock<Arc<TrieInputSorted>>>,
     /// Inputs for lazy computation.
     inputs: LazyOverlayInputs,
 }
@@ -79,7 +79,7 @@ impl LazyOverlay {
     /// The first call triggers computation (which may block waiting for deferred data).
     /// Subsequent calls return the cached result immediately.
     pub fn get(&self) -> &TrieInputSorted {
-        self.inner.get_or_init(|| self.compute())
+        self.inner.get_or_init(|| self.compute()).as_ref()
     }
 
     /// Returns the overlay as (nodes, state) tuple for use with `OverlayStateProviderFactory`.
@@ -89,23 +89,23 @@ impl LazyOverlay {
     }
 
     /// Compute the trie input overlay.
-    fn compute(&self) -> TrieInputSorted {
+    fn compute(&self) -> Arc<TrieInputSorted> {
         let anchor_hash = self.inputs.anchor_hash;
         let blocks = &self.inputs.blocks;
 
         if blocks.is_empty() {
             debug!(target: "chain_state::lazy_overlay", "No in-memory blocks, returning empty overlay");
-            return TrieInputSorted::default();
+            return Arc::new(TrieInputSorted::default());
         }
 
         // Fast path: Check if tip block's overlay is ready and anchor matches.
         // The tip block (first in list) has the cumulative overlay from all ancestors.
         if let Some(tip) = blocks.first() {
-            let data = tip.wait_cloned();
-            if let Some(anchored) = &data.anchored_trie_input {
+            let data = tip.wait_arc();
+            if let Some(anchored) = data.anchored_trie_input.as_ref() {
                 if anchored.anchor_hash == anchor_hash {
                     trace!(target: "chain_state::lazy_overlay", %anchor_hash, "Reusing tip block's cached overlay (fast path)");
-                    return (*anchored.trie_input).clone();
+                    return Arc::clone(&anchored.trie_input);
                 }
                 debug!(
                     target: "chain_state::lazy_overlay",
@@ -118,7 +118,7 @@ impl LazyOverlay {
 
         // Slow path: Merge all blocks' trie data into a new overlay.
         debug!(target: "chain_state::lazy_overlay", num_blocks = blocks.len(), "Merging blocks (slow path)");
-        Self::merge_blocks(blocks)
+        Arc::new(Self::merge_blocks(blocks))
     }
 
     /// Merge all blocks' trie data into a single [`TrieInputSorted`].
@@ -129,10 +129,13 @@ impl LazyOverlay {
             return TrieInputSorted::default();
         }
 
-        let state =
-            HashedPostStateSorted::merge_batch(blocks.iter().map(|b| b.wait_cloned().hashed_state));
-        let nodes =
-            TrieUpdatesSorted::merge_batch(blocks.iter().map(|b| b.wait_cloned().trie_updates));
+        let computed: Vec<_> = blocks.iter().map(DeferredTrieData::wait_arc).collect();
+        let state = HashedPostStateSorted::merge_batch(
+            computed.iter().map(|data| Arc::clone(&data.hashed_state)),
+        );
+        let nodes = TrieUpdatesSorted::merge_batch(
+            computed.iter().map(|data| Arc::clone(&data.trie_updates)),
+        );
 
         TrieInputSorted { state, nodes, prefix_sets: Default::default() }
     }


### PR DESCRIPTION
# Reuse deferred trie overlays without cloning trie bundles
## Evidence
- `artifacts/24216787910/bench-reth-results/baseline-1/combined_latency.csv` shows mean `sparse_trie_wait` is only 0.231 ms, so the remaining trie opportunity is CPU work in overlay preparation and reuse, not queueing.
- The baseline-1 samply profile shows the `prepare-overlay` thread spending its largest leaf sample buckets in `Arc::clone` (1151 samples) and `Option::get_or_insert_with` (831 samples), which matches the lazy-overlay fast path repeatedly reusing already-computed trie inputs.
- In `crates/chain-state/src/lazy_overlay.rs`, `LazyOverlay::compute` called `tip.wait_cloned()` even when it only needed `anchored_trie_input`, forcing a full `ComputedTrieData` clone on the fast path.
- In `crates/chain-state/src/deferred_trie.rs`, both `wait_cloned` and the parent-overlay reuse path cloned the full ready bundle even when callers only needed the shared anchored trie input or the sorted state/update Arcs.

## Hypothesis
If we keep ready deferred trie bundles behind shared `Arc`s and let lazy overlay / deferred-trie reuse paths borrow those shared results directly, gas throughput improves by ~0.3-0.8% because canonical overlay preparation and parent overlay reuse do less `Arc` churn on the hot in-memory state-root path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.3%

## Plan
- Update `crates/chain-state/src/deferred_trie.rs` so ready deferred trie data is stored as `Arc<ComputedTrieData>` and add a shared accessor for read-only fast paths.
- Update `crates/chain-state/src/lazy_overlay.rs` so the cached lazy overlay reuses `Arc<TrieInputSorted>` directly instead of cloning a full `TrieInputSorted`/`ComputedTrieData` bundle on the fast path.
- Verify with `cargo check -p reth-chain-state -p reth-engine-tree` and `cargo test -p reth-chain-state`.

## Agent Thread
https://ampcode.com/threads/T-019d74cc-6c6b-72d8-b27b-ae75ac09f7be