### PR TITLE
[autoopt] 20260413-3-lazy-overlay-single-wait

### DIFF
--- a/crates/chain-state/src/lazy_overlay.rs
+++ b/crates/chain-state/src/lazy_overlay.rs
@@ -129,10 +129,22 @@ impl LazyOverlay {
             return TrieInputSorted::default();
         }
 
-        let state =
-            HashedPostStateSorted::merge_batch(blocks.iter().map(|b| b.wait_cloned().hashed_state));
-        let nodes =
-            TrieUpdatesSorted::merge_batch(blocks.iter().map(|b| b.wait_cloned().trie_updates));
+        let computed: Vec<_> = blocks.iter().map(DeferredTrieData::wait_cloned).collect();
+
+        if let [block] = computed.as_slice() {
+            return TrieInputSorted {
+                state: Arc::clone(&block.hashed_state),
+                nodes: Arc::clone(&block.trie_updates),
+                prefix_sets: Default::default(),
+            }
+        }
+
+        let state = HashedPostStateSorted::merge_batch(
+            computed.iter().map(|block| Arc::clone(&block.hashed_state)),
+        );
+        let nodes = TrieUpdatesSorted::merge_batch(
+            computed.iter().map(|block| Arc::clone(&block.trie_updates)),
+        );
 
         TrieInputSorted { state, nodes, prefix_sets: Default::default() }
     }


### PR DESCRIPTION
# Materialize lazy overlay blocks once on the slow path
## Evidence
- `bench-reth-results/baseline-1/samply-profile.json.gz` shows the `prepare-overlay` worker dominated by `Option::get_or_insert_with` (36.17%) and `Arc::clone` (33.01%), which points to duplicate deferred-trie materialization and clone churn on the overlay-preparation path.
- `crates/chain-state/src/lazy_overlay.rs` slow path called `wait_cloned()` once to merge hashed state and again to merge trie updates, so each deferred block was locked and cloned twice before any actual merge work.
- This does not retry the previously regressing deferred-overlay reuse change; it keeps anchor matching and overlay composition semantics identical and only removes duplicate slow-path work.

## Hypothesis
If we materialize each deferred block once before merging a lazy overlay, gas throughput improves by ~0.2-0.5% because canonical overlay preparation does less repeated `wait_cloned` locking and `Arc` churn on the `prepare-overlay` worker.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Update `crates/chain-state/src/lazy_overlay.rs` so the slow-path merge collects deferred block data once and reuses it for both state and trie-update merges, with a direct single-block fast path.
- Leave fast-path anchor reuse unchanged.
- Verify with `cargo check -p reth-chain-state` and `cargo test -p reth-chain-state`.

## Agent Thread
https://ampcode.com/threads/T-019d8755-b6d8-749d-bf47-0434b3e63170