### PR TITLE
docs(rpc): mark admin_peerEvents, debug_traceChain, eth_mining, and eth_coinbase as not implemented

### DIFF
--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -164,6 +164,10 @@ Clears all transactions from the transaction pool. Returns the number of removed
 
 ## `admin_peerEvents`, `admin_peerEvents_unsubscribe`
 
+:::warning
+`admin_peerEvents` is not yet implemented. Calling this method returns an error.
+:::
+
 Subscribe to events received by peers over the network. This creates a subscription that emits notifications about peer connections and disconnections.
 
 The events provide information about peer activities such as when peers connect, disconnect, or experience errors. Each event contains details about the affected peer, including its enode URL, IP address, and the reason for the event.

--- a/docs/vocs/docs/pages/jsonrpc/debug.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/debug.mdx
@@ -55,6 +55,10 @@ Returns an array of recent bad blocks that the client has seen on the network.
 
 ## `debug_traceChain`
 
+:::warning
+`debug_traceChain` is not yet implemented. Calling this method returns an error.
+:::
+
 Returns the structured logs created during the execution of EVM between two blocks (excluding start) as a JSON object.
 
 | Client | Method invocation                                                    |

--- a/docs/vocs/docs/pages/jsonrpc/eth.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/eth.mdx
@@ -5,3 +5,7 @@ description: Standard Ethereum JSON-RPC API methods.
 # `eth` Namespace
 
 Documentation for the API methods in the `eth` namespace can be found on [ethereum.org](https://ethereum.org/en/developers/docs/apis/json-rpc/).
+
+:::warning
+`eth_coinbase` and `eth_mining` are not implemented in Reth and will return an error when called.
+:::


### PR DESCRIPTION
Closes #23240

Add `:::warning` callouts to `admin_peerEvents`, `debug_traceChain`, `eth_mining`, and `eth_coinbase` so docs accurately reflect that calling these methods returns an error.