### PR TITLE
fix: address nightly clippy warnings

### DIFF
--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -450,12 +450,11 @@ impl Command {
                 let name_str = name.to_string_lossy();
                 let index = if let Some(rest) = name_str.strip_prefix("payload_block_") {
                     rest.strip_suffix(".json")?.parse::<u64>().ok()?
-                } else if let Some(rest) = name_str.strip_prefix("big_block_") {
+                } else {
+                    let rest = name_str.strip_prefix("big_block_")?;
                     // "big_block_FROM_to_TO.json" — use FROM as the index
                     let rest = rest.strip_suffix(".json")?;
                     rest.split("_to_").next()?.parse::<u64>().ok()?
-                } else {
-                    return None;
                 };
                 Some((index, e.path()))
             })

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -248,7 +248,7 @@ impl Discv5 {
             discv5::Event::SocketUpdated(_) | discv5::Event::TalkRequest(_) |
             // `Discovered` not unique discovered peers
             discv5::Event::Discovered(_) => None,
-            discv5::Event::NodeInserted { replaced: _, .. } => {
+            discv5::Event::NodeInserted { .. } => {
 
                 // node has been inserted into kbuckets
 

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -479,7 +479,6 @@ impl<Network, Evm, Receipt, Header, Map, SimTx, RpcTx, TxEnv>
             evm,
             sim_tx_converter,
             rpc_tx_converter,
-            tx_env_converter: _,
             ..
         } = self;
         RpcConverter {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1801,13 +1801,9 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
         &mut self,
     ) -> Result<NewTransactionEvent<Tx>, tokio::sync::mpsc::error::TryRecvError> {
         loop {
-            match self.st.try_recv() {
-                Ok(event) => {
-                    if event.subpool == self.subpool {
-                        return Ok(event)
-                    }
-                }
-                Err(e) => return Err(e),
+            let event = self.st.try_recv()?;
+            if event.subpool == self.subpool {
+                return Ok(event)
             }
         }
     }


### PR DESCRIPTION
Updates a few small control-flow and pattern matches to satisfy new Clippy warnings from the latest nightly toolchain.

No behavior changes are intended; the diff is limited to Clippy-suggested rewrites in discv5, rpc conversion, transaction-pool, and reth-bench.

Validation:
- cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked -- -D warnings
