### PR TITLE
[autoopt] 20260414-006-single-block-lazy-overlay

### DIFF
--- a/crates/chain-state/src/lazy_overlay.rs
+++ b/crates/chain-state/src/lazy_overlay.rs
@@ -114,6 +114,15 @@ impl LazyOverlay {
                     "Anchor mismatch, falling back to merge"
                 );
             }
+
+            if blocks.len() == 1 {
+                trace!(target: "chain_state::lazy_overlay", %anchor_hash, "Using single block overlay directly");
+                return TrieInputSorted {
+                    state: data.hashed_state,
+                    nodes: data.trie_updates,
+                    prefix_sets: Default::default(),
+                }
+            }
         }
 
         // Slow path: Merge all blocks' trie data into a new overlay.


### PR DESCRIPTION
# Fast-path single-block lazy overlays
## Evidence
- The baseline `prepare-overlay` worker spends 35.26% of self samples in `Option::get_or_insert_with`, 16.74% in `Option` cloning, and another 13.22% in `Vec::push_mut`, pointing to overhead in the lazy-overlay materialization path rather than lock waiting.
- `crates/chain-state/src/lazy_overlay.rs` already has a fast path for reusing an anchored overlay, but when that misses it always falls through to `merge_blocks`, even if there is only one in-memory block to materialize.
- In the common linear-head case, a cached canonical overlay often covers just one deferred block after persistence advances the anchor, so the generic `merge_batch` machinery does extra iterator and merge setup work for no semantic gain.

## Hypothesis
If we special-case the single-block lazy-overlay fallback, gas throughput improves by ~0.1-0.3% because the overlay-preparation thread can reuse the one already-materialized trie bundle directly instead of paying the generic batch-merge path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- In `LazyOverlay::compute`, keep the existing anchored-overlay fast path.
- When that misses and there is exactly one deferred block, return its sorted hashed state and trie updates directly instead of calling `merge_blocks`.
- Verify with `cargo check -p reth-chain-state`, `cargo test -p reth-chain-state lazy_overlay`, and `cargo +nightly fmt --all --check`.