### PR TITLE
[autoopt] 20260415-15-in-memory-cursor-borrows

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -172,33 +172,39 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
     /// node.
     fn choose_next_entry(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         loop {
-            match (self.in_memory_cursor.current().cloned(), &self.cursor_entry) {
+            let mem_entry = self
+                .in_memory_cursor
+                .current()
+                .map(|(mem_key, maybe_node)| (*mem_key, maybe_node.as_ref()));
+            let db_entry = self.cursor_entry.as_ref().map(|(db_key, node)| (*db_key, node));
+
+            match (mem_entry, db_entry) {
                 (Some((mem_key, None)), _)
-                    if self.cursor_entry.as_ref().is_none_or(|(db_key, _)| &mem_key < db_key) =>
+                    if db_entry.is_none_or(|(db_key, _)| mem_key < db_key) =>
                 {
                     // If overlay has a removed node but DB cursor is exhausted or ahead of the
                     // in-memory cursor then move ahead in-memory, as there might be further
                     // non-removed overlay nodes.
                     self.in_memory_cursor.first_after(&mem_key);
                 }
-                (Some((mem_key, None)), Some((db_key, _))) if &mem_key == db_key => {
+                (Some((mem_key, None)), Some((db_key, _))) if mem_key == db_key => {
                     // If overlay has a removed node which is returned from DB then move both
                     // cursors ahead to the next key.
                     self.in_memory_cursor.first_after(&mem_key);
                     self.cursor_next()?;
                 }
                 (Some((mem_key, Some(node))), _)
-                    if self.cursor_entry.as_ref().is_none_or(|(db_key, _)| &mem_key <= db_key) =>
+                    if db_entry.is_none_or(|(db_key, _)| mem_key <= db_key) =>
                 {
                     // If overlay returns a node prior to the DB's node, or the DB is exhausted,
                     // then we return the overlay's node.
-                    return Ok(Some((mem_key, node)))
+                    return Ok(Some((mem_key, node.clone())))
                 }
                 // All other cases:
                 // - mem_key > db_key
                 // - overlay is exhausted
                 // Return the db_entry. If DB is also exhausted then this returns None.
-                _ => return Ok(self.cursor_entry.clone()),
+                _ => return Ok(db_entry.map(|(db_key, node)| (db_key, node.clone()))),
             }
         }
     }


### PR DESCRIPTION
# Borrow overlay entries inside the in-memory trie cursor
## Evidence
- In the `24463893386` baseline, the `trie-input` worker still spends about 65k inclusive samples in deferred trie changeset computation.
- The earlier changeset experiments that changed lookup order or returned value-only exact matches were neutral, but `compute_trie_changesets` still routes every overlay arbitration through `InMemoryTrieCursor`.
- `InMemoryTrieCursor::choose_next_entry` previously cloned the current overlay tuple before it knew whether it would be returned, so delete markers and DB-preferred branches still paid for extra `BranchNodeCompact` cloning work on a hot path.

## Hypothesis
If `InMemoryTrieCursor` compares overlay and DB entries by reference and clones the winning node only at the return point, gas throughput improves by ~0.1-0.4% because the deferred trie-input worker does less unnecessary overlay cloning while computing trie changesets.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/trie/src/trie_cursor/in_memory.rs` so `choose_next_entry` borrows overlay and DB entries for comparisons.
- Keep cursor semantics unchanged while cloning only the node that is actually returned.
- Verify with `cargo check -p reth-trie`, `cargo test -p reth-trie in_memory -- --nocapture`, and `cargo +nightly fmt --all --check`.