### PR TITLE
chore: remove BENCH_RUNNERS and queue position tracking from bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,7 +95,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
-  BENCH_RUNNERS: 2
 
 name: bench
 
@@ -377,36 +376,6 @@ jobs:
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            // Count queued/waiting bench runs ahead of this one.
-            // BENCH_RUNNERS is the number of self-hosted runners available.
-            let queueMsg = '';
-            let ahead = 0;
-            const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
-            try {
-              const statuses = ['queued', 'in_progress', 'waiting', 'requested', 'pending'];
-              const allRuns = [];
-              for (const status of statuses) {
-                const { data: { workflow_runs: r } } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'bench.yml',
-                  status,
-                  per_page: 100,
-                });
-                allRuns.push(...r);
-              }
-              const benchRuns = allRuns.filter(r => r.event === 'issue_comment' || r.event === 'workflow_dispatch');
-              const thisRun = benchRuns.find(r => r.id === context.runId);
-              const thisCreatedAt = thisRun ? new Date(thisRun.created_at) : new Date();
-              const totalAhead = benchRuns.filter(r => r.id !== context.runId && new Date(r.created_at) <= thisCreatedAt).length;
-              ahead = Math.max(0, totalAhead - numRunners + 1);
-              if (ahead > 0) {
-                queueMsg = `\n🔢 **Queue position:** ${ahead} job(s) ahead (${numRunners} runner(s))`;
-              }
-            } catch (e) {
-              core.info(`Skipping queue tracking: ${e.message}`);
-            }
-
             const actor = '${{ steps.args.outputs.actor }}';
             const blocks = '${{ steps.args.outputs.blocks }}';
             const warmup = '${{ steps.args.outputs.warmup }}';
@@ -438,92 +407,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: parseInt(pr),
-              body: `cc @${actor}\n\n🚀 Benchmark queued! [View run](${runUrl})\n\n⏳ **Status:** Waiting for runner...${queueMsg}\n\n${config}`,
+              body: `cc @${actor}\n\n🚀 Benchmark queued! [View run](${runUrl})\n\n⏳ **Status:** Waiting for runner...\n\n${config}`,
             });
             core.setOutput('comment-id', String(comment.id));
-            core.setOutput('queue-position', String(ahead || 0));
-
-      - name: Poll queue position
-        if: steps.ack.outputs.comment-id && steps.ack.outputs.queue-position != '0'
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.DEREK_PAT }}
-          script: |
-            const pr = '${{ steps.args.outputs.pr }}';
-            const commentId = parseInt('${{ steps.ack.outputs.comment-id }}');
-            const actor = '${{ steps.args.outputs.actor }}';
-            const blocks = '${{ steps.args.outputs.blocks }}';
-            const warmup = '${{ steps.args.outputs.warmup }}';
-            const baseline = '${{ steps.args.outputs.baseline-name }}';
-            const feature = '${{ steps.args.outputs.feature-name }}';
-            const samply = '${{ steps.args.outputs.samply }}' === 'true';
-            const slack = '${{ steps.args.outputs.slack }}' || 'always';
-            const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
-            const bal = '${{ steps.args.outputs.bal }}' || 'false';
-            const samplyNote = samply ? ', samply: `enabled`' : '';
-            const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
-            const balNote = bigBlocks && bal !== 'false' ? `, BAL: \`${bal}\`` : '';
-            const cores = '${{ steps.args.outputs.cores }}';
-            const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
-            const abbaEnabled = '${{ steps.args.outputs.abba }}' !== 'false';
-            const abbaNote = !abbaEnabled ? ', abba: `disabled`' : '';
-            const otlpEnabled = '${{ steps.args.outputs.otlp }}' !== 'false';
-            const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
-            const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
-            const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
-            const baselineArgsVal = '${{ steps.args.outputs.baseline-args }}';
-            const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
-            const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
-            const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
-            const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
-            async function getQueuePosition() {
-              const statuses = ['queued', 'in_progress', 'waiting', 'requested', 'pending'];
-              const allRuns = [];
-              for (const status of statuses) {
-                const { data: { workflow_runs: r } } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'bench.yml',
-                  status,
-                  per_page: 100,
-                });
-                allRuns.push(...r);
-              }
-              const benchRuns = allRuns.filter(r => r.event === 'issue_comment' || r.event === 'workflow_dispatch');
-              const thisRun = benchRuns.find(r => r.id === context.runId);
-              const thisCreatedAt = thisRun ? new Date(thisRun.created_at) : new Date();
-              const totalAhead = benchRuns.filter(r => r.id !== context.runId && new Date(r.created_at) <= thisCreatedAt).length;
-              return { ahead: Math.max(0, totalAhead - numRunners + 1), numRunners };
-            }
-
-            let lastPosition = parseInt('${{ steps.ack.outputs.queue-position }}');
-            const sleep = ms => new Promise(r => setTimeout(r, ms));
-
-            while (true) {
-              await sleep(10_000);
-              try {
-                const { ahead, numRunners } = await getQueuePosition();
-                if (ahead !== lastPosition) {
-                  lastPosition = ahead;
-                  const queueMsg = ahead > 0
-                    ? `\n🔢 **Queue position:** ${ahead} job(s) ahead (${numRunners} runner(s))`
-                    : '';
-                  await github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: commentId,
-                    body: `cc @${actor}\n\n🚀 Benchmark queued! [View run](${runUrl})\n\n⏳ **Status:** Waiting for runner...${queueMsg}\n\n${config}`,
-                  });
-                }
-                if (ahead === 0) break;
-              } catch (e) {
-                core.info(`Queue poll error: ${e.message}`);
-              }
-            }
 
   reth-bench:
     needs: reth-bench-ack


### PR DESCRIPTION
Removes the BENCH_RUNNERS env var and all queue position tracking logic (initial calculation + polling step). The queue display was informational only and didn't actually control concurrency — that's governed by runner availability.

Prompted by: alexey