### PR TITLE
fix(consensus): always validate minimum gas limit

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -403,7 +403,7 @@ pub fn validate_against_parent_gas_limit<
         })
     }
     // Check if the self gas limit is below the minimum required limit.
-    else if header.gas_limit() < MINIMUM_GAS_LIMIT {
+    if header.gas_limit() < MINIMUM_GAS_LIMIT {
         return Err(ConsensusError::GasLimitInvalidMinimum { child_gas_limit: header.gas_limit() })
     }
 


### PR DESCRIPTION
The minimum gas limit check was incorrectly chained as `else if` after comparing the header gas limit to the parent's. When the child's limit was greater than the parent's, that `if` branch was taken and the `else if` chain—including the minimum—was skipped. Use a standalone `if` so `MINIMUM_GAS_LIMIT` is always enforced.