### PR TITLE
perf(chain-state): flatten in-memory overlay for O(1) state reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,6 +7496,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "codspeed-criterion-compat",
  "derive_more",
  "metrics",
  "parking_lot",

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -54,6 +54,7 @@ reth-primitives-traits = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+criterion.workspace = true
 rand.workspace = true
 revm-state.workspace = true
 
@@ -85,3 +86,7 @@ test-utils = [
     "reth-ethereum-primitives/test-utils",
 ]
 rayon = ["dep:rayon"]
+
+[[bench]]
+name = "memory_overlay"
+harness = false

--- a/crates/chain-state/benches/memory_overlay.rs
+++ b/crates/chain-state/benches/memory_overlay.rs
@@ -1,0 +1,278 @@
+//! Benchmarks for `MemoryOverlayStateProvider` state-read hot paths.
+//!
+//! Two modes are compared:
+//! - **legacy**: every in-memory block carries a default/empty `DeferredBundleState`, forcing the
+//!   provider onto the historical O(N) iteration path for every lookup.
+//! - **flattened**: the newest in-memory block carries a pre-computed cumulative
+//!   `DeferredBundleState` anchored to the oldest block's parent hash, enabling the O(1) fast path
+//!   introduced for #20612.
+#![allow(missing_docs, unreachable_pub)]
+
+use alloy_consensus::{BlockHeader, Header};
+use alloy_primitives::{keccak256, map::U256Map, Address, B256, U256};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use reth_chain_state::{
+    ComputedBundleState, ComputedTrieData, DeferredBundleState, DeferredTrieData, ExecutedBlock,
+};
+use reth_chainspec::ChainSpec;
+use reth_ethereum_primitives::{Block, BlockBody, EthPrimitives, Receipt};
+use reth_execution_types::BlockExecutionOutput;
+use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
+use reth_storage_api::{noop::NoopProvider, AccountReader, BytecodeReader, StateProvider};
+use revm_database::BundleState;
+use revm_state::AccountInfo;
+use std::{hint::black_box, sync::Arc};
+
+const ACCOUNTS_PER_BLOCK: usize = 100;
+
+/// Deterministic, well-distributed address derived from `(block_idx, acct_idx)`.
+///
+/// Hashed through keccak so the resulting addresses don't cluster in a way
+/// that would defeat `FbBuildHasher` (alloy's `FxHasher`-based hasher is
+/// sensitive to low-entropy inputs, e.g. addresses with many zero bytes).
+fn make_address(block_idx: usize, acct_idx: usize) -> Address {
+    let mut seed = [0u8; 16];
+    seed[0..8].copy_from_slice(&(block_idx as u64).to_be_bytes());
+    seed[8..16].copy_from_slice(&(acct_idx as u64).to_be_bytes());
+    let hash = keccak256(seed);
+    Address::from_slice(&hash[12..32])
+}
+
+/// Deterministic, well-distributed bytecode hash.
+fn make_code_hash(block_idx: usize, acct_idx: usize) -> B256 {
+    let mut seed = [0u8; 24];
+    seed[0..8].copy_from_slice(&(block_idx as u64).to_be_bytes());
+    seed[8..16].copy_from_slice(&(acct_idx as u64).to_be_bytes());
+    seed[16..24].copy_from_slice(b"codehash");
+    keccak256(seed)
+}
+
+/// Build a single block's `BundleState` with `ACCOUNTS_PER_BLOCK` unique touched accounts.
+fn make_bundle(block_idx: usize, block_number: u64) -> BundleState {
+    let mut builder = BundleState::builder(block_number..=block_number);
+    for acct_idx in 0..ACCOUNTS_PER_BLOCK {
+        let addr = make_address(block_idx, acct_idx);
+        let info = AccountInfo {
+            balance: U256::from(acct_idx as u64 + 1),
+            nonce: block_number,
+            code_hash: make_code_hash(block_idx, acct_idx),
+            ..Default::default()
+        };
+        builder = builder.state_present_account_info(addr, info);
+
+        let slot_key = U256::from(acct_idx as u64);
+        let slot_value = U256::from(block_number);
+        let mut slots: U256Map<(U256, U256)> = U256Map::default();
+        slots.insert(slot_key, (U256::ZERO, slot_value));
+        builder = builder.state_storage(addr, slots);
+    }
+    builder.build()
+}
+
+/// Construct a minimal `RecoveredBlock` whose header carries the given
+/// `parent_hash` and `number`. All other fields are defaults.
+fn make_recovered(number: u64, parent_hash: B256) -> Arc<RecoveredBlock<Block>> {
+    let header = Header { parent_hash, number, ..Default::default() };
+    let sealed_block =
+        SealedBlock::from_sealed_parts(SealedHeader::seal_slow(header), BlockBody::default());
+    Arc::new(RecoveredBlock::new_sealed(sealed_block, Vec::new()))
+}
+
+/// Build `n` in-memory blocks, newest-to-oldest, with a real anchor + chain of
+/// `parent_hash` links so the flattened fast path's anchor validation can succeed.
+///
+/// If `flattened` is true, the newest block's `flattened_state` is populated
+/// with the cumulative bundle from all `n` blocks, anchored to `anchor`. All
+/// older blocks carry default flattened states.
+fn make_blocks(n: usize, anchor: B256, flattened: bool) -> Vec<ExecutedBlock<EthPrimitives>> {
+    let mut blocks: Vec<ExecutedBlock<EthPrimitives>> = Vec::with_capacity(n);
+    let mut parent_hash = anchor;
+    let mut cumulative: BundleState = BundleState::default();
+
+    for i in 0..n {
+        let block_number = i as u64 + 1;
+        let bundle = make_bundle(i, block_number);
+        // Maintain the cumulative flattened state for the newest block.
+        cumulative.extend(bundle.clone());
+
+        let recovered = make_recovered(block_number, parent_hash);
+        let next_parent_hash = recovered.hash();
+
+        let execution_output =
+            Arc::new(BlockExecutionOutput::<Receipt> { result: Default::default(), state: bundle });
+
+        // Only the last-constructed block (newest) gets the populated overlay.
+        let flattened_state = if flattened && i == n - 1 {
+            DeferredBundleState::ready(ComputedBundleState::new(
+                Arc::new(cumulative.clone()),
+                anchor,
+            ))
+        } else {
+            DeferredBundleState::default()
+        };
+
+        blocks.push(ExecutedBlock {
+            recovered_block: recovered,
+            execution_output,
+            trie_data: DeferredTrieData::ready(ComputedTrieData::default()),
+            flattened_state,
+        });
+
+        parent_hash = next_parent_hash;
+    }
+
+    // Provider expects newest-to-oldest ordering.
+    blocks.reverse();
+    blocks
+}
+
+fn make_provider(
+    blocks: Vec<ExecutedBlock<EthPrimitives>>,
+) -> reth_chain_state::MemoryOverlayStateProvider<EthPrimitives> {
+    let noop: NoopProvider<ChainSpec, EthPrimitives> = NoopProvider::default();
+    reth_chain_state::MemoryOverlayStateProvider::new(Box::new(noop), blocks)
+}
+
+fn bench_basic_account(c: &mut Criterion) {
+    let anchor = B256::repeat_byte(0xEE);
+    let mut group = c.benchmark_group("MemoryOverlay/basic_account");
+
+    for &num_blocks in &[8usize, 32, 64] {
+        let newest_block_idx = num_blocks - 1;
+        let oldest_block_idx = 0;
+
+        let addr_newest = make_address(newest_block_idx, ACCOUNTS_PER_BLOCK / 2);
+        let addr_oldest = make_address(oldest_block_idx, ACCOUNTS_PER_BLOCK / 2);
+        let addr_miss = make_address(num_blocks + 1, 0);
+
+        for &flattened in &[false, true] {
+            let variant = if flattened { "flattened" } else { "legacy" };
+            let blocks = make_blocks(num_blocks, anchor, flattened);
+
+            // Sanity check: verify the flattened bundle resolves both newest
+            // and oldest addresses before benchmarking. A miss here would mean
+            // the bench setup is wrong and numbers would be meaningless.
+            if flattened {
+                let newest_block = &blocks[0];
+                let oldest_block = &blocks[num_blocks - 1];
+                let flat = newest_block.flattened_state.wait_cloned();
+                assert_eq!(
+                    oldest_block.recovered_block.parent_hash(),
+                    flat.anchor_hash,
+                    "bench invariant: oldest.parent_hash must equal newest.flattened.anchor"
+                );
+                assert!(
+                    flat.bundle.account(&addr_newest).is_some(),
+                    "addr_newest must be in cumulative bundle"
+                );
+                assert!(
+                    flat.bundle.account(&addr_oldest).is_some(),
+                    "addr_oldest must be in cumulative bundle"
+                );
+            }
+
+            let provider = make_provider(blocks);
+
+            group.bench_function(
+                BenchmarkId::new(format!("{variant}/hit_newest"), num_blocks),
+                |b| {
+                    b.iter(|| {
+                        let _ = black_box(provider.basic_account(&black_box(addr_newest)).unwrap());
+                    });
+                },
+            );
+
+            group.bench_function(
+                BenchmarkId::new(format!("{variant}/hit_oldest"), num_blocks),
+                |b| {
+                    b.iter(|| {
+                        let _ = black_box(provider.basic_account(&black_box(addr_oldest)).unwrap());
+                    });
+                },
+            );
+
+            group.bench_function(BenchmarkId::new(format!("{variant}/miss"), num_blocks), |b| {
+                b.iter(|| {
+                    let _ = black_box(provider.basic_account(&black_box(addr_miss)).unwrap());
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_storage(c: &mut Criterion) {
+    let anchor = B256::repeat_byte(0xEE);
+    let mut group = c.benchmark_group("MemoryOverlay/storage");
+
+    for &num_blocks in &[8usize, 32, 64] {
+        let newest_block_idx = num_blocks - 1;
+        let oldest_block_idx = 0;
+
+        let slot = B256::from(U256::from((ACCOUNTS_PER_BLOCK / 2) as u64));
+        let addr_newest = make_address(newest_block_idx, ACCOUNTS_PER_BLOCK / 2);
+        let addr_oldest = make_address(oldest_block_idx, ACCOUNTS_PER_BLOCK / 2);
+        let addr_miss = make_address(num_blocks + 1, 0);
+
+        for &flattened in &[false, true] {
+            let variant = if flattened { "flattened" } else { "legacy" };
+            let provider = make_provider(make_blocks(num_blocks, anchor, flattened));
+
+            group.bench_function(
+                BenchmarkId::new(format!("{variant}/hit_newest"), num_blocks),
+                |b| {
+                    b.iter(|| {
+                        let _ = black_box(
+                            provider.storage(black_box(addr_newest), black_box(slot)).unwrap(),
+                        );
+                    });
+                },
+            );
+
+            group.bench_function(
+                BenchmarkId::new(format!("{variant}/hit_oldest"), num_blocks),
+                |b| {
+                    b.iter(|| {
+                        let _ = black_box(
+                            provider.storage(black_box(addr_oldest), black_box(slot)).unwrap(),
+                        );
+                    });
+                },
+            );
+
+            group.bench_function(BenchmarkId::new(format!("{variant}/miss"), num_blocks), |b| {
+                b.iter(|| {
+                    let _ =
+                        black_box(provider.storage(black_box(addr_miss), black_box(slot)).unwrap());
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_bytecode_miss(c: &mut Criterion) {
+    let anchor = B256::repeat_byte(0xEE);
+    let mut group = c.benchmark_group("MemoryOverlay/bytecode_by_hash");
+
+    for &num_blocks in &[8usize, 32, 64] {
+        let hash = B256::repeat_byte(0xAB);
+        for &flattened in &[false, true] {
+            let variant = if flattened { "flattened" } else { "legacy" };
+            let provider = make_provider(make_blocks(num_blocks, anchor, flattened));
+
+            group.bench_function(BenchmarkId::new(format!("{variant}/miss"), num_blocks), |b| {
+                b.iter(|| {
+                    let _ = black_box(provider.bytecode_by_hash(&black_box(hash)).unwrap());
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(memory_overlay_benches, bench_basic_account, bench_storage, bench_bytecode_miss);
+criterion_main!(memory_overlay_benches);

--- a/crates/chain-state/src/deferred_bundle.rs
+++ b/crates/chain-state/src/deferred_bundle.rs
@@ -1,0 +1,409 @@
+//! Deferred asynchronous flattening of in-memory [`BundleState`] overlays.
+//!
+//! Mirrors [`DeferredTrieData`](crate::DeferredTrieData) in shape and invariants:
+//! each in-memory block produces a handle that can be computed asynchronously
+//! in the background and accessed with a synchronous fallback. The flattened
+//! bundle aggregates all in-memory ancestor state changes into a single
+//! [`BundleState`], enabling O(1) account/storage/bytecode lookups in
+//! [`MemoryOverlayStateProvider`](crate::MemoryOverlayStateProvider) instead of
+//! O(N) iteration across every in-memory block.
+
+use alloy_primitives::B256;
+use parking_lot::Mutex;
+use reth_metrics::{metrics::Counter, Metrics};
+use revm_database::BundleState;
+use std::{
+    fmt,
+    sync::{Arc, LazyLock},
+};
+use tracing::{debug_span, instrument};
+
+/// Shared handle to an asynchronously-flattened [`BundleState`] overlay.
+///
+/// Uses a try-lock + fallback computation approach for deadlock-free access.
+/// If the deferred task hasn't completed, computes the flattened bundle
+/// synchronously from stored pending inputs rather than blocking.
+#[derive(Clone)]
+pub struct DeferredBundleState {
+    /// Shared deferred state holding either raw inputs (pending) or the computed result (ready).
+    state: Arc<Mutex<DeferredBundleStateInner>>,
+}
+
+/// Flattened bundle covering all in-memory ancestor blocks plus the owning block.
+///
+/// The `bundle` is an `Arc`-wrapped [`BundleState`] so that child blocks can
+/// reuse a parent's flattened overlay via structural sharing (`Arc::make_mut`).
+/// The `anchor_hash` identifies the persisted base state this overlay sits on
+/// top of; overlays anchored to different base states are not interchangeable.
+#[derive(Clone, Debug, Default)]
+pub struct ComputedBundleState {
+    /// Cumulative flattened bundle for all in-memory ancestors + this block.
+    pub bundle: Arc<BundleState>,
+    /// The persisted ancestor hash this overlay is anchored to.
+    pub anchor_hash: B256,
+}
+
+impl ComputedBundleState {
+    /// Construct a new [`ComputedBundleState`] anchored to the given persisted ancestor.
+    pub const fn new(bundle: Arc<BundleState>, anchor_hash: B256) -> Self {
+        Self { bundle, anchor_hash }
+    }
+}
+
+/// Metrics for deferred bundle flattening.
+#[derive(Metrics)]
+#[metrics(scope = "sync.block_validation")]
+struct DeferredBundleMetrics {
+    /// Number of times the flattened bundle was ready when a consumer asked
+    /// (the async background task finished first).
+    deferred_bundle_async_ready: Counter,
+    /// Number of times a consumer had to fall back to the synchronous path.
+    deferred_bundle_sync_fallback: Counter,
+}
+
+static DEFERRED_BUNDLE_METRICS: LazyLock<DeferredBundleMetrics> =
+    LazyLock::new(DeferredBundleMetrics::default);
+
+/// Internal state machine for [`DeferredBundleState`].
+enum DeferredBundleStateInner {
+    /// Flattened bundle has not been computed yet. Pending inputs are wrapped
+    /// in [`Option`] so they can be taken by a synchronous-fallback caller
+    /// without requiring the inputs to be [`Clone`].
+    Pending(Option<PendingBundleInputs>),
+    /// Flattened bundle has been computed and is ready to return.
+    Ready(ComputedBundleState),
+}
+
+/// Inputs held while a deferred bundle flattening is pending.
+struct PendingBundleInputs {
+    /// This block's own post-execution bundle state (from
+    /// [`BlockExecutionOutput::state`](reth_execution_types::BlockExecutionOutput)).
+    this_block_state: Arc<BundleState>,
+    /// Persisted ancestor hash this overlay is anchored to.
+    anchor_hash: B256,
+    /// Parent block's deferred bundle handle. When present and anchored to the
+    /// same base state, the parent's flattened bundle is reused rather than
+    /// recomputed from scratch.
+    parent: Option<DeferredBundleState>,
+}
+
+impl fmt::Debug for DeferredBundleState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock();
+        let tag = match &*state {
+            DeferredBundleStateInner::Pending(_) => "pending",
+            DeferredBundleStateInner::Ready(_) => "ready",
+        };
+        f.debug_struct("DeferredBundleState").field("state", &tag).finish()
+    }
+}
+
+impl Default for DeferredBundleState {
+    fn default() -> Self {
+        Self::ready(ComputedBundleState::default())
+    }
+}
+
+impl DeferredBundleState {
+    /// Create a new pending handle with fallback inputs for synchronous computation.
+    ///
+    /// The flattened bundle will be computed lazily the first time
+    /// [`Self::wait_cloned`] is called.
+    ///
+    /// # Arguments
+    /// * `this_block_state` - This block's post-execution [`BundleState`].
+    /// * `anchor_hash` - The persisted ancestor hash this overlay is anchored to.
+    /// * `parent` - Parent block's deferred bundle handle, if any.
+    pub fn pending(
+        this_block_state: Arc<BundleState>,
+        anchor_hash: B256,
+        parent: Option<Self>,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(DeferredBundleStateInner::Pending(Some(
+                PendingBundleInputs { this_block_state, anchor_hash, parent },
+            )))),
+        }
+    }
+
+    /// Create a handle that is already populated with a pre-computed flattened bundle.
+    pub fn ready(computed: ComputedBundleState) -> Self {
+        Self { state: Arc::new(Mutex::new(DeferredBundleStateInner::Ready(computed))) }
+    }
+
+    /// Returns the flattened bundle, computing synchronously if the async task
+    /// hasn't completed.
+    ///
+    /// - If the async task has completed (`Ready`), returns the cached result.
+    /// - If still pending, computes from stored inputs and caches the result so subsequent calls
+    ///   return immediately.
+    ///
+    /// Deadlock is avoided as long as the provided ancestor chain forms a DAG
+    /// (each block only holds handles to its ancestors). Sibling blocks are
+    /// never in each other's ancestor chains.
+    #[instrument(level = "debug", target = "engine::tree::deferred_bundle", skip_all)]
+    pub fn wait_cloned(&self) -> ComputedBundleState {
+        let mut state = self.state.lock();
+        match &mut *state {
+            DeferredBundleStateInner::Ready(computed) => {
+                DEFERRED_BUNDLE_METRICS.deferred_bundle_async_ready.increment(1);
+                computed.clone()
+            }
+            DeferredBundleStateInner::Pending(maybe_inputs) => {
+                DEFERRED_BUNDLE_METRICS.deferred_bundle_sync_fallback.increment(1);
+
+                let inputs = maybe_inputs.take().expect("inputs must be present in Pending state");
+
+                let computed = Self::flatten_inputs(
+                    inputs.this_block_state,
+                    inputs.anchor_hash,
+                    inputs.parent,
+                );
+                *state = DeferredBundleStateInner::Ready(computed.clone());
+
+                // Release the lock before the old `inputs` (and its potential
+                // last parent Arc) are dropped, to avoid holding this lock while
+                // destructors run on related handles.
+                drop(state);
+
+                computed
+            }
+        }
+    }
+
+    /// Flatten the current block's bundle onto the parent's cumulative overlay.
+    ///
+    /// # Reuse strategy
+    /// - **Parent present + anchor match**: clone the parent's `Arc<BundleState>` (cheap) and call
+    ///   `Arc::make_mut` to get exclusive access for extension. If the parent's Arc refcount is 1,
+    ///   no allocation happens; otherwise the backing state is cloned once (typical on reorg
+    ///   boundaries or when multiple consumers share the parent's handle).
+    /// - **Parent present + anchor mismatch**: discard the parent overlay — it is anchored to a
+    ///   different base state and cannot be reused safely. Fall through to using just this block's
+    ///   own state.
+    /// - **No parent**: first block after the persisted anchor; this block's own state IS the
+    ///   cumulative overlay.
+    ///
+    /// In all cases, the resulting [`ComputedBundleState`] is anchored to
+    /// `anchor_hash`.
+    fn flatten_inputs(
+        this_block_state: Arc<BundleState>,
+        anchor_hash: B256,
+        parent: Option<Self>,
+    ) -> ComputedBundleState {
+        let _span = debug_span!(target: "engine::tree::deferred_bundle", "flatten").entered();
+
+        let bundle = match parent {
+            Some(parent_handle) => {
+                let parent_computed = parent_handle.wait_cloned();
+                if parent_computed.anchor_hash == anchor_hash {
+                    // Reuse parent's cumulative bundle, extend with this block's diff.
+                    // `other` wins on conflicts per `BundleState::extend` semantics,
+                    // which matches the "newest overrides older" rule used by the
+                    // existing O(N) MemoryOverlayStateProvider iteration.
+                    let mut overlay = parent_computed.bundle;
+                    let bundle_mut = Arc::make_mut(&mut overlay);
+                    let this_owned = match Arc::try_unwrap(this_block_state) {
+                        Ok(state) => state,
+                        Err(arc) => (*arc).clone(),
+                    };
+                    bundle_mut.extend(this_owned);
+                    overlay
+                } else {
+                    // Anchor mismatch: parent's overlay was built against a
+                    // different persisted base (e.g. after a persistence event
+                    // changed what's on disk). Using it would yield incorrect
+                    // lookups, so fall back to this block's own state and let
+                    // the historical provider serve older state.
+                    this_block_state
+                }
+            }
+            None => this_block_state,
+        };
+
+        ComputedBundleState { bundle, anchor_hash }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, U256};
+    use revm_state::AccountInfo;
+    use std::{thread, time::Duration};
+
+    fn addr(byte: u8) -> Address {
+        Address::repeat_byte(byte)
+    }
+
+    fn anchor(byte: u8) -> B256 {
+        B256::repeat_byte(byte)
+    }
+
+    fn bundle_with_account(block_number: u64, address: Address, balance: u64) -> Arc<BundleState> {
+        let info =
+            AccountInfo { balance: U256::from(balance), nonce: block_number, ..Default::default() };
+        let bundle = BundleState::builder(block_number..=block_number)
+            .state_present_account_info(address, info)
+            .build();
+        Arc::new(bundle)
+    }
+
+    fn balance_of(bundle: &BundleState, address: Address) -> Option<U256> {
+        bundle.account(&address).and_then(|acc| acc.info.as_ref().map(|i| i.balance))
+    }
+
+    #[test]
+    fn ready_returns_cached_result() {
+        let computed =
+            ComputedBundleState::new(bundle_with_account(1, addr(0x11), 100), anchor(0xAA));
+        let handle = DeferredBundleState::ready(computed);
+
+        let got = handle.wait_cloned();
+        assert_eq!(got.anchor_hash, anchor(0xAA));
+        assert_eq!(balance_of(&got.bundle, addr(0x11)), Some(U256::from(100)));
+    }
+
+    #[test]
+    fn pending_without_parent_returns_own_state() {
+        let handle = DeferredBundleState::pending(
+            bundle_with_account(1, addr(0x22), 42),
+            anchor(0xBB),
+            None,
+        );
+
+        let got = handle.wait_cloned();
+        assert_eq!(got.anchor_hash, anchor(0xBB));
+        assert_eq!(balance_of(&got.bundle, addr(0x22)), Some(U256::from(42)));
+    }
+
+    #[test]
+    fn fallback_result_is_cached_on_second_call() {
+        let handle =
+            DeferredBundleState::pending(bundle_with_account(1, addr(0x33), 7), anchor(0xCC), None);
+
+        let first = handle.wait_cloned();
+        let second = handle.wait_cloned();
+
+        // Both calls observe the same Arc (second call hits the Ready branch).
+        assert!(Arc::ptr_eq(&first.bundle, &second.bundle));
+    }
+
+    #[test]
+    fn parent_same_anchor_extends_and_overrides() {
+        // Parent block sets addr(0xAA) balance = 100.
+        let parent = DeferredBundleState::pending(
+            bundle_with_account(1, addr(0xAA), 100),
+            anchor(0x01),
+            None,
+        );
+
+        // Child block overrides addr(0xAA) balance = 200 and introduces addr(0xBB).
+        let child_state = {
+            let info_aa = AccountInfo { balance: U256::from(200), nonce: 2, ..Default::default() };
+            let info_bb = AccountInfo { balance: U256::from(50), nonce: 0, ..Default::default() };
+            let bundle = BundleState::builder(2..=2)
+                .state_present_account_info(addr(0xAA), info_aa)
+                .state_present_account_info(addr(0xBB), info_bb)
+                .build();
+            Arc::new(bundle)
+        };
+        let child = DeferredBundleState::pending(child_state, anchor(0x01), Some(parent));
+
+        let computed = child.wait_cloned();
+        // Child wins on addr(0xAA).
+        assert_eq!(balance_of(&computed.bundle, addr(0xAA)), Some(U256::from(200)));
+        // Parent-only account survives.
+        assert_eq!(balance_of(&computed.bundle, addr(0xBB)), Some(U256::from(50)));
+        assert_eq!(computed.anchor_hash, anchor(0x01));
+    }
+
+    #[test]
+    fn parent_mismatched_anchor_is_ignored() {
+        // Parent is anchored to anchor(0x01), contains addr(0xCC).
+        let parent = DeferredBundleState::pending(
+            bundle_with_account(1, addr(0xCC), 999),
+            anchor(0x01),
+            None,
+        );
+
+        // Child claims anchor(0x02) — different base. Parent's overlay must be dropped.
+        let child = DeferredBundleState::pending(
+            bundle_with_account(2, addr(0xDD), 1),
+            anchor(0x02),
+            Some(parent),
+        );
+
+        let computed = child.wait_cloned();
+        assert_eq!(computed.anchor_hash, anchor(0x02));
+        // Parent-only account should NOT appear — anchor mismatch caused fallback.
+        assert_eq!(balance_of(&computed.bundle, addr(0xCC)), None);
+        // Child's own state is present.
+        assert_eq!(balance_of(&computed.bundle, addr(0xDD)), Some(U256::from(1)));
+    }
+
+    #[test]
+    fn siblings_off_shared_parent_do_not_corrupt_each_other() {
+        // Shared parent with addr(0xEE) = 10.
+        let parent = DeferredBundleState::pending(
+            bundle_with_account(1, addr(0xEE), 10),
+            anchor(0x01),
+            None,
+        );
+
+        // Pre-compute the parent so both siblings reuse the cached Arc.
+        let _ = parent.wait_cloned();
+
+        // Sibling A sets addr(0xEE) = 100.
+        let sibling_a_state = bundle_with_account(2, addr(0xEE), 100);
+        let sibling_a =
+            DeferredBundleState::pending(sibling_a_state, anchor(0x01), Some(parent.clone()));
+
+        // Sibling B sets addr(0xEE) = 200.
+        let sibling_b_state = bundle_with_account(2, addr(0xEE), 200);
+        let sibling_b =
+            DeferredBundleState::pending(sibling_b_state, anchor(0x01), Some(parent.clone()));
+
+        let a_computed = sibling_a.wait_cloned();
+        let b_computed = sibling_b.wait_cloned();
+
+        assert_eq!(balance_of(&a_computed.bundle, addr(0xEE)), Some(U256::from(100)));
+        assert_eq!(balance_of(&b_computed.bundle, addr(0xEE)), Some(U256::from(200)));
+
+        // Parent must still observe its original value; its cached bundle
+        // must not have been mutated by either child's `make_mut`.
+        let parent_again = parent.wait_cloned();
+        assert_eq!(balance_of(&parent_again.bundle, addr(0xEE)), Some(U256::from(10)));
+    }
+
+    #[test]
+    fn ready_handle_returns_quickly() {
+        let handle = DeferredBundleState::ready(ComputedBundleState::default());
+        let start = std::time::Instant::now();
+        let _ = handle.wait_cloned();
+        assert!(start.elapsed() < Duration::from_millis(20));
+    }
+
+    #[test]
+    fn concurrent_wait_cloned_is_consistent() {
+        let parent =
+            DeferredBundleState::pending(bundle_with_account(1, addr(0xFF), 1), anchor(0x01), None);
+        let child = DeferredBundleState::pending(
+            bundle_with_account(2, addr(0xFF), 2),
+            anchor(0x01),
+            Some(parent),
+        );
+
+        let c1 = child.clone();
+        let c2 = child;
+        let t1 = thread::spawn(move || c1.wait_cloned());
+        let t2 = thread::spawn(move || c2.wait_cloned());
+
+        let r1 = t1.join().unwrap();
+        let r2 = t2.join().unwrap();
+
+        assert_eq!(balance_of(&r1.bundle, addr(0xFF)), Some(U256::from(2)));
+        assert_eq!(balance_of(&r2.bundle, addr(0xFF)), Some(U256::from(2)));
+        assert!(Arc::ptr_eq(&r1.bundle, &r2.bundle));
+    }
+}

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotifications,
-    ChainInfoTracker, ComputedTrieData, DeferredTrieData, MemoryOverlayStateProvider,
+    ChainInfoTracker, ComputedTrieData, DeferredBundleState, DeferredTrieData,
+    MemoryOverlayStateProvider,
 };
 use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
 use alloy_eips::{BlockHashOrNumber, BlockNumHash};
@@ -760,6 +761,18 @@ pub struct ExecutedBlock<N: NodePrimitives = EthPrimitives> {
     /// This allows deferring the computation of the trie data which can be expensive.
     /// The data can be populated asynchronously after the block was validated.
     pub trie_data: DeferredTrieData,
+    /// Deferred cumulative flattened bundle state covering all in-memory
+    /// ancestors + this block.
+    ///
+    /// When populated (see [`DeferredBundleState::pending`]),
+    /// [`MemoryOverlayStateProvider`] reads for any in-memory block become
+    /// O(1) probes against the flattened overlay rather than O(N) iteration
+    /// across every in-memory block.
+    ///
+    /// Defaults to an empty, ready handle anchored to `B256::ZERO`. Consumers
+    /// treat this as "no overlay available" and fall back to the legacy
+    /// iteration path, preserving correctness.
+    pub flattened_state: DeferredBundleState,
 }
 
 impl<N: NodePrimitives> Default for ExecutedBlock<N> {
@@ -776,13 +789,15 @@ impl<N: NodePrimitives> Default for ExecutedBlock<N> {
                 state: Default::default(),
             }),
             trie_data: DeferredTrieData::ready(ComputedTrieData::default()),
+            flattened_state: DeferredBundleState::default(),
         }
     }
 }
 
 impl<N: NodePrimitives> PartialEq for ExecutedBlock<N> {
     fn eq(&self, other: &Self) -> bool {
-        // Trie data is computed asynchronously and doesn't define block identity.
+        // Deferred data (trie + flattened bundle) is computed asynchronously and
+        // doesn't define block identity.
         self.recovered_block == other.recovered_block &&
             self.execution_output == other.execution_output
     }
@@ -798,7 +813,12 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
         trie_data: ComputedTrieData,
     ) -> Self {
-        Self { recovered_block, execution_output, trie_data: DeferredTrieData::ready(trie_data) }
+        Self {
+            recovered_block,
+            execution_output,
+            trie_data: DeferredTrieData::ready(trie_data),
+            flattened_state: DeferredBundleState::default(),
+        }
     }
 
     /// Create a new [`ExecutedBlock`] with deferred trie data.
@@ -815,12 +835,33 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     /// occurs synchronously from stored inputs, so there is no blocking or deadlock risk.
     ///
     /// Use [`Self::new()`] instead when trie data is already computed and available immediately.
-    pub const fn with_deferred_trie_data(
+    pub fn with_deferred_trie_data(
         recovered_block: Arc<RecoveredBlock<N::Block>>,
         execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
         trie_data: DeferredTrieData,
     ) -> Self {
-        Self { recovered_block, execution_output, trie_data }
+        Self {
+            recovered_block,
+            execution_output,
+            trie_data,
+            flattened_state: DeferredBundleState::default(),
+        }
+    }
+
+    /// Create a new [`ExecutedBlock`] with both deferred trie data and a
+    /// deferred flattened bundle state.
+    ///
+    /// Use this constructor from the validation hot path (see
+    /// `spawn_deferred_trie_task` in the engine tree) to enable O(1) in-memory
+    /// state lookups. The flattened bundle is cumulative over all in-memory
+    /// ancestors + this block and is computed asynchronously in the background.
+    pub const fn with_deferred_bundle_state(
+        recovered_block: Arc<RecoveredBlock<N::Block>>,
+        execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
+        trie_data: DeferredTrieData,
+        flattened_state: DeferredBundleState,
+    ) -> Self {
+        Self { recovered_block, execution_output, trie_data, flattened_state }
     }
 
     /// Returns a reference to an inner [`SealedBlock`]
@@ -860,6 +901,17 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     #[inline]
     pub fn trie_data_handle(&self) -> DeferredTrieData {
         self.trie_data.clone()
+    }
+
+    /// Returns a clone of the deferred flattened bundle state handle.
+    ///
+    /// A handle is a lightweight reference that can be passed to descendants
+    /// without forcing flattening to happen immediately. The actual work runs
+    /// when [`DeferredBundleState::wait_cloned`] is called by a consumer
+    /// (typically [`MemoryOverlayStateProvider`] during state reads).
+    #[inline]
+    pub fn flattened_state_handle(&self) -> DeferredBundleState {
+        self.flattened_state.clone()
     }
 
     /// Returns the hashed state result of the execution outcome.

--- a/crates/chain-state/src/lib.rs
+++ b/crates/chain-state/src/lib.rs
@@ -17,6 +17,9 @@ pub use in_memory::*;
 mod deferred_trie;
 pub use deferred_trie::*;
 
+mod deferred_bundle;
+pub use deferred_bundle::*;
+
 mod lazy_overlay;
 pub use lazy_overlay::*;
 

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -12,7 +12,10 @@ use reth_trie::{
     MultiProofTargets, StorageMultiProof, TrieInput,
 };
 use revm_database::BundleState;
-use std::{borrow::Cow, sync::OnceLock};
+use std::{
+    borrow::Cow,
+    sync::{Arc, OnceLock},
+};
 
 /// A state provider that stores references to in-memory blocks along with their state as well as a
 /// reference of the historical state provider for fallback lookups.
@@ -66,6 +69,165 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
         hashed.extend(&storage);
         hashed
     }
+
+    /// Returns the cumulative flattened [`BundleState`] from the newest
+    /// in-memory block, but only when its anchor matches the current
+    /// persistence boundary.
+    ///
+    /// The anchor check compares the newest block's flattened-state anchor
+    /// against the oldest in-memory block's parent hash (the persisted base
+    /// this overlay sits on). A mismatch indicates a persistence event
+    /// occurred after the flattened state was computed; in that case the
+    /// overlay must not be reused, and callers fall back to per-block
+    /// iteration.
+    ///
+    /// Returns `None` when:
+    /// - `in_memory` is empty
+    /// - the oldest block's parent hash is `B256::ZERO` (no real anchor)
+    /// - the newest block carries a default/unpopulated flattened state
+    /// - persistence has shifted the anchor since the overlay was built
+    fn flattened_overlay(&self) -> Option<Arc<BundleState>> {
+        let newest = self.in_memory.first()?;
+        let oldest = self.in_memory.last()?;
+        let expected_anchor = oldest.recovered_block.parent_hash();
+        if expected_anchor == B256::ZERO {
+            return None;
+        }
+        let computed = newest.flattened_state.wait_cloned();
+        (computed.anchor_hash == expected_anchor).then_some(computed.bundle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ComputedBundleState, DeferredBundleState, DeferredTrieData, ExecutedBlock};
+    use alloy_consensus::Header;
+    use alloy_primitives::U256;
+    use reth_chainspec::ChainSpec;
+    use reth_ethereum_primitives::{Block, BlockBody, EthPrimitives, Receipt};
+    use reth_execution_types::BlockExecutionOutput;
+    use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
+    use reth_storage_api::noop::NoopProvider;
+    use revm_state::AccountInfo;
+
+    fn make_recovered(number: u64, parent_hash: B256) -> Arc<RecoveredBlock<Block>> {
+        let header = Header { parent_hash, number, ..Default::default() };
+        let sealed =
+            SealedBlock::from_sealed_parts(SealedHeader::seal_slow(header), BlockBody::default());
+        Arc::new(RecoveredBlock::new_sealed(sealed, Vec::new()))
+    }
+
+    fn executed_block_with(
+        parent_hash: B256,
+        block_number: u64,
+        account_addr: Address,
+        balance: u64,
+        flattened: Option<ComputedBundleState>,
+    ) -> ExecutedBlock<EthPrimitives> {
+        let info =
+            AccountInfo { balance: U256::from(balance), nonce: block_number, ..Default::default() };
+        let bundle = BundleState::builder(block_number..=block_number)
+            .state_present_account_info(account_addr, info)
+            .build();
+
+        let execution_output =
+            Arc::new(BlockExecutionOutput::<Receipt> { result: Default::default(), state: bundle });
+
+        let flattened_state = match flattened {
+            Some(c) => DeferredBundleState::ready(c),
+            None => DeferredBundleState::default(),
+        };
+
+        ExecutedBlock {
+            recovered_block: make_recovered(block_number, parent_hash),
+            execution_output,
+            trie_data: DeferredTrieData::ready(Default::default()),
+            flattened_state,
+        }
+    }
+
+    fn make_ref<'a>(
+        blocks: &'a [ExecutedBlock<EthPrimitives>],
+    ) -> MemoryOverlayStateProviderRef<'a, EthPrimitives> {
+        let noop: NoopProvider<ChainSpec, EthPrimitives> = NoopProvider::default();
+        MemoryOverlayStateProviderRef {
+            historical: Box::new(noop),
+            in_memory: Cow::Borrowed(blocks),
+            trie_input: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn flattened_overlay_available_when_anchor_matches() {
+        let anchor = B256::repeat_byte(0xAA);
+        let addr = Address::repeat_byte(0x01);
+
+        // Build chain: block1 parent = anchor, block2 parent = block1.hash()
+        let block1 = executed_block_with(anchor, 1, addr, 10, None);
+        let block1_hash = block1.recovered_block.hash();
+
+        // Flattened bundle covering block1 + block2, anchored to `anchor`.
+        let info2 = AccountInfo { balance: U256::from(20), nonce: 2, ..Default::default() };
+        let mut cumulative = block1.execution_output.state.clone();
+        cumulative
+            .extend(BundleState::builder(2..=2).state_present_account_info(addr, info2).build());
+        let flat = ComputedBundleState::new(Arc::new(cumulative), anchor);
+
+        let block2 = executed_block_with(block1_hash, 2, addr, 20, Some(flat));
+
+        // newest-to-oldest
+        let blocks = vec![block2, block1];
+        let provider = make_ref(&blocks);
+
+        // Sanity: anchor check succeeds.
+        assert!(provider.flattened_overlay().is_some());
+
+        // Lookup via fast path returns the *newest* value.
+        let acc = provider.basic_account(&addr).unwrap().expect("account present");
+        assert_eq!(acc.balance, U256::from(20));
+    }
+
+    #[test]
+    fn flattened_overlay_skipped_on_anchor_mismatch() {
+        let addr = Address::repeat_byte(0x02);
+        let real_anchor = B256::repeat_byte(0xBB);
+        let stale_anchor = B256::repeat_byte(0xCC);
+
+        let block1 = executed_block_with(real_anchor, 1, addr, 100, None);
+        let block1_hash = block1.recovered_block.hash();
+
+        // Flattened anchored to a DIFFERENT, stale anchor.
+        let cumulative = block1.execution_output.state.clone();
+        let flat = ComputedBundleState::new(Arc::new(cumulative), stale_anchor);
+        let block2 = executed_block_with(block1_hash, 2, addr, 200, Some(flat));
+
+        let blocks = vec![block2, block1];
+        let provider = make_ref(&blocks);
+
+        // Anchor mismatch: fast path must not activate.
+        assert!(provider.flattened_overlay().is_none());
+
+        // Correctness preserved via iteration fallback (newest wins).
+        let acc = provider.basic_account(&addr).unwrap().expect("account present");
+        assert_eq!(acc.balance, U256::from(200));
+    }
+
+    #[test]
+    fn flattened_overlay_skipped_when_anchor_is_zero() {
+        let addr = Address::repeat_byte(0x03);
+        // Oldest block's parent_hash is B256::ZERO (genesis-like edge case).
+        let block1 = executed_block_with(B256::ZERO, 1, addr, 5, None);
+        let block1_hash = block1.recovered_block.hash();
+        let flat =
+            ComputedBundleState::new(Arc::new(block1.execution_output.state.clone()), B256::ZERO);
+        let block2 = executed_block_with(block1_hash, 2, addr, 7, Some(flat));
+
+        let blocks = vec![block2, block1];
+        let provider = make_ref(&blocks);
+
+        assert!(provider.flattened_overlay().is_none());
+    }
 }
 
 impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N> {
@@ -111,6 +273,16 @@ impl<N: NodePrimitives> BlockHashReader for MemoryOverlayStateProviderRef<'_, N>
 
 impl<N: NodePrimitives> AccountReader for MemoryOverlayStateProviderRef<'_, N> {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        // Fast path: single HashMap probe against the cumulative flattened overlay.
+        if let Some(bundle) = self.flattened_overlay() {
+            return match bundle.account(address) {
+                Some(bundle_account) => Ok(bundle_account.info.as_ref().map(Into::into)),
+                None => self.historical.basic_account(address),
+            };
+        }
+
+        // Fallback: iterate newest-to-oldest when the flattened overlay is
+        // unavailable (no anchor, persistence boundary, legacy construction).
         for block in self.in_memory.iter() {
             if let Some(account) = block.execution_output.account(address) {
                 return Ok(account);
@@ -220,6 +392,15 @@ impl<N: NodePrimitives> StateProvider for MemoryOverlayStateProviderRef<'_, N> {
         address: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
+        if let Some(bundle) = self.flattened_overlay() {
+            if let Some(account) = bundle.account(&address) &&
+                let Some(value) = account.storage_slot(storage_key.into())
+            {
+                return Ok(Some(value));
+            }
+            return self.historical.storage(address, storage_key);
+        }
+
         for block in self.in_memory.iter() {
             if let Some(value) = block.execution_output.storage(&address, storage_key.into()) {
                 return Ok(Some(value));
@@ -232,6 +413,13 @@ impl<N: NodePrimitives> StateProvider for MemoryOverlayStateProviderRef<'_, N> {
 
 impl<N: NodePrimitives> BytecodeReader for MemoryOverlayStateProviderRef<'_, N> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        if let Some(bundle) = self.flattened_overlay() {
+            if let Some(contract) = bundle.bytecode(code_hash) {
+                return Ok(Some(Bytecode(contract)));
+            }
+            return self.historical.bytecode_by_hash(code_hash);
+        }
+
         for block in self.in_memory.iter() {
             if let Some(contract) = block.execution_output.bytecode(code_hash) {
                 return Ok(Some(contract));

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -57,7 +57,8 @@ use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 
 use crate::tree::payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
 use reth_chain_state::{
-    CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, ExecutionTimingStats, LazyOverlay,
+    CanonicalInMemoryState, DeferredBundleState, DeferredTrieData, ExecutedBlock,
+    ExecutionTimingStats, LazyOverlay,
 };
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -1634,6 +1635,11 @@ where
         let ancestors: Vec<DeferredTrieData> =
             overlay_blocks.iter().rev().map(|b| b.trie_data_handle()).collect();
 
+        // Grab the direct parent's deferred bundle handle so the flatten task
+        // can reuse the parent's cumulative overlay (Arc::make_mut + extend)
+        // instead of rebuilding from scratch.
+        let parent_bundle_handle = overlay_blocks.first().map(|b| b.flattened_state_handle());
+
         // Create deferred handle with fallback inputs in case the background task hasn't completed.
         // Resolve the lazy handle into Arc<HashedPostState>. By this point the hashed state has
         // already been computed and used for state root verification, so .get() returns instantly.
@@ -1644,6 +1650,16 @@ where
         let deferred_trie_data =
             DeferredTrieData::pending(hashed_state, trie_output, anchor_hash, ancestors);
         let deferred_handle_task = deferred_trie_data.clone();
+
+        // Construct the deferred flattened bundle handle for O(1)
+        // in-memory state reads via `MemoryOverlayStateProvider`. The
+        // flattening itself is performed by the same background task below
+        // by calling `wait_cloned()` on this handle, so the validation hot
+        // path doesn't pay the extend cost.
+        let this_block_bundle = Arc::new(execution_outcome.state.clone());
+        let deferred_bundle_state =
+            DeferredBundleState::pending(this_block_bundle, anchor_hash, parent_bundle_handle);
+        let deferred_bundle_task = deferred_bundle_state.clone();
         let block_validation_metrics = self.metrics.block_validation.clone();
 
         // Capture block info and cache handle for changeset computation
@@ -1671,6 +1687,13 @@ where
                 block_validation_metrics
                     .deferred_trie_compute_duration
                     .record(compute_start.elapsed().as_secs_f64());
+
+                // Pre-compute the flattened bundle overlay in the same task so
+                // that subsequent state reads on descendants observe an O(1)
+                // fast path. Panics here are isolated by the surrounding
+                // `catch_unwind`; consumers will fall back to synchronous
+                // computation via `wait_cloned` if the task panicked.
+                let _ = deferred_bundle_task.wait_cloned();
 
                 // Record sizes of the computed trie data
                 block_validation_metrics
@@ -1731,10 +1754,11 @@ where
             .executor()
             .spawn_blocking_named("trie-input", compute_trie_input_task);
 
-        ExecutedBlock::with_deferred_trie_data(
+        ExecutedBlock::with_deferred_bundle_state(
             Arc::new(block),
             execution_outcome,
             deferred_trie_data,
+            deferred_bundle_state,
         )
     }
 


### PR DESCRIPTION
  Adds a `DeferredBundleState` handle on `ExecutedBlock` that asynchronously                                                                                                                 
  flattens in-memory ancestor `BundleState`s into one cumulative overlay,          
  anchored to the oldest in-memory block's parent hash. `MemoryOverlayStateProvider`                                                                                                         
  reads collapse from O(N) iteration across every in-memory block to a single                                                                                                                
  HashMap probe, falling back to iteration on anchor mismatch (correctness
  preserved across persistence events).                                                                                                                                                      
                                                                                                                                                                                             
  Benchmarks at N=64 (default `--engine.memory-block-buffer-target`):
                                                                                                                                                                                             
  | read                 | legacy    | flattened | speedup |                       
  |----------------------|-----------|-----------|---------|                                                                                                                                 
  | `basic_account` miss | 153.9 ns  | 33.0 ns   | 4.67x   |                       
  | `storage` miss       | 277.5 ns  | 33.3 ns   | 8.33x   |                                                                                                                                 
  | `bytecode` miss      | 93.6 ns   | 34.0 ns   | 2.75x   |                       
                                                                                                                                                                                             
  Flattened timings stay flat regardless of N; legacy scales linearly.
  Bench reproducer: `crates/chain-state/benches/memory_overlay.rs`.                                                                                                                          
                                                                                   
  Follows the existing `DeferredTrieData` pattern (pending/ready state                                                                                                                       
  machine, anchor-hash validation, parent overlay reuse via `Arc::make_mut`).

Closes #20612