### PR TITLE
[autoopt] 20260414-011-save-blocks-cursor-reuse

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -642,6 +642,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // MDBX writes
             let mdbx_start = Instant::now();
+            let mut tx_senders_cursor =
+                (self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) &&
+                    EitherWriterDestination::senders(self).is_database())
+                .then(|| self.tx.cursor_write::<tables::TransactionSenders>())
+                .transpose()?;
+            let mut block_body_indices_cursor =
+                self.tx.cursor_write::<tables::BlockBodyIndices>()?;
+            let mut transaction_blocks_cursor =
+                self.tx.cursor_write::<tables::TransactionBlocks>()?;
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
             if !self.cached_storage_settings().storage_v2 &&
@@ -681,7 +690,13 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 let recovered_block = block.recovered_block();
 
                 let start = Instant::now();
-                self.insert_block_mdbx_only(recovered_block, tx_nums[i])?;
+                self.insert_block_mdbx_only(
+                    recovered_block,
+                    tx_nums[i],
+                    tx_senders_cursor.as_mut(),
+                    &mut block_body_indices_cursor,
+                    &mut transaction_blocks_cursor,
+                )?;
                 timings.insert_block += start.elapsed();
 
                 if save_mode.with_state() {
@@ -773,15 +788,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         &self,
         block: &RecoveredBlock<BlockTy<N>>,
         first_tx_num: TxNumber,
+        mut tx_senders_cursor: Option<&mut impl DbCursorRW<tables::TransactionSenders>>,
+        block_body_indices_cursor: &mut impl DbCursorRW<tables::BlockBodyIndices>,
+        transaction_blocks_cursor: &mut impl DbCursorRW<tables::TransactionBlocks>,
     ) -> ProviderResult<StoredBlockBodyIndices> {
-        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) &&
-            EitherWriterDestination::senders(self).is_database()
-        {
+        if let Some(cursor) = tx_senders_cursor.as_mut() {
             let start = Instant::now();
             let tx_nums_iter = std::iter::successors(Some(first_tx_num), |n| Some(n + 1));
-            let mut cursor = self.tx.cursor_write::<tables::TransactionSenders>()?;
             for (tx_num, sender) in tx_nums_iter.zip(block.senders_iter().copied()) {
-                cursor.append(tx_num, &sender)?;
+                (*cursor).append(tx_num, &sender)?;
             }
             self.metrics
                 .record_duration(metrics::Action::InsertTransactionSenders, start.elapsed());
@@ -794,7 +809,14 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         self.tx.put::<tables::HeaderNumbers>(block.hash(), block_number)?;
         self.metrics.record_duration(metrics::Action::InsertHeaderNumbers, start.elapsed());
 
-        self.write_block_body_indices(block_number, block.body(), first_tx_num, tx_count)?;
+        self.write_block_body_indices(
+            block_number,
+            block.body(),
+            first_tx_num,
+            tx_count,
+            block_body_indices_cursor,
+            transaction_blocks_cursor,
+        )?;
 
         Ok(StoredBlockBodyIndices { first_tx_num, tx_count })
     }
@@ -807,20 +829,19 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         body: &BodyTy<N>,
         first_tx_num: TxNumber,
         tx_count: u64,
+        block_body_indices_cursor: &mut impl DbCursorRW<tables::BlockBodyIndices>,
+        transaction_blocks_cursor: &mut impl DbCursorRW<tables::TransactionBlocks>,
     ) -> ProviderResult<()> {
         // MDBX: BlockBodyIndices
         let start = Instant::now();
-        self.tx
-            .cursor_write::<tables::BlockBodyIndices>()?
+        block_body_indices_cursor
             .append(block_number, &StoredBlockBodyIndices { first_tx_num, tx_count })?;
         self.metrics.record_duration(metrics::Action::InsertBlockBodyIndices, start.elapsed());
 
         // MDBX: TransactionBlocks (last tx -> block mapping)
         if tx_count > 0 {
             let start = Instant::now();
-            self.tx
-                .cursor_write::<tables::TransactionBlocks>()?
-                .append(first_tx_num + tx_count - 1, &block_number)?;
+            transaction_blocks_cursor.append(first_tx_num + tx_count - 1, &block_number)?;
             self.metrics.record_duration(metrics::Action::InsertTransactionBlocks, start.elapsed());
         }
 


### PR DESCRIPTION
# Reuse save_blocks MDBX cursors across block batches
## Evidence
- `artifacts/24407188705/bench-reth-results/summary.json` shows persistence wait dominating end-to-end latency at 29.57 ms mean / 265.62 ms p95.
- The baseline-1 samply profile shows the `persistence` thread at 297,408 samples, with `PersistenceService::on_save_blocks -> DatabaseProvider::save_blocks` accounting for 293,897 inclusive samples.
- In `crates/storage/provider/src/providers/database/provider.rs`, the hot `save_blocks()` loop reopened append-only MDBX cursors for `TransactionSenders`, `BlockBodyIndices`, and `TransactionBlocks` on every block even though the whole batch is already ordered and written inside one transaction.
- This stays clear of the previously rejected "batch save_blocks writes by table" direction by preserving the existing per-block write order and only removing repeated cursor-open overhead.

## Hypothesis
If we reuse the append-only MDBX cursors across the whole `save_blocks()` batch, gas throughput improves by ~0.2-0.6% because persistence avoids reopening the same write cursors for every block in the hottest disk-bound path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Open the MDBX sender/body-index/tx-block cursors once in `save_blocks()` and thread them through the existing helper calls.
- Keep the current write order and table contents identical.
- Verify with `cargo check -p reth-provider` and `cargo test -p reth-provider test_save_blocks_v2_table_assertions --lib`.