### PR TITLE
[autoopt] 20260420-3-fx-history-index-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9991,6 +9991,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
+ "rustc-hash",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -63,6 +63,7 @@ itertools.workspace = true
 rayon.workspace = true
 page_size.workspace = true
 num-traits.workspace = true
+rustc-hash.workspace = true
 tempfile = { workspace = true, optional = true }
 reqwest.workspace = true
 eyre.workspace = true

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -20,7 +20,8 @@ use reth_provider::{
 use reth_stages_api::StageError;
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{ChangeSetReader, StorageChangeSetReader};
-use std::{collections::HashMap, hash::Hash, ops::RangeBounds};
+use rustc_hash::FxHashMap;
+use std::{hash::Hash, ops::RangeBounds};
 use tracing::info;
 
 /// Number of blocks before pushing indices from cache to [`Collector`]
@@ -59,9 +60,9 @@ where
     let mut changeset_cursor = provider.tx_ref().cursor_read::<CS>()?;
 
     let mut collector = Collector::new(etl_config.file_size, etl_config.dir.clone());
-    let mut cache: HashMap<P, Vec<u64>> = HashMap::default();
+    let mut cache: FxHashMap<P, Vec<u64>> = FxHashMap::default();
 
-    let mut collect = |cache: &mut HashMap<P, Vec<u64>>| {
+    let mut collect = |cache: &mut FxHashMap<P, Vec<u64>>| {
         for (key, indices) in cache.drain() {
             let last = *indices.last().expect("qed");
             collector
@@ -179,7 +180,7 @@ where
     Provider: DBProvider + StorageChangeSetReader + StaticFileProviderFactory,
 {
     let mut collector = Collector::new(etl_config.file_size, etl_config.dir.clone());
-    let mut cache: HashMap<AddressStorageKey, Vec<u64>> = HashMap::default();
+    let mut cache: FxHashMap<AddressStorageKey, Vec<u64>> = FxHashMap::default();
 
     let mut insert_fn = |key: AddressStorageKey, indices: Vec<u64>| {
         let last = indices.last().expect("qed");


### PR DESCRIPTION
# Use FxHashMap for history index collection caches
## Evidence
- In the `24661085244` baseline profile, a hot `tokio-rt` thread spends about 6,105 exclusive samples in `Sip13Rounds::c_rounds` and about 4,796 exclusive samples in `reth_stages::stages::utils::collect_storage_history_indices`.
- `crates/stages/stages/src/stages/utils.rs` currently uses the default `HashMap` in both the generic `collect_history_indices` cache and the storage-history cache, so every accumulation step pays SipHash cost on sequentially generated stage keys.
- This does not overlap the prior RocksDB shard layout experiments; it targets the in-memory accumulation cache before those shards are flushed.

## Hypothesis
If we switch the history index accumulation caches to `FxHashMap`, gas throughput improves by ~0.2-0.5% because the sequential history-index collection path spends less CPU hashing hot cache keys.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.2%

## Plan
- Add `rustc-hash` to `crates/stages/stages/Cargo.toml`.
- Replace the default `HashMap` caches in `crates/stages/stages/src/stages/utils.rs` with `FxHashMap` for the generic changeset collector and storage-history collector.
- Verify with `cargo check -p reth-stages` and an existing storage-history stage test.