### PR TITLE
fix(rpc): don't cap eth_simulateV1 blockOverrides.gasLimit by --rpc.gascap

### DIFF
--- a/crates/ethereum/node/tests/e2e/simulate.rs
+++ b/crates/ethereum/node/tests/e2e/simulate.rs
@@ -148,6 +148,92 @@ async fn test_simulate_v1_block_gas_limit_override_above_rpc_gascap() -> eyre::R
 }
 
 #[tokio::test]
+async fn test_simulate_v1_explicit_call_gas_clamped_to_rpc_gascap() -> eyre::Result<()> {
+    use alloy_consensus::Transaction as _;
+
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    // Default --rpc.gascap is 50M.
+    let rpc_gascap_default = 50_000_000u64;
+    // Block-level override above rpc.gascap — allowed (matches the first fix).
+    let block_gas_limit = 100_000_000u64;
+    // Per-call explicit gas above rpc.gascap — op-geth clamps this to rpc.gascap.
+    let explicit_call_gas = 80_000_000u64;
+
+    let from: Address = "0xc000000000000000000000000000000000000000".parse()?;
+    let to: Address = "0xc100000000000000000000000000000000000000".parse()?;
+
+    let tx = TransactionRequest::default()
+        .from(from)
+        .to(to)
+        .gas_limit(explicit_call_gas)
+        .max_fee_per_gas(0)
+        .max_priority_fee_per_gas(0)
+        .value(U256::ZERO)
+        .nonce(0);
+
+    let sim_block = SimBlock::default()
+        .with_block_overrides(BlockOverrides {
+            gas_limit: Some(block_gas_limit),
+            ..Default::default()
+        })
+        .call(tx);
+
+    let payload = SimulatePayload::default().with_full_transactions().extend(sim_block);
+
+    let result: Vec<SimulatedBlock> =
+        provider.raw_request("eth_simulateV1".into(), (&payload, "latest")).await?;
+
+    assert_eq!(result.len(), 1, "expected exactly 1 simulated block");
+    assert_eq!(
+        result[0].inner.header.gas_limit, block_gas_limit,
+        "simulated block should reflect the overridden block gas limit",
+    );
+    assert_eq!(result[0].calls.len(), 1, "expected exactly 1 call result");
+    assert!(
+        result[0].calls[0].status,
+        "call should succeed after clamp, got error: {:?}",
+        result[0].calls[0].error
+    );
+
+    let txs = result[0]
+        .inner
+        .transactions
+        .as_transactions()
+        .expect("full transactions should be returned");
+    assert_eq!(txs.len(), 1, "expected exactly 1 transaction in simulated block");
+    assert_eq!(
+        txs[0].gas_limit(),
+        rpc_gascap_default,
+        "explicit call.gas ({explicit_call_gas}) above --rpc.gascap ({rpc_gascap_default}) \
+         must be clamped to --rpc.gascap; otherwise the RPC DoS envelope widens"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_simulate_v1_too_many_blocks_error() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/crates/ethereum/node/tests/e2e/simulate.rs
+++ b/crates/ethereum/node/tests/e2e/simulate.rs
@@ -80,6 +80,74 @@ async fn test_simulate_v1_with_max_fee_per_blob_gas_only() -> eyre::Result<()> {
 }
 
 #[tokio::test]
+async fn test_simulate_v1_block_gas_limit_override_above_rpc_gascap() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    // 100M — above the default RPC gas cap (50M) and above the 30M genesis block gas limit.
+    // The call itself uses ~21K gas, well under both bounds.
+    let high_gas_limit = 100_000_000u64;
+
+    let from: Address = "0xc000000000000000000000000000000000000000".parse()?;
+    let to: Address = "0xc100000000000000000000000000000000000000".parse()?;
+
+    let tx = TransactionRequest::default()
+        .from(from)
+        .to(to)
+        .gas_limit(100_000)
+        .max_fee_per_gas(0)
+        .max_priority_fee_per_gas(0)
+        .value(U256::ZERO)
+        .nonce(0);
+
+    let sim_block = SimBlock::default()
+        .with_block_overrides(BlockOverrides {
+            gas_limit: Some(high_gas_limit),
+            ..Default::default()
+        })
+        .call(tx);
+
+    let payload = SimulatePayload::default().extend(sim_block);
+
+    let result: Vec<SimulatedBlock> =
+        provider.raw_request("eth_simulateV1".into(), (&payload, "latest")).await?;
+
+    assert_eq!(result.len(), 1, "expected exactly 1 simulated block");
+    assert_eq!(
+        result[0].inner.header.gas_limit, high_gas_limit,
+        "simulated block should reflect the overridden gas limit"
+    );
+    assert_eq!(result[0].calls.len(), 1, "expected exactly 1 call result");
+    assert!(
+        result[0].calls[0].status,
+        "call should succeed, got error: {:?}",
+        result[0].calls[0].error
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_simulate_v1_too_many_blocks_error() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -154,13 +154,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     evm_env.block_env.inner_mut().prevrandao = Some(B256::ZERO);
 
                     if let Some(block_overrides) = block_overrides {
-                        // ensure we don't allow uncapped gas limit per block
-                        if let Some(gas_limit_override) = block_overrides.gas_limit &&
-                            gas_limit_override > evm_env.block_env.gas_limit() &&
-                            gas_limit_override > this.call_gas_limit()
-                        {
-                            return Err(EthApiError::other(EthSimulateError::GasLimitReached).into())
-                        }
                         apply_block_overrides(
                             block_overrides,
                             &mut db,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -101,6 +101,17 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let mut prev_block_number = parent.number();
                 let mut prev_timestamp = parent.timestamp();
 
+                // Shared simulation gas budget across every block and every call in this
+                // `eth_simulateV1` request. One RPC request gets one `--rpc.gascap` budget, and
+                // each call's actual gas usage depletes it — matching the spec's recommended
+                // DoS mitigation (bound total simulate gas at the `eth_call` cap, which is
+                // what geth/op-geth do via a single gas pool). `call_gas_limit() == 0` means
+                // "no cap", represented here as `u64::MAX`.
+                let mut remaining_budget = match this.call_gas_limit() {
+                    0 => u64::MAX,
+                    cap => cap,
+                };
+
                 for block in block_state_calls {
                     // Validate block number ordering if overridden
                     if let Some(number) = block.block_overrides.as_ref().and_then(|o| o.number) {
@@ -182,17 +193,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         }
 
                         if txs_without_gas_limit > 0 {
-                            // Per spec: "gasLimit: blockGasLimit - soFarUsedGasInBlock"
-                            // Divide remaining gas equally among transactions without gas
-                            let gas_per_tx = (block_gas_limit - total_specified_gas) /
-                                txs_without_gas_limit as u64;
-                            // Cap to RPC gas limit, matching spec behavior
-                            let call_gas_limit = this.call_gas_limit();
-                            if call_gas_limit > 0 {
-                                gas_per_tx.min(call_gas_limit)
-                            } else {
-                                gas_per_tx
-                            }
+                            // Per spec: "gasLimit: blockGasLimit - soFarUsedGasInBlock".
+                            // Divide remaining block gas equally among transactions without
+                            // explicit gas. The shared `remaining_budget` (rpc.gascap) is
+                            // applied dynamically inside `execute_transactions`, so no static
+                            // clamp to `call_gas_limit` is needed here.
+                            (block_gas_limit - total_specified_gas) / txs_without_gas_limit as u64
                         } else {
                             0
                         }
@@ -233,6 +239,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             default_gas_limit,
                             chain_id,
                             this.converter(),
+                            &mut remaining_budget,
                         )
                         .map_err(map_err)?
                     } else {
@@ -253,6 +260,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             default_gas_limit,
                             chain_id,
                             this.converter(),
+                            &mut remaining_budget,
                         )
                         .map_err(map_err)?
                     };

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -159,6 +159,13 @@ pub fn apply_precompile_overrides(
 /// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the
 /// given [`BlockExecutor`].
 ///
+/// `remaining_budget` is the shared `eth_simulateV1` gas budget across the whole simulation,
+/// initialized to `--rpc.gascap` and depleted by each call's actual `gas_used`. Use [`u64::MAX`]
+/// to disable the budget. Before each call executes, an explicit `gas` above the remaining
+/// budget is clamped down to the budget, so the total gas consumed across every block and
+/// every call in one `eth_simulateV1` request cannot exceed `--rpc.gascap`. This mirrors the
+/// behavior geth/op-geth implements via a single shared gas pool.
+///
 /// Returns all executed transactions and the result of the execution.
 ///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
@@ -169,6 +176,7 @@ pub fn execute_transactions<S, T>(
     default_gas_limit: u64,
     chain_id: u64,
     converter: &T,
+    remaining_budget: &mut u64,
 ) -> Result<
     (
         BlockBuilderOutcome<S::Primitives>,
@@ -183,12 +191,29 @@ where
     builder.apply_pre_execution_changes()?;
 
     let mut results = Vec::with_capacity(calls.len());
-    for call in calls {
-        // Resolve transaction, populate missing fields and enforce calls
-        // correctness.
+    for mut call in calls {
+        // Clamp per-call gas to the shared simulation budget. Without this, a caller can raise
+        // `blockOverrides.gasLimit` above `--rpc.gascap` and also set `calls[i].gas` above
+        // `--rpc.gascap`, amplifying the RPC DoS envelope beyond the operator's contract.
+        match call.as_ref().gas_limit() {
+            Some(gas) if gas > *remaining_budget => {
+                tracing::debug!(
+                    target: "rpc::eth::simulate",
+                    requested = gas,
+                    cap = *remaining_budget,
+                    "Caller gas above allowance, capping",
+                );
+                call.as_mut().set_gas_limit(*remaining_budget);
+            }
+            _ => {}
+        }
+
+        // Resolve transaction, populate missing fields and enforce calls correctness. Unset
+        // `gas` defaults to `default_gas_limit` clamped to the remaining budget, so the
+        // per-call ceiling is always `min(spec default, --rpc.gascap remaining)`.
         let tx = resolve_transaction(
             call,
-            default_gas_limit,
+            default_gas_limit.min(*remaining_budget),
             builder.evm().block().basefee(),
             chain_id,
             builder.evm_mut().db_mut(),
@@ -198,9 +223,16 @@ where
         // The effect for a layer-2 execution client is that it does not charge L1 cost.
         let tx = WithEncoded::new(Default::default(), tx);
 
+        let mut call_gas_used = 0u64;
         builder.execute_transaction_with_result_closure(tx, |result| {
-            results.push(result.result().result.clone())
+            call_gas_used = result.result().result.tx_gas_used();
+            results.push(result.result().result.clone());
         })?;
+
+        // Debit the shared budget by the call's actual gas usage (net of refunds), matching
+        // geth's gas-pool accounting: the pool reserves `gas_limit` upfront and refunds what
+        // the call didn't consume, so the running deduction equals `gas_used`.
+        *remaining_budget = remaining_budget.saturating_sub(call_gas_used);
     }
 
     // Pass noop provider to skip state root calculations.


### PR DESCRIPTION
Remove the pre-check that rejected `blockOverrides.gasLimit` above `max(base_block_gas_limit, --rpc.gascap)` in `eth_simulateV1`, matching geth/op-geth which apply no upfront ceiling on `BlockOverrides.GasLimit`.

`eth_simulateV1` exists to model hypothetical blocks, so forcing operators to raise `--rpc.gascap` globally just to simulate larger blocks defeats the override's purpose. `--rpc.gascap` still bounds defaulted per-call gas in `simulate_v1` and still applies to `eth_call` / `eth_estimateGas` via their own code paths; the existing sum check still rejects per-call gas sums that exceed the (possibly-overridden) block gas limit.

An e2e regression test (`crates/ethereum/node/tests/e2e/simulate.rs::test_simulate_v1_block_gas_limit_override_above_rpc_gascap`) spins up a node with defaults, submits `eth_simulateV1` with `blockOverrides.gasLimit = 100M` (above the default 50M `--rpc.gascap` and the 30M genesis block gas), and asserts the simulation succeeds.

## Reproduction against a live node

Tested against a reth node on Ethereum mainnet running default `--rpc.gascap = 50_000_000`. Both payloads are identical except for `blockOverrides.gasLimit`. The call is a USDC `transfer` from an EOA holding no USDC, which reverts with `ERC20: transfer amount exceeds balance` (actual gas used ~36K) — the revert itself is expected and only demonstrates that the handler actually executed.

`sim_low.json` — `blockOverrides.gasLimit = 0xF4240` (1,000,000). Succeeds both before and after this change.

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "eth_simulateV1",
  "params": [
    {
      "blockStateCalls": [
        {
          "blockOverrides": { "gasLimit": "0xF4240" },
          "calls": [
            {
              "from": "0x0000000000000000000000000000000000001234",
              "to":   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
              "data": "0xa9059cbb000000000000000000000000111111111111111111111111111111111111111100000000000000000000000000000000000000000000000000000000000F4240",
              "gas":  "0x7A120"
            }
          ]
        }
      ],
      "validation": false,
      "traceTransfers": false
    },
    "latest"
  ]
}
```

`sim_high.json` — identical payload, only `blockOverrides.gasLimit` changed to `0x5F5E100` (100,000,000). On `main` returns `{"code":-38026,"message":"Client adjustable limit reached"}`; on this branch returns a normal simulation result.

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "eth_simulateV1",
  "params": [
    {
      "blockStateCalls": [
        {
          "blockOverrides": { "gasLimit": "0x5F5E100" },
          "calls": [
            {
              "from": "0x0000000000000000000000000000000000001234",
              "to":   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
              "data": "0xa9059cbb000000000000000000000000111111111111111111111111111111111111111100000000000000000000000000000000000000000000000000000000000F4240",
              "gas":  "0x7A120"
            }
          ]
        }
      ],
      "validation": false,
      "traceTransfers": false
    },
    "latest"
  ]
}
```

```bash
curl -sS -X POST "$RPC_URL" -H 'Content-Type: application/json' -d @sim_low.json
curl -sS -X POST "$RPC_URL" -H 'Content-Type: application/json' -d @sim_high.json
```
