### PR TITLE
ci: bump MSRV job runner to depot-ubuntu-latest-8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -117,7 +117,7 @@ jobs:
 
   msrv:
     name: MSRV
-    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-8' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
MSRV job was running out of disk space on `depot-ubuntu-latest` (2 CPU, 100GB). Bumps to `depot-ubuntu-latest-8` (8 CPU, 150GB disk) to fix.

Prompted by: Alexey