### PR TITLE
[autoopt] 20260415-22-sparse-leaf-lookup-segments

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1312,14 +1312,14 @@ impl ArenaParallelSparseTrie {
             match &arena[current] {
                 ArenaSparseNode::EmptyRoot | ArenaSparseNode::TakenSubtrie => return None,
                 ArenaSparseNode::Leaf { key, value, .. } => {
-                    let remaining = full_path.slice(path_offset..);
-                    return (remaining == *key).then_some(value);
+                    return Self::path_matches_remaining(full_path, path_offset, key)
+                        .then_some(value);
                 }
                 ArenaSparseNode::Branch(b) => {
                     let short_key = &b.short_key;
                     let logical_end = path_offset + short_key.len();
                     if full_path.len() <= logical_end ||
-                        full_path.slice(path_offset..logical_end) != *short_key
+                        !Self::path_matches_segment(full_path, path_offset, short_key)
                     {
                         return None;
                     }
@@ -1362,8 +1362,7 @@ impl ArenaParallelSparseTrie {
                     return Ok(LeafLookup::NonExistent);
                 }
                 ArenaSparseNode::Leaf { key, value, .. } => {
-                    let remaining = full_path.slice(path_offset..);
-                    if remaining != *key {
+                    if !Self::path_matches_remaining(full_path, path_offset, key) {
                         return Ok(LeafLookup::NonExistent);
                     }
                     if let Some(expected) = expected_value &&
@@ -1385,7 +1384,7 @@ impl ArenaParallelSparseTrie {
                         return Ok(LeafLookup::NonExistent);
                     }
 
-                    if full_path.slice(path_offset..logical_end) != *short_key {
+                    if !Self::path_matches_segment(full_path, path_offset, short_key) {
                         return Ok(LeafLookup::NonExistent);
                     }
 
@@ -1420,6 +1419,22 @@ impl ArenaParallelSparseTrie {
                 }
             }
         }
+    }
+
+    fn path_matches_segment(full_path: &Nibbles, path_offset: usize, segment: &Nibbles) -> bool {
+        segment
+            .iter()
+            .enumerate()
+            .all(|(offset, nibble)| full_path.get_unchecked(path_offset + offset) == nibble)
+    }
+
+    fn path_matches_remaining(
+        full_path: &Nibbles,
+        path_offset: usize,
+        remaining: &Nibbles,
+    ) -> bool {
+        full_path.len() == path_offset + remaining.len() &&
+            Self::path_matches_segment(full_path, path_offset, remaining)
     }
 
     /// Encodes a leaf node's RLP and pushes it onto `rlp_node_buf`. If the leaf is already


### PR DESCRIPTION
# Compare sparse leaf lookup segments in place
## Evidence
- The baseline-1 samply profile for artifact `24463893386` still shows the `sparse-trie` worker spending about 3.6k inclusive samples in `ArenaParallelSparseTrie::get_leaf_value_in_arena`, alongside larger `SpecArrayEq` and nibble-size buckets that point to repeated path comparisons.
- `crates/trie/sparse/src/arena/mod.rs` used `Nibbles::slice` to materialize temporary suffixes for both branch short-key checks and exact leaf-key checks in `get_leaf_value_in_arena` and `find_leaf_in_arena`.
- This is distinct from the earlier regressing `ArenaCursor::seek` segment experiment: it stays in the immutable leaf-lookup helpers that are used after the trie has already been positioned.

## Hypothesis
If sparse leaf lookups compare the relevant segment of `full_path` in place instead of constructing temporary nibble slices first, gas throughput improves by ~0.1-0.3% because repeated leaf and branch lookups do less nibble copying on the sparse-trie worker.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/sparse/src/arena/mod.rs` to compare leaf keys and branch short keys directly against `full_path` offsets via small local helpers.
- Leave cursor traversal and trie mutation logic unchanged.
- Verify with `cargo check -p reth-trie-sparse` and `cargo test -p reth-trie-sparse --lib`.