### PR TITLE
fix(engine): include backpressure in newPayload prometheus latency

### DIFF
--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -196,6 +196,8 @@ pub enum BeaconEngineMessage<Payload: PayloadTypes> {
         payload: Payload::ExecutionData,
         /// The sender for returning payload status result.
         tx: oneshot::Sender<Result<PayloadStatus, BeaconOnNewPayloadError>>,
+        /// When this message was enqueued, used to measure backpressure wait time.
+        enqueued_at: Instant,
     },
     /// Message with new payload used by `reth_newPayload` endpoint.
     ///
@@ -288,7 +290,11 @@ where
         payload: Payload::ExecutionData,
     ) -> Result<PayloadStatus, BeaconOnNewPayloadError> {
         let (tx, rx) = oneshot::channel();
-        let _ = self.to_engine.send(BeaconEngineMessage::NewPayload { payload, tx });
+        let _ = self.to_engine.send(BeaconEngineMessage::NewPayload {
+            payload,
+            tx,
+            enqueued_at: Instant::now(),
+        });
         rx.await.map_err(|_| BeaconOnNewPayloadError::EngineUnavailable)?
     }
 

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -436,9 +436,12 @@ impl NewPayloadStatusMetrics {
         latest_forkchoice_updated_at: &mut Option<Instant>,
         result: &Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError>,
         gas_used: u64,
+        latency_override: Option<Duration>,
     ) {
         let finish = Instant::now();
-        let elapsed = finish - start;
+        // When a latency_override is provided (from enqueued_at-based timing that
+        // includes backpressure), use it instead of measuring from `start`.
+        let elapsed = latency_override.unwrap_or(finish - start);
 
         if let Some(prev_finish) = self.latest_finish_at {
             self.time_between_new_payloads.record(start - prev_finish);

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -436,12 +436,9 @@ impl NewPayloadStatusMetrics {
         latest_forkchoice_updated_at: &mut Option<Instant>,
         result: &Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError>,
         gas_used: u64,
-        latency_override: Option<Duration>,
+        latency: Duration,
     ) {
         let finish = Instant::now();
-        // When a latency_override is provided (from enqueued_at-based timing that
-        // includes backpressure), use it instead of measuring from `start`.
-        let elapsed = latency_override.unwrap_or(finish - start);
 
         if let Some(prev_finish) = self.latest_finish_at {
             self.time_between_new_payloads.record(start - prev_finish);
@@ -458,13 +455,13 @@ impl NewPayloadStatusMetrics {
                     if !outcome.already_seen {
                         self.new_payload_total_gas.record(gas_used as f64);
                         self.new_payload_total_gas_last.set(gas_used as f64);
-                        let gas_per_second = gas_used as f64 / elapsed.as_secs_f64();
+                        let gas_per_second = gas_used as f64 / latency.as_secs_f64();
                         self.new_payload_gas_per_second.record(gas_per_second);
                         self.new_payload_gas_per_second_last.set(gas_per_second);
 
-                        self.new_payload_latency.record(elapsed);
-                        self.new_payload_last.set(elapsed);
-                        self.gas_bucket.record(gas_used, elapsed);
+                        self.new_payload_latency.record(latency);
+                        self.new_payload_last.set(latency);
+                        self.gas_bucket.record(gas_used, latency);
                     }
                 }
                 PayloadStatusEnum::Syncing => self.new_payload_syncing.increment(1),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1618,6 +1618,7 @@ where
                                     &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
                                     &output,
                                     gas_used,
+                                    None,
                                 );
 
                                 let maybe_event =
@@ -1693,18 +1694,21 @@ where
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
                                 let mut output = self.on_new_payload(payload);
-                                self.metrics.engine.new_payload.update_response_metrics(
-                                    start,
-                                    &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
-                                    &output,
-                                    gas_used,
-                                );
 
                                 // Latency measures time from enqueue to completion, excluding
                                 // only the explicit persistence wait. This means backpressure
                                 // (time spent queued due to the engine being busy) is included,
                                 // reflecting real-world engine responsiveness.
-                                let latency = enqueued_at.elapsed() - explicit_persistence_wait;
+                                let latency =
+                                    enqueued_at.elapsed().saturating_sub(explicit_persistence_wait);
+
+                                self.metrics.engine.new_payload.update_response_metrics(
+                                    start,
+                                    &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
+                                    &output,
+                                    gas_used,
+                                    Some(latency),
+                                );
 
                                 let maybe_event =
                                     output.as_mut().ok().and_then(|out| out.event.take());

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1608,17 +1608,18 @@ where
                                     warn!(target: "engine::tree", ?state, elapsed=?start.elapsed(), "Failed to deliver forkchoiceUpdated response, receiver dropped (request cancelled): {err:?}");
                                 }
                             }
-                            BeaconEngineMessage::NewPayload { payload, tx } => {
+                            BeaconEngineMessage::NewPayload { payload, tx, enqueued_at } => {
                                 let start = Instant::now();
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
                                 let mut output = self.on_new_payload(payload);
+                                let latency = enqueued_at.elapsed();
                                 self.metrics.engine.new_payload.update_response_metrics(
                                     start,
                                     &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
                                     &output,
                                     gas_used,
-                                    None,
+                                    latency,
                                 );
 
                                 let maybe_event =
@@ -1707,7 +1708,7 @@ where
                                     &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
                                     &output,
                                     gas_used,
-                                    Some(latency),
+                                    latency,
                                 );
 
                                 let maybe_event =

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -682,6 +682,7 @@ async fn test_holesky_payload() {
                     sidecar: ExecutionPayloadSidecar::none(),
                 },
                 tx,
+                enqueued_at: std::time::Instant::now(),
             }
             .into(),
         ))

