### PR TITLE
fix(cli): support Windows in segmented download file writes

### DIFF
--- a/crates/cli/commands/src/download/fetch.rs
+++ b/crates/cli/commands/src/download/fetch.rs
@@ -706,7 +706,33 @@ impl SegmentedDownload {
         piece_progress_bytes: &AtomicU64,
         cancel_token: &CancellationToken,
     ) -> std::result::Result<(), PieceAttemptFailure> {
-        use std::os::unix::fs::FileExt;
+        #[cfg(unix)]
+        fn write_all_at(file: &std::fs::File, buf: &[u8], offset: u64) -> io::Result<()> {
+            use std::os::unix::fs::FileExt;
+            file.write_all_at(buf, offset)
+        }
+
+        #[cfg(windows)]
+        fn write_all_at(file: &std::fs::File, mut buf: &[u8], mut offset: u64) -> io::Result<()> {
+            use std::os::windows::fs::FileExt;
+            while !buf.is_empty() {
+                match file.seek_write(buf, offset) {
+                    Ok(0) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "failed to write whole buffer",
+                        ));
+                    }
+                    Ok(n) => {
+                        buf = &buf[n..];
+                        offset += n as u64;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            Ok(())
+        }
 
         let expected_len = piece.end - piece.start + 1;
 
@@ -753,7 +779,7 @@ impl SegmentedDownload {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    file.write_all_at(&buf[..n], offset)
+                    write_all_at(file, &buf[..n], offset)
                         .map_err(|error| PieceAttemptFailure::Terminal(error.into()))?;
                     offset += n as u64;
                     if let Some(progress) = shared {

--- a/crates/static-file/types/src/changeset_offsets.rs
+++ b/crates/static-file/types/src/changeset_offsets.rs
@@ -7,9 +7,37 @@ use crate::ChangesetOffset;
 use std::{
     fs::{File, OpenOptions},
     io::{self, Write},
-    os::unix::fs::FileExt,
     path::Path,
 };
+
+#[cfg(unix)]
+fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(buf, offset)
+}
+
+#[cfg(windows)]
+fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        match file.seek_read(buf, offset) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "failed to fill whole buffer",
+                ));
+            }
+            Ok(n) => {
+                let tmp = buf;
+                buf = &mut tmp[n..];
+                offset += n as u64;
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
 
 /// Writer for appending changeset offsets to a sidecar file.
 #[derive(Debug)]
@@ -185,7 +213,7 @@ impl ChangesetOffsetReader {
 
         let byte_pos = block_index * Self::RECORD_SIZE as u64;
         let mut buf = [0u8; Self::RECORD_SIZE];
-        self.file.read_exact_at(&mut buf, byte_pos)?;
+        read_exact_at(&self.file, &mut buf, byte_pos)?;
 
         let offset = u64::from_le_bytes(buf[..8].try_into().unwrap());
         let num_changes = u64::from_le_bytes(buf[8..].try_into().unwrap());
@@ -208,7 +236,7 @@ impl ChangesetOffsetReader {
 
         for i in 0..count {
             let pos = byte_pos + (i as u64) * Self::RECORD_SIZE as u64;
-            self.file.read_exact_at(&mut buf, pos)?;
+            read_exact_at(&self.file, &mut buf, pos)?;
             let offset = u64::from_le_bytes(buf[..8].try_into().unwrap());
             let num_changes = u64::from_le_bytes(buf[8..].try_into().unwrap());
             result.push(ChangesetOffset::new(offset, num_changes));

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -15,9 +15,9 @@ mod compression;
 mod event;
 mod segment;
 
-#[cfg(all(feature = "std", unix))]
+#[cfg(feature = "std")]
 mod changeset_offsets;
-#[cfg(all(feature = "std", unix))]
+#[cfg(feature = "std")]
 pub use changeset_offsets::{ChangesetOffsetReader, ChangesetOffsetWriter};
 
 use alloy_primitives::BlockNumber;


### PR DESCRIPTION
`SegmentedDownload::write_piece` used `std::os::unix::fs::FileExt::write_all_at`, which doesn't compile on Windows. Replaced the direct call with a small `write_all_at` helper that:
- uses `FileExt::write_all_at` on Unix,
- emulates it on Windows via `FileExt::seek_write` in a loop (handling partial writes, `WriteZero`, and `Interrupted`).

No behavior change on Unix.

I know that Windows is no longer a targeted support platform for reth, but this change has essentially zero cost and keeps `reth-cli-commands` building on Windows.