### PR TITLE
feat(tasks): implement reserved-cpu-cores thread pool reduction

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -227,11 +227,12 @@ impl LaunchContext {
             Err(err) => warn!(%err, "Failed to raise file descriptor limit"),
         }
 
-        // Configure the implicit global rayon pool for `par_iter` usage.
-        // TODO: reserved_cpu_cores is currently ignored because subtracting from thread pool
-        // sizes doesn't actually reserve CPU cores for other processes.
-        let _ = reserved_cpu_cores;
-        let num_threads = available_parallelism().map_or(1, NonZeroUsize::get);
+        // Configure the implicit global rayon pool for `par_iter` usage, reserving cores for
+        // non-reth processes.
+        let num_threads = available_parallelism()
+            .map_or(1, NonZeroUsize::get)
+            .saturating_sub(reserved_cpu_cores)
+            .max(1);
         if let Err(err) = ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .thread_name(|i| format!("rayon-{i:02}"))

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -336,7 +336,8 @@ pub struct EngineArgs {
     #[arg(long = "engine.multiproof-chunk-size", default_value_t = DefaultEngineValues::get_global().multiproof_chunk_size)]
     pub multiproof_chunk_size: usize,
 
-    /// Configure the number of reserved CPU cores for non-reth processes
+    /// Number of CPU cores to reserve for non-reth processes (e.g. consensus client). Thread
+    /// pool sizes are reduced by this amount, leaving headroom for other workloads.
     #[arg(long = "engine.reserved-cpu-cores", default_value_t = DefaultEngineValues::get_global().reserved_cpu_cores)]
     pub reserved_cpu_cores: usize,
 

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -37,7 +37,7 @@ use tokio::runtime::Runtime as TokioRuntime;
 pub const DEFAULT_THREAD_KEEP_ALIVE: Duration = Duration::from_secs(15);
 
 /// Default reserved CPU cores for OS and other processes.
-pub const DEFAULT_RESERVED_CPU_CORES: usize = 2;
+pub const DEFAULT_RESERVED_CPU_CORES: usize = 1;
 
 /// Default number of threads for the storage I/O pool.
 pub const DEFAULT_STORAGE_POOL_THREADS: usize = 16;
@@ -193,10 +193,12 @@ impl RayonConfig {
 
     /// Compute the default number of threads based on available parallelism.
     fn default_thread_count(&self) -> usize {
-        // TODO: reserved_cpu_cores is currently ignored because subtracting from thread pool
-        // sizes doesn't actually reserve CPU cores for other processes.
-        let _ = self.reserved_cpu_cores;
-        self.cpu_threads.unwrap_or_else(|| available_parallelism().map_or(1, NonZeroUsize::get))
+        self.cpu_threads.unwrap_or_else(|| {
+            available_parallelism()
+                .map_or(1, NonZeroUsize::get)
+                .saturating_sub(self.reserved_cpu_cores)
+                .max(1)
+        })
     }
 }
 
@@ -949,6 +951,30 @@ mod tests {
         let config = RayonConfig::default();
         let count = config.default_thread_count();
         assert!(count >= 1);
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn test_reserved_cpu_cores_reduces_thread_count() {
+        let parallelism = available_parallelism().map_or(1, NonZeroUsize::get);
+
+        let config = RayonConfig { reserved_cpu_cores: 0, ..Default::default() };
+        assert_eq!(config.default_thread_count(), parallelism);
+
+        let config = RayonConfig { reserved_cpu_cores: 2, ..Default::default() };
+        assert_eq!(config.default_thread_count(), parallelism.saturating_sub(2).max(1));
+
+        // Never goes below 1.
+        let config = RayonConfig { reserved_cpu_cores: usize::MAX, ..Default::default() };
+        assert_eq!(config.default_thread_count(), 1);
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn test_explicit_cpu_threads_ignores_reserved_cores() {
+        let config =
+            RayonConfig { cpu_threads: Some(8), reserved_cpu_cores: 4, ..Default::default() };
+        assert_eq!(config.default_thread_count(), 8);
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -969,7 +969,7 @@ Engine:
           [default: 5]
 
       --engine.reserved-cpu-cores <RESERVED_CPU_CORES>
-          Configure the number of reserved CPU cores for non-reth processes
+          Number of CPU cores to reserve for non-reth processes (e.g. consensus client). Thread pool sizes are reduced by this amount, leaving headroom for other workloads
 
           [default: 1]
 


### PR DESCRIPTION
The `--engine.reserved-cpu-cores` flag existed but was explicitly ignored with TODO comments. This makes it actually subtract from thread pool sizes so reth leaves headroom for co-located processes (CL client, OS, etc.).

Changes:
- `RayonConfig::default_thread_count()` now subtracts `reserved_cpu_cores` from `available_parallelism()`
- `LaunchContext::configure_globals()` does the same for the implicit global rayon pool
- Both use `saturating_sub().max(1)` to prevent zero-thread pools
- Aligned `DEFAULT_RESERVED_CPU_CORES` in `reth-tasks` to `1` (was `2`) to match `reth-engine-primitives`
- Updated CLI help text

Prompted by: DaniPopes