### PR TITLE
feat(trie): add partial persistence state plumbing

### DIFF
--- a/crates/optimism/storage/src/lib.rs
+++ b/crates/optimism/storage/src/lib.rs
@@ -25,8 +25,8 @@ mod tests {
     use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
     use reth_stages_types::{
         AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
-        HeadersCheckpoint, IndexHistoryCheckpoint, StageCheckpoint, StageUnitCheckpoint,
-        StorageHashingCheckpoint,
+        FinishCheckpoint, HeadersCheckpoint, IndexHistoryCheckpoint, StageCheckpoint,
+        StageUnitCheckpoint, StorageHashingCheckpoint,
     };
 
     #[test]
@@ -39,6 +39,7 @@ mod tests {
         assert_eq!(CompactU64::bitflag_encoded_bytes(), 1);
         assert_eq!(EntitiesCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(ExecutionCheckpoint::bitflag_encoded_bytes(), 0);
+        assert_eq!(FinishCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(HeadersCheckpoint::bitflag_encoded_bytes(), 0);
         assert_eq!(IndexHistoryCheckpoint::bitflag_encoded_bytes(), 0);
         assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
@@ -61,6 +62,7 @@ mod tests {
         validate_bitflag_backwards_compat!(CompactU64, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(EntitiesCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(ExecutionCheckpoint, UnusedBits::Zero);
+        validate_bitflag_backwards_compat!(FinishCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(HeadersCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(IndexHistoryCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(PruneCheckpoint, UnusedBits::NotZero);

--- a/crates/stages/stages/src/stages/finish.rs
+++ b/crates/stages/stages/src/stages/finish.rs
@@ -1,5 +1,6 @@
 use reth_stages_api::{
-    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+    ExecInput, ExecOutput, FinishCheckpoint, Stage, StageCheckpoint, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
 
 /// The finish stage.
@@ -20,7 +21,13 @@ impl<Provider> Stage<Provider> for FinishStage {
         _provider: &Provider,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
-        Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
+        let block_number = input.target();
+        Ok(ExecOutput {
+            checkpoint: StageCheckpoint::new(block_number).with_finish_stage_checkpoint(
+                FinishCheckpoint { partial_state_trie: Some(block_number) },
+            ),
+            done: true,
+        })
     }
 
     fn unwind(
@@ -28,7 +35,12 @@ impl<Provider> Stage<Provider> for FinishStage {
         _provider: &Provider,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
-        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
+        let block_number = input.unwind_to;
+        Ok(UnwindOutput {
+            checkpoint: StageCheckpoint::new(block_number).with_finish_stage_checkpoint(
+                FinishCheckpoint { partial_state_trie: Some(block_number) },
+            ),
+        })
     }
 }
 
@@ -78,7 +90,7 @@ mod tests {
             let end = input.target.unwrap_or_default() + 1;
 
             if start + 1 >= end {
-                return Ok(Vec::default())
+                return Ok(Vec::default());
             }
 
             let mut headers = random_header_range(&mut rng, start + 1..end, head.hash());
@@ -98,6 +110,11 @@ mod tests {
                     output.checkpoint.block_number,
                     input.target(),
                     "stage progress should always match progress of previous stage"
+                );
+                assert_eq!(
+                    output.checkpoint.finish_stage_checkpoint(),
+                    Some(FinishCheckpoint { partial_state_trie: Some(input.target()) }),
+                    "finish stage should emit its typed checkpoint payload"
                 );
             }
             Ok(())

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -144,6 +144,17 @@ pub struct IndexHistoryCheckpoint {
     pub progress: EntitiesCheckpoint,
 }
 
+/// Saves the progress of Finish stage.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FinishCheckpoint {
+    /// Highest block number for which the partial state trie is available.
+    pub partial_state_trie: Option<BlockNumber>,
+}
+
 /// Saves the progress of abstract stage iterating over or downloading entities.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
@@ -163,7 +174,7 @@ impl EntitiesCheckpoint {
     /// Return [None] if `total == 0`.
     pub fn fmt_percentage(&self) -> Option<String> {
         if self.total == 0 {
-            return None
+            return None;
         }
 
         // Calculate percentage with 2 decimal places.
@@ -257,17 +268,18 @@ impl StageCheckpoint {
         match stage_checkpoint {
             StageUnitCheckpoint::Account(AccountHashingCheckpoint {
                 progress: entities, ..
-            }) |
-            StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
+            })
+            | StageUnitCheckpoint::Storage(StorageHashingCheckpoint {
                 progress: entities, ..
-            }) |
-            StageUnitCheckpoint::Entities(entities) |
-            StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. }) |
-            StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. }) |
-            StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
+            })
+            | StageUnitCheckpoint::Entities(entities)
+            | StageUnitCheckpoint::Execution(ExecutionCheckpoint { progress: entities, .. })
+            | StageUnitCheckpoint::Headers(HeadersCheckpoint { progress: entities, .. })
+            | StageUnitCheckpoint::IndexHistory(IndexHistoryCheckpoint {
                 progress: entities,
                 ..
             }) => Some(entities),
+            StageUnitCheckpoint::Finish(_) => None,
         }
     }
 }
@@ -293,6 +305,8 @@ pub enum StageUnitCheckpoint {
     Headers(HeadersCheckpoint),
     /// Saves the progress of Index History stage.
     IndexHistory(IndexHistoryCheckpoint),
+    /// Saves the progress of Finish stage.
+    Finish(FinishCheckpoint),
 }
 
 impl StageUnitCheckpoint {
@@ -300,10 +314,10 @@ impl StageUnitCheckpoint {
     /// range.
     pub const fn set_block_range(&mut self, from: u64, to: u64) -> Option<CheckpointBlockRange> {
         match self {
-            Self::Account(AccountHashingCheckpoint { block_range, .. }) |
-            Self::Storage(StorageHashingCheckpoint { block_range, .. }) |
-            Self::Execution(ExecutionCheckpoint { block_range, .. }) |
-            Self::IndexHistory(IndexHistoryCheckpoint { block_range, .. }) => {
+            Self::Account(AccountHashingCheckpoint { block_range, .. })
+            | Self::Storage(StorageHashingCheckpoint { block_range, .. })
+            | Self::Execution(ExecutionCheckpoint { block_range, .. })
+            | Self::IndexHistory(IndexHistoryCheckpoint { block_range, .. }) => {
                 let old_range = *block_range;
                 *block_range = CheckpointBlockRange { from, to };
 
@@ -401,6 +415,15 @@ stage_unit_checkpoints!(
         index_history_stage_checkpoint,
         /// Sets the stage checkpoint to index history.
         with_index_history_stage_checkpoint
+    ),
+    (
+        6,
+        Finish,
+        FinishCheckpoint,
+        /// Returns the finish stage checkpoint, if any.
+        finish_stage_checkpoint,
+        /// Sets the stage checkpoint to finish.
+        with_finish_stage_checkpoint
     )
 );
 
@@ -428,5 +451,17 @@ mod tests {
         let encoded = checkpoint.to_compact(&mut buf);
         let (decoded, _) = MerkleCheckpoint::from_compact(&buf, encoded);
         assert_eq!(decoded, checkpoint);
+    }
+
+    #[test]
+    fn finish_checkpoint_builder_roundtrip() {
+        let checkpoint = StageCheckpoint::new(10)
+            .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(7) });
+
+        assert_eq!(
+            checkpoint.finish_stage_checkpoint(),
+            Some(FinishCheckpoint { partial_state_trie: Some(7) })
+        );
+        assert_eq!(checkpoint.entities(), None);
     }
 }

--- a/crates/stages/types/src/lib.rs
+++ b/crates/stages/types/src/lib.rs
@@ -18,7 +18,7 @@ pub use id::StageId;
 mod checkpoints;
 pub use checkpoints::{
     AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
-    HeadersCheckpoint, IndexHistoryCheckpoint, MerkleCheckpoint, StageCheckpoint,
+    FinishCheckpoint, HeadersCheckpoint, IndexHistoryCheckpoint, MerkleCheckpoint, StageCheckpoint,
     StageUnitCheckpoint, StorageHashingCheckpoint,
 };
 

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -327,8 +327,8 @@ mod tests {
         use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
         use reth_stages_types::{
             AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint,
-            ExecutionCheckpoint, HeadersCheckpoint, IndexHistoryCheckpoint, StageCheckpoint,
-            StageUnitCheckpoint, StorageHashingCheckpoint,
+            ExecutionCheckpoint, FinishCheckpoint, HeadersCheckpoint, IndexHistoryCheckpoint,
+            StageCheckpoint, StageUnitCheckpoint, StorageHashingCheckpoint,
         };
         assert_eq!(Account::bitflag_encoded_bytes(), 2);
         assert_eq!(AccountHashingCheckpoint::bitflag_encoded_bytes(), 1);
@@ -338,6 +338,7 @@ mod tests {
         assert_eq!(CompactU64::bitflag_encoded_bytes(), 1);
         assert_eq!(EntitiesCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(ExecutionCheckpoint::bitflag_encoded_bytes(), 0);
+        assert_eq!(FinishCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(HeadersCheckpoint::bitflag_encoded_bytes(), 0);
         assert_eq!(IndexHistoryCheckpoint::bitflag_encoded_bytes(), 0);
         assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
@@ -358,6 +359,7 @@ mod tests {
         validate_bitflag_backwards_compat!(CompactU64, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(EntitiesCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(ExecutionCheckpoint, UnusedBits::Zero);
+        validate_bitflag_backwards_compat!(FinishCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(HeadersCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(IndexHistoryCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(PruneCheckpoint, UnusedBits::NotZero);

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -216,7 +216,7 @@ impl HashedPostState {
                     let mut storage_not_in_targets = HashedStorage::default();
                     storage.storage.retain(|&slot, value| {
                         if storage_in_targets.contains(&slot) {
-                            return true
+                            return true;
                         }
 
                         storage_not_in_targets.storage.insert(slot, *value);
@@ -251,7 +251,7 @@ impl HashedPostState {
         });
         self.accounts.retain(|&address, account| {
             if targets.contains_key(&address) {
-                return true
+                return true;
             }
 
             state_updates_not_in_targets.accounts.insert(address, *account);
@@ -440,6 +440,34 @@ impl HashedPostStateSorted {
     pub const fn account_storages(&self) -> &B256Map<HashedStorageSorted> {
         &self.storages
     }
+
+    /// Returns the merged left-hand states with any addresses present on the right removed.
+    pub fn disjoint_by_keys(left: Vec<&Self>, right: Vec<&Self>) -> Self {
+        let accounts = HashedAccountsSorted::disjoint_by_keys(&left, &right);
+        let mut storages = B256Map::with_capacity_and_hasher(
+            left.iter().map(|state| state.storages.len()).sum(),
+            Default::default(),
+        );
+
+        for state in left.iter().rev() {
+            for (hashed_address, storage) in &state.storages {
+                if contains_hashed_post_state_key(&right, hashed_address) {
+                    continue;
+                }
+
+                match storages.entry(*hashed_address) {
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(storage.clone());
+                    }
+                    hash_map::Entry::Occupied(mut entry) => {
+                        merge_hashed_storage_sorted(entry.get_mut(), storage);
+                    }
+                }
+            }
+        }
+
+        Self { accounts, storages }
+    }
 }
 
 /// Sorted account state optimized for iterating during state trie calculation.
@@ -459,6 +487,76 @@ impl HashedAccountsSorted {
             .map(|(address, account)| (*address, Some(*account)))
             .chain(self.destroyed_accounts.iter().map(|address| (*address, None)))
             .sorted_by_key(|entry| *entry.0)
+    }
+
+    fn disjoint_by_keys(left: &[&HashedPostStateSorted], right: &[&HashedPostStateSorted]) -> Self {
+        let mut accounts =
+            Vec::with_capacity(left.iter().map(|state| state.accounts.accounts.len()).sum());
+        let mut cursors = vec![0; left.len()];
+
+        loop {
+            let Some(hashed_address) = left
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, state)| {
+                    state
+                        .accounts
+                        .accounts
+                        .get(cursors[idx])
+                        .map(|(hashed_address, _)| *hashed_address)
+                })
+                .min()
+            else {
+                break;
+            };
+
+            let mut winning_index = None;
+            let mut winning_account = None;
+            for (idx, state) in left.iter().enumerate() {
+                if state
+                    .accounts
+                    .accounts
+                    .get(cursors[idx])
+                    .is_some_and(|(candidate, _)| candidate == &hashed_address)
+                {
+                    winning_index = Some(idx);
+                    winning_account = Some(state.accounts.accounts[cursors[idx]].1);
+                    cursors[idx] += 1;
+                }
+            }
+
+            let Some(winning_index) = winning_index else {
+                continue;
+            };
+
+            if left[winning_index + 1..]
+                .iter()
+                .any(|state| state.accounts.destroyed_accounts.contains(&hashed_address))
+                || contains_hashed_post_state_key(right, &hashed_address)
+            {
+                continue;
+            }
+
+            accounts.push((hashed_address, winning_account.expect("winning account exists")));
+        }
+
+        let mut destroyed_accounts = HashSet::default();
+        for state in left.iter().rev() {
+            for hashed_address in &state.accounts.destroyed_accounts {
+                if destroyed_accounts.contains(hashed_address)
+                    || accounts
+                        .binary_search_by_key(hashed_address, |(candidate, _)| *candidate)
+                        .is_ok()
+                    || contains_hashed_post_state_key(right, hashed_address)
+                {
+                    continue;
+                }
+
+                destroyed_accounts.insert(*hashed_address);
+            }
+        }
+
+        Self { accounts, destroyed_accounts }
     }
 }
 
@@ -486,6 +584,54 @@ impl HashedStorageSorted {
             .map(|(hashed_slot, value)| (*hashed_slot, *value))
             .chain(self.zero_valued_slots.iter().map(|hashed_slot| (*hashed_slot, U256::ZERO)))
             .sorted_by_key(|entry| *entry.0)
+    }
+}
+
+fn contains_hashed_post_state_key(
+    states: &[&HashedPostStateSorted],
+    hashed_address: &B256,
+) -> bool {
+    states.iter().any(|state| {
+        state.accounts.destroyed_accounts.contains(hashed_address)
+            || state
+                .accounts
+                .accounts
+                .binary_search_by_key(hashed_address, |(candidate, _)| *candidate)
+                .is_ok()
+            || state.storages.contains_key(hashed_address)
+    })
+}
+
+fn merge_hashed_storage_sorted(dst: &mut HashedStorageSorted, src: &HashedStorageSorted) {
+    if dst.wiped {
+        return;
+    }
+
+    dst.wiped |= src.wiped;
+
+    for hashed_slot in &src.zero_valued_slots {
+        if dst
+            .non_zero_valued_slots
+            .binary_search_by_key(hashed_slot, |(candidate, _)| *candidate)
+            .is_err()
+            && !dst.zero_valued_slots.contains(hashed_slot)
+        {
+            dst.zero_valued_slots.insert(*hashed_slot);
+        }
+    }
+
+    for (hashed_slot, value) in &src.non_zero_valued_slots {
+        if dst.zero_valued_slots.contains(hashed_slot) {
+            continue;
+        }
+
+        match dst
+            .non_zero_valued_slots
+            .binary_search_by_key(hashed_slot, |(candidate, _)| *candidate)
+        {
+            Ok(_) => {}
+            Err(position) => dst.non_zero_valued_slots.insert(position, (*hashed_slot, *value)),
+        }
     }
 }
 
@@ -756,6 +902,97 @@ mod tests {
         let non_empty_state = HashedPostState::default()
             .with_accounts(vec![(keccak256(Address::random()), Some(Account::default()))]);
         assert!(!non_empty_state.is_empty());
+    }
+
+    #[test]
+    fn hashed_post_state_sorted_disjoint_by_keys() {
+        let addr1 = B256::with_last_byte(1);
+        let addr2 = B256::with_last_byte(2);
+        let addr3 = B256::with_last_byte(3);
+        let addr4 = B256::with_last_byte(4);
+        let addr5 = B256::with_last_byte(5);
+        let slot1 = B256::with_last_byte(11);
+        let slot2 = B256::with_last_byte(12);
+
+        let left1 = HashedPostStateSorted::new(
+            HashedAccountsSorted {
+                accounts: vec![
+                    (addr1, Account { nonce: 1, ..Default::default() }),
+                    (addr4, Account { nonce: 4, ..Default::default() }),
+                ],
+                destroyed_accounts: HashSet::from_iter([addr2]),
+            },
+            B256Map::from_iter([
+                (
+                    addr3,
+                    HashedStorageSorted {
+                        non_zero_valued_slots: vec![(slot1, U256::from(1))],
+                        zero_valued_slots: HashSet::default(),
+                        wiped: false,
+                    },
+                ),
+                (
+                    addr5,
+                    HashedStorageSorted {
+                        non_zero_valued_slots: vec![(slot1, U256::from(11))],
+                        zero_valued_slots: HashSet::default(),
+                        wiped: true,
+                    },
+                ),
+            ]),
+        );
+        let left2 = HashedPostStateSorted::new(
+            HashedAccountsSorted {
+                accounts: vec![(addr2, Account { nonce: 2, ..Default::default() })],
+                destroyed_accounts: HashSet::from_iter([addr1]),
+            },
+            B256Map::from_iter([
+                (
+                    addr3,
+                    HashedStorageSorted {
+                        non_zero_valued_slots: vec![(slot2, U256::from(2))],
+                        zero_valued_slots: HashSet::from_iter([slot1]),
+                        wiped: false,
+                    },
+                ),
+                (
+                    addr5,
+                    HashedStorageSorted {
+                        non_zero_valued_slots: vec![(slot2, U256::from(22))],
+                        zero_valued_slots: HashSet::from_iter([slot1]),
+                        wiped: false,
+                    },
+                ),
+            ]),
+        );
+        let right = HashedPostStateSorted::new(
+            HashedAccountsSorted {
+                accounts: vec![(addr2, Account { nonce: 9, ..Default::default() })],
+                destroyed_accounts: HashSet::default(),
+            },
+            B256Map::from_iter([(
+                addr3,
+                HashedStorageSorted {
+                    non_zero_valued_slots: vec![(slot1, U256::from(99))],
+                    zero_valued_slots: HashSet::default(),
+                    wiped: false,
+                },
+            )]),
+        );
+
+        let disjoint = HashedPostStateSorted::disjoint_by_keys(vec![&left1, &left2], vec![&right]);
+
+        assert_eq!(
+            disjoint.accounts.accounts,
+            vec![(addr4, Account { nonce: 4, ..Default::default() })]
+        );
+        assert_eq!(disjoint.accounts.destroyed_accounts, HashSet::from_iter([addr1]));
+        assert!(!disjoint.storages.contains_key(&addr3));
+
+        let addr5_storage = disjoint.storages.get(&addr5).unwrap();
+        assert!(addr5_storage.wiped);
+        assert_eq!(addr5_storage.non_zero_valued_slots, vec![(slot2, U256::from(22))]);
+        assert_eq!(addr5_storage.zero_valued_slots, HashSet::from_iter([slot1]));
     }
 
     fn create_state_for_multi_proof_targets() -> HashedPostState {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -432,6 +432,9 @@ impl TrieUpdatesSorted {
                 removed_nodes.insert(key.clone());
             }
         }
+        removed_nodes.retain(|key| {
+            account_nodes.binary_search_by(|(candidate, _)| candidate.cmp(key)).is_err()
+        });
 
         let mut storage_tries = B256Map::with_capacity_and_hasher(
             left.iter().map(|updates| updates.storage_tries.len()).sum(),
@@ -869,7 +872,7 @@ mod sorted_tests {
             disjoint.account_nodes.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>(),
             vec![key3.clone()]
         );
-        assert_eq!(disjoint.removed_nodes, HashSet::from_iter([key1, key3]));
+        assert_eq!(disjoint.removed_nodes, HashSet::from_iter([key1]));
 
         let addr2_storage = disjoint.storage_tries.get(&addr2).unwrap();
         assert!(addr2_storage.is_deleted);

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -22,9 +22,9 @@ pub struct TrieUpdates {
 impl TrieUpdates {
     /// Returns `true` if the updates are empty.
     pub fn is_empty(&self) -> bool {
-        self.account_nodes.is_empty() &&
-            self.removed_nodes.is_empty() &&
-            self.storage_tries.is_empty()
+        self.account_nodes.is_empty()
+            && self.removed_nodes.is_empty()
+            && self.storage_tries.is_empty()
     }
 
     /// Returns reference to updated account nodes.
@@ -376,6 +376,86 @@ impl TrieUpdatesSorted {
     pub const fn storage_tries_ref(&self) -> &B256Map<StorageTrieUpdatesSorted> {
         &self.storage_tries
     }
+
+    /// Returns the merged left-hand updates with any keys present on the right removed.
+    pub fn disjoint_by_keys(left: Vec<&Self>, right: Vec<&Self>) -> Self {
+        let mut account_nodes =
+            Vec::with_capacity(left.iter().map(|updates| updates.account_nodes.len()).sum());
+        let mut cursors = vec![0; left.len()];
+
+        loop {
+            let Some(key) = left
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, updates)| {
+                    updates.account_nodes.get(cursors[idx]).map(|(key, _)| key.clone())
+                })
+                .min()
+            else {
+                break;
+            };
+
+            let mut winning_index = None;
+            let mut winning_node = None;
+            for (idx, updates) in left.iter().enumerate() {
+                if updates
+                    .account_nodes
+                    .get(cursors[idx])
+                    .is_some_and(|(candidate, _)| candidate == &key)
+                {
+                    winning_index = Some(idx);
+                    winning_node = Some(updates.account_nodes[cursors[idx]].1.clone());
+                    cursors[idx] += 1;
+                }
+            }
+
+            let Some(winning_index) = winning_index else {
+                continue;
+            };
+
+            if left[winning_index + 1..].iter().any(|updates| updates.removed_nodes.contains(&key))
+                || contains_trie_account_key(&right, &key)
+            {
+                continue;
+            }
+
+            account_nodes.push((key, winning_node.expect("winning node exists")));
+        }
+
+        let mut removed_nodes = HashSet::default();
+        for updates in &left {
+            for key in &updates.removed_nodes {
+                if contains_trie_account_key(&right, key) {
+                    continue;
+                }
+
+                removed_nodes.insert(key.clone());
+            }
+        }
+
+        let mut storage_tries = B256Map::with_capacity_and_hasher(
+            left.iter().map(|updates| updates.storage_tries.len()).sum(),
+            Default::default(),
+        );
+        for updates in left.iter().rev() {
+            for (hashed_address, storage) in &updates.storage_tries {
+                if right.iter().any(|other| other.storage_tries.contains_key(hashed_address)) {
+                    continue;
+                }
+
+                match storage_tries.entry(*hashed_address) {
+                    alloy_primitives::map::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(storage.clone());
+                    }
+                    alloy_primitives::map::hash_map::Entry::Occupied(mut entry) => {
+                        merge_storage_trie_updates_sorted(entry.get_mut(), storage);
+                    }
+                }
+            }
+        }
+
+        Self { account_nodes, removed_nodes, storage_tries }
+    }
 }
 
 /// Sorted trie updates used for lookups and insertions.
@@ -403,6 +483,36 @@ impl StorageTrieUpdatesSorted {
     /// Returns reference to removed storage nodes.
     pub const fn removed_nodes_ref(&self) -> &HashSet<Nibbles> {
         &self.removed_nodes
+    }
+}
+
+fn contains_trie_account_key(states: &[&TrieUpdatesSorted], key: &Nibbles) -> bool {
+    states.iter().any(|state| {
+        state.removed_nodes.contains(key)
+            || state.account_nodes.binary_search_by(|(candidate, _)| candidate.cmp(key)).is_ok()
+    })
+}
+
+fn merge_storage_trie_updates_sorted(
+    dst: &mut StorageTrieUpdatesSorted,
+    src: &StorageTrieUpdatesSorted,
+) {
+    if dst.is_deleted {
+        return;
+    }
+
+    dst.is_deleted |= src.is_deleted;
+    dst.removed_nodes.extend(src.removed_nodes.iter().cloned());
+
+    for (key, node) in &src.storage_nodes {
+        if dst.removed_nodes.contains(key) {
+            continue;
+        }
+
+        match dst.storage_nodes.binary_search_by(|(candidate, _)| candidate.cmp(key)) {
+            Ok(_) => {}
+            Err(position) => dst.storage_nodes.insert(position, (key.clone(), node.clone())),
+        }
     }
 }
 
@@ -678,5 +788,95 @@ mod tests {
         let updates_deserialized: StorageTrieUpdates =
             serde_json::from_str(&updates_serialized).unwrap();
         assert_eq!(updates_deserialized, default_updates);
+    }
+}
+
+#[cfg(test)]
+mod sorted_tests {
+    use super::*;
+
+    #[test]
+    fn trie_updates_sorted_disjoint_by_keys() {
+        let key1 = Nibbles::from_vec(vec![0x1]);
+        let key2 = Nibbles::from_vec(vec![0x2]);
+        let key3 = Nibbles::from_vec(vec![0x3]);
+        let key4 = Nibbles::from_vec(vec![0x4]);
+        let slot1 = Nibbles::from_vec(vec![0xa]);
+        let slot2 = Nibbles::from_vec(vec![0xb]);
+        let slot3 = Nibbles::from_vec(vec![0xc]);
+        let addr1 = B256::with_last_byte(1);
+        let addr2 = B256::with_last_byte(2);
+
+        let left1 = TrieUpdatesSorted {
+            account_nodes: vec![
+                (key1.clone(), BranchNodeCompact::default()),
+                (key2.clone(), BranchNodeCompact::default()),
+            ],
+            removed_nodes: HashSet::from_iter([key3.clone(), key4.clone()]),
+            storage_tries: B256Map::from_iter([
+                (
+                    addr1,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: false,
+                        storage_nodes: vec![(slot1.clone(), BranchNodeCompact::default())],
+                        removed_nodes: HashSet::from_iter([slot2.clone()]),
+                    },
+                ),
+                (
+                    addr2,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: true,
+                        storage_nodes: Vec::default(),
+                        removed_nodes: HashSet::default(),
+                    },
+                ),
+            ]),
+        };
+        let left2 = TrieUpdatesSorted {
+            account_nodes: vec![
+                (key2.clone(), BranchNodeCompact::default()),
+                (key3.clone(), BranchNodeCompact::default()),
+            ],
+            removed_nodes: HashSet::from_iter([key1.clone()]),
+            storage_tries: B256Map::from_iter([
+                (
+                    addr1,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: false,
+                        storage_nodes: vec![(slot2.clone(), BranchNodeCompact::default())],
+                        removed_nodes: HashSet::from_iter([slot1.clone()]),
+                    },
+                ),
+                (
+                    addr2,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: false,
+                        storage_nodes: vec![(slot3.clone(), BranchNodeCompact::default())],
+                        removed_nodes: HashSet::default(),
+                    },
+                ),
+            ]),
+        };
+        let right = TrieUpdatesSorted {
+            account_nodes: vec![(key2.clone(), BranchNodeCompact::default())],
+            removed_nodes: HashSet::from_iter([key4.clone()]),
+            storage_tries: B256Map::from_iter([(addr1, StorageTrieUpdatesSorted::default())]),
+        };
+
+        let disjoint = TrieUpdatesSorted::disjoint_by_keys(vec![&left1, &left2], vec![&right]);
+
+        assert_eq!(
+            disjoint.account_nodes.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>(),
+            vec![key3.clone()]
+        );
+        assert_eq!(disjoint.removed_nodes, HashSet::from_iter([key1, key3]));
+
+        let addr2_storage = disjoint.storage_tries.get(&addr2).unwrap();
+        assert!(addr2_storage.is_deleted);
+        assert_eq!(
+            addr2_storage.storage_nodes.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>(),
+            vec![slot3]
+        );
+        assert!(!disjoint.storage_tries.contains_key(&addr1));
     }
 }


### PR DESCRIPTION
## Summary
- add a finish-stage checkpoint payload for `partial_state_trie`
- emit the finish checkpoint with `partial_state_trie = Some(block_number)`
- add allocation-conscious `disjoint_by_keys` helpers for `TrieUpdatesSorted` and `HashedPostStateSorted`

## Testing
- cargo test -p reth-stages finish -- --nocapture
- cargo check -p reth-stages-types -p reth-stages-api -p reth-stages -p reth-db-api -p reth-optimism-storage
- cargo test -p reth-trie-common
- cargo check -p reth-trie-common -p reth-trie -p reth-trie-db -p reth-trie-parallel -p reth-engine-tree

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: Brian