### PR TITLE
[autoopt] 20260415-17-rocksdb-partial-prune

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -2013,21 +2013,21 @@ impl<'a> RocksDBBatch<'a> {
         let mut updated = false;
         let mut last_remaining: Option<(K, BlockNumberList)> = None;
 
-        for (key, block_list) in shards {
+        for (key, mut block_list) in shards {
             if !is_sentinel(&key) && get_highest(&key) <= to_block {
                 delete_shard(self, key)?;
                 deleted = true;
             } else {
-                let original_len = block_list.len();
-                let filtered =
-                    BlockNumberList::new_pre_sorted(block_list.iter().filter(|&b| b > to_block));
+                // Roaring can drop the pruned prefix in place, which is cheaper than rebuilding
+                // the surviving suffix with a fresh iterator when a shard is only partially pruned.
+                let removed = block_list.0.remove_range(..=to_block);
 
-                if filtered.is_empty() {
+                if block_list.is_empty() {
                     delete_shard(self, key)?;
                     deleted = true;
-                } else if filtered.len() < original_len {
-                    put_shard(self, key.clone(), &filtered)?;
-                    last_remaining = Some((key, filtered));
+                } else if removed > 0 {
+                    put_shard(self, key.clone(), &block_list)?;
+                    last_remaining = Some((key, block_list));
                     updated = true;
                 } else {
                     last_remaining = Some((key, block_list));


### PR DESCRIPTION
# Prune RocksDB history shards in place
## Evidence
- `/home/ubuntu/autoopt/artifacts/24463893386/bench-reth-results/summary.json` shows `persistence_wait_us` dominating end-to-end latency at about 29.46 ms mean and 262.36 ms p95 per block.
- The baseline-1 samply profile still keeps the persistence thread inside `reth_prune::pruner::Pruner::run_with_provider`, `RocksDBProviderFactory::with_rocksdb_batch`, and `RocksDBBatch::prune_history_shards_inner`, with matching self-time in RocksDB decode / rebuild helpers.
- `crates/storage/provider/src/providers/rocksdb/provider.rs` rebuilt a fresh `BlockNumberList` from `block_list.iter().filter(...)` for every partially pruned shard even though the decoded roaring set can drop the pruned prefix in place.

## Hypothesis
If we remove pruned history entries from decoded roaring shard lists in place with `remove_range(..=to_block)`, gas throughput improves by ~0.1-0.4% because the persistence thread does less iterator and rebuild work in the partial-prune case that remains after the earlier no-op/full-delete fast paths.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/storage/provider/src/providers/rocksdb/provider.rs` so partial account/storage history prunes mutate the decoded shard instead of rebuilding it from an iterator.
- Preserve the existing full-delete and sentinel promotion behavior.