### PR TITLE
[autoopt] 20260414-009-packed-storage-decode-fastpath

### DIFF
--- a/crates/trie/common/src/nibbles.rs
+++ b/crates/trie/common/src/nibbles.rs
@@ -205,9 +205,7 @@ impl reth_codecs::Compact for PackedStoredNibbles {
     }
 
     fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
-        let nibble_count = buf[32] as usize;
-        let packed_len = nibble_count.div_ceil(2);
-        (Self(Nibbles::unpack(&buf[..packed_len]).slice(..nibble_count)), &buf[33..])
+        (Self(unpack_packed_nibbles(buf)), &buf[33..])
     }
 }
 
@@ -289,14 +287,29 @@ impl reth_codecs::Compact for PackedStoredNibblesSubKey {
     }
 
     fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
-        let nibble_count = buf[32] as usize;
-        let packed_len = nibble_count.div_ceil(2);
-        (Self(Nibbles::unpack(&buf[..packed_len]).slice(..nibble_count)), &buf[33..])
+        (Self(unpack_packed_nibbles(buf)), &buf[33..])
     }
 }
 
 #[cfg(any(test, feature = "reth-codec"))]
 reth_codecs::impl_compression_for_compact!(PackedStoredNibblesSubKey);
+
+#[cfg(any(test, feature = "reth-codec"))]
+#[inline]
+fn unpack_packed_nibbles(buf: &[u8]) -> Nibbles {
+    let nibble_count = buf[32] as usize;
+    assert!(nibble_count <= 64);
+
+    match nibble_count {
+        0 => Nibbles::default(),
+        64 => Nibbles::unpack_array(buf[..32].try_into().expect("slice has fixed width")),
+        _ => {
+            let packed_len = nibble_count.div_ceil(2);
+            let unpacked = unsafe { Nibbles::unpack_unchecked(&buf[..packed_len]) };
+            if nibble_count & 1 == 0 { unpacked } else { unpacked.slice(..nibble_count) }
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -222,10 +222,7 @@ where
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self
-            .0
-            .seek_exact(A::AccountKey::from(key))?
-            .map(|value| (A::account_key_to_nibbles(&value.0), value.1)))
+        Ok(self.0.seek_exact(A::AccountKey::from(key))?.map(|(_, node)| (key, node)))
     }
 
     fn seek(
@@ -322,14 +319,10 @@ where
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         let subkey = A::StorageSubKey::from(key);
-        Ok(self
-            .cursor
-            .seek_by_key_subkey(self.hashed_address, subkey.clone())?
-            .filter(|e| *e.nibbles() == subkey)
-            .map(|value| {
-                let (subkey, node) = value.into_parts();
-                (A::subkey_to_nibbles(&subkey), node)
-            }))
+        Ok(match self.cursor.seek_by_key_subkey(self.hashed_address, subkey.clone())? {
+            Some(value) if value.nibbles() == &subkey => Some((key, value.into_parts().1)),
+            _ => None,
+        })
     }
 
     fn seek(
@@ -439,6 +432,40 @@ mod tests {
             let trie_factory = DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref());
             let mut cursor = trie_factory.storage_trie_cursor(hashed_address).unwrap();
             assert_eq!(cursor.seek(key.into()).unwrap().unwrap().1, value);
+        });
+    }
+
+    #[test]
+    fn test_storage_cursor_seek_exact_requires_exact_subkey() {
+        use reth_storage_api::StorageSettingsCache;
+        use reth_trie::trie_cursor::{TrieCursor, TrieCursorFactory};
+
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let mut cursor = provider.tx_ref().cursor_dup_write::<tables::StoragesTrie>().unwrap();
+
+        let hashed_address = B256::random();
+        let existing = StoredNibblesSubKey::from(vec![0x2, 0x3]);
+        let missing = Nibbles::from_nibbles_unchecked(vec![0x2, 0x4]);
+        let value = BranchNodeCompact::new(1, 1, 1, vec![B256::random()], None);
+
+        cursor
+            .upsert(
+                hashed_address,
+                &StorageTrieEntry { nibbles: existing.clone(), node: value.clone() },
+            )
+            .unwrap();
+
+        crate::with_adapter!(provider, |A| {
+            let trie_factory = DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref());
+            let mut trie_cursor = trie_factory.storage_trie_cursor(hashed_address).unwrap();
+            let exact_key: Nibbles = existing.clone().into();
+
+            let exact = trie_cursor.seek_exact(exact_key).unwrap().unwrap();
+            assert_eq!(exact.0, exact_key);
+            assert_eq!(exact.1, value);
+
+            assert!(trie_cursor.seek_exact(missing).unwrap().is_none());
         });
     }
 }


### PR DESCRIPTION
# Fast-path packed trie exact decodes
## Evidence
- The baseline samply profile shows `<reth_trie_common::storage::PackedStorageTrieEntry as reth_codecs::Compact>::from_compact` with 6,059 exclusive samples and `BranchNodeCompact` decompression on the same storage-trie lookup path.
- The same profile shows `reth_trie::trie_cursor::in_memory::InMemoryTrieCursor<C>::cursor_seek` and exact trie lookups as a hot deferred-trie path, which means small decode work repeats many times during changeset/proof reads.
- `crates/trie/common/src/nibbles.rs` always unpacked packed nibble buffers via the generic path, and `crates/trie/db/src/trie_cursor.rs` rebuilt exact-match keys from decoded DB entries even when the caller had already provided the exact `Nibbles` being sought.

## Hypothesis
If we fast-path packed nibble decoding for common exact-width cases and stop reconstructing exact trie keys after exact cursor hits, gas throughput improves by ~0.2-0.5% because packed storage trie lookups do less redundant decode and key conversion work on the hot exact-seek path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Update `crates/trie/common/src/nibbles.rs` to use a dedicated packed nibble decode helper with zero/full-width fast paths.
- Update `crates/trie/db/src/trie_cursor.rs` so exact account/storage cursor lookups return the requested key directly and keep exact-subkey semantics covered by a regression test.
- Verify with `cargo check -p reth-trie-db` and `cargo test -p reth-trie-db trie_cursor --lib`.