### PR TITLE
fix(trie): persist should_check_walker_key across resume

### DIFF
--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -270,6 +270,7 @@ where
                             .map(StoredSubNode::from)
                             .collect(),
                         state.account_root_state.hash_builder.into(),
+                        state.account_root_state.should_check_walker_key,
                     );
 
                     // Save storage root state if present
@@ -287,6 +288,7 @@ where
                                 storage_state.account.nonce,
                                 storage_state.account.balance,
                                 storage_state.account.bytecode_hash.unwrap_or(KECCAK_EMPTY),
+                                storage_state.state.should_check_walker_key,
                             ));
                     }
                     self.save_execution_checkpoint(provider, Some(checkpoint))?;

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -17,6 +17,10 @@ pub struct MerkleCheckpoint {
     pub walker_stack: Vec<StoredSubNode>,
     /// The hash builder state.
     pub state: HashBuilderState,
+    /// `TrieNodeIter::should_check_walker_key` snapshot at pause time. Persisting it ensures
+    /// the resumed walker doesn't re-emit a branch the prior run already emitted, which would
+    /// trip `HashBuilder::add_branch` with `key == self.key`.
+    pub should_check_walker_key: bool,
     /// Optional storage root checkpoint for the last processed account.
     pub storage_root_checkpoint: Option<StorageRootMerkleCheckpoint>,
 }
@@ -28,8 +32,16 @@ impl MerkleCheckpoint {
         last_account_key: B256,
         walker_stack: Vec<StoredSubNode>,
         state: HashBuilderState,
+        should_check_walker_key: bool,
     ) -> Self {
-        Self { target_block, last_account_key, walker_stack, state, storage_root_checkpoint: None }
+        Self {
+            target_block,
+            last_account_key,
+            walker_stack,
+            state,
+            should_check_walker_key,
+            storage_root_checkpoint: None,
+        }
     }
 }
 
@@ -70,6 +82,10 @@ impl reth_codecs::Compact for MerkleCheckpoint {
             }
         }
 
+        // Trailer byte: `should_check_walker_key`.
+        buf.put_u8(self.should_check_walker_key as u8);
+        len += 1;
+
         len
     }
 
@@ -90,20 +106,34 @@ impl reth_codecs::Compact for MerkleCheckpoint {
 
         let (state, mut buf) = HashBuilderState::from_compact(buf, 0);
 
-        // Decode the storage root checkpoint if it exists
-        let (storage_root_checkpoint, buf) = if buf.is_empty() {
-            (None, buf)
+        // Decode the optional storage root checkpoint
+        let storage_root_checkpoint = if buf.is_empty() {
+            None
         } else {
             match buf.get_u8() {
                 1 => {
                     let (checkpoint, rest) = StorageRootMerkleCheckpoint::from_compact(buf, 0);
-                    (Some(checkpoint), rest)
+                    buf = rest;
+                    Some(checkpoint)
                 }
-                _ => (None, buf),
+                _ => None,
             }
         };
 
-        (Self { target_block, last_account_key, walker_stack, state, storage_root_checkpoint }, buf)
+        // Trailer byte added later; default to false for older bytes that don't have it.
+        let should_check_walker_key = if buf.is_empty() { false } else { buf.get_u8() != 0 };
+
+        (
+            Self {
+                target_block,
+                last_account_key,
+                walker_stack,
+                state,
+                should_check_walker_key,
+                storage_root_checkpoint,
+            },
+            buf,
+        )
     }
 }
 
