### PR TITLE
perf(eth-wire-types): encode DisconnectReason without heap allocation

### DIFF
--- a/crates/net/eth-wire-types/src/disconnect_reason.rs
+++ b/crates/net/eth-wire-types/src/disconnect_reason.rs
@@ -83,10 +83,10 @@ impl Encodable for DisconnectReason {
     /// The [`Encodable`] implementation for [`DisconnectReason`] encodes the disconnect reason in
     /// a single-element RLP list.
     fn encode(&self, out: &mut dyn BufMut) {
-        [*self as u8].encode(out);
+        alloy_rlp::encode_list(&[*self as u8], out);
     }
     fn length(&self) -> usize {
-        [*self as u8].length()
+        alloy_rlp::list_length(&[*self as u8])
     }
 }
 

--- a/crates/net/eth-wire-types/src/disconnect_reason.rs
+++ b/crates/net/eth-wire-types/src/disconnect_reason.rs
@@ -1,6 +1,5 @@
 //! `RLPx` disconnect reason sent to/received from peer
 
-use alloc::vec;
 use alloy_primitives::bytes::{Buf, BufMut};
 use alloy_rlp::{Decodable, Encodable, Header};
 use derive_more::Display;
@@ -84,10 +83,10 @@ impl Encodable for DisconnectReason {
     /// The [`Encodable`] implementation for [`DisconnectReason`] encodes the disconnect reason in
     /// a single-element RLP list.
     fn encode(&self, out: &mut dyn BufMut) {
-        vec![*self as u8].encode(out);
+        [*self as u8].encode(out);
     }
     fn length(&self) -> usize {
-        vec![*self as u8].length()
+        [*self as u8].length()
     }
 }
 


### PR DESCRIPTION
Performance optimization: `DisconnectReason` RLP encoding used `vec![u8]`, which allocates on every encode/length call. Use a one-element stack array instead so the disconnect reason is encoded without a heap allocation.