### PR TITLE
[autoopt] 20260420-006-payload-reuse-tx-root

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -97,7 +97,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, error, info, instrument, trace, warn, Span};
+use tracing::{debug, debug_span, error, info, instrument, trace, warn};
 
 /// Output of block or payload validation.
 pub type ValidationOutcome<N, E = InsertPayloadError<BlockTy<N>>> =
@@ -600,17 +600,7 @@ where
             });
 
         let block = convert_to_block(input)?;
-        let transaction_root = is_payload.then(|| {
-            let body = block.body().clone();
-            let parent_span = Span::current();
-            let num_hash = block.num_hash();
-            self.payload_processor.executor().spawn_blocking_named("payload-tx-root", move || {
-                let _span =
-                    debug_span!(target: "engine::tree::payload_validator", parent: parent_span, "payload_tx_root", block = ?num_hash)
-                        .entered();
-                body.calculate_tx_root()
-            })
-        });
+        let transaction_root = is_payload.then(|| block.header().transactions_root());
         let block = block.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
@@ -631,12 +621,6 @@ where
                 })
                 .ok()
         };
-        let transaction_root = transaction_root.map(|handle| {
-            let _span =
-                debug_span!(target: "engine::tree::payload_validator", "wait_payload_tx_root")
-                    .entered();
-            handle.try_into_inner().expect("sole handle")
-        });
 
         let hashed_state = ensure_ok_post_block!(
             self.validate_post_execution(


### PR DESCRIPTION
# Reuse the payload conversion transaction root in validation
## Evidence
- The `24661085244` baseline profile shows two separate `newPayload` helpers hashing transactions: `payload-convert` spends 3,014 weighted samples in `alloy_trie::root::ordered_trie_root_encoded` while converting the payload, and `payload-tx-root` spends another 3,199 samples in `calculate_transaction_root` immediately afterward.
- `crates/engine/tree/src/tree/payload_validator.rs` currently spawns `payload-tx-root` after `convert_to_block(input)?`, even though `convert_payload_to_block` already goes through `ensure_well_formed_payload -> into_block_raw()` and computes the header transaction root from the same payload transactions.
- This candidate stays in `crates/engine/tree/src/tree/payload_validator.rs` and does not overlap the prior storage/trie persistence ideas.

## Hypothesis
If we reuse the transaction root already computed during payload conversion instead of hashing the payload body again in `validate_block_with_state`, gas throughput improves by ~0.2-0.6% because `engine_newPayload` removes one full ordered-trie hash and the follow-up wait on that worker.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Update `crates/engine/tree/src/tree/payload_validator.rs` so payload validation passes `block.header().transactions_root()` into pre-execution validation instead of spawning `payload-tx-root`.
- Keep the downloaded-block path unchanged so non-payload blocks still validate their body against the header normally.
- Verify with `cargo check -p reth-engine-tree` and `cargo test -p reth-engine-tree validate_block`.