### PR TITLE
feat(rpc): expose auth HTTP transport middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9649,6 +9649,7 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "pin-project",
+ "reqwest 0.13.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",

--- a/bin/reth-bb/src/main.rs
+++ b/bin/reth-bb/src/main.rs
@@ -176,6 +176,7 @@ impl BbAddOns {
             BasicEngineApiBuilder::default(),
             BasicEngineValidatorBuilder::default(),
             Default::default(),
+            Default::default(),
         )
     }
 }

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -37,7 +37,6 @@ reth-rpc-eth-types.workspace = true
 reth-engine-local.workspace = true
 reth-engine-primitives = { workspace = true, features = ["std"] }
 reth-payload-primitives.workspace = true
-
 # ethereum
 alloy-eips.workspace = true
 alloy-network.workspace = true

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -26,9 +26,10 @@ use reth_node_builder::{
     },
     node::{FullNodeTypes, NodeTypes},
     rpc::{
-        BasicEngineApiBuilder, BasicEngineValidatorBuilder, EngineApiBuilder, EngineValidatorAddOn,
-        EngineValidatorBuilder, EthApiBuilder, EthApiCtx, Identity, PayloadValidatorBuilder,
-        RethRpcAddOns, RpcAddOns, RpcHandle,
+        BasicEngineApiBuilder, BasicEngineValidatorBuilder, Either, EngineApiBuilder,
+        EngineValidatorAddOn, EngineValidatorBuilder, EthApiBuilder, EthApiCtx, Identity,
+        PayloadValidatorBuilder, RethAuthHttpMiddleware, RethRpcAddOns, RethRpcMiddleware,
+        RpcAddOns, RpcHandle, Stack,
     },
     BuilderContext, DebugNode, Node, NodeAdapter,
 };
@@ -39,7 +40,7 @@ use reth_rpc::{
     TestingApi, ValidationApi,
 };
 use reth_rpc_api::servers::{BlockSubmissionValidationApiServer, TestingApiServer};
