### PR TITLE
[autoopt] 20260420-002-history-shard-tail-reuse

### DIFF
--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -113,6 +113,14 @@ where
     Ok(())
 }
 
+fn retain_history_tail(list: &mut Vec<u64>, keep_from: usize) {
+    let tail_len = list.len().saturating_sub(keep_from);
+    if tail_len > 0 {
+        list.copy_within(keep_from.., 0);
+    }
+    list.truncate(tail_len);
+}
+
 /// Collects account history indices using a provider that implements `ChangeSetReader`.
 pub(crate) fn collect_account_history_indices<Provider>(
     provider: &Provider,
@@ -333,12 +341,11 @@ where
         return Ok(());
     }
 
-    // Split: flush the first N shards, keep the remainder buffered.
+    // Flush the first N shards in place and keep the remainder buffered.
     let flush_len = shards_to_flush * NUM_OF_INDICES_IN_SHARD;
-    let remainder = list.split_off(flush_len);
 
     // Write each complete shard with its highest block number as the key.
-    for chunk in list.chunks(NUM_OF_INDICES_IN_SHARD) {
+    for chunk in list[..flush_len].chunks(NUM_OF_INDICES_IN_SHARD) {
         let highest = *chunk.last().expect("chunk is non-empty");
         let key = ShardedKey::new(address, highest);
         let value = BlockNumberList::new_pre_sorted(chunk.iter().copied());
@@ -350,8 +357,7 @@ where
         }
     }
 
-    // Keep the remaining indices for the next iteration.
-    *list = remainder;
+    retain_history_tail(list, flush_len);
     Ok(())
 }
 
@@ -555,12 +561,11 @@ where
         return Ok(());
     }
 
-    // Split: flush the first N shards, keep the remainder buffered.
+    // Flush the first N shards in place and keep the remainder buffered.
     let flush_len = shards_to_flush * NUM_OF_INDICES_IN_SHARD;
-    let remainder = list.split_off(flush_len);
 
     // Write each complete shard with its highest block number as the key.
-    for chunk in list.chunks(NUM_OF_INDICES_IN_SHARD) {
+    for chunk in list[..flush_len].chunks(NUM_OF_INDICES_IN_SHARD) {
         let highest = *chunk.last().expect("chunk is non-empty");
         let key = StorageShardedKey::new(address, storage_key, highest);
         let value = BlockNumberList::new_pre_sorted(chunk.iter().copied());
@@ -572,8 +577,7 @@ where
         }
     }
 
-    // Keep the remaining indices for the next iteration.
-    *list = remainder;
+    retain_history_tail(list, flush_len);
     Ok(())
 }
 


### PR DESCRIPTION
# Reuse History Shard Tail Buffers During Load
## Evidence
The same benchmark artifact shows persistence as the main bottleneck, with a 23.425 ms mean persistence wait and repeated `on_save_blocks` ranges overlapping with payload processing waiting on persistence-adjacent work.

The baseline samply profile shows `reth_stages::stages::utils::load_storage_history` at 34,048 weighted samples and `reth_stages::stages::utils::load_account_history` at 10,527 weighted samples. Both hot paths flush partial shards repeatedly, and the current implementation allocates a fresh remainder vector via `split_off` on every partial flush.

## Hypothesis
If we keep the unflushed history-shard tail in place with `copy_within` and `truncate` instead of allocating a new remainder vector on each partial flush, gas throughput improves by ~0.3-0.8% because account and storage history loading performs less allocation churn while writing shards.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.3%

## Plan
Change `crates/stages/stages/src/stages/utils.rs` so the partial-flush helpers for account and storage history write the flushed prefix in place and retain the buffered tail without `Vec::split_off`.