### PR TITLE
fix(node): downgrade prune config log from warn to info

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -195,7 +195,7 @@ impl LaunchContext {
                 should_save = true;
             }
         } else if !reth_config.prune.is_default() {
-            warn!(target: "reth::cli", "Pruning configuration is present in the config file, but no CLI arguments are provided. Using config from file.");
+            info!(target: "reth::cli", "Pruning configuration is present in the config file, but no CLI arguments are provided. Using config from file.");
         }
 
         if should_save {


### PR DESCRIPTION
Having a prune config in the toml without CLI args is normal usage, not a warning-worthy condition. Downgrades to info.

Prompted by: Brian