-use reth_rpc_builder::{config::RethRpcServerConfig, middleware::RethRpcMiddleware};
+use reth_rpc_builder::config::RethRpcServerConfig;
 use reth_rpc_eth_api::{
     helpers::{
         config::{EthConfigApiServer, EthConfigHandler},
@@ -165,17 +166,21 @@ pub struct EthereumAddOns<
     EB = BasicEngineApiBuilder<PVB>,
     EVB = BasicEngineValidatorBuilder<PVB>,
     RpcMiddleware = Identity,
+    AuthHttpMiddleware = Identity,
 > {
-    inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
+    inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>,
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
+    EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
 {
     /// Creates a new instance from the inner `RpcAddOns`.
-    pub const fn new(inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>) -> Self {
+    pub const fn new(
+        inner: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>,
+    ) -> Self {
         Self { inner }
     }
 }
@@ -199,11 +204,13 @@ where
             BasicEngineApiBuilder::default(),
             BasicEngineValidatorBuilder::default(),
             Default::default(),
+            Identity::new(),
         ))
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
+    EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
@@ -212,7 +219,7 @@ where
     pub fn with_engine_api<T>(
         self,
         engine_api_builder: T,
-    ) -> EthereumAddOns<N, EthB, PVB, T, EVB, RpcMiddleware>
+    ) -> EthereumAddOns<N, EthB, PVB, T, EVB, RpcMiddleware, AuthHttpMiddleware>
     where
         T: Send,
     {
@@ -224,7 +231,7 @@ where
     pub fn with_payload_validator<V, T>(
         self,
         payload_validator_builder: T,
-    ) -> EthereumAddOns<N, EthB, T, EB, EVB, RpcMiddleware> {
+    ) -> EthereumAddOns<N, EthB, T, EB, EVB, RpcMiddleware, AuthHttpMiddleware> {
         let Self { inner } = self;
         EthereumAddOns::new(inner.with_payload_validator(payload_validator_builder))
     }
@@ -233,12 +240,51 @@ where
     pub fn with_rpc_middleware<T>(
         self,
         rpc_middleware: T,
-    ) -> EthereumAddOns<N, EthB, PVB, EB, EVB, T>
+    ) -> EthereumAddOns<N, EthB, PVB, EB, EVB, T, AuthHttpMiddleware>
     where
         T: Send,
     {
         let Self { inner } = self;
         EthereumAddOns::new(inner.with_rpc_middleware(rpc_middleware))
+    }
+
+    /// Configures the HTTP transport middleware for the auth / Engine API server.
+    pub fn with_auth_http_middleware<T>(
+        self,
+        auth_http_middleware: T,
+    ) -> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, T>
+    where
+        T: Send,
+    {
+        let Self { inner } = self;
+        EthereumAddOns::new(inner.with_auth_http_middleware(auth_http_middleware))
+    }
+
+    /// Stacks an additional HTTP transport middleware layer for the auth / Engine API server.
+    pub fn layer_auth_http_middleware<T>(
+        self,
+        layer: T,
+    ) -> EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, Stack<AuthHttpMiddleware, T>> {
+        let Self { inner } = self;
+        EthereumAddOns::new(inner.layer_auth_http_middleware(layer))
+    }
+
+    /// Conditionally stacks an HTTP transport middleware layer for the auth / Engine API server.
+    #[expect(clippy::type_complexity)]
+    pub fn option_layer_auth_http_middleware<T>(
+        self,
+        layer: Option<T>,
+    ) -> EthereumAddOns<
+        N,
+        EthB,
+        PVB,
+        EB,
+        EVB,
+        RpcMiddleware,
+        Stack<AuthHttpMiddleware, Either<T, Identity>>,
+    > {
+        let Self { inner } = self;
+        EthereumAddOns::new(inner.option_layer_auth_http_middleware(layer))
     }
 
     /// Sets the tokio runtime for the RPC servers.
@@ -250,8 +296,8 @@ where
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
-    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> NodeAddOns<N>
+    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
@@ -268,6 +314,7 @@ where
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
     RpcMiddleware: RethRpcMiddleware,
+    AuthHttpMiddleware: RethAuthHttpMiddleware<Identity>,
 {
     type Handle = RpcHandle<N, EthB::EthApi>;
 
@@ -323,8 +370,8 @@ where
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RethRpcAddOns<N>
-    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> RethRpcAddOns<N>
+    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
@@ -341,6 +388,7 @@ where
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
     RpcMiddleware: RethRpcMiddleware,
+    AuthHttpMiddleware: RethAuthHttpMiddleware<Identity>,
 {
     type EthApi = EthB::EthApi;
 
@@ -349,8 +397,8 @@ where
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
-    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> EngineValidatorAddOn<N>
+    for EthereumAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
@@ -367,6 +415,7 @@ where
     EthApiError: FromEvmError<N::Evm>,
     EvmFactoryFor<N::Evm>: EvmFactory<Tx = TxEnv>,
     RpcMiddleware: Send,
+    AuthHttpMiddleware: Send,
 {
     type ValidatorBuilder = EVB;
 

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -1,9 +1,15 @@
 //! Builder support for rpc components.
 
-pub use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceBuilder};
+pub use jsonrpsee::{
+    core::middleware::layer::Either,
+    server::middleware::rpc::{RpcService, RpcServiceBuilder},
+};
 use reth_engine_tree::tree::WaitForCaches;
 pub use reth_engine_tree::tree::{BasicEngineValidator, EngineValidator};
-pub use reth_rpc_builder::{middleware::RethRpcMiddleware, Identity, Stack};
+pub use reth_rpc_builder::{
+    middleware::{RethAuthHttpMiddleware, RethRpcMiddleware},
+    Identity, Stack,
+};
 pub use reth_trie_db::ChangesetCache;
 
 use crate::{
@@ -12,7 +18,7 @@ use crate::{
 };
 use alloy_rpc_types::engine::ClientVersionV1;
 use alloy_rpc_types_engine::ExecutionData;
-use jsonrpsee::{core::middleware::layer::Either, RpcModule};
+use jsonrpsee::RpcModule;
 use parking_lot::Mutex;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
@@ -517,6 +523,7 @@ pub struct RpcAddOns<
     EB = BasicEngineApiBuilder<PVB>,
     EVB = BasicEngineValidatorBuilder<PVB>,
     RpcMiddleware = Identity,
+    AuthHttpMiddleware = Identity,
 > {
     /// Additional RPC add-ons.
     pub hooks: RpcHooks<Node, EthB::EthApi>,
@@ -533,12 +540,17 @@ pub struct RpcAddOns<
     /// This middleware is applied to all RPC requests across all transports (HTTP, WS, IPC).
     /// See [`RpcAddOns::with_rpc_middleware`] for more details.
     rpc_middleware: RpcMiddleware,
+    /// Configurable HTTP transport middleware for the auth server.
+    ///
+    /// This middleware is applied after JWT authentication and before JSON-RPC parsing on the
+    /// auth / Engine API server, giving access to the raw HTTP request.
+    auth_http_middleware: AuthHttpMiddleware,
     /// Optional custom tokio runtime for the RPC server.
     tokio_runtime: Option<tokio::runtime::Handle>,
 }
 
-impl<Node, EthB, PVB, EB, EVB, RpcMiddleware> Debug
-    for RpcAddOns<Node, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<Node, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> Debug
+    for RpcAddOns<Node, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     Node: FullNodeComponents,
     EthB: EthApiBuilder<Node>,
@@ -558,7 +570,8 @@ where
     }
 }
 
-impl<Node, EthB, PVB, EB, EVB, RpcMiddleware> RpcAddOns<Node, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<Node, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
+    RpcAddOns<Node, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     Node: FullNodeComponents,
     EthB: EthApiBuilder<Node>,
@@ -570,6 +583,7 @@ where
         engine_api_builder: EB,
         engine_validator_builder: EVB,
         rpc_middleware: RpcMiddleware,
+        auth_http_middleware: AuthHttpMiddleware,
     ) -> Self {
         Self {
             hooks: RpcHooks::default(),
@@ -578,6 +592,7 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime: None,
         }
     }
@@ -586,13 +601,14 @@ where
     pub fn with_engine_api<T>(
         self,
         engine_api_builder: T,
-    ) -> RpcAddOns<Node, EthB, PVB, T, EVB, RpcMiddleware> {
+    ) -> RpcAddOns<Node, EthB, PVB, T, EVB, RpcMiddleware, AuthHttpMiddleware> {
         let Self {
             hooks,
             eth_api_builder,
             payload_validator_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
             ..
         } = self;
@@ -603,6 +619,7 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         }
     }
