### PR TITLE
[autoopt] 20260414-008-sparse-prune-retained-slices

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2670,8 +2670,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
             return 0;
         }
 
-        let mut retained_leaves = retained_leaves.to_vec();
-        retained_leaves.sort_unstable();
+        let retained_leaves = if retained_leaves.windows(2).all(|w| w[0] <= w[1]) {
+            Cow::Borrowed(retained_leaves)
+        } else {
+            let mut retained = retained_leaves.to_vec();
+            retained.sort_unstable();
+            retained.dedup();
+            Cow::Owned(retained)
+        };
 
         let threshold = self.parallelism_thresholds.min_leaves_for_prune;
 

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -1158,8 +1158,14 @@ impl SparseTrie for ParallelSparseTrie {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.reset();
 
-        let mut retained_leaves = retained_leaves.to_vec();
-        retained_leaves.sort_unstable();
+        let retained_leaves = if retained_leaves.windows(2).all(|w| w[0] <= w[1]) {
+            Cow::Borrowed(retained_leaves)
+        } else {
+            let mut retained = retained_leaves.to_vec();
+            retained.sort_unstable();
+            retained.dedup();
+            Cow::Owned(retained)
+        };
 
         let mut effective_pruned_roots = Vec::<Nibbles>::new();
         let mut stack: SmallVec<[Nibbles; 32]> = SmallVec::new();

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -875,8 +875,9 @@ where
         self.hot_accounts_lfu.decay_and_evict(max_hot_accounts);
         let retained = self.hot_slots_lfu.retained_slots_by_address();
 
-        let retained_account_paths: Vec<Nibbles> =
+        let mut retained_account_paths: Vec<Nibbles> =
             self.hot_accounts_lfu.keys().map(|k| Nibbles::unpack(*k)).collect();
+        retained_account_paths.sort_unstable();
 
         let retained_accounts = retained_account_paths.len();
         let retained_storage_tries = retained.len();


### PR DESCRIPTION
# Reuse sorted retained leaves during sparse-trie pruning
## Evidence
- The baseline samply profile shows `reth_trie_sparse::arena::ArenaSparseSubtrie::prune` with 6,150 exclusive samples on the sparse-trie maintenance path.
- `SparseStateTrie::prune` already computes one LFU-selected retained set for the whole prune pass, but the arena and parallel trie implementations each cloned and re-sorted `retained_leaves` again inside every prune call.
- The hot internal caller already supplies sorted per-address slot lists from `retained_slots_by_address`, so most of that clone/sort work was avoidable bookkeeping rather than trie logic.

## Hypothesis
If we sort retained account leaves once in `SparseStateTrie::prune` and let sparse-trie prune implementations borrow already sorted slices instead of cloning them, gas throughput improves by ~0.2-0.6% because sparse-trie pruning does less repeated leaf-list allocation and sorting on the hot cache-maintenance path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Sort account LFU retention once in `crates/trie/sparse/src/state.rs`.
- Update `crates/trie/sparse/src/arena/mod.rs` and `crates/trie/sparse/src/parallel.rs` to borrow sorted `retained_leaves` when possible and only allocate on unsorted fallback inputs.
- Verify with `cargo check -p reth-trie-sparse` and `cargo test -p reth-trie-sparse prune --lib`.