### PR TITLE
fix(net): correct full-tx propagation peer boundary

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1050,7 +1050,7 @@ where
                 continue
             }
             // determine whether to send full tx objects or hashes.
-            let mut builder = if peer_idx > max_num_full {
+            let mut builder = if peer_idx >= max_num_full {
                 PropagateTransactionsBuilder::pooled(peer.version)
             } else {
                 PropagateTransactionsBuilder::full(peer.version)


### PR DESCRIPTION
Fixes an off-by-one when selecting pooled vs full transaction propagation: peers are enumerated from zero, so the first full_peer_count peers should receive full objects. The previous check used `>` and caused one additional peer to receive full broadcasts.