### PR TITLE
refactor: decouple `CachedStateMetrics` from `SavedCache`

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -25,6 +25,7 @@ use std::{
     },
     time::Duration,
 };
+use std::fmt;
 use tracing::{debug_span, instrument, trace, warn};
 
 /// Alignment in bytes for entries in the fixed-cache.
@@ -147,6 +148,29 @@ pub enum CachedStatus<T> {
     Cached(T),
 }
 
+/// The source that is using the execution cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachedStateMetricsSource {
+    /// Engine (validation / newPayload processing).
+    Engine,
+    /// Payload builder.
+    Builder,
+    /// Test-only.
+    #[cfg(any(test, feature = "test-utils"))]
+    Test,
+}
+
+impl fmt::Display for CachedStateMetricsSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Engine => f.write_str("engine"),
+            Self::Builder => f.write_str("builder"),
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Test => f.write_str("test"),
+        }
+    }
+}
+
 /// Metrics for the cached state provider, showing hits / misses for each cache
 #[derive(Metrics, Clone)]
 #[metrics(scope = "sync.caching")]
@@ -222,9 +246,10 @@ impl CachedStateMetrics {
         self.account_cache_collisions.set(0);
     }
 
-    /// Returns a new zeroed-out instance of [`CachedStateMetrics`].
-    pub fn zeroed() -> Self {
-        let zeroed = Self::default();
+    /// Returns a new zeroed-out instance of [`CachedStateMetrics`] with a `source` label
+    /// to distinguish between different callers (e.g., engine vs builder).
+    pub fn zeroed(source: CachedStateMetricsSource) -> Self {
+        let zeroed = Self::new_with_labels(&[("source", source.to_string())]);
         zeroed.reset();
         zeroed
     }
@@ -919,9 +944,6 @@ pub struct SavedCache {
     /// The caches used for the provider.
     caches: ExecutionCache,
 
-    /// Metrics for the cached state provider (includes size/capacity/collisions from fixed-cache)
-    metrics: CachedStateMetrics,
-
     /// A guard to track in-flight usage of this cache.
     /// The cache is considered available if the strong count is 1.
     usage_guard: Arc<()>,
@@ -932,8 +954,8 @@ pub struct SavedCache {
 
 impl SavedCache {
     /// Creates a new instance with the internals
-    pub fn new(hash: B256, caches: ExecutionCache, metrics: CachedStateMetrics) -> Self {
-        Self { hash, caches, metrics, usage_guard: Arc::new(()), disable_cache_metrics: false }
+    pub fn new(hash: B256, caches: ExecutionCache) -> Self {
+        Self { hash, caches, usage_guard: Arc::new(()), disable_cache_metrics: false }
     }
 
     /// Sets whether to disable cache metrics recording.
@@ -947,9 +969,9 @@ impl SavedCache {
         self.hash
     }
 
-    /// Splits the cache into its caches, metrics, and `disable_cache_metrics` flag, consuming it.
-    pub fn split(self) -> (ExecutionCache, CachedStateMetrics, bool) {
-        (self.caches, self.metrics, self.disable_cache_metrics)
+    /// Splits the cache into its caches and `disable_cache_metrics` flag, consuming it.
+    pub fn split(self) -> (ExecutionCache, bool) {
+        (self.caches, self.disable_cache_metrics)
     }
 
     /// Returns true if the cache is available for use (no other tasks are currently using it).
@@ -967,20 +989,15 @@ impl SavedCache {
         &self.caches
     }
 
-    /// Returns the metrics associated with this cache.
-    pub const fn metrics(&self) -> &CachedStateMetrics {
-        &self.metrics
-    }
-
     /// Updates the cache metrics (size/capacity/collisions) from the stats handlers.
     ///
     /// Note: This can be expensive with large cached state. Use
     /// `with_disable_cache_metrics(true)` to skip.
-    pub fn update_metrics(&self) {
+    pub fn update_metrics(&self, metrics: &CachedStateMetrics) {
         if self.disable_cache_metrics {
             return
         }
-        self.caches.update_metrics(&self.metrics);
+        self.caches.update_metrics(metrics);
     }
 
     /// Clears all caches, resetting them to empty state,
@@ -1018,7 +1035,7 @@ mod tests {
 
         let caches = ExecutionCache::new(1000);
         let state_provider =
-            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed());
+            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed(CachedStateMetricsSource::Test));
 
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());
@@ -1038,7 +1055,7 @@ mod tests {
 
         let caches = ExecutionCache::new(1000);
         let state_provider =
-            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed());
+            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed(CachedStateMetricsSource::Test));
 
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());
@@ -1075,7 +1092,7 @@ mod tests {
     #[test]
     fn test_saved_cache_is_available() {
         let execution_cache = ExecutionCache::new(1000);
-        let cache = SavedCache::new(B256::ZERO, execution_cache, CachedStateMetrics::zeroed());
+        let cache = SavedCache::new(B256::ZERO, execution_cache);
 
         assert!(cache.is_available(), "Cache should be available initially");
 
@@ -1088,7 +1105,7 @@ mod tests {
     fn test_saved_cache_multiple_references() {
         let execution_cache = ExecutionCache::new(1000);
         let cache =
-            SavedCache::new(B256::from([2u8; 32]), execution_cache, CachedStateMetrics::zeroed());
+            SavedCache::new(B256::from([2u8; 32]), execution_cache);
 
         let guard1 = cache.clone_guard_for_test();
         let guard2 = cache.clone_guard_for_test();

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -151,11 +151,11 @@ pub enum CachedStatus<T> {
 /// The source that is using the execution cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CachedStateMetricsSource {
-    /// Engine (validation / newPayload processing).
+    /// Engine (validation).
     Engine,
     /// Payload builder.
     Builder,
-    /// Test-only.
+    /// Tests.
     #[cfg(any(test, feature = "test-utils"))]
     Test,
 }
@@ -958,11 +958,6 @@ impl SavedCache {
     /// Returns the hash for this cache
     pub const fn executed_block_hash(&self) -> B256 {
         self.hash
-    }
-
-    /// Consumes the `SavedCache` and returns the inner [`ExecutionCache`].
-    pub fn into_inner(self) -> ExecutionCache {
-        self.caches
     }
 
     /// Returns true if the cache is available for use (no other tasks are currently using it).

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -19,13 +19,13 @@ use reth_trie::{
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
 use std::{
+    fmt,
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
 };
-use std::fmt;
 use tracing::{debug_span, instrument, trace, warn};
 
 /// Alignment in bytes for entries in the fixed-cache.
@@ -947,21 +947,12 @@ pub struct SavedCache {
     /// A guard to track in-flight usage of this cache.
     /// The cache is considered available if the strong count is 1.
     usage_guard: Arc<()>,
-
-    /// Whether to skip cache metrics recording (can be expensive with large cached state).
-    disable_cache_metrics: bool,
 }
 
 impl SavedCache {
     /// Creates a new instance with the internals
     pub fn new(hash: B256, caches: ExecutionCache) -> Self {
-        Self { hash, caches, usage_guard: Arc::new(()), disable_cache_metrics: false }
-    }
-
-    /// Sets whether to disable cache metrics recording.
-    pub const fn with_disable_cache_metrics(mut self, disable: bool) -> Self {
-        self.disable_cache_metrics = disable;
-        self
+        Self { hash, caches, usage_guard: Arc::new(()) }
     }
 
     /// Returns the hash for this cache
@@ -969,9 +960,9 @@ impl SavedCache {
         self.hash
     }
 
-    /// Splits the cache into its caches and `disable_cache_metrics` flag, consuming it.
-    pub fn split(self) -> (ExecutionCache, bool) {
-        (self.caches, self.disable_cache_metrics)
+    /// Consumes the `SavedCache` and returns the inner [`ExecutionCache`].
+    pub fn into_inner(self) -> ExecutionCache {
+        self.caches
     }
 
     /// Returns true if the cache is available for use (no other tasks are currently using it).
@@ -990,14 +981,10 @@ impl SavedCache {
     }
 
     /// Updates the cache metrics (size/capacity/collisions) from the stats handlers.
-    ///
-    /// Note: This can be expensive with large cached state. Use
-    /// `with_disable_cache_metrics(true)` to skip.
-    pub fn update_metrics(&self, metrics: &CachedStateMetrics) {
-        if self.disable_cache_metrics {
-            return
+    pub fn update_metrics(&self, metrics: Option<&CachedStateMetrics>) {
+        if let Some(metrics) = metrics {
+            self.caches.update_metrics(metrics);
         }
-        self.caches.update_metrics(metrics);
     }
 
     /// Clears all caches, resetting them to empty state,
@@ -1034,8 +1021,11 @@ mod tests {
         provider.extend_accounts(vec![(address, account)]);
 
         let caches = ExecutionCache::new(1000);
-        let state_provider =
-            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed(CachedStateMetricsSource::Test));
+        let state_provider = CachedStateProvider::new(
+            provider,
+            caches,
+            CachedStateMetrics::zeroed(CachedStateMetricsSource::Test),
+        );
 
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());
@@ -1054,8 +1044,11 @@ mod tests {
         provider.extend_accounts(vec![(address, account)]);
 
         let caches = ExecutionCache::new(1000);
-        let state_provider =
-            CachedStateProvider::new(provider, caches, CachedStateMetrics::zeroed(CachedStateMetricsSource::Test));
+        let state_provider = CachedStateProvider::new(
+            provider,
+            caches,
+            CachedStateMetrics::zeroed(CachedStateMetricsSource::Test),
+        );
 
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());
@@ -1104,8 +1097,7 @@ mod tests {
     #[test]
     fn test_saved_cache_multiple_references() {
         let execution_cache = ExecutionCache::new(1000);
-        let cache =
-            SavedCache::new(B256::from([2u8; 32]), execution_cache);
+        let cache = SavedCache::new(B256::from([2u8; 32]), execution_cache);
 
         let guard1 = cache.clone_guard_for_test();
         let guard2 = cache.clone_guard_for_test();

--- a/crates/engine/execution-cache/src/lib.rs
+++ b/crates/engine/execution-cache/src/lib.rs
@@ -165,11 +165,7 @@ mod tests {
         let hash = B256::from([1u8; 32]);
 
         cache.update_with_guard(|slot| {
-            *slot = Some(SavedCache::new(
-                hash,
-                ExecutionCache::new(1_000),
-                CachedStateMetrics::zeroed(),
-            ))
+            *slot = Some(SavedCache::new(hash, ExecutionCache::new(1_000)))
         });
 
         let first = cache.get_cache_for(hash);
@@ -185,11 +181,7 @@ mod tests {
         let hash = B256::from([2u8; 32]);
 
         cache.update_with_guard(|slot| {
-            *slot = Some(SavedCache::new(
-                hash,
-                ExecutionCache::new(1_000),
-                CachedStateMetrics::zeroed(),
-            ))
+            *slot = Some(SavedCache::new(hash, ExecutionCache::new(1_000)))
         });
 
         let checked_out = cache.get_cache_for(hash);
@@ -207,11 +199,7 @@ mod tests {
         let hash_b = B256::from([0xBB; 32]);
 
         cache.update_with_guard(|slot| {
-            *slot = Some(SavedCache::new(
-                hash_a,
-                ExecutionCache::new(1_000),
-                CachedStateMetrics::zeroed(),
-            ))
+            *slot = Some(SavedCache::new(hash_a, ExecutionCache::new(1_000)))
         });
 
         let checked_out = cache.get_cache_for(hash_b);

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -71,7 +71,8 @@ pub use payload_validator::{BasicEngineValidator, EngineValidator};
 pub use persistence_state::PersistenceState;
 pub use reth_engine_primitives::TreeConfig;
 pub use reth_execution_cache::{
-    CachedStateMetrics, CachedStateProvider, ExecutionCache, PayloadExecutionCache, SavedCache,
+    CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider, ExecutionCache,
+    PayloadExecutionCache, SavedCache,
 };
 
 pub mod state;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -97,7 +97,7 @@ where
     /// The most recent cache used for execution.
     execution_cache: PayloadExecutionCache,
     /// Metrics for the execution cache.
-    cache_metrics: CachedStateMetrics,
+    cache_metrics: Option<CachedStateMetrics>,
     /// Metrics for trie operations
     trie_metrics: MultiProofTaskMetrics,
     /// Cross-block cache size in bytes.
@@ -122,8 +122,6 @@ where
     sparse_trie_max_hot_accounts: usize,
     /// Whether sparse trie cache pruning is fully disabled.
     disable_sparse_trie_cache_pruning: bool,
-    /// Whether to disable cache metrics recording.
-    disable_cache_metrics: bool,
 }
 
 impl<N, Evm> PayloadProcessor<Evm>
@@ -157,8 +155,8 @@ where
             sparse_trie_max_hot_slots: config.sparse_trie_max_hot_slots(),
             sparse_trie_max_hot_accounts: config.sparse_trie_max_hot_accounts(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
-            disable_cache_metrics: config.disable_cache_metrics(),
-            cache_metrics: CachedStateMetrics::zeroed(CachedStateMetricsSource::Engine),
+            cache_metrics: (!config.disable_cache_metrics())
+                .then(|| CachedStateMetrics::zeroed(CachedStateMetricsSource::Engine)),
         }
     }
 }
@@ -534,9 +532,10 @@ where
             debug!("creating new execution cache on cache miss");
             let start = Instant::now();
             let cache = ExecutionCache::new(self.cross_block_cache_size);
-            self.cache_metrics.record_cache_creation(start.elapsed());
+            if let Some(metrics) = &self.cache_metrics {
+                metrics.record_cache_creation(start.elapsed());
+            }
             SavedCache::new(parent_hash, cache)
-                .with_disable_cache_metrics(self.disable_cache_metrics)
         }
     }
 
@@ -683,7 +682,6 @@ where
         block_with_parent: BlockWithParent,
         bundle_state: &BundleState,
     ) {
-        let disable_cache_metrics = self.disable_cache_metrics;
         let cache_metrics = self.cache_metrics.clone();
         self.execution_cache.update_with_guard(|cached| {
             if cached.as_ref().is_some_and(|c| c.executed_block_hash() != block_with_parent.parent) {
@@ -697,23 +695,18 @@ where
 
             // Take existing cache (if any) or create fresh caches
             let caches = match cached.take() {
-                Some(existing) => {
-                    let (caches, _) = existing.split();
-                    caches
-                }
+                Some(existing) => existing.into_inner(),
                 None => ExecutionCache::new(self.cross_block_cache_size),
             };
 
             // Insert the block's bundle state into cache
-            let new_cache =
-                SavedCache::new(block_with_parent.block.hash, caches)
-                    .with_disable_cache_metrics(disable_cache_metrics);
+            let new_cache = SavedCache::new(block_with_parent.block.hash, caches);
             if new_cache.cache().insert_state(bundle_state).is_err() {
                 *cached = None;
                 debug!(target: "engine::caching", "cleared execution cache on update error");
                 return
             }
-            new_cache.update_metrics(&cache_metrics);
+            new_cache.update_metrics(cache_metrics.as_ref());
 
             // Replace with the updated cache
             *cached = Some(new_cache);
@@ -809,7 +802,7 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
 
     /// Returns engine cache metrics if a cache exists for prewarming.
     pub fn cache_metrics(&self) -> Option<CachedStateMetrics> {
-        self.prewarm_handle.saved_cache.is_some().then(|| self.prewarm_handle.cache_metrics.clone())
+        self.prewarm_handle.cache_metrics.clone()
     }
 
     /// Returns a reference to the shared executed transaction index counter.
@@ -861,7 +854,7 @@ pub struct CacheTaskHandle<R> {
     /// loop. Prewarm workers skip transactions below this index.
     executed_tx_index: Arc<AtomicUsize>,
     /// Metrics for the execution cache.
-    cache_metrics: CachedStateMetrics,
+    cache_metrics: Option<CachedStateMetrics>,
 }
 
 impl<R: Send + Sync + 'static> CacheTaskHandle<R> {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -4,8 +4,8 @@ use super::precompile_cache::PrecompileCacheMap;
 use crate::tree::{
     payload_processor::prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
     sparse_trie::SparseTrieCacheTask,
-    CacheWaitDurations, CachedStateMetrics, ExecutionCache, PayloadExecutionCache, SavedCache,
-    StateProviderBuilder, TreeConfig, WaitForCaches,
+    CacheWaitDurations, CachedStateMetrics, CachedStateMetricsSource, ExecutionCache,
+    PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig, WaitForCaches,
 };
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal};
@@ -96,6 +96,8 @@ where
     executor: Runtime,
     /// The most recent cache used for execution.
     execution_cache: PayloadExecutionCache,
+    /// Metrics for the execution cache.
+    cache_metrics: CachedStateMetrics,
     /// Metrics for trie operations
     trie_metrics: MultiProofTaskMetrics,
     /// Cross-block cache size in bytes.
@@ -156,6 +158,7 @@ where
             sparse_trie_max_hot_accounts: config.sparse_trie_max_hot_accounts(),
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             disable_cache_metrics: config.disable_cache_metrics(),
+            cache_metrics: CachedStateMetrics::zeroed(CachedStateMetricsSource::Engine),
         }
     }
 }
@@ -482,6 +485,7 @@ where
             saved_cache: saved_cache.clone(),
             provider: provider_builder,
             metrics: PrewarmMetrics::default(),
+            cache_metrics: self.cache_metrics.clone(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
             executed_tx_index: Arc::clone(&executed_tx_index),
             precompile_cache_disabled: self.precompile_cache_disabled,
@@ -509,7 +513,12 @@ where
             });
         }
 
-        CacheTaskHandle { saved_cache, to_prewarm_task: Some(to_prewarm_task), executed_tx_index }
+        CacheTaskHandle {
+            saved_cache,
+            to_prewarm_task: Some(to_prewarm_task),
+            executed_tx_index,
+            cache_metrics: self.cache_metrics.clone(),
+        }
     }
 
     /// Returns the cache for the given parent hash.
@@ -525,9 +534,8 @@ where
             debug!("creating new execution cache on cache miss");
             let start = Instant::now();
             let cache = ExecutionCache::new(self.cross_block_cache_size);
-            let metrics = CachedStateMetrics::zeroed();
-            metrics.record_cache_creation(start.elapsed());
-            SavedCache::new(parent_hash, cache, metrics)
+            self.cache_metrics.record_cache_creation(start.elapsed());
+            SavedCache::new(parent_hash, cache)
                 .with_disable_cache_metrics(self.disable_cache_metrics)
         }
     }
@@ -676,6 +684,7 @@ where
         bundle_state: &BundleState,
     ) {
         let disable_cache_metrics = self.disable_cache_metrics;
+        let cache_metrics = self.cache_metrics.clone();
         self.execution_cache.update_with_guard(|cached| {
             if cached.as_ref().is_some_and(|c| c.executed_block_hash() != block_with_parent.parent) {
                 debug!(
@@ -687,25 +696,24 @@ where
             }
 
             // Take existing cache (if any) or create fresh caches
-            let (caches, cache_metrics, _) = match cached.take() {
-                Some(existing) => existing.split(),
-                None => (
-                    ExecutionCache::new(self.cross_block_cache_size),
-                    CachedStateMetrics::zeroed(),
-                    false,
-                ),
+            let caches = match cached.take() {
+                Some(existing) => {
+                    let (caches, _) = existing.split();
+                    caches
+                }
+                None => ExecutionCache::new(self.cross_block_cache_size),
             };
 
             // Insert the block's bundle state into cache
             let new_cache =
-                SavedCache::new(block_with_parent.block.hash, caches, cache_metrics)
+                SavedCache::new(block_with_parent.block.hash, caches)
                     .with_disable_cache_metrics(disable_cache_metrics);
             if new_cache.cache().insert_state(bundle_state).is_err() {
                 *cached = None;
                 debug!(target: "engine::caching", "cleared execution cache on update error");
                 return
             }
-            new_cache.update_metrics();
+            new_cache.update_metrics(&cache_metrics);
 
             // Replace with the updated cache
             *cached = Some(new_cache);
@@ -799,9 +807,9 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
         self.prewarm_handle.saved_cache.as_ref().map(|cache| cache.cache().clone())
     }
 
-    /// Returns a clone of the cache metrics used by prewarming
+    /// Returns engine cache metrics if a cache exists for prewarming.
     pub fn cache_metrics(&self) -> Option<CachedStateMetrics> {
-        self.prewarm_handle.saved_cache.as_ref().map(|cache| cache.metrics().clone())
+        self.prewarm_handle.saved_cache.is_some().then(|| self.prewarm_handle.cache_metrics.clone())
     }
 
     /// Returns a reference to the shared executed transaction index counter.
@@ -852,6 +860,8 @@ pub struct CacheTaskHandle<R> {
     /// Shared counter tracking the next transaction index to be executed by the main execution
     /// loop. Prewarm workers skip transactions below this index.
     executed_tx_index: Arc<AtomicUsize>,
+    /// Metrics for the execution cache.
+    cache_metrics: CachedStateMetrics,
 }
 
 impl<R: Send + Sync + 'static> CacheTaskHandle<R> {
@@ -946,8 +956,7 @@ mod tests {
     use crate::tree::{
         payload_processor::{evm_state_to_hashed_post_state, ExecutionEnv, PayloadProcessor},
         precompile_cache::PrecompileCacheMap,
-        CachedStateMetrics, ExecutionCache, PayloadExecutionCache, SavedCache,
-        StateProviderBuilder, TreeConfig,
+        ExecutionCache, PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig,
     };
     use alloy_eips::eip1898::{BlockNumHash, BlockWithParent};
     use alloy_evm::block::StateChangeSource;
@@ -973,7 +982,7 @@ mod tests {
 
     fn make_saved_cache(hash: B256) -> SavedCache {
         let execution_cache = ExecutionCache::new(1_000);
-        SavedCache::new(hash, execution_cache, CachedStateMetrics::zeroed())
+        SavedCache::new(hash, execution_cache)
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -695,7 +695,7 @@ where
 
             // Take existing cache (if any) or create fresh caches
             let caches = match cached.take() {
-                Some(existing) => existing.into_inner(),
+                Some(existing) => existing.cache().clone(),
                 None => ExecutionCache::new(self.cross_block_cache_size),
             };
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -14,7 +14,8 @@
 use crate::tree::{
     payload_processor::multiproof::StateRootMessage,
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
-    CachedStateProvider, ExecutionEnv, PayloadExecutionCache, SavedCache, StateProviderBuilder,
+    CachedStateMetrics, CachedStateProvider, ExecutionEnv, PayloadExecutionCache, SavedCache,
+    StateProviderBuilder,
 };
 use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::BlockAccessList;
@@ -276,19 +277,21 @@ where
     ) {
         let start = Instant::now();
 
-        let Self { execution_cache, ctx: PrewarmContext { env, metrics, saved_cache, .. }, .. } =
-            self;
+        let Self {
+            execution_cache,
+            ctx: PrewarmContext { env, metrics, cache_metrics, saved_cache, .. },
+            ..
+        } = self;
         let hash = env.hash;
 
         if let Some(saved_cache) = saved_cache {
             debug!(target: "engine::caching", parent_hash=?hash, "Updating execution cache");
-            // Perform all cache operations atomically under the lock
             execution_cache.update_with_guard(|cached| {
                 // consumes the `SavedCache` held by the prewarming task, which releases its usage
                 // guard
-                let (caches, cache_metrics, disable_cache_metrics) = saved_cache.split();
-                let new_cache = SavedCache::new(hash, caches, cache_metrics)
-                    .with_disable_cache_metrics(disable_cache_metrics);
+                let (caches, disable_cache_metrics) = saved_cache.split();
+                let new_cache =
+                    SavedCache::new(hash, caches).with_disable_cache_metrics(disable_cache_metrics);
 
                 // Insert state into cache while holding the lock
                 // Access the BundleState through the shared ExecutionOutcome
@@ -299,7 +302,7 @@ where
                     return;
                 }
 
-                new_cache.update_metrics();
+                new_cache.update_metrics(&cache_metrics);
 
                 if valid_block_rx.recv().is_ok() {
                     // Replace the shared cache with the new one; the previous cache (if any) is
@@ -521,6 +524,8 @@ where
     pub provider: StateProviderBuilder<N, P>,
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
+    /// Metrics for the execution cache.
+    pub cache_metrics: CachedStateMetrics,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
     pub terminate_execution: Arc<AtomicBool>,
     /// Shared counter tracking the next transaction index to be executed by the main execution
@@ -562,9 +567,11 @@ where
         // Use the caches to create a new provider with caching
         if let Some(saved_cache) = &self.saved_cache {
             let caches = saved_cache.cache().clone();
-            let cache_metrics = saved_cache.metrics().clone();
-            state_provider =
-                Box::new(CachedStateProvider::new_prewarm(state_provider, caches, cache_metrics));
+            state_provider = Box::new(CachedStateProvider::new_prewarm(
+                state_provider,
+                caches,
+                self.cache_metrics.clone(),
+            ));
         }
 
         let state_provider = StateProviderDatabase::new(state_provider);
@@ -665,8 +672,11 @@ where
             };
             let boxed: Box<dyn AccountReader> = if let Some(saved) = &self.saved_cache {
                 let caches = saved.cache().clone();
-                let cache_metrics = saved.metrics().clone();
-                Box::new(CachedStateProvider::new_prewarm(inner, caches, cache_metrics))
+                Box::new(CachedStateProvider::new_prewarm(
+                    inner,
+                    caches,
+                    self.cache_metrics.clone(),
+                ))
             } else {
                 Box::new(inner)
             };
@@ -761,8 +771,11 @@ where
                 let saved_cache =
                     self.saved_cache.as_ref().expect("BAL prewarm should only run with cache");
                 let caches = saved_cache.cache().clone();
-                let cache_metrics = saved_cache.metrics().clone();
-                slot.insert(CachedStateProvider::new_prewarm(built, caches, cache_metrics))
+                slot.insert(CachedStateProvider::new_prewarm(
+                    built,
+                    caches,
+                    self.cache_metrics.clone(),
+                ))
             }
         };
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -289,9 +289,8 @@ where
             execution_cache.update_with_guard(|cached| {
                 // consumes the `SavedCache` held by the prewarming task, which releases its usage
                 // guard
-                let (caches, disable_cache_metrics) = saved_cache.split();
-                let new_cache =
-                    SavedCache::new(hash, caches).with_disable_cache_metrics(disable_cache_metrics);
+                let caches = saved_cache.into_inner();
+                let new_cache = SavedCache::new(hash, caches);
 
                 // Insert state into cache while holding the lock
                 // Access the BundleState through the shared ExecutionOutcome
@@ -302,7 +301,7 @@ where
                     return;
                 }
 
-                new_cache.update_metrics(&cache_metrics);
+                new_cache.update_metrics(cache_metrics.as_ref());
 
                 if valid_block_rx.recv().is_ok() {
                     // Replace the shared cache with the new one; the previous cache (if any) is
@@ -525,7 +524,8 @@ where
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
     /// Metrics for the execution cache.
-    pub cache_metrics: CachedStateMetrics,
+    /// Metrics for the execution cache. `None` disables metrics recording.
+    pub cache_metrics: Option<CachedStateMetrics>,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
     pub terminate_execution: Arc<AtomicBool>,
     /// Shared counter tracking the next transaction index to be executed by the main execution
@@ -570,7 +570,7 @@ where
             state_provider = Box::new(CachedStateProvider::new_prewarm(
                 state_provider,
                 caches,
-                self.cache_metrics.clone(),
+                self.cache_metrics.clone().unwrap_or_default(),
             ));
         }
 
@@ -675,7 +675,7 @@ where
                 Box::new(CachedStateProvider::new_prewarm(
                     inner,
                     caches,
-                    self.cache_metrics.clone(),
+                    self.cache_metrics.clone().unwrap_or_default(),
                 ))
             } else {
                 Box::new(inner)
@@ -774,7 +774,7 @@ where
                 slot.insert(CachedStateProvider::new_prewarm(
                     built,
                     caches,
-                    self.cache_metrics.clone(),
+                    self.cache_metrics.clone().unwrap_or_default(),
                 ))
             }
         };

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -289,7 +289,7 @@ where
             execution_cache.update_with_guard(|cached| {
                 // consumes the `SavedCache` held by the prewarming task, which releases its usage
                 // guard
-                let caches = saved_cache.into_inner();
+                let caches = saved_cache.cache().clone();
                 let new_cache = SavedCache::new(hash, caches);
 
                 // Insert state into cache while holding the lock

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -25,7 +25,7 @@ use reth_evm::{
     ConfigureEvm, Evm, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::EthEvmConfig;
-use reth_execution_cache::CachedStateProvider;
+use reth_execution_cache::{CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider};
 use reth_payload_builder::{BlobSidecars, EthBuiltPayload};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadAttributes;
@@ -172,7 +172,9 @@ where
         state_provider = Box::new(CachedStateProvider::new(
             state_provider,
             execution_cache.cache().clone(),
-            execution_cache.metrics().clone(),
+            // It's ok to recreate the cache every time, because it's cheap to do so for a vanilla
+            // Ethereum builder every 12s.
+            CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder),
         ));
     }
     let state = StateProviderDatabase::new(state_provider.as_ref());


### PR DESCRIPTION
1. Adds `CachedStateMetricsSource` enum so metrics are distinguished by caller (engine/builder).
3. Removes the metrics field from `SavedCache` entirely — metrics are now owned by `PayloadProcessor` and threaded through `CacheTaskHandle` and `PrewarmContext`.