### PR TITLE
[autoopt] 20260415-12-tree-overlay-handles

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1564,11 +1564,13 @@ where
         parent_hash: B256,
         state: &EngineApiTreeState<N>,
     ) -> (Option<LazyOverlay>, B256) {
-        // Get blocks leading to the parent to determine the anchor
-        let (anchor_hash, blocks) =
-            state.tree_state.blocks_by_hash(parent_hash).unwrap_or_else(|| (parent_hash, vec![]));
+        // Get deferred trie handles leading to the parent to determine the anchor.
+        let (anchor_hash, handles) = state
+            .tree_state
+            .trie_handles_by_hash(parent_hash)
+            .unwrap_or_else(|| (parent_hash, vec![]));
 
-        if blocks.is_empty() {
+        if handles.is_empty() {
             debug!(target: "engine::tree::payload_validator", "Parent found on disk, no lazy overlay needed");
             return (None, anchor_hash);
         }
@@ -1587,12 +1589,9 @@ where
         debug!(
             target: "engine::tree::payload_validator",
             %anchor_hash,
-            num_blocks = blocks.len(),
+            num_blocks = handles.len(),
             "Creating lazy overlay for in-memory blocks"
         );
-
-        // Extract deferred trie data handles (non-blocking)
-        let handles: Vec<DeferredTrieData> = blocks.iter().map(|b| b.trie_data_handle()).collect();
 
         (Some(LazyOverlay::new(anchor_hash, handles)), anchor_hash)
     }
@@ -1626,13 +1625,12 @@ where
         let (anchor_hash, overlay_blocks) = ctx
             .state()
             .tree_state
-            .blocks_by_hash(block.parent_hash())
+            .trie_handles_by_hash(block.parent_hash())
             .unwrap_or_else(|| (block.parent_hash(), Vec::new()));
 
         // Collect lightweight ancestor trie data handles. We don't call trie_data() here;
         // the merge and any fallback sorting happens in the compute_trie_input_task.
-        let ancestors: Vec<DeferredTrieData> =
-            overlay_blocks.iter().rev().map(|b| b.trie_data_handle()).collect();
+        let ancestors: Vec<DeferredTrieData> = overlay_blocks.into_iter().rev().collect();
 
         // Create deferred handle with fallback inputs in case the background task hasn't completed.
         // Resolve the lazy handle into Arc<HashedPostState>. By this point the hashed state has

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -101,6 +101,23 @@ impl<N: NodePrimitives> TreeState<N> {
         Some((parent_hash, blocks))
     }
 
+    /// Returns deferred trie handles for all available blocks for the given hash that lead back to
+    /// the canonical chain, from newest to oldest, and the parent hash of the oldest returned
+    /// block.
+    ///
+    /// Returns `None` if the block for the given hash is not found.
+    pub fn trie_handles_by_hash(&self, hash: B256) -> Option<(B256, Vec<DeferredTrieData>)> {
+        let block = self.blocks_by_hash.get(&hash)?;
+        let mut parent_hash = block.recovered_block().parent_hash();
+        let mut handles = vec![block.trie_data_handle()];
+        while let Some(executed) = self.blocks_by_hash.get(&parent_hash) {
+            parent_hash = executed.recovered_block().parent_hash();
+            handles.push(executed.trie_data_handle());
+        }
+
+        Some((parent_hash, handles))
+    }
+
     /// Prepares a cached lazy overlay for the current canonical head.
     ///
     /// This should be called after the canonical head changes to optimistically
@@ -113,14 +130,11 @@ impl<N: NodePrimitives> TreeState<N> {
         let canonical_hash = self.current_canonical_head.hash;
 
         // Get blocks leading to the canonical head
-        let Some((anchor_hash, blocks)) = self.blocks_by_hash(canonical_hash) else {
+        let Some((anchor_hash, handles)) = self.trie_handles_by_hash(canonical_hash) else {
             // Canonical head not in memory (persisted), no overlay needed
             self.cached_canonical_overlay = None;
             return None;
         };
-
-        // Extract deferred trie data handles from blocks (newest to oldest)
-        let handles: Vec<DeferredTrieData> = blocks.iter().map(|b| b.trie_data_handle()).collect();
 
         let overlay = LazyOverlay::new(anchor_hash, handles);
         self.cached_canonical_overlay = Some(PreparedCanonicalOverlay {
@@ -133,7 +147,7 @@ impl<N: NodePrimitives> TreeState<N> {
             target: "engine::tree",
             %canonical_hash,
             %anchor_hash,
-            num_blocks = blocks.len(),
+            num_blocks = overlay.num_blocks(),
             "Prepared cached canonical overlay"
         );
 


### PR DESCRIPTION
# Collect overlay trie handles without cloning ancestor blocks
## Evidence
- In the `24463893386` baseline-1 samply profile, the engine thread still spends samples in `TreeState::blocks_by_hash`, `get_parent_lazy_overlay`, `prepare_canonical_overlay`, and `LazyOverlay` / `DeferredTrieData` clone-drop paths while validating payloads.
- Those call sites only need deferred trie handles, but they currently clone full `ExecutedBlock` chains first and then immediately map them down to `DeferredTrieData` handles.
- The sampled engine thread shows this shape directly: `TreeState::blocks_by_hash` (~57 inclusive samples), `get_parent_lazy_overlay` (~40), `prepare_canonical_overlay` (~7), plus matching `LazyOverlay` and `DeferredTrieData` clone/drop samples.

## Hypothesis
If we walk the tree once and collect deferred trie handles directly for lazy overlay preparation and deferred trie setup, gas throughput improves by ~0.1-0.3% because payload validation avoids cloning ancestor `ExecutedBlock` chains just to discard everything except their trie handles.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Add a `TreeState` helper that returns `DeferredTrieData` handles for an ancestor chain without cloning `ExecutedBlock`s.
- Use that helper in canonical overlay preparation and in the payload validator's lazy-overlay / deferred-trie setup paths.
- Verify with `cargo check -p reth-engine-tree`, `cargo test -p reth-engine-tree apply_chain_update --lib`, `cargo test -p reth-engine-tree execution_cache_mismatch_parent_clears_and_returns --lib`, and `cargo +nightly fmt --all --check`.