### PR TITLE
fix(era-downloader): infer ERA1 from indexed file names

### DIFF
--- a/crates/era-downloader/src/client.rs
+++ b/crates/era-downloader/src/client.rs
@@ -9,7 +9,6 @@ use std::{future::Future, path::Path, str::FromStr};
 use tokio::{
     fs::{self, File},
     io::{self, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt},
-    try_join,
 };
 
 /// Downloaded index page filename
@@ -53,7 +52,8 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
 
     /// Constructs [`EraClient`] using `client` to download from `url` into `folder`.
     ///
-    /// The file type is auto-detected from the URL. Use
+    /// The initial file type hint is inferred from the URL. File lists and downloads re-detect
+    /// the effective type from filenames when possible. Use
     /// [`with_era_type`](Self::with_era_type) to override.
     pub fn new(client: Http, url: Url, folder: impl Into<Box<Path>>) -> Self {
         let era_type = EraFileType::from_url(url.as_str());
@@ -79,6 +79,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
             .next_back()
             .ok_or_eyre("empty path segments")?;
         let path = path.join(file_name);
+        let file_type = self.file_type_from_name(file_name);
 
         if !self.is_downloaded(file_name, &path).await? {
             let number = self
@@ -107,7 +108,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
                 }
             }
 
-            if self.era_type == EraFileType::Era1 {
+            if file_type == EraFileType::Era1 {
                 self.assert_checksum(number, actual_checksum?)
                     .await
                     .map_err(|e| eyre!("{e} for {file_name} at {}", path.display()))?;
@@ -161,12 +162,16 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     /// Returns the number of files in the `folder`.
     pub async fn files_count(&self) -> usize {
         let mut count = 0usize;
-
-        let file_extension = self.era_type.extension().trim_start_matches('.');
+        let file_type = self.stored_era_type().await;
 
         if let Ok(mut dir) = fs::read_dir(&self.folder).await {
             while let Ok(Some(entry)) = dir.next_entry().await {
-                if entry.path().extension() == Some(file_extension.as_ref()) {
+                if entry
+                    .file_name()
+                    .to_str()
+                    .and_then(EraFileType::from_filename)
+                    .is_some_and(|entry_type| entry_type == file_type)
+                {
                     count += 1;
                 }
             }
@@ -183,26 +188,28 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
         let index_path = self.folder.to_path_buf().join(INDEX_HTML_FILE);
         let checksums_path = self.folder.to_path_buf().join(Self::CHECKSUMS);
 
+        self.download_file_to_path(self.url.clone(), &index_path).await?;
+
+        let era_type = self.detect_era_type_from_index(&index_path).await?;
+
         // Only for era1, we download also checksums file
-        if self.era_type == EraFileType::Era1 {
+        if era_type == EraFileType::Era1 {
             let checksums_url = self.url.join(Self::CHECKSUMS)?;
-            try_join!(
-                self.download_file_to_path(self.url.clone(), &index_path),
-                self.download_file_to_path(checksums_url, &checksums_path)
-            )?;
-        } else {
-            // Download only index file
-            self.download_file_to_path(self.url.clone(), &index_path).await?;
+            self.download_file_to_path(checksums_url, &checksums_path).await?;
         }
 
         // Parse and extract era filenames from index.html
-        self.extract_era_filenames(&index_path).await?;
+        self.extract_era_filenames(&index_path, era_type).await?;
 
         Ok(())
     }
 
     /// Extracts ERA filenames from `index.html` and writes them to the index file
-    async fn extract_era_filenames(&self, index_path: &Path) -> eyre::Result<()> {
+    async fn extract_era_filenames(
+        &self,
+        index_path: &Path,
+        era_type: EraFileType,
+    ) -> eyre::Result<()> {
         let file = File::open(index_path).await?;
         let reader = io::BufReader::new(file);
         let mut lines = reader.lines();
@@ -211,15 +218,9 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
         let file = File::create(&path).await?;
         let mut writer = io::BufWriter::new(file);
 
-        let ext = self.era_type.extension();
-        let ext_len = ext.len();
-
         while let Some(line) = lines.next_line().await? {
-            if let Some(j) = line.find(ext) &&
-                let Some(i) = line[..j].rfind(|c: char| !c.is_alphanumeric() && c != '-')
-            {
-                let era = &line[i + 1..j + ext_len];
-                writer.write_all(era.as_bytes()).await?;
+            if let Some(file_name) = era_file_name_from_line(&line, era_type) {
+                writer.write_all(file_name.as_bytes()).await?;
                 writer.write_all(b"\n").await?;
             }
         }
@@ -258,7 +259,7 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
 
         match File::open(path).await {
             Ok(file) => {
-                if self.era_type == EraFileType::Era1 {
+                if self.file_type_from_name(name) == EraFileType::Era1 {
                     let number = self
                         .file_name_to_number(name)
                         .ok_or_else(|| eyre!("Cannot parse ERA number from {name}"))?;
@@ -328,6 +329,65 @@ impl<Http: HttpClient + Clone> EraClient<Http> {
     fn file_name_to_number(&self, file_name: &str) -> Option<usize> {
         file_name.split('-').nth(1).and_then(|v| usize::from_str(v).ok())
     }
+
+    fn file_type_from_name(&self, file_name: &str) -> EraFileType {
+        EraFileType::from_filename(file_name).unwrap_or(self.era_type)
+    }
+
+    async fn detect_era_type_from_index(&self, index_path: &Path) -> eyre::Result<EraFileType> {
+        let file = File::open(index_path).await?;
+        let reader = io::BufReader::new(file);
+        let mut lines = reader.lines();
+        let mut detected = None;
+
+        while let Some(line) = lines.next_line().await? {
+            if let Some(file_name) = era_file_name_from_line(&line, EraFileType::Era1)
+                .or_else(|| era_file_name_from_line(&line, EraFileType::Era))
+            {
+                let file_type =
+                    EraFileType::from_filename(file_name).expect("filtered ERA file names");
+
+                if let Some(current) = detected {
+                    if current != file_type {
+                        return Err(eyre!("Mixed ERA file types found in {}", index_path.display()));
+                    }
+                } else {
+                    detected = Some(file_type);
+                }
+            }
+        }
+
+        Ok(detected.unwrap_or(self.era_type))
+    }
+
+    async fn stored_era_type(&self) -> EraFileType {
+        let index_path = self.folder.to_path_buf().join("index");
+
+        if let Ok(file) = File::open(&index_path).await {
+            let reader = io::BufReader::new(file);
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(file_type) = EraFileType::from_filename(line.trim()) {
+                    return file_type;
+                }
+            }
+        }
+
+        let index_html_path = self.folder.to_path_buf().join(INDEX_HTML_FILE);
+        if fs::metadata(&index_html_path).await.is_ok() &&
+            let Ok(file_type) = self.detect_era_type_from_index(&index_html_path).await
+        {
+            return file_type;
+        }
+
+        self.era_type
+    }
+}
+
+fn era_file_name_from_line(line: &str, era_type: EraFileType) -> Option<&str> {
+    line.split(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '.')
+        .find(|token| EraFileType::from_filename(token) == Some(era_type))
 }
 
 async fn checksum(mut reader: impl AsyncRead + Unpin) -> eyre::Result<Vec<u8>> {

--- a/crates/era-downloader/tests/it/checksums.rs
+++ b/crates/era-downloader/tests/it/checksums.rs
@@ -10,6 +10,7 @@ use test_case::test_case;
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
 #[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
+#[test_case("https://snapshots.reth.rs/history/mainnet/"; "url-without-era1-substring")]
 #[tokio::test]
 async fn test_invalid_checksum_returns_error(url: &str) {
     let base_url = Url::from_str(url).unwrap();
@@ -64,17 +65,23 @@ impl HttpClient for FailingClient {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(crate::ERA1_NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(crate::ERA1_ETH_PORTAL),
             "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(crate::ERA1_ITHACA),
+            "https://snapshots.reth.rs/history/mainnet/" => Bytes::from_static(crate::ERA1_ITHACA),
             "https://mainnet.era1.nimbus.team/checksums.txt" |
             "https://era1.ethportal.net/checksums.txt" |
-            "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(CHECKSUMS),
+            "https://era.ithaca.xyz/era1/checksums.txt" |
+            "https://snapshots.reth.rs/history/mainnet/checksums.txt" => {
+                Bytes::from_static(CHECKSUMS)
+            }
             "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" |
             "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
+            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" |
+            "https://snapshots.reth.rs/history/mainnet/mainnet-00000-5ec1ffb8.era1" => {
                 Bytes::from_static(crate::ERA1_MAINNET_0)
             }
             "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" |
             "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
+            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" |
+            "https://snapshots.reth.rs/history/mainnet/mainnet-00001-a5364e9a.era1" => {
                 Bytes::from_static(crate::ERA1_MAINNET_1)
             }
             v => unimplemented!("Unexpected URL \"{v}\""),

--- a/crates/era-downloader/tests/it/checksums.rs
+++ b/crates/era-downloader/tests/it/checksums.rs
@@ -64,7 +64,7 @@ impl HttpClient for FailingClient {
         Ok(futures::stream::iter(vec![Ok(match url.as_str() {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(crate::ERA1_NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(crate::ERA1_ETH_PORTAL),
-            "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(crate::ERA1_ITHACA),
+            "https://era.ithaca.xyz/era1/index.html" |
             "https://snapshots.reth.rs/history/mainnet/" => Bytes::from_static(crate::ERA1_ITHACA),
             "https://mainnet.era1.nimbus.team/checksums.txt" |
             "https://era1.ethportal.net/checksums.txt" |

--- a/crates/era-downloader/tests/it/list.rs
+++ b/crates/era-downloader/tests/it/list.rs
@@ -9,6 +9,7 @@ use test_case::test_case;
 #[test_case("https://mainnet.era1.nimbus.team/"; "nimbus")]
 #[test_case("https://era1.ethportal.net/"; "ethportal")]
 #[test_case("https://era.ithaca.xyz/era1/index.html"; "ithaca")]
+#[test_case("https://snapshots.reth.rs/history/mainnet/"; "url-without-era1-substring")]
 #[tokio::test]
 async fn test_getting_era1_file_name_after_fetching_file_list(url: &str) {
     let url = Url::from_str(url).unwrap();

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -44,7 +44,7 @@ impl HttpClient for StubClient {
             // Era1 urls
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(ERA1_NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(ERA1_ETH_PORTAL),
-            "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(ERA1_ITHACA),
+            "https://era.ithaca.xyz/era1/index.html" |
             "https://snapshots.reth.rs/history/mainnet/" => Bytes::from_static(ERA1_ITHACA),
             "https://mainnet.era1.nimbus.team/checksums.txt" |
             "https://era1.ethportal.net/checksums.txt" |

--- a/crates/era-downloader/tests/it/main.rs
+++ b/crates/era-downloader/tests/it/main.rs
@@ -45,17 +45,23 @@ impl HttpClient for StubClient {
             "https://mainnet.era1.nimbus.team/" => Bytes::from_static(ERA1_NIMBUS),
             "https://era1.ethportal.net/" => Bytes::from_static(ERA1_ETH_PORTAL),
             "https://era.ithaca.xyz/era1/index.html" => Bytes::from_static(ERA1_ITHACA),
+            "https://snapshots.reth.rs/history/mainnet/" => Bytes::from_static(ERA1_ITHACA),
             "https://mainnet.era1.nimbus.team/checksums.txt" |
             "https://era1.ethportal.net/checksums.txt" |
-            "https://era.ithaca.xyz/era1/checksums.txt" => Bytes::from_static(ERA1_CHECKSUMS),
+            "https://era.ithaca.xyz/era1/checksums.txt" |
+            "https://snapshots.reth.rs/history/mainnet/checksums.txt" => {
+                Bytes::from_static(ERA1_CHECKSUMS)
+            }
             "https://era1.ethportal.net/mainnet-00000-5ec1ffb8.era1" |
             "https://mainnet.era1.nimbus.team/mainnet-00000-5ec1ffb8.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" => {
+            "https://era.ithaca.xyz/era1/mainnet-00000-5ec1ffb8.era1" |
+            "https://snapshots.reth.rs/history/mainnet/mainnet-00000-5ec1ffb8.era1" => {
                 Bytes::from_static(ERA1_MAINNET_0)
             }
             "https://era1.ethportal.net/mainnet-00001-a5364e9a.era1" |
             "https://mainnet.era1.nimbus.team/mainnet-00001-a5364e9a.era1" |
-            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" => {
+            "https://era.ithaca.xyz/era1/mainnet-00001-a5364e9a.era1" |
+            "https://snapshots.reth.rs/history/mainnet/mainnet-00001-a5364e9a.era1" => {
                 Bytes::from_static(ERA1_MAINNET_1)
             }
             // Era urls

--- a/crates/era/src/common/file_ops.rs
+++ b/crates/era/src/common/file_ops.rs
@@ -226,9 +226,17 @@ impl EraFileType {
     }
 
     /// Detect file type from URL
-    /// By default, it assumes `Era` type
+    /// Heuristic only: prefer explicit overrides or file/index-based detection when available.
+    /// By default, it assumes `Era` type.
     pub fn from_url(url: &str) -> Self {
-        if url.contains("era1") {
+        if let Some(file_type) = Self::from_filename(url.rsplit('/').next().unwrap_or_default()) {
+            return file_type;
+        }
+
+        if url
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .any(|part| part.eq_ignore_ascii_case("era1"))
+        {
             Self::Era1
         } else {
             Self::Era
@@ -241,5 +249,26 @@ pub fn format_hash(hash: Option<[u8; 4]>) -> String {
     match hash {
         Some(h) => format!("{:02x}{:02x}{:02x}{:02x}", h[0], h[1], h[2], h[3]),
         None => "00000000".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EraFileType;
+
+    #[test]
+    fn detects_era1_urls_from_filenames_and_tokens() {
+        assert_eq!(
+            EraFileType::from_url("https://mirror.example.com/mainnet-00000-deadbeef.era1"),
+            EraFileType::Era1
+        );
+        assert_eq!(
+            EraFileType::from_url("https://mirror.example.com/snapshots/sepolia-era1/index.html"),
+            EraFileType::Era1
+        );
+        assert_eq!(
+            EraFileType::from_url("https://mirror.example.com/snapshots/mainnet/index.html"),
+            EraFileType::Era
+        );
     }
 }


### PR DESCRIPTION
Make `EraClient` derive the effective file type from indexed file names and downloaded file names instead of letting `url.contains("era1")` decide whether the downloader should follow the `.era` or `.era1` path.

This keeps index extraction, download URLs, and checksum verification correct for ERA1 mirrors whose base URLs do not include `era1`, while preserving `with_era_type` as an explicit override.