### PR TITLE
[autoopt] 20260420-3-wiped-storage-write-fast-path

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -281,12 +281,30 @@ where
         &mut self,
         updates: &StorageTrieUpdatesSorted,
     ) -> Result<usize, DatabaseError> {
+        let mut num_entries = 0;
+
         // The storage trie for this account has to be deleted.
         if updates.is_deleted() && self.cursor.seek_exact(self.hashed_address)?.is_some() {
             self.cursor.delete_current_duplicates()?;
         }
 
-        let mut num_entries = 0;
+        if updates.is_deleted() {
+            for (nibbles, maybe_updated) in
+                updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
+            {
+                num_entries += 1;
+
+                if let Some(node) = maybe_updated {
+                    self.cursor.upsert(
+                        self.hashed_address,
+                        &A::StorageValue::new(A::StorageSubKey::from(*nibbles), node.clone()),
+                    )?;
+                }
+            }
+
+            return Ok(num_entries)
+        }
+
         for (nibbles, maybe_updated) in updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
         {
             num_entries += 1;


### PR DESCRIPTION
# Skip redundant probes after wiping a storage trie
## Evidence
- The baseline-1 latency data is still dominated by `persistence_wait`, with a mean of about 23.3ms per block and p95 above 222ms.
- The baseline-1 samply persistence thread spends about 134k inclusive samples in `write_trie_updates_sorted`, which still funnels through `DatabaseStorageTrieCursor::write_storage_trie_updates_sorted` for storage trie persistence.
- In `crates/trie/db/src/trie_cursor.rs`, `write_storage_trie_updates_sorted` deletes all duplicates up front when `updates.is_deleted()`, but still performs a `seek_by_key_subkey` existence probe for every subsequent storage node even though the trie has already been cleared for that account.

## Hypothesis
If we special-case wiped storage trie writes to delete duplicates once and then insert replacement nodes without per-node existence probes, gas throughput improves by ~0.5-1.5% because persistence avoids redundant MDBX cursor seeks on a hot write path.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.5%

## Plan
- Update `crates/trie/db/src/trie_cursor.rs` so the wiped-storage branch clears duplicates once, then writes only the surviving `Some(node)` updates directly.