### PR TITLE
feat(rpc): add debug_storageRangeAt

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -2,7 +2,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, U64};
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{ExecutionWitness, StorageRangeResult};
 use alloy_rpc_types_eth::{Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -395,7 +395,7 @@ pub trait DebugApi<TxReq: RpcObject> {
         contract_address: Address,
         key_start: B256,
         max_result: u64,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<StorageRangeResult>;
 
     /// Returns the structured logs created during the execution of EVM against a block pulled
     /// from the pool of bad ones and returns them as a JSON object. For the second parameter see

--- a/crates/rpc/rpc-eth-api/src/helpers/mod.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/mod.rs
@@ -26,6 +26,10 @@ pub mod receipt;
 pub mod signer;
 pub mod spec;
 pub mod state;
+/// Inspector for collecting per-transaction storage diffs during replay.
+pub mod storage_diff_inspector;
+/// Overlay helpers for applying in-block storage diffs to paged storage range queries.
+pub mod storage_overlay;
 pub mod trace;
 pub mod transaction;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/storage_diff_inspector.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/storage_diff_inspector.rs
@@ -1,0 +1,104 @@
+use alloy_primitives::{Address, StorageKey, StorageValue, B256};
+use revm::{
+    bytecode::OpCode,
+    context::ContextTr,
+    inspector::Inspector,
+    interpreter::{
+        interpreter_types::{InputsTr, Jumps, StackTr},
+        Interpreter, InterpreterTypes,
+    },
+};
+use std::collections::{BTreeMap, HashMap};
+
+/// Storage diff per transaction. Outer `Vec` is ordered by transaction index.
+pub type StorageDiffs = Vec<HashMap<Address, BTreeMap<StorageKey, StorageValue>>>;
+
+/// Captures per-transaction storage diffs by watching `SSTORE` instructions during replay.
+#[derive(Clone, Debug, Default)]
+pub struct StorageDiffInspector {
+    current_tx: HashMap<Address, BTreeMap<StorageKey, StorageValue>>,
+    tx_diffs: StorageDiffs,
+}
+
+impl StorageDiffInspector {
+    /// Creates a new inspector instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Marks the end of the current transaction and stores the accumulated diff.
+    pub fn finish_transaction(&mut self) {
+        self.tx_diffs.push(self.current_tx.drain().collect());
+    }
+
+    /// Returns collected diffs, consuming the inspector.
+    pub fn into_diffs(mut self) -> StorageDiffs {
+        if !self.current_tx.is_empty() {
+            self.finish_transaction();
+        }
+        self.tx_diffs
+    }
+
+    fn record_sstore<INTR: InterpreterTypes>(&mut self, interp: &Interpreter<INTR>) {
+        let contract = interp.input.target_address();
+        let stack = &interp.stack;
+        let len = stack.len();
+        if len < 2 {
+            return;
+        }
+
+        let data = stack.data();
+        let slot: StorageKey = B256::from(data[len - 1]);
+        let value: StorageValue = data[len - 2];
+        self.current_tx.entry(contract).or_default().insert(slot, value);
+    }
+}
+
+impl<CTX, INTR> Inspector<CTX, INTR> for StorageDiffInspector
+where
+    CTX: ContextTr,
+    INTR: InterpreterTypes,
+{
+    fn step(&mut self, interp: &mut Interpreter<INTR>, _context: &mut CTX) {
+        if let Some(opcode) = OpCode::new(interp.bytecode.opcode()) &&
+            opcode == OpCode::SSTORE
+        {
+            self.record_sstore(interp);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+
+    #[test]
+    fn finish_transaction_moves_current_diff() {
+        let mut inspector = StorageDiffInspector::new();
+        let addr = Address::repeat_byte(0x11);
+        let key = StorageKey::from(B256::from(U256::from(1)));
+        let value: StorageValue = U256::from(2);
+        inspector.current_tx.entry(addr).or_default().insert(key, value);
+
+        inspector.finish_transaction();
+        assert!(inspector.current_tx.is_empty());
+        assert_eq!(inspector.tx_diffs.len(), 1);
+        let slots = inspector.tx_diffs[0].get(&addr).unwrap();
+        assert_eq!(slots.get(&key), Some(&value));
+    }
+
+    #[test]
+    fn into_diffs_flushes_pending_tx() {
+        let mut inspector = StorageDiffInspector::new();
+        let addr = Address::repeat_byte(0x22);
+        let key = StorageKey::from(B256::from(U256::from(3)));
+        let value: StorageValue = U256::from(4);
+        inspector.current_tx.entry(addr).or_default().insert(key, value);
+
+        let diffs = inspector.into_diffs();
+        assert_eq!(diffs.len(), 1);
+        let slots = diffs[0].get(&addr).unwrap();
+        assert_eq!(slots.get(&key), Some(&value));
+    }
+}

--- a/crates/rpc/rpc-eth-api/src/helpers/storage_overlay.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/storage_overlay.rs
@@ -1,0 +1,257 @@
+use crate::helpers::storage_diff_inspector::StorageDiffs;
+use alloy_primitives::{keccak256, Address, StorageKey, StorageValue, B256};
+use reth_storage_api::{
+    errors::provider::ProviderResult, StorageRangeEntry, StorageRangeProvider, StorageRangeResult,
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+};
+
+const STORAGE_PAGE: usize = 512;
+
+/// Provides a storage-range view that overlays pending slot diffs on top of a historical provider.
+pub struct StorageRangeOverlay<'a> {
+    base: &'a dyn StorageRangeProvider,
+    overlays: HashMap<Address, BTreeMap<B256, StorageRangeEntry>>,
+}
+
+impl fmt::Debug for StorageRangeOverlay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageRangeOverlay").field("overlays", &self.overlays).finish()
+    }
+}
+
+impl<'a> StorageRangeOverlay<'a> {
+    /// Creates a new overlay that delegates to `base` for accounts without pending diffs.
+    pub fn new(base: &'a dyn StorageRangeProvider) -> Self {
+        Self { base, overlays: HashMap::new() }
+    }
+
+    /// Registers the merged storage slots for `account` that should shadow the base provider.
+    pub fn add_account_overlay(
+        &mut self,
+        account: Address,
+        slots: BTreeMap<B256, StorageRangeEntry>,
+    ) {
+        self.overlays.insert(account, slots);
+    }
+
+    /// Returns the merged slots for `account` taking into account diffs up to `tx_idx`
+    /// (inclusive). If the account was untouched, `None` is returned.
+    pub fn merged_slots_for_account(
+        base: &dyn StorageRangeProvider,
+        account: Address,
+        diffs: &StorageDiffs,
+        tx_idx: usize,
+    ) -> ProviderResult<Option<BTreeMap<B256, StorageRangeEntry>>> {
+        if diffs.is_empty() {
+            return Ok(None)
+        }
+
+        let limit = tx_idx.min(diffs.len().saturating_sub(1));
+        let mut relevant = Vec::new();
+        for tx_diff in diffs.iter().take(limit + 1) {
+            if let Some(slots) = tx_diff.get(&account) {
+                relevant.push(slots);
+            }
+        }
+
+        if relevant.is_empty() {
+            return Ok(None)
+        }
+
+        let mut merged = collect_account_slots(base, account)?;
+        apply_diffs(&mut merged, relevant);
+        Ok(Some(merged))
+    }
+}
+
+impl StorageRangeProvider for StorageRangeOverlay<'_> {
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: StorageKey,
+        max_slots: usize,
+    ) -> ProviderResult<StorageRangeResult> {
+        if let Some(overlay) = self.overlays.get(&account) {
+            return Ok(range_from_map(overlay, start_key, max_slots))
+        }
+
+        self.base.storage_range(account, start_key, max_slots)
+    }
+}
+
+fn range_from_map(
+    map: &BTreeMap<B256, StorageRangeEntry>,
+    start_key: StorageKey,
+    max_slots: usize,
+) -> StorageRangeResult {
+    if max_slots == 0 {
+        return StorageRangeResult::empty()
+    }
+
+    let mut slots = Vec::new();
+    let mut next_key = None;
+    for (hash, entry) in map.range(start_key..) {
+        if slots.len() < max_slots {
+            slots.push(entry.clone());
+        } else {
+            next_key = Some(*hash);
+            break;
+        }
+    }
+
+    StorageRangeResult { slots, next_key }
+}
+
+fn collect_account_slots(
+    provider: &dyn StorageRangeProvider,
+    account: Address,
+) -> ProviderResult<BTreeMap<B256, StorageRangeEntry>> {
+    let mut slots = BTreeMap::new();
+    let mut start = B256::ZERO;
+
+    loop {
+        let StorageRangeResult { slots: chunk_slots, next_key } =
+            provider.storage_range(account, start, STORAGE_PAGE)?;
+        for entry in &chunk_slots {
+            slots.insert(entry.hash, entry.clone());
+        }
+
+        if let Some(next) = next_key {
+            if chunk_slots.is_empty() && next == start {
+                break;
+            }
+            start = next;
+        } else {
+            break;
+        }
+    }
+
+    Ok(slots)
+}
+
+fn apply_diffs<'a, I>(merged: &mut BTreeMap<B256, StorageRangeEntry>, diffs: I)
+where
+    I: IntoIterator<Item = &'a BTreeMap<StorageKey, StorageValue>>,
+{
+    for diff in diffs {
+        for (slot, value) in diff {
+            let hash = keccak256(*slot);
+            if value.is_zero() {
+                merged.remove(&hash);
+            } else {
+                merged.insert(hash, StorageRangeEntry { hash, key: *slot, value: *value });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestRangeProvider {
+        slots: BTreeMap<B256, StorageRangeEntry>,
+    }
+
+    impl TestRangeProvider {
+        fn new(slots: impl IntoIterator<Item = (u8, u64)>) -> Self {
+            let mut map = BTreeMap::new();
+            for (slot, value) in slots {
+                let key = StorageKey::with_last_byte(slot);
+                let hash = keccak256(key);
+                map.insert(hash, StorageRangeEntry { hash, key, value: StorageValue::from(value) });
+            }
+            Self { slots: map }
+        }
+    }
+
+    impl StorageRangeProvider for TestRangeProvider {
+        fn storage_range(
+            &self,
+            _account: Address,
+            start_key: StorageKey,
+            max_slots: usize,
+        ) -> ProviderResult<StorageRangeResult> {
+            Ok(range_from_map(&self.slots, start_key, max_slots))
+        }
+    }
+
+    #[test]
+    fn merges_diffs_and_removals() {
+        let base = TestRangeProvider::new([(0x01, 10), (0x02, 20)]);
+        let account = Address::repeat_byte(0x11);
+
+        let mut tx_diff = HashMap::new();
+        tx_diff.insert(
+            account,
+            BTreeMap::from([
+                (StorageKey::with_last_byte(0x01), StorageValue::from(30)),
+                (StorageKey::with_last_byte(0x02), StorageValue::ZERO),
+                (StorageKey::with_last_byte(0x03), StorageValue::from(40)),
+            ]),
+        );
+        let diffs = vec![tx_diff];
+
+        let merged = StorageRangeOverlay::merged_slots_for_account(&base, account, &diffs, 0)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(
+            merged.get(&keccak256(StorageKey::with_last_byte(0x01))).unwrap().value,
+            StorageValue::from(30)
+        );
+        assert_eq!(
+            merged.get(&keccak256(StorageKey::with_last_byte(0x03))).unwrap().value,
+            StorageValue::from(40)
+        );
+        assert!(!merged.contains_key(&keccak256(StorageKey::with_last_byte(0x02))));
+    }
+
+    #[test]
+    fn overlay_provider_prefers_overrides() {
+        let base = TestRangeProvider::new([(0x01, 1), (0x02, 2)]);
+        let account = Address::repeat_byte(0x44);
+
+        let key1 = StorageKey::with_last_byte(0x01);
+        let key4 = StorageKey::with_last_byte(0x04);
+        let hash1 = keccak256(key1);
+        let hash4 = keccak256(key4);
+        let merged = BTreeMap::from([
+            (hash1, StorageRangeEntry { hash: hash1, key: key1, value: StorageValue::from(9) }),
+            (hash4, StorageRangeEntry { hash: hash4, key: key4, value: StorageValue::from(4) }),
+        ]);
+
+        let mut overlay = StorageRangeOverlay::new(&base);
+        overlay.add_account_overlay(account, merged);
+
+        let res = overlay.storage_range(account, B256::ZERO, 10).expect("range");
+        assert_eq!(res.slots.len(), 2);
+        let mut by_hash = BTreeMap::new();
+        for entry in res.slots {
+            by_hash.insert(entry.hash, entry);
+        }
+        assert_eq!(
+            by_hash.get(&hash1).unwrap(),
+            &StorageRangeEntry { hash: hash1, key: key1, value: StorageValue::from(9) }
+        );
+        assert_eq!(
+            by_hash.get(&hash4).unwrap(),
+            &StorageRangeEntry { hash: hash4, key: key4, value: StorageValue::from(4) }
+        );
+
+        let other = overlay.storage_range(Address::ZERO, B256::ZERO, 10).expect("range");
+        assert_eq!(other.slots.len(), 2);
+        let mut other_by_hash = BTreeMap::new();
+        for entry in other.slots {
+            other_by_hash.insert(entry.hash, entry);
+        }
+        assert_eq!(
+            other_by_hash.get(&keccak256(StorageKey::with_last_byte(0x02))).unwrap().value,
+            StorageValue::from(2)
+        );
+    }
+}

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -5,7 +5,9 @@ use alloy_genesis::ChainConfig;
 use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{
+    ExecutionWitness, StorageMap, StorageRangeResult as RpcStorageRangeResult, StorageResult,
+};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
@@ -25,21 +27,29 @@ use reth_revm::{db::State, witness::ExecutionWitnessRecord};
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
-    helpers::{EthTransactions, TraceExt},
+    helpers::{
+        storage_diff_inspector::{StorageDiffInspector, StorageDiffs},
+        storage_overlay::StorageRangeOverlay,
+        EthTransactions, TraceExt,
+    },
     FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::EthApiError;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
-    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, TransactionVariant,
+    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, StorageRangeProvider,
+    StorageRangeResult as ProviderStorageRangeResult, TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
 use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
@@ -204,6 +214,133 @@ where
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
 
         self.trace_block(block, evm_env, opts).await
+    }
+
+    /// Replays the transactions of `block_id` with [`StorageDiffInspector`] and returns the
+    /// collected diffs.
+    ///
+    /// If `highest_tx_index` is provided, execution stops after the transaction at that index has
+    /// been applied (inclusive).
+    pub async fn run_with_storage_diff_inspector(
+        &self,
+        block_id: BlockId,
+        highest_tx_index: Option<u64>,
+    ) -> Result<StorageDiffs, Eth::Error> {
+        let block = self
+            .eth_api()
+            .recovered_block(block_id)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
+
+        let max_index = match highest_tx_index {
+            Some(idx) => Some(usize::try_from(idx).map_err(|_| {
+                Eth::Error::from_eth_err(EthApiError::InvalidParams(
+                    "tx index exceeds architecture limits".to_string(),
+                ))
+            })?),
+            None => None,
+        };
+
+        self.eth_api()
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
+                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+
+                let mut inspector = StorageDiffInspector::new();
+                for (idx, tx) in block.transactions_recovered().enumerate() {
+                    if let Some(limit) = max_index &&
+                        idx > limit
+                    {
+                        break
+                    }
+
+                    let tx_env = eth_api.evm_config().tx_env(tx);
+                    {
+                        let mut evm = eth_api.evm_config().evm_with_env_and_inspector(
+                            &mut db,
+                            evm_env.clone(),
+                            &mut inspector,
+                        );
+                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+                    }
+                    inspector.finish_transaction();
+                }
+
+                Ok::<_, Eth::Error>(inspector.into_diffs())
+            })
+            .await
+    }
+
+    /// Computes the storage range for the given block, transaction index and account, taking into
+    /// account the writes performed up to the specified transaction.
+    pub async fn storage_range_at(
+        &self,
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> Result<RpcStorageRangeResult, Eth::Error> {
+        if max_result == 0 {
+            return Err(
+                EthApiError::InvalidParams("maxResult must be greater than zero".into()).into()
+            )
+        }
+
+        let block_id: BlockId = block_hash.into();
+        let block = self
+            .eth_api()
+            .recovered_block(block_id)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+        let tx_count = block.body().transactions().len();
+        if tx_idx >= tx_count {
+            return Err(EthApiError::InvalidParams(format!(
+                "transaction index {tx_idx} out of bounds for block with {tx_count} transactions"
+            ))
+            .into())
+        }
+
+        let diffs = self.run_with_storage_diff_inspector(block_id, Some(tx_idx as u64)).await?;
+        let max_slots = usize::try_from(max_result).map_err(|_| {
+            Eth::Error::from_eth_err(EthApiError::InvalidParams(
+                "maxResult exceeds supported limits".to_string(),
+            ))
+        })?;
+        let start_key = key_start;
+        let parent_hash = block.parent_hash();
+
+        self.eth_api()
+            .spawn_blocking_io(move |this| {
+                let storage_provider = this
+                    .provider()
+                    .storage_range_by_block_hash(parent_hash)
+                    .map_err(Eth::Error::from_eth_err)?;
+                let base = storage_provider.as_ref();
+
+                let overlay_slots = StorageRangeOverlay::merged_slots_for_account(
+                    base,
+                    contract_address,
+                    &diffs,
+                    tx_idx,
+                )
+                .map_err(Eth::Error::from_eth_err)?;
+
+                if let Some(overlay_slots) = overlay_slots {
+                    let mut overlay = StorageRangeOverlay::new(base);
+                    overlay.add_account_overlay(contract_address, overlay_slots);
+                    return overlay
+                        .storage_range(contract_address, start_key, max_slots)
+                        .map(convert_storage_range)
+                        .map_err(Eth::Error::from_eth_err);
+                }
+
+                storage_provider
+                    .storage_range(contract_address, start_key, max_slots)
+                    .map(convert_storage_range)
+                    .map_err(Eth::Error::from_eth_err)
+            })
+            .await
     }
 
     /// Trace the transaction according to the provided options.
@@ -1053,13 +1190,15 @@ where
 
     async fn debug_storage_range_at(
         &self,
-        _block_hash: B256,
-        _tx_idx: usize,
-        _contract_address: Address,
-        _key_start: B256,
-        _max_result: u64,
-    ) -> RpcResult<()> {
-        Ok(())
+        block_hash: B256,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: B256,
+        max_result: u64,
+    ) -> RpcResult<RpcStorageRangeResult> {
+        Self::storage_range_at(self, block_hash, tx_idx, contract_address, key_start, max_result)
+            .await
+            .map_err(Into::into)
     }
 
     async fn debug_trace_bad_block(
@@ -1118,6 +1257,18 @@ impl<Eth: RpcNodeCore> Clone for DebugApi<Eth> {
     }
 }
 
+fn convert_storage_range(range: ProviderStorageRangeResult) -> RpcStorageRangeResult {
+    let mut storage = BTreeMap::new();
+    for entry in range.slots {
+        storage.insert(
+            entry.hash,
+            StorageResult { key: entry.key, value: B256::from(entry.value.to_be_bytes()) },
+        );
+    }
+
+    RpcStorageRangeResult { storage: StorageMap(storage), next_key: range.next_key }
+}
+
 struct DebugApiInner<Eth: RpcNodeCore> {
     /// The implementation of `eth` API
     eth_api: Eth,
@@ -1173,5 +1324,247 @@ impl<B: BlockTrait> BadBlockStore<B> {
 impl<B: BlockTrait> Default for BadBlockStore<B> {
     fn default() -> Self {
         Self::new(64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{eth::helpers::types::EthRpcConverter, EthApi};
+    use alloy_consensus::{Header, TxLegacy};
+    use alloy_primitives::{keccak256, StorageKey, StorageValue, TxKind, U256};
+    use futures::stream::empty;
+    use reth_chainspec::ChainSpec;
+    use reth_db_api::models::StoredBlockBodyIndices;
+    use reth_ethereum_primitives::{
+        Block as EthBlock, BlockBody as EthBlockBody, Transaction as EthTransaction,
+    };
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_network_api::noop::NoopNetwork;
+    use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use reth_rpc_eth_api::node::RpcNodeCoreAdapter;
+    use reth_storage_api::StorageRangeEntry as ProviderStorageRangeEntry;
+    use reth_tasks::Runtime;
+    use reth_testing_utils::generators::{self, sign_tx_with_key_pair};
+    use reth_transaction_pool::test_utils::{testing_pool, TestPool};
+
+    type TestRpcNode = RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig>;
+    type TestEthApi = EthApi<TestRpcNode, EthRpcConverter<ChainSpec>>;
+
+    fn make_sstore_code(slot: u8, value: u8) -> Bytes {
+        Bytes::from(vec![0x60, value, 0x60, slot, 0x55, 0x00])
+    }
+
+    fn build_debug_api_with_contract_writes(
+        writes: &[(u8, u8)],
+    ) -> (DebugApi<TestEthApi>, BlockId, Vec<Address>) {
+        let provider = MockEthProvider::default();
+        let mut rng = generators::rng();
+        let keypair = generators::generate_key(&mut rng);
+        let sender = public_key_to_address(keypair.public_key());
+        provider.add_account(
+            sender,
+            ExtendedAccount::new(0, U256::from(1_000_000_000_000_000_000u128)),
+        );
+
+        let mut contract_addresses = Vec::new();
+        let mut txs = Vec::new();
+        for (idx, (slot, value)) in writes.iter().copied().enumerate() {
+            let address = Address::repeat_byte(0x80 + idx as u8);
+            contract_addresses.push(address);
+            provider.add_account(
+                address,
+                ExtendedAccount::new(0, U256::ZERO).with_bytecode(make_sstore_code(slot, value)),
+            );
+            let tx = EthTransaction::Legacy(TxLegacy {
+                chain_id: Some(1),
+                nonce: idx as u64,
+                gas_price: 1,
+                gas_limit: 100_000,
+                to: TxKind::Call(address),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            });
+            txs.push(sign_tx_with_key_pair(keypair, tx));
+        }
+
+        let mut header = Header {
+            number: 1,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1),
+            ..Header::default()
+        };
+        header.parent_hash = B256::with_last_byte(0xAA);
+        let parent = Header { number: 0, ..Header::default() };
+        provider.add_header(header.parent_hash, parent);
+        let block = EthBlock {
+            header: header.clone(),
+            body: EthBlockBody { transactions: txs.clone(), ..Default::default() },
+        };
+        let block_hash = header.hash_slow();
+        provider.add_block(block_hash, block);
+        provider.add_block_body_indices(
+            header.number,
+            StoredBlockBodyIndices { first_tx_num: 0, tx_count: txs.len() as u64 },
+        );
+
+        let evm_config = EthEvmConfig::new(provider.chain_spec());
+        let eth_api =
+            EthApi::builder(provider, testing_pool(), NoopNetwork::default(), evm_config).build();
+
+        let executor = Runtime::test();
+        let events = empty::<ConsensusEngineEvent<<TestEthApi as RpcNodeCore>::Primitives>>();
+        let debug_api = DebugApi::new(eth_api, BlockingTaskGuard::new(4), &executor, events);
+        (debug_api, BlockId::Hash(block_hash.into()), contract_addresses)
+    }
+
+    fn build_debug_api_with_base_storage(
+        base_storage: &[(u8, u64)],
+        write: (u8, u8),
+    ) -> (DebugApi<TestEthApi>, B256, Address) {
+        let provider = MockEthProvider::default();
+        let mut rng = generators::rng();
+        let keypair = generators::generate_key(&mut rng);
+        let sender = public_key_to_address(keypair.public_key());
+        provider.add_account(
+            sender,
+            ExtendedAccount::new(0, U256::from(1_000_000_000_000_000_000u128)),
+        );
+
+        let contract = Address::repeat_byte(0x99);
+        let base_storage = base_storage
+            .iter()
+            .map(|(slot, value)| (StorageKey::with_last_byte(*slot), StorageValue::from(*value)));
+        provider.add_account(
+            contract,
+            ExtendedAccount::new(0, U256::ZERO)
+                .with_bytecode(make_sstore_code(write.0, write.1))
+                .extend_storage(base_storage),
+        );
+
+        let tx = sign_tx_with_key_pair(
+            keypair,
+            EthTransaction::Legacy(TxLegacy {
+                chain_id: Some(1),
+                nonce: 0,
+                gas_price: 1,
+                gas_limit: 100_000,
+                to: TxKind::Call(contract),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }),
+        );
+        let mut header = Header {
+            number: 1,
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1),
+            ..Header::default()
+        };
+        header.parent_hash = B256::with_last_byte(0xBB);
+        let parent = Header { number: 0, ..Header::default() };
+        provider.add_header(header.parent_hash, parent);
+        let block = EthBlock {
+            header: header.clone(),
+            body: EthBlockBody { transactions: vec![tx], ..Default::default() },
+        };
+        let block_hash = header.hash_slow();
+        provider.add_block(block_hash, block);
+        provider.add_block_body_indices(
+            header.number,
+            StoredBlockBodyIndices { first_tx_num: 0, tx_count: 1 },
+        );
+
+        let evm_config = EthEvmConfig::new(provider.chain_spec());
+        let eth_api =
+            EthApi::builder(provider, testing_pool(), NoopNetwork::default(), evm_config).build();
+
+        let executor = Runtime::test();
+        let events = empty::<ConsensusEngineEvent<<TestEthApi as RpcNodeCore>::Primitives>>();
+        let debug_api = DebugApi::new(eth_api, BlockingTaskGuard::new(4), &executor, events);
+        (debug_api, block_hash, contract)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn collects_storage_diffs_for_block() {
+        let (api, block_id, contracts) = build_debug_api_with_contract_writes(&[(1, 0x2A)]);
+        let diffs = api.run_with_storage_diff_inspector(block_id, None).await.unwrap();
+        assert_eq!(diffs.len(), 1);
+
+        let slot = StorageKey::with_last_byte(1);
+        let value = StorageValue::from(0x2A);
+        let slots = diffs[0].get(&contracts[0]).expect("contract entry must exist");
+        assert_eq!(slots.get(&slot), Some(&value));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn respects_tx_index_limit() {
+        let (api, block_id, contracts) =
+            build_debug_api_with_contract_writes(&[(1, 0x10), (2, 0x20)]);
+
+        let capped = api.run_with_storage_diff_inspector(block_id, Some(0)).await.unwrap();
+        assert_eq!(capped.len(), 1);
+        let first_contract_diff = capped[0].get(&contracts[0]).expect("first tx diff missing");
+        assert_eq!(
+            first_contract_diff.get(&StorageKey::with_last_byte(1)),
+            Some(&StorageValue::from(0x10))
+        );
+        assert!(!capped[0].contains_key(&contracts[1]));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn storage_range_at_merges_parent_state_and_overlay() {
+        let (api, block_hash, contract) = build_debug_api_with_base_storage(&[(1, 10)], (2, 42));
+
+        let range = api.storage_range_at(block_hash, 0, contract, B256::ZERO, 10).await.unwrap();
+
+        assert_eq!(range.next_key, None);
+        assert_eq!(range.storage.len(), 2);
+        assert_eq!(
+            range.storage.get(&keccak256(StorageKey::with_last_byte(1))).unwrap(),
+            &StorageResult {
+                key: StorageKey::with_last_byte(1),
+                value: B256::from(StorageValue::from(10).to_be_bytes()),
+            }
+        );
+        assert_eq!(
+            range.storage.get(&keccak256(StorageKey::with_last_byte(2))).unwrap(),
+            &StorageResult {
+                key: StorageKey::with_last_byte(2),
+                value: B256::from(StorageValue::from(42).to_be_bytes()),
+            }
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn storage_range_at_supports_pagination() {
+        let (api, block_hash, contract) =
+            build_debug_api_with_base_storage(&[(1, 10), (2, 20)], (3, 30));
+
+        let range = api.storage_range_at(block_hash, 0, contract, B256::ZERO, 2).await.unwrap();
+
+        assert_eq!(range.storage.len(), 2);
+        assert_eq!(range.next_key, Some(keccak256(StorageKey::with_last_byte(3))));
+    }
+
+    #[test]
+    fn converts_storage_range_result() {
+        let entry = ProviderStorageRangeEntry {
+            hash: B256::from(U256::from(4)),
+            key: B256::from(U256::from(1)),
+            value: U256::from(2),
+        };
+        let range = ProviderStorageRangeResult {
+            slots: vec![entry.clone()],
+            next_key: Some(StorageKey::from(B256::from(U256::from(3)))),
+        };
+
+        let rpc = convert_storage_range(range);
+        assert_eq!(rpc.next_key, Some(B256::from(U256::from(3))));
+        assert_eq!(rpc.storage.len(), 1);
+        let (key, slot) = rpc.storage.0.iter().next().unwrap();
+        assert_eq!(key, &entry.hash);
+        assert_eq!(slot.key, entry.key);
+        assert_eq!(slot.value, B256::from(entry.value.to_be_bytes()));
     }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -27,7 +27,10 @@ use reth_primitives_traits::{Account, RecoveredBlock, SealedHeader, StorageEntry
 use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::{BlockBodyIndicesProvider, NodePrimitivesProvider, StorageChangeSetReader};
+use reth_storage_api::{
+    BlockBodyIndicesProvider, NodePrimitivesProvider, StorageChangeSetReader,
+    StorageRangeProviderBox,
+};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{HashedPostState, KeccakKeyHasher};
 use revm_database::BundleState;
@@ -564,6 +567,14 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
     fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
         self.consistent_provider()?.into_state_provider_at_block_hash(block_hash)
+    }
+
+    fn storage_range_by_block_hash(
+        &self,
+        block_hash: BlockHash,
+    ) -> ProviderResult<StorageRangeProviderBox> {
+        trace!(target: "providers::blockchain", ?block_hash, "Getting storage range by block hash");
+        self.consistent_provider()?.into_storage_range_provider_at_block_hash(block_hash)
     }
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -27,7 +27,8 @@ use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, DatabaseProviderFactory, NodePrimitivesProvider, StateProvider,
-    StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
+    StateProviderBox, StorageChangeSetReader, StorageRangeProviderBox,
+    TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use revm_database::states::PlainStorageRevert;
@@ -617,6 +618,24 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             return Ok(Box::new(block_state.state_provider(latest_historical)));
         }
         storage_provider.try_into_history_at_block(block_number)
+    }
+
+    /// Consumes the provider and returns a storage range provider for the specific block hash.
+    pub(crate) fn into_storage_range_provider_at_block_hash(
+        self,
+        block_hash: BlockHash,
+    ) -> ProviderResult<StorageRangeProviderBox> {
+        let block_number =
+            self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        self.ensure_canonical_block(block_number)?;
+
+        let Self { storage_provider, head_block, .. } = self;
+        if head_block.as_ref().and_then(|blocks| blocks.block_on_chain(block_hash.into())).is_some()
+        {
+            return Err(ProviderError::UnsupportedProvider)
+        }
+
+        storage_provider.try_into_storage_range_history_at_block(block_number)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -17,8 +17,9 @@ use crate::{
     LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
     PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
     RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
-    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+    StaticFileProviderFactory, StatsReader, StorageRangeProviderBox, StorageReader,
+    StorageTrieWriter, TransactionVariant, TransactionsProvider, TransactionsProviderExt,
+    TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -938,6 +939,52 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.
+        if let Some(prune_checkpoint_block_number) =
+            account_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
+        {
+            state_provider = state_provider.with_lowest_available_account_history_block_number(
+                prune_checkpoint_block_number + 1,
+            );
+        }
+        if let Some(prune_checkpoint_block_number) =
+            storage_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
+        {
+            state_provider = state_provider.with_lowest_available_storage_history_block_number(
+                prune_checkpoint_block_number + 1,
+            );
+        }
+
+        Ok(Box::new(state_provider))
+    }
+
+    fn try_into_storage_range_history_at_block(
+        self,
+        mut block_number: BlockNumber,
+    ) -> ProviderResult<StorageRangeProviderBox> {
+        if !self.cached_storage_settings().storage_v2 {
+            return Err(ProviderError::UnsupportedProvider)
+        }
+
+        let best_block = self.best_block_number().unwrap_or_default();
+        if block_number > best_block {
+            return Err(ProviderError::BlockNotExecuted {
+                requested: block_number,
+                executed: best_block,
+            });
+        }
+
+        // HistoricalStateProvider reads the state at the start of the provided block number.
+        // Advancing by one keeps the semantics aligned with `history_by_block_*`, which expose the
+        // state after the requested block executed.
+        block_number += 1;
+
+        let account_history_prune_checkpoint =
+            self.get_prune_checkpoint(PruneSegment::AccountHistory)?;
+        let storage_history_prune_checkpoint =
+            self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
+
+        let mut state_provider = HistoricalStateProvider::new(self, block_number);
+
         if let Some(prune_checkpoint_block_number) =
             account_history_prune_checkpoint.and_then(|checkpoint| checkpoint.block_number)
         {

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -16,7 +16,8 @@ use reth_db_api::{
         StorageSettings,
     },
     table::{Compress, Decode, Decompress, Encode, Table},
-    tables, BlockNumberList, DatabaseError,
+    tables::{self, StoragesHistory},
+    BlockNumberList, DatabaseError,
 };
 use reth_primitives_traits::{BlockBody as _, FastInstant as Instant};
 use reth_prune_types::PruneMode;
@@ -1561,6 +1562,89 @@ impl<'db> RocksReadSnapshot<'db> {
                     .unwrap_or(false)
             },
         )
+    }
+
+    /// Walks unique visible storage-history keys for the given account in plain-key order.
+    ///
+    /// Visibility is bounded by `visible_tip`, matching the MDBX snapshot this `RocksDB` snapshot
+    /// is paired with. The callback receives each unique plain storage key at most once and may
+    /// return `Ok(false)` to stop iteration early.
+    pub(crate) fn walk_visible_storage_history_keys(
+        &self,
+        address: Address,
+        start_key: B256,
+        visible_tip: BlockNumber,
+        mut on_key: impl FnMut(B256) -> ProviderResult<bool>,
+    ) -> ProviderResult<()> {
+        let cf = self.cf_handle::<StoragesHistory>()?;
+        let mut iter = self.inner.raw_iterator_cf(cf);
+        let start = StorageShardedKey::new(address, start_key, 0u64).encode();
+
+        iter.seek(start.as_ref());
+        iter.status().map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        let decode_key = |key_bytes: &[u8]| {
+            StorageShardedKey::decode(key_bytes)
+                .map_err(|_| ProviderError::Database(DatabaseError::Decode))
+        };
+        let decode_value = |value_bytes: &[u8]| {
+            BlockNumberList::decompress(value_bytes)
+                .map_err(|_| ProviderError::Database(DatabaseError::Decode))
+        };
+
+        while iter.valid() {
+            let Some(key_bytes) = iter.key() else {
+                break;
+            };
+            let key = decode_key(key_bytes)?;
+            if key.address != address {
+                break;
+            }
+
+            let storage_key = key.sharded_key.key;
+            let mut visible = iter
+                .value()
+                .map(decode_value)
+                .transpose()?
+                .and_then(|list| list.iter().next())
+                .is_some_and(|first| first <= visible_tip);
+
+            iter.next();
+            while iter.valid() {
+                let Some(next_key_bytes) = iter.key() else {
+                    break;
+                };
+                let next_key = decode_key(next_key_bytes)?;
+                if next_key.address != address || next_key.sharded_key.key != storage_key {
+                    break;
+                }
+                visible |= iter
+                    .value()
+                    .map(decode_value)
+                    .transpose()?
+                    .and_then(|list| list.iter().next())
+                    .is_some_and(|first| first <= visible_tip);
+                iter.next();
+            }
+
+            if visible && !on_key(storage_key)? {
+                break;
+            }
+        }
+
+        iter.status().map_err(|e| {
+            ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        Ok(())
     }
 
     /// Generic history lookup using the snapshot's raw iterator.

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -3,7 +3,7 @@ use crate::{
     ProviderError, RocksDBProviderFactory, StateProvider, StateRootProvider,
 };
 use alloy_eips::merge::EPOCH_SLOTS;
-use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use alloy_primitives::{keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     table::Table,
@@ -14,7 +14,8 @@ use reth_db_api::{
 use reth_primitives_traits::{Account, Bytecode};
 use reth_storage_api::{
     BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider, StateProofProvider,
-    StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
+    StorageChangeSetReader, StorageRangeEntry, StorageRangeProvider, StorageRangeResult,
+    StorageRootProvider, StorageSettingsCache,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
@@ -32,7 +33,7 @@ use reth_trie_db::{
     DatabaseStorageProof, DatabaseStorageRoot,
 };
 
-use std::fmt::Debug;
+use std::{collections::BTreeMap, fmt::Debug};
 
 type DbStateRoot<'a, TX, A> = StateRoot<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
@@ -210,7 +211,21 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
     where
         Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
     {
-        match self.storage_history_lookup(address, lookup_key)? {
+        let history = self.storage_history_lookup(address, lookup_key)?;
+        self.storage_by_lookup_key_with_history_info(address, lookup_key, history)
+    }
+
+    /// Resolves a storage value using the provided historical lookup result.
+    fn storage_by_lookup_key_with_history_info(
+        &self,
+        address: Address,
+        lookup_key: B256,
+        history: HistoryInfo,
+    ) -> ProviderResult<Option<StorageValue>>
+    where
+        Provider: StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider,
+    {
+        match history {
             HistoryInfo::NotYetWritten => Ok(None),
             HistoryInfo::InChangeset(changeset_block_number) => self
                 .provider
@@ -569,7 +584,6 @@ impl<Provider> HashedPostStateProvider for HistoricalStateProviderRef<'_, Provid
 impl<
         Provider: DBProvider
             + BlockNumReader
-            + BlockHashReader
             + ChangeSetReader
             + StorageChangeSetReader
             + StorageSettingsCache
@@ -584,6 +598,76 @@ impl<
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
         self.storage_by_lookup_key(address, storage_key)
+    }
+}
+
+impl<
+        Provider: DBProvider
+            + BlockNumReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + StorageSettingsCache
+            + RocksDBProviderFactory
+            + NodePrimitivesProvider,
+    > StorageRangeProvider for HistoricalStateProviderRef<'_, Provider>
+{
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: StorageKey,
+        max_slots: usize,
+    ) -> ProviderResult<StorageRangeResult> {
+        if max_slots == 0 {
+            return Ok(StorageRangeResult::empty())
+        }
+        if !self.provider.cached_storage_settings().storage_v2 {
+            return Err(ProviderError::UnsupportedProvider)
+        }
+        if !self.lowest_available_blocks.is_storage_history_available(self.block_number) {
+            return Err(ProviderError::StateAtBlockPruned(self.block_number))
+        }
+
+        let visible_tip = self.provider.best_block_number()?;
+        let mut slots_by_hash = BTreeMap::new();
+
+        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
+            let rocksdb = rocksdb_ref
+                .expect("storage_v2 historical range queries require a RocksDB snapshot");
+
+            rocksdb.walk_visible_storage_history_keys(account, B256::ZERO, visible_tip, |key| {
+                let history = rocksdb.storage_history_info(
+                    account,
+                    key,
+                    self.block_number,
+                    self.lowest_available_blocks.storage_history_block_number,
+                    visible_tip,
+                )?;
+                let Some(value) =
+                    self.storage_by_lookup_key_with_history_info(account, key, history)?
+                else {
+                    return Ok(true);
+                };
+                if value.is_zero() {
+                    return Ok(true);
+                }
+
+                let hash = keccak256(key);
+                slots_by_hash.insert(hash, StorageRangeEntry { hash, key, value });
+                Ok(true)
+            })
+        })?;
+
+        let mut slots = Vec::with_capacity(max_slots);
+        let mut next_key = None;
+        for (hash, entry) in slots_by_hash.range(start_key..) {
+            if slots.len() == max_slots {
+                next_key = Some(*hash);
+                break;
+            }
+            slots.push(entry.clone());
+        }
+
+        Ok(StorageRangeResult { slots, next_key })
     }
 }
 
@@ -647,6 +731,27 @@ impl<Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumR
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
 reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provider> where [Provider: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader + StorageChangeSetReader + StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider]);
+
+impl<
+        Provider: DBProvider
+            + BlockNumReader
+            + BlockHashReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + StorageSettingsCache
+            + RocksDBProviderFactory
+            + NodePrimitivesProvider,
+    > StorageRangeProvider for HistoricalStateProvider<Provider>
+{
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: StorageKey,
+        max_slots: usize,
+    ) -> ProviderResult<StorageRangeResult> {
+        self.as_ref().storage_range(account, start_key, max_slots)
+    }
+}
 
 /// Lowest blocks at which different parts of the state are available.
 /// They may be [Some] if pruning is enabled.
@@ -779,7 +884,8 @@ mod tests {
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_storage_api::{
         BlockHashReader, BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-        NodePrimitivesProvider, StorageChangeSetReader, StorageSettingsCache,
+        NodePrimitivesProvider, StorageChangeSetReader, StorageRangeEntry, StorageRangeProvider,
+        StorageRangeResult, StorageSettingsCache,
     };
     use reth_storage_errors::provider::ProviderError;
 
@@ -1322,6 +1428,135 @@ mod tests {
             HistoricalStateProviderRef::new(&db, 1000).storage(HIGHER_ADDRESS, STORAGE),
             Ok(Some(v)) if v == U256::from(1000)
         ));
+    }
+
+    #[test]
+    fn history_provider_storage_range_hashed_state() {
+        use crate::BlockWriter;
+        use alloy_primitives::keccak256;
+        use reth_db_api::{
+            models::StorageSettings,
+            tables::{HashedAccounts, HashedStorages},
+        };
+        use reth_execution_types::ExecutionOutcome;
+        use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
+        use revm_database::BundleState;
+        use revm_state::AccountInfo;
+        use std::collections::HashMap;
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let slot1_key = B256::with_last_byte(1);
+        let slot2_key = B256::with_last_byte(2);
+        let slot3_key = B256::with_last_byte(3);
+        let slot1 = U256::from_be_bytes(*slot1_key);
+        let slot2 = U256::from_be_bytes(*slot2_key);
+        let slot3 = U256::from_be_bytes(*slot3_key);
+
+        let account: AccountInfo =
+            Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None }.into();
+
+        let mut rng = generators::rng();
+        let blocks = random_block_range(
+            &mut rng,
+            0..=15,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+
+        let mut addr_storage = HashMap::default();
+        addr_storage.insert(slot1, (U256::ZERO, U256::from(100)));
+        addr_storage.insert(slot2, (U256::ZERO, U256::from(200)));
+        addr_storage.insert(slot3, (U256::ZERO, U256::from(300)));
+
+        type Revert = Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>;
+        let mut reverts: Vec<Revert> = vec![Vec::new(); 16];
+        reverts[5] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot1, U256::ZERO)])];
+        reverts[7] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot2, U256::ZERO)])];
+        reverts[12] = vec![(ADDRESS, Some(Some(account.clone())), vec![(slot3, U256::ZERO)])];
+
+        let bundle = BundleState::new([(ADDRESS, None, Some(account), addr_storage)], reverts, []);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .append_blocks_with_state(
+                blocks
+                    .into_iter()
+                    .map(|b| b.try_recover().expect("failed to seal block with senders"))
+                    .collect(),
+                &ExecutionOutcome { bundle, first_block: 0, ..Default::default() },
+                Default::default(),
+            )
+            .unwrap();
+
+        let hashed_address = keccak256(ADDRESS);
+        provider_rw
+            .tx_ref()
+            .put::<HashedStorages>(
+                hashed_address,
+                StorageEntry { key: keccak256(slot1_key), value: U256::from(100) },
+            )
+            .unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<HashedStorages>(
+                hashed_address,
+                StorageEntry { key: keccak256(slot2_key), value: U256::from(200) },
+            )
+            .unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<HashedStorages>(
+                hashed_address,
+                StorageEntry { key: keccak256(slot3_key), value: U256::from(300) },
+            )
+            .unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<HashedAccounts>(
+                hashed_address,
+                Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None },
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+
+        let paged =
+            HistoricalStateProviderRef::new(&db, 16).storage_range(ADDRESS, B256::ZERO, 2).unwrap();
+        assert_eq!(
+            paged,
+            StorageRangeResult {
+                slots: vec![
+                    StorageRangeEntry {
+                        hash: keccak256(slot2_key),
+                        key: slot2_key,
+                        value: U256::from(200),
+                    },
+                    StorageRangeEntry {
+                        hash: keccak256(slot1_key),
+                        key: slot1_key,
+                        value: U256::from(100),
+                    },
+                ],
+                next_key: Some(keccak256(slot3_key)),
+            }
+        );
+
+        let resumed = HistoricalStateProviderRef::new(&db, 16)
+            .storage_range(ADDRESS, paged.next_key.unwrap(), 10)
+            .unwrap();
+        assert_eq!(
+            resumed,
+            StorageRangeResult {
+                slots: vec![StorageRangeEntry {
+                    hash: keccak256(slot3_key),
+                    key: slot3_key,
+                    value: U256::from(300),
+                }],
+                next_key: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -35,7 +35,8 @@ use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
     BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory,
     HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
-    StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
+    StorageChangeSetReader, StorageRangeEntry, StorageRangeProvider, StorageRangeProviderBox,
+    StorageRangeResult, StorageRootProvider, StorageSettingsCache,
 };
 use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
 use reth_trie::{
@@ -663,18 +664,22 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockRe
 
     fn recovered_block(
         &self,
-        _id: BlockHashOrNumber,
+        id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
+        self.block(id)?
+            .map(|block| block.try_into_recovered().map_err(|_| ProviderError::SenderRecoveryError))
+            .transpose()
     }
 
     fn sealed_block_with_senders(
         &self,
-        _id: BlockHashOrNumber,
+        id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
+        self.block(id)?
+            .map(|block| block.try_into_recovered().map_err(|_| ProviderError::SenderRecoveryError))
+            .transpose()
     }
 
     fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
@@ -890,6 +895,47 @@ where
     }
 }
 
