### PR TITLE
fix(net): seed peer range from handshake status

### DIFF
--- a/crates/net/eth-wire-types/src/status.rs
+++ b/crates/net/eth-wire-types/src/status.rs
@@ -1,4 +1,4 @@
-use crate::EthVersion;
+use crate::{BlockRangeUpdate, EthVersion};
 use alloy_chains::{Chain, NamedChain};
 use alloy_hardforks::{EthereumHardfork, ForkId, Head};
 use alloy_primitives::{hex, B256, U256};
@@ -76,6 +76,19 @@ impl UnifiedStatus {
     pub const fn set_history_range(&mut self, earliest: u64, latest: u64) {
         self.earliest_block = Some(earliest);
         self.latest_block = Some(latest);
+    }
+
+    /// Returns the peer's advertised `BlockRangeUpdate` if this status came from an `eth/69+`
+    /// handshake.
+    pub fn block_range_update(&self) -> Option<BlockRangeUpdate> {
+        (self.version >= EthVersion::Eth69)
+            .then_some(())
+            .and_then(|_| self.earliest_block.zip(self.latest_block))
+            .map(|(earliest, latest)| BlockRangeUpdate {
+                earliest,
+                latest,
+                latest_hash: self.blockhash,
+            })
     }
 
     /// Sets the [`EthVersion`] for the status.
@@ -457,7 +470,7 @@ impl Display for StatusMessage {
 }
 #[cfg(test)]
 mod tests {
-    use crate::{EthVersion, Status, StatusEth69, StatusMessage, UnifiedStatus};
+    use crate::{BlockRangeUpdate, EthVersion, Status, StatusEth69, StatusMessage, UnifiedStatus};
     use alloy_consensus::constants::MAINNET_GENESIS_HASH;
     use alloy_genesis::Genesis;
     use alloy_hardforks::{EthereumHardfork, ForkHash, ForkId, Head};
@@ -562,6 +575,30 @@ mod tests {
         let status_message = unified_status.into_message();
         let roundtripped_unified_status = UnifiedStatus::from_message(status_message);
         assert_eq!(unified_status, roundtripped_unified_status);
+    }
+
+    #[test]
+    fn block_range_update_for_eth69_status() {
+        let latest_hash =
+            b256!("0xfeb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d");
+        let status = UnifiedStatus::builder()
+            .version(EthVersion::Eth69)
+            .earliest_block(Some(10))
+            .latest_block(Some(20))
+            .blockhash(latest_hash)
+            .build();
+
+        assert_eq!(
+            status.block_range_update(),
+            Some(BlockRangeUpdate { earliest: 10, latest: 20, latest_hash })
+        );
+    }
+
+    #[test]
+    fn block_range_update_is_none_for_legacy_status() {
+        let status = UnifiedStatus::builder().version(EthVersion::Eth68).build();
+
+        assert!(status.block_range_update().is_none());
     }
 
     #[test]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -175,6 +175,7 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     pub(crate) terminate_message:
         Option<(PollSender<ActiveSessionMessage<N>>, ActiveSessionMessage<N>)>,
     /// The eth69 range info for the remote peer.
+    /// This is `None` for peers negotiating versions below `eth/69`.
     pub(crate) range_info: Option<BlockRangeInfo>,
     /// The eth69 range info for the local node (this node).
     /// This represents the range of blocks that this node can serve to other peers.

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -553,6 +553,9 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 // the `SessionManager` always has an accurate view of total buffered broadcast
                 // pressure for a peer.
                 let broadcast_items = BroadcastItemCounter::new();
+                let remote_range_info = status.block_range_update().map(|update| {
+                    BlockRangeInfo::new(update.earliest, update.latest, update.latest_hash)
+                });
 
                 let session = ActiveSession {
                     next_id: 0,
@@ -579,7 +582,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     internal_request_timeout: Arc::clone(&timeout),
                     protocol_breach_request_timeout: self.protocol_breach_request_timeout,
                     terminate_message: None,
-                    range_info: None,
+                    range_info: remote_range_info.clone(),
                     local_range_info: self.local_range_info.clone(),
                     range_update_interval,
                     last_sent_latest_block: None,
@@ -619,7 +622,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     messages,
                     direction,
                     timeout,
-                    range_info: None,
+                    range_info: remote_range_info,
                 })
             }
             PendingSessionEvent::Disconnected { remote_addr, session_id, direction, error } => {


### PR DESCRIPTION
Supersedes #23444

Before this change, ETH69 peers could advertise a block range in the handshake status, but sessions were still initialized with `range_info: None`. `State::on_session_activated()` then passed that `None` into `StateFetcher`, so fetch peer selection never saw the peer's advertised range. Later `BlockRangeUpdate` messages only updated the session-local copy.

Seed the remote peer range info from the handshake status when the session is established, and add a small `UnifiedStatus::block_range_update()` helper to keep the conversion at the protocol boundary.

Validation:
- `cargo +nightly fmt --all --check`
- `cargo test -p reth-eth-wire-types block_range_update -- --nocapture`
- `cargo +nightly clippy -p reth-eth-wire-types --lib -- -A warnings -W clippy::or_fun_call`