### PR TITLE
[autoopt] 20260415-16-rocksdb-prune-lazy-decompress

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1994,7 +1994,7 @@ impl<'a> RocksDBBatch<'a> {
     #[expect(clippy::too_many_arguments)]
     fn prune_history_shards_inner<K>(
         &mut self,
-        shards: Vec<(K, BlockNumberList)>,
+        shards: Vec<(K, Option<BlockNumberList>)>,
         to_block: BlockNumber,
         get_highest: impl Fn(&K) -> u64,
         is_sentinel: impl Fn(&K) -> bool,
@@ -2014,10 +2014,11 @@ impl<'a> RocksDBBatch<'a> {
         let mut last_remaining: Option<(K, BlockNumberList)> = None;
 
         for (key, block_list) in shards {
-            if !is_sentinel(&key) && get_highest(&key) <= to_block {
+            if block_list.is_none() || (!is_sentinel(&key) && get_highest(&key) <= to_block) {
                 delete_shard(self, key)?;
                 deleted = true;
             } else {
+                let block_list = block_list.expect("missing block list handled above");
                 let original_len = block_list.len();
                 let filtered =
                     BlockNumberList::new_pre_sorted(block_list.iter().filter(|&b| b > to_block));
@@ -2061,7 +2062,12 @@ impl<'a> RocksDBBatch<'a> {
         address: Address,
         to_block: BlockNumber,
     ) -> ProviderResult<PruneShardOutcome> {
-        let shards = self.provider.account_history_shards(address)?;
+        let shards = self
+            .provider
+            .account_history_shards(address)?
+            .into_iter()
+            .map(|(key, value)| (key, Some(value)))
+            .collect();
         self.prune_history_shards_inner(
             shards,
             to_block,
@@ -2150,11 +2156,15 @@ impl<'a> RocksDBBatch<'a> {
                 let key = ShardedKey::<Address>::decode(key_bytes)
                     .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
 
-                let Some(value_bytes) = iter.value() else { break };
-                let value = BlockNumberList::decompress(value_bytes)
-                    .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                if key.highest_block_number <= *to_block && key.highest_block_number != u64::MAX {
+                    shards.push((key, None));
+                } else {
+                    let Some(value_bytes) = iter.value() else { break };
+                    let value = BlockNumberList::decompress(value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    shards.push((key, Some(value)));
+                }
 
-                shards.push((key, value));
                 iter.next();
             }
 
@@ -2187,7 +2197,12 @@ impl<'a> RocksDBBatch<'a> {
         storage_key: B256,
         to_block: BlockNumber,
     ) -> ProviderResult<PruneShardOutcome> {
-        let shards = self.provider.storage_history_shards(address, storage_key)?;
+        let shards = self
+            .provider
+            .storage_history_shards(address, storage_key)?
+            .into_iter()
+            .map(|(key, value)| (key, Some(value)))
+            .collect();
         self.prune_history_shards_inner(
             shards,
             to_block,
@@ -2277,11 +2292,17 @@ impl<'a> RocksDBBatch<'a> {
                 let key = StorageShardedKey::decode(key_bytes)
                     .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
 
-                let Some(value_bytes) = iter.value() else { break };
-                let value = BlockNumberList::decompress(value_bytes)
-                    .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                if key.sharded_key.highest_block_number <= *to_block &&
+                    key.sharded_key.highest_block_number != u64::MAX
+                {
+                    shards.push((key, None));
+                } else {
+                    let Some(value_bytes) = iter.value() else { break };
+                    let value = BlockNumberList::decompress(value_bytes)
+                        .map_err(|_| ProviderError::Database(DatabaseError::Decode))?;
+                    shards.push((key, Some(value)));
+                }
 
-                shards.push((key, value));
                 iter.next();
             }
 


### PR DESCRIPTION
# Skip history-list decompression for fully pruned RocksDB shards
## Evidence
- The `24463893386` baseline persistence thread still spends substantial inclusive time in `AccountHistory::prune_rocksdb`, `StorageHistory::prune_rocksdb`, and `RocksDBBatch::prune_history_shards_inner` while `save_blocks` is backpressured on persistence.
- A prior fast path that skipped no-op shard rebuilds was neutral, but the batch pruning code still eagerly decompressed every `BlockNumberList` before it knew whether a non-sentinel shard would be deleted wholesale by its `highest_block_number`.
- For history shards whose non-sentinel key is already fully below the prune block, the block list bytes are never needed: pruning only needs the key to issue the delete.

## Hypothesis
If batch history pruning deletes obviously fully-pruned non-sentinel shards without first decompressing their `BlockNumberList`, gas throughput improves by ~0.1-0.3% because the persistence thread does less RocksDB decode work while pruning history indices.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/storage/provider/src/providers/rocksdb/provider.rs` so batch pruning can mark delete-only shards and let `prune_history_shards_inner` skip decompression for them.
- Keep sentinel normalization and filtered rewrites unchanged for shards that still need their block lists.
- Verify with `cargo check -p reth-provider`, `cargo test -p reth-provider test_prune_account_history_batch -- --nocapture`, `cargo test -p reth-provider test_prune_storage_history_batch -- --nocapture`, and `cargo +nightly fmt --all --check`.