+impl<T, ChainSpec> StorageRangeProvider for MockEthProvider<T, ChainSpec>
+where
+    T: NodePrimitives,
+    ChainSpec: EthChainSpec + Send + Sync + 'static,
+{
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: StorageKey,
+        max_slots: usize,
+    ) -> ProviderResult<StorageRangeResult> {
+        if max_slots == 0 {
+            return Ok(StorageRangeResult::empty())
+        }
+
+        let lock = self.accounts.lock();
+        let Some(account) = lock.get(&account) else { return Ok(StorageRangeResult::empty()) };
+
+        let mut slots = Vec::with_capacity(max_slots);
+        let mut next_key = None;
+
+        let mut entries = account
+            .storage
+            .iter()
+            .filter(|(_, value)| !value.is_zero())
+            .map(|(key, value)| (keccak256(*key), *key, *value))
+            .collect::<Vec<_>>();
+        entries.sort_unstable_by_key(|(hash, _, _)| *hash);
+
+        for (hash, key, value) in entries.into_iter().filter(|(hash, _, _)| *hash >= start_key) {
+            if slots.len() == max_slots {
+                next_key = Some(hash);
+                break;
+            }
+            slots.push(StorageRangeEntry { hash, key, value });
+        }
+
+        Ok(StorageRangeResult { slots, next_key })
+    }
+}
+
 impl<T, ChainSpec> BytecodeReader for MockEthProvider<T, ChainSpec>
 where
     T: NodePrimitives,
