### PR TITLE
test(rpc): cover disabled fee charge prestate diffs

### DIFF
--- a/crates/ethereum/node/tests/e2e/prestate.rs
+++ b/crates/ethereum/node/tests/e2e/prestate.rs
@@ -1,10 +1,11 @@
 use alloy_eips::BlockId;
 use alloy_genesis::{Genesis, GenesisAccount};
-use alloy_primitives::address;
+use alloy_primitives::{address, Address, U256};
 use alloy_provider::ext::DebugApi;
-use alloy_rpc_types_eth::{Transaction, TransactionRequest};
+use alloy_rpc_types_eth::{Bundle, StateContext, Transaction, TransactionRequest};
 use alloy_rpc_types_trace::geth::{
-    AccountState, GethDebugTracingOptions, PreStateConfig, PreStateFrame,
+    AccountState, GethDebugTracingCallOptions, GethDebugTracingOptions, PreStateConfig,
+    PreStateFrame,
 };
 use eyre::{eyre, Result};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
@@ -18,6 +19,9 @@ use std::sync::Arc;
 
 const PRESTATE_SNAPSHOT: &str =
     include_str!("../../../../../testing/prestate/tx-selfdestruct-prestate.json");
+const FEE_CHARGE_CALLER: Address = address!("0x1000000000000000000000000000000000000001");
+const FEE_CHARGE_CALL_TARGET: Address = address!("0x2000000000000000000000000000000000000002");
+const FEE_CHARGE_BENEFICIARY: Address = address!("0x3000000000000000000000000000000000000003");
 
 /// Replays the selfdestruct transaction via `debug_traceCall` and ensures Reth's prestate matches
 /// Geth's captured snapshot.
@@ -108,6 +112,115 @@ async fn debug_trace_call_matches_geth_prestate_snapshot() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for <https://github.com/paradigmxyz/reth/issues/23475>.
+///
+/// `debug_traceCall` disables fee charging for simulations, so the prestate tracer must not
+/// invent caller debits or beneficiary credits when `diffMode` is enabled.
+#[tokio::test]
+async fn debug_trace_call_prestate_diff_mode_skips_fee_balance_changes() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut genesis: Genesis = MAINNET.genesis().clone();
+    genesis.coinbase = FEE_CHARGE_BENEFICIARY;
+    genesis
+        .alloc
+        .insert(FEE_CHARGE_CALLER, GenesisAccount::default().with_balance(regression_balance()));
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(genesis)
+            .cancun_activated()
+            .prague_activated()
+            .build(),
+    );
+
+    let runtime = Runtime::test();
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_rpc(
+        RpcServerArgs::default()
+            .with_unused_ports()
+            .with_http()
+            .with_http_api(RpcModuleSelection::all_modules().into()),
+    );
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime)
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    let provider = node.rpc_server_handle().eth_http_provider().unwrap();
+
+    let trace: PreStateFrame = provider
+        .debug_trace_call_prestate(
+            regression_request(),
+            BlockId::latest(),
+            regression_trace_options(),
+        )
+        .await?;
+
+    assert_no_phantom_fee_diff(&trace);
+
+    Ok(())
+}
+
+/// Regression test for <https://github.com/paradigmxyz/reth/issues/23475>.
+///
+/// `debug_traceCallMany` shares the same simulation path as `debug_traceCall`, so it must also
+/// avoid reporting fee-related balance deltas when fee charging is disabled.
+#[tokio::test]
+async fn debug_trace_call_many_prestate_diff_mode_skips_fee_balance_changes() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut genesis: Genesis = MAINNET.genesis().clone();
+    genesis.coinbase = FEE_CHARGE_BENEFICIARY;
+    genesis
+        .alloc
+        .insert(FEE_CHARGE_CALLER, GenesisAccount::default().with_balance(regression_balance()));
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(genesis)
+            .cancun_activated()
+            .prague_activated()
+            .build(),
+    );
+
+    let runtime = Runtime::test();
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_rpc(
+        RpcServerArgs::default()
+            .with_unused_ports()
+            .with_http()
+            .with_http_api(RpcModuleSelection::all_modules().into()),
+    );
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime)
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    let provider = node.rpc_server_handle().eth_http_provider().unwrap();
+
+    let traces: Vec<Vec<PreStateFrame>> = provider
+        .debug_trace_call_many_as(
+            vec![Bundle { transactions: vec![regression_request()], block_override: None }],
+            StateContext::default(),
+            regression_trace_options(),
+        )
+        .await?;
+
+    let trace = traces
+        .first()
+        .and_then(|bundle| bundle.first())
+        .ok_or_else(|| eyre!("expected a single debug_traceCallMany result"))?;
+
+    assert_no_phantom_fee_diff(trace);
+
+    Ok(())
+}
+
 fn expected_snapshot_frame() -> Result<PreStateFrame> {
     #[derive(Deserialize)]
     struct Snapshot {
@@ -128,4 +241,40 @@ fn account_state_to_genesis(value: AccountState) -> GenesisAccount {
         .with_nonce(value.nonce)
         .with_code(code)
         .with_storage(storage)
+}
+
+fn regression_request() -> TransactionRequest {
+    TransactionRequest::default()
+        .from(FEE_CHARGE_CALLER)
+        .to(FEE_CHARGE_CALL_TARGET)
+        .gas_limit(21_000)
+        .gas_price(1)
+}
+
+fn regression_trace_options() -> GethDebugTracingCallOptions {
+    GethDebugTracingOptions::prestate_tracer(PreStateConfig {
+        diff_mode: Some(true),
+        ..Default::default()
+    })
+    .into()
+}
+
+fn regression_balance() -> U256 {
+    U256::from(1_000_000_000_u64)
+}
+
+fn assert_no_phantom_fee_diff(trace: &PreStateFrame) {
+    let diff = trace.as_diff().expect("expected diff-mode prestate trace");
+
+    let caller_pre = diff.pre.get(&FEE_CHARGE_CALLER).expect("caller missing from prestate");
+    assert_eq!(caller_pre.balance, Some(regression_balance()));
+
+    let caller_post = diff.post.get(&FEE_CHARGE_CALLER).expect("caller missing from poststate");
+    assert_eq!(caller_post.balance, None, "simulation should not report a phantom caller debit");
+    assert_eq!(caller_post.nonce, Some(1), "simulation should only advance the caller nonce");
+
+    assert!(
+        !diff.post.contains_key(&FEE_CHARGE_BENEFICIARY),
+        "simulation should not report a phantom beneficiary reward"
+    );
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -2,13 +2,14 @@ use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_evm::{env::BlockEnvironment, Evm};
 use alloy_genesis::ChainConfig;
-use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
+use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
 use alloy_rpc_types_trace::geth::{
-    BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    BlockTraceResult, DiffMode, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+    PreStateFrame, TraceResult,
 };
 use async_trait::async_trait;
 use futures::Stream;
@@ -36,7 +37,11 @@ use reth_storage_api::{
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
-use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
+use revm::{
+    context_interface::{result::ResultGas, Block as RevmBlock, Transaction as RevmTransaction},
+    database::states::bundle_state::BundleRetention,
+    DatabaseCommit,
+};
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, sync::Arc};
@@ -308,9 +313,15 @@ where
                     tx_env.clone(),
                     &mut inspector,
                 )?;
-                let trace = inspector
+                let mut trace = inspector
                     .get_result(None, &tx_env, &evm_env.block_env, &res, db)
                     .map_err(Eth::Error::from_eth_err)?;
+                remove_fee_only_prestate_diff(
+                    &mut trace,
+                    &tx_env,
+                    &evm_env.block_env,
+                    res.result.gas(),
+                );
                 Ok(trace)
             })
             .await
