### PR TITLE
chore(bench): pin junk to last core, give reth the big-cache CCD

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -442,7 +442,7 @@ run_bench() {
   cd "$RETH_REPO"
   if command -v taskset &>/dev/null; then
     # Pin the bench harness to the last core, leaving lower cores for reth.
-    local last_cpu=$(( $(nproc --all) - 1 ))
+    local last_cpu=$(( $(nproc) - 1 ))
     taskset -c "$last_cpu" "${SCRIPTS_DIR}/bench-reth-run.sh" "$label" "$binary" "$output_dir"
   else
     "${SCRIPTS_DIR}/bench-reth-run.sh" "$label" "$binary" "$output_dir"

--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -441,7 +441,9 @@ run_bench() {
   echo "▸ Running benchmark: ${label}..."
   cd "$RETH_REPO"
   if command -v taskset &>/dev/null; then
-    taskset -c 0 "${SCRIPTS_DIR}/bench-reth-run.sh" "$label" "$binary" "$output_dir"
+    # Pin the bench harness to the last core, leaving lower cores for reth.
+    local last_cpu=$(( $(nproc --all) - 1 ))
+    taskset -c "$last_cpu" "${SCRIPTS_DIR}/bench-reth-run.sh" "$label" "$binary" "$output_dir"
   else
     "${SCRIPTS_DIR}/bench-reth-run.sh" "$label" "$binary" "$output_dir"
   fi

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -99,11 +99,15 @@ free -h
 grep Cached /proc/meminfo
 
 # Start reth
-# CPU layout: last core = OS/IRQs/reth-bench/aux, lower cores = reth node.
+# CPU layout: last online core = OS/IRQs/reth-bench/aux, lower cores = reth node.
 # On AMD EPYC (Zen 5) with asymmetric L3 (96 MiB on CCD 0 vs 32 MiB on CCD 1),
 # this gives reth all of the big-cache chiplet (cores 0-7).
+#
+# Count only online CPUs so we skip offlined SMT siblings, but read from
+# /sys instead of nproc because this script may itself be pinned to a single
+# core via taskset (nproc would then return 1).
 RETH_BENCH="$(which reth-bench)"
-ONLINE=$(nproc)
+ONLINE=$(grep -c '^processor' /proc/cpuinfo)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -103,7 +103,7 @@ grep Cached /proc/meminfo
 # On AMD EPYC (Zen 5) with asymmetric L3 (96 MiB on CCD 0 vs 32 MiB on CCD 1),
 # this gives reth all of the big-cache chiplet (cores 0-7).
 RETH_BENCH="$(which reth-bench)"
-ONLINE=$(nproc --all)
+ONLINE=$(nproc)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -99,14 +99,16 @@ free -h
 grep Cached /proc/meminfo
 
 # Start reth
-# CPU layout: core 0 = OS/IRQs/reth-bench/aux, cores 1+ = reth node
+# CPU layout: last core = OS/IRQs/reth-bench/aux, lower cores = reth node.
+# On AMD EPYC (Zen 5) with asymmetric L3 (96 MiB on CCD 0 vs 32 MiB on CCD 1),
+# this gives reth all of the big-cache chiplet (cores 0-7).
 RETH_BENCH="$(which reth-bench)"
 ONLINE=$(nproc --all)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES
 fi
-RETH_CPUS="1-${MAX_RETH}"
+RETH_CPUS="0-$((MAX_RETH - 1))"
 
 BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
 

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -500,7 +500,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-1","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"$(date +%s)","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-1"
 
       - name: "Run benchmark: feature (1/2)"
@@ -509,7 +509,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-1","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"$(date +%s)","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth "$BENCH_WORK_DIR/feature-1"
 
       - name: "Run benchmark: feature (2/2)"
@@ -518,7 +518,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-2","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"$(date +%s)","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth "$BENCH_WORK_DIR/feature-2"
 
       - name: "Run benchmark: baseline (2/2)"
@@ -529,7 +529,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-2","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-2"
 
       - name: Stop metrics proxy & generate Grafana URL

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -500,7 +500,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-1","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"$(date +%s)","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-1"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-1"
 
       - name: "Run benchmark: feature (1/2)"
         id: run-feature-1
@@ -508,7 +509,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-1","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"$(date +%s)","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth "$BENCH_WORK_DIR/feature-1"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth "$BENCH_WORK_DIR/feature-1"
 
       - name: "Run benchmark: feature (2/2)"
         id: run-feature-2
@@ -516,7 +518,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-2","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"$(date +%s)","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth "$BENCH_WORK_DIR/feature-2"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature ../reth-feature/target/profiling/reth "$BENCH_WORK_DIR/feature-2"
 
       - name: "Run benchmark: baseline (2/2)"
         id: run-baseline-2
@@ -526,7 +529,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-2","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-2"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline ../reth-baseline/target/profiling/reth "$BENCH_WORK_DIR/baseline-2"
 
       - name: Stop metrics proxy & generate Grafana URL
         id: metrics

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1019,7 +1019,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-1","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline "../reth-baseline/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/baseline-1"
 
       - name: "Run benchmark: feature (1/2)"
@@ -1033,7 +1033,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-1","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature "../reth-feature/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/feature-1"
 
       - name: "Run benchmark: feature (2/2)"
@@ -1048,7 +1048,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-2","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature "../reth-feature/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/feature-2"
 
       - name: "Run benchmark: baseline (2/2)"
@@ -1063,7 +1063,7 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-2","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          LAST_CPU=$(( $(nproc --all) - 1 ))
+          LAST_CPU=$(( $(nproc) - 1 ))
           taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline "../reth-baseline/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/baseline-2"
 
       - name: Stop metrics proxy & generate Grafana URL

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1019,7 +1019,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-1","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh baseline "../reth-baseline/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/baseline-1"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline "../reth-baseline/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/baseline-1"
 
       - name: "Run benchmark: feature (1/2)"
         id: run-feature-1
@@ -1032,7 +1033,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-1","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh feature "../reth-feature/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/feature-1"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature "../reth-feature/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/feature-1"
 
       - name: "Run benchmark: feature (2/2)"
         if: env.BENCH_ABBA != 'false'
@@ -1046,7 +1048,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"feature-2","run_type":"feature","git_ref":"${FEATURE_REF}","bench_sha":"${FEATURE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh feature "../reth-feature/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/feature-2"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh feature "../reth-feature/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/feature-2"
 
       - name: "Run benchmark: baseline (2/2)"
         if: env.BENCH_ABBA != 'false'
@@ -1060,7 +1063,8 @@ jobs:
           cat > "$BENCH_LABELS_FILE" <<LABELS
           {"benchmark_run":"baseline-2","run_type":"baseline","git_ref":"${BASELINE_REF}","bench_sha":"${BASELINE_REF}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
-          taskset -c 0 .github/scripts/bench-reth-run.sh baseline "../reth-baseline/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/baseline-2"
+          LAST_CPU=$(( $(nproc --all) - 1 ))
+          taskset -c "$LAST_CPU" .github/scripts/bench-reth-run.sh baseline "../reth-baseline/target/profiling/${BENCH_NODE_BIN}" "$BENCH_WORK_DIR/baseline-2"
 
       - name: Stop metrics proxy & generate Grafana URL
         id: metrics


### PR DESCRIPTION
On our AMD EPYC Zen 5 bench box, CCD 0 (cores 0-7) has 96 MiB L3 while CCD 1 (cores 8-15) only has 32 MiB. Previously we pinned OS/IRQs/reth-bench to core 0 (big-cache CCD) and gave reth cores 1-15. This flips it: reth gets cores 0 through N-2 (including all of CCD 0) and junk goes to the last core on the smaller-cache CCD.

Prompted by: DaniPopes