@@ -958,6 +1004,13 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> StatePr
     }
 
     fn history_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn storage_range_by_block_hash(
+        &self,
+        _block: BlockHash,
+    ) -> ProviderResult<StorageRangeProviderBox> {
         Ok(Box::new(self.clone()))
     }
 

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -2,7 +2,7 @@ use super::{
     AccountReader, BlockHashReader, BlockIdReader, StateProofProvider, StateRootProvider,
     StorageRootProvider,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue, B256, U256};
@@ -28,6 +28,35 @@ pub trait StateReader: Send {
 
 /// Type alias of boxed [`StateProvider`].
 pub type StateProviderBox = Box<dyn StateProvider + Send + 'static>;
+/// Type alias of boxed [`StorageRangeProvider`].
+pub type StorageRangeProviderBox = Box<dyn StorageRangeProvider + Send + 'static>;
+
+/// Result of a storage range query matching the semantics of `debug_storageRangeAt`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StorageRangeEntry {
+    /// Hashed storage slot key used for paging.
+    pub hash: B256,
+    /// Plain storage slot key preimage.
+    pub key: StorageKey,
+    /// Value stored at the slot.
+    pub value: StorageValue,
+}
+
+/// Result of a storage range query matching the semantics of `debug_storageRangeAt`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StorageRangeResult {
+    /// Collected storage entries ordered by hashed slot key.
+    pub slots: Vec<StorageRangeEntry>,
+    /// Hashed key to resume iteration from, if more slots remain.
+    pub next_key: Option<B256>,
+}
+
+impl StorageRangeResult {
+    /// Creates an empty range result.
+    pub const fn empty() -> Self {
+        Self { slots: Vec::new(), next_key: None }
+    }
+}
 
 /// An abstraction for a type that provides state data.
 #[auto_impl(&, Arc, Box)]
