### PR TITLE
chore(ci): unify bench workflows to use DEREK_TOKEN

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -154,7 +154,7 @@ jobs:
         id: args
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
@@ -361,7 +361,7 @@ jobs:
         id: ack
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             if (context.eventName === 'issue_comment') {
               await github.rest.reactions.createForIssueComment({
@@ -447,7 +447,7 @@ jobs:
         if: steps.ack.outputs.comment-id && steps.ack.outputs.queue-position != '0'
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const pr = '${{ steps.args.outputs.pr }}';
             const commentId = parseInt('${{ steps.ack.outputs.comment-id }}');
@@ -588,7 +588,7 @@ jobs:
         if: env.BENCH_COMMENT_ID
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -817,7 +817,7 @@ jobs:
         if: env.BENCH_COMMENT_ID && steps.snapshot-check.outputs.needed == 'true'
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Building binaries (snapshot update pending)...'});
@@ -1004,7 +1004,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmarks...'});
@@ -1266,7 +1266,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const fs = require('fs');
 
@@ -1371,7 +1371,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const abba = (process.env.BENCH_ABBA || 'true') !== 'false';
             const steps_status = [
@@ -1427,7 +1427,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.DEREK_PAT }}
+          github-token: ${{ secrets.DEREK_TOKEN }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({


### PR DESCRIPTION
bench.yml used `DEREK_PAT` for GitHub API calls while bench-scheduled.yml used `DEREK_TOKEN`. The release bench failed at the "Push charts" step (exit 128) likely because of a token mismatch. This unifies all 9 occurrences in bench.yml to use `DEREK_TOKEN`.

Prompted by: Alexey