### PR TITLE
[autoopt] 20260420-003-rocksdb-history-full-shard-rotate

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -1818,8 +1818,21 @@ impl<'a> RocksDBBatch<'a> {
         );
 
         let last_key = ShardedKey::new(address, u64::MAX);
-        let last_shard_opt = self.provider.get::<tables::AccountsHistory>(last_key.clone())?;
-        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+        let mut last_shard = self
+            .provider
+            .get::<tables::AccountsHistory>(last_key.clone())?
+            .unwrap_or_else(BlockNumberList::empty);
+
+        if last_shard.len() == NUM_OF_INDICES_IN_SHARD as u64 {
+            let highest_block_number =
+                last_shard.iter().next_back().expect("non-empty shard has a highest block");
+            self.delete::<tables::AccountsHistory>(last_key.clone())?;
+            self.put::<tables::AccountsHistory>(
+                ShardedKey::new(address, highest_block_number),
+                &last_shard,
+            )?;
+            last_shard = BlockNumberList::empty();
+        }
 
         last_shard.append(indices).map_err(ProviderError::other)?;
 
@@ -1880,8 +1893,21 @@ impl<'a> RocksDBBatch<'a> {
         );
 
         let last_key = StorageShardedKey::last(address, storage_key);
-        let last_shard_opt = self.provider.get::<tables::StoragesHistory>(last_key.clone())?;
-        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+        let mut last_shard = self
+            .provider
+            .get::<tables::StoragesHistory>(last_key.clone())?
+            .unwrap_or_else(BlockNumberList::empty);
+
+        if last_shard.len() == NUM_OF_INDICES_IN_SHARD as u64 {
+            let highest_block_number =
+                last_shard.iter().next_back().expect("non-empty shard has a highest block");
+            self.delete::<tables::StoragesHistory>(last_key.clone())?;
+            self.put::<tables::StoragesHistory>(
+                StorageShardedKey::new(address, storage_key, highest_block_number),
+                &last_shard,
+            )?;
+            last_shard = BlockNumberList::empty();
+        }
 
         last_shard.append(indices).map_err(ProviderError::other)?;
 


### PR DESCRIPTION
# Rotate Full RocksDB History Sentinel Shards Before Append
## Evidence
Persistence dominates the current benchmark, with a 23.425 ms mean persistence wait and a 222.709 ms p95 persistence wait.

The baseline samply profile shows `reth_provider::providers::rocksdb::provider::RocksDBBatch::get` at 23,586 weighted samples, plus `EitherWriter::get_last_storage_history_shard` at 17,502 and `EitherWriter::get_last_account_history_shard` at 6,145. In the storage-v2 path, `save_blocks` appends history through RocksDB batch helpers, and the current append logic re-chunks an already-full sentinel shard together with newly appended indices.

## Hypothesis
If we rotate a full `u64::MAX` history sentinel shard to its concrete highest-block key before appending new indices, gas throughput improves by ~0.5-1.5% because incremental RocksDB history writes stop re-reading and re-chunking the old full 2,000-entry shard on every follow-up append.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.5%

## Plan
Change `crates/storage/provider/src/providers/rocksdb/provider.rs` so `append_account_history_shard` and `append_storage_history_shard` fast-path already-full sentinel shards into a completed shard before building the next sentinel tail.