### PR TITLE
feat(net): add BAL requirement to block access list requests

### DIFF
--- a/crates/net/network/src/fetch/client.rs
+++ b/crates/net/network/src/fetch/client.rs
@@ -6,7 +6,7 @@ use futures::{future, future::Either};
 use reth_eth_wire::{BlockAccessLists, EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::{
-    block_access_lists::client::BlockAccessListsClient,
+    block_access_lists::client::{BalRequirement, BlockAccessListsClient},
     bodies::client::{BodiesClient, BodiesFut},
     download::DownloadClient,
     error::{PeerRequestResult, RequestError},
@@ -136,10 +136,28 @@ impl<N: NetworkPrimitives> BlockAccessListsClient for FetchClient<N> {
         hashes: Vec<B256>,
         priority: Priority,
     ) -> Self::Output {
+        self.get_block_access_lists_with_priority_and_requirement(
+            hashes,
+            priority,
+            BalRequirement::Mandatory,
+        )
+    }
+
+    fn get_block_access_lists_with_priority_and_requirement(
+        &self,
+        hashes: Vec<B256>,
+        priority: Priority,
+        requirement: BalRequirement,
+    ) -> Self::Output {
         let (response, rx) = oneshot::channel();
         if self
             .request_tx
-            .send(DownloadRequest::GetBlockAccessLists { request: hashes, response, priority })
+            .send(DownloadRequest::GetBlockAccessLists {
+                request: hashes,
+                response,
+                priority,
+                requirement,
+            })
             .is_ok()
         {
             Box::pin(FlattenedResponse::from(rx))

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -160,15 +160,10 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     /// full history available
     fn next_best_peer(&self, requirement: BestPeerRequirements) -> Option<PeerId> {
         // filter out peers that aren't idle or don't meet the requirement
-        let mut idle = self.peers.iter().filter(|(_, peer)| {
-            peer.state.is_idle() &&
-                match &requirement {
-                    BestPeerRequirements::EthVersion(ver) => {
-                        peer.capabilities.supports_eth_at_least(ver)
-                    }
-                    _ => true,
-                }
-        });
+        let mut idle = self
+            .peers
+            .iter()
+            .filter(|(_, peer)| peer.state.is_idle() && peer.satisfies(&requirement));
 
         let mut best_peer = idle.next()?;
 
@@ -497,6 +492,16 @@ impl Peer {
 
     fn range(&self) -> Option<RangeInclusive<u64>> {
         self.range_info.as_ref().map(|info| info.range())
+    }
+
+    /// Returns whether this peer can serve requests with the given hard requirements.
+    fn satisfies(&self, requirement: &BestPeerRequirements) -> bool {
+        match requirement {
+            BestPeerRequirements::EthVersion(ver) => self.capabilities.supports_eth_at_least(ver),
+            BestPeerRequirements::None |
+            BestPeerRequirements::FullBlock |
+            BestPeerRequirements::FullBlockRange(_) => true,
+        }
     }
 
     /// Returns true if this peer has a better range than the other peer for serving the requested

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -197,7 +197,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     }
 
     /// Returns whether any connected peer can serve BAL requests.
-    fn has_bal_capable_peer(&self) -> bool {
+    fn has_eth71_peer(&self) -> bool {
         self.peers.values().any(|peer| {
             !matches!(peer.state, PeerState::Closing) &&
                 peer.capabilities.supports_eth_at_least(&EthVersion::Eth71)
@@ -244,7 +244,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
                                 requirement: BalRequirement::Optional,
                                 ..
                             }
-                        ) && !self.has_bal_capable_peer()
+                        ) && !self.has_eth71_peer()
                         {
                             request.send_err_response(RequestError::UnsupportedCapability);
                             continue

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -206,9 +206,13 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
     /// Returns the next action to return
     fn poll_action(&mut self) -> PollAction {
-        // We only pop once we know the queue is non-empty.
+        // we only check and not pop here since we don't know yet whether a peer is available.
         if self.queued_requests.is_empty() {
             return PollAction::NoRequests
+        }
+
+        if self.peers.is_empty() {
+            return PollAction::NoPeersAvailable
         }
 
         let request = self.queued_requests.pop_front().expect("not empty");
@@ -252,7 +256,8 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
                         match request.get_priority() {
                             Priority::High => {
-                                // Queue before the first normal request.
+                                // find first normal request and queue before it; add this request
+                                // to the back of the high-priority queue
                                 let pos = self
                                     .queued_requests
                                     .iter()

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -237,14 +237,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
                 // poll incoming requests
                 match self.download_requests_rx.poll_next_unpin(cx) {
                     Poll::Ready(Some(request)) => {
-                        if matches!(
-                            request,
-                            DownloadRequest::GetBlockAccessLists {
-                                requirement: BalRequirement::Optional,
-                                ..
-                            }
-                        ) && !self.has_eth71_peer()
-                        {
+                        if request.is_optional_bal() && !self.has_eth71_peer() {
                             request.send_err_response(RequestError::UnsupportedCapability);
                             continue
                         }
@@ -666,6 +659,11 @@ impl<N: NetworkPrimitives> DownloadRequest<N> {
     /// Returns `true` if this request is normal priority.
     const fn is_normal_priority(&self) -> bool {
         self.get_priority().is_normal()
+    }
+
+    /// Returns `true` if this is an optional BAL request.
+    const fn is_optional_bal(&self) -> bool {
+        matches!(self, Self::GetBlockAccessLists { requirement: BalRequirement::Optional, .. })
     }
 
     /// Sends an error response to the waiting caller.

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -13,6 +13,7 @@ use reth_eth_wire::{
 };
 use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::{
+    block_access_lists::client::BalRequirement,
     error::{EthResponseValidator, PeerRequestResult, RequestError, RequestResult},
     headers::client::HeadersRequest,
     priority::Priority,
@@ -195,28 +196,39 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
         Some(*best_peer.0)
     }
 
+    /// Returns whether any connected peer can serve BAL requests.
+    fn has_bal_capable_peer(&self) -> bool {
+        self.peers.values().any(|peer| {
+            !matches!(peer.state, PeerState::Closing) &&
+                peer.capabilities.supports_eth_at_least(&EthVersion::Eth71)
+        })
+    }
+
     /// Returns the next action to return
     fn poll_action(&mut self) -> PollAction {
-        // we only check and not pop here since we don't know yet whether a peer is available.
-        if self.queued_requests.is_empty() {
-            return PollAction::NoRequests
+        loop {
+            // we only check and not pop here since we don't know yet whether a peer is available.
+            if self.queued_requests.is_empty() {
+                return PollAction::NoRequests
+            }
+
+            let request = self.queued_requests.pop_front().expect("not empty");
+            let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
+                if request.should_complete_without_capable_peer(self.has_bal_capable_peer()) {
+                    request.send_err_response(RequestError::UnsupportedCapability);
+                    continue
+                }
+
+                // no peer matches this request's requirements; requeue at the back so other
+                // queued requests get a chance on the next poll instead of head-of-line blocking.
+                self.queued_requests.push_back(request);
+                return PollAction::NoPeersAvailable
+            };
+
+            let request = self.prepare_block_request(peer_id, request);
+
+            return PollAction::Ready(FetchAction::BlockRequest { peer_id, request })
         }
-
-        if self.peers.is_empty() {
-            return PollAction::NoPeersAvailable
-        }
-
-        let request = self.queued_requests.pop_front().expect("not empty");
-        let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
-            // no peer matches this request's requirements; requeue at the back so other
-            // queued requests get a chance on the next poll instead of head-of-line blocking.
-            self.queued_requests.push_back(request);
-            return PollAction::NoPeersAvailable
-        };
-
-        let request = self.prepare_block_request(peer_id, request);
-
-        PollAction::Ready(FetchAction::BlockRequest { peer_id, request })
     }
 
     /// Advance the state the syncer
@@ -602,6 +614,7 @@ pub(crate) enum DownloadRequest<N: NetworkPrimitives> {
         request: Vec<B256>,
         response: oneshot::Sender<PeerRequestResult<BlockAccessLists>>,
         priority: Priority,
+        requirement: BalRequirement,
     },
     /// Download receipts for the given block hashes and send response through channel
     GetReceipts {
@@ -637,6 +650,22 @@ impl<N: NetworkPrimitives> DownloadRequest<N> {
     /// Returns `true` if this request is normal priority.
     const fn is_normal_priority(&self) -> bool {
         self.get_priority().is_normal()
+    }
+
+    /// Returns whether the request may complete locally when no capable peer exists.
+    const fn should_complete_without_capable_peer(&self, has_bal_capable_peer: bool) -> bool {
+        matches!(self, Self::GetBlockAccessLists { requirement: BalRequirement::Optional, .. }) &&
+            !has_bal_capable_peer
+    }
+
+    /// Sends an error response to the waiting caller.
+    fn send_err_response(self, err: RequestError) {
+        let _ = match self {
+            Self::GetBlockHeaders { response, .. } => response.send(Err(err)).ok(),
+            Self::GetBlockBodies { response, .. } => response.send(Err(err)).ok(),
+            Self::GetBlockAccessLists { response, .. } => response.send(Err(err)).ok(),
+            Self::GetReceipts { response, .. } => response.send(Err(err)).ok(),
+        };
     }
 
     /// Returns the best peer requirements for this request.
@@ -1541,6 +1570,7 @@ mod tests {
             request: vec![],
             response: tx,
             priority: Priority::Normal,
+            requirement: BalRequirement::Mandatory,
         });
 
         let waker = noop_waker();
@@ -1582,5 +1612,77 @@ mod tests {
         if let Poll::Ready(FetchAction::BlockRequest { peer_id, .. }) = fetcher.poll(&mut cx) {
             assert_eq!(peer_id, peer_71);
         }
+    }
+
+    #[tokio::test]
+    async fn test_optional_bal_request_completes_without_capable_peer() {
+        use futures::task::noop_waker;
+        use std::task::{Context, Poll};
+
+        let manager = PeersManager::new(PeersConfig::default());
+        let mut fetcher =
+            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
+
+        let peer_old = B512::random();
+        let caps_old = Arc::new(Capabilities::new(vec![]));
+        fetcher.new_active_peer(
+            peer_old,
+            B256::random(),
+            100,
+            caps_old,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+
+        let (tx, rx) = oneshot::channel();
+        fetcher.queued_requests.push_back(DownloadRequest::GetBlockAccessLists {
+            request: vec![],
+            response: tx,
+            priority: Priority::Normal,
+            requirement: BalRequirement::Optional,
+        });
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
+        assert!(fetcher.queued_requests.is_empty());
+        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::UnsupportedCapability);
+    }
+
+    #[tokio::test]
+    async fn test_optional_bal_request_waits_for_busy_capable_peer() {
+        use futures::task::noop_waker;
+        use std::task::{Context, Poll};
+
+        let manager = PeersManager::new(PeersConfig::default());
+        let mut fetcher =
+            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
+
+        let peer_71 = B512::random();
+        let caps_71 = Arc::new(Capabilities::from(vec![Capability::new("eth".into(), 71)]));
+        fetcher.new_active_peer(
+            peer_71,
+            B256::random(),
+            100,
+            caps_71,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+        fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
+
+        let (tx, _rx) = oneshot::channel();
+        fetcher.queued_requests.push_back(DownloadRequest::GetBlockAccessLists {
+            request: vec![],
+            response: tx,
+            priority: Priority::Normal,
+            requirement: BalRequirement::Optional,
+        });
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
+        assert_eq!(fetcher.queued_requests.len(), 1);
     }
 }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -237,6 +237,8 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
                 // poll incoming requests
                 match self.download_requests_rx.poll_next_unpin(cx) {
                     Poll::Ready(Some(request)) => {
+                        // Optional BAL requests should not wait for future peer churn if no
+                        // connected peer can serve them right now.
                         if request.is_optional_bal() && !self.has_eth71_peer() {
                             request.send_err_response(RequestError::UnsupportedCapability);
                             continue

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -212,9 +212,15 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
         let request = self.queued_requests.pop_front().expect("not empty");
         let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
-            // no peer matches this request's requirements; requeue at the back so other
-            // queued requests get a chance on the next poll instead of head-of-line blocking.
-            self.queued_requests.push_back(request);
+            // Optional BAL requests can lose their eth/71 peer while queued; complete them
+            // instead of waiting for future peer churn.
+            if request.is_optional_bal() && !self.has_eth71_peer() {
+                request.send_err_response(RequestError::UnsupportedCapability);
+            } else {
+                // no peer matches this request's requirements; requeue at the back so other
+                // queued requests get a chance on the next poll instead of head-of-line blocking.
+                self.queued_requests.push_back(request);
+            }
             return PollAction::NoPeersAvailable
         };
 
@@ -1700,5 +1706,61 @@ mod tests {
 
         assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
         assert_eq!(fetcher.queued_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_queued_optional_bal_request_rejected_after_eth71_disconnect() {
+        use futures::task::noop_waker;
+        use std::task::{Context, Poll};
+
+        let manager = PeersManager::new(PeersConfig::default());
+        let mut fetcher =
+            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
+
+        let peer_old = B512::random();
+        let caps_old = Arc::new(Capabilities::new(vec![]));
+        fetcher.new_active_peer(
+            peer_old,
+            B256::random(),
+            100,
+            caps_old,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+
+        let peer_71 = B512::random();
+        let caps_71 = Arc::new(Capabilities::from(vec![Capability::new("eth".into(), 71)]));
+        fetcher.new_active_peer(
+            peer_71,
+            B256::random(),
+            100,
+            caps_71,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+        fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
+
+        let (tx, rx) = oneshot::channel();
+        fetcher
+            .download_requests_tx
+            .send(DownloadRequest::GetBlockAccessLists {
+                request: vec![],
+                response: tx,
+                priority: Priority::Normal,
+                requirement: BalRequirement::Optional,
+            })
+            .unwrap();
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
+        assert_eq!(fetcher.queued_requests.len(), 1);
+
+        fetcher.on_session_closed(&peer_71);
+
+        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
+        assert!(fetcher.queued_requests.is_empty());
+        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::UnsupportedCapability);
     }
 }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -206,24 +206,22 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
     /// Returns the next action to return
     fn poll_action(&mut self) -> PollAction {
-        loop {
-            // we only check and not pop here since we don't know yet whether a peer is available.
-            if self.queued_requests.is_empty() {
-                return PollAction::NoRequests
-            }
-
-            let request = self.queued_requests.pop_front().expect("not empty");
-            let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
-                // no peer matches this request's requirements; requeue at the back so other
-                // queued requests get a chance on the next poll instead of head-of-line blocking.
-                self.queued_requests.push_back(request);
-                return PollAction::NoPeersAvailable
-            };
-
-            let request = self.prepare_block_request(peer_id, request);
-
-            return PollAction::Ready(FetchAction::BlockRequest { peer_id, request })
+        // We only pop once we know the queue is non-empty.
+        if self.queued_requests.is_empty() {
+            return PollAction::NoRequests
         }
+
+        let request = self.queued_requests.pop_front().expect("not empty");
+        let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
+            // no peer matches this request's requirements; requeue at the back so other
+            // queued requests get a chance on the next poll instead of head-of-line blocking.
+            self.queued_requests.push_back(request);
+            return PollAction::NoPeersAvailable
+        };
+
+        let request = self.prepare_block_request(peer_id, request);
+
+        PollAction::Ready(FetchAction::BlockRequest { peer_id, request })
     }
 
     /// Advance the state the syncer

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -160,15 +160,10 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     /// full history available
     fn next_best_peer(&self, requirement: BestPeerRequirements) -> Option<PeerId> {
         // filter out peers that aren't idle or don't meet the requirement
-        let mut idle = self.peers.iter().filter(|(_, peer)| {
-            peer.state.is_idle() &&
-                match &requirement {
-                    BestPeerRequirements::EthVersion(ver) => {
-                        peer.capabilities.supports_eth_at_least(ver)
-                    }
-                    _ => true,
-                }
-        });
+        let mut idle = self
+            .peers
+            .iter()
+            .filter(|(_, peer)| peer.state.is_idle() && peer.satisfies(&requirement));
 
         let mut best_peer = idle.next()?;
 
@@ -206,9 +201,19 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
     /// Returns the next action to return
     fn poll_action(&mut self) -> PollAction {
-        // We only pop once we know the queue is non-empty.
+        // we only check and not pop here since we don't know yet whether a peer is available.
         if self.queued_requests.is_empty() {
             return PollAction::NoRequests
+        }
+
+        self.reject_optional_bal_requests_without_eth71();
+
+        if self.queued_requests.is_empty() {
+            return PollAction::NoRequests
+        }
+
+        if self.peers.is_empty() {
+            return PollAction::NoPeersAvailable
         }
 
         let request = self.queued_requests.pop_front().expect("not empty");
@@ -252,7 +257,8 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
                         match request.get_priority() {
                             Priority::High => {
-                                // Queue before the first normal request.
+                                // find first normal request and queue before it; add this request
+                                // to the back of the high-priority queue
                                 let pos = self
                                     .queued_requests
                                     .iter()
@@ -274,6 +280,24 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
             if self.queued_requests.is_empty() || no_peers_available {
                 return Poll::Pending
+            }
+        }
+    }
+
+    /// Rejects queued optional BAL requests if no connected peer can serve them.
+    fn reject_optional_bal_requests_without_eth71(&mut self) {
+        if self.has_eth71_peer() {
+            return
+        }
+
+        let mut idx = 0;
+        while idx < self.queued_requests.len() {
+            if self.queued_requests[idx].is_optional_bal() {
+                if let Some(request) = self.queued_requests.remove(idx) {
+                    request.send_err_response(RequestError::UnsupportedCapability);
+                }
+            } else {
+                idx += 1;
             }
         }
     }
@@ -321,9 +345,24 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     ///
     /// Caution: this expects that the peer is _not_ closed.
     fn followup_request(&mut self, peer_id: PeerId) -> Option<BlockResponseOutcome> {
-        let req = self.queued_requests.pop_front()?;
-        let req = self.prepare_block_request(peer_id, req);
-        Some(BlockResponseOutcome::Request(peer_id, req))
+        self.reject_optional_bal_requests_without_eth71();
+
+        let queued_len = self.queued_requests.len();
+        for _ in 0..queued_len {
+            let req = self.queued_requests.pop_front()?;
+            let can_request = self.peers.get(&peer_id).is_some_and(|peer| {
+                peer.state.is_idle() && peer.satisfies(&req.best_peer_requirements())
+            });
+
+            if can_request {
+                let req = self.prepare_block_request(peer_id, req);
+                return Some(BlockResponseOutcome::Request(peer_id, req))
+            }
+
+            self.queued_requests.push_back(req);
+        }
+
+        None
     }
 
     /// Called on a `GetBlockHeaders` response from a peer.
@@ -494,6 +533,16 @@ impl Peer {
         self.range_info.as_ref().map(|info| info.range())
     }
 
+    /// Returns whether this peer can serve requests with the given hard requirements.
+    fn satisfies(&self, requirement: &BestPeerRequirements) -> bool {
+        match requirement {
+            BestPeerRequirements::EthVersion(ver) => self.capabilities.supports_eth_at_least(ver),
+            BestPeerRequirements::None |
+            BestPeerRequirements::FullBlock |
+            BestPeerRequirements::FullBlockRange(_) => true,
+        }
+    }
+
     /// Returns true if this peer has a better range than the other peer for serving the requested
     /// range.
     ///
@@ -656,6 +705,11 @@ impl<N: NetworkPrimitives> DownloadRequest<N> {
     /// Returns `true` if this request is normal priority.
     const fn is_normal_priority(&self) -> bool {
         self.get_priority().is_normal()
+    }
+
+    /// Returns `true` if this is an optional BAL request.
+    const fn is_optional_bal(&self) -> bool {
+        matches!(self, Self::GetBlockAccessLists { requirement: BalRequirement::Optional, .. })
     }
 
     /// Sends an error response to the waiting caller.
@@ -1690,5 +1744,99 @@ mod tests {
 
         assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
         assert_eq!(fetcher.queued_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_queued_optional_bal_request_rejected_after_eth71_disconnect() {
+        use futures::task::noop_waker;
+        use std::task::{Context, Poll};
+
+        let manager = PeersManager::new(PeersConfig::default());
+        let mut fetcher =
+            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
+
+        let peer_71 = B512::random();
+        let caps_71 = Arc::new(Capabilities::from(vec![Capability::new("eth".into(), 71)]));
+        fetcher.new_active_peer(
+            peer_71,
+            B256::random(),
+            100,
+            caps_71,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+        fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
+
+        let (tx, rx) = oneshot::channel();
+        fetcher
+            .download_requests_tx
+            .send(DownloadRequest::GetBlockAccessLists {
+                request: vec![],
+                response: tx,
+                priority: Priority::Normal,
+                requirement: BalRequirement::Optional,
+            })
+            .unwrap();
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
+        assert_eq!(fetcher.queued_requests.len(), 1);
+
+        fetcher.on_session_closed(&peer_71);
+
+        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
+        assert!(fetcher.queued_requests.is_empty());
+        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::UnsupportedCapability);
+    }
+
+    #[tokio::test]
+    async fn test_followup_skips_bal_for_peer_without_eth71() {
+        let manager = PeersManager::new(PeersConfig::default());
+        let mut fetcher =
+            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
+
+        let peer_old = B512::random();
+        let caps_old = Arc::new(Capabilities::new(vec![]));
+        fetcher.new_active_peer(
+            peer_old,
+            B256::random(),
+            100,
+            caps_old,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+        fetcher.peers.get_mut(&peer_old).expect("peer exists").state = PeerState::GetBlockHeaders;
+
+        let peer_71 = B512::random();
+        let caps_71 = Arc::new(Capabilities::from(vec![Capability::new("eth".into(), 71)]));
+        fetcher.new_active_peer(
+            peer_71,
+            B256::random(),
+            100,
+            caps_71,
+            Arc::new(AtomicU64::new(10)),
+            None,
+        );
+        fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
+
+        let (tx, _rx) = oneshot::channel();
+        fetcher.queued_requests.push_back(DownloadRequest::GetBlockAccessLists {
+            request: vec![],
+            response: tx,
+            priority: Priority::Normal,
+            requirement: BalRequirement::Optional,
+        });
+
+        assert!(fetcher.on_block_headers_response(peer_old, Ok(Vec::<Header>::new())).is_none());
+        assert_eq!(fetcher.queued_requests.len(), 1);
+        assert!(matches!(
+            fetcher.queued_requests.front(),
+            Some(DownloadRequest::GetBlockAccessLists {
+                requirement: BalRequirement::Optional,
+                ..
+            })
+        ));
     }
 }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -214,11 +214,6 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
             let request = self.queued_requests.pop_front().expect("not empty");
             let Some(peer_id) = self.next_best_peer(request.best_peer_requirements()) else {
-                if request.should_complete_without_capable_peer(self.has_bal_capable_peer()) {
-                    request.send_err_response(RequestError::UnsupportedCapability);
-                    continue
-                }
-
                 // no peer matches this request's requirements; requeue at the back so other
                 // queued requests get a chance on the next poll instead of head-of-line blocking.
                 self.queued_requests.push_back(request);
@@ -244,21 +239,34 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             loop {
                 // poll incoming requests
                 match self.download_requests_rx.poll_next_unpin(cx) {
-                    Poll::Ready(Some(request)) => match request.get_priority() {
-                        Priority::High => {
-                            // find the first normal request and queue before, add this request to
-                            // the back of the high-priority queue
-                            let pos = self
-                                .queued_requests
-                                .iter()
-                                .position(|req| req.is_normal_priority())
-                                .unwrap_or(0);
-                            self.queued_requests.insert(pos, request);
+                    Poll::Ready(Some(request)) => {
+                        if matches!(
+                            request,
+                            DownloadRequest::GetBlockAccessLists {
+                                requirement: BalRequirement::Optional,
+                                ..
+                            }
+                        ) && !self.has_bal_capable_peer()
+                        {
+                            request.send_err_response(RequestError::UnsupportedCapability);
+                            continue
                         }
-                        Priority::Normal => {
-                            self.queued_requests.push_back(request);
+
+                        match request.get_priority() {
+                            Priority::High => {
+                                // Queue before the first normal request.
+                                let pos = self
+                                    .queued_requests
+                                    .iter()
+                                    .position(|req| req.is_normal_priority())
+                                    .unwrap_or(0);
+                                self.queued_requests.insert(pos, request);
+                            }
+                            Priority::Normal => {
+                                self.queued_requests.push_back(request);
+                            }
                         }
-                    },
+                    }
                     Poll::Ready(None) => {
                         unreachable!("channel can't close")
                     }
@@ -650,12 +658,6 @@ impl<N: NetworkPrimitives> DownloadRequest<N> {
     /// Returns `true` if this request is normal priority.
     const fn is_normal_priority(&self) -> bool {
         self.get_priority().is_normal()
-    }
-
-    /// Returns whether the request may complete locally when no capable peer exists.
-    const fn should_complete_without_capable_peer(&self, has_bal_capable_peer: bool) -> bool {
-        matches!(self, Self::GetBlockAccessLists { requirement: BalRequirement::Optional, .. }) &&
-            !has_bal_capable_peer
     }
 
     /// Sends an error response to the waiting caller.
@@ -1615,7 +1617,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_optional_bal_request_completes_without_capable_peer() {
+    async fn test_optional_bal_request_rejected_without_eth71_peer() {
         use futures::task::noop_waker;
         use std::task::{Context, Poll};
 
@@ -1635,12 +1637,15 @@ mod tests {
         );
 
         let (tx, rx) = oneshot::channel();
-        fetcher.queued_requests.push_back(DownloadRequest::GetBlockAccessLists {
-            request: vec![],
-            response: tx,
-            priority: Priority::Normal,
-            requirement: BalRequirement::Optional,
-        });
+        fetcher
+            .download_requests_tx
+            .send(DownloadRequest::GetBlockAccessLists {
+                request: vec![],
+                response: tx,
+                priority: Priority::Normal,
+                requirement: BalRequirement::Optional,
+            })
+            .unwrap();
 
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
@@ -1651,7 +1656,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_optional_bal_request_waits_for_busy_capable_peer() {
+    async fn test_optional_bal_request_waits_for_busy_eth71_peer() {
         use futures::task::noop_waker;
         use std::task::{Context, Poll};
 
@@ -1672,12 +1677,15 @@ mod tests {
         fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
 
         let (tx, _rx) = oneshot::channel();
-        fetcher.queued_requests.push_back(DownloadRequest::GetBlockAccessLists {
-            request: vec![],
-            response: tx,
-            priority: Priority::Normal,
-            requirement: BalRequirement::Optional,
-        });
+        fetcher
+            .download_requests_tx
+            .send(DownloadRequest::GetBlockAccessLists {
+                request: vec![],
+                response: tx,
+                priority: Priority::Normal,
+                requirement: BalRequirement::Optional,
+            })
+            .unwrap();
 
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -160,10 +160,15 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     /// full history available
     fn next_best_peer(&self, requirement: BestPeerRequirements) -> Option<PeerId> {
         // filter out peers that aren't idle or don't meet the requirement
-        let mut idle = self
-            .peers
-            .iter()
-            .filter(|(_, peer)| peer.state.is_idle() && peer.satisfies(&requirement));
+        let mut idle = self.peers.iter().filter(|(_, peer)| {
+            peer.state.is_idle() &&
+                match &requirement {
+                    BestPeerRequirements::EthVersion(ver) => {
+                        peer.capabilities.supports_eth_at_least(ver)
+                    }
+                    _ => true,
+                }
+        });
 
         let mut best_peer = idle.next()?;
 
@@ -201,19 +206,9 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
     /// Returns the next action to return
     fn poll_action(&mut self) -> PollAction {
-        // we only check and not pop here since we don't know yet whether a peer is available.
+        // We only pop once we know the queue is non-empty.
         if self.queued_requests.is_empty() {
             return PollAction::NoRequests
-        }
-
-        self.reject_optional_bal_requests_without_eth71();
-
-        if self.queued_requests.is_empty() {
-            return PollAction::NoRequests
-        }
-
-        if self.peers.is_empty() {
-            return PollAction::NoPeersAvailable
         }
 
         let request = self.queued_requests.pop_front().expect("not empty");
@@ -257,8 +252,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
                         match request.get_priority() {
                             Priority::High => {
-                                // find first normal request and queue before it; add this request
-                                // to the back of the high-priority queue
+                                // Queue before the first normal request.
                                 let pos = self
                                     .queued_requests
                                     .iter()
@@ -280,24 +274,6 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
 
             if self.queued_requests.is_empty() || no_peers_available {
                 return Poll::Pending
-            }
-        }
-    }
-
-    /// Rejects queued optional BAL requests if no connected peer can serve them.
-    fn reject_optional_bal_requests_without_eth71(&mut self) {
-        if self.has_eth71_peer() {
-            return
-        }
-
-        let mut idx = 0;
-        while idx < self.queued_requests.len() {
-            if self.queued_requests[idx].is_optional_bal() {
-                if let Some(request) = self.queued_requests.remove(idx) {
-                    request.send_err_response(RequestError::UnsupportedCapability);
-                }
-            } else {
-                idx += 1;
             }
         }
     }
@@ -345,24 +321,9 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     ///
     /// Caution: this expects that the peer is _not_ closed.
     fn followup_request(&mut self, peer_id: PeerId) -> Option<BlockResponseOutcome> {
-        self.reject_optional_bal_requests_without_eth71();
-
-        let queued_len = self.queued_requests.len();
-        for _ in 0..queued_len {
-            let req = self.queued_requests.pop_front()?;
-            let can_request = self.peers.get(&peer_id).is_some_and(|peer| {
-                peer.state.is_idle() && peer.satisfies(&req.best_peer_requirements())
-            });
-
-            if can_request {
-                let req = self.prepare_block_request(peer_id, req);
-                return Some(BlockResponseOutcome::Request(peer_id, req))
-            }
-
-            self.queued_requests.push_back(req);
-        }
-
-        None
+        let req = self.queued_requests.pop_front()?;
+        let req = self.prepare_block_request(peer_id, req);
+        Some(BlockResponseOutcome::Request(peer_id, req))
     }
 
     /// Called on a `GetBlockHeaders` response from a peer.
@@ -533,16 +494,6 @@ impl Peer {
         self.range_info.as_ref().map(|info| info.range())
     }
 
-    /// Returns whether this peer can serve requests with the given hard requirements.
-    fn satisfies(&self, requirement: &BestPeerRequirements) -> bool {
-        match requirement {
-            BestPeerRequirements::EthVersion(ver) => self.capabilities.supports_eth_at_least(ver),
-            BestPeerRequirements::None |
-            BestPeerRequirements::FullBlock |
-            BestPeerRequirements::FullBlockRange(_) => true,
-        }
-    }
-
     /// Returns true if this peer has a better range than the other peer for serving the requested
     /// range.
     ///
@@ -705,11 +656,6 @@ impl<N: NetworkPrimitives> DownloadRequest<N> {
     /// Returns `true` if this request is normal priority.
     const fn is_normal_priority(&self) -> bool {
         self.get_priority().is_normal()
-    }
-
-    /// Returns `true` if this is an optional BAL request.
-    const fn is_optional_bal(&self) -> bool {
-        matches!(self, Self::GetBlockAccessLists { requirement: BalRequirement::Optional, .. })
     }
 
     /// Sends an error response to the waiting caller.
@@ -1744,99 +1690,5 @@ mod tests {
 
         assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
         assert_eq!(fetcher.queued_requests.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_queued_optional_bal_request_rejected_after_eth71_disconnect() {
-        use futures::task::noop_waker;
-        use std::task::{Context, Poll};
-
-        let manager = PeersManager::new(PeersConfig::default());
-        let mut fetcher =
-            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
-
-        let peer_71 = B512::random();
-        let caps_71 = Arc::new(Capabilities::from(vec![Capability::new("eth".into(), 71)]));
-        fetcher.new_active_peer(
-            peer_71,
-            B256::random(),
-            100,
-            caps_71,
-            Arc::new(AtomicU64::new(10)),
-            None,
-        );
-        fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
-
-        let (tx, rx) = oneshot::channel();
-        fetcher
-            .download_requests_tx
-            .send(DownloadRequest::GetBlockAccessLists {
-                request: vec![],
-                response: tx,
-                priority: Priority::Normal,
-                requirement: BalRequirement::Optional,
-            })
-            .unwrap();
-
-        let waker = noop_waker();
-        let mut cx = Context::from_waker(&waker);
-
-        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
-        assert_eq!(fetcher.queued_requests.len(), 1);
-
-        fetcher.on_session_closed(&peer_71);
-
-        assert!(matches!(fetcher.poll(&mut cx), Poll::Pending));
-        assert!(fetcher.queued_requests.is_empty());
-        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::UnsupportedCapability);
-    }
-
-    #[tokio::test]
-    async fn test_followup_skips_bal_for_peer_without_eth71() {
-        let manager = PeersManager::new(PeersConfig::default());
-        let mut fetcher =
-            StateFetcher::<EthNetworkPrimitives>::new(manager.handle(), Default::default());
-
-        let peer_old = B512::random();
-        let caps_old = Arc::new(Capabilities::new(vec![]));
-        fetcher.new_active_peer(
-            peer_old,
-            B256::random(),
-            100,
-            caps_old,
-            Arc::new(AtomicU64::new(10)),
-            None,
-        );
-        fetcher.peers.get_mut(&peer_old).expect("peer exists").state = PeerState::GetBlockHeaders;
-
-        let peer_71 = B512::random();
-        let caps_71 = Arc::new(Capabilities::from(vec![Capability::new("eth".into(), 71)]));
-        fetcher.new_active_peer(
-            peer_71,
-            B256::random(),
-            100,
-            caps_71,
-            Arc::new(AtomicU64::new(10)),
-            None,
-        );
-        fetcher.peers.get_mut(&peer_71).expect("peer exists").state = PeerState::GetBlockHeaders;
-
-        let (tx, _rx) = oneshot::channel();
-        fetcher.queued_requests.push_back(DownloadRequest::GetBlockAccessLists {
-            request: vec![],
-            response: tx,
-            priority: Priority::Normal,
-            requirement: BalRequirement::Optional,
-        });
-
-        assert!(fetcher.on_block_headers_response(peer_old, Ok(Vec::<Header>::new())).is_none());
-        assert_eq!(fetcher.queued_requests.len(), 1);
-        assert!(matches!(
-            fetcher.queued_requests.front(),
-            Some(DownloadRequest::GetBlockAccessLists {
-                requirement: BalRequirement::Optional,
-                ..
-            })
-        ));
     }
 }

--- a/crates/net/p2p/src/block_access_lists/client.rs
+++ b/crates/net/p2p/src/block_access_lists/client.rs
@@ -4,6 +4,17 @@ use auto_impl::auto_impl;
 use futures::Future;
 use reth_eth_wire_types::BlockAccessLists;
 
+/// Controls whether a BAL request must wait for a capable peer or may complete early when none are
+/// available.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BalRequirement {
+    /// Keep waiting until an eth/71-capable peer is available.
+    #[default]
+    Mandatory,
+    /// Return early if no connected peer can serve BALs.
+    Optional,
+}
+
 /// A client capable of downloading block access lists.
 #[auto_impl(&, Arc, Box)]
 pub trait BlockAccessListsClient: DownloadClient {
@@ -12,7 +23,24 @@ pub trait BlockAccessListsClient: DownloadClient {
 
     ///  Fetches the block access lists for given hashes.
     fn get_block_access_lists(&self, hashes: Vec<B256>) -> Self::Output {
-        self.get_block_access_lists_with_priority(hashes, Priority::Normal)
+        self.get_block_access_lists_with_priority_and_requirement(
+            hashes,
+            Priority::Normal,
+            BalRequirement::Mandatory,
+        )
+    }
+
+    /// Fetches the block access lists for given hashes with the requested BAL availability policy.
+    fn get_block_access_lists_with_requirement(
+        &self,
+        hashes: Vec<B256>,
+        requirement: BalRequirement,
+    ) -> Self::Output {
+        self.get_block_access_lists_with_priority_and_requirement(
+            hashes,
+            Priority::Normal,
+            requirement,
+        )
     }
 
     ///  Fetches the block access lists for given hashes with priority
@@ -20,5 +48,19 @@ pub trait BlockAccessListsClient: DownloadClient {
         &self,
         hashes: Vec<B256>,
         priority: Priority,
+    ) -> Self::Output {
+        self.get_block_access_lists_with_priority_and_requirement(
+            hashes,
+            priority,
+            BalRequirement::Mandatory,
+        )
+    }
+
+    /// Fetches the block access lists for given hashes with priority and BAL availability policy.
+    fn get_block_access_lists_with_priority_and_requirement(
+        &self,
+        hashes: Vec<B256>,
+        priority: Priority,
+        requirement: BalRequirement,
     ) -> Self::Output;
 }

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -57,8 +57,8 @@ impl<H: BlockHeader> EthResponseValidator for RequestResult<Vec<H>> {
     /// [`RequestError::ConnectionDropped`] should be ignored here because this is already handled
     /// when the dropped connection is handled.
     ///
-    /// [`RequestError::UnsupportedCapability`] is not used yet because we only support active
-    /// session for eth protocol.
+    /// [`RequestError::UnsupportedCapability`] is also used for locally rejected optional requests,
+    /// which should not affect peer reputation.
     fn reputation_change_err(&self) -> Option<ReputationChangeKind> {
         if let Err(err) = self {
             match err {

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -1110,10 +1110,11 @@ mod tests {
     impl BlockAccessListsClient for FullBlockWithAccessListsClient {
         type Output = futures::future::Ready<PeerRequestResult<BlockAccessLists>>;
 
-        fn get_block_access_lists_with_priority(
+        fn get_block_access_lists_with_priority_and_requirement(
             &self,
             hashes: Vec<B256>,
             _priority: Priority,
+            _requirement: crate::block_access_lists::client::BalRequirement,
         ) -> Self::Output {
             self.access_list_requests.fetch_add(1, Ordering::SeqCst);
 

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -54,7 +54,7 @@ pub mod snap;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
-pub use block_access_lists::client::BlockAccessListsClient;
+pub use block_access_lists::client::{BalRequirement, BlockAccessListsClient};
 pub use bodies::client::BodiesClient;
 pub use headers::client::HeadersClient;
 pub use receipts::client::ReceiptsClient;


### PR DESCRIPTION
This PR adds a BAL request requirement to the network fetch path, so callers can choose between Mandatory and Optional handling.
  Mandatory preserves the existing behavior, while Optional lets the local reth node stop waiting when no connected peer can serve
  BALs.

  Roadmap:

  - validate returned BALs against the block header hash and return them as Sealed<Bytes>
  - extend the same requirement and validation flow to full-block range requests
  
  @mattsse 