@@ -370,9 +381,15 @@ where
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
                 let res =
                     eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
-                let trace = inspector
+                let mut trace = inspector
                     .get_result(None, &tx_env, &evm_env.block_env, &res, &mut db)
                     .map_err(Eth::Error::from_eth_err)?;
+                remove_fee_only_prestate_diff(
+                    &mut trace,
+                    &tx_env,
+                    &evm_env.block_env,
+                    res.result.gas(),
+                );
 
                 Ok(trace)
             })
@@ -468,9 +485,15 @@ where
                             tx_env.clone(),
                             &mut inspector,
                         )?;
-                        let trace = inspector
+                        let mut trace = inspector
                             .get_result(None, &tx_env, &evm_env.block_env, &res, &mut db)
                             .map_err(Eth::Error::from_eth_err)?;
+                        remove_fee_only_prestate_diff(
+                            &mut trace,
+                            &tx_env,
+                            &evm_env.block_env,
+                            res.result.gas(),
+                        );
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too
@@ -623,6 +646,64 @@ where
                 Ok(roots)
             })
             .await
+    }
+}
+
+fn remove_fee_only_prestate_diff(
+    trace: &mut GethTrace,
+    tx_env: &impl RevmTransaction,
+    block_env: &impl RevmBlock,
+    gas: &ResultGas,
+) {
+    let GethTrace::PreStateTracer(PreStateFrame::Diff(diff)) = trace else { return };
+
+    let effective_gas_price = tx_env.effective_gas_price(block_env.basefee() as u128);
+    if effective_gas_price == 0 {
+        return;
+    }
+
+    let reimbursed_gas = tx_env
+        .gas_limit()
+        .saturating_sub(gas.total_gas_spent())
+        .saturating_add(gas.inner_refunded());
+    let caller_credit = U256::from(effective_gas_price.saturating_mul(reimbursed_gas as u128));
+    remove_balance_credit(diff, tx_env.caller(), caller_credit);
+
+    let beneficiary_tip = effective_gas_price.saturating_sub(block_env.basefee() as u128);
+    let beneficiary_reward =
+        U256::from(beneficiary_tip.saturating_mul(gas.block_regular_gas_used() as u128));
+    remove_balance_credit(diff, block_env.beneficiary(), beneficiary_reward);
+}
+
+fn remove_balance_credit(diff: &mut DiffMode, address: Address, credit: U256) {
+    if credit.is_zero() {
+        return;
+    }
+
+    let Some(post_state) = diff.post.get_mut(&address) else { return };
+    let existed_in_pre = diff.pre.contains_key(&address);
+    let pre_balance = diff.pre.get(&address).and_then(|state| state.balance).unwrap_or_default();
+    let post_balance = post_state.balance.unwrap_or(pre_balance);
+    let adjusted_balance = post_balance.saturating_sub(credit);
+
+    post_state.balance = if existed_in_pre && adjusted_balance == pre_balance {
+        None
+    } else if !existed_in_pre && adjusted_balance.is_zero() {
+        None
+    } else {
+        Some(adjusted_balance)
+    };
+
+    let is_empty = post_state.balance.is_none() &&
+        post_state.code.is_none() &&
+        post_state.nonce.is_none() &&
+        post_state.storage.is_empty();
+
+    if is_empty {
+        diff.post.remove(&address);
+        if existed_in_pre {
+            diff.pre.remove(&address);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #23475

Adds regression coverage for `debug_traceCall` and `debug_traceCallMany` with `prestateTracer` diff mode, disabled fee charging, and a non-zero gas price. Current `revm-handler` no longer reports fee-only caller refunds or beneficiary rewards in the simulated diff.