### PR TITLE
fix(net): seed block range on first BlockRangeUpdate

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -363,6 +363,9 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
                 if let Some(range_info) = self.range_info.as_ref() {
                     range_info.update(msg.earliest, msg.latest, msg.latest_hash);
+                } else {
+                    self.range_info =
+                        Some(BlockRangeInfo::new(msg.earliest, msg.latest, msg.latest_hash));
                 }
 
                 OnIncomingMessageOutcome::Ok


### PR DESCRIPTION
Handles `EthMessage::BlockRangeUpdate` when the session has no `range_info` yet. Previously only `BlockRangeInfo::update` ran for `Some`, so the first update was dropped. Seed `BlockRangeInfo::new` from the message when `range_info` is `None`.