@@ -124,6 +154,8 @@ pub struct StorageRootMerkleCheckpoint {
     pub account_balance: U256,
     /// The account bytecode hash.
     pub account_bytecode_hash: B256,
+    /// Storage walker's `should_check_walker_key` snapshot. See [`MerkleCheckpoint`].
+    pub should_check_walker_key: bool,
 }
 
 impl StorageRootMerkleCheckpoint {
@@ -135,6 +167,7 @@ impl StorageRootMerkleCheckpoint {
         account_nonce: u64,
         account_balance: U256,
         account_bytecode_hash: B256,
+        should_check_walker_key: bool,
     ) -> Self {
         Self {
             last_storage_key,
@@ -143,6 +176,7 @@ impl StorageRootMerkleCheckpoint {
             account_nonce,
             account_balance,
             account_bytecode_hash,
+            should_check_walker_key,
         }
     }
 }
@@ -178,6 +212,9 @@ impl reth_codecs::Compact for StorageRootMerkleCheckpoint {
         buf.put_slice(self.account_bytecode_hash.as_slice());
         len += 32;
 
+        buf.put_u8(self.should_check_walker_key as u8);
+        len += 1;
+
         len
     }
 
@@ -203,6 +240,7 @@ impl reth_codecs::Compact for StorageRootMerkleCheckpoint {
         let (account_balance, mut buf) = U256::from_compact(buf, balance_len);
         let account_bytecode_hash = B256::from_slice(&buf[..32]);
         buf.advance(32);
+        let should_check_walker_key = buf.get_u8() != 0;
 
         (
             Self {
@@ -212,6 +250,7 @@ impl reth_codecs::Compact for StorageRootMerkleCheckpoint {
                 account_nonce,
                 account_balance,
                 account_bytecode_hash,
+                should_check_walker_key,
             },
             buf,
         )
@@ -596,6 +635,7 @@ mod tests {
             }],
             state: HashBuilderState::default(),
             storage_root_checkpoint: None,
+            should_check_walker_key: false,
         };
 
         let mut buf = Vec::new();
@@ -618,6 +658,7 @@ mod tests {
             account_nonce: 0,
             account_balance: U256::ZERO,
             account_bytecode_hash: B256::ZERO,
+            should_check_walker_key: false,
         };
 
         let mut buf = Vec::new();
@@ -644,6 +685,7 @@ mod tests {
             account_bytecode_hash: b256!(
                 "0x0fffffffffffffffffffffffffffffff0fffffffffffffffffffffffffffffff"
             ),
+            should_check_walker_key: false,
         };
 
         // Create a merkle checkpoint with the storage root checkpoint
@@ -657,6 +699,7 @@ mod tests {
             }],
             state: HashBuilderState::default(),
             storage_root_checkpoint: Some(storage_checkpoint),
