### PR TITLE
refactor(rpc): accept BlockId in block_access_list_raw

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -407,5 +407,5 @@ pub trait EngineEthApi<TxReq: RpcObject, B: RpcObject, R: RpcObject> {
 
     /// Returns the EIP-7928 block access list bytes for a block by number.
     #[method(name = "getBlockAccessListRaw")]
-    async fn block_access_list_raw(&self, number: BlockNumberOrTag) -> RpcResult<Option<Bytes>>;
+    async fn block_access_list_raw(&self, block: BlockId) -> RpcResult<Option<Bytes>>;
 }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -419,7 +419,7 @@ pub trait EthApi<
 
     /// Returns the EIP-7928 block access list bytes for a block by number.
     #[method(name = "getBlockAccessListRaw")]
-    async fn block_access_list_raw(&self, number: BlockNumberOrTag) -> RpcResult<Option<Bytes>>;
+    async fn block_access_list_raw(&self, block: BlockId) -> RpcResult<Option<Bytes>>;
 }
 
 #[async_trait::async_trait]
@@ -942,10 +942,10 @@ where
         Ok(Some(json))
     }
     /// Handler for: `eth_getBlockAccessListRaw`
-    async fn block_access_list_raw(&self, number: BlockNumberOrTag) -> RpcResult<Option<Bytes>> {
-        trace!(target: "rpc::eth", ?number, "Serving eth_getBlockAccessListRaw");
+    async fn block_access_list_raw(&self, block: BlockId) -> RpcResult<Option<Bytes>> {
+        trace!(target: "rpc::eth", ?block, "Serving eth_getBlockAccessListRaw");
 
-        let bal = self.get_block_access_list(number.into()).await?;
+        let bal = self.get_block_access_list(block).await?;
         Ok(bal.map(|b: BlockAccessList| alloy_rlp::encode(b).into()))
     }
 }

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -161,7 +161,7 @@ where
     }
 
     /// Handler for `getBlockAccessListRaw`
-    async fn block_access_list_raw(&self, number: BlockNumberOrTag) -> Result<Option<Bytes>> {
-        self.eth.block_access_list_raw(number).instrument(engine_span!()).await
+    async fn block_access_list_raw(&self, block: BlockId) -> Result<Option<Bytes>> {
+        self.eth.block_access_list_raw(block).instrument(engine_span!()).await
     }
 }


### PR DESCRIPTION
Changes `block_access_list_raw` to accept `BlockId` instead of `BlockNumberOrTag`, consistent with the underlying `get_block_access_list` helper which already takes `BlockId`.

Prompted by: mattsse