### PR TITLE
[autoopt] 20260416-3-rocks-history-inplace-prune

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -2013,21 +2013,21 @@ impl<'a> RocksDBBatch<'a> {
         let mut updated = false;
         let mut last_remaining: Option<(K, BlockNumberList)> = None;
 
-        for (key, block_list) in shards {
+        for (key, mut block_list) in shards {
             if !is_sentinel(&key) && get_highest(&key) <= to_block {
                 delete_shard(self, key)?;
                 deleted = true;
             } else {
-                let original_len = block_list.len();
-                let filtered =
-                    BlockNumberList::new_pre_sorted(block_list.iter().filter(|&b| b > to_block));
+                // Roaring can drop the pruned prefix in place, which is cheaper than rebuilding
+                // the surviving suffix with a fresh iterator when a shard is only partially pruned.
+                let removed = block_list.0.remove_range(..=to_block);
 
-                if filtered.is_empty() {
+                if block_list.is_empty() {
                     delete_shard(self, key)?;
                     deleted = true;
-                } else if filtered.len() < original_len {
-                    put_shard(self, key.clone(), &filtered)?;
-                    last_remaining = Some((key, filtered));
+                } else if removed > 0 {
+                    put_shard(self, key.clone(), &block_list)?;
+                    last_remaining = Some((key, block_list));
                     updated = true;
                 } else {
                     last_remaining = Some((key, block_list));


### PR DESCRIPTION
# Prune RocksDB history shards in place
## Evidence
- The `24502704479` baseline profile shows pruning still on the persistence critical path: `RocksDBBatch::prune_storage_history_batch` accounts for about 31,581 inclusive samples, `prune_account_history_batch` about 20,333, and `prune_history_shards_inner` about 18,261.
- The same profile attributes about 13,923 inclusive samples to `IntegerList::new_pre_sorted`, which matches shard pruning rebuilding surviving block-number suffixes from scratch.
- The baseline reth logs show account/storage history pruning taking around 81.58 ms and 90.20 ms in adjacent save-block cycles, so even bookkeeping work after block writes is large enough to affect throughput.

## Hypothesis
If we prune partially affected RocksDB history shards in place with Roaring range removal instead of rebuilding each surviving suffix into a fresh `IntegerList`, gas throughput improves by ~0.2-0.5% because the persistence thread does less roaring allocation and bitmap reconstruction during pruning.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Update `crates/storage/provider/src/providers/rocksdb/provider.rs` so `prune_history_shards_inner` trims block numbers `<= to_block` directly from the existing roaring-backed list.
- Keep shard deletion and sentinel re-keying semantics unchanged.
- Verify with `cargo check -p reth-provider`, `cargo test -p reth-provider prune_account_history_batch_multiple_sorted_targets`, and `cargo test -p reth-provider prune_storage_history_batch_multiple_sorted_targets`.