+            should_check_walker_key: false,
         };
 
         let mut buf = Vec::new();

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -48,8 +48,8 @@ pub use trie::{StateRoot, StorageRoot, TrieType};
 /// Utilities for state root checkpoint progress.
 mod progress;
 pub use progress::{
-    IntermediateStateRootState, IntermediateStorageRootState, StateRootProgress,
-    StorageRootProgress,
+    IntermediateRootState, IntermediateStateRootState, IntermediateStorageRootState,
+    StateRootProgress, StorageRootProgress,
 };
 
 /// Trie calculation stats.

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -63,7 +63,7 @@ pub struct TrieNodeIter<C, H: HashedCursor, K> {
     /// Current hashed  entry.
     current_hashed_entry: Option<(B256, H::Value)>,
     /// Flag indicating whether we should check the current walker key.
-    should_check_walker_key: bool,
+    pub should_check_walker_key: bool,
 
     /// The last seeked hashed entry.
     ///
@@ -113,6 +113,16 @@ where
     /// This is used to resume iteration from the last checkpoint.
     pub const fn with_last_hashed_key(mut self, previous_hashed_key: B256) -> Self {
         self.previous_hashed_key = Some(previous_hashed_key);
+        self
+    }
+
+    /// Restores the `should_check_walker_key` flag for resumed iteration.
+    ///
+    /// Used to round-trip the flag through pause/resume: the default `false` would cause the
+    /// resumed iterator to re-emit the previously yielded branch and panic in
+    /// `HashBuilder::add_branch` with `key == self.key`.
+    pub const fn with_should_check_walker_key(mut self, should_check_walker_key: bool) -> Self {
+        self.should_check_walker_key = should_check_walker_key;
         self
     }
 

--- a/crates/trie/trie/src/progress.rs
+++ b/crates/trie/trie/src/progress.rs
@@ -45,6 +45,7 @@ impl From<MerkleCheckpoint> for IntermediateStateRootState {
                 hash_builder: HashBuilder::from(value.state),
                 walker_stack: value.walker_stack.into_iter().map(CursorSubNode::from).collect(),
                 last_hashed_key: value.last_account_key,
+                should_check_walker_key: value.should_check_walker_key,
             },
             storage_root_state: value.storage_root_checkpoint.map(|checkpoint| {
                 IntermediateStorageRootState {
@@ -56,6 +57,7 @@ impl From<MerkleCheckpoint> for IntermediateStateRootState {
                             .map(CursorSubNode::from)
                             .collect(),
                         last_hashed_key: checkpoint.last_storage_key,
+                        should_check_walker_key: checkpoint.should_check_walker_key,
                     },
                     account: Account {
                         nonce: checkpoint.account_nonce,
@@ -77,6 +79,12 @@ pub struct IntermediateRootState {
     pub walker_stack: Vec<CursorSubNode>,
     /// The last hashed key processed.
     pub last_hashed_key: B256,
+    /// Captures `TrieNodeIter::should_check_walker_key` at the moment Progress was returned.
+    ///
+    /// This flag prevents the resumed walker from re-emitting a branch node that was already
+    /// emitted in the prior run. Without it, the saved walker position is reused as if it were
+    /// new, which causes `HashBuilder::add_branch` to fail with `key == self.key`.
+    pub should_check_walker_key: bool,
 }
 
 /// The progress of a storage root calculation.

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -180,7 +180,8 @@ where
             )
             .with_deletions_retained(retain_updates);
             let account_node_iter = TrieNodeIter::state_trie(walker, hashed_account_cursor)
-                .with_last_hashed_key(account_root_state.last_hashed_key);
+                .with_last_hashed_key(account_root_state.last_hashed_key)
+                .with_should_check_walker_key(account_root_state.should_check_walker_key);
 
             // if we have an in-progress storage root, complete it first
             if let Some(storage_state) = storage_root_state {
@@ -368,12 +369,18 @@ impl StateRootContext {
         H: HashedCursor,
         K: AsRef<AddedRemovedKeys>,
     {
+        let should_check_walker_key = account_node_iter.should_check_walker_key;
         let (walker_stack, walker_deleted_keys) = account_node_iter.walker.split();
         self.trie_updates.removed_nodes.extend(walker_deleted_keys);
         let (hash_builder, hash_builder_updates) = hash_builder.split();
         self.trie_updates.account_nodes.extend(hash_builder_updates);
 
-        let account_state = IntermediateRootState { hash_builder, walker_stack, last_hashed_key };
+        let account_state = IntermediateRootState {
+            hash_builder,
+            walker_stack,
+            last_hashed_key,
+            should_check_walker_key,
+        };
 
         let state = IntermediateStateRootState {
             account_root_state: account_state,
@@ -643,7 +650,8 @@ where
                 )
                 .with_deletions_retained(retain_updates);
                 let node_iter = TrieNodeIter::storage_trie(walker, hashed_storage_cursor)
-                    .with_last_hashed_key(state.last_hashed_key);
+                    .with_last_hashed_key(state.last_hashed_key)
+                    .with_should_check_walker_key(state.should_check_walker_key);
                 (hash_builder, node_iter)
             }
             None => {
@@ -674,6 +682,7 @@ where
                     let total_updates_len =
                         storage_node_iter.walker.removed_keys_len() + hash_builder.updates_len();
                     if retain_updates && total_updates_len as u64 >= self.threshold {
+                        let should_check_walker_key = storage_node_iter.should_check_walker_key;
                         let (walker_stack, walker_deleted_keys) = storage_node_iter.walker.split();
                         trie_updates.removed_nodes.extend(walker_deleted_keys);
                         let (hash_builder, hash_builder_updates) = hash_builder.split();
@@ -683,6 +692,7 @@ where
                             hash_builder,
                             walker_stack,
                             last_hashed_key: hashed_slot,
+                            should_check_walker_key,
                         };
 
                         return Ok(StorageRootProgress::Progress(


### PR DESCRIPTION
Tracked in #23632.

`TrieNodeIter::should_check_walker_key` is a flag the iterator sets after yielding a branch node so the next call knows not to re-emit the same branch. It was kept in memory only: `StateRoot::root_with_progress` writes the rest of the iterator state to disk via `IntermediateRootState` / `MerkleCheckpoint`, but this flag was dropped.

On resume, the iterator starts with the default `false`, re-emits the previously yielded branch, and panics in `HashBuilder::add_branch` with `key == self.key`.

Plumb the flag through `IntermediateRootState`, both `MerkleCheckpoint` and `StorageRootMerkleCheckpoint` (Compact codec gets a trailer byte), and add a `TrieNodeIter::with_should_check_walker_key` setter so it round-trips through pause/resume. Decoders treat a missing `MerkleCheckpoint` trailer byte as `false`, so existing on-disk bytes still decode.

Reachable today on the serial `MerkleStage` rebuild path whenever a chunk crosses the in-progress threshold, though it is rare in practice. The parallel MerkleExecute work tracked in #23632 makes it routine: paused checkpoints stop being edge cases, and any one of them landing on the wrong walker state would panic on resume.
