### PR TITLE
[autoopt] 20260415-2-overlay-cursor-borrow

### DIFF
--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -172,27 +172,30 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
     /// node.
     fn choose_next_entry(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         loop {
-            match (self.in_memory_cursor.current().cloned(), &self.cursor_entry) {
-                (Some((mem_key, None)), _)
-                    if self.cursor_entry.as_ref().is_none_or(|(db_key, _)| &mem_key < db_key) =>
+            let mem_entry =
+                self.in_memory_cursor.current().map(|(key, node)| (*key, node.as_ref()));
+
+            match (mem_entry, self.cursor_entry.as_ref()) {
+                (Some((mem_key, None)), db_entry)
+                    if db_entry.is_none_or(|(db_key, _)| mem_key < *db_key) =>
                 {
                     // If overlay has a removed node but DB cursor is exhausted or ahead of the
                     // in-memory cursor then move ahead in-memory, as there might be further
                     // non-removed overlay nodes.
                     self.in_memory_cursor.first_after(&mem_key);
                 }
-                (Some((mem_key, None)), Some((db_key, _))) if &mem_key == db_key => {
+                (Some((mem_key, None)), Some((db_key, _))) if mem_key == *db_key => {
                     // If overlay has a removed node which is returned from DB then move both
                     // cursors ahead to the next key.
                     self.in_memory_cursor.first_after(&mem_key);
                     self.cursor_next()?;
                 }
-                (Some((mem_key, Some(node))), _)
-                    if self.cursor_entry.as_ref().is_none_or(|(db_key, _)| &mem_key <= db_key) =>
+                (Some((mem_key, Some(node))), db_entry)
+                    if db_entry.is_none_or(|(db_key, _)| mem_key <= *db_key) =>
                 {
                     // If overlay returns a node prior to the DB's node, or the DB is exhausted,
                     // then we return the overlay's node.
-                    return Ok(Some((mem_key, node)))
+                    return Ok(Some((mem_key, node.clone())))
                 }
                 // All other cases:
                 // - mem_key > db_key


### PR DESCRIPTION
# Borrow overlay trie entries while merging cursor results
## Evidence
- In `/home/ubuntu/autoopt/artifacts/24463893386/bench-reth-results/baseline-1/samply-profile.json.gz`, the `trie-input` worker spends about 64.9k inclusive samples in `compute_trie_changesets`, 62.5k in `InMemoryTrieCursor::seek_exact`, and 51.1k in `InMemoryTrieCursor::cursor_seek`.
- `InMemoryTrieCursor::choose_next_entry` currently clones the overlay entry before it knows whether the overlay or DB cursor will win, so exact-hit, tombstone, and miss paths all pay clone cost while only one branch actually returns a node.
- This path still sits directly on deferred trie changeset computation, which remains one of the hottest non-execution threads after the earlier overlay exact-hit work.

## Hypothesis
If we compare overlay and DB trie entries by borrowed references and only clone the winning overlay node on return, gas throughput improves by ~0.1-0.3% because deferred trie changeset computation does less `BranchNodeCompact` clone churn on every cursor merge step.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/trie/src/trie_cursor/in_memory.rs` so `choose_next_entry` snapshots only the overlay key and an optional borrowed node reference, then clones the overlay node only on the return path.
- Keep all merge ordering and tombstone semantics unchanged.
- Verify with `cargo check -p reth-trie` and `cargo test -p reth-trie trie_cursor::in_memory`.