### PR TITLE
perf(engine): downgrade sparse trie spans to trace

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -128,7 +128,7 @@ where
         let parent_span = tracing::Span::current();
         let hashing_metrics = metrics.clone();
         executor.spawn_blocking_named("trie-hashing", move || {
-            let _span = debug_span!(parent: parent_span, "run_hashing_task").entered();
+            let _span = trace_span!(parent: parent_span, "run_hashing_task").entered();
             Self::run_hashing_task(updates, hashed_state_tx, hashing_metrics)
         });
 
@@ -177,7 +177,7 @@ where
                     SparseTrieTaskMessage::PrefetchProofs(targets)
                 }
                 StateRootMessage::StateUpdate(_, state) => {
-                    let _span = debug_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
+                    let _span = trace_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
                     let hashed = evm_state_to_hashed_post_state(state);
                     SparseTrieTaskMessage::HashedState(hashed)
                 }
@@ -252,7 +252,7 @@ where
     /// This concludes once the last state update has been received and processed.
     #[instrument(
         name = "SparseTrieCacheTask::run",
-        level = "debug",
+        level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
@@ -542,7 +542,7 @@ where
     /// Applies all account and storage leaf updates to corresponding tries and collects any new
     /// multiproof targets.
     #[instrument(
-        level = "debug",
+        level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
@@ -551,7 +551,7 @@ where
             if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
         // Process all storage updates, skipping tries with no pending updates.
-        let span = debug_span!("process_storage_leaf_updates").entered();
+        let span = trace_span!("process_storage_leaf_updates").entered();
         for (address, updates) in storage_updates {
             if updates.is_empty() {
                 continue;
@@ -596,7 +596,7 @@ where
     ///
     /// Returns whether any updates were drained (applied to the trie).
     #[instrument(
-        level = "debug",
+        level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
@@ -638,11 +638,6 @@ where
     /// 3. but the storage root hasn't been updated yet,
     ///
     /// we trigger state root computation on a rayon pool.
-    #[instrument(
-        level = "debug",
-        target = "engine::tree::payload_processor::sparse_trie",
-        skip_all
-    )]
     fn compute_drained_storage_roots(&mut self) {
         let addresses_to_compute_roots: Vec<_> = self
             .storage_updates
@@ -665,9 +660,14 @@ where
             }
         }
 
-        let parent_span = tracing::Span::current();
+        if tries_to_compute_roots.is_empty() {
+            return;
+        }
+
+        let parent_span =
+            debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
-            let _enter = debug_span!(
+            let _enter = trace_span!(
                 target: "engine::tree::payload_processor::sparse_trie",
                 parent: &parent_span,
                 "storage_root",
@@ -688,7 +688,7 @@ where
     /// storage roots, and promotes corresponding pending account updates into proper leaf updates
     /// for accounts trie.
     #[instrument(
-        level = "debug",
+        level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
@@ -702,7 +702,7 @@ where
         self.compute_drained_storage_roots();
 
         loop {
-            let span = debug_span!("promote_updates", promoted = tracing::field::Empty).entered();
+            let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
             // Now handle pending account updates that can be upgraded to a proper update.
             let account_rlp_buf = &mut self.account_rlp_buf;
             let mut num_promoted = 0;
@@ -770,7 +770,7 @@ where
             return;
         }
 
-        let _span = debug_span!("dispatch_pending_targets").entered();
+        let _span = trace_span!("dispatch_pending_targets").entered();
         let (targets, chunking_length) = self.pending_targets.take();
         dispatch_with_chunking(
             targets,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -252,7 +252,7 @@ where
     /// This concludes once the last state update has been received and processed.
     #[instrument(
         name = "SparseTrieCacheTask::run",
-        level = "trace",
+        level = "debug",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
@@ -667,7 +667,7 @@ where
         let parent_span =
             debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
-            let _enter = trace_span!(
+            let _enter = debug_span!(
                 target: "engine::tree::payload_processor::sparse_trie",
                 parent: &parent_span,
                 "storage_root",


### PR DESCRIPTION
Downgrade most spans in `sparse_trie.rs` to `trace` so they don't show up in OTLP traces by default. Only `process_new_updates` (top-level, no children) and `reveal_decoded_multiproof_v2` remain at `debug`.

`compute_drained_storage_roots` stays at `debug` but the span is now only created when there are actually roots to compute.

Prompted by: Arsenii