### PR TITLE
fix(rpc): restore Osaka gas cap for eth_createAccessList

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -20,6 +20,7 @@ use reth_node_core::{
 };
 use reth_node_ethereum::EthereumNode;
 use reth_payload_primitives::BuiltPayload;
+use reth_primitives_traits::constants::MAX_TX_GAS_LIMIT_OSAKA;
 use reth_rpc_api::servers::AdminApiServer;
 use reth_tasks::Runtime;
 use std::{
@@ -335,6 +336,61 @@ async fn test_eth_config() -> eyre::Result<()> {
     assert_eq!(config.last.unwrap().activation_time, osaka_timestamp);
     assert_eq!(config.current.activation_time, prague_timestamp);
     assert_eq!(config.next.unwrap().activation_time, osaka_timestamp);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_create_access_list_respects_osaka_tx_gas_cap() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .osaka_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let signer = wallet.wallet_gen().swap_remove(0);
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(signer.clone()))
+        .connect_http(node.rpc_url());
+
+    let latest_block = provider.get_block_by_number(0_u64.into()).await?.unwrap();
+    let gas_limit = MAX_TX_GAS_LIMIT_OSAKA + 1;
+
+    assert!(gas_limit > MAX_TX_GAS_LIMIT_OSAKA);
+    assert!(gas_limit < latest_block.header.gas_limit);
+
+    let request = GasWaster::deploy_builder(&provider, U256::ZERO)
+        .from(signer.address())
+        .into_transaction_request();
+
+    let result = provider.create_access_list(&request).await?;
+
+    assert!(result.error.is_none());
+    assert!(result.gas_used > U256::ZERO);
+
+    let above_cap_request = GasWaster::deploy_builder(&provider, U256::ZERO)
+        .from(signer.address())
+        .gas(gas_limit)
+        .into_transaction_request();
+
+    let err = provider.create_access_list(&above_cap_request).await.unwrap_err().to_string();
+    assert!(
+        err.contains("intrinsic gas too high") || err.contains("cap"),
+        "unexpected error: {err}"
+    );
 
     Ok(())
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -501,16 +501,21 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // consistent with prepare_call_env and estimate_gas_with.
             evm_env.cfg_env.disable_fee_charge = true;
 
-            // Disable EIP-7825 transaction gas limit cap so that the gas limit
-            // fallback (block gas limit) is not rejected when it exceeds the
-            // per-tx cap (2^24 ≈ 16.7M post-Osaka).
-            evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+            if !request_has_gas_limit {
+                let mut gas_limit = evm_env
+                    .cfg_env
+                    .tx_gas_limit_cap
+                    .unwrap_or(u64::MAX)
+                    .min(evm_env.block_env.gas_limit());
 
-            if !request_has_gas_limit && tx_env.gas_price() > 0 {
-                let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
-                // no gas limit was provided in the request, so we need to cap the request's gas
-                // limit
-                tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit()));
+                if tx_env.gas_price() > 0 {
+                    gas_limit =
+                        gas_limit.min(this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?);
+                }
+
+                // If the request omitted `gas`, pick a default that stays valid under the
+                // current tx gas cap (e.g. EIP-7825 post-Osaka).
+                tx_env.set_gas_limit(gas_limit);
             }
 
             let mut inspector = AccessListInspector::new(initial);


### PR DESCRIPTION
Restores the Osaka tx gas cap for `eth_createAccessList`.

When `gas` is omitted, the RPC now chooses a default gas limit that stays within the current tx gas cap while still respecting the block gas limit and caller allowance. This prevents `eth_createAccessList` from accepting requests that exceed the Osaka per-tx cap.