### PR TITLE
feat(ci): add slack=on-win mode to bench workflows

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -250,6 +250,8 @@ async function success({ core, context }) {
     }
   }
 
+  const slackMode = process.env.BENCH_SLACK || 'always';
+
   // Post to public channel if any metric shows significant improvement or regression
   const channel = process.env.SLACK_BENCH_CHANNEL;
   let postedToChannel = false;
@@ -262,6 +264,14 @@ async function success({ core, context }) {
     } else {
       core.info('No significant improvement, skipping public channel notification');
     }
+  }
+
+  // In on-win mode, only notify on improvement — skip DM fallback entirely
+  if (slackMode === 'on-win') {
+    if (!postedToChannel) {
+      core.info('on-win mode: no improvement detected, skipping all notifications');
+    }
+    return;
   }
 
   // DM the actor only when results were not posted to the public channel

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -35,6 +35,7 @@ on:
         type: choice
         options:
           - always
+          - on-win
           - on-error
           - never
       mode:
@@ -757,7 +758,7 @@ jobs:
             await core.summary.addRaw(md).write();
 
       - name: Send Slack notification (success)
-        if: success() && env.BENCH_SLACK == 'always'
+        if: success() && (env.BENCH_SLACK == 'always' || env.BENCH_SLACK == 'on-win')
         uses: actions/github-script@v8
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
@@ -785,7 +786,15 @@ jobs:
             // Filter notifications based on mode
             const changes = summary.changes || {};
             const mode = process.env.BENCH_MODE || 'nightly';
+            const slackMode = process.env.BENCH_SLACK || 'always';
             const hasRegression = Object.values(changes).some(c => c.sig === 'bad');
+            const hasImprovement = Object.values(changes).some(c => c.sig === 'good');
+
+            // on-win mode: only notify on improvements
+            if (slackMode === 'on-win' && !hasImprovement) {
+              core.info('on-win mode: no improvement detected, skipping Slack notification');
+              return;
+            }
 
             // Hourly mode: only notify on regressions
             if (mode === 'hourly' && !hasRegression) {
@@ -904,7 +913,7 @@ jobs:
             }
 
       - name: Send Slack notification (failure)
-        if: failure() && env.BENCH_SLACK != 'never'
+        if: failure() && env.BENCH_SLACK != 'never' && env.BENCH_SLACK != 'on-win'
         uses: actions/github-script@v8
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -78,6 +78,7 @@ on:
         type: choice
         options:
           - always
+          - on-win
           - on-error
           - never
       abba:
@@ -156,8 +157,8 @@ jobs:
           github-token: ${{ secrets.DEREK_PAT }}
           script: |
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
-            const validSlackModes = new Set(['always', 'on-error', 'never']);
-            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [slack=always|on-error|never] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
+            const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
+            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [slack=always|on-win|on-error|never] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
             let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks, bal;
             let explicitWarmup = false;
 
@@ -1353,7 +1354,7 @@ jobs:
             });
 
       - name: Send Slack notification (success)
-        if: success() && env.BENCH_SLACK == 'always'
+        if: success() && (env.BENCH_SLACK == 'always' || env.BENCH_SLACK == 'on-win')
         uses: actions/github-script@v8
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
@@ -1398,7 +1399,7 @@ jobs:
             });
 
       - name: Send Slack notification (failure)
-        if: failure() && env.BENCH_SLACK != 'never'
+        if: failure() && env.BENCH_SLACK != 'never' && env.BENCH_SLACK != 'on-win'
         uses: actions/github-script@v8
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}


### PR DESCRIPTION
Adds an `on-win` Slack notification policy for the bench workflows. With `slack=on-win`, the bench posts to the Slack channel only when a significant improvement is detected — regressions, neutral results, failures, and DM fallbacks are all suppressed.

**Changes:**
- `bench.yml`: add `on-win` to the `slack` input choices, `validSlackModes`, usage string, and update step conditions
- `bench-scheduled.yml`: add `on-win` to choices and inline notification logic
- `bench-slack-notify.js`: early-return after channel post in `on-win` mode, skipping DM fallback