### PR TITLE
[autoopt] 20260415-3-sparse-logical-path-cache

### DIFF
--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -171,14 +171,6 @@ impl ArenaCursor {
         logical_branch_path_len(arena, self.stack.last().expect("cursor is non-empty"))
     }
 
-    /// Returns the absolute path of a child at `child_nibble` under the branch at the top of
-    /// the stack. The result is `stack_head.path + branch.short_key + child_nibble`.
-    pub(super) fn child_path(&self, arena: &NodeArena, child_nibble: u8) -> Nibbles {
-        let mut path = logical_branch_path(arena, self.stack.last().expect("cursor is non-empty"));
-        path.push_unchecked(child_nibble);
-        path
-    }
-
     /// Returns the logical path of the parent branch entry (second from top of the stack).
     /// Panics if the stack has fewer than 2 entries.
     pub(super) fn parent_logical_branch_path(&self, arena: &NodeArena) -> Nibbles {
@@ -248,7 +240,7 @@ impl ArenaCursor {
         }
 
         loop {
-            let Some(head) = self.stack.last_mut() else {
+            let Some(head) = self.stack.last() else {
                 return NextResult::Done;
             };
             let head_idx = head.index;
@@ -261,6 +253,7 @@ impl ArenaCursor {
             let state_mask = branch.state_mask;
             let start = head.next_dense_idx;
             let child_depth = self.stack.len();
+            let branch_path = logical_branch_path(arena, head);
 
             let mut descended = false;
             for (branch_child_idx, nibble) in BranchChildIter::new(state_mask) {
@@ -277,7 +270,8 @@ impl ArenaCursor {
                     // Record where to resume iteration when we return to this entry.
                     self.stack.last_mut().expect("head exists").next_dense_idx =
                         branch_child_idx.get() + 1;
-                    let path = self.child_path(arena, nibble);
+                    let mut path = branch_path;
+                    path.push_unchecked(nibble);
                     self.push(arena, child_idx, path);
                     descended = true;
                     break;
@@ -351,7 +345,8 @@ impl ArenaCursor {
                 }
                 ArenaSparseNodeBranchChild::Revealed(child_idx) => {
                     let child_idx = *child_idx;
-                    let path = self.child_path(arena, child_nibble);
+                    let mut path = head_branch_logical_path;
+                    path.push_unchecked(child_nibble);
                     self.push(arena, child_idx, path);
                 }
             }


### PR DESCRIPTION
# Reuse sparse cursor branch paths within traversal steps
## Evidence
- In the baseline-1 sparse-trie worker, `ArenaCursor::seek::{{closure}}`, `SpecArrayEq`, `Nibbles::byte_len`, `ArenaCursor::head_logical_branch_path_len`, and `ArenaCursor::child_path` all still show up in the hot traversal path after the earlier cursor-path win.
- The current `ArenaCursor::next` and `ArenaCursor::seek` logic rebuilt the same logical branch path twice in one traversal step: once for the prefix comparison/length lookup and again to construct the child path.
- Prior regressions came from changing comparison strategy inside `seek`; this direction keeps the existing branch/leaf divergence semantics and only removes duplicate path materialization within a single step.

## Hypothesis
If we reuse the already-built logical branch path inside each `ArenaCursor::next` and `ArenaCursor::seek` step, gas throughput improves by ~0.1-0.4% because sparse-trie leaf updates do less nibble-path construction on a still-hot traversal path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/sparse/src/arena/cursor.rs` so `next` and `seek` build a branch logical path once per step and derive the pushed child path from that local value.
- Keep existing seek/divergence behavior unchanged.
- Verify with `cargo check -p reth-trie-sparse` and `cargo test -p reth-trie-sparse`.