### PR TITLE
perf(stages): parallelize incremental MerkleExecute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9991,6 +9991,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
+ "reth-trie-parallel",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9088,6 +9088,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
+ "reth-trie-parallel",
  "secp256k1 0.30.0",
  "serde_json",
  "tempfile",

--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -170,6 +170,7 @@ where
         // Forces updating the root instead of calculating from scratch
         rebuild_threshold: u64::MAX,
         incremental_threshold: u64::MAX,
+        parallel: None,
     };
 
     loop {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -194,8 +194,6 @@ where
     validator: V,
     /// Changeset cache for in-memory trie changesets
     changeset_cache: ChangesetCache,
-    /// Task runtime for spawning parallel work.
-    runtime: reth_tasks::Runtime,
 }
 
 impl<N, P, Evm, V> BasicEngineValidator<P, Evm, V>
@@ -232,12 +230,8 @@ where
         runtime: reth_tasks::Runtime,
     ) -> Self {
         let precompile_cache_map = PrecompileCacheMap::default();
-        let payload_processor = PayloadProcessor::new(
-            runtime.clone(),
-            evm_config.clone(),
-            &config,
-            precompile_cache_map.clone(),
-        );
+        let payload_processor =
+            PayloadProcessor::new(runtime, evm_config.clone(), &config, precompile_cache_map.clone());
         Self {
             provider,
             consensus,
@@ -250,7 +244,6 @@ where
             metrics: EngineApiMetrics::default(),
             validator,
             changeset_cache,
-            runtime,
         }
     }
 
@@ -1097,8 +1090,7 @@ where
         let prefix_sets = hashed_state.construct_prefix_sets().freeze();
         let overlay_factory =
             overlay_factory.with_extended_hashed_state_overlay(hashed_state.clone_into_sorted());
-        ParallelStateRoot::new(overlay_factory, prefix_sets, self.runtime.clone())
-            .incremental_root_with_updates()
+        ParallelStateRoot::new(overlay_factory, prefix_sets).incremental_root_with_updates()
     }
 
     /// Compute state root for the given hashed post state in serial.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -194,6 +194,8 @@ where
     validator: V,
     /// Changeset cache for in-memory trie changesets
     changeset_cache: ChangesetCache,
+    /// Task runtime for spawning parallel work.
+    runtime: reth_tasks::Runtime,
 }
 
 impl<N, P, Evm, V> BasicEngineValidator<P, Evm, V>
@@ -230,8 +232,12 @@ where
         runtime: reth_tasks::Runtime,
     ) -> Self {
         let precompile_cache_map = PrecompileCacheMap::default();
-        let payload_processor =
-            PayloadProcessor::new(runtime, evm_config.clone(), &config, precompile_cache_map.clone());
+        let payload_processor = PayloadProcessor::new(
+            runtime.clone(),
+            evm_config.clone(),
+            &config,
+            precompile_cache_map.clone(),
+        );
         Self {
             provider,
             consensus,
@@ -244,6 +250,7 @@ where
             metrics: EngineApiMetrics::default(),
             validator,
             changeset_cache,
+            runtime,
         }
     }
 
@@ -1090,7 +1097,8 @@ where
         let prefix_sets = hashed_state.construct_prefix_sets().freeze();
         let overlay_factory =
             overlay_factory.with_extended_hashed_state_overlay(hashed_state.clone_into_sorted());
-        ParallelStateRoot::new(overlay_factory, prefix_sets).incremental_root_with_updates()
+        ParallelStateRoot::new(overlay_factory, prefix_sets, self.runtime.clone())
+            .incremental_root_with_updates()
     }
 
     /// Compute state root for the given hashed post state in serial.

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -54,6 +54,7 @@ reth-tokio-util.workspace = true
 reth-tracing.workspace = true
 reth-transaction-pool.workspace = true
 reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-trie-parallel.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-node-ethstats.workspace = true
 

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -70,6 +70,7 @@ where
         evm_config,
         exex_manager_handle,
         era_import_source,
+        task_executor.clone(),
     )?;
 
     Ok(pipeline)
