### PR TITLE
test: remove unsafe env::set_var(RUST_LOG) from tests

### DIFF
--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -491,7 +491,6 @@ mod tests {
     fn parse_env_filter_directives() {
         let temp_dir = tempfile::tempdir().unwrap();
 
-        unsafe { std::env::set_var("RUST_LOG", "info,evm=debug") };
         let reth = Cli::try_parse_args_from([
             "reth",
             "init",

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -698,8 +698,6 @@ mod test {
     use ::enr::{CombinedKey, EnrKey};
     use rand_08::thread_rng;
     use reth_chainspec::MAINNET;
-    use reth_tracing::init_test_tracing;
-    use std::env;
     use tracing::trace;
 
     fn discv5_noop() -> Discv5 {
@@ -937,11 +935,6 @@ mod test {
 
     #[test]
     fn get_fork_id_with_different_network_stack_ids() {
-        unsafe {
-            env::set_var("RUST_LOG", "net::discv5=trace");
-        }
-        init_test_tracing();
-
         let fork_id = MAINNET.latest_fork_id();
         let sk = SecretKey::new(&mut thread_rng());
 


### PR DESCRIPTION
Two tests mutated process-global `RUST_LOG` via `unsafe env::set_var` without restoring it. The discv5 one was debug leftover — assertions do not read logs. The `parse_env_filter_directives` test still covers directive parsing via `--log.file.filter`; the `RUST_LOG` read path is handled by `EnvFilter::from_env_lossy` itself.