### PR TITLE
[autoopt] 20260415-10-mdbx-prebound-metrics

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -2,7 +2,7 @@
 
 use super::utils::*;
 use crate::{
-    metrics::{DatabaseEnvMetrics, Operation},
+    metrics::{DatabaseEnvMetrics, Operation, OperationMetrics},
     DatabaseError,
 };
 use reth_db_api::{
@@ -29,18 +29,62 @@ pub struct Cursor<K: TransactionKind, T: Table> {
     pub(crate) inner: reth_libmdbx::Cursor<K>,
     /// Cache buffer that receives compressed values.
     buf: Vec<u8>,
-    /// Reference to metric handles in the DB environment. If `None`, metrics are not recorded.
-    metrics: Option<Arc<DatabaseEnvMetrics>>,
+    /// Pre-bound metric handles for cursor write operations. If `None`, metrics are not recorded.
+    metrics: Option<CursorWriteMetrics>,
     /// Phantom data to enforce encoding/decoding.
     _dbi: PhantomData<T>,
 }
 
+#[derive(Debug)]
+struct CursorWriteMetrics {
+    upsert: OperationMetrics,
+    insert: OperationMetrics,
+    append: OperationMetrics,
+    append_dup: OperationMetrics,
+    delete_current: OperationMetrics,
+    delete_current_duplicates: OperationMetrics,
+}
+
+impl CursorWriteMetrics {
+    fn new<T: Table>(metrics: &DatabaseEnvMetrics) -> Option<Self> {
+        Some(Self {
+            upsert: metrics.operation_metrics(T::NAME, Operation::CursorUpsert)?,
+            insert: metrics.operation_metrics(T::NAME, Operation::CursorInsert)?,
+            append: metrics.operation_metrics(T::NAME, Operation::CursorAppend)?,
+            append_dup: metrics.operation_metrics(T::NAME, Operation::CursorAppendDup)?,
+            delete_current: metrics.operation_metrics(T::NAME, Operation::CursorDeleteCurrent)?,
+            delete_current_duplicates: metrics
+                .operation_metrics(T::NAME, Operation::CursorDeleteCurrentDuplicates)?,
+        })
+    }
+
+    fn for_operation(&self, operation: Operation) -> &OperationMetrics {
+        match operation {
+            Operation::CursorUpsert => &self.upsert,
+            Operation::CursorInsert => &self.insert,
+            Operation::CursorAppend => &self.append,
+            Operation::CursorAppendDup => &self.append_dup,
+            Operation::CursorDeleteCurrent => &self.delete_current,
+            Operation::CursorDeleteCurrentDuplicates => &self.delete_current_duplicates,
+            _ => unreachable!("cursor metrics only support write operations"),
+        }
+    }
+}
+
 impl<K: TransactionKind, T: Table> Cursor<K, T> {
-    pub(crate) const fn new_with_metrics(
+    pub(crate) fn new_with_metrics(
         inner: reth_libmdbx::Cursor<K>,
         metrics: Option<Arc<DatabaseEnvMetrics>>,
     ) -> Self {
-        Self { inner, buf: Vec::new(), metrics, _dbi: PhantomData }
+        Self {
+            inner,
+            buf: Vec::new(),
+            metrics: match metrics {
+                Some(metrics) => CursorWriteMetrics::new::<T>(&metrics),
+                None => None,
+            },
+            _dbi: PhantomData,
+        }
     }
 
     /// If `self.metrics` is `Some(...)`, record a metric with the provided operation and value
@@ -53,8 +97,8 @@ impl<K: TransactionKind, T: Table> Cursor<K, T> {
         value_size: Option<usize>,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        if let Some(metrics) = self.metrics.clone() {
-            metrics.record_operation(T::NAME, operation, value_size, || f(self))
+        if let Some(metrics) = self.metrics.as_ref().map(|m| m.for_operation(operation).clone()) {
+            metrics.record(value_size, || f(self))
         } else {
             f(self)
         }

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -112,6 +112,15 @@ impl DatabaseEnvMetrics {
         }
     }
 
+    /// Returns the cached metric handles for the given table operation, if metrics are enabled.
+    pub(crate) fn operation_metrics(
+        &self,
+        table: &'static str,
+        operation: Operation,
+    ) -> Option<OperationMetrics> {
+        self.operations.get(&(table, operation)).cloned()
+    }
+
     /// Record metrics for opening a database transaction.
     pub(crate) fn record_opened_transaction(&self, mode: TransactionMode) {
         self.transactions


### PR DESCRIPTION
# Prebind MDBX cursor metric handles
## Evidence
- The `24463893386` baseline summary still shows persistence wait dominating end-to-end latency at about 29.46 ms mean per block, far above sparse-trie wait.
- In the baseline-1 samply profile, the persistence thread spends about 179k inclusive samples in `Cursor::execute_with_operation_metric`, about 177k in `DatabaseEnvMetrics::record_operation`, and about 174k in `OperationMetrics::record` while `save_blocks` flushes MDBX writes.
- The cursor write path cloned the shared environment metrics handle and hashed `(table, operation)` back into the metrics map for every cursor upsert/append/delete, even though each cursor only ever records the same fixed set of write operations for one table.

## Hypothesis
If we prebind the MDBX cursor's write-operation metric handles once when the cursor is created, gas throughput improves by ~0.2-0.5% because the persistence thread avoids repeated `Arc` refcount churn and hashmap lookups on a hot write path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Update `crates/storage/db/src/metrics.rs` to expose cloned operation handles.
- Update `crates/storage/db/src/implementation/mdbx/cursor.rs` so each cursor resolves its write-operation metrics once and records through those cached handles.
- Verify with `cargo check -p reth-db`, `cargo test -p reth-db cursor --lib`, and `cargo +nightly fmt --all --check`.