### PR TITLE
[autoopt] 20260415-1-storage-trie-overwrite-fastpath

### DIFF
--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -111,6 +111,11 @@ pub trait DbCursorRW<T: Table> {
     /// exists in a table, and insert a new row if the specified value doesn't already exist
     fn upsert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
+    /// Database operation that overwrites the value at the current cursor position.
+    ///
+    /// Callers must ensure the cursor is already positioned at the entry to update.
+    fn put_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
+
     /// Database operation that will insert a row at a given key. If the key is already
     /// present, the operation will result in an error.
     fn insert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -364,6 +364,14 @@ impl<T: Table> DbCursorRW<T> for CursorMock {
         Ok(())
     }
 
+    fn put_current(
+        &mut self,
+        _key: <T as Table>::Key,
+        _value: &<T as Table>::Value,
+    ) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
     /// Inserts a key-value pair at the current cursor position.
     /// **Mock behavior**: Always succeeds without modifying any data.
     fn insert(

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -276,6 +276,28 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
         )
     }
 
+    fn put_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
+        let key = key.encode();
+        let value = compress_to_buf_or_ref!(self, value);
+        self.execute_with_operation_metric(
+            Operation::CursorUpsert,
+            Some(value.unwrap_or(&self.buf).len()),
+            |this| {
+                this.inner
+                    .put(key.as_ref(), value.unwrap_or(&this.buf), WriteFlags::CURRENT)
+                    .map_err(|e| {
+                        DatabaseWriteError {
+                            info: e.into(),
+                            operation: DatabaseWriteOperation::CursorUpsert,
+                            table_name: T::NAME,
+                            key: key.into_vec(),
+                        }
+                        .into()
+                    })
+            },
+        )
+    }
+
     fn insert(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = compress_to_buf_or_ref!(self, value);

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -291,17 +291,22 @@ where
         {
             num_entries += 1;
             let nibbles = A::StorageSubKey::from(*nibbles);
-            // Delete the old entry if it exists.
-            if self
-                .cursor
-                .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
-                .as_ref()
-                .is_some_and(|e| *e.nibbles() == nibbles)
-            {
-                self.cursor.delete_current()?;
+            let existing = self.cursor.seek_by_key_subkey(self.hashed_address, nibbles.clone())?;
+
+            if let Some(existing) = existing.as_ref().filter(|entry| *entry.nibbles() == nibbles) {
+                match maybe_updated {
+                    Some(node) if existing.node() == node => continue,
+                    Some(node) => {
+                        self.cursor.put_current(
+                            self.hashed_address,
+                            &A::StorageValue::new(nibbles, node.clone()),
+                        )?;
+                    }
+                    None => self.cursor.delete_current()?,
+                }
+                continue;
             }
 
-            // There is an updated version of this node, insert new entry.
             if let Some(node) = maybe_updated {
                 self.cursor
                     .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
@@ -439,6 +444,54 @@ mod tests {
             let trie_factory = DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref());
             let mut cursor = trie_factory.storage_trie_cursor(hashed_address).unwrap();
             assert_eq!(cursor.seek(key.into()).unwrap().unwrap().1, value);
+        });
+    }
+
+    #[test]
+    fn write_storage_trie_updates_replaces_exact_matches_in_place() {
+        use reth_storage_api::StorageSettingsCache;
+
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::random();
+        let key = Nibbles::from_nibbles([0x2, 0x3]);
+
+        let original = BranchNodeCompact::new(0b0011, 0b0001, 0, vec![], None);
+        let updated = BranchNodeCompact::new(0b0111, 0b0011, 0, vec![], None);
+
+        crate::with_adapter!(provider, |A| {
+            let mut raw = provider
+                .tx_ref()
+                .cursor_dup_write::<<A as TrieTableAdapter>::StorageTrieTable>()
+                .unwrap();
+            raw.upsert(
+                hashed_address,
+                &<<A as TrieKeyAdapter>::StorageValue as StorageTrieEntryLike>::new(
+                    <A as TrieKeyAdapter>::StorageSubKey::from(key),
+                    original.clone(),
+                ),
+            )
+            .unwrap();
+
+            let trie_factory = DatabaseTrieCursorFactory::<_, A>::new(provider.tx_ref());
+            let mut cursor = trie_factory.storage_trie_cursor(hashed_address).unwrap();
+            let updates = StorageTrieUpdatesSorted {
+                is_deleted: false,
+                storage_nodes: vec![(key, Some(updated.clone()))],
+            };
+            cursor.write_storage_trie_updates_sorted(&updates).unwrap();
+
+            let entries = provider
+                .tx_ref()
+                .cursor_dup_read::<<A as TrieTableAdapter>::StorageTrieTable>()
+                .unwrap()
+                .walk_dup(Some(hashed_address), None)
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].1.node(), &updated);
         });
     }
 }


### PR DESCRIPTION
# Overwrite exact storage-trie nodes in place
## Evidence
- `/home/ubuntu/autoopt/artifacts/24463893386/bench-reth-results/summary.json` still shows persistence wait dominating end-to-end latency at about 29.46 ms mean per block.
- In `/home/ubuntu/autoopt/artifacts/24463893386/bench-reth-results/baseline-1/samply-profile.json.gz`, the persistence thread keeps about 75k inclusive samples in `DatabaseStorageTrieCursor::write_storage_trie_updates_sorted`.
- The current storage-trie writer still does a full `delete_current` plus `upsert` cycle for exact dupsort matches, and it also rewrites exact matches even when the new `BranchNodeCompact` is identical to the existing one.

## Hypothesis
If we overwrite exact storage-trie dupsort entries in place and skip identical rewrites, gas throughput improves by ~0.2-0.6% because the persistence thread does less MDBX mutation work while flushing trie updates.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Add a `put_current` cursor operation to the MDBX-backed write cursor API.
- Update `crates/trie/db/src/trie_cursor.rs` so exact storage-trie matches either skip identical nodes, replace the current dupsort entry in place, or delete it only when the update removes the node.
- Verify with `cargo check -p reth-db-api -p reth-db -p reth-trie-db` and `cargo test -p reth-trie-db write_storage_trie_updates_replaces_exact_matches_in_place`.