### PR TITLE
[autoopt] 20260415-20-sparse-pending-roots

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -640,9 +640,14 @@ where
     /// we trigger state root computation on a rayon pool.
     fn compute_drained_storage_roots(&mut self) {
         let addresses_to_compute_roots: Vec<_> = self
-            .storage_updates
-            .iter()
-            .filter_map(|(address, updates)| updates.is_empty().then_some(*address))
+            .pending_account_updates
+            .keys()
+            .filter_map(|address| {
+                self.storage_updates
+                    .get(address)
+                    .is_some_and(|updates| updates.is_empty())
+                    .then_some(*address)
+            })
             .collect();
 
         struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);


### PR DESCRIPTION
# Compute drained storage roots only for pending accounts
## Evidence
- `bench-reth-results/summary.json` for artifact `24463893386` shows sparse-trie wait still averaging about 0.44 ms per block and about 2.07 ms at p95, so there is still measurable headroom in the cache-update side of payload validation.
- The baseline-1 samply profile attributes about 21.2k inclusive samples in the `sparse-trie` worker to `SparseTrieCacheTask::promote_pending_account_updates`, which is the phase that waits for storage roots before converting pending account touches into account-leaf updates.
- `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs` computed roots for every drained storage trie in `storage_updates`, even when the corresponding account no longer existed in `pending_account_updates` and no promotion work was waiting on that root.

## Hypothesis
If we compute drained storage roots only for accounts that are still pending promotion, gas throughput improves by ~0.1-0.3% because the sparse-trie worker avoids rescanning and hashing drained storage tries that no longer block any account update.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs` so `compute_drained_storage_roots` scopes its candidate set to `pending_account_updates` instead of every empty entry in `storage_updates`.
- Keep promotion semantics unchanged: only drained storage tries that still gate an account update should be hashed.
- Verify with `cargo check -p reth-engine-tree` and `cargo test -p reth-engine-tree sparse_trie --lib`.