### PR TITLE
fix(trie): length-prefix StoredSubNode inner node in compact codec

### DIFF
--- a/crates/trie/common/src/subnode.rs
+++ b/crates/trie/common/src/subnode.rs
@@ -36,7 +36,12 @@ impl reth_codecs::Compact for StoredSubNode {
         if let Some(node) = &self.node {
             buf.put_u8(1);
             len += 1;
-            len += node.to_compact(buf);
+
+            let mut node_buf = Vec::new();
+            let node_len = node.to_compact(&mut node_buf);
+            buf.put_u16(node_len as u16);
+            buf.put_slice(&node_buf);
+            len += 2 + node_len;
         } else {
             len += 1;
             buf.put_u8(0);
@@ -57,8 +62,9 @@ impl reth_codecs::Compact for StoredSubNode {
 
         let node_exists = buf.get_u8() != 0;
         let node = node_exists.then(|| {
-            let (node, rest) = BranchNodeCompact::from_compact(buf, 0);
-            buf = rest;
+            let node_len = buf.get_u16() as usize;
+            let (node, _) = BranchNodeCompact::from_compact(&buf[..node_len], node_len);
+            buf.advance(node_len);
             node
         });
 
@@ -92,5 +98,34 @@ mod tests {
         let (decoded, _) = StoredSubNode::from_compact(&encoded[..], 0);
 
         assert_eq!(subnode, decoded);
+    }
+
+    // Covers `state_mask` values whose BE u16 encoding collides with a valid
+    // `BranchNodeCompact` compact length (6 + 32*N). Without an explicit length
+    // prefix, a heuristic decoder over-reads these and corrupts the trailing bytes.
+    #[test]
+    fn subnode_with_colliding_state_mask_roundtrips_with_trailing_bytes() {
+        for mask in [6u16, 38, 70, 550] {
+            let subnode = StoredSubNode {
+                key: vec![0x01, 0x02],
+                nibble: Some(0x03),
+                node: Some(BranchNodeCompact {
+                    state_mask: TrieMask::new(mask),
+                    tree_mask: TrieMask::new(0),
+                    hash_mask: TrieMask::new(mask),
+                    hashes: vec![B256::ZERO; mask.count_ones() as usize].into(),
+                    root_hash: None,
+                }),
+            };
+
+            let mut encoded = vec![];
+            subnode.to_compact(&mut encoded);
+            encoded.extend_from_slice(&[0xaa, 0xbb]);
+
+            let (decoded, rest) = StoredSubNode::from_compact(&encoded[..], 0);
+
+            assert_eq!(subnode, decoded, "mask={mask}");
+            assert_eq!(rest, &[0xaa, 0xbb], "mask={mask}");
+        }
     }
 }

--- a/crates/trie/common/src/subnode.rs
+++ b/crates/trie/common/src/subnode.rs
@@ -34,7 +34,12 @@ impl reth_codecs::Compact for StoredSubNode {
         }
 
         if let Some(node) = &self.node {
-            buf.put_u8(1);
+            // Tag `2`: length-prefixed payload. Tag `1` is the legacy form whose
+            // decoder relied on a heuristic over the remaining buffer and could
+            // over-read when `state_mask` collided with a plausible payload length.
+            // New writes always emit tag `2`; reads still accept `1` so checkpoint
+            // bytes written by an older binary remain loadable.
+            buf.put_u8(2);
             len += 1;
 
             let mut node_buf = Vec::new();
@@ -60,13 +65,24 @@ impl reth_codecs::Compact for StoredSubNode {
         let nibbles_exists = buf.get_u8() != 0;
         let nibble = nibbles_exists.then(|| buf.get_u8());
 
-        let node_exists = buf.get_u8() != 0;
-        let node = node_exists.then(|| {
-            let node_len = buf.get_u16() as usize;
-            let (node, _) = BranchNodeCompact::from_compact(&buf[..node_len], node_len);
-            buf.advance(node_len);
-            node
-        });
+        // Node tag: `0` None, `1` legacy (no length prefix), `2` length-prefixed.
+        // Legacy bytes decode only when the subnode sits at the tail of the
+        // buffer, which is the same constraint the old decoder carried.
+        let node = match buf.get_u8() {
+            0 => None,
+            1 => {
+                let (node, rest) = BranchNodeCompact::from_compact(buf, 0);
+                buf = rest;
+                Some(node)
+            }
+            2 => {
+                let node_len = buf.get_u16() as usize;
+                let (node, _) = BranchNodeCompact::from_compact(&buf[..node_len], node_len);
+                buf.advance(node_len);
+                Some(node)
+            }
+            tag => panic!("invalid StoredSubNode node tag: {tag}"),
+        };
 
         (Self { key, nibble, node }, buf)
     }
@@ -127,5 +143,33 @@ mod tests {
             assert_eq!(subnode, decoded, "mask={mask}");
             assert_eq!(rest, &[0xaa, 0xbb], "mask={mask}");
         }
+    }
+
+    // Legacy (tag `1`) bytes still decode when the subnode is at the tail of the
+    // buffer. This matches the constraint the pre-fix decoder already carried
+    // (`BranchNodeCompact::from_compact` asserts `buf.len() % 32 == 6`).
+    #[test]
+    fn subnode_decodes_legacy_v1_tag() {
+        let node = BranchNodeCompact {
+            state_mask: TrieMask::new(0x0001),
+            tree_mask: TrieMask::new(0),
+            hash_mask: TrieMask::new(0x0001),
+            hashes: vec![B256::ZERO].into(),
+            root_hash: None,
+        };
+
+        // Hand-crafted v1 wire format:
+        //   [key_len: u16=0][nibble_tag=0][node_tag=1][BranchNodeCompact raw bytes]
+        let mut v1 = Vec::new();
+        v1.extend_from_slice(&0u16.to_be_bytes());
+        v1.push(0);
+        v1.push(1);
+        node.to_compact(&mut v1);
+
+        let (decoded, rest) = StoredSubNode::from_compact(&v1[..], 0);
+        assert!(rest.is_empty());
+        assert_eq!(decoded.key, Vec::<u8>::new());
+        assert_eq!(decoded.nibble, None);
+        assert_eq!(decoded.node, Some(node));
     }
 }


### PR DESCRIPTION
Tracked in #23632.

StoredSubNode writes the inner BranchNodeCompact payload without a length prefix, so the decoder guesses where it ends by reading bytes and checking if they look like a valid branch node. When state_mask (big-endian u16) collides with a plausible compact length (e.g. 6, 38, 70, 550), the decoder eats too far and corrupts the wrapping MerkleCheckpoint.

BranchNodeCompact::from_compact's assert_eq!(buf.len() % 32, 6) masks this today, but one extra field anywhere downstream is enough to flip it into a startup panic on resume.

This isn't hypothetical: the parallel MerkleExecute work tracked in #23632 adds a should_check_walker_key byte to MerkleCheckpoint's trailer and exercises the Progress/Resume path far more often. Without this fix, any user upgrading with a paused MerkleExecute checkpoint whose walker_stack contains a Some(node) would hit the assertion on restart.

Tag the inner node with a version byte — 1 = legacy (no length prefix), 2 = new ([len: u16][payload]). Writers always emit 2; readers accept both, so the decoder always knows the exact byte count while old paused checkpoints still decode. Includes a regression test for the colliding mask values.