### PR TITLE
feat(storage): add trie node persistence metrics to save_blocks

### DIFF
--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -125,6 +125,26 @@ pub(crate) struct DatabaseProviderMetrics {
     save_blocks_commit_sf_last: Gauge,
     /// Last duration of `RocksDB` commit in `save_blocks`
     save_blocks_commit_rocksdb_last: Gauge,
+    /// Number of account trie nodes added per `save_blocks`
+    save_blocks_account_trie_nodes_added: Histogram,
+    /// Number of account trie nodes removed per `save_blocks`
+    save_blocks_account_trie_nodes_removed: Histogram,
+    /// Total key bytes for added account trie nodes per `save_blocks`
+    save_blocks_account_trie_key_bytes_added: Histogram,
+    /// Total key bytes for removed account trie nodes per `save_blocks`
+    save_blocks_account_trie_key_bytes_removed: Histogram,
+    /// Total value bytes for added account trie nodes per `save_blocks`
+    save_blocks_account_trie_value_bytes_added: Histogram,
+    /// Number of storage trie nodes added per `save_blocks`
+    save_blocks_storage_trie_nodes_added: Histogram,
+    /// Number of storage trie nodes removed per `save_blocks`
+    save_blocks_storage_trie_nodes_removed: Histogram,
+    /// Total key bytes for added storage trie nodes per `save_blocks`
+    save_blocks_storage_trie_key_bytes_added: Histogram,
+    /// Total key bytes for removed storage trie nodes per `save_blocks`
+    save_blocks_storage_trie_key_bytes_removed: Histogram,
+    /// Total value bytes for added storage trie nodes per `save_blocks`
+    save_blocks_storage_trie_value_bytes_added: Histogram,
 }
 
 /// Timings collected during a `save_blocks` call.
@@ -141,6 +161,32 @@ pub(crate) struct SaveBlocksTimings {
     pub update_history_indices: Duration,
     pub update_pipeline_stages: Duration,
     pub batch_size: u64,
+    pub trie_stats: TrieNodePersistenceStats,
+}
+
+/// Stats about trie nodes persisted during a `save_blocks` call.
+#[derive(Debug, Default)]
+pub(crate) struct TrieNodePersistenceStats {
+    /// Number of account trie nodes added (upserted).
+    pub account_nodes_added: u64,
+    /// Number of account trie nodes removed (deleted).
+    pub account_nodes_removed: u64,
+    /// Total key size in bytes for account trie nodes added.
+    pub account_key_bytes_added: u64,
+    /// Total key size in bytes for account trie nodes removed.
+    pub account_key_bytes_removed: u64,
+    /// Total value size in bytes for account trie nodes added.
+    pub account_value_bytes_added: u64,
+    /// Number of storage trie nodes added (upserted).
+    pub storage_nodes_added: u64,
+    /// Number of storage trie nodes removed (deleted).
+    pub storage_nodes_removed: u64,
+    /// Total key size in bytes for storage trie nodes added.
+    pub storage_key_bytes_added: u64,
+    /// Total key size in bytes for storage trie nodes removed.
+    pub storage_key_bytes_removed: u64,
+    /// Total value size in bytes for storage trie nodes added.
+    pub storage_value_bytes_added: u64,
 }
 
 /// Timings collected during a `commit` call.
