### PR TITLE
fix: remove expect() from miner_fee in payload builder

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -373,7 +373,9 @@ where
         block_transactions_rlp_length += tx_rlp_len;
 
         // update and add to total fees
-        let miner_fee = miner_fee.expect("fee is always valid; execution succeeded");
+        let miner_fee = miner_fee.ok_or_else(|| {
+            PayloadBuilderError::Internal("missing miner fee after execution".into())
+        })?;
         total_fees += U256::from(miner_fee) * U256::from(gas_used);
         cumulative_gas_used += gas_used;
 


### PR DESCRIPTION
What does this change do?
Replaces a production expect() call in the payload builder with proper error handling using ok_or_else.

Why is this needed?
Using expect() in production execution paths can cause node panics if the assumption is violated. This change ensures the node fails safely instead of crashing.

What is the impact?

Improves reliability and safety
Prevents potential runtime panics
Aligns with Rust best practices for error handling in critical systems

How was this tested?
Run existing tests with:
cargo test