@@ -611,13 +628,14 @@ where
     pub fn with_payload_validator<T>(
         self,
         payload_validator_builder: T,
-    ) -> RpcAddOns<Node, EthB, T, EB, EVB, RpcMiddleware> {
+    ) -> RpcAddOns<Node, EthB, T, EB, EVB, RpcMiddleware, AuthHttpMiddleware> {
         let Self {
             hooks,
             eth_api_builder,
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
             ..
         } = self;
@@ -628,6 +646,7 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         }
     }
@@ -636,13 +655,14 @@ where
     pub fn with_engine_validator<T>(
         self,
         engine_validator_builder: T,
-    ) -> RpcAddOns<Node, EthB, PVB, EB, T, RpcMiddleware> {
+    ) -> RpcAddOns<Node, EthB, PVB, EB, T, RpcMiddleware, AuthHttpMiddleware> {
         let Self {
             hooks,
             eth_api_builder,
             payload_validator_builder,
             engine_api_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
             ..
         } = self;
@@ -653,6 +673,7 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         }
     }
@@ -698,13 +719,14 @@ where
     pub fn with_rpc_middleware<T>(
         self,
         rpc_middleware: T,
-    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, T> {
+    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, T, AuthHttpMiddleware> {
         let Self {
             hooks,
             eth_api_builder,
             payload_validator_builder,
             engine_api_builder,
             engine_validator_builder,
+            auth_http_middleware,
             tokio_runtime,
             ..
         } = self;
@@ -715,8 +737,85 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         }
+    }
+
+    /// Configures the HTTP transport middleware for the auth / Engine API server.
+    ///
+    /// This middleware is applied after JWT authentication and before JSON-RPC parsing,
+    /// giving access to the raw HTTP request (headers, body, etc.).
+    pub fn with_auth_http_middleware<T>(
+        self,
+        auth_http_middleware: T,
+    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, RpcMiddleware, T> {
+        let Self {
+            hooks,
+            eth_api_builder,
+            payload_validator_builder,
+            engine_api_builder,
+            engine_validator_builder,
+            rpc_middleware,
+            tokio_runtime,
+            ..
+        } = self;
+        RpcAddOns {
+            hooks,
+            eth_api_builder,
+            payload_validator_builder,
+            engine_api_builder,
+            engine_validator_builder,
+            rpc_middleware,
+            auth_http_middleware,
+            tokio_runtime,
+        }
+    }
+
+    /// Stacks an additional HTTP transport middleware layer for the auth / Engine API server.
+    pub fn layer_auth_http_middleware<T>(
+        self,
+        layer: T,
+    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, RpcMiddleware, Stack<AuthHttpMiddleware, T>> {
+        let Self {
+            hooks,
+            eth_api_builder,
+            payload_validator_builder,
+            engine_api_builder,
+            engine_validator_builder,
+            rpc_middleware,
+            auth_http_middleware,
+            tokio_runtime,
+        } = self;
+        let auth_http_middleware = Stack::new(auth_http_middleware, layer);
+        RpcAddOns {
+            hooks,
+            eth_api_builder,
+            payload_validator_builder,
+            engine_api_builder,
+            engine_validator_builder,
+            rpc_middleware,
+            auth_http_middleware,
+            tokio_runtime,
+        }
+    }
+
+    /// Conditionally stacks an HTTP transport middleware layer for the auth / Engine API server.
+    #[expect(clippy::type_complexity)]
+    pub fn option_layer_auth_http_middleware<T>(
+        self,
+        layer: Option<T>,
+    ) -> RpcAddOns<
+        Node,
+        EthB,
+        PVB,
+        EB,
+        EVB,
+        RpcMiddleware,
+        Stack<AuthHttpMiddleware, Either<T, Identity>>,
+    > {
+        let layer = layer.map(Either::Left).unwrap_or(Either::Right(Identity::new()));
+        self.layer_auth_http_middleware(layer)
     }
 
     /// Sets the tokio runtime for the RPC servers.
@@ -730,6 +829,7 @@ where
             engine_validator_builder,
             engine_api_builder,
             rpc_middleware,
+            auth_http_middleware,
             ..
         } = self;
         Self {
@@ -739,6 +839,7 @@ where
             engine_validator_builder,
             engine_api_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         }
     }
@@ -747,7 +848,7 @@ where
     pub fn layer_rpc_middleware<T>(
         self,
         layer: T,
-    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, Stack<RpcMiddleware, T>> {
+    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, Stack<RpcMiddleware, T>, AuthHttpMiddleware> {
         let Self {
             hooks,
             eth_api_builder,
@@ -755,6 +856,7 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         } = self;
         let rpc_middleware = Stack::new(rpc_middleware, layer);
@@ -765,6 +867,7 @@ where
             engine_api_builder,
             engine_validator_builder,
             rpc_middleware,
+            auth_http_middleware,
             tokio_runtime,
         }
     }
@@ -774,7 +877,15 @@ where
     pub fn option_layer_rpc_middleware<T>(
         self,
         layer: Option<T>,
-    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, Stack<RpcMiddleware, Either<T, Identity>>> {
+    ) -> RpcAddOns<
+        Node,
+        EthB,
+        PVB,
+        EB,
+        EVB,
+        Stack<RpcMiddleware, Either<T, Identity>>,
+        AuthHttpMiddleware,
+    > {
         let layer = layer.map(Either::Left).unwrap_or(Either::Right(Identity::new()));
         self.layer_rpc_middleware(layer)
     }
@@ -800,7 +911,8 @@ where
     }
 }
 
-impl<Node, EthB, EV, EB, Engine> Default for RpcAddOns<Node, EthB, EV, EB, Engine, Identity>
+impl<Node, EthB, EV, EB, Engine> Default
+    for RpcAddOns<Node, EthB, EV, EB, Engine, Identity, Identity>
 where
     Node: FullNodeComponents,
     EthB: EthApiBuilder<Node>,
@@ -815,11 +927,13 @@ where
             EB::default(),
             Engine::default(),
             Default::default(),
+            Identity::new(),
         )
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
+    RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents,
     N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