@@ -90,6 +119,22 @@ pub trait StateProvider:
     }
 }
 
+/// Optional trait for providers that can iterate storage slots in key order.
+#[auto_impl(&, Arc, Box)]
+pub trait StorageRangeProvider {
+    /// Returns storage slots for `account` starting at the hashed storage key `start_key`
+    /// (inclusive) and capped by `max_slots`.
+    ///
+    /// When additional slots are available beyond `max_slots`, `next_key` in the result contains
+    /// the hashed key where the caller should resume.
+    fn storage_range(
+        &self,
+        account: Address,
+        start_key: StorageKey,
+        max_slots: usize,
+    ) -> ProviderResult<StorageRangeResult>;
+}
+
 /// Minimal requirements to read a full account, for example, to validate its new transactions
 pub trait AccountInfoReader: AccountReader + BytecodeReader {}
 impl<T: AccountReader + BytecodeReader> AccountInfoReader for T {}
@@ -115,6 +160,15 @@ pub trait TryIntoHistoricalStateProvider {
         self,
         block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox>;
+
+    /// Returns a historical [`StorageRangeProvider`] indexed by the given historic block number.
+    ///
+    /// This follows the same inclusive semantics as [`Self::try_into_history_at_block`]: passing
+    /// block `n` yields the state after block `n` was executed.
+    fn try_into_storage_range_history_at_block(
+        self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<StorageRangeProviderBox>;
 }
 
 /// Light wrapper that returns `StateProvider` implementations that correspond to the given

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue
 use auto_impl::auto_impl;
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::Bytecode;
-use reth_storage_errors::provider::ProviderResult;
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
 
@@ -228,6 +228,19 @@ pub trait StateProviderFactory: BlockIdReader + Send {
     ///
     /// Note: this only looks at historical blocks, not pending blocks.
     fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox>;
+
+    /// Returns a historical [`StorageRangeProvider`] indexed by the given block hash.
+    ///
+    /// This follows the same inclusive semantics as [`Self::history_by_block_hash`]: passing a
+    /// block hash yields the state after that block was executed.
+    ///
+    /// Default implementation returns [`ProviderError::UnsupportedProvider`].
+    fn storage_range_by_block_hash(
+        &self,
+        _block: BlockHash,
+    ) -> ProviderResult<StorageRangeProviderBox> {
+        Err(ProviderError::UnsupportedProvider)
+    }
 
     /// Returns _any_ [StateProvider] with matching block hash.
     ///


### PR DESCRIPTION
Stacked on #23616.

Implements `debug_storageRangeAt` on top of the storage-range provider primitive for storage_v2. It replays the target block from parent state up to `txIndex` and overlays the observed `SSTORE` writes on the paged storage range view.

Tested with `cargo test -p reth-provider history_provider_storage_range_hashed_state`, `cargo test -p reth-rpc-eth-api storage_`, and `cargo test -p reth-rpc storage_range_at`.