--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -25,6 +25,7 @@ use std::{
     future::Future,
     pin::Pin,
     task::{ready, Context, Poll},
+    time::Instant,
 };
 use tokio::sync::oneshot;
 use tracing::*;
@@ -143,7 +144,7 @@ where
             let next = ready!(this.stream.poll_next_unpin(cx));
             let item = match (next, &this.last_forkchoice_state) {
                 (
-                    Some(BeaconEngineMessage::NewPayload { payload, tx }),
+                    Some(BeaconEngineMessage::NewPayload { payload, tx, enqueued_at }),
                     Some(last_forkchoice_state),
                 ) if this.forkchoice_states_forwarded > this.frequency &&
                         // Only enter reorg state if new payload attaches to current head.
@@ -173,6 +174,7 @@ where
                             return Poll::Ready(Some(BeaconEngineMessage::NewPayload {
                                 payload,
                                 tx,
+                                enqueued_at,
                             }))
                         }
                     };
@@ -191,11 +193,12 @@ where
 
                     let queue = VecDeque::from([
                         // Current payload
-                        BeaconEngineMessage::NewPayload { payload, tx },
+                        BeaconEngineMessage::NewPayload { payload, tx, enqueued_at },
                         // Reorg payload
                         BeaconEngineMessage::NewPayload {
                             payload: T::block_to_payload(reorg_block),
                             tx: reorg_payload_tx,
+                            enqueued_at: Instant::now(),
                         },
                         // Reorg forkchoice state
                         BeaconEngineMessage::ForkchoiceUpdated {

--- a/crates/engine/util/src/skip_new_payload.rs
+++ b/crates/engine/util/src/skip_new_payload.rs
@@ -41,7 +41,7 @@ where
         loop {
             let next = ready!(this.stream.poll_next_unpin(cx));
             let item = match next {
-                Some(BeaconEngineMessage::NewPayload { payload, tx }) => {
+                Some(BeaconEngineMessage::NewPayload { payload, tx, enqueued_at }) => {
                     if this.skipped < this.threshold {
                         *this.skipped += 1;
                         tracing::warn!(
@@ -56,7 +56,7 @@ where
                         continue
                     }
                     *this.skipped = 0;
-                    Some(BeaconEngineMessage::NewPayload { payload, tx })
+                    Some(BeaconEngineMessage::NewPayload { payload, tx, enqueued_at })
                 }
                 next => next,
             };

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -413,7 +413,7 @@ mod tests {
         tokio::spawn(async move {
             while let Some(message) = from_engine.recv().await {
                 match message {
-                    BeaconEngineMessage::NewPayload { payload: _, tx } => {
+                    BeaconEngineMessage::NewPayload { payload: _, tx, .. } => {
                         tx.send(Ok(PayloadStatus::new(responses.new_payload.clone(), None)))
                             .unwrap();
                     }


### PR DESCRIPTION
Follow-up to #23541 — the prometheus `new_payload_latency` metric was still using `Instant::now()` right before `on_new_payload`, excluding backpressure. Now passes `enqueued_at`-based latency (`enqueued_at.elapsed() - explicit_persistence_wait`) to `update_response_metrics`, matching the RPC-returned timing.

Prompted by: brian