@@ -197,6 +243,18 @@ impl DatabaseProviderMetrics {
         self.save_blocks_update_pipeline_stages_last
             .set(timings.update_pipeline_stages.as_secs_f64());
         self.save_blocks_batch_size_last.set(timings.batch_size as f64);
+
+        let ts = &timings.trie_stats;
+        self.save_blocks_account_trie_nodes_added.record(ts.account_nodes_added as f64);
+        self.save_blocks_account_trie_nodes_removed.record(ts.account_nodes_removed as f64);
+        self.save_blocks_account_trie_key_bytes_added.record(ts.account_key_bytes_added as f64);
+        self.save_blocks_account_trie_key_bytes_removed.record(ts.account_key_bytes_removed as f64);
+        self.save_blocks_account_trie_value_bytes_added.record(ts.account_value_bytes_added as f64);
+        self.save_blocks_storage_trie_nodes_added.record(ts.storage_nodes_added as f64);
+        self.save_blocks_storage_trie_nodes_removed.record(ts.storage_nodes_removed as f64);
+        self.save_blocks_storage_trie_key_bytes_added.record(ts.storage_key_bytes_added as f64);
+        self.save_blocks_storage_trie_key_bytes_removed.record(ts.storage_key_bytes_removed as f64);
+        self.save_blocks_storage_trie_value_bytes_added.record(ts.storage_value_bytes_added as f64);
     }
 
     /// Records all commit timings.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -724,6 +724,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 let merged_trie =
                     TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
                 if !merged_trie.is_empty() {
+                    collect_trie_node_stats(&merged_trie, &mut timings.trie_stats);
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }
                 timings.write_trie_updates += start.elapsed();
@@ -3090,6 +3091,57 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
             cursor = db_storage_trie_cursor.cursor;
         }
         Ok(())
+    }
+}
+
+/// Returns the approximate byte size of a `BranchNodeCompact` value.
+///
+/// Layout: 3 × u16 masks (6 bytes) + hashes (32 bytes each) + optional root hash (32 bytes).
+fn branch_node_compact_byte_size(node: &reth_trie::BranchNodeCompact) -> u64 {
+    6 + node.hash_mask.count_ones() as u64 * 32 + if node.root_hash.is_some() { 32 } else { 0 }
+}
+
+/// Collects counts and byte sizes of trie nodes about to be persisted.
+fn collect_trie_node_stats(
+    trie_updates: &TrieUpdatesSorted,
+    stats: &mut metrics::TrieNodePersistenceStats,
+) {
+    // Account trie nodes (skip empty-key root entries, matching write_account_trie_updates).
+    for (key, updated_node) in trie_updates.account_nodes_ref() {
+        let key_bytes = key.len() as u64;
+        match updated_node {
+            Some(node) => {
+                if !key.is_empty() {
+                    stats.account_nodes_added += 1;
+                    stats.account_key_bytes_added += key_bytes;
+                    stats.account_value_bytes_added += branch_node_compact_byte_size(node);
+                }
+            }
+            None => {
+                stats.account_nodes_removed += 1;
+                stats.account_key_bytes_removed += key_bytes;
+            }
+        }
+    }
+
+    // Storage trie nodes (skip empty-key entries, matching write_storage_trie_updates_sorted).
+    for storage_trie in trie_updates.storage_tries_ref().values() {
+        for (key, updated_node) in
+            storage_trie.storage_nodes_ref().iter().filter(|(n, _)| !n.is_empty())
+        {
+            let key_bytes = key.len() as u64;
+            match updated_node {
+                Some(node) => {
+                    stats.storage_nodes_added += 1;
+                    stats.storage_key_bytes_added += key_bytes;
+                    stats.storage_value_bytes_added += branch_node_compact_byte_size(node);
+                }
+                None => {
+                    stats.storage_nodes_removed += 1;
+                    stats.storage_key_bytes_removed += key_bytes;
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Records per-batch counts and byte sizes of account/storage trie nodes persisted during `save_blocks`. Breaks down added vs removed nodes, key sizes (nibble length), and value sizes (`BranchNodeCompact` payload).

New metrics (all histograms, recorded once per `save_blocks` call):
- `save_blocks_account_trie_nodes_added` / `_removed`
- `save_blocks_account_trie_key_bytes_added` / `_removed`
- `save_blocks_account_trie_value_bytes_added`
- `save_blocks_storage_trie_nodes_added` / `_removed`
- `save_blocks_storage_trie_key_bytes_added` / `_removed`
- `save_blocks_storage_trie_value_bytes_added`

Counting logic mirrors the write path: empty-key root entries are skipped for both account and storage trie nodes.

Prompted by: pep