### PR TITLE
perf(tracing): also disable target attribute in OTLP spans

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -667,13 +667,21 @@ where
         let parent_span =
             debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
-            let _enter = debug_span!(
-                target: "engine::tree::payload_processor::sparse_trie",
-                parent: &parent_span,
-                "storage_root",
-                ?address
-            )
-            .entered();
+            let span = if tracing::enabled!(tracing::Level::TRACE) {
+                debug_span!(
+                    target: "engine::tree::payload_processor::sparse_trie",
+                    parent: &parent_span,
+                    "storage_root",
+                    ?address
+                )
+            } else {
+                debug_span!(
+                    target: "engine::tree::payload_processor::sparse_trie",
+                    parent: &parent_span,
+                    "storage_root",
+                )
+            };
+            let _enter = span.entered();
             // SAFETY:
             // - pointers are created from `storage_tries_mut().get_mut(address)` above;
             // - `addresses_to_compute_roots` comes from map iteration, so addresses are unique;

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -65,7 +65,8 @@ where
     Ok(tracing_opentelemetry::layer()
         .with_tracer(tracer)
         .with_location(false)
-        .with_tracked_inactivity(false))
+        .with_tracked_inactivity(false)
+        .with_target(false))
 }
 
 /// Creates a tracing layer that exports logs to an OTLP endpoint.

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -66,7 +66,8 @@ where
         .with_tracer(tracer)
         .with_location(false)
         .with_tracked_inactivity(false)
-        .with_target(false))
+        .with_target(false)
+        .with_threads(false))
 }
 
 /// Creates a tracing layer that exports logs to an OTLP endpoint.

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,8 @@ ignore = [
     "RUSTSEC-2023-0089",
     # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru upgrade requires a discv5 bump first
     "RUSTSEC-2026-0002",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
+    "RUSTSEC-2026-0097",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Follow-up to #23447. Also disables the `target` attribute on OTLP spans — it's redundant with the span name and adds ~90 bytes per span (~9% of trace size).

Prompted by: klkvr