### PR TITLE
feat(cli): add --compare-changesets flag to re-execute command

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -5,7 +5,6 @@ use crate::common::{
     EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
-use alloy_primitives::B256;
 use clap::Parser;
 use eyre::WrapErr;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
@@ -15,6 +14,7 @@ use reth_consensus::FullConsensus;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected};
 use reth_provider::{
+    changesets_utils::{reverts_to_account_changesets, reverts_to_storage_changesets},
     BlockNumReader, BlockReader, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
     ReceiptProvider, StaticFileProviderFactory, StorageChangeSetReader, TransactionVariant,
 };
@@ -265,27 +265,24 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                 .to_plain_state_reverts();
 
                             // Account changesets
-                            let mut exec_account_changesets: Vec<_> = plain_reverts
-                                .accounts[prev_reverts_len]
-                                .iter()
-                                .map(|(address, info)| {
-                                    reth_db_api::models::AccountBeforeTx {
-                                        address: *address,
-                                        info: info.as_ref().map(|i| i.into()),
-                                    }
-                                })
-                                .collect();
-                            exec_account_changesets.sort_by_key(|a| a.address);
+                            let mut exec_accounts =
+                                reverts_to_account_changesets(
+                                    plain_reverts.accounts
+                                        .into_iter()
+                                        .nth(prev_reverts_len)
+                                        .unwrap_or_default(),
+                                );
+                            exec_accounts.sort_by_key(|a| a.address);
 
-                            let mut db_account_changesets =
+                            let mut db_accounts =
                                 provider.account_block_changeset(block.number())?;
-                            db_account_changesets.sort_by_key(|a| a.address);
+                            db_accounts.sort_by_key(|a| a.address);
 
