### PR TITLE
[autoopt] 20260415-8-trie-value-lookups

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -228,6 +228,13 @@ where
             .map(|value| (A::account_key_to_nibbles(&value.0), value.1)))
     }
 
+    fn seek_exact_value(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        Ok(self.0.seek_exact(A::AccountKey::from(key))?.map(|(_, node)| node))
+    }
+
     fn seek(
         &mut self,
         key: Nibbles,
@@ -330,6 +337,18 @@ where
                 let (subkey, node) = value.into_parts();
                 (A::subkey_to_nibbles(&subkey), node)
             }))
+    }
+
+    fn seek_exact_value(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        let subkey = A::StorageSubKey::from(key);
+        Ok(self
+            .cursor
+            .seek_by_key_subkey(self.hashed_address, subkey.clone())?
+            .filter(|entry| *entry.nibbles() == subkey)
+            .map(|entry| entry.into_parts().1))
     }
 
     fn seek(

--- a/crates/trie/trie/src/changesets.rs
+++ b/crates/trie/trie/src/changesets.rs
@@ -107,7 +107,7 @@ where
     // For each changed account node, look up its current value
     // The input is already sorted, so the output will be sorted
     for (path, _new_node) in trie_updates.account_nodes_ref() {
-        let old_node = cursor.seek_exact(*path)?.map(|(_path, node)| node);
+        let old_node = cursor.seek_exact_value(*path)?;
         account_changesets.push((*path, old_node));
     }
 
@@ -134,7 +134,7 @@ fn compute_storage_changesets(
     // For each changed storage node, look up its current value
     // The input is already sorted, so the output will be sorted
     for (path, _new_node) in &storage_updates.storage_nodes {
-        let old_node = cursor.seek_exact(*path)?.map(|(_path, node)| node);
+        let old_node = cursor.seek_exact_value(*path)?;
         storage_changesets.push((*path, old_node));
     }
 

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -226,6 +226,32 @@ impl<C: TrieCursor> TrieCursor for InMemoryTrieCursor<'_, C> {
         Ok(entry)
     }
 
+    fn seek_exact_value(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        self.cursor_seek(key)?;
+        let mem_entry = self.in_memory_cursor.seek(&key);
+
+        self.seeked = true;
+
+        let entry = match (mem_entry, &self.cursor_entry) {
+            (Some((mem_key, entry_inner)), _) if *mem_key == key => entry_inner.clone(),
+            (_, Some((db_key, node))) if db_key == &key => Some(node.clone()),
+            _ => None,
+        };
+
+        let next_key = entry.as_ref().map(|_| key);
+        debug_assert!(
+            self.last_key.is_none_or(|last| next_key.is_none_or(|next| next >= last)),
+            "Cannot return entry {:?} previous to the last returned entry at {:?}",
+            next_key,
+            self.last_key,
+        );
+        self.last_key = next_key;
+        Ok(entry)
+    }
+
     fn seek(
         &mut self,
         key: Nibbles,

--- a/crates/trie/trie/src/trie_cursor/metrics.rs
+++ b/crates/trie/trie/src/trie_cursor/metrics.rs
@@ -155,6 +155,17 @@ impl<'metrics, C: TrieCursor> TrieCursor for InstrumentedTrieCursor<'metrics, C>
         result
     }
 
+    fn seek_exact_value(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        let start = Instant::now();
+        self.metrics.seek_exact_count += 1;
+        let result = self.cursor.seek_exact_value(key);
+        self.metrics.total_duration += start.elapsed();
+        result
+    }
+
     fn seek(
         &mut self,
         key: Nibbles,

--- a/crates/trie/trie/src/trie_cursor/mod.rs
+++ b/crates/trie/trie/src/trie_cursor/mod.rs
@@ -59,6 +59,14 @@ pub trait TrieCursor {
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;
 
+    /// Move the cursor to the key and return only the exact-match node value.
+    fn seek_exact_value(
+        &mut self,
+        key: Nibbles,
+    ) -> Result<Option<BranchNodeCompact>, DatabaseError> {
+        Ok(self.seek_exact(key)?.map(|(_, node)| node))
+    }
+
     /// Move the cursor to the key and return a value matching of greater than the key.
     fn seek(&mut self, key: Nibbles)
         -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError>;


### PR DESCRIPTION
# Return exact trie changeset lookups by value only
## Evidence
- In the `24407188705` baseline profile, the `trie-input` worker spends about 67k inclusive samples in `reth_trie::changesets::compute_trie_changesets`.
- The same worker spends about 30.9k inclusive samples under `DatabaseAccountTrieCursor::seek` and about 19.8k under `DatabaseStorageTrieCursor::seek`, while hot leaf samples include `node_key`, `Nibbles::len`, and branch-node decode work.
- `crates/trie/trie/src/changesets.rs` was calling `seek_exact(...).map(|(_path, node)| node)` for every exact lookup, so the DB-backed cursors were decoding and returning trie keys that changeset computation immediately discarded.

## Hypothesis
If exact trie changeset lookups return only the node value instead of reconstructing the matched key, gas throughput improves by ~0.1-0.4% because the deferred trie-input worker does less per-lookup key decoding and tuple construction on a hot MDBX lookup path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Add a `seek_exact_value` fast path to `crates/trie/trie/src/trie_cursor/mod.rs` and override it in `crates/trie/db/src/trie_cursor.rs` for DB-backed account and storage cursors.
- Switch `crates/trie/trie/src/changesets.rs` to the value-only API, keeping exact-match semantics unchanged.
- Verify with `cargo check -p reth-trie -p reth-trie-db` and `cargo test -p reth-trie changesets -- --nocapture`.