### PR TITLE
fix(rpc): prevent panic in log subscription on broadcast lag

### DIFF
--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -447,10 +447,10 @@ where
 
     /// Returns a stream that yields all logs that match the given filter.
     fn log_stream(&self, filter: Filter) -> impl Stream<Item = Log> {
-        BroadcastStream::new(self.eth_api.provider().subscribe_to_canonical_state())
-            .map(move |canon_state| {
-                canon_state.expect("new block subscription never ends").block_receipts()
-            })
+        self.eth_api
+            .provider()
+            .canonical_state_stream()
+            .map(move |canon_state| canon_state.block_receipts())
             .flat_map(futures::stream::iter)
             .flat_map(move |(block_receipts, removed)| {
                 let all_logs = logs_utils::matching_block_logs_with_tx_hashes(


### PR DESCRIPTION
tl;dr: `log_stream` was calling `.expect()` on a raw `BroadcastStream` result, which panics when the subscriber falls behind. Switched to `canonical_state_stream()` which already handles lag gracefully.

The `log_stream` function constructed its own `BroadcastStream` and unwrapped the `Result` with `.expect("new block subscription never ends")`. A `Lagged` error from tokio broadcast (subscriber too slow) would panic the subscription task. `canonical_state_stream()` wraps the same broadcast channel but its `CanonStateNotificationStream` implementation logs the lag at debug level and retries, matching how `new_headers_stream` already works.