@@ -90,6 +91,7 @@ pub fn build_pipeline<N, H, B, Evm>(
     evm_config: Evm,
     exex_manager_handle: ExExManagerHandle<N::Primitives>,
     era_import_source: Option<EraImportSource>,
+    task_executor: TaskExecutor,
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
@@ -125,6 +127,7 @@ where
                 provider_factory.clone(),
                 stage_config.merkle.rebuild_threshold,
                 stage_config.merkle.incremental_threshold,
+                task_executor,
             ))
             .set(ExecutionStage::new(
                 evm_config,

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -16,15 +16,20 @@ use reth_network_p2p::{
     bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader, BlockClient,
 };
 use reth_node_api::HeaderTy;
-use reth_provider::{providers::ProviderNodeTypes, ProviderFactory};
+use reth_provider::{
+    providers::{OverlayStateProviderFactory, ProviderNodeTypes},
+    ProviderFactory,
+};
 use reth_stages::{
     prelude::DefaultStages,
-    stages::{EraImportSource, ExecutionStage, ParallelMerkleExecutionStage},
+    stages::{EraImportSource, ExecutionStage, MerkleParallelConfig, MerkleStage},
     Pipeline, StageSet,
 };
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::debug;
+use reth_trie_db::ChangesetCache;
+use reth_trie_parallel::dispatcher::ParallelStateRootDispatcher;
 use tokio::sync::watch;
 
 /// Constructs a [Pipeline] that's wired to the network
@@ -123,12 +128,21 @@ where
                 prune_config.segments,
                 era_import_source,
             )
-            .set(ParallelMerkleExecutionStage::new(
-                provider_factory.clone(),
-                stage_config.merkle.rebuild_threshold,
-                stage_config.merkle.incremental_threshold,
-                task_executor,
-            ))
+            .set(
+                MerkleStage::new_execution(
+                    stage_config.merkle.rebuild_threshold,
+                    stage_config.merkle.incremental_threshold,
+                )
+                .with_parallel(MerkleParallelConfig::new(Arc::new(
+                    ParallelStateRootDispatcher::new(
+                        OverlayStateProviderFactory::new(
+                            provider_factory.clone(),
+                            ChangesetCache::new(),
+                        ),
+                        task_executor,
+                    ),
+                ))),
+            )
             .set(ExecutionStage::new(
                 evm_config,
                 consensus,

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -19,7 +19,7 @@ use reth_node_api::HeaderTy;
 use reth_provider::{providers::ProviderNodeTypes, ProviderFactory};
 use reth_stages::{
     prelude::DefaultStages,
-    stages::{EraImportSource, ExecutionStage},
+    stages::{EraImportSource, ExecutionStage, ParallelMerkleExecutionStage},
     Pipeline, StageSet,
 };
 use reth_static_file::StaticFileProducer;
@@ -121,6 +121,11 @@ where
                 prune_config.segments,
                 era_import_source,
             )
+            .set(ParallelMerkleExecutionStage::new(
+                provider_factory.clone(),
+                stage_config.merkle.rebuild_threshold,
+                stage_config.merkle.incremental_threshold,
+            ))
             .set(ExecutionStage::new(
                 evm_config,
                 consensus,

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -42,6 +42,7 @@ reth-static-file-types.workspace = true
 reth-tasks.workspace = true
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-trie-parallel.workspace = true
 
 reth-testing-utils = { workspace = true, optional = true }
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -782,6 +782,269 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn parallel_merkle_multi_chunk_execute() {
+        let (previous_stage, stage_progress) = (200, 100);
+        let rebuild_threshold = 100;
+        let incremental_threshold = 10;
+
+        let mut runner = MerkleTestRunner {
+            db: TestStageDB::default(),
+            clean_threshold: rebuild_threshold,
+            incremental_threshold,
+        };
+
+        let input = ExecInput {
+            target: Some(previous_stage),
+            checkpoint: Some(StageCheckpoint::new(stage_progress)),
+        };
+
+        runner.seed_execution(input).expect("failed to seed execution");
+
+        let factory = runner.db().factory.clone();
+        let mut stage = ParallelMerkleExecutionStage::new(
+            factory.clone(),
+            rebuild_threshold,
+            incremental_threshold,
+        );
+        stage.parallel_storage_tries_threshold = 0;
+
+        let mut current_input = input;
+        let mut iterations = 0usize;
+        let result = loop {
+            iterations += 1;
+            assert!(iterations <= 100, "parallel merkle stage did not finish");
+
+            let provider_rw = factory.provider_rw().expect("failed to create provider");
+            let output = stage.execute(&*provider_rw, current_input).expect("stage execute failed");
+            provider_rw.commit().expect("failed to commit");
+
+            if output.done {
+                break output;
+            }
+
+            current_input =
+                ExecInput { target: Some(previous_stage), checkpoint: Some(output.checkpoint) };
+        };
+
+        assert!(iterations > 1, "expected multi-chunk execution");
+        assert_eq!(result.checkpoint.block_number, previous_stage);
+
+        let provider = factory.provider().unwrap();
+        let expected_header = provider.header_by_number(previous_stage).unwrap().unwrap();
+        let expected_root = expected_header.state_root;
+
+        let actual_root = runner
+            .db()
+            .query_with_provider(|provider| {
+                Ok(reth_trie_db::with_adapter!(provider, |A| {
+                    DbStateRoot::<_, A>::incremental_root_with_updates(
+                        &provider,
+                        stage_progress + 1..=previous_stage,
+                    )
+                }))
+            })
+            .unwrap();
+
+        assert_eq!(
+            actual_root.unwrap().0,
+            expected_root,
+            "State root mismatch after parallel multi-chunk processing"
+        );
+    }
+
+    /// Regression: assert that the `TrieUpdates` emitted by the parallel incremental root
+    /// calculator are bit-for-bit identical to what the serial `DbStateRoot` produces on the
+    /// same seeded state (single-shot). Equivalence here is the invariant required for
+    /// unwinding: if parallel writes a different set of trie nodes than serial would, later
+    /// incremental calls (like `MerkleStage::Unwind`) read those nodes and compute a divergent
+    /// root.
+    #[tokio::test]
+    async fn parallel_trie_updates_match_serial() {
+        use reth_trie::updates::TrieUpdatesSorted;
+        use reth_trie_db::ChangesetCache;
+
+        let (previous_stage, stage_progress) = (200, 100);
+        let mut runner = MerkleTestRunner {
+            db: TestStageDB::default(),
+            clean_threshold: 10_000,
+            incremental_threshold: 10_000,
+        };
+
+        let input = ExecInput {
+            target: Some(previous_stage),
+            checkpoint: Some(StageCheckpoint::new(stage_progress)),
+        };
+
+        runner.seed_execution(input).expect("failed to seed execution");
+
+        let factory = runner.db().factory.clone();
+
+        let (serial_root, serial_updates) = {
+            let provider = factory.provider().unwrap();
+            reth_trie_db::with_adapter!(&provider, |A| {
+                DbStateRoot::<_, A>::incremental_root_with_updates(
+                    &provider,
+                    stage_progress + 1..=previous_stage,
+                )
+            })
+            .unwrap()
+        };
+
+        let prefix_sets = {
+            let provider = factory.provider().unwrap();
+            load_prefix_sets_with_provider(&provider, stage_progress + 1..=previous_stage).unwrap()
+        };
+        let overlay_factory = reth_provider::providers::OverlayStateProviderFactory::new(
+            factory,
+            ChangesetCache::new(),
+        );
+        let (parallel_root, parallel_updates) =
+            ParallelStateRoot::new(overlay_factory, prefix_sets)
+                .incremental_root_with_updates()
+                .unwrap();
+
+        assert_eq!(serial_root, parallel_root, "state roots diverged");
+
+        let serial_sorted: TrieUpdatesSorted = serial_updates.into_sorted();
+        let parallel_sorted: TrieUpdatesSorted = parallel_updates.into_sorted();
+        assert_eq!(
+            serial_sorted, parallel_sorted,
+            "parallel trie updates diverged from serial; parallel is writing different nodes"
+        );
+    }
+
+    /// Reproduces the mainnet `MerkleUnwind` failure: multi-chunk `ParallelMerkleExecutionStage`
+    /// followed by a serial unwind must leave the trie tables in a state from which
+    /// `DbStateRoot::incremental_root_with_updates(range)` produces the same root that the serial
+    /// implementation would on a freshly executed chain.
+    ///
+    /// The check here is that, after running parallel multi-chunk execute to `previous_stage`,
+    /// the resulting `AccountsTrie` / `StoragesTrie` tables are bit-for-bit identical to what
+    /// serial `MerkleStage::Execution` multi-chunk would have produced for the same seed. If
+    /// they diverge, incremental unwind will silently recompute a wrong root because it inherits
+    /// the parallel-produced nodes for paths whose changes lie outside the unwind range.
+    #[tokio::test]
+    async fn parallel_multi_chunk_trie_tables_match_serial() {
+        let (previous_stage, stage_progress) = (200, 100);
+        let rebuild_threshold = 100;
+        let incremental_threshold = 10;
+
+        let mut runner = MerkleTestRunner {
+            db: TestStageDB::default(),
+            clean_threshold: rebuild_threshold,
+            incremental_threshold,
+        };
+
+        let input = ExecInput {
+            target: Some(previous_stage),
+            checkpoint: Some(StageCheckpoint::new(stage_progress)),
+        };
+
+        runner.seed_execution(input).expect("failed to seed execution");
+        let factory = runner.db().factory.clone();
+
+        // Run parallel multi-chunk.
+        let mut parallel_stage = ParallelMerkleExecutionStage::new(
+            factory.clone(),
+            rebuild_threshold,
+            incremental_threshold,
+        );
+        parallel_stage.parallel_storage_tries_threshold = 0;
+
+        let mut current_input = input;
+        loop {
+            let provider_rw = factory.provider_rw().expect("failed to create provider");
+            let output = parallel_stage
+                .execute(&*provider_rw, current_input)
+                .expect("parallel stage execute failed");
+            provider_rw.commit().expect("failed to commit");
+            if output.done {
+                break;
+            }
+            current_input =
+                ExecInput { target: Some(previous_stage), checkpoint: Some(output.checkpoint) };
+        }
+
+        // Snapshot parallel trie tables.
+        let parallel_snapshot = dump_trie_tables(&factory);
+
+        // Reset trie tables + stage checkpoint, then run serial multi-chunk on the same
+        // HashedAccounts/HashedStorages.
+        {
+            let provider_rw = factory.provider_rw().unwrap();
+            let tx = provider_rw.tx_ref();
+            tx.clear::<tables::AccountsTrie>().unwrap();
+            tx.clear::<tables::StoragesTrie>().unwrap();
+            provider_rw
+                .save_stage_checkpoint(StageId::MerkleExecute, StageCheckpoint::new(stage_progress))
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        let mut serial_stage = MerkleStage::new_execution(rebuild_threshold, incremental_threshold);
+        let mut current_input = input;
+        loop {
+            let provider_rw = factory.provider_rw().expect("failed to create provider");
+            let output = serial_stage
+                .execute(&*provider_rw, current_input)
+                .expect("serial stage execute failed");
+            provider_rw.commit().expect("failed to commit");
+            if output.done {
+                break;
+            }
+            current_input =
+                ExecInput { target: Some(previous_stage), checkpoint: Some(output.checkpoint) };
+        }
+
+        let serial_snapshot = dump_trie_tables(&factory);
+
+        assert_eq!(
+            parallel_snapshot, serial_snapshot,
+            "parallel multi-chunk wrote different trie nodes than serial multi-chunk; \
+             unwind will read stale/wrong nodes"
+        );
+    }
+
+    fn dump_trie_tables<F>(factory: &F) -> DumpedTrie
+    where
+        F: reth_provider::DatabaseProviderROFactory,
+        F::Provider: DBProvider,
+    {
+        use reth_db_api::cursor::DbCursorRO;
+        use reth_trie::{BranchNodeCompact, StorageTrieEntry, StoredNibbles};
+
+        let provider = factory.database_provider_ro().unwrap();
+        let tx = provider.tx_ref();
+
+        let mut accounts: Vec<(StoredNibbles, BranchNodeCompact)> = Vec::new();
+        {
+            let mut cur = tx.cursor_read::<tables::AccountsTrie>().unwrap();
+            let mut entry = cur.first().unwrap();
+            while let Some((k, v)) = entry {
+                accounts.push((k, v));
+                entry = cur.next().unwrap();
+            }
+        }
+
+        let mut storages: Vec<(B256, StorageTrieEntry)> = Vec::new();
+        {
+            let mut cur = tx.cursor_dup_read::<tables::StoragesTrie>().unwrap();
+            let mut entry = cur.first().unwrap();
+            while let Some((k, v)) = entry {
+                storages.push((k, v));
+                entry = cur.next().unwrap();
+            }
+        }
+        DumpedTrie { accounts, storages }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct DumpedTrie {
+        accounts: Vec<(reth_trie::StoredNibbles, reth_trie::BranchNodeCompact)>,
+        storages: Vec<(B256, reth_trie::StorageTrieEntry)>,
+    }
+
     struct MerkleTestRunner {
         db: TestStageDB,
         clean_threshold: u64,

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -175,16 +175,25 @@ pub struct ParallelMerkleExecutionStage<Factory> {
     rebuild_threshold: u64,
     incremental_threshold: u64,
     parallel_storage_tries_threshold: usize,
+    /// Runtime used by `ParallelStateRoot` to dispatch storage-root workers onto reth's
+    /// named `storage_pool` rayon threads.
+    runtime: reth_tasks::Runtime,
 }
 
 impl<Factory> ParallelMerkleExecutionStage<Factory> {
     /// Create a new stage.
-    pub fn new(factory: Factory, rebuild_threshold: u64, incremental_threshold: u64) -> Self {
+    pub fn new(
+        factory: Factory,
+        rebuild_threshold: u64,
+        incremental_threshold: u64,
+        runtime: reth_tasks::Runtime,
+    ) -> Self {
         Self {
             overlay_factory: OverlayStateProviderFactory::new(factory, ChangesetCache::new()),
             rebuild_threshold,
             incremental_threshold,
             parallel_storage_tries_threshold: PARALLEL_MERKLE_STORAGE_TRIE_THRESHOLD,
+            runtime,
         }
     }
 
@@ -222,9 +231,13 @@ impl<Factory> ParallelMerkleExecutionStage<Factory> {
         );
 
         if use_parallel {
-            return ParallelStateRoot::new(self.overlay_factory.clone(), prefix_sets)
-                .incremental_root_with_updates()
-                .map_err(|e| StageError::Fatal(Box::new(e)))
+            return ParallelStateRoot::new(
+                self.overlay_factory.clone(),
+                prefix_sets,
+                self.runtime.clone(),
+            )
+            .incremental_root_with_updates()
+            .map_err(|e| StageError::Fatal(Box::new(e)))
         }
 
         reth_trie_db::with_adapter!(provider, |A| {
@@ -806,6 +819,7 @@ mod tests {
             factory.clone(),
             rebuild_threshold,
             incremental_threshold,
+            reth_tasks::Runtime::test(),
         );
         stage.parallel_storage_tries_threshold = 0;
 
@@ -900,7 +914,7 @@ mod tests {
             ChangesetCache::new(),
         );
         let (parallel_root, parallel_updates) =
-            ParallelStateRoot::new(overlay_factory, prefix_sets)
+            ParallelStateRoot::new(overlay_factory, prefix_sets, reth_tasks::Runtime::test())
                 .incremental_root_with_updates()
                 .unwrap();
 
@@ -949,6 +963,7 @@ mod tests {
             factory.clone(),
             rebuild_threshold,
             incremental_threshold,
+            reth_tasks::Runtime::test(),
         );
         parallel_stage.parallel_storage_tries_threshold = 0;
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -8,8 +8,7 @@ use reth_db_api::{
 };
 use reth_primitives_traits::{GotExpected, SealedHeader};
 use reth_provider::{
-    providers::OverlayStateProviderFactory, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-    DatabaseProviderROFactory, HeaderProvider, ProviderError, StageCheckpointReader,
+    ChangeSetReader, DBProvider, HeaderProvider, ProviderError, StageCheckpointReader,
     StageCheckpointWriter, StatsReader, StorageChangeSetReader, StorageSettingsCache, TrieWriter,
 };
 use reth_stages_api::{
@@ -17,13 +16,12 @@ use reth_stages_api::{
     StageCheckpoint, StageError, StageId, StorageRootMerkleCheckpoint, UnwindInput, UnwindOutput,
 };
 use reth_trie::{
-    hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
+    updates::{TrieUpdates, TrieUpdatesSorted},
     IntermediateStateRootState, StateRoot, StateRootProgress, StoredSubNode,
 };
-use reth_trie_db::{load_prefix_sets_with_provider, ChangesetCache, DatabaseStateRoot};
-use reth_trie_parallel::root::ParallelStateRoot;
-
-use std::fmt::Debug;
+use reth_trie_db::{load_prefix_sets_with_provider, DatabaseStateRoot};
+use reth_trie_parallel::dispatcher::IncrementalStateRootDispatcher;
+use std::{fmt::Debug, sync::Arc};
 
 type DbStateRoot<'a, TX, A> = StateRoot<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
@@ -58,8 +56,35 @@ pub const MERKLE_STAGE_DEFAULT_REBUILD_THRESHOLD: u64 = 100_000;
 /// new state root for this many blocks, in batches, repeating until we reach the desired block
 /// number.
 pub const MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD: u64 = 7_000;
-/// Minimum number of modified storage tries in a chunk before using parallel state root.
-const PARALLEL_MERKLE_STORAGE_TRIE_THRESHOLD: usize = 1_024;
+/// Default minimum number of modified storage tries in a chunk before using the parallel
+/// state-root dispatcher. Below this threshold the per-chunk rayon scheduling overhead is not
+/// worth the parallelism.
+pub const MERKLE_STAGE_DEFAULT_PARALLEL_STORAGE_TRIE_THRESHOLD: usize = 1_024;
+
+/// Optional parallel-execution configuration for [`MerkleStage::Execution`].
+///
+/// When set, the incremental chunked path will dispatch through
+/// [`IncrementalStateRootDispatcher`] for chunks whose modified storage-trie count meets
+/// `storage_tries_threshold`. Smaller chunks fall through to the serial `DbStateRoot` path
+/// (the rayon scheduling overhead isn't worth it).
+#[derive(Clone, Debug)]
+pub struct MerkleParallelConfig {
+    /// Dispatcher used for the parallel path.
+    pub dispatcher: Arc<dyn IncrementalStateRootDispatcher>,
+    /// Minimum number of modified storage tries in a chunk before using the dispatcher.
+    pub storage_tries_threshold: usize,
+}
+
+impl MerkleParallelConfig {
+    /// Create a new configuration using
+    /// [`MERKLE_STAGE_DEFAULT_PARALLEL_STORAGE_TRIE_THRESHOLD`] as the chunk threshold.
+    pub fn new(dispatcher: Arc<dyn IncrementalStateRootDispatcher>) -> Self {
+        Self {
+            dispatcher,
+            storage_tries_threshold: MERKLE_STAGE_DEFAULT_PARALLEL_STORAGE_TRIE_THRESHOLD,
+        }
+    }
+}
 
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and
@@ -95,6 +120,10 @@ pub enum MerkleStage {
         /// incremental mode will calculate the state root by calculating the new state root for
         /// some number of blocks, repeating until we reach the desired block number.
         incremental_threshold: u64,
+        /// Optional parallel execution configuration. When `None`, the incremental path runs
+        /// the serial `DbStateRoot`. When `Some`, chunks whose modified-storage-trie count
+        /// meets the threshold are dispatched through the parallel calculator.
+        parallel: Option<MerkleParallelConfig>,
     },
     /// The unwind portion of the merkle stage.
     Unwind,
@@ -108,6 +137,8 @@ pub enum MerkleStage {
         /// incremental mode will calculate the state root by calculating the new state root for
         /// some number of blocks, repeating until we reach the desired block number.
         incremental_threshold: u64,
+        /// Optional parallel execution configuration; see [`MerkleStage::Execution`].
+        parallel: Option<MerkleParallelConfig>,
     },
 }
 
@@ -117,6 +148,7 @@ impl MerkleStage {
         Self::Execution {
             rebuild_threshold: MERKLE_STAGE_DEFAULT_REBUILD_THRESHOLD,
             incremental_threshold: MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD,
+            parallel: None,
         }
     }
 
@@ -127,7 +159,24 @@ impl MerkleStage {
 
     /// Create new instance of [`MerkleStage::Execution`].
     pub const fn new_execution(rebuild_threshold: u64, incremental_threshold: u64) -> Self {
-        Self::Execution { rebuild_threshold, incremental_threshold }
+        Self::Execution { rebuild_threshold, incremental_threshold, parallel: None }
+    }
+
+    /// Enable parallel execution for the incremental path.
+    ///
+    /// Only applies to [`MerkleStage::Execution`] and [`MerkleStage::Both`]; other variants
+    /// are returned unchanged.
+    pub fn with_parallel(self, config: MerkleParallelConfig) -> Self {
+        match self {
+            Self::Execution { rebuild_threshold, incremental_threshold, .. } => {
+                Self::Execution { rebuild_threshold, incremental_threshold, parallel: Some(config) }
+            }
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Both { rebuild_threshold, incremental_threshold, .. } => {
+                Self::Both { rebuild_threshold, incremental_threshold, parallel: Some(config) }
+            }
+            other => other,
+        }
     }
 
     /// Gets the hashing progress
@@ -165,176 +214,6 @@ impl MerkleStage {
     }
 }
 
-/// Executes the incremental merkle stage using the existing parallel state-root calculator.
-///
-/// This is intentionally limited to the incremental path. Rebuild/unwind still use the original
-/// implementation until the parallel path has stronger validation coverage.
-#[derive(Debug, Clone)]
-pub struct ParallelMerkleExecutionStage<Factory> {
-    overlay_factory: OverlayStateProviderFactory<Factory>,
-    rebuild_threshold: u64,
-    incremental_threshold: u64,
-    parallel_storage_tries_threshold: usize,
-    /// Runtime used by `ParallelStateRoot` to dispatch storage-root workers onto reth's
-    /// named `storage_pool` rayon threads.
-    runtime: reth_tasks::Runtime,
-}
-
-impl<Factory> ParallelMerkleExecutionStage<Factory> {
-    /// Create a new stage.
-    pub fn new(
-        factory: Factory,
-        rebuild_threshold: u64,
-        incremental_threshold: u64,
-        runtime: reth_tasks::Runtime,
-    ) -> Self {
-        Self {
-            overlay_factory: OverlayStateProviderFactory::new(factory, ChangesetCache::new()),
-            rebuild_threshold,
-            incremental_threshold,
-            parallel_storage_tries_threshold: PARALLEL_MERKLE_STORAGE_TRIE_THRESHOLD,
-            runtime,
-        }
-    }
-
-    const fn fallback_stage(&self) -> MerkleStage {
-        MerkleStage::new_execution(self.rebuild_threshold, self.incremental_threshold)
-    }
-
-    fn incremental_root<Provider>(
-        &self,
-        provider: &Provider,
-        range: std::ops::RangeInclusive<BlockNumber>,
-    ) -> Result<(B256, TrieUpdates), StageError>
-    where
-        Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + StorageSettingsCache,
-        Factory: DatabaseProviderFactory + Clone + Send + Sync + 'static,
-        Factory::Provider: StageCheckpointReader
-            + reth_provider::PruneCheckpointReader
-            + reth_provider::BlockNumReader
-            + ChangeSetReader
-            + StorageChangeSetReader
-            + StorageSettingsCache,
-    {
-        let prefix_sets = load_prefix_sets_with_provider(provider, range.clone())
-            .map_err(|e| StageError::Fatal(Box::new(e)))?;
-        let storage_trie_count = prefix_sets.storage_prefix_sets.len();
-        let use_parallel = storage_trie_count >= self.parallel_storage_tries_threshold;
-
-        debug!(
-            target: "sync::stages::merkle::exec",
-            ?range,
-            storage_trie_count,
-            parallel_threshold = self.parallel_storage_tries_threshold,
-            use_parallel,
-            "Loaded prefix sets for incremental merkle chunk"
-        );
-
-        if use_parallel {
-            return ParallelStateRoot::new(
-                self.overlay_factory.clone(),
-                prefix_sets,
-                self.runtime.clone(),
-            )
-            .incremental_root_with_updates()
-            .map_err(|e| StageError::Fatal(Box::new(e)))
-        }
-
-        reth_trie_db::with_adapter!(provider, |A| {
-            DbStateRoot::<_, A>::from_tx(provider.tx_ref())
-                .with_prefix_sets(prefix_sets)
-                .root_with_updates()
-        })
-        .map_err(|e| StageError::Fatal(Box::new(e)))
-    }
-}
-
-impl<Provider, Factory> Stage<Provider> for ParallelMerkleExecutionStage<Factory>
-where
-    Provider: DBProvider<Tx: DbTxMut>
-        + TrieWriter
-        + StatsReader
-        + HeaderProvider
-        + ChangeSetReader
-        + StorageChangeSetReader
-        + StorageSettingsCache
-        + StageCheckpointReader
-        + StageCheckpointWriter,
-    Factory: DatabaseProviderFactory + Clone + Send + Sync + 'static,
-    Factory::Provider: StageCheckpointReader
-        + reth_provider::PruneCheckpointReader
-        + reth_provider::BlockNumReader
-        + ChangeSetReader
-        + StorageChangeSetReader
-        + StorageSettingsCache,
-    OverlayStateProviderFactory<Factory>: DatabaseProviderROFactory,
-    <OverlayStateProviderFactory<Factory> as DatabaseProviderROFactory>::Provider:
-        TrieCursorFactory + HashedCursorFactory,
-{
-    fn id(&self) -> StageId {
-        StageId::MerkleExecute
-    }
-
-    fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
-        let range = input.next_block_range();
-        let (from_block, to_block) = range.clone().into_inner();
-
-        if range.is_empty() || to_block - from_block > self.rebuild_threshold || from_block == 1 {
-            return self.fallback_stage().execute(provider, input)
-        }
-
-        let current_block_number = input.checkpoint().block_number;
-        let target_block = provider
-            .header_by_number(to_block)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(to_block.into()))?;
-
-        let chunk_to = std::cmp::min(from_block + self.incremental_threshold, to_block);
-        let chunk_range = from_block..=chunk_to;
-        debug!(
-            target: "sync::stages::merkle::exec",
-            current = ?current_block_number,
-            target = ?to_block,
-            incremental_threshold = self.incremental_threshold,
-            chunk_range = ?chunk_range,
-            "Processing chunk"
-        );
-
-        let (root, updates) =
-            self.incremental_root(provider, chunk_range.clone()).map_err(|e| {
-                error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, ?chunk_range, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
-                e
-            })?;
-        provider.write_trie_updates(updates)?;
-
-        if chunk_to < to_block {
-            return Ok(ExecOutput { checkpoint: StageCheckpoint::new(chunk_to), done: false })
-        }
-
-        let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
-            provider.count_entries::<tables::HashedStorages>()?)
-            as u64;
-        let entities_checkpoint =
-            EntitiesCheckpoint { processed: total_hashed_entries, total: total_hashed_entries };
-
-        validate_state_root(root, SealedHeader::seal_slow(target_block), to_block)?;
-
-        Ok(ExecOutput {
-            checkpoint: StageCheckpoint::new(to_block)
-                .with_entities_stage_checkpoint(entities_checkpoint),
-            done: true,
-        })
-    }
-
-    fn unwind(
-        &mut self,
-        _provider: &Provider,
-        input: UnwindInput,
-    ) -> Result<UnwindOutput, StageError> {
-        info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
-        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
-    }
-}
-
 impl<Provider> Stage<Provider> for MerkleStage
 where
     Provider: DBProvider<Tx: DbTxMut>
@@ -359,17 +238,17 @@ where
 
     /// Execute the stage.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
-        let (threshold, incremental_threshold) = match self {
+        let (threshold, incremental_threshold, parallel) = match self {
             Self::Unwind => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
                 return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
             }
-            Self::Execution { rebuild_threshold, incremental_threshold } => {
-                (*rebuild_threshold, *incremental_threshold)
+            Self::Execution { rebuild_threshold, incremental_threshold, parallel } => {
+                (*rebuild_threshold, *incremental_threshold, parallel.clone())
             }
             #[cfg(any(test, feature = "test-utils"))]
-            Self::Both { rebuild_threshold, incremental_threshold } => {
-                (*rebuild_threshold, *incremental_threshold)
+            Self::Both { rebuild_threshold, incremental_threshold, parallel } => {
+                (*rebuild_threshold, *incremental_threshold, parallel.clone())
             }
         };
 
@@ -488,6 +367,7 @@ where
         } else {
             debug!(target: "sync::stages::merkle::exec", current = ?current_block_number, target = ?to_block, "Updating trie in chunks");
             let mut final_root = None;
+            let mut trie_updates_overlay = Arc::new(TrieUpdatesSorted::default());
             for start_block in range.step_by(incremental_threshold as usize) {
                 let chunk_to = std::cmp::min(start_block + incremental_threshold, to_block);
                 let chunk_range = start_block..=chunk_to;
@@ -499,14 +379,28 @@ where
                     chunk_range = ?chunk_range,
                     "Processing chunk"
                 );
-                let (root, updates) = reth_trie_db::with_adapter!(provider, |A| {
-                    DbStateRoot::<_, A>::incremental_root_with_updates(provider, chunk_range)
-                })
+                let (root, updates) = compute_incremental_chunk(
+                    provider,
+                    chunk_range.clone(),
+                    parallel.as_ref(),
+                    Arc::clone(&trie_updates_overlay),
+                )
                 .map_err(|e| {
-                    error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
-                    StageError::Fatal(Box::new(e))
+                    error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, ?chunk_range, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
+                    e
                 })?;
-                provider.write_trie_updates(updates)?;
+                if parallel.is_some() && chunk_to < to_block {
+                    // Parallel chunks open fresh read-only providers and cannot see writes made in
+                    // this transaction. Keep prior chunk updates in an in-memory trie overlay so
+                    // later parallel chunks observe the same intermediate trie state as serial
+                    // chunks using this provider transaction.
+                    let updates = updates.into_sorted();
+                    provider.write_trie_updates_sorted(&updates)?;
+                    Arc::make_mut(&mut trie_updates_overlay).extend_ref_and_sort(&updates);
+                } else {
+                    provider.write_trie_updates(updates)?;
+                }
+
                 final_root = Some(root);
             }
 
@@ -609,6 +503,57 @@ where
     }
 }
 
+/// Compute one incremental-chunk state root, dispatching to the parallel calculator when
+/// the optional `parallel` config is provided and the chunk's modified-storage-trie count
+/// crosses its threshold. Otherwise falls through to the serial [`DbStateRoot`].
+fn compute_incremental_chunk<Provider>(
+    provider: &Provider,
+    chunk_range: std::ops::RangeInclusive<BlockNumber>,
+    parallel: Option<&MerkleParallelConfig>,
+    trie_updates_overlay: Arc<TrieUpdatesSorted>,
+) -> Result<(B256, TrieUpdates), StageError>
+where
+    Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + StorageSettingsCache,
+{
+    if let Some(parallel) = parallel {
+        let prefix_sets = load_prefix_sets_with_provider(provider, chunk_range.clone())
+            .map_err(|e| StageError::Fatal(Box::new(e)))?;
+        let storage_trie_count = prefix_sets.storage_prefix_sets.len();
+        let use_parallel = storage_trie_count >= parallel.storage_tries_threshold;
+
+        debug!(
+            target: "sync::stages::merkle::exec",
+            ?chunk_range,
+            storage_trie_count,
+            parallel_threshold = parallel.storage_tries_threshold,
+            use_parallel,
+            "Loaded prefix sets for incremental merkle chunk"
+        );
+
+        if use_parallel {
+            return parallel
+                .dispatcher
+                .incremental_root_with_updates(
+                    prefix_sets,
+                    (!trie_updates_overlay.is_empty()).then_some(trie_updates_overlay),
+                )
+                .map_err(|e| StageError::Fatal(Box::new(e)));
+        }
+
+        return reth_trie_db::with_adapter!(provider, |A| {
+            DbStateRoot::<_, A>::from_tx(provider.tx_ref())
+                .with_prefix_sets(prefix_sets)
+                .root_with_updates()
+        })
+        .map_err(|e| StageError::Fatal(Box::new(e)));
+    }
+
+    reth_trie_db::with_adapter!(provider, |A| {
+        DbStateRoot::<_, A>::incremental_root_with_updates(provider, chunk_range)
+    })
+    .map_err(|e| StageError::Fatal(Box::new(e)))
+}
+
 /// Check that the computed state root matches the root in the expected header.
 #[inline]
 fn validate_state_root<H: BlockHeader + Sealable + Debug>(
@@ -640,7 +585,10 @@ mod tests {
     use assert_matches::assert_matches;
     use reth_db_api::cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO};
     use reth_primitives_traits::{SealedBlock, StorageEntry};
-    use reth_provider::{providers::StaticFileWriter, StaticFileProviderFactory};
+    use reth_provider::{
+        providers::{OverlayStateProviderFactory, StaticFileWriter},
+        StaticFileProviderFactory,
+    };
     use reth_stages_api::StageUnitCheckpoint;
     use reth_static_file_types::StaticFileSegment;
     use reth_testing_utils::generators::{
@@ -648,7 +596,61 @@ mod tests {
         random_contract_account_range, BlockParams, BlockRangeParams,
     };
     use reth_trie::test_utils::{state_root, state_root_prehashed};
-    use std::collections::BTreeMap;
+    use reth_trie_db::ChangesetCache;
+    use reth_trie_parallel::{dispatcher::ParallelStateRootDispatcher, root::ParallelStateRoot};
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    /// Build a parallel-execution config that forces the parallel path (threshold = 0).
+    fn test_parallel_config<F>(factory: F) -> MerkleParallelConfig
+    where
+        F: reth_provider::DatabaseProviderFactory + Clone + Send + Sync + std::fmt::Debug + 'static,
+        F::Provider: reth_provider::StageCheckpointReader
+            + reth_provider::PruneCheckpointReader
+            + reth_provider::BlockNumReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + StorageSettingsCache,
+    {
+        test_parallel_config_with_counter(factory).0
+    }
+
+    fn test_parallel_config_with_counter<F>(factory: F) -> (MerkleParallelConfig, Arc<AtomicUsize>)
+    where
+        F: reth_provider::DatabaseProviderFactory + Clone + Send + Sync + std::fmt::Debug + 'static,
+        F::Provider: reth_provider::StageCheckpointReader
+            + reth_provider::PruneCheckpointReader
+            + reth_provider::BlockNumReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + StorageSettingsCache,
+    {
+        let overlay = OverlayStateProviderFactory::new(factory, ChangesetCache::new());
+        let inner =
+            Arc::new(ParallelStateRootDispatcher::new(overlay, reth_tasks::Runtime::test()));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let dispatcher = Arc::new(CountingDispatcher { inner, calls: Arc::clone(&calls) });
+        (MerkleParallelConfig { dispatcher, storage_tries_threshold: 0 }, calls)
+    }
+
+    #[derive(Debug)]
+    struct CountingDispatcher {
+        inner: Arc<dyn IncrementalStateRootDispatcher>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl IncrementalStateRootDispatcher for CountingDispatcher {
+        fn incremental_root_with_updates(
+            &self,
+            prefix_sets: reth_trie::prefix_set::TriePrefixSets,
+            trie_updates_overlay: Option<Arc<TrieUpdatesSorted>>,
+        ) -> Result<(B256, TrieUpdates), reth_trie_parallel::root::ParallelStateRootError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.incremental_root_with_updates(prefix_sets, trie_updates_overlay)
+        }
+    }
 
     stage_test_suite_ext!(MerkleTestRunner, merkle);
 
@@ -815,13 +817,9 @@ mod tests {
         runner.seed_execution(input).expect("failed to seed execution");
 
         let factory = runner.db().factory.clone();
-        let mut stage = ParallelMerkleExecutionStage::new(
-            factory.clone(),
-            rebuild_threshold,
-            incremental_threshold,
-            reth_tasks::Runtime::test(),
-        );
-        stage.parallel_storage_tries_threshold = 0;
+        let (parallel_config, parallel_calls) = test_parallel_config_with_counter(factory.clone());
+        let mut stage = MerkleStage::new_execution(rebuild_threshold, incremental_threshold)
+            .with_parallel(parallel_config);
 
         let mut current_input = input;
         let mut iterations = 0usize;
@@ -841,7 +839,8 @@ mod tests {
                 ExecInput { target: Some(previous_stage), checkpoint: Some(output.checkpoint) };
         };
 
-        assert!(iterations > 1, "expected multi-chunk execution");
+        assert_eq!(iterations, 1, "expected unified merkle stage to finish in one execute call");
+        assert!(parallel_calls.load(Ordering::Relaxed) > 1, "expected multiple parallel chunks");
         assert_eq!(result.checkpoint.block_number, previous_stage);
 
         let provider = factory.provider().unwrap();
@@ -876,7 +875,6 @@ mod tests {
     #[tokio::test]
     async fn parallel_trie_updates_match_serial() {
         use reth_trie::updates::TrieUpdatesSorted;
-        use reth_trie_db::ChangesetCache;
 
         let (previous_stage, stage_progress) = (200, 100);
         let mut runner = MerkleTestRunner {
@@ -909,10 +907,7 @@ mod tests {
             let provider = factory.provider().unwrap();
             load_prefix_sets_with_provider(&provider, stage_progress + 1..=previous_stage).unwrap()
         };
-        let overlay_factory = reth_provider::providers::OverlayStateProviderFactory::new(
-            factory,
-            ChangesetCache::new(),
-        );
+        let overlay_factory = OverlayStateProviderFactory::new(factory, ChangesetCache::new());
         let (parallel_root, parallel_updates) =
             ParallelStateRoot::new(overlay_factory, prefix_sets, reth_tasks::Runtime::test())
                 .incremental_root_with_updates()
@@ -928,8 +923,8 @@ mod tests {
         );
     }
 
-    /// Reproduces the mainnet `MerkleUnwind` failure: multi-chunk `ParallelMerkleExecutionStage`
-    /// followed by a serial unwind must leave the trie tables in a state from which
+    /// Reproduces the mainnet `MerkleUnwind` failure: multi-chunk parallel merkle execution
+    /// followed by serial unwind must leave the trie tables in a state from which
     /// `DbStateRoot::incremental_root_with_updates(range)` produces the same root that the serial
     /// implementation would on a freshly executed chain.
     ///
@@ -959,13 +954,9 @@ mod tests {
         let factory = runner.db().factory.clone();
 
         // Run parallel multi-chunk.
-        let mut parallel_stage = ParallelMerkleExecutionStage::new(
-            factory.clone(),
-            rebuild_threshold,
-            incremental_threshold,
-            reth_tasks::Runtime::test(),
-        );
-        parallel_stage.parallel_storage_tries_threshold = 0;
+        let mut parallel_stage =
+            MerkleStage::new_execution(rebuild_threshold, incremental_threshold)
+                .with_parallel(test_parallel_config(factory.clone()));
 
         let mut current_input = input;
         loop {
@@ -1087,6 +1078,7 @@ mod tests {
             Self::S::Both {
                 rebuild_threshold: self.clean_threshold,
                 incremental_threshold: self.incremental_threshold,
+                parallel: None,
             }
         }
     }

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -8,15 +8,20 @@ use reth_db_api::{
 };
 use reth_primitives_traits::{GotExpected, SealedHeader};
 use reth_provider::{
-    ChangeSetReader, DBProvider, HeaderProvider, ProviderError, StageCheckpointReader,
+    providers::OverlayStateProviderFactory, ChangeSetReader, DBProvider, DatabaseProviderFactory,
+    DatabaseProviderROFactory, HeaderProvider, ProviderError, StageCheckpointReader,
     StageCheckpointWriter, StatsReader, StorageChangeSetReader, StorageSettingsCache, TrieWriter,
 };
 use reth_stages_api::{
     BlockErrorKind, EntitiesCheckpoint, ExecInput, ExecOutput, MerkleCheckpoint, Stage,
     StageCheckpoint, StageError, StageId, StorageRootMerkleCheckpoint, UnwindInput, UnwindOutput,
 };
-use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress, StoredSubNode};
-use reth_trie_db::DatabaseStateRoot;
+use reth_trie::{
+    hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
+    IntermediateStateRootState, StateRoot, StateRootProgress, StoredSubNode,
+};
+use reth_trie_db::{load_prefix_sets_with_provider, ChangesetCache, DatabaseStateRoot};
+use reth_trie_parallel::root::ParallelStateRoot;
 
 use std::fmt::Debug;
 
@@ -53,6 +58,8 @@ pub const MERKLE_STAGE_DEFAULT_REBUILD_THRESHOLD: u64 = 100_000;
 /// new state root for this many blocks, in batches, repeating until we reach the desired block
 /// number.
 pub const MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD: u64 = 7_000;
+/// Minimum number of modified storage tries in a chunk before using parallel state root.
+const PARALLEL_MERKLE_STORAGE_TRIE_THRESHOLD: usize = 1_024;
 
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and
@@ -155,6 +162,163 @@ impl MerkleStage {
             checkpoint.to_compact(&mut buf);
         }
         Ok(provider.save_stage_checkpoint_progress(StageId::MerkleExecute, buf)?)
+    }
+}
+
+/// Executes the incremental merkle stage using the existing parallel state-root calculator.
+///
+/// This is intentionally limited to the incremental path. Rebuild/unwind still use the original
+/// implementation until the parallel path has stronger validation coverage.
+#[derive(Debug, Clone)]
+pub struct ParallelMerkleExecutionStage<Factory> {
+    overlay_factory: OverlayStateProviderFactory<Factory>,
+    rebuild_threshold: u64,
+    incremental_threshold: u64,
+    parallel_storage_tries_threshold: usize,
+}
+
+impl<Factory> ParallelMerkleExecutionStage<Factory> {
+    /// Create a new stage.
+    pub fn new(factory: Factory, rebuild_threshold: u64, incremental_threshold: u64) -> Self {
+        Self {
+            overlay_factory: OverlayStateProviderFactory::new(factory, ChangesetCache::new()),
+            rebuild_threshold,
+            incremental_threshold,
+            parallel_storage_tries_threshold: PARALLEL_MERKLE_STORAGE_TRIE_THRESHOLD,
+        }
+    }
+
+    const fn fallback_stage(&self) -> MerkleStage {
+        MerkleStage::new_execution(self.rebuild_threshold, self.incremental_threshold)
+    }
+
+    fn incremental_root<Provider>(
+        &self,
+        provider: &Provider,
+        range: std::ops::RangeInclusive<BlockNumber>,
+    ) -> Result<(B256, TrieUpdates), StageError>
+    where
+        Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + StorageSettingsCache,
+        Factory: DatabaseProviderFactory + Clone + Send + Sync + 'static,
+        Factory::Provider: StageCheckpointReader
+            + reth_provider::PruneCheckpointReader
+            + reth_provider::BlockNumReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + StorageSettingsCache,
+    {
+        let prefix_sets = load_prefix_sets_with_provider(provider, range.clone())
+            .map_err(|e| StageError::Fatal(Box::new(e)))?;
+        let storage_trie_count = prefix_sets.storage_prefix_sets.len();
+        let use_parallel = storage_trie_count >= self.parallel_storage_tries_threshold;
+
+        debug!(
+            target: "sync::stages::merkle::exec",
+            ?range,
+            storage_trie_count,
+            parallel_threshold = self.parallel_storage_tries_threshold,
+            use_parallel,
+            "Loaded prefix sets for incremental merkle chunk"
+        );
+
+        if use_parallel {
+            return ParallelStateRoot::new(self.overlay_factory.clone(), prefix_sets)
+                .incremental_root_with_updates()
+                .map_err(|e| StageError::Fatal(Box::new(e)))
+        }
+
+        reth_trie_db::with_adapter!(provider, |A| {
+            DbStateRoot::<_, A>::from_tx(provider.tx_ref())
+                .with_prefix_sets(prefix_sets)
+                .root_with_updates()
+        })
+        .map_err(|e| StageError::Fatal(Box::new(e)))
+    }
+}
+
+impl<Provider, Factory> Stage<Provider> for ParallelMerkleExecutionStage<Factory>
+where
+    Provider: DBProvider<Tx: DbTxMut>
+        + TrieWriter
+        + StatsReader
+        + HeaderProvider
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + StorageSettingsCache
+        + StageCheckpointReader
+        + StageCheckpointWriter,
+    Factory: DatabaseProviderFactory + Clone + Send + Sync + 'static,
+    Factory::Provider: StageCheckpointReader
+        + reth_provider::PruneCheckpointReader
+        + reth_provider::BlockNumReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + StorageSettingsCache,
+    OverlayStateProviderFactory<Factory>: DatabaseProviderROFactory,
+    <OverlayStateProviderFactory<Factory> as DatabaseProviderROFactory>::Provider:
+        TrieCursorFactory + HashedCursorFactory,
+{
+    fn id(&self) -> StageId {
+        StageId::MerkleExecute
+    }
+
+    fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
+        let range = input.next_block_range();
+        let (from_block, to_block) = range.clone().into_inner();
+
+        if range.is_empty() || to_block - from_block > self.rebuild_threshold || from_block == 1 {
+            return self.fallback_stage().execute(provider, input)
+        }
+
+        let current_block_number = input.checkpoint().block_number;
+        let target_block = provider
+            .header_by_number(to_block)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(to_block.into()))?;
+
+        let chunk_to = std::cmp::min(from_block + self.incremental_threshold, to_block);
+        let chunk_range = from_block..=chunk_to;
+        debug!(
+            target: "sync::stages::merkle::exec",
+            current = ?current_block_number,
+            target = ?to_block,
+            incremental_threshold = self.incremental_threshold,
+            chunk_range = ?chunk_range,
+            "Processing chunk"
+        );
+
+        let (root, updates) =
+            self.incremental_root(provider, chunk_range.clone()).map_err(|e| {
+                error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, ?chunk_range, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
+                e
+            })?;
+        provider.write_trie_updates(updates)?;
+
+        if chunk_to < to_block {
+            return Ok(ExecOutput { checkpoint: StageCheckpoint::new(chunk_to), done: false })
+        }
+
+        let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
+            provider.count_entries::<tables::HashedStorages>()?)
+            as u64;
+        let entities_checkpoint =
+            EntitiesCheckpoint { processed: total_hashed_entries, total: total_hashed_entries };
+
+        validate_state_root(root, SealedHeader::seal_slow(target_block), to_block)?;
+
+        Ok(ExecOutput {
+            checkpoint: StageCheckpoint::new(to_block)
+                .with_entities_stage_checkpoint(entities_checkpoint),
+            done: true,
+        })
+    }
+
+    fn unwind(
+        &mut self,
+        _provider: &Provider,
+        input: UnwindInput,
+    ) -> Result<UnwindOutput, StageError> {
+        info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
+        Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
     }
 }
 
@@ -459,7 +623,7 @@ mod tests {
         stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, StorageKind,
         TestRunnerError, TestStageDB, UnwindStageTestRunner,
     };
-    use alloy_primitives::{keccak256, U256};
+    use alloy_primitives::{keccak256, B256, U256};
     use assert_matches::assert_matches;
     use reth_db_api::cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO};
     use reth_primitives_traits::{SealedBlock, StorageEntry};

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -136,6 +136,29 @@ impl<F> OverlayStateProviderFactory<F> {
         self
     }
 
+    /// Set a trie updates overlay while preserving any existing hashed state overlay.
+    pub fn with_trie_updates_overlay(
+        mut self,
+        trie_updates: Option<Arc<TrieUpdatesSorted>>,
+    ) -> Self {
+        self.overlay_source = trie_updates.map(|updates| {
+            let (mut trie, state) =
+                self.overlay_source.as_ref().map(OverlaySource::resolve).unwrap_or_else(|| {
+                    (
+                        Arc::new(TrieUpdatesSorted::default()),
+                        Arc::new(HashedPostStateSorted::default()),
+                    )
+                });
+
+            Arc::make_mut(&mut trie).extend_ref_and_sort(&updates);
+
+            OverlaySource::Immediate { trie, state }
+        });
+        // Clear the overlay cache since we've updated the source.
+        self.overlay_cache = Default::default();
+        self
+    }
+
     /// Set a lazy overlay that will be computed on first access.
     ///
     /// Convenience method that wraps the lazy overlay in `OverlaySource::Lazy`.

--- a/crates/trie/parallel/src/dispatcher.rs
+++ b/crates/trie/parallel/src/dispatcher.rs
@@ -1,0 +1,81 @@
+//! Dispatcher trait for incremental state-root computation.
+//!
+//! This trait lets the merkle stage call into a parallel implementation without
+//! threading the underlying `Factory` generic through its type signatures. The
+//! concrete [`ParallelStateRootDispatcher`] wraps the factory + runtime so the
+//! caller only needs to hold an `Arc<dyn IncrementalStateRootDispatcher>`.
+
+use crate::root::{ParallelStateRoot, ParallelStateRootError};
+use alloy_primitives::B256;
+use reth_provider::{
+    providers::OverlayStateProviderFactory, BlockNumReader, ChangeSetReader,
+    DatabaseProviderFactory, DatabaseProviderROFactory, PruneCheckpointReader,
+    StageCheckpointReader, StorageChangeSetReader, StorageSettingsCache,
+};
+use reth_tasks::Runtime;
+use reth_trie::{
+    hashed_cursor::HashedCursorFactory,
+    prefix_set::TriePrefixSets,
+    trie_cursor::TrieCursorFactory,
+    updates::{TrieUpdates, TrieUpdatesSorted},
+};
+use std::{fmt::Debug, sync::Arc};
+
+/// Type-erased entry point for parallel incremental state-root computation.
+///
+/// Consumers (e.g. the merkle stage) hold this as `Arc<dyn IncrementalStateRootDispatcher>`
+/// so the underlying factory generic does not leak into their type signatures.
+pub trait IncrementalStateRootDispatcher: Debug + Send + Sync {
+    /// Compute the incremental state root + trie updates for the given prefix sets.
+    fn incremental_root_with_updates(
+        &self,
+        prefix_sets: TriePrefixSets,
+        trie_updates_overlay: Option<Arc<TrieUpdatesSorted>>,
+    ) -> Result<(B256, TrieUpdates), ParallelStateRootError>;
+}
+
+/// Default dispatcher backed by [`ParallelStateRoot`].
+#[derive(Debug, Clone)]
+pub struct ParallelStateRootDispatcher<F> {
+    overlay_factory: OverlayStateProviderFactory<F>,
+    runtime: Runtime,
+}
+
+impl<F> ParallelStateRootDispatcher<F> {
+    /// Create a new dispatcher from an overlay factory and a runtime.
+    pub const fn new(overlay_factory: OverlayStateProviderFactory<F>, runtime: Runtime) -> Self {
+        Self { overlay_factory, runtime }
+    }
+}
+
+impl<F> IncrementalStateRootDispatcher for ParallelStateRootDispatcher<F>
+where
+    F: DatabaseProviderFactory + Debug + Clone + Send + Sync + 'static,
+    F::Provider: StageCheckpointReader
+        + PruneCheckpointReader
+        + BlockNumReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + StorageSettingsCache,
+    OverlayStateProviderFactory<F>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    fn incremental_root_with_updates(
+        &self,
+        prefix_sets: TriePrefixSets,
+        trie_updates_overlay: Option<Arc<TrieUpdatesSorted>>,
+    ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
+        let overlay_factory = match trie_updates_overlay {
+            Some(trie) if !trie.is_empty() => {
+                self.overlay_factory.clone().with_trie_updates_overlay(Some(trie))
+            }
+            _ => self.overlay_factory.clone(),
+        };
+
+        ParallelStateRoot::new(overlay_factory, prefix_sets, self.runtime.clone())
+            .incremental_root_with_updates()
+    }
+}

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -17,6 +17,9 @@ pub mod stats;
 /// Implementation of parallel state root computation.
 pub mod root;
 
+/// Dispatcher trait for type-erased parallel incremental state-root computation.
+pub mod dispatcher;
+
 /// Implementation of parallel proof computation.
 pub mod proof_task;
 

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -117,15 +117,26 @@ where
             self.runtime.cpu_pool().spawn(move || {
                 let result = (|| -> Result<_, ParallelStateRootError> {
                     let provider = factory.database_provider_ro()?;
-                    Ok(StorageRoot::new_hashed(
+                    let storage_root = StorageRoot::new_hashed(
                         &provider,
                         &provider,
                         hashed_address,
                         prefix_set,
                         #[cfg(feature = "metrics")]
                         metrics,
-                    )
-                    .calculate(retain_updates)?)
+                    );
+                    // Use `root_with_updates` / `root`, not `calculate`: those wrappers set
+                    // `with_no_threshold()` first, guaranteeing the storage walker runs to
+                    // completion. `calculate` may return `Progress` for accounts whose
+                    // hashed-entries-walked exceeds the default threshold (XEN-class accounts
+                    // in pipeline chunks), and `ParallelStateRoot` has no mechanism to
+                    // resume a paused worker.
+                    Ok(if retain_updates {
+                        let (root, _, updates) = storage_root.root_with_updates()?;
+                        (root, updates)
+                    } else {
+                        (storage_root.root()?, Default::default())
+                    })
                 })();
                 let _ = tx.send(result);
             });
@@ -155,7 +166,7 @@ where
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
-                    let storage_root_result = match storage_roots.remove(&hashed_address) {
+                    let (storage_root, updates) = match storage_roots.remove(&hashed_address) {
                         Some(rx) => rx.recv().map_err(|_| {
                             ParallelStateRootError::StorageRoot(StorageRootError::Database(
                                 DatabaseError::Other(format!(
@@ -174,26 +185,20 @@ where
                                 .get(&hashed_address)
                                 .cloned()
                                 .unwrap_or_default();
-                            StorageRoot::new_hashed(
+                            let storage_root = StorageRoot::new_hashed(
                                 &provider,
                                 &provider,
                                 hashed_address,
                                 fallback_prefix_set,
                                 #[cfg(feature = "metrics")]
                                 self.metrics.storage_trie.clone(),
-                            )
-                            .calculate(retain_updates)?
-                        }
-                    };
-
-                    let (storage_root, _, updates) = match storage_root_result {
-                        reth_trie::StorageRootProgress::Complete(root, _, updates) => (root, (), updates),
-                        reth_trie::StorageRootProgress::Progress(..) => {
-                            return Err(ParallelStateRootError::StorageRoot(
-                                StorageRootError::Database(DatabaseError::Other(
-                                    "StorageRoot returned Progress variant in parallel trie calculation".to_string()
-                                ))
-                            ))
+                            );
+                            if retain_updates {
+                                let (root, _, updates) = storage_root.root_with_updates()?;
+                                (root, updates)
+                            } else {
+                                (storage_root.root()?, Default::default())
+                            }
                         }
                     };
 

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -5,7 +5,6 @@ use alloy_primitives::B256;
 use alloy_rlp::{BufMut, Encodable};
 use itertools::Itertools;
 use reth_execution_errors::{SparseTrieError, StateProofError, StorageRootError};
-use reth_primitives_traits::Account;
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
@@ -13,15 +12,11 @@ use reth_trie::{
     node_iter::{TrieElement, TrieNodeIter},
     prefix_set::TriePrefixSets,
     trie_cursor::TrieCursorFactory,
-    updates::{StorageTrieUpdates, TrieUpdates},
+    updates::TrieUpdates,
     walker::TrieWalker,
     HashBuilder, Nibbles, StorageRoot, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use std::{
-    collections::BTreeMap,
-    sync::mpsc,
-    time::{Duration, Instant},
-};
+use std::{collections::BTreeMap, sync::mpsc};
 use thiserror::Error;
 use tracing::*;
 
@@ -67,14 +62,14 @@ where
 {
     /// Calculate incremental state root in parallel.
     pub fn incremental_root(self) -> Result<B256, ParallelStateRootError> {
-        self.calculate(false).map(|(root, _, _)| root)
+        self.calculate(false).map(|(root, _)| root)
     }
 
     /// Calculate incremental state root with updates in parallel.
     pub fn incremental_root_with_updates(
         self,
     ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
-        self.calculate(true).map(|(root, _, updates)| (root, updates))
+        self.calculate(true)
     }
 
     /// Computes the state root by calculating storage roots in parallel for modified accounts,
@@ -82,91 +77,68 @@ where
     fn calculate(
         self,
         retain_updates: bool,
-    ) -> Result<(B256, usize, TrieUpdates), ParallelStateRootError> {
-        let Self {
-            factory,
-            prefix_sets,
-            #[cfg(feature = "metrics")]
-            metrics,
-        } = self;
-
+    ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
         let mut tracker = ParallelTrieTracker::default();
-        let total_start = Instant::now();
-        let mut state_root_ctx = ParallelStateRootContext::new();
-        let storage_prefix_sets = prefix_sets.storage_prefix_sets.clone();
+        let storage_prefix_sets = self.prefix_sets.storage_prefix_sets.clone();
         let storage_root_targets = StorageRootTargets::new(
-            prefix_sets.account_prefix_set.iter().map(|nibbles| B256::from_slice(&nibbles.pack())),
-            prefix_sets.storage_prefix_sets,
+            self.prefix_sets
+                .account_prefix_set
+                .iter()
+                .map(|nibbles| B256::from_slice(&nibbles.pack())),
+            self.prefix_sets.storage_prefix_sets,
         );
-        let total_storage_root_targets = storage_root_targets.len();
 
-        tracker.set_precomputed_storage_roots(total_storage_root_targets as u64);
-        debug!(
-            target: "trie::parallel_state_root",
-            len = total_storage_root_targets,
-            "pre-calculating storage roots"
-        );
+        // Pre-calculate storage roots in parallel for accounts which were changed.
+        tracker.set_precomputed_storage_roots(storage_root_targets.len() as u64);
+        debug!(target: "trie::parallel_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
         let mut storage_roots = BTreeMap::new();
-        let mut spawn_duration = Duration::ZERO;
 
-        // Eagerly dispatch every modified-storage target onto the global rayon pool. Rayon's
-        // work-stealing scheduler caps actual parallelism at ~CPU-cores, so queueing all targets
-        // up front is bounded in practice and matches the parallelism style of `sender_recovery`
-        // and `hashing_storage`.
         for (hashed_address, prefix_set) in
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
         {
-            let factory = factory.clone();
+            let factory = self.factory.clone();
             #[cfg(feature = "metrics")]
-            let metrics = metrics.storage_trie.clone();
+            let metrics = self.metrics.storage_trie.clone();
 
             let (tx, rx) = mpsc::sync_channel(1);
-            let spawn_start = Instant::now();
+
+            // Dispatch storage-root computation onto the global rayon pool so a bounded set of
+            // worker threads (≈ CPU cores) consumes targets via work-stealing.
             rayon::spawn(move || {
-                let task_start = Instant::now();
                 let result = (|| -> Result<_, ParallelStateRootError> {
                     let provider = factory.database_provider_ro()?;
-                    let storage_root = StorageRoot::new_hashed(
+                    Ok(StorageRoot::new_hashed(
                         &provider,
                         &provider,
                         hashed_address,
                         prefix_set,
                         #[cfg(feature = "metrics")]
                         metrics,
-                    );
-                    Ok(if retain_updates {
-                        storage_root.root_with_updates()?
-                    } else {
-                        (storage_root.root()?, 0, Default::default())
-                    })
+                    )
+                    .calculate(retain_updates)?)
                 })();
-                let _ = tx.send(StorageRootTaskOutput { result, duration: task_start.elapsed() });
+                let _ = tx.send(result);
             });
-            spawn_duration += spawn_start.elapsed();
             storage_roots.insert(hashed_address, rx);
         }
 
         trace!(target: "trie::parallel_state_root", "calculating state root");
-        let provider = factory.database_provider_ro()?;
+        let mut trie_updates = TrieUpdates::default();
+
+        let provider = self.factory.database_provider_ro()?;
 
         let walker = TrieWalker::<_>::state_trie(
             provider.account_trie_cursor().map_err(ProviderError::Database)?,
-            prefix_sets.account_prefix_set,
+            self.prefix_sets.account_prefix_set,
         )
         .with_deletions_retained(retain_updates);
         let mut account_node_iter = TrieNodeIter::state_trie(
             walker,
             provider.hashed_account_cursor().map_err(ProviderError::Database)?,
         );
+
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);
-
-        let account_walk_start = Instant::now();
-        let mut recv_wait_duration = Duration::ZERO;
-        let mut received_task_duration = Duration::ZERO;
-        let mut max_task_duration = Duration::ZERO;
-        let mut precomputed_storage_roots = 0usize;
-        let mut fallback_storage_roots = 0usize;
-
+        let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
         while let Some(node) = account_node_iter.try_next().map_err(ProviderError::Database)? {
             match node {
                 TrieElement::Branch(node) => {
@@ -183,82 +155,69 @@ where
                         storage_roots.pop_first();
                     }
 
-                    let (storage_root, walked, storage_updates) = if let Some(rx) =
-                        storage_roots.remove(&hashed_address)
-                    {
-                        precomputed_storage_roots += 1;
-                        recv_storage_root_task_output(
-                            hashed_address,
-                            rx,
-                            &mut recv_wait_duration,
-                            &mut received_task_duration,
-                            &mut max_task_duration,
-                        )?
-                    } else {
-                        fallback_storage_roots += 1;
-                        tracker.inc_missed_leaves();
-                        // Defense-in-depth: if no worker ran this account's storage root, fall
-                        // back to the real prefix set. Using an empty `PrefixSet` would return
-                        // the on-disk root and drop this chunk's storage updates.
-                        let fallback_prefix_set =
-                            storage_prefix_sets.get(&hashed_address).cloned().unwrap_or_default();
-                        StorageRoot::new_hashed(
-                            &provider,
-                            &provider,
-                            hashed_address,
-                            fallback_prefix_set,
-                            #[cfg(feature = "metrics")]
-                            metrics.storage_trie.clone(),
-                        )
-                        .root_with_updates()?
+                    let storage_root_result = match storage_roots.remove(&hashed_address) {
+                        Some(rx) => rx.recv().map_err(|_| {
+                            ParallelStateRootError::StorageRoot(StorageRootError::Database(
+                                DatabaseError::Other(format!(
+                                    "channel closed for {hashed_address}"
+                                )),
+                            ))
+                        })??,
+                        // Since we do not store all intermediate nodes in the database, there might
+                        // be a possibility of re-adding a non-modified leaf to the hash builder.
+                        None => {
+                            tracker.inc_missed_leaves();
+                            // Defense-in-depth: if no worker ran this account's storage root,
+                            // fall back to the real prefix set. Using an empty `PrefixSet` would
+                            // return the on-disk root and drop this chunk's storage updates.
+                            let fallback_prefix_set = storage_prefix_sets
+                                .get(&hashed_address)
+                                .cloned()
+                                .unwrap_or_default();
+                            StorageRoot::new_hashed(
+                                &provider,
+                                &provider,
+                                hashed_address,
+                                fallback_prefix_set,
+                                #[cfg(feature = "metrics")]
+                                self.metrics.storage_trie.clone(),
+                            )
+                            .calculate(retain_updates)?
+                        }
                     };
 
-                    state_root_ctx.add_leaf(
-                        hashed_address,
-                        account,
-                        storage_root,
-                        walked,
-                        storage_updates,
-                        &mut hash_builder,
-                        retain_updates,
-                    )?;
+                    let (storage_root, _, updates) = match storage_root_result {
+                        reth_trie::StorageRootProgress::Complete(root, _, updates) => (root, (), updates),
+                        reth_trie::StorageRootProgress::Progress(..) => {
+                            return Err(ParallelStateRootError::StorageRoot(
+                                StorageRootError::Database(DatabaseError::Other(
+                                    "StorageRoot returned Progress variant in parallel trie calculation".to_string()
+                                ))
+                            ))
+                        }
+                    };
+
+                    if retain_updates {
+                        trie_updates.insert_storage_updates(hashed_address, updates);
+                    }
+
+                    account_rlp.clear();
+                    let account = account.into_trie_account(storage_root);
+                    account.encode(&mut account_rlp as &mut dyn BufMut);
+                    hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
                 }
             }
         }
-        let account_walk_duration = account_walk_start.elapsed();
 
-        let root_start = Instant::now();
         let root = hash_builder.root();
-        let root_duration = root_start.elapsed();
 
-        let finalize_start = Instant::now();
         let removed_keys = account_node_iter.walker.take_removed_keys();
-        let ParallelStateRootContext { mut trie_updates, hashed_entries_walked, .. } =
-            state_root_ctx;
-        trie_updates.finalize(hash_builder, removed_keys, prefix_sets.destroyed_accounts);
-        let finalize_duration = finalize_start.elapsed();
+        trie_updates.finalize(hash_builder, removed_keys, self.prefix_sets.destroyed_accounts);
 
         let stats = tracker.finish();
-        let total_duration = total_start.elapsed();
 
         #[cfg(feature = "metrics")]
-        metrics.record_state_trie(stats);
-
-        debug!(
-            target: "trie::parallel_state_root",
-            spawned_tasks = total_storage_root_targets,
-            precomputed_storage_roots,
-            fallback_storage_roots,
-            ?spawn_duration,
-            ?account_walk_duration,
-            ?recv_wait_duration,
-            ?received_task_duration,
-            ?max_task_duration,
-            ?root_duration,
-            ?finalize_duration,
-            ?total_duration,
-            "Calculated parallel state root timings"
-        );
+        self.metrics.record_state_trie(stats);
 
         trace!(
             target: "trie::parallel_state_root",
@@ -271,7 +230,7 @@ where
             "Calculated state root"
         );
 
-        Ok((root, hashed_entries_walked, trie_updates))
+        Ok((root, trie_updates))
     }
 }
 
@@ -321,78 +280,6 @@ impl From<StateProofError> for ParallelStateRootError {
             }
         }
     }
-}
-
-struct StorageRootTaskOutput {
-    result: Result<(B256, usize, StorageTrieUpdates), ParallelStateRootError>,
-    duration: Duration,
-}
-
-/// Mutable state threaded through the account walker: reusable encoding buffer, accumulated
-/// trie updates, and running counters recorded into the final stats.
-#[derive(Debug)]
-struct ParallelStateRootContext {
-    /// Reusable buffer for encoding account data.
-    account_rlp: Vec<u8>,
-    /// Accumulates updates from account and storage root calculation.
-    trie_updates: TrieUpdates,
-    /// Tracks total hashed entries walked.
-    hashed_entries_walked: usize,
-}
-
-impl ParallelStateRootContext {
-    fn new() -> Self {
-        Self {
-            account_rlp: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
-            trie_updates: TrieUpdates::default(),
-            hashed_entries_walked: 0,
-        }
-    }
-
-    /// Emits a leaf node into the hash builder after the storage root for the corresponding
-    /// account has been produced (either by a worker or by the fallback path).
-    #[allow(clippy::too_many_arguments)]
-    fn add_leaf(
-        &mut self,
-        hashed_address: B256,
-        account: Account,
-        storage_root: B256,
-        storage_slots_walked: usize,
-        storage_updates: StorageTrieUpdates,
-        hash_builder: &mut HashBuilder,
-        retain_updates: bool,
-    ) -> Result<(), ParallelStateRootError> {
-        self.hashed_entries_walked += storage_slots_walked;
-        if retain_updates {
-            self.trie_updates.insert_storage_updates(hashed_address, storage_updates);
-        }
-
-        self.account_rlp.clear();
-        let trie_account = account.into_trie_account(storage_root);
-        trie_account.encode(&mut self.account_rlp as &mut dyn BufMut);
-        hash_builder.add_leaf(Nibbles::unpack(hashed_address), &self.account_rlp);
-
-        Ok(())
-    }
-}
-
-fn recv_storage_root_task_output(
-    hashed_address: B256,
-    rx: mpsc::Receiver<StorageRootTaskOutput>,
-    recv_wait_duration: &mut Duration,
-    received_task_duration: &mut Duration,
-    max_task_duration: &mut Duration,
-) -> Result<(B256, usize, StorageTrieUpdates), ParallelStateRootError> {
-    let recv_start = Instant::now();
-    let output = rx.recv().map_err(|_| {
-        ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
-            format!("channel closed for {hashed_address}"),
-        )))
-    })?;
-    *recv_wait_duration += recv_start.elapsed();
-    *received_task_duration += output.duration;
-    *max_task_duration = (*max_task_duration).max(output.duration);
-    output.result
 }
 
 #[cfg(test)]

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -83,6 +83,11 @@ where
         retain_updates: bool,
     ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
         let mut tracker = ParallelTrieTracker::default();
+        // Retain a copy of the storage prefix sets so the worker-miss fallback below can build a
+        // `StorageRoot` with the account's actual modified slots, not an empty `PrefixSet`. With
+        // an empty set the fallback would silently return the on-disk root and discard the
+        // chunk's storage updates.
+        let storage_prefix_sets = self.prefix_sets.storage_prefix_sets.clone();
         let storage_root_targets = StorageRootTargets::new(
             self.prefix_sets
                 .account_prefix_set
@@ -161,11 +166,15 @@ where
                         // be a possibility of re-adding a non-modified leaf to the hash builder.
                         None => {
                             tracker.inc_missed_leaves();
+                            let fallback_prefix_set = storage_prefix_sets
+                                .get(&hashed_address)
+                                .cloned()
+                                .unwrap_or_default();
                             StorageRoot::new_hashed(
                                 &provider,
                                 &provider,
                                 hashed_address,
-                                Default::default(),
+                                fallback_prefix_set,
                                 #[cfg(feature = "metrics")]
                                 self.metrics.storage_trie.clone(),
                             )

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use reth_execution_errors::{SparseTrieError, StateProofError, StorageRootError};
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
-use reth_tasks::Runtime;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory,
     node_iter::{TrieElement, TrieNodeIter},
@@ -37,8 +36,6 @@ pub struct ParallelStateRoot<Factory> {
     factory: Factory,
     // Prefix sets indicating which portions of the trie need to be recomputed.
     prefix_sets: TriePrefixSets,
-    /// The runtime handle for spawning blocking tasks.
-    runtime: Runtime,
     /// Parallel state root metrics.
     #[cfg(feature = "metrics")]
     metrics: ParallelStateRootMetrics,
@@ -46,11 +43,10 @@ pub struct ParallelStateRoot<Factory> {
 
 impl<Factory> ParallelStateRoot<Factory> {
     /// Create new parallel state root calculator.
-    pub fn new(factory: Factory, prefix_sets: TriePrefixSets, runtime: Runtime) -> Self {
+    pub fn new(factory: Factory, prefix_sets: TriePrefixSets) -> Self {
         Self {
             factory,
             prefix_sets,
-            runtime,
             #[cfg(feature = "metrics")]
             metrics: ParallelStateRootMetrics::default(),
         }
@@ -101,8 +97,6 @@ where
         debug!(target: "trie::parallel_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
         let mut storage_roots = HashMap::with_capacity(storage_root_targets.len());
 
-        let handle = self.runtime.handle().clone();
-
         for (hashed_address, prefix_set) in
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
         {
@@ -112,8 +106,10 @@ where
 
             let (tx, rx) = mpsc::sync_channel(1);
 
-            // Spawn a blocking task to calculate account's storage root from database I/O
-            drop(handle.spawn_blocking(move || {
+            // Dispatch storage-root computation onto the global rayon pool so a bounded set of
+            // worker threads (≈ CPU cores) consumes targets via work-stealing, matching the
+            // stage-level parallelism pattern used by `sender_recovery` and `hashing_storage`.
+            rayon::spawn(move || {
                 let result = (|| -> Result<_, ParallelStateRootError> {
                     let provider = factory.database_provider_ro()?;
                     Ok(StorageRoot::new_hashed(
@@ -127,7 +123,7 @@ where
                     .calculate(retain_updates)?)
                 })();
                 let _ = tx.send(result);
-            }));
+            });
             storage_roots.insert(hashed_address, rx);
         }
 
@@ -337,9 +333,8 @@ mod tests {
             provider_rw.commit().unwrap();
         }
 
-        let runtime = reth_tasks::Runtime::test();
         assert_eq!(
-            ParallelStateRoot::new(overlay_factory.clone(), Default::default(), runtime.clone())
+            ParallelStateRoot::new(overlay_factory.clone(), Default::default())
                 .incremental_root()
                 .unwrap(),
             test_utils::state_root(state.clone())
@@ -375,7 +370,7 @@ mod tests {
             overlay_factory.with_hashed_state_overlay(Some(Arc::new(hashed_state.into_sorted())));
 
         assert_eq!(
-            ParallelStateRoot::new(overlay_factory, prefix_sets.freeze(), runtime)
+            ParallelStateRoot::new(overlay_factory, prefix_sets.freeze())
                 .incremental_root()
                 .unwrap(),
             test_utils::state_root(state)

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -5,6 +5,7 @@ use alloy_primitives::B256;
 use alloy_rlp::{BufMut, Encodable};
 use itertools::Itertools;
 use reth_execution_errors::{SparseTrieError, StateProofError, StorageRootError};
+use reth_primitives_traits::Account;
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
@@ -12,11 +13,15 @@ use reth_trie::{
     node_iter::{TrieElement, TrieNodeIter},
     prefix_set::TriePrefixSets,
     trie_cursor::TrieCursorFactory,
-    updates::TrieUpdates,
+    updates::{StorageTrieUpdates, TrieUpdates},
     walker::TrieWalker,
     HashBuilder, Nibbles, StorageRoot, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use std::{collections::HashMap, sync::mpsc};
+use std::{
+    collections::BTreeMap,
+    sync::mpsc,
+    time::{Duration, Instant},
+};
 use thiserror::Error;
 use tracing::*;
 
@@ -62,14 +67,14 @@ where
 {
     /// Calculate incremental state root in parallel.
     pub fn incremental_root(self) -> Result<B256, ParallelStateRootError> {
-        self.calculate(false).map(|(root, _)| root)
+        self.calculate(false).map(|(root, _, _)| root)
     }
 
     /// Calculate incremental state root with updates in parallel.
     pub fn incremental_root_with_updates(
         self,
     ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
-        self.calculate(true)
+        self.calculate(true).map(|(root, _, updates)| (root, updates))
     }
 
     /// Computes the state root by calculating storage roots in parallel for modified accounts,
@@ -77,139 +82,183 @@ where
     fn calculate(
         self,
         retain_updates: bool,
-    ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
+    ) -> Result<(B256, usize, TrieUpdates), ParallelStateRootError> {
+        let Self {
+            factory,
+            prefix_sets,
+            #[cfg(feature = "metrics")]
+            metrics,
+        } = self;
+
         let mut tracker = ParallelTrieTracker::default();
-        // Retain a copy of the storage prefix sets so the worker-miss fallback below can build a
-        // `StorageRoot` with the account's actual modified slots, not an empty `PrefixSet`. With
-        // an empty set the fallback would silently return the on-disk root and discard the
-        // chunk's storage updates.
-        let storage_prefix_sets = self.prefix_sets.storage_prefix_sets.clone();
+        let total_start = Instant::now();
+        let mut state_root_ctx = ParallelStateRootContext::new();
+        let storage_prefix_sets = prefix_sets.storage_prefix_sets.clone();
         let storage_root_targets = StorageRootTargets::new(
-            self.prefix_sets
-                .account_prefix_set
-                .iter()
-                .map(|nibbles| B256::from_slice(&nibbles.pack())),
-            self.prefix_sets.storage_prefix_sets,
+            prefix_sets.account_prefix_set.iter().map(|nibbles| B256::from_slice(&nibbles.pack())),
+            prefix_sets.storage_prefix_sets,
         );
+        let total_storage_root_targets = storage_root_targets.len();
 
-        // Pre-calculate storage roots in parallel for accounts which were changed.
-        tracker.set_precomputed_storage_roots(storage_root_targets.len() as u64);
-        debug!(target: "trie::parallel_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
-        let mut storage_roots = HashMap::with_capacity(storage_root_targets.len());
+        tracker.set_precomputed_storage_roots(total_storage_root_targets as u64);
+        debug!(
+            target: "trie::parallel_state_root",
+            len = total_storage_root_targets,
+            "pre-calculating storage roots"
+        );
+        let mut storage_roots = BTreeMap::new();
+        let mut spawn_duration = Duration::ZERO;
 
+        // Eagerly dispatch every modified-storage target onto the global rayon pool. Rayon's
+        // work-stealing scheduler caps actual parallelism at ~CPU-cores, so queueing all targets
+        // up front is bounded in practice and matches the parallelism style of `sender_recovery`
+        // and `hashing_storage`.
         for (hashed_address, prefix_set) in
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
         {
-            let factory = self.factory.clone();
+            let factory = factory.clone();
             #[cfg(feature = "metrics")]
-            let metrics = self.metrics.storage_trie.clone();
+            let metrics = metrics.storage_trie.clone();
 
             let (tx, rx) = mpsc::sync_channel(1);
-
-            // Dispatch storage-root computation onto the global rayon pool so a bounded set of
-            // worker threads (≈ CPU cores) consumes targets via work-stealing, matching the
-            // stage-level parallelism pattern used by `sender_recovery` and `hashing_storage`.
+            let spawn_start = Instant::now();
             rayon::spawn(move || {
+                let task_start = Instant::now();
                 let result = (|| -> Result<_, ParallelStateRootError> {
                     let provider = factory.database_provider_ro()?;
-                    Ok(StorageRoot::new_hashed(
+                    let storage_root = StorageRoot::new_hashed(
                         &provider,
                         &provider,
                         hashed_address,
                         prefix_set,
                         #[cfg(feature = "metrics")]
                         metrics,
-                    )
-                    .calculate(retain_updates)?)
+                    );
+                    Ok(if retain_updates {
+                        storage_root.root_with_updates()?
+                    } else {
+                        (storage_root.root()?, 0, Default::default())
+                    })
                 })();
-                let _ = tx.send(result);
+                let _ = tx.send(StorageRootTaskOutput { result, duration: task_start.elapsed() });
             });
+            spawn_duration += spawn_start.elapsed();
             storage_roots.insert(hashed_address, rx);
         }
 
         trace!(target: "trie::parallel_state_root", "calculating state root");
-        let mut trie_updates = TrieUpdates::default();
-
-        let provider = self.factory.database_provider_ro()?;
+        let provider = factory.database_provider_ro()?;
 
         let walker = TrieWalker::<_>::state_trie(
             provider.account_trie_cursor().map_err(ProviderError::Database)?,
-            self.prefix_sets.account_prefix_set,
+            prefix_sets.account_prefix_set,
         )
         .with_deletions_retained(retain_updates);
         let mut account_node_iter = TrieNodeIter::state_trie(
             walker,
             provider.hashed_account_cursor().map_err(ProviderError::Database)?,
         );
-
         let mut hash_builder = HashBuilder::default().with_updates(retain_updates);
-        let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+
+        let account_walk_start = Instant::now();
+        let mut recv_wait_duration = Duration::ZERO;
+        let mut received_task_duration = Duration::ZERO;
+        let mut max_task_duration = Duration::ZERO;
+        let mut precomputed_storage_roots = 0usize;
+        let mut fallback_storage_roots = 0usize;
+
         while let Some(node) = account_node_iter.try_next().map_err(ProviderError::Database)? {
             match node {
                 TrieElement::Branch(node) => {
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
-                    let storage_root_result = match storage_roots.remove(&hashed_address) {
-                        Some(rx) => rx.recv().map_err(|_| {
-                            ParallelStateRootError::StorageRoot(StorageRootError::Database(
-                                DatabaseError::Other(format!(
-                                    "channel closed for {hashed_address}"
-                                )),
-                            ))
-                        })??,
-                        // Since we do not store all intermediate nodes in the database, there might
-                        // be a possibility of re-adding a non-modified leaf to the hash builder.
-                        None => {
-                            tracker.inc_missed_leaves();
-                            let fallback_prefix_set = storage_prefix_sets
-                                .get(&hashed_address)
-                                .cloned()
-                                .unwrap_or_default();
-                            StorageRoot::new_hashed(
-                                &provider,
-                                &provider,
-                                hashed_address,
-                                fallback_prefix_set,
-                                #[cfg(feature = "metrics")]
-                                self.metrics.storage_trie.clone(),
-                            )
-                            .calculate(retain_updates)?
+                    // Drop receivers for accounts the walker has already passed: their results
+                    // are no longer needed and holding the receivers would let the corresponding
+                    // workers' completion sit in memory until end-of-walk.
+                    while let Some((storage_hashed_address, _)) = storage_roots.first_key_value() {
+                        if *storage_hashed_address >= hashed_address {
+                            break;
                         }
-                    };
-
-                    let (storage_root, _, updates) = match storage_root_result {
-                        reth_trie::StorageRootProgress::Complete(root, _, updates) => (root, (), updates),
-                        reth_trie::StorageRootProgress::Progress(..) => {
-                            return Err(ParallelStateRootError::StorageRoot(
-                                StorageRootError::Database(DatabaseError::Other(
-                                    "StorageRoot returned Progress variant in parallel trie calculation".to_string()
-                                ))
-                            ))
-                        }
-                    };
-
-                    if retain_updates {
-                        trie_updates.insert_storage_updates(hashed_address, updates);
+                        storage_roots.pop_first();
                     }
 
-                    account_rlp.clear();
-                    let account = account.into_trie_account(storage_root);
-                    account.encode(&mut account_rlp as &mut dyn BufMut);
-                    hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
+                    let (storage_root, walked, storage_updates) = if let Some(rx) =
+                        storage_roots.remove(&hashed_address)
+                    {
+                        precomputed_storage_roots += 1;
+                        recv_storage_root_task_output(
+                            hashed_address,
+                            rx,
+                            &mut recv_wait_duration,
+                            &mut received_task_duration,
+                            &mut max_task_duration,
+                        )?
+                    } else {
+                        fallback_storage_roots += 1;
+                        tracker.inc_missed_leaves();
+                        // Defense-in-depth: if no worker ran this account's storage root, fall
+                        // back to the real prefix set. Using an empty `PrefixSet` would return
+                        // the on-disk root and drop this chunk's storage updates.
+                        let fallback_prefix_set =
+                            storage_prefix_sets.get(&hashed_address).cloned().unwrap_or_default();
+                        StorageRoot::new_hashed(
+                            &provider,
+                            &provider,
+                            hashed_address,
+                            fallback_prefix_set,
+                            #[cfg(feature = "metrics")]
+                            metrics.storage_trie.clone(),
+                        )
+                        .root_with_updates()?
+                    };
+
+                    state_root_ctx.add_leaf(
+                        hashed_address,
+                        account,
+                        storage_root,
+                        walked,
+                        storage_updates,
+                        &mut hash_builder,
+                        retain_updates,
+                    )?;
                 }
             }
         }
+        let account_walk_duration = account_walk_start.elapsed();
 
+        let root_start = Instant::now();
         let root = hash_builder.root();
+        let root_duration = root_start.elapsed();
 
+        let finalize_start = Instant::now();
         let removed_keys = account_node_iter.walker.take_removed_keys();
-        trie_updates.finalize(hash_builder, removed_keys, self.prefix_sets.destroyed_accounts);
+        let ParallelStateRootContext { mut trie_updates, hashed_entries_walked, .. } =
+            state_root_ctx;
+        trie_updates.finalize(hash_builder, removed_keys, prefix_sets.destroyed_accounts);
+        let finalize_duration = finalize_start.elapsed();
 
         let stats = tracker.finish();
+        let total_duration = total_start.elapsed();
 
         #[cfg(feature = "metrics")]
-        self.metrics.record_state_trie(stats);
+        metrics.record_state_trie(stats);
+
+        debug!(
+            target: "trie::parallel_state_root",
+            spawned_tasks = total_storage_root_targets,
+            precomputed_storage_roots,
+            fallback_storage_roots,
+            ?spawn_duration,
+            ?account_walk_duration,
+            ?recv_wait_duration,
+            ?received_task_duration,
+            ?max_task_duration,
+            ?root_duration,
+            ?finalize_duration,
+            ?total_duration,
+            "Calculated parallel state root timings"
+        );
 
         trace!(
             target: "trie::parallel_state_root",
@@ -222,7 +271,7 @@ where
             "Calculated state root"
         );
 
-        Ok((root, trie_updates))
+        Ok((root, hashed_entries_walked, trie_updates))
     }
 }
 
@@ -274,6 +323,78 @@ impl From<StateProofError> for ParallelStateRootError {
     }
 }
 
+struct StorageRootTaskOutput {
+    result: Result<(B256, usize, StorageTrieUpdates), ParallelStateRootError>,
+    duration: Duration,
+}
+
+/// Mutable state threaded through the account walker: reusable encoding buffer, accumulated
+/// trie updates, and running counters recorded into the final stats.
+#[derive(Debug)]
+struct ParallelStateRootContext {
+    /// Reusable buffer for encoding account data.
+    account_rlp: Vec<u8>,
+    /// Accumulates updates from account and storage root calculation.
+    trie_updates: TrieUpdates,
+    /// Tracks total hashed entries walked.
+    hashed_entries_walked: usize,
+}
+
+impl ParallelStateRootContext {
+    fn new() -> Self {
+        Self {
+            account_rlp: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
+            trie_updates: TrieUpdates::default(),
+            hashed_entries_walked: 0,
+        }
+    }
+
+    /// Emits a leaf node into the hash builder after the storage root for the corresponding
+    /// account has been produced (either by a worker or by the fallback path).
+    #[allow(clippy::too_many_arguments)]
+    fn add_leaf(
+        &mut self,
+        hashed_address: B256,
+        account: Account,
+        storage_root: B256,
+        storage_slots_walked: usize,
+        storage_updates: StorageTrieUpdates,
+        hash_builder: &mut HashBuilder,
+        retain_updates: bool,
+    ) -> Result<(), ParallelStateRootError> {
+        self.hashed_entries_walked += storage_slots_walked;
+        if retain_updates {
+            self.trie_updates.insert_storage_updates(hashed_address, storage_updates);
+        }
+
+        self.account_rlp.clear();
+        let trie_account = account.into_trie_account(storage_root);
+        trie_account.encode(&mut self.account_rlp as &mut dyn BufMut);
+        hash_builder.add_leaf(Nibbles::unpack(hashed_address), &self.account_rlp);
+
+        Ok(())
+    }
+}
+
+fn recv_storage_root_task_output(
+    hashed_address: B256,
+    rx: mpsc::Receiver<StorageRootTaskOutput>,
+    recv_wait_duration: &mut Duration,
+    received_task_duration: &mut Duration,
+    max_task_duration: &mut Duration,
+) -> Result<(B256, usize, StorageTrieUpdates), ParallelStateRootError> {
+    let recv_start = Instant::now();
+    let output = rx.recv().map_err(|_| {
+        ParallelStateRootError::StorageRoot(StorageRootError::Database(DatabaseError::Other(
+            format!("channel closed for {hashed_address}"),
+        )))
+    })?;
+    *recv_wait_duration += recv_start.elapsed();
+    *received_task_duration += output.duration;
+    *max_task_duration = (*max_task_duration).max(output.duration);
+    output.result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,7 +403,7 @@ mod tests {
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
     use reth_trie::{test_utils, HashedPostState, HashedStorage};
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     #[tokio::test]
     async fn random_parallel_root() {

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use reth_execution_errors::{SparseTrieError, StateProofError, StorageRootError};
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
+use reth_tasks::Runtime;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory,
     node_iter::{TrieElement, TrieNodeIter},
@@ -36,6 +37,10 @@ pub struct ParallelStateRoot<Factory> {
     factory: Factory,
     // Prefix sets indicating which portions of the trie need to be recomputed.
     prefix_sets: TriePrefixSets,
+    /// Runtime handle. Storage-root workers are dispatched onto
+    /// [`Runtime::storage_pool`] so they get reth's named storage threads, panic handler,
+    /// and configurable pool size instead of rayon's anonymous global pool.
+    runtime: Runtime,
     /// Parallel state root metrics.
     #[cfg(feature = "metrics")]
     metrics: ParallelStateRootMetrics,
@@ -43,10 +48,11 @@ pub struct ParallelStateRoot<Factory> {
 
 impl<Factory> ParallelStateRoot<Factory> {
     /// Create new parallel state root calculator.
-    pub fn new(factory: Factory, prefix_sets: TriePrefixSets) -> Self {
+    pub fn new(factory: Factory, prefix_sets: TriePrefixSets, runtime: Runtime) -> Self {
         Self {
             factory,
             prefix_sets,
+            runtime,
             #[cfg(feature = "metrics")]
             metrics: ParallelStateRootMetrics::default(),
         }
@@ -102,9 +108,13 @@ where
 
             let (tx, rx) = mpsc::sync_channel(1);
 
-            // Dispatch storage-root computation onto the global rayon pool so a bounded set of
-            // worker threads (≈ CPU cores) consumes targets via work-stealing.
-            rayon::spawn(move || {
+            // Dispatch storage-root computation onto reth's `cpu_pool` — a rayon pool sized
+            // to `available_parallelism()` with named `cpu-NN` threads and a reth-wide
+            // panic handler. Sticking with the configured pool (rather than `rayon::spawn`
+            // on the global default) keeps the workers visible to profilers and respects
+            // reth's `RayonConfig`. `storage_pool` would oversubscribe on hosts where
+            // `DEFAULT_STORAGE_POOL_THREADS (= 16)` exceeds physical CPU threads.
+            self.runtime.cpu_pool().spawn(move || {
                 let result = (|| -> Result<_, ParallelStateRootError> {
                     let provider = factory.database_provider_ro()?;
                     Ok(StorageRoot::new_hashed(
@@ -331,8 +341,9 @@ mod tests {
             provider_rw.commit().unwrap();
         }
 
+        let runtime = reth_tasks::Runtime::test();
         assert_eq!(
-            ParallelStateRoot::new(overlay_factory.clone(), Default::default())
+            ParallelStateRoot::new(overlay_factory.clone(), Default::default(), runtime.clone())
                 .incremental_root()
                 .unwrap(),
             test_utils::state_root(state.clone())
@@ -368,7 +379,7 @@ mod tests {
             overlay_factory.with_hashed_state_overlay(Some(Arc::new(hashed_state.into_sorted())));
 
         assert_eq!(
-            ParallelStateRoot::new(overlay_factory, prefix_sets.freeze())
+            ParallelStateRoot::new(overlay_factory, prefix_sets.freeze(), runtime)
                 .incremental_root()
                 .unwrap(),
             test_utils::state_root(state)

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -16,7 +16,7 @@ use reth_trie::{
     walker::TrieWalker,
     HashBuilder, Nibbles, StorageRoot, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use std::{collections::BTreeMap, sync::mpsc};
+use std::{collections::HashMap, sync::mpsc};
 use thiserror::Error;
 use tracing::*;
 
@@ -91,7 +91,7 @@ where
         // Pre-calculate storage roots in parallel for accounts which were changed.
         tracker.set_precomputed_storage_roots(storage_root_targets.len() as u64);
         debug!(target: "trie::parallel_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
-        let mut storage_roots = BTreeMap::new();
+        let mut storage_roots = HashMap::with_capacity(storage_root_targets.len());
 
         for (hashed_address, prefix_set) in
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
@@ -145,16 +145,6 @@ where
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
-                    // Drop receivers for accounts the walker has already passed: their results
-                    // are no longer needed and holding the receivers would let the corresponding
-                    // workers' completion sit in memory until end-of-walk.
-                    while let Some((storage_hashed_address, _)) = storage_roots.first_key_value() {
-                        if *storage_hashed_address >= hashed_address {
-                            break;
-                        }
-                        storage_roots.pop_first();
-                    }
-
                     let storage_root_result = match storage_roots.remove(&hashed_address) {
                         Some(rx) => rx.recv().map_err(|_| {
                             ParallelStateRootError::StorageRoot(StorageRootError::Database(


### PR DESCRIPTION
Adds `ParallelMerkleExecutionStage` driving `ParallelStateRoot` for the incremental path. The pipeline's `MerkleExecute` slot routes to the new stage, which dispatches based on the input:

| Input | Routes to |
|---|---|
| range > `rebuild_threshold` (default 100k, full rebuild) | serial `MerkleStage::Execution` |
| `from_block == 1` (initial merkleization) | serial `MerkleStage::Execution` |
| chunk modifies < 1024 storage tries (parallel overhead too high) | serial `MerkleStage::Execution` |
| empty range | no-op |
| otherwise (incremental, ≥ 1024 modified storage tries) | **`ParallelStateRoot`** |

`MerkleStage::Unwind` keeps the `MerkleUnwind` slot. The serial rebuild path — including its existing Progress/Resume + intra-storage checkpointing that handles XEN-class accounts — is unchanged.

## `ParallelStateRoot::calculate` changes

- `tokio::spawn_blocking` → `rayon::spawn` (work-stealing pool sized to CPU cores, matching `sender_recovery` / `hashing_storage`).
- Eager spawn-all → bounded frontier (`max_in_flight_storage_root_tasks`).
- Worker-miss fallback uses the account's real `storage_prefix_set` instead of `Default::default()` (the empty-set path silently dropped storage updates when the frontier throttled).

## Equivalence

- `parallel_trie_updates_match_serial` — `(root, TrieUpdates)` bit-for-bit identical to serial.
- `parallel_multi_chunk_trie_tables_match_serial` — multi-chunk run leaves `AccountsTrie` / `StoragesTrie` matching serial.

## Bench

Hetzner i7-8700, 12 threads, mainnet:

| Workload | Serial | Parallel | Δ |
|---|---:|---:|---:|
| 2000 blocks (24885314 → 24887313) | 38.0 s | 30.2 s | **−21 %** |
| 7000 blocks (24885314 → 24892314) | 112.4 s | 85.8 s | **−24 %** |
| 13811 blocks (24887313 → 24901124), includes a heavy account | 814 s | 494 s | **−39 %** |

The 13811-block chunk contains one heavy account whose storage root alone takes ~60 s; absorbing it on a worker while the main thread keeps walking is the main driver of the 39 % win. 

## Scope

- Engine tree (sparse trie) live-sync path is untouched.
- Worker granularity is per-account; intra-account storage parallelism is out of scope (XEN-class single-account stalls remain).
- `root_with_progress` intentionally not exposed — bench shows per-`Progress` overhead in parallel is ~100× serial, so chunks run single-shot.
