### PR TITLE
fix(provider): size block_range buffer for inclusive span

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1160,7 +1160,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             return Ok(Vec::new())
         }
 
-        let len = range.end().saturating_sub(*range.start()) as usize;
+        let len = range.end().saturating_sub(*range.start()) as usize + 1;
         let mut blocks = Vec::with_capacity(len);
 
         let headers = headers_range(range.clone())?;


### PR DESCRIPTION
`block_range` builds blocks for a `RangeInclusive<BlockNumber>`. The element count is `end - start + 1`, but the preallocation used `end - start`, shorting `Vec::with_capacity` by one.