### PR TITLE
[autoopt] 20260414-003-inline-small-payload-tx-root

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -599,17 +599,26 @@ where
                 hashed_state_provider.hashed_post_state(&hashed_state_output.state)
             });
 
+        const INLINE_PAYLOAD_TX_ROOT_THRESHOLD: usize = 128;
+
         let block = convert_to_block(input)?;
         let transaction_root = is_payload.then(|| {
-            let body = block.body().clone();
-            let parent_span = Span::current();
-            let num_hash = block.num_hash();
-            self.payload_processor.executor().spawn_blocking_named("payload-tx-root", move || {
-                let _span =
-                    debug_span!(target: "engine::tree::payload_validator", parent: parent_span, "payload_tx_root", block = ?num_hash)
-                        .entered();
-                body.calculate_tx_root()
-            })
+            if block.body().transactions().len() <= INLINE_PAYLOAD_TX_ROOT_THRESHOLD {
+                Either::Left(block.body().calculate_tx_root())
+            } else {
+                let body = block.body().clone();
+                let parent_span = Span::current();
+                let num_hash = block.num_hash();
+                Either::Right(self.payload_processor.executor().spawn_blocking_named(
+                    "payload-tx-root",
+                    move || {
+                        let _span =
+                            debug_span!(target: "engine::tree::payload_validator", parent: parent_span, "payload_tx_root", block = ?num_hash)
+                                .entered();
+                        body.calculate_tx_root()
+                    },
+                ))
+            }
         });
         let block = block.with_senders(senders);
 
@@ -631,11 +640,14 @@ where
                 })
                 .ok()
         };
-        let transaction_root = transaction_root.map(|handle| {
-            let _span =
-                debug_span!(target: "engine::tree::payload_validator", "wait_payload_tx_root")
-                    .entered();
-            handle.try_into_inner().expect("sole handle")
+        let transaction_root = transaction_root.map(|transaction_root| match transaction_root {
+            Either::Left(root) => root,
+            Either::Right(handle) => {
+                let _span =
+                    debug_span!(target: "engine::tree::payload_validator", "wait_payload_tx_root")
+                        .entered();
+                handle.try_into_inner().expect("sole handle")
+            }
         });
 
         let hashed_state = ensure_ok_post_block!(


### PR DESCRIPTION
# Inline transaction roots for small payloads
## Evidence
- The baseline engine thread still spends work in payload validation around post-execution helpers after transaction execution completes.
- For both baseline latency runs, 41 of 500 blocks have `transaction_count <= 128`, so a meaningful slice of payloads are small enough that scheduler and clone overhead can dominate the tx-root helper task.
- The payload validator currently clones the full block body and spawns a dedicated `payload-tx-root` blocking task for every payload, then waits on that handle before post-execution validation.

## Hypothesis
If we compute the transaction root inline for small payloads and only spawn the background task for larger bodies, gas throughput improves by ~0.1-0.4% because we avoid extra body cloning and blocking-task wakeups on the small-payload tail.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Change `crates/engine/tree/src/tree/payload_validator.rs` so payloads with at most 128 transactions compute `calculate_tx_root()` inline.
- Keep the existing spawned path for larger payloads to preserve concurrency where it matters.