### PR TITLE
chore(bench): reduce default blocks to 200, warmup to 20 for big-blocks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,7 @@ on:
       blocks:
         description: "Number of blocks to benchmark"
         required: false
-        default: "500"
+        default: "200"
         type: string
       big_blocks:
         description: "Use big blocks mode (pre-generated merged payloads with reth-bb)"
@@ -154,11 +154,13 @@ jobs:
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [no-slack] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
             let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks, bal;
+            let explicitWarmup = false;
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
-              blocks = '${{ github.event.inputs.blocks }}' || '500';
+              blocks = '${{ github.event.inputs.blocks }}' || '200';
               warmup = '${{ github.event.inputs.warmup }}' || '100';
+              if (warmup !== '100') explicitWarmup = true;
               baseline = '${{ github.event.inputs.baseline }}';
               feature = '${{ github.event.inputs.feature }}';
               samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
@@ -197,7 +199,7 @@ jobs:
               const enumArgs = new Map([['bal', validBalModes]]);
               const durationArgs = new Set(['wait-time']);
               const stringArgs = new Set(['baseline-args', 'feature-args']);
-              const defaults = { blocks: '500', warmup: '100', baseline: '', feature: '', samply: 'false', 'no-slack': 'false', 'big-blocks': 'false', bal: 'false', cores: '0', abba: 'true', otlp: 'true', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
+              const defaults = { blocks: '200', warmup: '100', baseline: '', feature: '', samply: 'false', 'no-slack': 'false', 'big-blocks': 'false', bal: 'false', cores: '0', abba: 'true', otlp: 'true', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -247,6 +249,7 @@ jobs:
                     invalid.push(`\`${key}=${value}\` (must be a positive integer)`);
                   } else {
                     defaults[key] = value;
+                    if (key === 'warmup') explicitWarmup = true;
                   }
                 } else if (refArgs.has(key)) {
                   if (!value) {
@@ -288,6 +291,11 @@ jobs:
               var waitTime = defaults['wait-time'];
               var baselineNodeArgs = defaults['baseline-args'];
               var featureNodeArgs = defaults['feature-args'];
+            }
+
+            // Default warmup to 20 for big-blocks mode unless explicitly set
+            if (bigBlocks === 'true' && !explicitWarmup) {
+              warmup = '20';
             }
 
             if (!validBalModes.has(bal)) {


### PR DESCRIPTION
- Default blocks: 500 → 200
- Default warmup for big-blocks mode: 100 → 20 (only when warmup isn't explicitly set)
- Non-big-blocks warmup default remains 100