### PR TITLE
chore: release 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7319,7 +7319,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7367,7 +7367,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bb"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7441,7 +7441,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bench"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7489,7 +7489,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7521,7 +7521,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7541,7 +7541,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7642,7 +7642,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7651,7 +7651,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -7705,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7723,7 +7723,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7735,7 +7735,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7749,7 +7749,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7837,7 +7837,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -7884,7 +7884,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7910,7 +7910,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7935,7 +7935,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7963,7 +7963,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8001,7 +8001,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8057,7 +8057,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8084,7 +8084,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8106,7 +8106,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8202,7 +8202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8251,7 +8251,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8269,7 +8269,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8295,7 +8295,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8305,7 +8305,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8343,7 +8343,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8409,7 +8409,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8432,7 +8432,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8464,7 +8464,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8477,7 +8477,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8527,7 +8527,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8561,7 +8561,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8583,7 +8583,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8601,7 +8601,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "eyre",
@@ -8710,7 +8710,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -8727,7 +8727,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8736,7 +8736,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8769,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "bytes",
  "futures",
@@ -8791,7 +8791,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8808,7 +8808,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -8816,7 +8816,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "futures",
  "metrics",
@@ -8827,7 +8827,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8910,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8934,7 +8934,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -8956,7 +8956,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8973,7 +8973,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8986,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9004,7 +9004,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9027,7 +9027,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9154,7 +9154,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9260,7 +9260,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "bytes",
  "eyre",
@@ -9289,7 +9289,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9323,7 +9323,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9368,7 +9368,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9410,7 +9410,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9461,7 +9461,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9494,11 +9494,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "2.0.0"
+version = "2.1.0"
 
 [[package]]
 name = "reth-prune-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9518,7 +9518,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9534,7 +9534,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9614,7 +9614,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-genesis",
@@ -9644,7 +9644,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9663,7 +9663,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -9721,7 +9721,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9741,7 +9741,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9797,7 +9797,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9842,7 +9842,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9890,7 +9890,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9907,7 +9907,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9937,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9999,7 +9999,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10033,7 +10033,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10072,7 +10072,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10090,7 +10090,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10113,7 +10113,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10130,7 +10130,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10159,7 +10159,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10179,7 +10179,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10204,7 +10204,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "eyre",
@@ -10222,7 +10222,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "eyre",
@@ -10239,7 +10239,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10289,7 +10289,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10322,7 +10322,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -10354,7 +10354,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10385,7 +10385,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -10417,7 +10417,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v2.0.0',
+      text: 'v2.1.0',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Prepares the release candidate and tag for version 2.1.0.

- Bumps workspace version to `2.1.0` in `Cargo.toml`
- Updates `Cargo.lock` via `cargo update --workspace`
- Updates vocs topNav version to `v2.1.0`