### PR TITLE
fix(ci): use proper Slack mention for AI bot in bench failure alerts

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -948,7 +948,7 @@ jobs:
               },
               {
                 type: 'section',
-                text: { type: 'mrkdwn', text: `*${modeLabel} regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>\n@ai investigate this` },
+                text: { type: 'mrkdwn', text: `*${modeLabel} regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>\n<@U0AAA8F0JEM> investigate this` },
               },
               {
                 type: 'actions',


### PR DESCRIPTION
The bench failure notification used plain text `@ai` which Slack doesn't resolve into a mention token. The bot checks for `<@BOT_USER_ID>` in the message to decide whether it's been mentioned — plain text `@ai` doesn't match, so it silently ignores the alert.

Switches to the proper `<@U0AAA8F0JEM>` format so the bot actually triggers on bench failures.

Prompted by: Alexey