### PR TITLE
perf(re-execute): relax executor reset thresholds

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -138,7 +138,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             let cancellation = cancellation.clone();
             let next_block = Arc::clone(&next_block);
             tasks.spawn_blocking(move || {
-                let executor_lifetime = Duration::from_secs(120);
+                let executor_lifetime = Duration::from_secs(600);
 
                 loop {
                     if cancellation.is_cancelled() {
@@ -245,7 +245,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         let _ = stats_tx.send(block.gas_used());
 
                         // Reset DB once in a while to avoid OOM or read tx timeouts
-                        if executor.size_hint() > 1_000_000 ||
+                        if executor.size_hint() > 5_000_000 ||
                             executor_created.elapsed() > executor_lifetime
                         {
                             executor =


### PR DESCRIPTION
Increase state cache size limit from 1M to 5M entries and executor lifetime from 120s to 600s. Preserves hot state caches longer during re-execute, reducing redundant DB lookups for frequently accessed accounts and storage slots.

## Benchmark (dev-emma, 3 runs, blocks 21M–21.001M)

| | Baseline (main) | Feature | 
|---|---|---|
| Run 1 | 0.478 Ggas/s | 0.520 Ggas/s |
| Run 2 | 0.486 Ggas/s | 0.520 Ggas/s |
| Run 3 | 0.480 Ggas/s | 0.512 Ggas/s |
| **Mean** | **0.481 Ggas/s** | **0.517 Ggas/s** |

**+7.5% ±1.5% (sig=good)** — statistically significant at 95% CI via Welch's t-test.

## Changes
- `crates/cli/commands/src/re_execute.rs`: `size_hint` threshold 1M → 5M, `executor_lifetime` 120s → 600s