### PR TITLE
fix(txpool,rpc): skip tx gas limit cap enforcement when EIP-8037 is active

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -25,7 +25,7 @@ use reth_rpc_eth_types::{
 use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
 use revm::{
     context::Block,
-    context_interface::{result::ExecutionResult, Transaction},
+    context_interface::{result::ExecutionResult, Cfg, Transaction},
     primitives::KECCAK_EMPTY,
 };
 use tracing::trace;
@@ -69,6 +69,12 @@ pub trait EstimateCall: Call {
 
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
+
+        // EIP-8037: When state gas is enabled, tx.gas can exceed the per-tx gas limit cap
+        // because the cap only applies to regular gas (state gas uses a reservoir).
+        if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+            evm_env.cfg_env.tx_gas_limit_cap = None;
+        }
 
         // Keep a copy of gas related request values
         let tx_request_gas_limit = request.as_ref().gas_limit();

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -70,20 +70,19 @@ pub trait EstimateCall: Call {
         // set nonce to None so that the correct nonce is chosen by the EVM
         request.as_mut().take_nonce();
 
-        // EIP-8037: When state gas is enabled, tx.gas can exceed the per-tx gas limit cap
-        // because the cap only applies to regular gas (state gas uses a reservoir).
-        if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
-            evm_env.cfg_env.tx_gas_limit_cap = None;
-        }
-
         // Keep a copy of gas related request values
         let tx_request_gas_limit = request.as_ref().gas_limit();
         let tx_request_gas_price = request.as_ref().gas_price();
         // the gas limit of the corresponding block
-        let max_gas_limit = evm_env.cfg_env.tx_gas_limit_cap.map_or_else(
-            || evm_env.block_env.gas_limit(),
-            |cap| cap.min(evm_env.block_env.gas_limit()),
-        );
+        let max_gas_limit = evm_env
+            .cfg_env
+            .tx_gas_limit_cap
+            // If EIP-8037 is enabled, the transaction gas limit cap is not applicable
+            .filter(|_| !evm_env.cfg_env.is_amsterdam_eip8037_enabled())
+            .map_or_else(
+                || evm_env.block_env.gas_limit(),
+                |cap| cap.min(evm_env.block_env.gas_limit()),
+            );
 
         // Determine the highest possible gas limit, considering both the request's specified limit
         // and the block's limit.

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -876,9 +876,17 @@ where
         self.fork_tracker
             .max_initcode_size
             .store(evm_env.cfg_env.max_initcode_size(), std::sync::atomic::Ordering::Relaxed);
+        // EIP-8037: When state gas is enabled, `tx.gas` can exceed the per-tx gas limit cap
+        // because the cap only applies to regular gas (state gas uses a reservoir).
+        // Store 0 to disable the txpool-level check.
+        let tx_gas_limit_cap = if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+            0
+        } else {
+            evm_env.cfg_env.tx_gas_limit_cap()
+        };
         self.fork_tracker
             .tx_gas_limit_cap
-            .store(evm_env.cfg_env.tx_gas_limit_cap(), std::sync::atomic::Ordering::Relaxed);
+            .store(tx_gas_limit_cap, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn max_gas_limit(&self) -> u64 {
@@ -1060,7 +1068,12 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
             // no custom transaction types by default
             other_tx_types: U256::ZERO,
 
-            tx_gas_limit_cap: evm_env.cfg_env.tx_gas_limit_cap(),
+            // EIP-8037: When state gas is enabled, tx.gas can exceed the per-tx cap
+            tx_gas_limit_cap: if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+                0
+            } else {
+                evm_env.cfg_env.tx_gas_limit_cap()
+            },
             max_initcode_size: evm_env.cfg_env.max_initcode_size(),
 
             // EIP-7594 sidecars are accepted by default (standard Ethereum behavior)


### PR DESCRIPTION
With EIP-8037 (Amsterdam), the EIP-7825 per-tx gas limit cap only applies to `regular_gas`, not to `tx.gas`. State gas uses a reservoir model that allows `tx.gas` to exceed `TX_MAX_GAS_LIMIT`. Revm already skips the `tx.gas_limit > cap` check internally when `enable_amsterdam_eip8037` is set, but reth's txpool and gas estimation independently enforce the cap.

- **txpool**: store `0` (no cap) in the fork tracker when EIP-8037 is active, so the `tx_gas_limit_cap > 0 && tx.gas_limit > cap` check is skipped
- **eth_estimateGas**: set `tx_gas_limit_cap = None` when EIP-8037 is active so the estimation upper bound falls back to the block gas limit

Prompted by: klkvr