@@ -827,6 +941,7 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
+    AuthHttpMiddleware: RethAuthHttpMiddleware<Identity>,
 {
     /// Launches only the regular RPC server (HTTP/WS/IPC), without the authenticated Engine API
     /// server.
@@ -913,6 +1028,7 @@ where
         F: FnOnce(RpcModuleContainer<'_, N, EthB::EthApi>) -> eyre::Result<()>,
     {
         let rpc_middleware = self.rpc_middleware.clone();
+        let auth_http_middleware = self.auth_http_middleware.clone();
         let tokio_runtime = self.tokio_runtime.clone();
         let setup_ctx = self.setup_rpc_components(ctx, ext).await?;
         let RpcSetupContext {
@@ -933,6 +1049,8 @@ where
             .set_rpc_middleware(rpc_middleware)
             .with_tokio_runtime(tokio_runtime);
 
+        let auth_config = auth_config.with_http_middleware(auth_http_middleware);
+
         let (rpc, auth) = if disable_auth {
             // Only launch the RPC server, use a noop auth handle
             let rpc = Self::launch_rpc_server_internal(server_config, &modules).await?;
@@ -942,7 +1060,7 @@ where
             // launch servers concurrently
             let (rpc, auth) = futures::future::try_join(
                 Self::launch_rpc_server_internal(server_config, &modules),
-                Self::launch_auth_server_internal(auth_module_clone, auth_config),
+                Self::launch_auth_server_internal(auth_config.start(auth_module_clone)),
             )
             .await?;
             (rpc, auth)
@@ -1087,10 +1205,9 @@ where
 
     /// Helper to launch the auth server
     async fn launch_auth_server_internal(
-        auth_module: AuthRpcModule,
-        auth_config: reth_rpc_builder::auth::AuthServerConfig,
+        start_fut: impl Future<Output = Result<AuthServerHandle, reth_rpc_builder::error::RpcError>>,
     ) -> eyre::Result<AuthServerHandle> {
-        auth_module.start_server(auth_config)
+        start_fut
             .await
             .map_err(Into::into)
             .inspect(|handle| {
@@ -1120,8 +1237,8 @@ where
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
-    for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> NodeAddOns<N>
+    for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents,
     <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
@@ -1130,6 +1247,7 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
+    AuthHttpMiddleware: RethAuthHttpMiddleware<Identity>,
 {
     type Handle = RpcHandle<N, EthB::EthApi>;
 
@@ -1150,8 +1268,8 @@ pub trait RethRpcAddOns<N: FullNodeComponents>:
     fn hooks_mut(&mut self) -> &mut RpcHooks<N, Self::EthApi>;
 }
 
-impl<N: FullNodeComponents, EthB, EV, EB, Engine, RpcMiddleware> RethRpcAddOns<N>
-    for RpcAddOns<N, EthB, EV, EB, Engine, RpcMiddleware>
+impl<N: FullNodeComponents, EthB, EV, EB, Engine, RpcMiddleware, AuthHttpMiddleware>
+    RethRpcAddOns<N> for RpcAddOns<N, EthB, EV, EB, Engine, RpcMiddleware, AuthHttpMiddleware>
 where
     Self: NodeAddOns<N, Handle = RpcHandle<N, EthB::EthApi>>,
     EthB: EthApiBuilder<N>,
@@ -1221,8 +1339,8 @@ pub trait EngineValidatorAddOn<Node: FullNodeComponents>: Send {
     fn engine_validator_builder(&self) -> Self::ValidatorBuilder;
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
-    for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> EngineValidatorAddOn<N>
+    for RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
@@ -1230,6 +1348,7 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: Send,
+    AuthHttpMiddleware: Send,
 {
     type ValidatorBuilder = EVB;
 

--- a/crates/rpc/rpc-builder/Cargo.toml
+++ b/crates/rpc/rpc-builder/Cargo.toml
@@ -77,3 +77,4 @@ alloy-rpc-types-engine.workspace = true
 
 serde_json.workspace = true
 clap = { workspace = true, features = ["derive"] }
+reqwest.workspace = true

--- a/crates/rpc/rpc-builder/src/auth.rs
+++ b/crates/rpc/rpc-builder/src/auth.rs
@@ -1,12 +1,12 @@
 use crate::{
     error::{RpcError, ServerKind},
-    middleware::RethRpcMiddleware,
+    middleware::{RethAuthHttpMiddleware, RethRpcMiddleware},
 };
 use http::header::AUTHORIZATION;
 use jsonrpsee::{
     core::{client::SubscriptionClientT, RegisterMethodError},
     http_client::HeaderMap,
-    server::{AlreadyStoppedError, RpcModule},
+    server::{AlreadyStoppedError, RpcModule, ServerConfig, ServerConfigBuilder},
     ws_client::RpcServiceBuilder,
     Methods,
 };
@@ -20,12 +20,11 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tower::layer::util::Identity;
 
 pub use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::server::{ServerConfig, ServerConfigBuilder};
 pub use reth_ipc::server::Builder as IpcServerBuilder;
 
 /// Server configuration for the auth server.
 #[derive(Debug)]
-pub struct AuthServerConfig<RpcMiddleware = Identity> {
+pub struct AuthServerConfig<RpcMiddleware = Identity, HttpMiddleware = Identity> {
     /// Where the server should listen.
     pub(crate) socket_addr: SocketAddr,
     /// The secret for the auth layer of the server.
@@ -38,6 +37,8 @@ pub struct AuthServerConfig<RpcMiddleware = Identity> {
     pub(crate) ipc_endpoint: Option<String>,
     /// Configurable RPC middleware
     pub(crate) rpc_middleware: RpcMiddleware,
+    /// Configurable HTTP transport middleware, applied after JWT authentication.
+    pub(crate) http_middleware: HttpMiddleware,
 }
 
 // === impl AuthServerConfig ===
@@ -48,15 +49,23 @@ impl AuthServerConfig {
         AuthServerConfigBuilder::new(secret)
     }
 }
-impl<RpcMiddleware> AuthServerConfig<RpcMiddleware> {
+impl<RpcMiddleware, HttpMiddleware> AuthServerConfig<RpcMiddleware, HttpMiddleware> {
     /// Returns the address the server will listen on.
     pub const fn address(&self) -> SocketAddr {
         self.socket_addr
     }
 
     /// Configures the rpc middleware.
-    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> AuthServerConfig<T> {
-        let Self { socket_addr, secret, server_config, ipc_server_config, ipc_endpoint, .. } = self;
+    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> AuthServerConfig<T, HttpMiddleware> {
+        let Self {
+            socket_addr,
+            secret,
+            server_config,
+            ipc_server_config,
+            ipc_endpoint,
+            http_middleware,
+            ..
+        } = self;
         AuthServerConfig {
             socket_addr,
             secret,
@@ -64,13 +73,44 @@ impl<RpcMiddleware> AuthServerConfig<RpcMiddleware> {
             ipc_server_config,
             ipc_endpoint,
             rpc_middleware,
+            http_middleware,
+        }
+    }
+
+    /// Configures the HTTP transport middleware.
+    ///
+    /// This middleware is applied after JWT authentication and before JSON-RPC parsing,
+    /// giving access to the raw HTTP request (headers, body, etc.).
+    pub fn with_http_middleware<T>(self, http_middleware: T) -> AuthServerConfig<RpcMiddleware, T> {
+        let Self {
+            socket_addr,
+            secret,
+            server_config,
+            ipc_server_config,
+            ipc_endpoint,
+            rpc_middleware,
+            ..
+        } = self;
+        AuthServerConfig {
+            socket_addr,
+            secret,
+            server_config,
+            ipc_server_config,
+            ipc_endpoint,
+            rpc_middleware,
+            http_middleware,
         }
     }
 
     /// Convenience function to start a server in one step.
+    ///
+    /// The `HttpMiddleware` type parameter configures additional HTTP transport middleware
+    /// that runs after JWT authentication. When set to `Identity` (the default), only JWT
+    /// authentication is applied.
     pub async fn start(self, module: AuthRpcModule) -> Result<AuthServerHandle, RpcError>
     where
         RpcMiddleware: RethRpcMiddleware,
+        HttpMiddleware: RethAuthHttpMiddleware<RpcMiddleware>,
     {
         let Self {
             socket_addr,
@@ -79,11 +119,13 @@ impl<RpcMiddleware> AuthServerConfig<RpcMiddleware> {
             ipc_server_config,
             ipc_endpoint,
             rpc_middleware,
+            http_middleware,
         } = self;
 
-        // Create auth middleware.
+        // Create auth middleware with JWT authentication in front of the user-provided
+        // transport middleware.
         let middleware =
-            tower::ServiceBuilder::new().layer(AuthLayer::new(JwtAuthValidator::new(secret)));
+            tower::ServiceBuilder::new().layer(AuthHttpLayer::new(secret, http_middleware));
 
         let rpc_middleware = RpcServiceBuilder::default().layer(rpc_middleware);
 
@@ -117,15 +159,47 @@ impl<RpcMiddleware> AuthServerConfig<RpcMiddleware> {
     }
 }
 
+/// A combined tower layer that applies JWT authentication before custom HTTP middleware.
+///
+/// This composes `AuthLayer<JwtAuthValidator>` around a user-provided `HttpMiddleware` into a
+/// single `tower::Layer`. Requests first pass through JWT validation and only authenticated
+/// requests are forwarded into the custom middleware.
+struct AuthHttpLayer<HttpMiddleware> {
+    auth_layer: AuthLayer<JwtAuthValidator>,
+    http_middleware: HttpMiddleware,
+}
+
+impl<HttpMiddleware> AuthHttpLayer<HttpMiddleware> {
+    const fn new(secret: JwtSecret, http_middleware: HttpMiddleware) -> Self {
+        Self { auth_layer: AuthLayer::new(JwtAuthValidator::new(secret)), http_middleware }
+    }
+}
+
+impl<S, HttpMiddleware> tower::Layer<S> for AuthHttpLayer<HttpMiddleware>
+where
+    HttpMiddleware: tower::Layer<S> + Clone,
+    AuthLayer<JwtAuthValidator>: tower::Layer<<HttpMiddleware as tower::Layer<S>>::Service>,
+{
+    type Service = <AuthLayer<JwtAuthValidator> as tower::Layer<
+        <HttpMiddleware as tower::Layer<S>>::Service,
+    >>::Service;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        let http_service = self.http_middleware.layer(inner);
+        self.auth_layer.layer(http_service)
+    }
+}
+
 /// Builder type for configuring an `AuthServerConfig`.
 #[derive(Debug)]
-pub struct AuthServerConfigBuilder<RpcMiddleware = Identity> {
+pub struct AuthServerConfigBuilder<RpcMiddleware = Identity, HttpMiddleware = Identity> {
     socket_addr: Option<SocketAddr>,
     secret: JwtSecret,
     server_config: Option<ServerConfigBuilder>,
     ipc_server_config: Option<IpcServerBuilder<Identity, Identity>>,
     ipc_endpoint: Option<String>,
     rpc_middleware: RpcMiddleware,
+    http_middleware: HttpMiddleware,
 }
 
 // === impl AuthServerConfigBuilder ===
@@ -140,14 +214,26 @@ impl AuthServerConfigBuilder {
             ipc_server_config: None,
             ipc_endpoint: None,
             rpc_middleware: Identity::new(),
+            http_middleware: Identity::new(),
         }
     }
 }
 
-impl<RpcMiddleware> AuthServerConfigBuilder<RpcMiddleware> {
+impl<RpcMiddleware, HttpMiddleware> AuthServerConfigBuilder<RpcMiddleware, HttpMiddleware> {
     /// Configures the rpc middleware.
-    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> AuthServerConfigBuilder<T> {
-        let Self { socket_addr, secret, server_config, ipc_server_config, ipc_endpoint, .. } = self;
+    pub fn with_rpc_middleware<T>(
+        self,
+        rpc_middleware: T,
+    ) -> AuthServerConfigBuilder<T, HttpMiddleware> {
+        let Self {
+            socket_addr,
+            secret,
+            server_config,
+            ipc_server_config,
+            ipc_endpoint,
+            http_middleware,
+            ..
+        } = self;
         AuthServerConfigBuilder {
             socket_addr,
             secret,
@@ -155,6 +241,35 @@ impl<RpcMiddleware> AuthServerConfigBuilder<RpcMiddleware> {
             ipc_server_config,
             ipc_endpoint,
             rpc_middleware,
+            http_middleware,
+        }
+    }
+
+    /// Configures the HTTP transport middleware.
+    ///
+    /// This middleware is applied after JWT authentication and before JSON-RPC parsing,
+    /// giving access to the raw HTTP request (headers, body, etc.).
+    pub fn with_http_middleware<T>(
+        self,
+        http_middleware: T,
+    ) -> AuthServerConfigBuilder<RpcMiddleware, T> {
+        let Self {
+            socket_addr,
+            secret,
+            server_config,
+            ipc_server_config,
+            ipc_endpoint,
+            rpc_middleware,
+            ..
+        } = self;
+        AuthServerConfigBuilder {
+            socket_addr,
+            secret,
+            server_config,
+            ipc_server_config,
+            ipc_endpoint,
+            rpc_middleware,
+            http_middleware,
         }
     }
 
@@ -200,7 +315,7 @@ impl<RpcMiddleware> AuthServerConfigBuilder<RpcMiddleware> {
     }
 
     /// Build the `AuthServerConfig`.
-    pub fn build(self) -> AuthServerConfig<RpcMiddleware> {
+    pub fn build(self) -> AuthServerConfig<RpcMiddleware, HttpMiddleware> {
         AuthServerConfig {
             socket_addr: self.socket_addr.unwrap_or_else(|| {
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), constants::DEFAULT_AUTH_PORT)
@@ -233,6 +348,7 @@ impl<RpcMiddleware> AuthServerConfigBuilder<RpcMiddleware> {
             }),
             ipc_endpoint: self.ipc_endpoint,
             rpc_middleware: self.rpc_middleware,
+            http_middleware: self.http_middleware,
         }
     }
 }
@@ -289,10 +405,14 @@ impl AuthRpcModule {
     }
 
     /// Convenience function for starting a server
-    pub async fn start_server(
+    pub async fn start_server<RpcMiddleware, HttpMiddleware>(
         self,
-        config: AuthServerConfig,
-    ) -> Result<AuthServerHandle, RpcError> {
+        config: AuthServerConfig<RpcMiddleware, HttpMiddleware>,
+    ) -> Result<AuthServerHandle, RpcError>
+    where
+        RpcMiddleware: RethRpcMiddleware,
+        HttpMiddleware: RethAuthHttpMiddleware<RpcMiddleware>,
+    {
         config.start(self).await
     }
 }
@@ -397,7 +517,7 @@ impl AuthServerHandle {
                     .build(ipc_endpoint)
                     .await
                     .expect("Failed to create ipc client"),
-            )
+            );
         }
         None
     }

--- a/crates/rpc/rpc-builder/src/middleware.rs
+++ b/crates/rpc/rpc-builder/src/middleware.rs
@@ -1,5 +1,10 @@
-use jsonrpsee::server::middleware::rpc::RpcService;
-use tower::Layer;
+use jsonrpsee::server::{
+    middleware::rpc::RpcService, HttpRequest, HttpResponse, TowerServiceNoHttp,
+};
+use tower::{
+    layer::util::{Identity, Stack},
+    Layer,
+};
 
 /// A Helper alias trait for the RPC middleware supported by the server.
 pub trait RethRpcMiddleware:
@@ -30,6 +35,42 @@ impl<T> RethRpcMiddleware for T where
                          + Sync
                          + Clone
                          + 'static,
+        > + Clone
+        + Send
+        + 'static
+{
+}
+
+/// Inner HTTP transport service type for auth-server middleware.
+pub type AuthHttpService<RM> = TowerServiceNoHttp<Stack<RM, Identity>>;
+
+/// Helper alias trait for auth-server HTTP transport middleware layers.
+pub trait RethAuthHttpMiddleware<RM>:
+    tower::Layer<
+        AuthHttpService<RM>,
+        Service: tower::Service<
+            HttpRequest,
+            Response = HttpResponse,
+            Error = tower::BoxError,
+            Future: Send,
+        > + Send
+                     + Clone,
+    > + Clone
+    + Send
+    + 'static
+{
+}
+
+impl<T, RM> RethAuthHttpMiddleware<RM> for T where
+    T: tower::Layer<
+            AuthHttpService<RM>,
+            Service: tower::Service<
+                HttpRequest,
+                Response = HttpResponse,
+                Error = tower::BoxError,
+                Future: Send,
+            > + Send
+                         + Clone,
         > + Clone
         + Send
         + 'static

--- a/crates/rpc/rpc-builder/tests/it/auth.rs
+++ b/crates/rpc/rpc-builder/tests/it/auth.rs
@@ -1,16 +1,90 @@
 //! Auth server tests
 
-use crate::utils::launch_auth;
+use crate::utils::{launch_auth, launch_auth_with_config, test_address};
 use alloy_primitives::U64;
 use alloy_rpc_types_engine::{
     ExecutionPayloadInputV2, ExecutionPayloadV1, ForkchoiceState, PayloadId,
 };
-use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
+use http::header::{AUTHORIZATION, CONTENT_TYPE};
+use jsonrpsee::{
+    core::client::{ClientT, SubscriptionClientT},
+    server::{HttpRequest, HttpResponse},
+};
 use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_ethereum_primitives::{Block, TransactionSigned};
 use reth_primitives_traits::block::Block as _;
 use reth_rpc_api::clients::EngineApiClient;
-use reth_rpc_layer::JwtSecret;
+use reth_rpc_builder::auth::AuthServerConfig;
+use reth_rpc_layer::{secret_to_bearer_header, JwtSecret};
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+#[derive(Clone, Default)]
+struct CountingAuthHttpLayer {
+    count: Arc<AtomicUsize>,
+    content_types: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+impl CountingAuthHttpLayer {
+    fn count(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    fn seen_content_types(&self) -> Vec<Option<String>> {
+        self.content_types.lock().unwrap().clone()
+    }
+}
+
+impl<S> Layer<S> for CountingAuthHttpLayer {
+    type Service = CountingAuthHttpService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CountingAuthHttpService {
+            inner,
+            count: self.count.clone(),
+            content_types: self.content_types.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CountingAuthHttpService<S> {
+    inner: S,
+    count: Arc<AtomicUsize>,
+    content_types: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+impl<S> Service<HttpRequest> for CountingAuthHttpService<S>
+where
+    S: Service<HttpRequest, Response = HttpResponse, Error = tower::BoxError> + Send + Clone,
+    S::Future: Send + 'static,
+{
+    type Response = HttpResponse;
+    type Error = tower::BoxError;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: HttpRequest) -> Self::Future {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.content_types.lock().unwrap().push(
+            request
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned),
+        );
+        self.inner.call(request)
+    }
+}
 
 #[expect(unused_must_use)]
 async fn test_basic_engine_calls<C>(client: &C)
@@ -57,4 +131,56 @@ async fn test_auth_endpoints_ws() {
     let handle = launch_auth(secret).await;
     let client = handle.ws_client().await;
     test_basic_engine_calls(&client).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_http_middleware_runs_only_after_jwt() {
+    reth_tracing::init_test_tracing();
+
+    let secret = JwtSecret::random();
+    let layer = CountingAuthHttpLayer::default();
+    let config = AuthServerConfig::builder(secret).socket_addr(test_address()).build();
+    let handle = launch_auth_with_config(config.with_http_middleware(layer.clone())).await;
+
+    let response = reqwest::Client::new()
+        .post(handle.http_url())
+        .header(CONTENT_TYPE, "application/json")
+        .body(
+            serde_json::to_vec(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "engine_exchangeCapabilities",
+                "params": [[]],
+                "id": 1
+            }))
+            .unwrap(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert_eq!(layer.count(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auth_http_middleware_sees_transport_headers_before_json_rpc_parsing() {
+    reth_tracing::init_test_tracing();
+
+    let secret = JwtSecret::random();
+    let layer = CountingAuthHttpLayer::default();
+    let config = AuthServerConfig::builder(secret).socket_addr(test_address()).build();
+    let handle = launch_auth_with_config(config.with_http_middleware(layer.clone())).await;
+
+    let response = reqwest::Client::new()
+        .post(handle.http_url())
+        .header(AUTHORIZATION, secret_to_bearer_header(&secret))
+        .header(CONTENT_TYPE, "application/ssz")
+        .body("not-json")
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success() || response.status().is_client_error());
+    assert_eq!(layer.count(), 1);
+    assert_eq!(layer.seen_content_types(), vec![Some("application/ssz".to_owned())]);
 }

--- a/crates/rpc/rpc-builder/tests/it/utils.rs
+++ b/crates/rpc/rpc-builder/tests/it/utils.rs
@@ -14,6 +14,7 @@ use reth_payload_builder::test_utils::spawn_test_payload_service;
 use reth_provider::test_utils::NoopProvider;
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerConfig, AuthServerHandle},
+    middleware::{RethAuthHttpMiddleware, RethRpcMiddleware},
     RpcModuleBuilder, RpcServerConfig, RpcServerHandle, TransportRpcModuleConfig,
 };
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
@@ -28,12 +29,23 @@ use tokio::sync::mpsc::unbounded_channel;
 
 /// Localhost with port 0 so a free port is used.
 pub const fn test_address() -> SocketAddr {
-    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0))
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
 }
 
 /// Launches a new server for the auth module
 pub async fn launch_auth(secret: JwtSecret) -> AuthServerHandle {
     let config = AuthServerConfig::builder(secret).socket_addr(test_address()).build();
+    launch_auth_with_config(config).await
+}
+
+/// Launches a new server for the auth module with the given config.
+pub async fn launch_auth_with_config<RpcMiddleware, HttpMiddleware>(
+    config: AuthServerConfig<RpcMiddleware, HttpMiddleware>,
+) -> AuthServerHandle
+where
+    RpcMiddleware: RethRpcMiddleware,
+    HttpMiddleware: RethAuthHttpMiddleware<RpcMiddleware>,
+{
     let (tx, _rx) = unbounded_channel();
     let beacon_engine_handle = ConsensusEngineHandle::<EthEngineTypes>::new(tx);
     let client = ClientVersionV1 {


### PR DESCRIPTION
Closes #23538

Exposes HTTP transport middleware for the auth / Engine API server through the Node Builder RPC add-ons and auth server config.

This adds a dedicated auth HTTP middleware hook, wires it through `RpcAddOns` / `EthereumAddOns`, and keeps the middleware ordering at `JWT -> custom HTTP middleware -> JSON-RPC` so raw authenticated HTTP requests can be inspected before JSON-RPC parsing.

It also adds helper layering APIs for auth transport middleware and coverage for authenticated transport interception plus the JWT-ordering behavior.