### PR TITLE
chore(ci): add @ai investigate to bench failure alerts

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -939,7 +939,7 @@ jobs:
               },
               {
                 type: 'section',
-                text: { type: 'mrkdwn', text: `*${modeLabel} regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>` },
+                text: { type: 'mrkdwn', text: `*${modeLabel} regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>\n@ai investigate this` },
               },
               {
                 type: 'actions',


### PR DESCRIPTION
Appends `@ai investigate this` to the Slack failure notification in `bench-scheduled.yml` so the AI agent auto-triages bench failures.

Prompted by: alexey