### PR TITLE
[autoopt] 20260420-005-sparse-step-path-reuse

### DIFF
--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -171,14 +171,6 @@ impl ArenaCursor {
         logical_branch_path_len(arena, self.stack.last().expect("cursor is non-empty"))
     }
 
-    /// Returns the absolute path of a child at `child_nibble` under the branch at the top of
-    /// the stack. The result is `stack_head.path + branch.short_key + child_nibble`.
-    pub(super) fn child_path(&self, arena: &NodeArena, child_nibble: u8) -> Nibbles {
-        let mut path = logical_branch_path(arena, self.stack.last().expect("cursor is non-empty"));
-        path.push_unchecked(child_nibble);
-        path
-    }
-
     /// Returns the logical path of the parent branch entry (second from top of the stack).
     /// Panics if the stack has fewer than 2 entries.
     pub(super) fn parent_logical_branch_path(&self, arena: &NodeArena) -> Nibbles {
@@ -248,7 +240,7 @@ impl ArenaCursor {
         }
 
         loop {
-            let Some(head) = self.stack.last_mut() else {
+            let Some(head) = self.stack.last() else {
                 return NextResult::Done;
             };
             let head_idx = head.index;
@@ -258,6 +250,7 @@ impl ArenaCursor {
                 return NextResult::NonBranch;
             };
 
+            let head_branch_logical_path = self.head_logical_branch_path(arena);
             let state_mask = branch.state_mask;
             let start = head.next_dense_idx;
             let child_depth = self.stack.len();
@@ -277,7 +270,8 @@ impl ArenaCursor {
                     // Record where to resume iteration when we return to this entry.
                     self.stack.last_mut().expect("head exists").next_dense_idx =
                         branch_child_idx.get() + 1;
-                    let path = self.child_path(arena, nibble);
+                    let mut path = head_branch_logical_path;
+                    path.push_unchecked(nibble);
                     self.push(arena, child_idx, path);
                     descended = true;
                     break;
@@ -351,7 +345,8 @@ impl ArenaCursor {
                 }
                 ArenaSparseNodeBranchChild::Revealed(child_idx) => {
                     let child_idx = *child_idx;
-                    let path = self.child_path(arena, child_nibble);
+                    let mut path = head_branch_logical_path;
+                    path.push_unchecked(child_nibble);
                     self.push(arena, child_idx, path);
                 }
             }


### PR DESCRIPTION
# Reuse sparse cursor branch paths within traversal steps
## Evidence
- In the `24661085244` baseline sparse-trie worker, the hot self buckets still include `ArenaCursor::seek::{{closure}}` (5,947 samples), `SpecArrayEq` (6,460), `nybbles::byte_len` (3,474), and `Nibbles::len` (2,444) even after the earlier sparse cursor-path win.
- `crates/trie/sparse/src/arena/cursor.rs` was still rebuilding the same logical branch path twice in a single traversal step: once to compare or measure the branch path, and again immediately after to construct the pushed child path.
- This stays in `crates/trie/sparse/src/arena/cursor.rs`, builds on the earlier cursor-path win, and avoids the previously regressing in-place seek comparison changes.

## Hypothesis
If we reuse the already-built logical branch path inside each sparse cursor `next` and `seek` step, gas throughput improves by ~0.1-0.4% because leaf traversal avoids duplicate nibble-path materialization on a still-hot sparse-trie path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.1%

## Plan
- Update `crates/trie/sparse/src/arena/cursor.rs` so `next` and `seek` derive pushed child paths from the logical branch path they already built for the current step.
- Keep branch divergence semantics unchanged.
- Verify with `cargo check -p reth-trie-sparse` and `cargo test -p reth-trie-sparse`.