### PR TITLE
fix(provider): prevent stale state reads using in-memory execution tip

### DIFF
--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -223,6 +223,17 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
     pub async fn run_loop(&mut self) -> Result<ControlFlow, PipelineError> {
         self.move_to_static_files()?;
 
+        // Seed the execution tip tracker from the database so that ConsistentProvider
+        // has an accurate view even on restart or after a previous sync run.
+        {
+            let provider = self.provider_factory.database_provider_ro()?;
+            let execution_tip = provider
+                .get_stage_checkpoint(StageId::Execution)?
+                .map(|c| c.block_number)
+                .unwrap_or_default();
+            self.provider_factory.set_execution_tip(execution_tip);
+        }
+
         let mut previous_stage = None;
         for stage_index in 0..self.stages.len() {
             let stage = &self.stages[stage_index];
@@ -405,6 +416,11 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
 
                         provider_rw.commit()?;
 
+                        // Update the in-memory execution tip after unwind
+                        if stage_id == StageId::Execution {
+                            self.provider_factory.set_execution_tip(checkpoint.block_number);
+                        }
+
                         stage.post_unwind_commit()?;
 
                         provider_rw = self.provider_factory.unwind_provider_rw()?;
@@ -497,6 +513,13 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
 
                     // Invoke stage post commit hook.
                     self.stage(stage_index).post_execute_commit()?;
+
+                    // Update the in-memory execution tip so that ConsistentProvider
+                    // can detect when plain state is ahead of the Finish checkpoint
+                    // without reading stage checkpoints from the database.
+                    if stage_id == StageId::Execution {
+                        self.provider_factory.set_execution_tip(checkpoint.block_number);
+                    }
 
                     // Notify event listeners and update metrics.
                     self.event_sender.notify(PipelineEvent::Ran {

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -105,6 +105,11 @@ pub enum ProviderError {
     /// State is not available for the given block number because it is pruned.
     #[error("state at block #{_0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+    /// State is temporarily unavailable because a pipeline sync is in progress and plain state
+    /// has been modified past this block. The block was fully executed in a prior pipeline run,
+    /// but its state cannot be safely read until the current run completes.
+    #[error("state at block #{_0} is temporarily unavailable, pipeline sync in progress")]
+    StateUnavailableDuringSync(BlockNumber),
     /// State is not available because the block has not been executed yet.
     #[error("state at block #{requested} is not available, block has not been executed yet (latest executed: #{executed})")]
     BlockNotExecuted {

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -52,6 +52,12 @@ pub struct ConsistentProvider<N: ProviderNodeTypes> {
     head_block: Option<Arc<BlockState<N::Primitives>>>,
     /// In-memory canonical state. This is not a snapshot, and can change! Use with caution.
     canonical_in_memory_state: CanonicalInMemoryState<N::Primitives>,
+    /// Snapshot of the execution tip at time of creation.
+    ///
+    /// This is the latest block number whose plain state has been committed by the Execution
+    /// stage. If this is ahead of `StageId::Finish` (the visible best block), then plain state
+    /// is dirty and state at the Finish-tip block cannot be safely served.
+    execution_tip: BlockNumber,
 }
 
 impl<N: ProviderNodeTypes> ConsistentProvider<N> {
@@ -73,7 +79,10 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         // entirely. Resulting in gaps on the range.
         let head_block = state.head_state();
         let storage_provider = storage_provider_factory.database_provider_ro()?;
-        Ok(Self { storage_provider, head_block, canonical_in_memory_state: state })
+        // Snapshot the execution tip *after* opening the DB snapshot. This makes the guard
+        // conservative: the execution tip can only be >= the actual DB state, never behind it.
+        let execution_tip = storage_provider_factory.execution_tip();
+        Ok(Self { storage_provider, head_block, canonical_in_memory_state: state, execution_tip })
     }
 
     // Helper function to convert range bounds
@@ -122,7 +131,13 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
 
         self.get_in_memory_or_storage_by_block(
             block_hash.into(),
-            |_| self.storage_provider.history_by_block_hash(block_hash),
+            |_| {
+                // Falling through to DB — check that plain state is safe to read
+                if let Some(block_number) = self.storage_provider.block_number(block_hash)? {
+                    self.ensure_db_state_available(block_number)?;
+                }
+                self.storage_provider.history_by_block_hash(block_hash)
+            },
             |block_state| {
                 let state_provider = self.block_state_provider_ref(block_state)?;
                 Ok(Box::new(state_provider))
@@ -605,7 +620,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
         self.ensure_canonical_block(block_number)?;
 
-        let Self { storage_provider, head_block, .. } = self;
+        let Self { storage_provider, head_block, execution_tip, .. } = self;
         if let Some(Some(block_state)) =
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
@@ -616,6 +631,13 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             let latest_historical = storage_provider.try_into_history_at_block(block_number)?;
             return Ok(Box::new(block_state.state_provider(latest_historical)));
         }
+
+        // Falling through to DB — check that plain state is safe to read
+        let best_block = storage_provider.best_block_number()?;
+        if block_number == best_block && execution_tip > best_block {
+            return Err(ProviderError::StateUnavailableDuringSync(block_number));
+        }
+
         storage_provider.try_into_history_at_block(block_number)
     }
 }
@@ -637,6 +659,24 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         } else {
             Ok(())
         }
+    }
+
+    /// Ensures that the database state can be safely read for the given block.
+    ///
+    /// During pipeline sync, the Execution stage commits plain state independently from the
+    /// Finish stage. If execution has moved past the visible best block (Finish checkpoint),
+    /// neither `LatestStateProvider` nor `HistoricalStateProvider` can return correct state
+    /// because plain state is already at a higher block.
+    ///
+    /// This check uses the in-memory execution tip (snapshotted at provider creation) instead
+    /// of reading `StageId::Execution` from the database on every request.
+    #[inline]
+    fn ensure_db_state_available(&self, block_number: BlockNumber) -> ProviderResult<()> {
+        let best_block = self.storage_provider.best_block_number()?;
+        if block_number == best_block && self.execution_tip > best_block {
+            return Err(ProviderError::StateUnavailableDuringSync(block_number));
+        }
+        Ok(())
     }
 }
 
@@ -762,7 +802,10 @@ impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
-        self.head_block.as_ref().map(|b| Ok(b.number())).unwrap_or_else(|| self.last_block_number())
+        self.head_block
+            .as_ref()
+            .map(|b| Ok(b.number()))
+            .unwrap_or_else(|| self.storage_provider.best_block_number())
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -99,6 +99,13 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     /// Only set for read-only factories. Can be disabled if there is no concurrent read-write
     /// factory writing to the database (e.g as part of a running reth node).
     read_only_sync: Option<Arc<ReadOnlySyncState>>,
+    /// Tracks the latest block number whose plain state has been written by the Execution stage.
+    ///
+    /// During pipeline sync, the Execution stage can commit plain state ahead of the Finish
+    /// checkpoint. This tracker allows [`ConsistentProvider`] to detect that window and reject
+    /// state requests that would return stale data, without reading stage checkpoints from the
+    /// database on every request.
+    execution_tip: Arc<AtomicU64>,
 }
 
 impl<N: NodeTypesForProvider> ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>> {
@@ -155,6 +162,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             runtime,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             read_only_sync: None,
+            execution_tip: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -196,6 +204,26 @@ impl<N: NodeTypesWithDB> ProviderFactory<N> {
     pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
         self.minimum_pruning_distance = distance;
         self
+    }
+
+    /// Returns the current execution tip tracked in memory.
+    ///
+    /// This is the latest block number whose plain state has been committed by the Execution
+    /// stage. During pipeline sync, this may be ahead of `StageId::Finish`.
+    pub fn execution_tip(&self) -> BlockNumber {
+        self.execution_tip.load(Ordering::Relaxed)
+    }
+
+    /// Updates the in-memory execution tip.
+    ///
+    /// Should be called by the pipeline after `StageId::Execution` commits a new checkpoint.
+    pub fn set_execution_tip(&self, block_number: BlockNumber) {
+        self.execution_tip.store(block_number, Ordering::Relaxed);
+    }
+
+    /// Returns a shared reference to the execution tip tracker.
+    pub fn execution_tip_tracker(&self) -> Arc<AtomicU64> {
+        self.execution_tip.clone()
     }
 
     /// Enables on-demand syncing of `RocksDB` secondary and static file indexes for read-only
@@ -958,6 +986,7 @@ where
             runtime,
             minimum_pruning_distance,
             read_only_sync,
+            execution_tip,
         } = self;
         f.debug_struct("ProviderFactory")
             .field("db", &db)
@@ -974,6 +1003,7 @@ where
                 "read_only_sync",
                 &read_only_sync.as_ref().map(|s| s.last_synced_txnid.load(Ordering::Relaxed)),
             )
+            .field("execution_tip", &execution_tip.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -992,6 +1022,7 @@ impl<N: NodeTypesWithDB> Clone for ProviderFactory<N> {
             runtime: self.runtime.clone(),
             minimum_pruning_distance: self.minimum_pruning_distance,
             read_only_sync: self.read_only_sync.clone(),
+            execution_tip: self.execution_tip.clone(),
         }
     }
 }


### PR DESCRIPTION
Alternative to #23070 — uses an in-memory execution tip tracker instead of reading `StageId::Execution` from the database on every state request.

Adds an `Arc<AtomicU64>` to `ProviderFactory` that tracks the latest block committed by the Execution stage. The pipeline updates it after each Execution commit/unwind, and `ConsistentProvider` snapshots it on construction to detect when plain state is ahead of the Finish checkpoint.

Also fixes `ConsistentProvider::best_block_number()` to fall back to `storage_provider.best_block_number()` (Finish checkpoint) instead of `last_block_number()` (header frontier).

Draft — needs tests and further review.

Prompted by: mattsse