### PR TITLE
fix(ci): only perform full-recover when needed

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -872,7 +872,13 @@ jobs:
         run: |
           sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
           sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
-          sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+          if mountpoint -q "$SCHELK_MOUNT"; then
+            sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+          # After a runner reboot, schelk's state may still say the volume is mounted
+          # even though the dm-era device and filesystem mount are gone.
+          elif sudo jq -e '.is_mounted == true' /var/lib/schelk/state.json >/dev/null 2>&1; then
+            sudo schelk full-recover -y || true
+          fi
           rm -rf "$BENCH_WORK_DIR"
           mkdir -p "$BENCH_WORK_DIR"
 


### PR DESCRIPTION
Right now the full recover is triggered whenever `schelk recover`
returns non-zero error code. This, however, is wrong because
it may return a non-zero error code when schelk failed
to do what it was asked for, but nothing is broken and no full
recover is needed. For example, when the volume is not mounted
it will return a non-zero code. The result of that is
an unnecessary full-recovery.

This PR fixes this by doing a more smart decision for full-recovery.
now we are going to do that if:

1. the mountpoint is mounted but we failed to recover. Full recover.
2. the mountpoint is not mounted but schelk's app state says
   it is. This indicates a reboot or a crash. In that case we
   go for the full recovery.

There are two signs when we need to do a full-rec
