### PR TITLE
feat(miner): add --dev.payload-wait-time to LocalMiner

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -141,6 +141,11 @@ pub struct LocalMiner<T: PayloadTypes, B, Pool: TransactionPool + Unpin> {
     last_header: SealedHeaderFor<<T::BuiltPayload as BuiltPayload>::Primitives>,
     /// Stores latest mined blocks.
     last_block_hashes: VecDeque<B256>,
+    /// Optional sleep duration between initiating payload building and resolving.
+    ///
+    /// When set, the miner sleeps after `fork_choice_updated` before calling
+    /// `resolve_kind`, giving the payload job time for multiple rebuild attempts.
+    payload_wait_time: Option<Duration>,
 }
 
 impl<T, B, Pool> LocalMiner<T, B, Pool>
@@ -170,7 +175,14 @@ where
             payload_builder,
             last_block_hashes: VecDeque::from([last_header.hash()]),
             last_header,
+            payload_wait_time: None,
         }
+    }
+
+    /// Sets the payload wait time, if any.
+    pub const fn with_payload_wait_time_opt(mut self, wait_time: Option<Duration>) -> Self {
+        self.payload_wait_time = wait_time;
+        self
     }
 
     /// Runs the [`LocalMiner`] in a loop, polling the miner and building payloads.
@@ -237,6 +249,10 @@ where
         }
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
+
+        if let Some(wait_time) = self.payload_wait_time {
+            tokio::time::sleep(wait_time).await;
+        }
 
         let Some(Ok(payload)) =
             self.payload_builder.resolve_kind(payload_id, PayloadKind::WaitForPending).await

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -308,6 +308,13 @@ where
             let dev_mining_mode =
                 mining_mode.unwrap_or_else(|| handle.node.config.dev_mining_mode(pool));
             let payload_wait_time = config.dev.payload_wait_time;
+            if let (Some(wait_time), Some(block_time)) = (payload_wait_time, config.dev.block_time)
+            {
+                eyre::ensure!(
+                    wait_time <= block_time,
+                    "--dev.payload-wait-time ({wait_time:?}) must be <= --dev.block-time ({block_time:?})"
+                );
+            }
             handle.node.task_executor.spawn_critical_task("local engine", async move {
                 LocalMiner::new(
                     blockchain_db,

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -307,6 +307,7 @@ where
 
             let dev_mining_mode =
                 mining_mode.unwrap_or_else(|| handle.node.config.dev_mining_mode(pool));
+            let payload_wait_time = config.dev.payload_wait_time;
             handle.node.task_executor.spawn_critical_task("local engine", async move {
                 LocalMiner::new(
                     blockchain_db,
@@ -315,6 +316,7 @@ where
                     dev_mining_mode,
                     payload_builder_handle,
                 )
+                .with_payload_wait_time_opt(payload_wait_time)
                 .run()
                 .await
             });

--- a/crates/node/core/src/args/dev.rs
+++ b/crates/node/core/src/args/dev.rs
@@ -42,6 +42,22 @@ pub struct DevArgs {
     )]
     pub block_time: Option<Duration>,
 
+    /// Time to wait after initiating payload building before resolving.
+    ///
+    /// Introduces a sleep between `fork_choice_updated` and `resolve_kind` in the
+    /// local miner, giving the payload job time for multiple rebuild attempts with
+    /// new transactions from the pool.
+    ///
+    /// Parses strings using [`humantime::parse_duration`]
+    /// --dev.payload-wait-time 450ms
+    #[arg(
+        long = "dev.payload-wait-time",
+        help_heading = "Dev testnet",
+        value_parser = parse_duration,
+        verbatim_doc_comment
+    )]
+    pub payload_wait_time: Option<Duration>,
+
     /// Derive dev accounts from a fixed mnemonic instead of random ones.
     #[arg(
         long = "dev.mnemonic",
@@ -60,6 +76,7 @@ impl Default for DevArgs {
             dev: false,
             block_max_transactions: None,
             block_time: None,
+            payload_wait_time: None,
             dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
         }
     }
@@ -86,6 +103,7 @@ mod tests {
                 dev: false,
                 block_max_transactions: None,
                 block_time: None,
+                payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -97,6 +115,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: None,
                 block_time: None,
+                payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -108,6 +127,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: None,
                 block_time: None,
+                payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -125,6 +145,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: Some(2),
                 block_time: None,
+                payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -137,6 +158,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: None,
                 block_time: Some(std::time::Duration::from_secs(1)),
+                payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -840,6 +840,16 @@ Dev testnet:
           Parses strings using [`humantime::parse_duration`]
           --dev.block-time 12s
 
+      --dev.payload-wait-time <PAYLOAD_WAIT_TIME>
+          Time to wait after initiating payload building before resolving.
+
+          Introduces a sleep between `fork_choice_updated` and `resolve_kind` in the
+          local miner, giving the payload job time for multiple rebuild attempts with
+          new transactions from the pool.
+
+          Parses strings using [`humantime::parse_duration`]
+          --dev.payload-wait-time 450ms
+
       --dev.mnemonic <MNEMONIC>
           Derive dev accounts from a fixed mnemonic instead of random ones.
 


### PR DESCRIPTION
Introduces a sleep between `fork_choice_updated` and `resolve_kind` in `--dev` mode, giving the payload job time for multiple rebuild attempts with new transactions from the pool.