### PR TITLE
[autoopt] 20260415-5-rocksdb-prune-fast-path

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -2018,6 +2018,19 @@ impl<'a> RocksDBBatch<'a> {
                 delete_shard(self, key)?;
                 deleted = true;
             } else {
+                let first_block = block_list.iter().next();
+                if first_block.is_some_and(|block| block > to_block) {
+                    last_remaining = Some((key, block_list));
+                    continue;
+                }
+
+                let last_block = block_list.iter().next_back();
+                if last_block.is_some_and(|block| block <= to_block) {
+                    delete_shard(self, key)?;
+                    deleted = true;
+                    continue;
+                }
+
                 let original_len = block_list.len();
                 let filtered =
                     BlockNumberList::new_pre_sorted(block_list.iter().filter(|&b| b > to_block));


### PR DESCRIPTION
# Skip no-op RocksDB history shard rebuilds during pruning
## Evidence
- In the `24407188705` baseline persistence thread, `RocksDBBatch::prune_account_history_batch` accounts for about 39.5k inclusive samples and `prune_storage_history_batch` adds about 21.8k more.
- The same stacks show about 10.9k inclusive samples in `prune_history_shards_inner`, with additional time in `roaring::treemap::from_sorted_iter` and `RoaringTreemap::append` rebuilding filtered `BlockNumberList`s.
- The current pruning logic rebuilds a filtered list even when a shard is obviously unchanged (`first_block > to_block`) or obviously fully removable (`last_block <= to_block`).

## Hypothesis
If we short-circuit unchanged and fully-pruned history shards before rebuilding `BlockNumberList`s, gas throughput improves by ~0.1-0.4% because persistence spends less CPU in RocksDB pruning on blocks where history shards are untouched or trivially deleted.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/storage/provider/src/providers/rocksdb/provider.rs` so `prune_history_shards_inner` skips `BlockNumberList::new_pre_sorted(...)` when the shard is known to remain unchanged or be deleted wholesale.
- Reuse the existing `reth-provider` prune regression coverage to verify account and storage pruning semantics still match the old behavior.
- Verify with `cargo check -p reth-provider` and `cargo test -p reth-provider test_prune_ -- --nocapture`.