### PR TITLE
perf(tracing): disable location and inactivity tracking in OTLP span export

### DIFF
--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -62,7 +62,10 @@ where
     global::set_tracer_provider(tracer_provider.clone());
 
     let tracer = tracer_provider.tracer(otlp_config.service_name);
-    Ok(tracing_opentelemetry::layer().with_tracer(tracer))
+    Ok(tracing_opentelemetry::layer()
+        .with_tracer(tracer)
+        .with_location(false)
+        .with_tracked_inactivity(false))
 }
 
 /// Creates a tracing layer that exports logs to an OTLP endpoint.


### PR DESCRIPTION
Disables `code.file.path`, `code.module.name`, `code.line.number`, `busy_ns`, and `idle_ns` attributes on exported OTLP spans by calling `.with_location(false).with_tracked_inactivity(false)` on the `OpenTelemetryLayer`.

These attributes are redundant — the span `name` (from `#[instrument]`) and `target` already identify the source location. They account for ~55% of per-span byte overhead (~500 bytes out of ~900 per span). On a production validator with shared sparse trie enabled, a single block build can produce 9,000+ spans. Without this change, traces hit Tempo's `max_bytes_per_trace` limit and get rejected.

Prompted by: klkvr