-                            if exec_account_changesets != db_account_changesets {
+                            if exec_accounts != db_accounts {
                                 let err = eyre::eyre!(
                                     "account changeset mismatch at block {}\n  \
-                                     execution: {exec_account_changesets:?}\n  \
-                                     database:  {db_account_changesets:?}",
+                                     execution: {exec_accounts:?}\n  \
+                                     database:  {db_accounts:?}",
                                     block.number()
                                 );
                                 error!(%err);
@@ -299,32 +296,24 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
 
                             // Storage changesets
-                            let mut exec_storage_changesets: Vec<_> = plain_reverts
-                                .storage[prev_reverts_len]
-                                .iter()
-                                .flat_map(|revert| {
-                                    revert.storage_revert.iter().map(|(key, value)| {
-                                        reth_db_api::models::StorageBeforeTx {
-                                            address: revert.address,
-                                            key: B256::from(key.to_be_bytes()),
-                                            value: value.to_previous_value(),
-                                        }
-                                    })
-                                })
-                                .collect();
-                            exec_storage_changesets
-                                .sort_by_key(|s| (s.address, s.key));
+                            let mut exec_storage =
+                                reverts_to_storage_changesets(
+                                    plain_reverts.storage
+                                        .into_iter()
+                                        .nth(prev_reverts_len)
+                                        .unwrap_or_default(),
+                                );
+                            exec_storage.sort_by_key(|s| (s.address, s.key));
 
-                            let mut db_storage_changesets =
+                            let mut db_storage =
                                 provider.storage_block_changeset(block.number())?;
-                            db_storage_changesets
-                                .sort_by_key(|s| (s.address, s.key));
+                            db_storage.sort_by_key(|s| (s.address, s.key));
 
-                            if exec_storage_changesets != db_storage_changesets {
+                            if exec_storage != db_storage {
                                 let err = eyre::eyre!(
                                     "storage changeset mismatch at block {}\n  \
-                                     execution: {exec_storage_changesets:?}\n  \
-                                     database:  {db_storage_changesets:?}",
+                                     execution: {exec_storage:?}\n  \
+                                     database:  {db_storage:?}",
                                     block.number()
                                 );
                                 error!(%err);

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -5,6 +5,7 @@ use crate::common::{
     EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
+use alloy_primitives::{Address, B256, U256};
 use clap::Parser;
 use eyre::WrapErr;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
@@ -12,14 +13,18 @@ use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::cancellation::CancellationToken;
 use reth_consensus::FullConsensus;
 use reth_evm::{execute::Executor, ConfigureEvm};
-use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected};
+use reth_primitives_traits::{format_gas_throughput, Account, BlockBody, GotExpected};
 use reth_provider::{
-    BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory, ReceiptProvider,
-    StaticFileProviderFactory, TransactionVariant,
+    BlockNumReader, BlockReader, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
+    ReceiptProvider, StaticFileProviderFactory, StorageChangeSetReader, TransactionVariant,
 };
-use reth_revm::database::StateProviderDatabase;
+use reth_revm::{
+    database::StateProviderDatabase,
+    revm::database::states::{reverts::AccountInfoRevert, RevertToSlot},
+};
 use reth_stages::stages::calculate_gas_used_from_headers;
 use std::{
+    collections::BTreeMap,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -56,6 +61,14 @@ pub struct Command<C: ChainSpecParser> {
     /// Continues with execution when an invalid block is encountered and collects these blocks.
     #[arg(long)]
     skip_invalid_blocks: bool,
+
+    /// Compare execution state outputs against stored changesets.
+    ///
+    /// For each block, compares the account and storage changes produced by execution
+    /// against the changesets stored in the database. Uses per-block execution instead
+    /// of batching when enabled.
+    #[arg(long)]
+    compare_changesets: bool,
 }
 
 impl<C: ChainSpecParser> Command<C> {
@@ -118,6 +131,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         };
 
         let skip_invalid_blocks = self.skip_invalid_blocks;
+        let compare_changesets = self.compare_changesets;
         let blocks_per_chunk = self.blocks_per_chunk;
         let (stats_tx, mut stats_rx) = mpsc::unbounded_channel();
         let (info_tx, mut info_rx) = mpsc::unbounded_channel();
@@ -164,6 +178,67 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         let block = provider_factory
                             .recovered_block(block.into(), TransactionVariant::NoHash)?
                             .unwrap();
+
+                        if compare_changesets {
+                            // Use per-block execution to get the BundleState for comparison.
+                            let block_executor = evm_config.executor(db_at(block.number() - 1));
+                            let output = match block_executor.execute(&block) {
+                                Ok(output) => output,
+                                Err(err) => {
+                                    if skip_invalid_blocks {
+                                        let _ =
+                                            info_tx.send((block, eyre::Report::new(err)));
+                                        continue
+                                    }
+                                    return Err(err.into())
+                                }
+                            };
+
+                            if let Err(err) = consensus
+                                .validate_block_post_execution(&block, &output.result, None)
+                                .wrap_err_with(|| {
+                                    format!(
+                                        "Failed to validate block {} {}",
+                                        block.number(),
+                                        block.hash()
+                                    )
+                                })
+                            {
+                                if skip_invalid_blocks {
+                                    let _ = info_tx.send((block, err));
+                                    continue
+                                }
+                                return Err(err);
+                            }
+
+                            // Compare state changes against stored changesets.
+                            let provider =
+                                DatabaseProviderFactory::database_provider_ro(&provider_factory)?;
+
+                            if let Err(err) =
+                                compare_state_with_changesets(&output.state, block.number(), &provider)
+                            {
+                                error!(
+                                    number = block.number(),
+                                    %err,
+                                    "Changeset mismatch"
+                                );
+                                if skip_invalid_blocks {
+                                    let _ = info_tx.send((
+                                        block,
+                                        eyre::eyre!("Changeset mismatch: {err}"),
+                                    ));
+                                    continue
+                                }
+                                return Err(eyre::eyre!(
+                                    "Changeset mismatch at block {}: {err}",
+                                    block.number()
+                                ));
+                            }
+
+                            let _ = stats_tx.send(block.gas_used());
+                            continue;
+                        }
 
                         let result = match executor.execute_one(&block) {
                             Ok(result) => result,
@@ -333,3 +408,118 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         Ok(())
     }
 }
+
+/// Compares the execution state output (`BundleState`) against the changesets stored in the
+/// database for the given block number.
+///
+/// The `BundleState` reverts represent the "previous" values before the block was applied,
+/// which should match exactly what the database stores as changesets.
+fn compare_state_with_changesets(
+    bundle: &reth_revm::revm::database::BundleState,
+    block_number: u64,
+    provider: &impl ProviderWithChangesets,
+) -> eyre::Result<()> {
+    let reverts = &bundle.reverts;
+    if reverts.len() != 1 {
+        eyre::bail!(
+            "expected exactly 1 revert frame from single-block execution, got {}",
+            reverts.len()
+        );
+    }
+
+    let block_reverts = &reverts[0];
+
+    // --- Account changeset comparison ---
+    let db_account_changesets = provider
+        .account_block_changeset(block_number)
+        .wrap_err("failed to read account changesets from database")?;
+
+    // Build normalized maps: Address -> Option<Account>
+    // DoNothing means account info wasn't changed, so no entry in the changeset.
+    // DeleteIt means the account was created in this block; reverting means removing it (None).
+    // RevertTo(info) means the account existed before with the given info.
+    let mut exec_accounts: BTreeMap<Address, Option<Account>> = BTreeMap::new();
+    for (address, revert) in block_reverts {
+        match &revert.account {
+            AccountInfoRevert::DoNothing => {}
+            AccountInfoRevert::DeleteIt => {
+                exec_accounts.insert(*address, None);
+            }
+            AccountInfoRevert::RevertTo(info) => {
+                exec_accounts.insert(*address, Some(info.into()));
+            }
+        }
+    }
+
+    let mut db_accounts: BTreeMap<Address, Option<Account>> = BTreeMap::new();
+    for changeset in &db_account_changesets {
+        db_accounts.insert(changeset.address, changeset.info);
+    }
+
+    if exec_accounts != db_accounts {
+        let only_in_exec: Vec<_> =
+            exec_accounts.keys().filter(|k| !db_accounts.contains_key(*k)).collect();
+        let only_in_db: Vec<_> =
+            db_accounts.keys().filter(|k| !exec_accounts.contains_key(*k)).collect();
+        let mismatched: Vec<_> = exec_accounts
+            .iter()
+            .filter(|(k, v)| db_accounts.get(*k).is_some_and(|db_v| db_v != *v))
+            .map(|(k, _)| k)
+            .collect();
+
+        eyre::bail!(
+            "account changeset mismatch: \
+             only_in_execution={only_in_exec:?}, \
+             only_in_db={only_in_db:?}, \
+             value_mismatch={mismatched:?}"
+        );
+    }
+
+    // --- Storage changeset comparison ---
+    let db_storage_changesets = provider
+        .storage_changeset(block_number)
+        .wrap_err("failed to read storage changesets from database")?;
+
+    // Build normalized map: (Address, B256 key) -> U256 value
+    let mut exec_storage: BTreeMap<(Address, B256), U256> = BTreeMap::new();
+    for (address, revert) in block_reverts {
+        for (slot, value) in &revert.storage {
+            let key = B256::from(slot.to_be_bytes());
+            let prev_value = match value {
+                RevertToSlot::Some(v) => *v,
+                RevertToSlot::Destroyed => U256::ZERO,
+            };
+            exec_storage.insert((*address, key), prev_value);
+        }
+    }
+
+    let mut db_storage: BTreeMap<(Address, B256), U256> = BTreeMap::new();
+    for (block_number_address, entry) in &db_storage_changesets {
+        db_storage.insert((block_number_address.address(), entry.key), entry.value);
+    }
+
+    if exec_storage != db_storage {
+        let only_in_exec: Vec<_> =
+            exec_storage.keys().filter(|k| !db_storage.contains_key(*k)).collect();
+        let only_in_db: Vec<_> =
+            db_storage.keys().filter(|k| !exec_storage.contains_key(*k)).collect();
+        let mismatched: Vec<_> = exec_storage
+            .iter()
+            .filter(|(k, v)| db_storage.get(*k).is_some_and(|db_v| db_v != *v))
+            .map(|(k, _)| k)
+            .collect();
+
+        eyre::bail!(
+            "storage changeset mismatch: \
+             only_in_execution={only_in_exec:?}, \
+             only_in_db={only_in_db:?}, \
+             value_mismatch={mismatched:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Helper trait combining the changeset reader traits needed for comparison.
+trait ProviderWithChangesets: ChangeSetReader + StorageChangeSetReader {}
+impl<T: ChangeSetReader + StorageChangeSetReader> ProviderWithChangesets for T {}

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -65,8 +65,7 @@ pub struct Command<C: ChainSpecParser> {
     /// Compare execution state outputs against stored changesets.
     ///
     /// For each block, compares the account and storage changes produced by execution
-    /// against the changesets stored in the database. Uses per-block execution instead
-    /// of batching when enabled.
+    /// against the changesets stored in the database.
     #[arg(long)]
     compare_changesets: bool,
 }
@@ -179,66 +178,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             .recovered_block(block.into(), TransactionVariant::NoHash)?
                             .unwrap();
 
-                        if compare_changesets {
-                            // Use per-block execution to get the BundleState for comparison.
-                            let block_executor = evm_config.executor(db_at(block.number() - 1));
-                            let output = match block_executor.execute(&block) {
-                                Ok(output) => output,
-                                Err(err) => {
-                                    if skip_invalid_blocks {
-                                        let _ =
-                                            info_tx.send((block, eyre::Report::new(err)));
-                                        continue
-                                    }
-                                    return Err(err.into())
-                                }
-                            };
-
-                            if let Err(err) = consensus
-                                .validate_block_post_execution(&block, &output.result, None)
-                                .wrap_err_with(|| {
-                                    format!(
-                                        "Failed to validate block {} {}",
-                                        block.number(),
-                                        block.hash()
-                                    )
-                                })
-                            {
-                                if skip_invalid_blocks {
-                                    let _ = info_tx.send((block, err));
-                                    continue
-                                }
-                                return Err(err);
-                            }
-
-                            // Compare state changes against stored changesets.
-                            let provider =
-                                DatabaseProviderFactory::database_provider_ro(&provider_factory)?;
-
-                            if let Err(err) =
-                                compare_state_with_changesets(&output.state, block.number(), &provider)
-                            {
-                                error!(
-                                    number = block.number(),
-                                    %err,
-                                    "Changeset mismatch"
-                                );
-                                if skip_invalid_blocks {
-                                    let _ = info_tx.send((
-                                        block,
-                                        eyre::eyre!("Changeset mismatch: {err}"),
-                                    ));
-                                    continue
-                                }
-                                return Err(eyre::eyre!(
-                                    "Changeset mismatch at block {}: {err}",
-                                    block.number()
-                                ));
-                            }
-
-                            let _ = stats_tx.send(block.gas_used());
-                            continue;
-                        }
+                        let prev_reverts_len = executor.bundle_state().reverts.len();
 
                         let result = match executor.execute_one(&block) {
                             Ok(result) => result,
@@ -317,6 +257,36 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
                             return Err(err);
                         }
+
+                        if compare_changesets {
+                            let block_reverts = &executor.bundle_state().reverts[prev_reverts_len];
+                            let provider =
+                                DatabaseProviderFactory::database_provider_ro(&provider_factory)?;
+
+                            if let Err(err) =
+                                compare_block_changesets(block_reverts, block.number(), &provider)
+                            {
+                                error!(
+                                    number = block.number(),
+                                    %err,
+                                    "Changeset mismatch"
+                                );
+                                if skip_invalid_blocks {
+                                    executor =
+                                        evm_config.batch_executor(db_at(block.number()));
+                                    let _ = info_tx.send((
+                                        block,
+                                        eyre::eyre!("Changeset mismatch: {err}"),
+                                    ));
+                                    continue 'blocks;
+                                }
+                                return Err(eyre::eyre!(
+                                    "Changeset mismatch at block {}: {err}",
+                                    block.number()
+                                ));
+                            }
+                        }
+
                         let _ = stats_tx.send(block.gas_used());
 
                         // Reset DB once in a while to avoid OOM or read tx timeouts
@@ -409,35 +379,20 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
     }
 }
 
-/// Compares the execution state output (`BundleState`) against the changesets stored in the
-/// database for the given block number.
-///
-/// The `BundleState` reverts represent the "previous" values before the block was applied,
-/// which should match exactly what the database stores as changesets.
-fn compare_state_with_changesets(
-    bundle: &reth_revm::revm::database::BundleState,
+/// Compares a single block's revert frame against the changesets stored in the database.
+fn compare_block_changesets(
+    block_reverts: &[(Address, reth_revm::revm::database::states::reverts::AccountRevert)],
     block_number: u64,
-    provider: &impl ProviderWithChangesets,
+    provider: &(impl ChangeSetReader + StorageChangeSetReader),
 ) -> eyre::Result<()> {
-    let reverts = &bundle.reverts;
-    if reverts.len() != 1 {
-        eyre::bail!(
-            "expected exactly 1 revert frame from single-block execution, got {}",
-            reverts.len()
-        );
-    }
-
-    let block_reverts = &reverts[0];
-
     // --- Account changeset comparison ---
     let db_account_changesets = provider
         .account_block_changeset(block_number)
         .wrap_err("failed to read account changesets from database")?;
 
-    // Build normalized maps: Address -> Option<Account>
-    // DoNothing means account info wasn't changed, so no entry in the changeset.
-    // DeleteIt means the account was created in this block; reverting means removing it (None).
-    // RevertTo(info) means the account existed before with the given info.
+    // DoNothing: account info unchanged, no changeset entry.
+    // DeleteIt: account was created in this block; revert = remove it (None).
+    // RevertTo(info): account existed before with the given info.
     let mut exec_accounts: BTreeMap<Address, Option<Account>> = BTreeMap::new();
     for (address, revert) in block_reverts {
         match &revert.account {
@@ -480,7 +435,6 @@ fn compare_state_with_changesets(
         .storage_changeset(block_number)
         .wrap_err("failed to read storage changesets from database")?;
 
-    // Build normalized map: (Address, B256 key) -> U256 value
     let mut exec_storage: BTreeMap<(Address, B256), U256> = BTreeMap::new();
     for (address, revert) in block_reverts {
         for (slot, value) in &revert.storage {
@@ -519,7 +473,3 @@ fn compare_state_with_changesets(
 
     Ok(())
 }
-
-/// Helper trait combining the changeset reader traits needed for comparison.
-trait ProviderWithChangesets: ChangeSetReader + StorageChangeSetReader {}
-impl<T: ChangeSetReader + StorageChangeSetReader> ProviderWithChangesets for T {}

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -5,7 +5,7 @@ use crate::common::{
     EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::B256;
 use clap::Parser;
 use eyre::WrapErr;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
@@ -13,18 +13,14 @@ use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_util::cancellation::CancellationToken;
 use reth_consensus::FullConsensus;
 use reth_evm::{execute::Executor, ConfigureEvm};
-use reth_primitives_traits::{format_gas_throughput, Account, BlockBody, GotExpected};
+use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected};
 use reth_provider::{
     BlockNumReader, BlockReader, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
     ReceiptProvider, StaticFileProviderFactory, StorageChangeSetReader, TransactionVariant,
 };
-use reth_revm::{
-    database::StateProviderDatabase,
-    revm::database::states::{reverts::AccountInfoRevert, RevertToSlot},
-};
+use reth_revm::database::StateProviderDatabase;
 use reth_stages::stages::calculate_gas_used_from_headers;
 use std::{
-    collections::BTreeMap,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -259,31 +255,86 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         }
 
                         if compare_changesets {
-                            let block_reverts = &executor.bundle_state().reverts[prev_reverts_len];
                             let provider =
                                 DatabaseProviderFactory::database_provider_ro(&provider_factory)?;
 
-                            if let Err(err) =
-                                compare_block_changesets(block_reverts, block.number(), &provider)
-                            {
-                                error!(
-                                    number = block.number(),
-                                    %err,
-                                    "Changeset mismatch"
+                            // Convert execution reverts to the same format the DB stores.
+                            let plain_reverts = executor
+                                .bundle_state()
+                                .reverts
+                                .to_plain_state_reverts();
+
+                            // Account changesets
+                            let mut exec_account_changesets: Vec<_> = plain_reverts
+                                .accounts[prev_reverts_len]
+                                .iter()
+                                .map(|(address, info)| {
+                                    reth_db_api::models::AccountBeforeTx {
+                                        address: *address,
+                                        info: info.as_ref().map(|i| i.into()),
+                                    }
+                                })
+                                .collect();
+                            exec_account_changesets.sort_by_key(|a| a.address);
+
+                            let mut db_account_changesets =
+                                provider.account_block_changeset(block.number())?;
+                            db_account_changesets.sort_by_key(|a| a.address);
+
+                            if exec_account_changesets != db_account_changesets {
+                                let err = eyre::eyre!(
+                                    "account changeset mismatch at block {}\n  \
+                                     execution: {exec_account_changesets:?}\n  \
+                                     database:  {db_account_changesets:?}",
+                                    block.number()
                                 );
+                                error!(%err);
                                 if skip_invalid_blocks {
                                     executor =
                                         evm_config.batch_executor(db_at(block.number()));
-                                    let _ = info_tx.send((
-                                        block,
-                                        eyre::eyre!("Changeset mismatch: {err}"),
-                                    ));
+                                    let _ = info_tx.send((block, err));
                                     continue 'blocks;
                                 }
-                                return Err(eyre::eyre!(
-                                    "Changeset mismatch at block {}: {err}",
+                                return Err(err);
+                            }
+
+                            // Storage changesets
+                            let mut exec_storage_changesets: Vec<_> = plain_reverts
+                                .storage[prev_reverts_len]
+                                .iter()
+                                .flat_map(|revert| {
+                                    revert.storage_revert.iter().map(|(key, value)| {
+                                        reth_db_api::models::StorageBeforeTx {
+                                            address: revert.address,
+                                            key: B256::from(key.to_be_bytes()),
+                                            value: value.to_previous_value(),
+                                        }
+                                    })
+                                })
+                                .collect();
+                            exec_storage_changesets
+                                .sort_by_key(|s| (s.address, s.key));
+
+                            let mut db_storage_changesets =
+                                provider.storage_block_changeset(block.number())?;
+                            db_storage_changesets
+                                .sort_by_key(|s| (s.address, s.key));
+
+                            if exec_storage_changesets != db_storage_changesets {
+                                let err = eyre::eyre!(
+                                    "storage changeset mismatch at block {}\n  \
+                                     execution: {exec_storage_changesets:?}\n  \
+                                     database:  {db_storage_changesets:?}",
                                     block.number()
-                                ));
+                                );
+                                error!(%err);
+                                if skip_invalid_blocks {
+                                    executor =
+                                        evm_config.batch_executor(db_at(block.number()));
+                                    let _ = info_tx.send((block, err));
+                                    continue 'blocks;
+                                }
+                                return Err(err);
                             }
                         }
 
@@ -377,99 +428,4 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
         Ok(())
     }
-}
-
-/// Compares a single block's revert frame against the changesets stored in the database.
-fn compare_block_changesets(
-    block_reverts: &[(Address, reth_revm::revm::database::states::reverts::AccountRevert)],
-    block_number: u64,
-    provider: &(impl ChangeSetReader + StorageChangeSetReader),
-) -> eyre::Result<()> {
-    // --- Account changeset comparison ---
-    let db_account_changesets = provider
-        .account_block_changeset(block_number)
-        .wrap_err("failed to read account changesets from database")?;
-
-    // DoNothing: account info unchanged, no changeset entry.
-    // DeleteIt: account was created in this block; revert = remove it (None).
-    // RevertTo(info): account existed before with the given info.
-    let mut exec_accounts: BTreeMap<Address, Option<Account>> = BTreeMap::new();
-    for (address, revert) in block_reverts {
-        match &revert.account {
-            AccountInfoRevert::DoNothing => {}
-            AccountInfoRevert::DeleteIt => {
-                exec_accounts.insert(*address, None);
-            }
-            AccountInfoRevert::RevertTo(info) => {
-                exec_accounts.insert(*address, Some(info.into()));
-            }
-        }
-    }
-
-    let mut db_accounts: BTreeMap<Address, Option<Account>> = BTreeMap::new();
-    for changeset in &db_account_changesets {
-        db_accounts.insert(changeset.address, changeset.info);
-    }
-
-    if exec_accounts != db_accounts {
-        let only_in_exec: Vec<_> =
-            exec_accounts.keys().filter(|k| !db_accounts.contains_key(*k)).collect();
-        let only_in_db: Vec<_> =
-            db_accounts.keys().filter(|k| !exec_accounts.contains_key(*k)).collect();
-        let mismatched: Vec<_> = exec_accounts
-            .iter()
-            .filter(|(k, v)| db_accounts.get(*k).is_some_and(|db_v| db_v != *v))
-            .map(|(k, _)| k)
-            .collect();
-
-        eyre::bail!(
-            "account changeset mismatch: \
-             only_in_execution={only_in_exec:?}, \
-             only_in_db={only_in_db:?}, \
-             value_mismatch={mismatched:?}"
-        );
-    }
-
-    // --- Storage changeset comparison ---
-    let db_storage_changesets = provider
-        .storage_changeset(block_number)
-        .wrap_err("failed to read storage changesets from database")?;
-
-    let mut exec_storage: BTreeMap<(Address, B256), U256> = BTreeMap::new();
-    for (address, revert) in block_reverts {
-        for (slot, value) in &revert.storage {
-            let key = B256::from(slot.to_be_bytes());
-            let prev_value = match value {
-                RevertToSlot::Some(v) => *v,
-                RevertToSlot::Destroyed => U256::ZERO,
-            };
-            exec_storage.insert((*address, key), prev_value);
-        }
-    }
-
-    let mut db_storage: BTreeMap<(Address, B256), U256> = BTreeMap::new();
-    for (block_number_address, entry) in &db_storage_changesets {
-        db_storage.insert((block_number_address.address(), entry.key), entry.value);
-    }
-
-    if exec_storage != db_storage {
-        let only_in_exec: Vec<_> =
-            exec_storage.keys().filter(|k| !db_storage.contains_key(*k)).collect();
-        let only_in_db: Vec<_> =
-            db_storage.keys().filter(|k| !exec_storage.contains_key(*k)).collect();
-        let mismatched: Vec<_> = exec_storage
-            .iter()
-            .filter(|(k, v)| db_storage.get(*k).is_some_and(|db_v| db_v != *v))
-            .map(|(k, _)| k)
-            .collect();
-
-        eyre::bail!(
-            "storage changeset mismatch: \
-             only_in_execution={only_in_exec:?}, \
-             only_in_db={only_in_db:?}, \
-             value_mismatch={mismatched:?}"
-        );
-    }
-
-    Ok(())
 }

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -14,9 +14,9 @@ use reth_consensus::FullConsensus;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected};
 use reth_provider::{
-    changesets_utils::{reverts_to_account_changesets, reverts_to_storage_changesets},
-    BlockNumReader, BlockReader, ChainSpecProvider, ChangeSetReader, DatabaseProviderFactory,
-    ReceiptProvider, StaticFileProviderFactory, StorageChangeSetReader, TransactionVariant,
+    providers::BlockchainProvider, BlockNumReader, BlockReader, ChainSpecProvider,
+    DatabaseProviderFactory, ReceiptProvider, StateReader, StaticFileProviderFactory,
+    TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages::stages::calculate_gas_used_from_headers;
@@ -116,6 +116,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             min_block..=max_block,
         )?;
 
+        let blockchain_provider = self
+            .compare_changesets
+            .then(|| BlockchainProvider::new(provider_factory.clone()))
+            .transpose()?;
+
         let db_at = {
             let provider_factory = provider_factory.clone();
             move |block_number: u64| {
@@ -139,6 +144,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let mut tasks = JoinSet::new();
         for _ in 0..num_tasks {
             let provider_factory = provider_factory.clone();
+            let blockchain_provider = blockchain_provider.clone();
             let evm_config = components.evm_config().clone();
             let consensus = components.consensus().clone();
             let db_at = db_at.clone();
@@ -255,34 +261,38 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                         }
 
                         if compare_changesets {
-                            let provider =
-                                DatabaseProviderFactory::database_provider_ro(&provider_factory)?;
-
-                            // Convert execution reverts to the same format the DB stores.
-                            let plain_reverts = executor
+                            let exec_reverts = executor
                                 .bundle_state()
                                 .reverts
                                 .to_plain_state_reverts();
 
-                            // Account changesets
-                            let mut exec_accounts =
-                                reverts_to_account_changesets(
-                                    plain_reverts.accounts
-                                        .into_iter()
-                                        .nth(prev_reverts_len)
-                                        .unwrap_or_default(),
-                                );
-                            exec_accounts.sort_by_key(|a| a.address);
+                            let db_outcome = StateReader::get_state(
+                                blockchain_provider
+                                    .as_ref()
+                                    .expect("initialized when compare_changesets is true"),
+                                block.number(),
+                            )?
+                                .ok_or_else(|| {
+                                    eyre::eyre!(
+                                        "no state found in database for block {}",
+                                        block.number()
+                                    )
+                                })?;
+                            let db_reverts = db_outcome.bundle.reverts.to_plain_state_reverts();
 
-                            let mut db_accounts =
-                                provider.account_block_changeset(block.number())?;
-                            db_accounts.sort_by_key(|a| a.address);
+                            // Compare account changesets
+                            let exec_accounts = exec_reverts.accounts
+                                .get(prev_reverts_len)
+                                .cloned()
+                                .unwrap_or_default();
+                            let db_accounts = db_reverts.accounts
+                                .into_iter()
+                                .next()
+                                .unwrap_or_default();
 
                             if exec_accounts != db_accounts {
                                 let err = eyre::eyre!(
-                                    "account changeset mismatch at block {}\n  \
-                                     execution: {exec_accounts:?}\n  \
-                                     database:  {db_accounts:?}",
+                                    "account changeset mismatch at block {}",
                                     block.number()
                                 );
                                 error!(%err);
@@ -295,25 +305,19 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                 return Err(err);
                             }
 
-                            // Storage changesets
-                            let mut exec_storage =
-                                reverts_to_storage_changesets(
-                                    plain_reverts.storage
-                                        .into_iter()
-                                        .nth(prev_reverts_len)
-                                        .unwrap_or_default(),
-                                );
-                            exec_storage.sort_by_key(|s| (s.address, s.key));
-
-                            let mut db_storage =
-                                provider.storage_block_changeset(block.number())?;
-                            db_storage.sort_by_key(|s| (s.address, s.key));
+                            // Compare storage changesets
+                            let exec_storage = exec_reverts.storage
+                                .get(prev_reverts_len)
+                                .cloned()
+                                .unwrap_or_default();
+                            let db_storage = db_reverts.storage
+                                .into_iter()
+                                .next()
+                                .unwrap_or_default();
 
                             if exec_storage != db_storage {
                                 let err = eyre::eyre!(
-                                    "storage changeset mismatch at block {}\n  \
-                                     execution: {exec_storage:?}\n  \
-                                     database:  {db_storage:?}",
+                                    "storage changeset mismatch at block {}",
                                     block.number()
                                 );
                                 error!(%err);

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -14,9 +14,8 @@ use reth_consensus::FullConsensus;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_primitives_traits::{format_gas_throughput, BlockBody, GotExpected};
 use reth_provider::{
-    providers::BlockchainProvider, BlockNumReader, BlockReader, ChainSpecProvider,
-    DatabaseProviderFactory, ReceiptProvider, StateReader, StaticFileProviderFactory,
-    TransactionVariant,
+    BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory, ReceiptProvider,
+    StaticFileProviderFactory, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages::stages::calculate_gas_used_from_headers;
@@ -116,11 +115,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             min_block..=max_block,
         )?;
 
-        let blockchain_provider = self
-            .compare_changesets
-            .then(|| BlockchainProvider::new(provider_factory.clone()))
-            .transpose()?;
-
         let db_at = {
             let provider_factory = provider_factory.clone();
             move |block_number: u64| {
@@ -144,7 +138,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let mut tasks = JoinSet::new();
         for _ in 0..num_tasks {
             let provider_factory = provider_factory.clone();
-            let blockchain_provider = blockchain_provider.clone();
             let evm_config = components.evm_config().clone();
             let consensus = components.consensus().clone();
             let db_at = db_at.clone();
@@ -266,18 +259,16 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                 .reverts
                                 .to_plain_state_reverts();
 
-                            let db_outcome = StateReader::get_state(
-                                blockchain_provider
-                                    .as_ref()
-                                    .expect("initialized when compare_changesets is true"),
-                                block.number(),
+                            let db_outcome = DatabaseProviderFactory::database_provider_ro(
+                                &provider_factory,
                             )?
-                                .ok_or_else(|| {
-                                    eyre::eyre!(
-                                        "no state found in database for block {}",
-                                        block.number()
-                                    )
-                                })?;
+                            .get_state(block.number()..=block.number())?
+                            .ok_or_else(|| {
+                                eyre::eyre!(
+                                    "no state found in database for block {}",
+                                    block.number()
+                                )
+                            })?;
                             let db_reverts = db_outcome.bundle.reverts.to_plain_state_reverts();
 
                             // Compare account changesets

--- a/crates/evm/evm/src/either.rs
+++ b/crates/evm/evm/src/either.rs
@@ -73,6 +73,13 @@ where
         }
     }
 
+    fn bundle_state(&self) -> &revm::database::BundleState {
+        match self {
+            Self::Left(a) => a.bundle_state(),
+            Self::Right(b) => b.bundle_state(),
+        }
+    }
+
     fn size_hint(&self) -> usize {
         match self {
             Self::Left(a) => a.size_hint(),

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -141,6 +141,9 @@ pub trait Executor<DB: Database>: Sized {
     /// Consumes the executor and returns the [`State`] containing all state changes.
     fn into_state(self) -> State<DB>;
 
+    /// Returns a reference to the current [`BundleState`].
+    fn bundle_state(&self) -> &BundleState;
+
     /// The size hint of the batch's tracked state size.
     ///
     /// This is used to optimize DB commits depending on the size of the state.
@@ -589,6 +592,10 @@ where
         self.db
     }
 
+    fn bundle_state(&self) -> &BundleState {
+        &self.db.bundle_state
+    }
+
     fn size_hint(&self) -> usize {
         self.db.bundle_state.size_hint()
     }
@@ -691,6 +698,10 @@ mod tests {
         }
 
         fn into_state(self) -> State<DB> {
+            unreachable!()
+        }
+
+        fn bundle_state(&self) -> &BundleState {
             unreachable!()
         }
 

--- a/crates/storage/provider/src/changesets_utils/mod.rs
+++ b/crates/storage/provider/src/changesets_utils/mod.rs
@@ -2,3 +2,37 @@
 
 mod state_reverts;
 pub use state_reverts::StorageRevertsIter;
+
+use alloy_primitives::{Address, B256};
+use reth_db_api::models::{AccountBeforeTx, StorageBeforeTx};
+use revm_database::states::PlainStorageRevert;
+
+/// Converts a single block's account reverts from a
+/// [`PlainStateReverts`](revm_database::states::PlainStateReverts) into [`AccountBeforeTx`]
+/// entries, matching the format stored in the database.
+pub fn reverts_to_account_changesets(
+    reverts: impl IntoIterator<Item = (Address, Option<impl Into<reth_primitives_traits::Account>>)>,
+) -> Vec<AccountBeforeTx> {
+    reverts
+        .into_iter()
+        .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) })
+        .collect()
+}
+
+/// Converts a single block's storage reverts from a
+/// [`PlainStateReverts`](revm_database::states::PlainStateReverts) into [`StorageBeforeTx`]
+/// entries, matching the format stored in the database.
+pub fn reverts_to_storage_changesets(
+    reverts: impl IntoIterator<Item = PlainStorageRevert>,
+) -> Vec<StorageBeforeTx> {
+    reverts
+        .into_iter()
+        .flat_map(|revert| {
+            revert.storage_revert.into_iter().map(move |(key, value)| StorageBeforeTx {
+                address: revert.address,
+                key: B256::from(key.to_be_bytes()),
+                value: value.to_previous_value(),
+            })
+        })
+        .collect()
+}

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -184,8 +184,9 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             storage_changeset.extend(changeset);
         }
 
+        let state_provider = self.state_by_block_number_ref(end_block_number)?;
         let (state, reverts) =
-            self.populate_bundle_state(account_changeset, storage_changeset, end_block_number)?;
+            populate_bundle_state(account_changeset, storage_changeset, &*state_provider)?;
 
         let mut receipt_iter =
             self.receipts_by_tx_range(from_transaction_num..=to_transaction_num)?.into_iter();
@@ -213,76 +214,60 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             Vec::new(),
         )))
     }
+}
 
-    /// Populate a [`BundleStateInit`] and [`RevertsInit`] based on the given storage and account
-    /// changesets.
-    ///
-    /// Storage changeset keys are always plain (unhashed). Current values are read via
-    /// [`StateProvider::storage`], which handles hashing internally when `use_hashed_state` is
-    /// enabled.
-    fn populate_bundle_state(
-        &self,
-        account_changeset: Vec<(u64, AccountBeforeTx)>,
-        storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
-        block_range_end: BlockNumber,
-    ) -> ProviderResult<(BundleStateInit, RevertsInit)> {
-        let mut state: BundleStateInit = HashMap::default();
-        let mut reverts: RevertsInit = HashMap::default();
-        let state_provider = self.state_by_block_number_ref(block_range_end)?;
+/// Populate a [`BundleStateInit`] and [`RevertsInit`] based on the given account and storage
+/// changesets and a [`StateProvider`] for current values.
+pub(crate) fn populate_bundle_state(
+    account_changeset: Vec<(u64, AccountBeforeTx)>,
+    storage_changeset: Vec<(BlockNumberAddress, StorageEntry)>,
+    state_provider: &dyn StateProvider,
+) -> ProviderResult<(BundleStateInit, RevertsInit)> {
+    let mut state: BundleStateInit = HashMap::default();
+    let mut reverts: RevertsInit = HashMap::default();
 
-        // add account changeset changes
-        for (block_number, account_before) in account_changeset.into_iter().rev() {
-            let AccountBeforeTx { info: old_info, address } = account_before;
-            match state.entry(address) {
-                hash_map::Entry::Vacant(entry) => {
-                    let new_info = state_provider.basic_account(&address)?;
-                    entry.insert((old_info, new_info, HashMap::default()));
-                }
-                hash_map::Entry::Occupied(mut entry) => {
-                    // overwrite old account state.
-                    entry.get_mut().0 = old_info;
-                }
+    for (block_number, account_before) in account_changeset.into_iter().rev() {
+        let AccountBeforeTx { info: old_info, address } = account_before;
+        match state.entry(address) {
+            hash_map::Entry::Vacant(entry) => {
+                let new_info = state_provider.basic_account(&address)?;
+                entry.insert((old_info, new_info, HashMap::default()));
             }
-            // insert old info into reverts.
-            reverts.entry(block_number).or_default().entry(address).or_default().0 = Some(old_info);
+            hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().0 = old_info;
+            }
         }
-
-        // add storage changeset changes
-        for (block_and_address, old_storage) in storage_changeset.into_iter().rev() {
-            let BlockNumberAddress((block_number, address)) = block_and_address;
-            // get account state or insert from plain state.
-            let account_state = match state.entry(address) {
-                hash_map::Entry::Vacant(entry) => {
-                    let present_info = state_provider.basic_account(&address)?;
-                    entry.insert((present_info, present_info, HashMap::default()))
-                }
-                hash_map::Entry::Occupied(entry) => entry.into_mut(),
-            };
-
-            // match storage.
-            match account_state.2.entry(old_storage.key) {
-                hash_map::Entry::Vacant(entry) => {
-                    let new_storage_value =
-                        state_provider.storage(address, old_storage.key)?.unwrap_or_default();
-                    entry.insert((old_storage.value, new_storage_value));
-                }
-                hash_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().0 = old_storage.value;
-                }
-            };
-
-            reverts
-                .entry(block_number)
-                .or_default()
-                .entry(address)
-                .or_default()
-                .1
-                .push(old_storage);
-        }
-
-        Ok((state, reverts))
+        reverts.entry(block_number).or_default().entry(address).or_default().0 = Some(old_info);
     }
 
+    for (block_and_address, old_storage) in storage_changeset.into_iter().rev() {
+        let BlockNumberAddress((block_number, address)) = block_and_address;
+        let account_state = match state.entry(address) {
+            hash_map::Entry::Vacant(entry) => {
+                let present_info = state_provider.basic_account(&address)?;
+                entry.insert((present_info, present_info, HashMap::default()))
+            }
+            hash_map::Entry::Occupied(entry) => entry.into_mut(),
+        };
+
+        match account_state.2.entry(old_storage.key) {
+            hash_map::Entry::Vacant(entry) => {
+                let new_storage_value =
+                    state_provider.storage(address, old_storage.key)?.unwrap_or_default();
+                entry.insert((old_storage.value, new_storage_value));
+            }
+            hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().0 = old_storage.value;
+            }
+        };
+
+        reverts.entry(block_number).or_default().entry(address).or_default().1.push(old_storage);
+    }
+
+    Ok((state, reverts))
+}
+
+impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     /// Fetches a range of data from both in-memory state and persistent storage while a predicate
     /// is met.
     ///
@@ -1641,7 +1626,7 @@ impl<N: ProviderNodeTypes> StateReader for ConsistentProvider<N> {
             let state = state.block_ref().execution_outcome().clone();
             Ok(Some(ExecutionOutcome::from((state, block))))
         } else {
-            Self::get_state(self, block..=block)
+            self.storage_provider.get_state(block..=block)
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1,6 +1,7 @@
 use crate::{
     changesets_utils::StorageRevertsIter,
     providers::{
+        consistent::populate_bundle_state,
         database::{chain::ChainStorage, metrics},
         rocksdb::{PendingRocksDBBatches, RocksDBProvider, RocksDBWriteCtx},
         static_file::{StaticFileWriteCtx, StaticFileWriter},
@@ -342,6 +343,82 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     /// Sets the prune modes for provider.
     pub fn set_prune_modes(&mut self, prune_modes: PruneModes) {
         self.prune_modes = prune_modes;
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    /// Reconstructs an [`ExecutionOutcome`] from the database changesets and receipts for the
+    /// given block range.
+    pub fn get_state(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> ProviderResult<Option<ExecutionOutcome<ReceiptTy<N>>>> {
+        if range.is_empty() {
+            return Ok(None)
+        }
+        let start_block_number = *range.start();
+        let end_block_number = *range.end();
+
+        let mut block_bodies = Vec::new();
+        for block_num in range.clone() {
+            let block_body = self
+                .block_body_indices(block_num)?
+                .ok_or(ProviderError::BlockBodyIndicesNotFound(block_num))?;
+            block_bodies.push((block_num, block_body))
+        }
+
+        let Some(from_transaction_num) = block_bodies.first().map(|body| body.1.first_tx_num())
+        else {
+            return Ok(None)
+        };
+        let Some(to_transaction_num) = block_bodies.last().map(|body| body.1.last_tx_num()) else {
+            return Ok(None)
+        };
+
+        let mut account_changeset = Vec::new();
+        for block_num in range.clone() {
+            let changeset =
+                self.account_block_changeset(block_num)?.into_iter().map(|elem| (block_num, elem));
+            account_changeset.extend(changeset);
+        }
+
+        let mut storage_changeset = Vec::new();
+        for block_num in range {
+            let changeset = self.storage_changeset(block_num)?;
+            storage_changeset.extend(changeset);
+        }
+
+        let block_hash = self
+            .block_hash(end_block_number)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(end_block_number.into()))?;
+        let state_provider = self.history_by_block_hash(block_hash)?;
+
+        let (state, reverts) =
+            populate_bundle_state(account_changeset, storage_changeset, &*state_provider)?;
+
+        let mut receipt_iter =
+            self.receipts_by_tx_range(from_transaction_num..=to_transaction_num)?.into_iter();
+
+        let mut receipts = Vec::with_capacity(block_bodies.len());
+        for (_, block_body) in block_bodies {
+            let mut block_receipts = Vec::with_capacity(block_body.tx_count as usize);
+            for tx_num in block_body.tx_num_range() {
+                let receipt = receipt_iter
+                    .next()
+                    .ok_or_else(|| ProviderError::ReceiptNotFound(tx_num.into()))?;
+                block_receipts.push(receipt);
+            }
+            receipts.push(block_receipts);
+        }
+
+        Ok(Some(ExecutionOutcome::new_init(
+            state,
+            reverts,
+            Vec::new(),
+            receipts,
+            start_block_number,
+            Vec::new(),
+        )))
     }
 }
 


### PR DESCRIPTION
Adds `--compare-changesets` to `reth re-execute`. When enabled, each block is executed independently and the resulting `BundleState` reverts are compared against the account/storage changesets stored in the database.

- Account reverts: maps `DeleteIt` → `None`, `RevertTo(info)` → `Some(Account)`, skips `DoNothing`
- Storage reverts: converts `U256` slot keys to `B256`, handles `Destroyed` as `U256::ZERO`
- On mismatch, reports which addresses/slots differ; respects `--skip-invalid-blocks`

Co-Authored-By: Arsenii Kulikov <62447812+klkvr@users.noreply.github.com>

Prompted by: klkvr