### PR TITLE
fix(cli): open stage dump environment read-write

### DIFF
--- a/crates/cli/commands/src/stage/dump/mod.rs
+++ b/crates/cli/commands/src/stage/dump/mod.rs
@@ -29,7 +29,10 @@ use execution::dump_execution_stage;
 mod merkle;
 use merkle::dump_merkle_stage;
 
-/// `reth dump-stage` command
+/// `reth dump-stage` command.
+///
+/// Note: mutates the source datadir (unwinds hashing/merkle/execution before copying tables).
+/// Stop the node and back up the datadir first.
 #[derive(Debug, Parser)]
 pub struct Command<C: ChainSpecParser> {
     #[command(flatten)]
@@ -100,8 +103,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         Comp: CliNodeComponents<N>,
         F: FnOnce(Arc<C::ChainSpec>) -> Comp,
     {
+        // `unwind_and_copy` opens a RW provider on the source datadir, so open RW here.
         let Environment { provider_factory, .. } =
-            self.env.init::<N>(AccessRights::RO, runtime.clone())?;
+            self.env.init::<N>(AccessRights::RW, runtime.clone())?;
         let tool = DbTool::new(provider_factory)?;
         let components = components(tool.chain());
         let evm_config = components.evm_config().clone();


### PR DESCRIPTION
While trying to isolate a regression I ran `reth stage dump merkle` on `main` and it fails immediately with `the environment opened in read-only` — the top-level command opens the source datadir RO, but every subcommand's `unwind_and_copy` asks for a RW provider on the same env (broken since #8590).

Open RW so the subcommands run, and add a top-level note that the command does mutate the source datadir.