### PR TITLE
revert: "chore(ci): add set -x to all GHA bash scripts (#23413)"

### DIFF
--- a/.github/scripts/bench-reth-build.sh
+++ b/.github/scripts/bench-reth-build.sh
@@ -16,7 +16,7 @@
 #
 # Required: mc (MinIO client) with a configured alias
 # Optional env: BENCH_BIG_BLOCKS (true/false) — build reth-bb instead of reth
-set -euxo pipefail
+set -euo pipefail
 
 MC="mc"
 MODE="$1"

--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -26,7 +26,7 @@
 #
 # The script delegates to the existing bench-reth-*.sh scripts in the reth
 # repo for the actual build, snapshot, and run steps.
-set -euxo pipefail
+set -euo pipefail
 
 # ── PATH ──────────────────────────────────────────────────────────────
 # Ensure cargo and user-local bins (mc, uv) are visible

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -13,7 +13,7 @@
 #               BENCH_OTLP_TRACES_ENDPOINT (OTLP HTTP endpoint for traces, e.g. https://host/insert/opentelemetry/v1/traces)
 #               BENCH_OTLP_LOGS_ENDPOINT (OTLP HTTP endpoint for logs, e.g. https://host/insert/opentelemetry/v1/logs)
 #               BENCH_OTLP_DISABLED (true to skip OTLP export even if endpoints are set)
-set -euxo pipefail
+set -euo pipefail
 
 LABEL="$1"
 BINARY="$2"

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -18,7 +18,7 @@
 #   BENCH_JOB_URL      – link to the Actions job
 #   BENCH_ACTOR        – user who triggered the benchmark
 #   BENCH_CONFIG       – config summary line
-set -euxo pipefail
+set -euo pipefail
 
 MC="mc"
 BUCKET="minio/reth-snapshots"

--- a/.github/scripts/bench-scheduled-refs.sh
+++ b/.github/scripts/bench-scheduled-refs.sh
@@ -32,7 +32,7 @@
 #   state/release-last-feature-ref  (release, from decofe/reth-bench-charts repo)
 #
 # Requires: gh (GitHub CLI), jq, date, git (hourly mode), curl, DEREK_TOKEN env
-set -euxo pipefail
+set -euo pipefail
 
 FORCE="${1:-false}"
 MODE="${2:-nightly}"

--- a/.github/scripts/check_rv32imac.sh
+++ b/.github/scripts/check_rv32imac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uxo pipefail
+set -uo pipefail
 
 crates_to_check=(
     reth-network-peers

--- a/.github/scripts/check_wasm.sh
+++ b/.github/scripts/check_wasm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uxo pipefail
+set -uo pipefail
 
 readarray -t crates < <(
   cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name' | grep '^reth' | sort

--- a/.github/scripts/install_geth.sh
+++ b/.github/scripts/install_geth.sh
@@ -2,7 +2,7 @@
 
 # Installs Geth (https://geth.ethereum.org) in $HOME/bin for x86_64 Linux.
 
-set -exo pipefail
+set -eo pipefail
 
 GETH_BUILD=${GETH_BUILD:-"1.13.4-3f907d6a"}
 

--- a/.github/scripts/verify_image_arch.sh
+++ b/.github/scripts/verify_image_arch.sh
@@ -7,7 +7,7 @@
 # Environment:
 #   DRY_RUN=true  - Skip actual verification, just print what would be checked.
 
-set -euxo pipefail
+set -euo pipefail
 
 TARGETS="${1:-}"
 REGISTRY="${2:-}"


### PR DESCRIPTION
Reverts #23413.

`set -x` in `bench-reth-snapshot.sh` dumps the full snapshot manifest JSON twice (~162K lines of `chunk_sizes` numbers), producing over 50% of the entire 314K line job log as noise. Same issue applies to `bench-reth-run.sh` (323 lines of traced commands per run × 4 runs).

See https://github.com/paradigmxyz/reth/pull/23413#issuecomment-4231256973

Prompted by: pep