### PR TITLE
[autoopt] 20260414-007-proof-v2-tail-stack

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -365,17 +365,16 @@ where
         &mut self,
         targets: &mut Option<TargetsCursor<'a>>,
     ) -> Result<(), StateProofError> {
+        if matches!(self.child_stack.last(), Some(ProofTrieBranchChild::RlpNode(_))) {
+            trace!(target: TRACE_TARGET, "Last child already committed");
+            return Ok(())
+        }
+
         let Some(child_path) = self.last_child_path() else { return Ok(()) };
         let child =
             self.child_stack.pop().expect("child_stack can't be empty if there's a child path");
 
-        // If the child is already an `RlpNode` then there is nothing to do, push it back on with no
-        // changes.
-        if let ProofTrieBranchChild::RlpNode(_rlp_node) = &child {
-            trace!(target: TRACE_TARGET, ?_rlp_node, "Already RlpNode, pushing onto stack");
-            self.child_stack.push(child);
-            return Ok(())
-        }
+        debug_assert!(!matches!(child, ProofTrieBranchChild::RlpNode(_)));
 
         // Only commit immediately if retained for the proof. Otherwise, defer conversion
         // to pop_branch() to give DeferredEncoder time for async work.
@@ -537,8 +536,11 @@ where
             "A branch must have at least two children, got {num_children}"
         );
 
-        // Collect children into RlpNode Vec. Children are in lexicographic order.
-        for child in self.child_stack.drain(self.child_stack.len() - num_children..) {
+        // Pop the tail children directly; they're already contiguous on the stack.
+        rlp_nodes_buf.reserve(num_children);
+        let remaining_children = self.child_stack.len() - num_children;
+        while self.child_stack.len() > remaining_children {
+            let child = self.child_stack.pop().expect("checked child stack length");
             let child_rlp_node = match child {
                 ProofTrieBranchChild::RlpNode(rlp_node) => rlp_node,
                 uncommitted_child => {
@@ -554,10 +556,11 @@ where
             };
             rlp_nodes_buf.push(child_rlp_node);
         }
+        rlp_nodes_buf.reverse();
 
         debug_assert_eq!(
             rlp_nodes_buf.len(),
-            branch.state_mask.count_ones() as usize,
+            num_children,
             "children length must match number of bits set in state_mask"
         );
 


### PR DESCRIPTION
# Avoid proof tail stack churn
## Evidence
- The baseline samply profile shows `reth_trie::proof_v2::ProofCalculator<TC,HC,VE>::proof_subtrie` at 536,213 inclusive samples, with `commit_last_child` (8,386 exclusive) and `pop_branch` on the hot proof-construction path.
- `crates/trie/trie/src/proof_v2/mod.rs` repeatedly popped and re-pushed children that were already `RlpNode`s, and used `Vec::drain` to peel contiguous tail children even though the branch children are always stored at the end of `child_stack`.
- This path runs inside the state-root proof workers that dominate the trie-side CPU profile, so shaving stack churn here directly targets the sampled bottleneck instead of changing proof semantics.

## Hypothesis
If we hard-fast-path already committed proof children and replace tail `drain` calls with direct stack pops in `proof_v2`, gas throughput improves by ~0.3-0.8% because proof generation does less child-stack bookkeeping in the hottest branch assembly path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.3%

## Plan
- Update `crates/trie/trie/src/proof_v2/mod.rs` so `commit_last_child` returns immediately when the tail child is already committed.
- Replace the tail `drain` in `pop_branch` with a pop-and-reverse loop over the contiguous branch children.
- Verify with `cargo check -p reth-trie` and `cargo test -p reth-trie proof_v2 --lib`.