### PR TITLE
[autoopt] 20260415-21-proof-branch-skip-shortcircuit

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -875,21 +875,20 @@ where
                 child_path.push_unchecked(nibble);
                 if !self.prefix_set.contains(&child_path) {
                     num_unmatched += 1;
+                    if num_unmatched > 1 {
+                        return false;
+                    }
                 }
             }
         }
 
-        if num_unmatched <= 1 {
-            trace!(
-                target: TRACE_TARGET,
-                ?cached_path,
-                ?num_unmatched,
-                "Skipping cached branch: all but <=1 children match prefix set, branch may collapse",
-            );
-            true
-        } else {
-            false
-        }
+        trace!(
+            target: TRACE_TARGET,
+            ?cached_path,
+            ?num_unmatched,
+            "Skipping cached branch: all but <=1 children match prefix set, branch may collapse",
+        );
+        true
     }
 
     /// Attempts to pop off the top branch of the `cached_branch_stack`, returning


### PR DESCRIPTION
# Stop cached-branch skip scans after the second miss
## Evidence
- In the baseline-1 samply profile from artifact `24463893386`, proof-v2 work is still substantial: about 533k inclusive samples in `ProofCalculator::proof_subtrie`, about 365k in `next_uncached_key_range`, and about 184k in `trie_cursor_seek`.
- The same profile still samples `ProofCalculator::should_skip_cached_branch` on this path, and that helper sits directly under cached-branch seek decisions during proof construction.
- `crates/trie/trie/src/proof_v2/mod.rs` only needs to know whether more than one child falls outside the prefix set, but `should_skip_cached_branch` kept scanning every remaining child nibble even after the second miss made the answer definitively `false`.

## Hypothesis
If `should_skip_cached_branch` returns immediately once it sees a second unmatched child, gas throughput improves by ~0.1-0.2% because proof-v2 cached-branch seeks stop doing unnecessary prefix-set probes on branches that are already known not to collapse.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/trie/src/proof_v2/mod.rs` so `should_skip_cached_branch` short-circuits as soon as `num_unmatched > 1`.
- Preserve the existing behavior for branches that still qualify for skipping and keep the trace only on the true path.
- Verify with `cargo check -p reth-trie` and `cargo test -p reth-trie proof_v2 --lib`.