### PR TITLE
[autoopt] 20260415-7-owned-trie-write

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -67,7 +67,7 @@ use reth_storage_api::{
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
 use reth_trie::{
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
-    HashedPostStateSorted,
+    BranchNodeCompact, HashedPostStateSorted, Nibbles,
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
 use revm_database::states::{
@@ -721,10 +721,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                let merged_trie =
-                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
+                let trie_updates =
+                    blocks.iter().rev().map(|b| b.trie_updates()).collect::<Vec<_>>();
+                let merged_trie = TrieUpdatesSorted::merge_slice(&trie_updates);
                 if !merged_trie.is_empty() {
-                    self.write_trie_updates_sorted(&merged_trie)?;
+                    self.write_trie_updates_sorted_owned(merged_trie)?;
                 }
                 timings.write_trie_updates += start.elapsed();
             }
@@ -3073,6 +3074,35 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         Ok(())
     }
 
+    fn write_account_trie_updates_owned<A: TrieTableAdapter>(
+        tx: &TX,
+        account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+        num_entries: &mut usize,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut,
+    {
+        let mut account_trie_cursor = tx.cursor_write::<A::AccountTrieTable>()?;
+        for (key, updated_node) in account_nodes {
+            match updated_node {
+                Some(node) => {
+                    if !key.is_empty() {
+                        *num_entries += 1;
+                        account_trie_cursor.upsert(A::AccountKey::from(key), &node)?;
+                    }
+                }
+                None => {
+                    *num_entries += 1;
+                    let key = A::AccountKey::from(key);
+                    if account_trie_cursor.seek_exact(key)?.is_some() {
+                        account_trie_cursor.delete_current()?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn write_storage_tries<A: TrieTableAdapter>(
         tx: &TX,
         storage_tries: Vec<(&B256, &StorageTrieUpdatesSorted)>,
@@ -3090,6 +3120,58 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
             cursor = db_storage_trie_cursor.cursor;
         }
         Ok(())
+    }
+
+    fn write_storage_tries_owned<A: TrieTableAdapter>(
+        tx: &TX,
+        mut storage_tries: Vec<(B256, StorageTrieUpdatesSorted)>,
+        num_entries: &mut usize,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut,
+    {
+        storage_tries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+        let mut cursor = tx.cursor_dup_write::<A::StorageTrieTable>()?;
+        for (hashed_address, storage_trie_updates) in storage_tries {
+            let mut db_storage_trie_cursor: DatabaseStorageTrieCursor<_, A> =
+                DatabaseStorageTrieCursor::new(cursor, hashed_address);
+            *num_entries += db_storage_trie_cursor
+                .write_storage_trie_updates_sorted_owned(storage_trie_updates)?;
+            cursor = db_storage_trie_cursor.cursor;
+        }
+        Ok(())
+    }
+
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_trie_updates_sorted_owned(
+        &self,
+        trie_updates: TrieUpdatesSorted,
+    ) -> ProviderResult<usize> {
+        if trie_updates.is_empty() {
+            return Ok(0)
+        }
+
+        let (account_nodes, storage_tries) = trie_updates.into_parts();
+        let mut account_nodes = Some(account_nodes);
+        let mut storage_tries = Some(storage_tries.into_iter().collect::<Vec<_>>());
+        let mut num_entries = 0;
+
+        reth_trie_db::with_adapter!(self, |A| {
+            Self::write_account_trie_updates_owned::<A>(
+                self.tx_ref(),
+                account_nodes.take().expect("with_adapter executes once"),
+                &mut num_entries,
+            )?;
+            Self::write_storage_tries_owned::<A>(
+                self.tx_ref(),
+                storage_tries.take().expect("with_adapter executes once"),
+                &mut num_entries,
+            )?;
+            Ok::<_, ProviderError>(())
+        })?;
+
+        Ok(num_entries)
     }
 }
 

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -594,6 +594,13 @@ impl TrieUpdatesSorted {
         &self.storage_tries
     }
 
+    /// Splits the sorted updates into owned account-node and storage-trie collections.
+    pub fn into_parts(
+        self,
+    ) -> (Vec<(Nibbles, Option<BranchNodeCompact>)>, B256Map<StorageTrieUpdatesSorted>) {
+        (self.account_nodes, self.storage_tries)
+    }
+
     /// Returns the total number of updates including account nodes and all storage updates.
     pub fn total_len(&self) -> usize {
         self.account_nodes.len() +
@@ -783,6 +790,11 @@ impl StorageTrieUpdatesSorted {
     /// Returns `true` if there are no storage node updates.
     pub const fn is_empty(&self) -> bool {
         self.storage_nodes.is_empty()
+    }
+
+    /// Splits the sorted storage updates into the wipe flag and owned node list.
+    pub fn into_parts(self) -> (bool, Vec<(Nibbles, Option<BranchNodeCompact>)>) {
+        (self.is_deleted, self.storage_nodes)
     }
 
     /// Extends the storage trie updates with another set of sorted updates.

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -281,8 +281,9 @@ where
         &mut self,
         updates: &StorageTrieUpdatesSorted,
     ) -> Result<usize, DatabaseError> {
-        // The storage trie for this account has to be deleted.
-        if updates.is_deleted() && self.cursor.seek_exact(self.hashed_address)?.is_some() {
+        let trie_was_wiped =
+            updates.is_deleted() && self.cursor.seek_exact(self.hashed_address)?.is_some();
+        if trie_was_wiped {
             self.cursor.delete_current_duplicates()?;
         }
 
@@ -292,11 +293,11 @@ where
             num_entries += 1;
             let nibbles = A::StorageSubKey::from(*nibbles);
             // Delete the old entry if it exists.
-            if self
-                .cursor
-                .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
-                .as_ref()
-                .is_some_and(|e| *e.nibbles() == nibbles)
+            if !trie_was_wiped &&
+                self.cursor
+                    .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
+                    .as_ref()
+                    .is_some_and(|e| *e.nibbles() == nibbles)
             {
                 self.cursor.delete_current()?;
             }
@@ -305,6 +306,39 @@ where
             if let Some(node) = maybe_updated {
                 self.cursor
                     .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
+            }
+        }
+
+        Ok(num_entries)
+    }
+
+    /// Writes storage updates by value so callers can reuse merged trie nodes without cloning.
+    pub fn write_storage_trie_updates_sorted_owned(
+        &mut self,
+        updates: StorageTrieUpdatesSorted,
+    ) -> Result<usize, DatabaseError> {
+        let (is_deleted, storage_nodes) = updates.into_parts();
+        let trie_was_wiped = is_deleted && self.cursor.seek_exact(self.hashed_address)?.is_some();
+        if trie_was_wiped {
+            self.cursor.delete_current_duplicates()?;
+        }
+
+        let mut num_entries = 0;
+        for (nibbles, maybe_updated) in storage_nodes.into_iter().filter(|(n, _)| !n.is_empty()) {
+            num_entries += 1;
+            let nibbles = A::StorageSubKey::from(nibbles);
+            if !trie_was_wiped &&
+                self.cursor
+                    .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
+                    .as_ref()
+                    .is_some_and(|e| *e.nibbles() == nibbles)
+            {
+                self.cursor.delete_current()?;
+            }
+
+            if let Some(node) = maybe_updated {
+                let value = A::StorageValue::new(nibbles, node);
+                self.cursor.upsert(self.hashed_address, &value)?;
             }
         }
 


### PR DESCRIPTION
# Write merged trie updates by value in save_blocks
## Evidence
- The `24407188705` baseline artifact is dominated by persistence wait, averaging about 29.57 ms in `summary.json`.
- The baseline-1 samply profile keeps the persistence thread under `DatabaseProvider::save_blocks -> write_trie_updates_sorted`, with large inclusive sample counts in MDBX cursor put/delete work.
- `save_blocks` already batch-merges trie updates before writing them, but the old write path immediately re-borrowed that merged structure and cloned `BranchNodeCompact` values again when inserting storage trie nodes.

## Hypothesis
If we keep `save_blocks` on an owned `TrieUpdatesSorted` fast path and move merged trie nodes straight into the persistence writer, gas throughput improves by ~0.2-0.6% because the persistence thread does less clone and per-node duplicate-delete work while flushing trie updates.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Update `crates/storage/provider/src/providers/database/provider.rs` to merge trie updates into an owned value and write them through a dedicated owned fast path.
- Update `crates/trie/db/src/trie_cursor.rs` and `crates/trie/common/src/updates.rs` so storage trie updates can be consumed by value and skip exact-delete probes after a full trie wipe.
- Verify with `cargo check -p reth-provider -p reth-trie-db -p reth-trie-common` and `cargo test -p reth-provider test_write_trie_updates_sorted -- --nocapture`.