### PR TITLE
[autoopt] 20260415-3-proof-popstack

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -366,16 +366,16 @@ where
         targets: &mut Option<TargetsCursor<'a>>,
     ) -> Result<(), StateProofError> {
         let Some(child_path) = self.last_child_path() else { return Ok(()) };
-        let child =
-            self.child_stack.pop().expect("child_stack can't be empty if there's a child path");
 
         // If the child is already an `RlpNode` then there is nothing to do, push it back on with no
         // changes.
-        if let ProofTrieBranchChild::RlpNode(_rlp_node) = &child {
+        if let Some(ProofTrieBranchChild::RlpNode(_rlp_node)) = self.child_stack.last() {
             trace!(target: TRACE_TARGET, ?_rlp_node, "Already RlpNode, pushing onto stack");
-            self.child_stack.push(child);
             return Ok(())
         }
+
+        let child =
+            self.child_stack.pop().expect("child_stack can't be empty if there's a child path");
 
         // Only commit immediately if retained for the proof. Otherwise, defer conversion
         // to pop_branch() to give DeferredEncoder time for async work.
@@ -538,7 +538,8 @@ where
         );
 
         // Collect children into RlpNode Vec. Children are in lexicographic order.
-        for child in self.child_stack.drain(self.child_stack.len() - num_children..) {
+        for _ in 0..num_children {
+            let child = self.child_stack.pop().expect("stack is missing necessary children");
             let child_rlp_node = match child {
                 ProofTrieBranchChild::RlpNode(rlp_node) => rlp_node,
                 uncommitted_child => {
@@ -554,6 +555,7 @@ where
             };
             rlp_nodes_buf.push(child_rlp_node);
         }
+        rlp_nodes_buf.reverse();
 
         debug_assert_eq!(
             rlp_nodes_buf.len(),


### PR DESCRIPTION
# Pop proof branch children directly from the stack
## Evidence
- In `/home/ubuntu/autoopt/artifacts/24463893386/bench-reth-results/baseline-1/samply-profile.json.gz`, proof workers spend about 359.9k inclusive samples in `ProofCalculator::next_uncached_key_range`.
- Hot leaf samples under that path still include about 6.4k in `ProofCalculator::pop_branch` and about 5.8k in `ProofCalculator::commit_last_child`, alongside path-handling work like `node_key` and `Nibbles::len`.
- The current proof builder pops and re-pushes already committed `RlpNode` children and drains whole branch tails before rebuilding the same child order in a temporary buffer.

## Hypothesis
If we leave already-committed proof children on the stack and pop only the exact number of branch children directly into the temporary RLP buffer, gas throughput improves by ~0.1-0.4% because proof construction does less stack churn on a still-hot multiproof path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/trie/src/proof_v2/mod.rs` so `commit_last_child` peeks for existing `RlpNode` children and `pop_branch` pops children directly before reversing once to restore lexicographic order.
- Keep proof ordering and retained-node semantics unchanged.
- Verify with `cargo check -p reth-trie` and `cargo test -p reth-trie proof_v2`.