### PR TITLE
perf(txpool): avoid cloning BTreeMap in BestTransactions

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -1,15 +1,16 @@
 use crate::{
     error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
     identifier::{SenderId, TransactionId},
-    pool::pending::PendingTransaction,
+    pool::pending::{PendingTransaction, SenderTransactions},
     PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction,
 };
 use alloy_consensus::Transaction;
 use alloy_primitives::map::AddressSet;
 use core::fmt;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
+use rustc_hash::FxHashMap;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
+    collections::{BTreeSet, HashSet, VecDeque},
     sync::Arc,
 };
 use tokio::sync::broadcast::{error::TryRecvError, Receiver};
@@ -82,9 +83,13 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
 /// transaction with the current on chain nonce.
 #[derive(Debug)]
 pub struct BestTransactions<T: TransactionOrdering> {
-    /// Contains a copy of _all_ transactions of the pending pool at the point in time this
-    /// iterator was created.
-    pub(crate) all: BTreeMap<TransactionId, PendingTransaction<T>>,
+    /// Per-sender transaction chain snapshots. Each `Arc` is shared with the pool; only touched
+    /// senders pay any clone cost.
+    pub(crate) by_sender: FxHashMap<SenderId, Arc<SenderTransactions<T>>>,
+    /// Transactions received via broadcast channel after this iterator was created.
+    pub(crate) new_transaction_buffer: FxHashMap<SenderId, Vec<PendingTransaction<T>>>,
+    /// Tracks the last yielded nonce per sender so ancestor lookups skip consumed transactions.
+    pub(crate) yielded_nonce: FxHashMap<SenderId, u64>,
     /// Transactions that can be executed right away: these have the expected nonce.
     ///
     /// Once an `independent` transaction with the nonce `N` is returned, it unlocks `N+1`, which
@@ -116,12 +121,27 @@ impl<T: TransactionOrdering> BestTransactions<T> {
         self.invalid.insert(tx.sender_id());
     }
 
+    /// Looks up a transaction by sender and nonce across snapshot and broadcast buffer.
+    pub(crate) fn get(&self, id: &TransactionId) -> Option<&PendingTransaction<T>> {
+        if let Some(&last_nonce) = self.yielded_nonce.get(&id.sender) {
+            if id.nonce <= last_nonce {
+                return None;
+            }
+        }
+        if let Some(txs) = self.new_transaction_buffer.get(&id.sender) {
+            if let Some(tx) = txs.iter().find(|tx| tx.transaction.nonce() == id.nonce) {
+                return Some(tx);
+            }
+        }
+        self.by_sender.get(&id.sender)?.get_by_nonce(id.nonce)
+    }
+
     /// Returns the ancestor the given transaction, the transaction with `nonce - 1`.
     ///
     /// Note: for a transaction with nonce higher than the current on chain nonce this will always
     /// return an ancestor since all transactions in this pool are gapless.
     pub(crate) fn ancestor(&self, id: &TransactionId) -> Option<&PendingTransaction<T>> {
-        self.all.get(&id.unchecked_ancestor()?)
+        self.get(&id.unchecked_ancestor()?)
     }
 
     /// Non-blocking read on the new pending transactions subscription channel
@@ -159,7 +179,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
     /// set.
     fn pop_best(&mut self) -> Option<PendingTransaction<T>> {
         self.independent.pop_last().inspect(|best| {
-            self.all.remove(best.transaction.id());
+            self.yielded_nonce.insert(best.transaction.sender_id(), best.transaction.nonce());
         })
     }
 
@@ -168,19 +188,17 @@ impl<T: TransactionOrdering> BestTransactions<T> {
     fn add_new_transactions(&mut self) {
         for _ in 0..MAX_NEW_TRANSACTIONS_PER_BATCH {
             if let Some(pending_tx) = self.try_recv() {
-                //  same logic as PendingPool::add_transaction/PendingPool::best_with_unlocked
-
                 match pending_tx {
                     IncomingTransaction::Process(tx) => {
                         let tx_id = *tx.transaction.id();
                         if self.ancestor(&tx_id).is_none() {
                             self.independent.insert(tx.clone());
                         }
-                        self.all.insert(tx_id, tx);
+                        self.new_transaction_buffer.entry(tx_id.sender).or_default().push(tx);
                     }
                     IncomingTransaction::Stash(tx) => {
                         let tx_id = *tx.transaction.id();
-                        self.all.insert(tx_id, tx);
+                        self.new_transaction_buffer.entry(tx_id.sender).or_default().push(tx);
                     }
                 }
             } else {
@@ -211,7 +229,7 @@ impl<T: TransactionOrdering> BestTransactions<T> {
             }
 
             // Insert transactions that just got unlocked.
-            if let Some(unlocked) = self.all.get(&best.unlocks()) {
+            if let Some(unlocked) = self.get(&best.unlocks()) {
                 self.independent.insert(unlocked.clone());
             }
 
@@ -462,7 +480,7 @@ mod tests {
         }
 
         let mut best = pool.best();
-        assert_eq!(best.all.len(), num_tx as usize);
+        assert_eq!(best.by_sender.values().map(|c| c.txs.len()).sum::<usize>(), num_tx as usize);
         assert_eq!(best.independent.len(), 1);
 
         // check tx are returned in order
@@ -723,9 +741,8 @@ mod tests {
         // Add new transactions to the iterator
         best.add_new_transactions();
 
-        // Verify that the new transaction has been added to the 'all' map
-        assert_eq!(best.all.len(), 6);
-        assert!(best.all.contains_key(valid_new_tx.id()));
+        // Verify that the new transaction has been added to the buffer
+        assert!(best.get(valid_new_tx.id()).is_some());
 
         // Verify that the new transaction has been added to the 'independent' set
         assert_eq!(best.independent.len(), 2);
@@ -770,9 +787,8 @@ mod tests {
         // Add new transactions to the iterator
         best.add_new_transactions();
 
-        // Verify that the new transaction has been added to the 'all' map
-        assert_eq!(best.all.len(), 6);
-        assert!(best.all.contains_key(valid_new_tx1.id()));
+        // Verify that the new transaction has been added to the buffer
+        assert!(best.get(valid_new_tx1.id()).is_some());
 
         // Verify that the new transaction has been added to the 'independent' set
         assert_eq!(best.independent.len(), 2);
@@ -793,9 +809,8 @@ mod tests {
         // Add new transactions to the iterator
         best.add_new_transactions();
 
-        // Verify that the new transaction has been added to 'all'
-        assert_eq!(best.all.len(), 7);
-        assert!(best.all.contains_key(valid_new_tx2.id()));
+        // Verify that the new transaction has been added to the buffer
+        assert!(best.get(valid_new_tx2.id()).is_some());
 
         // Verify that the new transaction has not been added to the 'independent' set
         assert_eq!(best.independent.len(), 2);

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -47,6 +47,9 @@ pub struct PendingPool<T: TransactionOrdering> {
     ///
     /// See also [`reth_primitives_traits::InMemorySize::size`].
     size_of: SizeTracker,
+    /// Per-sender transaction chains. Each chain is wrapped in `Arc` so that
+    /// [`BestTransactions`] iterators can snapshot them without cloning entries.
+    by_sender: FxHashMap<SenderId, Arc<SenderTransactions<T>>>,
     /// Used to broadcast new transactions that have been added to the `PendingPool` to existing
     /// `static_files` of this pool.
     new_transaction_notifier: broadcast::Sender<PendingTransaction<T>>,
@@ -70,6 +73,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
             independent_transactions: Default::default(),
             highest_nonces: Default::default(),
             size_of: Default::default(),
+            by_sender: Default::default(),
             new_transaction_notifier,
         }
     }
@@ -84,6 +88,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         self.independent_transactions.clear();
         self.highest_nonces.clear();
         self.size_of.reset();
+        self.by_sender.clear();
         std::mem::take(&mut self.by_id)
     }
 
@@ -107,7 +112,9 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// Invalid transactions are skipped.
     pub fn best(&self) -> BestTransactions<T> {
         BestTransactions {
-            all: self.by_id.clone(),
+            by_sender: self.by_sender.clone(),
+            new_transaction_buffer: Default::default(),
+            yielded_nonce: Default::default(),
             independent: self.independent_transactions.values().cloned().collect(),
             invalid: Default::default(),
             new_transaction_receiver: Some(self.new_transaction_notifier.subscribe()),
@@ -143,14 +150,14 @@ impl<T: TransactionOrdering> PendingPool<T> {
     ) -> BestTransactionsWithFees<T> {
         let mut best = self.best();
         for (submission_id, tx) in (self.submission_id + 1..).zip(unlocked) {
-            debug_assert!(!best.all.contains_key(tx.id()), "transaction already included");
+            debug_assert!(best.get(tx.id()).is_none(), "transaction already included");
             let priority = self.ordering.priority(&tx.transaction, base_fee);
             let tx_id = *tx.id();
             let transaction = PendingTransaction { submission_id, transaction: tx, priority };
             if best.ancestor(&tx_id).is_none() {
                 best.independent.insert(transaction.clone());
             }
-            best.all.insert(tx_id, transaction);
+            best.new_transaction_buffer.entry(tx_id.sender).or_default().push(transaction);
         }
 
         BestTransactionsWithFees { best, base_fee, base_fee_per_blob_gas }
@@ -199,6 +206,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
             } else {
                 self.size_of += tx.transaction.size();
                 self.update_independents_and_highest_nonces(&tx);
+                self.update_sender_chain(id.sender, id.nonce, tx.clone());
                 self.by_id.insert(id, tx);
             }
         }
@@ -244,6 +252,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
                 self.size_of += tx.transaction.size();
                 self.update_independents_and_highest_nonces(&tx);
+                self.update_sender_chain(id.sender, id.nonce, tx.clone());
                 self.by_id.insert(id, tx);
             }
         }
@@ -276,6 +285,41 @@ impl<T: TransactionOrdering> PendingPool<T> {
         }
     }
 
+    /// Updates the sender chain for the given sender/nonce with a new transaction.
+    fn update_sender_chain(&mut self, sender: SenderId, nonce: u64, tx: PendingTransaction<T>) {
+        match self.by_sender.entry(sender) {
+            Entry::Occupied(mut entry) => {
+                let chain = Arc::make_mut(entry.get_mut());
+                let idx = (nonce - chain.base_nonce) as usize;
+                if idx >= chain.txs.len() {
+                    chain.txs.push(tx);
+                } else {
+                    chain.txs.insert(idx, tx);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(SenderTransactions { base_nonce: nonce, txs: vec![tx] }));
+            }
+        }
+    }
+
+    /// Removes a transaction from its sender chain.
+    fn remove_from_sender_chain(&mut self, id: &TransactionId) {
+        if let Entry::Occupied(mut entry) = self.by_sender.entry(id.sender) {
+            let chain = Arc::make_mut(entry.get_mut());
+            if let Some(idx) = id.nonce.checked_sub(chain.base_nonce).map(|i| i as usize) {
+                if idx < chain.txs.len() {
+                    chain.txs.remove(idx);
+                }
+            }
+            if chain.txs.is_empty() {
+                entry.remove();
+            } else {
+                chain.base_nonce = chain.txs[0].transaction.nonce();
+            }
+        }
+    }
+
     /// Adds a new transactions to the pending queue.
     ///
     /// # Panics
@@ -302,6 +346,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let tx = PendingTransaction { submission_id, transaction: tx, priority };
 
         self.update_independents_and_highest_nonces(&tx);
+        self.update_sender_chain(tx_id.sender, tx_id.nonce, tx.clone());
 
         // send the new transaction to any existing pendingpool static file iterators
         if self.new_transaction_notifier.receiver_count() > 0 {
@@ -331,6 +376,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
         let tx = self.by_id.remove(id)?;
         self.size_of -= tx.transaction.size();
+        self.remove_from_sender_chain(id);
 
         match self.highest_nonces.entry(id.sender) {
             Entry::Occupied(mut entry) => {
@@ -605,6 +651,29 @@ impl<T: TransactionOrdering> PendingPool<T> {
             self.independent_transactions.len(),
             "highest_nonces.len() != independent_transactions.len()"
         );
+    }
+}
+
+/// Nonce-sorted transactions for a single sender, wrapped in `Arc` for cheap snapshot sharing
+/// with [`BestTransactions`] iterators.
+#[derive(Debug)]
+pub(crate) struct SenderTransactions<T: TransactionOrdering> {
+    /// The lowest nonce in this chain.
+    pub(crate) base_nonce: u64,
+    /// Transactions sorted ascending by nonce. `txs[0]` has nonce `base_nonce`.
+    pub(crate) txs: Vec<PendingTransaction<T>>,
+}
+
+impl<T: TransactionOrdering> SenderTransactions<T> {
+    pub(crate) fn get_by_nonce(&self, nonce: u64) -> Option<&PendingTransaction<T>> {
+        let idx = nonce.checked_sub(self.base_nonce)? as usize;
+        self.txs.get(idx)
+    }
+}
+
+impl<T: TransactionOrdering> Clone for SenderTransactions<T> {
+    fn clone(&self) -> Self {
+        Self { base_nonce: self.base_nonce, txs: self.txs.clone() }
     }
 }
 


### PR DESCRIPTION
Adds a `by_sender` index to `PendingPool`: `FxHashMap<SenderId, Arc<SenderTransactions<T>>>` where each `SenderTransactions` is a nonce-sorted `Vec` for one sender.

`best()` snapshots by cloning `Arc` handles — O(num_senders) refcount bumps, zero tx data copied. Pool mutations use `Arc::make_mut` on the affected sender's chain only, so cost is proportional to that sender's chain length (typically 1-2 txs), not pool size.

Under load (100k pool, burst of incoming txs), neither `best()` nor `add_transaction()` pays an O(pool_size) clone.

Prompted by: onbjerg