### PR TITLE
fix(rpc): disable EIP-7825 tx gas limit cap for eth_simulateV1 defaults

### DIFF
--- a/crates/ethereum/node/tests/e2e/simulate.rs
+++ b/crates/ethereum/node/tests/e2e/simulate.rs
@@ -118,3 +118,61 @@ async fn test_simulate_v1_too_many_blocks_error() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_simulate_v1_validation_ignores_osaka_tx_gas_cap_for_default_gas() -> eyre::Result<()>
+{
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .osaka_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    let from: Address = "0xc000000000000000000000000000000000000000".parse()?;
+    let to: Address = "0xc100000000000000000000000000000000000000".parse()?;
+
+    let tx = TransactionRequest::default()
+        .from(from)
+        .to(to)
+        .max_fee_per_gas(0)
+        .max_priority_fee_per_gas(0)
+        .value(U256::ZERO)
+        .input(Default::default());
+
+    let state_overrides =
+        StateOverridesBuilder::default().with_balance(from, U256::from(1u64)).build();
+
+    let sim_block = SimBlock::default()
+        .with_block_overrides(BlockOverrides { base_fee: Some(U256::ZERO), ..Default::default() })
+        .with_state_overrides(state_overrides)
+        .call(tx);
+
+    let payload = SimulatePayload::default().with_validation().extend(sim_block);
+
+    let result: Vec<SimulatedBlock> =
+        provider.raw_request("eth_simulateV1".into(), (&payload, "latest")).await?;
+
+    assert_eq!(result.len(), 1, "expected exactly 1 simulated block");
+    assert_eq!(result[0].calls.len(), 1, "expected exactly 1 call result");
+    assert!(result[0].calls[0].status, "expected call to succeed");
+    assert!(result[0].calls[0].error.is_none(), "expected no error");
+
+    Ok(())
+}

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -142,9 +142,13 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         // If not explicitly required, we disable nonce check <https://github.com/paradigmxyz/reth/issues/16108>
                         evm_env.cfg_env.disable_nonce_check = true;
                         evm_env.cfg_env.disable_base_fee = true;
-                        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
                         evm_env.block_env.inner_mut().basefee = 0;
                     }
+
+                    // Disable EIP-7825 transaction gas limit cap so the default per-call gas
+                    // allocation remains valid even when Osaka's per-tx cap is lower than the
+                    // block gas limit.
+                    evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
 
                     let SimBlock { block_overrides, state_overrides, calls } = block;
 


### PR DESCRIPTION
Disables the EIP-7825 per-transaction gas cap when `eth_simulateV1` fills in the default gas limit for a simulated transaction. This keeps validated simulations aligned with the existing Osaka handling in `eth_call` and `eth_createAccessList`.

Adds an Osaka e2e regression for validation-mode simulations without an explicit gas limit.