### PR TITLE
fix(bench): use previous snapshot to avoid block fetch failures

### DIFF
--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -24,7 +24,7 @@ MC="mc"
 BUCKET="minio/reth-snapshots"
 # Allow overriding the snapshot name (e.g. for big-blocks mode where the
 # big-blocks manifest specifies which base snapshot to use).
-SNAPSHOT_NAME="${BENCH_SNAPSHOT_NAME:-reth-1-minimal-stable}"
+SNAPSHOT_NAME="${BENCH_SNAPSHOT_NAME:-reth-1-minimal-stable-previous}"
 MANIFEST_PATH="${SNAPSHOT_NAME}/manifest.json"
 DATADIR_NAME="datadir"
 HASH_MODE_SUFFIX=""


### PR DESCRIPTION
The hourly bench has been failing with `Block not found` because the latest snapshot is too close to the chain tip, leaving insufficient blocks for the bench to replay (needs 2500 blocks of headroom). Switches the default to `reth-1-minimal-stable-previous` which has more runway.

Prompted by: Alexey