### PR TITLE
[autoopt] 20260414-005-skip-stale-prewarm-send

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -250,9 +250,14 @@ where
             + Sync
             + 'static,
     {
+        let executed_tx_index = Arc::new(AtomicUsize::new(0));
+
         // start preparing transactions immediately
-        let (prewarm_rx, execution_rx) =
-            self.spawn_tx_iterator(transactions, env.transaction_count);
+        let (prewarm_rx, execution_rx) = self.spawn_tx_iterator(
+            transactions,
+            env.transaction_count,
+            Arc::clone(&executed_tx_index),
+        );
 
         let span = Span::current();
 
@@ -270,6 +275,7 @@ where
             provider_builder,
             Some(state_root_handle.updates_tx().clone()),
             bal,
+            executed_tx_index,
         );
 
         PayloadHandle {
@@ -295,9 +301,20 @@ where
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
     {
-        let (prewarm_rx, execution_rx) =
-            self.spawn_tx_iterator(transactions, env.transaction_count);
-        let prewarm_handle = self.spawn_caching_with(env, prewarm_rx, provider_builder, None, bal);
+        let executed_tx_index = Arc::new(AtomicUsize::new(0));
+        let (prewarm_rx, execution_rx) = self.spawn_tx_iterator(
+            transactions,
+            env.transaction_count,
+            Arc::clone(&executed_tx_index),
+        );
+        let prewarm_handle = self.spawn_caching_with(
+            env,
+            prewarm_rx,
+            provider_builder,
+            None,
+            bal,
+            executed_tx_index,
+        );
         PayloadHandle {
             state_root_handle: None,
             install_state_hook: false,
@@ -387,6 +404,7 @@ where
         &self,
         transactions: I,
         transaction_count: usize,
+        executed_tx_index: Arc<AtomicUsize>,
     ) -> (
         mpsc::Receiver<(usize, WithTxEnv<TxEnvFor<Evm>, I::Recovered>)>,
         mpsc::Receiver<Result<WithTxEnv<TxEnvFor<Evm>, I::Recovered>, I::Error>>,
@@ -406,7 +424,13 @@ where
             );
             self.executor.spawn_blocking_named("tx-iterator", move || {
                 let (transactions, convert) = transactions.into_parts();
-                convert_serial(transactions.into_iter(), &convert, &prewarm_tx, &execute_tx);
+                convert_serial(
+                    transactions.into_iter(),
+                    &convert,
+                    &prewarm_tx,
+                    &execute_tx,
+                    &executed_tx_index,
+                );
             });
         } else {
             // Parallel path — recover signatures in parallel on rayon, stream results
@@ -424,7 +448,13 @@ where
 
                 // Convert the first few transactions sequentially so execution can
                 // start immediately without waiting for rayon work-stealing.
-                convert_serial(all.into_iter(), &convert, &prewarm_tx, &execute_tx);
+                convert_serial(
+                    all.into_iter(),
+                    &convert,
+                    &prewarm_tx,
+                    &execute_tx,
+                    &executed_tx_index,
+                );
 
                 // Convert the remaining transactions in parallel.
                 rest.into_par_iter()
@@ -438,7 +468,12 @@ where
                         let tx = tx.map(|tx| {
                             let (tx_env, tx) = tx.into_parts();
                             let tx = WithTxEnv { tx_env, tx: Arc::new(tx) };
-                            let _ = prewarm_tx.send((idx, tx.clone()));
+                            send_to_prewarm_if_fresh(
+                                idx,
+                                &tx,
+                                &prewarm_tx,
+                                &executed_tx_index,
+                            );
                             tx
                         });
                         let _ = execute_tx.send(tx);
@@ -464,6 +499,7 @@ where
         provider_builder: StateProviderBuilder<N, P>,
         to_sparse_trie_task: Option<CrossbeamSender<StateRootMessage>>,
         bal: Option<Arc<BlockAccessList>>,
+        executed_tx_index: Arc<AtomicUsize>,
     ) -> CacheTaskHandle<N::Receipt>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
@@ -472,8 +508,6 @@ where
             self.disable_transaction_prewarming || env.transaction_count < SMALL_BLOCK_TX_THRESHOLD;
 
         let saved_cache = self.disable_state_cache.not().then(|| self.cache_for(env.parent_hash));
-
-        let executed_tx_index = Arc::new(AtomicUsize::new(0));
 
         // configure prewarming
         let prewarm_ctx = PrewarmContext {
@@ -720,6 +754,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
     convert: &C,
     prewarm_tx: &mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>,
     execute_tx: &mpsc::SyncSender<Result<WithTxEnv<TxEnv, Recovered>, Err>>,
+    executed_tx_index: &AtomicUsize,
 ) where
     Tx: ExecutableTxParts<TxEnv, InnerTx, Recovered = Recovered>,
     TxEnv: Clone,
@@ -732,10 +767,23 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
             WithTxEnv { tx_env, tx: Arc::new(tx) }
         });
         if let Ok(tx) = &tx {
-            let _ = prewarm_tx.send((idx, tx.clone()));
+            send_to_prewarm_if_fresh(idx, tx, prewarm_tx, executed_tx_index);
         }
         let _ = execute_tx.send(tx);
         trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
+    }
+}
+
+fn send_to_prewarm_if_fresh<TxEnv, Recovered>(
+    idx: usize,
+    tx: &WithTxEnv<TxEnv, Recovered>,
+    prewarm_tx: &mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>,
+    executed_tx_index: &AtomicUsize,
+) where
+    TxEnv: Clone,
+{
+    if idx >= executed_tx_index.load(std::sync::atomic::Ordering::Relaxed) {
+        let _ = prewarm_tx.send((idx, tx.clone()));
     }
 }
 


### PR DESCRIPTION
# Skip stale prewarm fan-out in tx iterator
## Evidence
- The baseline `tx-iterator` worker still spends measurable self time in fan-out overhead around `<alloy_eip2930::AccessList as Clone>::clone` (3.02%) and `<reth_evm::execute::WithTxEnv<_> as Clone>::clone` (2.23%) while the main costlier signature recovery proceeds.
- The baseline `prewarm` worker is dominated by `fixed_cache::Cache::insert::{{closure}}` (41.65% self), which means wasted prewarm work that loses the race to main execution still burns CPU in two places: on the iterator clone/send path and inside cache insertion.
- `PayloadProcessor` already tracks `executed_tx_index` so prewarm workers can skip transactions the main executor has passed, but the tx iterator still cloned and sent those stale transactions to the prewarm channel before the skip happened.

## Hypothesis
If we stop cloning and enqueueing transactions whose index is already behind `executed_tx_index`, gas throughput improves by ~0.2-0.6% because the payload pipeline does less stale `TxEnv` cloning, channel traffic, and prewarm cache churn once execution outruns prewarming.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Thread the shared `executed_tx_index` into `spawn_tx_iterator` and `convert_serial`.
- Skip the prewarm-channel send when the main execution loop has already advanced past that transaction index, while keeping the execute stream unchanged.
- Verify with `cargo check -p reth-engine-tree`, `cargo test -p reth-engine-tree payload_processor`, and `cargo +nightly fmt --all --check`.