### PR TITLE
fix(transaction-pool): reject underpriced replacements with zero priority fee

### DIFF
--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -470,7 +470,6 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
 
         // Check max priority fee per gas (relevant for EIP-1559 transactions only)
         if existing_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas != 0 &&
             replacement_max_priority_fee_per_gas <
                 required_bumped_fee(existing_max_priority_fee_per_gas)
         {


### PR DESCRIPTION
When the pooled EIP-1559 transaction had a non-zero max priority fee, the replacement bump check was skipped if the replacement's priority fee was zero. That allowed replacing with a zero-tip transaction without meeting the configured bump. Remove the guard so the bump rule applies consistently.