### PR TITLE
[autoopt] 20260414-004-wait-caches-fast-path

### DIFF
--- a/crates/engine/execution-cache/src/lib.rs
+++ b/crates/engine/execution-cache/src/lib.rs
@@ -107,6 +107,16 @@ impl PayloadExecutionCache {
     /// This is useful for synchronization before starting payload processing.
     ///
     /// Returns the time spent waiting for the lock.
+    pub fn try_wait_for_availability(&self) -> Option<Duration> {
+        self.inner.try_lock().map(|_guard| Duration::ZERO)
+    }
+
+    /// Waits until the execution cache becomes available for use.
+    ///
+    /// This acquires a write lock to ensure exclusive access, then immediately releases it.
+    /// This is useful for synchronization before starting payload processing.
+    ///
+    /// Returns the time spent waiting for the lock.
     pub fn wait_for_availability(&self) -> Duration {
         let start = Instant::now();
         // Acquire lock to wait for any current holders to finish

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -167,6 +167,18 @@ where
     fn wait_for_caches(&self) -> CacheWaitDurations {
         debug!(target: "engine::tree::payload_processor", "Waiting for execution cache and sparse trie locks");
 
+        // The common case is that both caches are already idle. Avoid spawning two short-lived
+        // blocking workers when we can confirm that immediately.
+        if let (Some(execution_cache_duration), Some(sparse_trie_duration)) = (
+            self.execution_cache.try_wait_for_availability(),
+            self.sparse_state_trie.try_wait_for_availability(),
+        ) {
+            return CacheWaitDurations {
+                execution_cache: execution_cache_duration,
+                sparse_trie: sparse_trie_duration,
+            }
+        }
+
         // Wait for both caches in parallel using std threads
         let execution_cache = self.execution_cache.clone();
         let sparse_trie = self.sparse_state_trie.clone();

--- a/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
@@ -37,6 +37,17 @@ impl SharedPreservedSparseTrie {
     /// before starting payload processing.
     ///
     /// Returns the time spent waiting for the lock.
+    pub(super) fn try_wait_for_availability(&self) -> Option<std::time::Duration> {
+        self.0.try_lock().map(|_guard| std::time::Duration::ZERO)
+    }
+
+    /// Waits until the sparse trie lock becomes available.
+    ///
+    /// This acquires and immediately releases the lock, ensuring that any
+    /// ongoing operations complete before returning. Useful for synchronization
+    /// before starting payload processing.
+    ///
+    /// Returns the time spent waiting for the lock.
     pub(super) fn wait_for_availability(&self) -> std::time::Duration {
         let start = Instant::now();
         let _guard = self.0.lock();


### PR DESCRIPTION
# Fast-path uncontended payload cache waits
## Evidence
- `bench-reth-results/summary.json` shows `execution_cache_wait_us` at 0.0 ms mean/p95 and `sparse_trie_wait_us` at only 0.396 ms mean, so lock contention is usually not the bottleneck.
- The baseline reth logs still show `Processing reth_newPayload wait_for_caches=true` before every payload, followed by separate `wait-exec-cache` and `wait-sparse-tri` worker activity even when both waits resolve in nanoseconds to microseconds.
- `crates/engine/tree/src/tree/payload_processor/mod.rs` always spawned two short-lived blocking tasks just to wait for these locks, even in the common uncontended case where both locks were immediately available.

## Hypothesis
If we add an uncontended fast path for the execution-cache and sparse-trie availability checks, gas throughput improves by ~0.1-0.4% because every payload avoids two unnecessary blocking-task wakeups on the zero-wait path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Add `try_wait_for_availability()` helpers to the execution cache and preserved sparse trie wrappers.
- In `PayloadProcessor::wait_for_caches`, return immediately when both locks are instantly available and fall back to the existing parallel wait path only under contention.
- Verify with `cargo check -p reth-engine-tree -p reth-execution-cache`, `cargo test -p reth-execution-cache`, and `cargo test -p reth-engine-tree payload_processor`.