### PR TITLE
fix(txpool): do not mark ExceedsFeeCap as a bad transaction

### DIFF
--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -353,7 +353,10 @@ impl InvalidPoolTransactionError {
                 // local setting
                 false
             }
-            Self::ExceedsFeeCap { max_tx_fee_wei: _, tx_fee_cap_wei: _ } => true,
+            Self::ExceedsFeeCap { max_tx_fee_wei: _, tx_fee_cap_wei: _ } => {
+                // local setting
+                false
+            }
             Self::ExceedsMaxInitCodeSize(_, _) => true,
             Self::OversizedData { .. } => true,
             Self::Underpriced => {


### PR DESCRIPTION
Closes #23449

`ExceedsFeeCap` only fires for locally submitted transactions when the node's `tx_fee_cap` is exceeded. that's a per-node config, not a protocol rule, so `is_bad_transaction` shouldn't return `true` for it. returning `true` also caches the hash in `bad_imports` which is wrong for a tx that's only locally rejected.

`MaxTxGasLimitExceeded` and `Underpriced` already return `false` with a `// local setting` comment for the same reason. this makes `ExceedsFeeCap` consistent with those.
