### PR TITLE
[autoopt] 20260414-012-trie-exact-node-lookups

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -228,6 +228,13 @@ where
             .map(|value| (A::account_key_to_nibbles(&value.0), value.1)))
     }
 
+    fn seek_exact_node(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        Ok(self.0.seek_exact(A::AccountKey::from(key))?.map(|(_, node)| node))
+    }
+
     fn seek(
         &mut self,
         key: Nibbles,
@@ -330,6 +337,18 @@ where
                 let (subkey, node) = value.into_parts();
                 (A::subkey_to_nibbles(&subkey), node)
             }))
+    }
+
+    fn seek_exact_node(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        let subkey = A::StorageSubKey::from(key);
+        Ok(self
+            .cursor
+            .seek_by_key_subkey(self.hashed_address, subkey.clone())?
+            .filter(|e| *e.nibbles() == subkey)
+            .map(|value| value.into_parts().1))
     }
 
     fn seek(

--- a/crates/trie/trie/src/changesets.rs
+++ b/crates/trie/trie/src/changesets.rs
@@ -107,7 +107,7 @@ where
     // For each changed account node, look up its current value
     // The input is already sorted, so the output will be sorted
     for (path, _new_node) in trie_updates.account_nodes_ref() {
-        let old_node = cursor.seek_exact(*path)?.map(|(_path, node)| node);
+        let old_node = cursor.seek_exact_node(*path)?;
         account_changesets.push((*path, old_node));
     }
 
@@ -134,7 +134,7 @@ fn compute_storage_changesets(
     // For each changed storage node, look up its current value
     // The input is already sorted, so the output will be sorted
     for (path, _new_node) in &storage_updates.storage_nodes {
-        let old_node = cursor.seek_exact(*path)?.map(|(_path, node)| node);
+        let old_node = cursor.seek_exact_node(*path)?;
         storage_changesets.push((*path, old_node));
     }
 

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -226,6 +226,25 @@ impl<C: TrieCursor> TrieCursor for InMemoryTrieCursor<'_, C> {
         Ok(entry)
     }
 
+    fn seek_exact_node(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        self.cursor_seek(key)?;
+        let mem_entry = self.in_memory_cursor.seek(&key);
+
+        self.seeked = true;
+
+        let entry = match (mem_entry, &self.cursor_entry) {
+            (Some((mem_key, entry_inner)), _) if *mem_key == key => entry_inner.clone(),
+            (_, Some((db_key, node))) if db_key == &key => Some(node.clone()),
+            _ => None,
+        };
+
+        self.last_key = entry.as_ref().map(|_| key);
+        Ok(entry)
+    }
+
     fn seek(
         &mut self,
         key: Nibbles,

--- a/crates/trie/trie/src/trie_cursor/metrics.rs
+++ b/crates/trie/trie/src/trie_cursor/metrics.rs
@@ -155,6 +155,17 @@ impl<'metrics, C: TrieCursor> TrieCursor for InstrumentedTrieCursor<'metrics, C>
         result
     }
 
+    fn seek_exact_node(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        let start = Instant::now();
+        self.metrics.seek_exact_count += 1;
+        let result = self.cursor.seek_exact_node(key);
+        self.metrics.total_duration += start.elapsed();
+        result
+    }
+
     fn seek(
         &mut self,
         key: Nibbles,

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -59,6 +59,15 @@ pub trait TrieCursor {
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
 
+    /// Move the cursor to the key and return only the node if it is an exact match.
+    #[inline]
+    fn seek_exact_node(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        Ok(self.seek_exact(key)?.map(|(_, node)| node))
+    }
+
     /// Move the cursor to the key and return a value matching of greater than the key.
     fn seek(&mut self, key: Nibbles)
         -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;


### PR DESCRIPTION
# Avoid rebuilding exact trie lookup pairs in changeset reads
## Evidence
- The baseline-1 samply profile shows the `trie-input` worker at 68,365 samples, with `compute_trie_changesets` at 67,228 inclusive samples, `InMemoryTrieCursor::seek_exact` at 64,955, and `cursor_seek` at 52,418.
- The same thread spends large self time in `node_key` (21,595 samples), `BranchNodeCompact` decompression (2,691), and `PackedStorageTrieEntry::from_compact` (1,489), which is consistent with exact lookups doing extra key materialization around each hit.
- `crates/trie/trie/src/changesets.rs` only needs the old node value, but `seek_exact()` returned a full `(path, node)` pair, forcing exact-hit cursor paths to rebuild keys that are immediately discarded.
- This is distinct from the previously tried monotonic-seek and packed-decode directions: it keeps the lookup schedule unchanged and only trims unused exact-hit work.

## Hypothesis
If we add an exact-hit cursor API that returns only the node and use it in trie changeset computation, gas throughput improves by ~0.2-0.5% because exact trie lookups avoid rebuilding keys that the changeset path never consumes.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Extend the trie cursor trait with `seek_exact_node()` and override it in the in-memory and database cursor implementations.
- Switch account/storage changeset reads to the new API while preserving cursor metrics accounting.
- Verify with `cargo check -p reth-trie -p reth-trie-db`, `cargo test -p reth-trie changesets --lib`, and targeted trie-db cursor tests.