### PR TITLE
perf(cli): parallelize db repair-trie verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7666,6 +7666,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "reth-trie-parallel",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -10428,6 +10429,7 @@ dependencies = [
 name = "reth-trie-parallel"
 version = "2.1.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-eip7928",
  "alloy-evm",
  "alloy-primitives",
@@ -10441,10 +10443,12 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rand 0.9.4",
  "rayon",
+ "reth-db-api",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-storage-api",
  "reth-storage-errors",
  "reth-tasks",
  "reth-trie",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -53,6 +53,7 @@ reth-tasks.workspace = true
 reth-storage-api.workspace = true
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-trie-parallel.workspace = true
 reth-trie-common = { workspace = true, optional = true }
 reth-primitives-traits.workspace = true
 reth-discv4.workspace = true

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -319,6 +319,9 @@ where
 
 type StorageResult = eyre::Result<StorageMessage>;
 
+// Each account's storage result stream must come from exactly one producer, and that producer must
+// send every inconsistency before it sends the final root for the account. `wait_for_storage_root`
+// relies on that ordering when it buffers future-account messages.
 #[derive(Debug)]
 enum StorageMessage {
     Root { account: B256, root: B256 },
@@ -440,20 +443,27 @@ where
             let job_rx = Arc::clone(&job_rx);
             let result_tx = result_tx.clone();
 
-            scope.spawn(move || loop {
-                let account = match job_rx.lock().expect("poisoned storage job receiver").recv() {
-                    Ok(account) => account,
-                    Err(_) => break,
+            scope.spawn(move || {
+                let provider = match make_provider() {
+                    Ok(provider) => provider.disable_long_read_transaction_safety(),
+                    Err(err) => {
+                        let _ = result_tx.send(Err(err));
+                        return;
+                    }
                 };
 
-                let result = (|| -> eyre::Result<()> {
-                    let provider = make_provider()?.disable_long_read_transaction_safety();
-                    verify_storage_account::<A, _>(&provider, account, &result_tx)
-                })();
+                loop {
+                    let account = match job_rx.lock().expect("poisoned storage job receiver").recv()
+                    {
+                        Ok(account) => account,
+                        Err(_) => break,
+                    };
 
-                if let Err(err) = result {
-                    let _ = result_tx.send(Err(err));
-                    break;
+                    if let Err(err) = verify_storage_account::<A, _>(&provider, account, &result_tx)
+                    {
+                        let _ = result_tx.send(Err(err));
+                        break;
+                    }
                 }
             });
         }

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -1,3 +1,6 @@
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_primitives::B256;
+use alloy_rlp::{BufMut, Encodable};
 use clap::Parser;
 use metrics::{self, Counter};
 use reth_chainspec::EthChainSpec;
@@ -5,6 +8,7 @@ use reth_cli_util::parse_socket_address;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::Database,
+    tables,
     transaction::{DbTx, DbTxMut},
 };
 use reth_db_common::DbTool;
@@ -20,17 +24,28 @@ use reth_node_metrics::{
 };
 use reth_provider::{providers::ProviderNodeTypes, ChainSpecProvider, StageCheckpointReader};
 use reth_stages::StageId;
-use reth_storage_api::StorageSettingsCache;
+use reth_storage_api::{DBProvider, StorageSettingsCache};
 use reth_tasks::TaskExecutor;
 use reth_trie::{
-    verify::{Output, Verifier},
-    Nibbles,
+    hashed_cursor::HashedCursorFactory,
+    metrics::TrieRootMetrics,
+    node_iter::{TrieElement, TrieNodeIter},
+    trie_cursor::{depth_first, DepthFirstTrieIterator, TrieCursor, TrieCursorFactory},
+    updates::TrieUpdates,
+    verify::Output,
+    walker::TrieWalker,
+    BranchNodeCompact, HashBuilder, Nibbles, StorageRoot, TrieType, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use reth_trie_db::{
     DatabaseHashedCursorFactory, DatabaseTrieCursorFactory, StorageTrieEntryLike, TrieTableAdapter,
 };
 use std::{
+    cmp::Ordering,
+    collections::BTreeMap,
     net::SocketAddr,
+    num::NonZeroUsize,
+    sync::{mpsc, Arc, Mutex},
+    thread,
     time::{Duration, Instant},
 };
 use tracing::{info, warn};
@@ -82,7 +97,6 @@ impl Command {
                     pprof_dump_dir,
                 );
 
-                // Spawn the metrics server
                 if let Err(e) = MetricServer::new(config).serve().await {
                     tracing::error!("Metrics server error: {}", e);
                 }
@@ -104,7 +118,6 @@ impl Command {
 }
 
 fn verify_only<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
-    // Log the database block tip from Finish stage checkpoint
     let finish_checkpoint = tool
         .provider_factory
         .provider()?
@@ -112,55 +125,43 @@ fn verify_only<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
         .unwrap_or_default();
     info!("Database block tip: {}", finish_checkpoint.block_number);
 
-    // Get a database transaction directly from the database
-    let db = tool.provider_factory.db_ref();
-    let mut tx = db.tx()?;
-    tx.disable_long_read_transaction_safety();
-
-    reth_trie_db::with_adapter!(tool.provider_factory, |A| do_verify_only::<_, A>(&tx))
-}
-
-fn do_verify_only<TX: DbTx, A: TrieTableAdapter>(tx: &TX) -> eyre::Result<()> {
-    // Create the verifier
-    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
-    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
-    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory)?;
-
     let metrics = RepairTrieMetrics::new();
-
     let mut inconsistent_nodes = 0;
     let start_time = Instant::now();
     let mut last_progress_time = Instant::now();
 
-    // Iterate over the verifier and repair inconsistencies
-    for output_result in verifier {
-        let output = output_result?;
+    reth_trie_db::with_adapter!(tool.provider_factory, |A| {
+        parallel_verify::<A, _, _, _>(
+            &|| Ok(tool.provider_factory.provider()?.disable_long_read_transaction_safety()),
+            |output| {
+                if let Output::Progress(path) = output {
+                    if last_progress_time.elapsed() > PROGRESS_PERIOD {
+                        output_progress(path, start_time, inconsistent_nodes);
+                        last_progress_time = Instant::now();
+                    }
+                } else {
+                    warn!("Inconsistency found: {output:?}");
+                    inconsistent_nodes += 1;
 
-        if let Output::Progress(path) = output {
-            if last_progress_time.elapsed() > PROGRESS_PERIOD {
-                output_progress(path, start_time, inconsistent_nodes);
-                last_progress_time = Instant::now();
-            }
-        } else {
-            warn!("Inconsistency found: {output:?}");
-            inconsistent_nodes += 1;
+                    match output {
+                        Output::AccountExtra(_, _) |
+                        Output::AccountWrong { .. } |
+                        Output::AccountMissing(_, _) => {
+                            metrics.account_inconsistencies.increment(1);
+                        }
+                        Output::StorageExtra(_, _, _) |
+                        Output::StorageWrong { .. } |
+                        Output::StorageMissing(_, _, _) => {
+                            metrics.storage_inconsistencies.increment(1);
+                        }
+                        Output::Progress(_) => unreachable!(),
+                    }
+                }
 
-            // Record metrics based on output type
-            match output {
-                Output::AccountExtra(_, _) |
-                Output::AccountWrong { .. } |
-                Output::AccountMissing(_, _) => {
-                    metrics.account_inconsistencies.increment(1);
-                }
-                Output::StorageExtra(_, _, _) |
-                Output::StorageWrong { .. } |
-                Output::StorageMissing(_, _, _) => {
-                    metrics.storage_inconsistencies.increment(1);
-                }
-                Output::Progress(_) => unreachable!(),
-            }
-        }
-    }
+                Ok(())
+            },
+        )
+    })?;
 
     info!("Found {} inconsistencies (dry run - no changes made)", inconsistent_nodes);
 
@@ -204,19 +205,18 @@ fn verify_checkpoints(provider: impl StageCheckpointReader) -> eyre::Result<()> 
 }
 
 fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
-    // Get a read-write database provider
     let mut provider_rw = tool.provider_factory.provider_rw()?;
 
-    // Log the database block tip from Finish stage checkpoint
     let finish_checkpoint = provider_rw.get_stage_checkpoint(StageId::Finish)?.unwrap_or_default();
     info!("Database block tip: {}", finish_checkpoint.block_number);
 
-    // Check that a pipeline sync isn't in progress.
     verify_checkpoints(provider_rw.as_ref())?;
 
     let inconsistent_nodes = reth_trie_db::with_adapter!(tool.provider_factory, |A| {
-        do_verify_and_repair::<_, A>(&mut provider_rw)?
-    });
+        do_verify_and_repair::<_, A, _, _>(&mut provider_rw, &|| {
+            Ok(tool.provider_factory.provider()?.disable_long_read_transaction_safety())
+        })
+    })?;
 
     if inconsistent_nodes == 0 {
         info!("No inconsistencies found");
@@ -228,42 +228,31 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
     Ok(())
 }
 
-fn do_verify_and_repair<N: ProviderNodeTypes, A: TrieTableAdapter>(
+fn do_verify_and_repair<N: ProviderNodeTypes, A: TrieTableAdapter + Send, P, F>(
     provider_rw: &mut reth_provider::DatabaseProviderRW<N::DB, N>,
+    make_provider: &F,
 ) -> eyre::Result<usize>
 where
-    <N::DB as reth_db_api::database::Database>::TXMut: DbTxMut + DbTx,
+    P: DBProvider + Send,
+    P::Tx: DbTx,
+    F: Fn() -> eyre::Result<P> + Sync,
+    <N::DB as Database>::TXMut: DbTxMut + DbTx,
 {
-    // Create cursors for making modifications with
     let tx = provider_rw.tx_mut();
     tx.disable_long_read_transaction_safety();
     let mut account_trie_cursor = tx.cursor_write::<A::AccountTrieTable>()?;
     let mut storage_trie_cursor = tx.cursor_dup_write::<A::StorageTrieTable>()?;
 
-    // Create the cursor factories. These cannot accept the `&mut` tx above because they
-    // require it to be AsRef.
-    let tx = provider_rw.tx_ref();
-    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
-    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
-
-    // Create the verifier
-    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory)?;
-
     let metrics = RepairTrieMetrics::new();
-
     let mut inconsistent_nodes = 0;
     let start_time = Instant::now();
     let mut last_progress_time = Instant::now();
 
-    // Iterate over the verifier and repair inconsistencies
-    for output_result in verifier {
-        let output = output_result?;
-
+    parallel_verify::<A, _, _, _>(make_provider, |output| {
         if !matches!(output, Output::Progress(_)) {
             warn!("Inconsistency found, will repair: {output:?}");
             inconsistent_nodes += 1;
 
-            // Record metrics based on output type
             match &output {
                 Output::AccountExtra(_, _) |
                 Output::AccountWrong { .. } |
@@ -281,14 +270,12 @@ where
 
         match output {
             Output::AccountExtra(path, _node) => {
-                // Extra account node in trie, remove it
                 let key: A::AccountKey = path.into();
                 if account_trie_cursor.seek_exact(key)?.is_some() {
                     account_trie_cursor.delete_current()?;
                 }
             }
             Output::StorageExtra(account, path, _node) => {
-                // Extra storage node in trie, remove it
                 let subkey: A::StorageSubKey = path.into();
                 if storage_trie_cursor
                     .seek_by_key_subkey(account, subkey.clone())?
@@ -300,15 +287,11 @@ where
             }
             Output::AccountWrong { path, expected: node, .. } |
             Output::AccountMissing(path, node) => {
-                // Wrong/missing account node value, upsert it
                 let key: A::AccountKey = path.into();
                 account_trie_cursor.upsert(key, &node)?;
             }
             Output::StorageWrong { account, path, expected: node, .. } |
             Output::StorageMissing(account, path, node) => {
-                // Wrong/missing storage node value, upsert it
-                // (We can't just use `upsert` method with a dup cursor, it's not properly
-                // supported)
                 let subkey: A::StorageSubKey = path.into();
                 let entry = A::StorageValue::new(subkey.clone(), node);
                 if storage_trie_cursor
@@ -327,24 +310,446 @@ where
                 }
             }
         }
-    }
+
+        Ok(())
+    })?;
 
     Ok(inconsistent_nodes as usize)
 }
 
+type StorageResult = eyre::Result<StorageMessage>;
+
+#[derive(Debug)]
+enum StorageMessage {
+    Root { account: B256, root: B256 },
+    Output(Output),
+}
+
+#[derive(Debug)]
+struct RepairTrieCursorVerifier<I> {
+    account: Option<B256>,
+    trie_iter: I,
+    curr: Option<(Nibbles, BranchNodeCompact)>,
+}
+
+impl<C: TrieCursor> RepairTrieCursorVerifier<DepthFirstTrieIterator<C>> {
+    fn new(account: Option<B256>, trie_cursor: C) -> eyre::Result<Self> {
+        let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
+        let curr = trie_iter.next().transpose()?;
+        Ok(Self { account, trie_iter, curr })
+    }
+
+    const fn output_extra(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
+        if let Some(account) = self.account {
+            Output::StorageExtra(account, path, node)
+        } else {
+            Output::AccountExtra(path, node)
+        }
+    }
+
+    const fn output_wrong(
+        &self,
+        path: Nibbles,
+        expected: BranchNodeCompact,
+        found: BranchNodeCompact,
+    ) -> Output {
+        if let Some(account) = self.account {
+            Output::StorageWrong { account, path, expected, found }
+        } else {
+            Output::AccountWrong { path, expected, found }
+        }
+    }
+
+    const fn output_missing(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
+        if let Some(account) = self.account {
+            Output::StorageMissing(account, path, node)
+        } else {
+            Output::AccountMissing(path, node)
+        }
+    }
+
+    fn next(&mut self, path: Nibbles, node: BranchNodeCompact) -> eyre::Result<Vec<Output>> {
+        let mut outputs = Vec::new();
+
+        loop {
+            if self.curr.is_none() {
+                outputs.push(self.output_missing(path, node));
+                return Ok(outputs)
+            }
+
+            let (curr_path, curr_node) = self.curr.as_ref().expect("not None");
+            match depth_first::cmp(&path, curr_path) {
+                Ordering::Less => {
+                    outputs.push(self.output_missing(path, node));
+                    return Ok(outputs)
+                }
+                Ordering::Equal => {
+                    if *curr_node != node {
+                        outputs.push(self.output_wrong(path, node, curr_node.clone()));
+                    }
+                    self.curr = self.trie_iter.next().transpose()?;
+                    return Ok(outputs)
+                }
+                Ordering::Greater => {
+                    outputs.push(self.output_extra(*curr_path, curr_node.clone()));
+                    self.curr = self.trie_iter.next().transpose()?;
+                }
+            }
+        }
+    }
+
+    fn finalize(&mut self) -> eyre::Result<Vec<Output>> {
+        let mut outputs = Vec::new();
+        while let Some((curr_path, curr_node)) = self.curr.take() {
+            outputs.push(self.output_extra(curr_path, curr_node));
+            self.curr = self.trie_iter.next().transpose()?;
+        }
+        Ok(outputs)
+    }
+}
+
+fn parallel_verify<A, P, F, O>(make_provider: &F, mut on_output: O) -> eyre::Result<()>
+where
+    A: TrieTableAdapter + Send,
+    P: DBProvider + Send,
+    P::Tx: DbTx,
+    F: Fn() -> eyre::Result<P> + Sync,
+    O: FnMut(Output) -> eyre::Result<()>,
+{
+    let storage_workers = storage_worker_count();
+    info!(storage_workers, "Verifying storage tries in parallel");
+
+    let (job_tx, job_rx) = mpsc::sync_channel(storage_workers.saturating_mul(2).max(1));
+    let job_rx = Arc::new(Mutex::new(job_rx));
+    let (result_tx, result_rx) = mpsc::channel();
+
+    thread::scope(|scope| -> eyre::Result<()> {
+        {
+            let result_tx = result_tx.clone();
+            let job_tx = job_tx.clone();
+            scope.spawn(move || {
+                if let Err(err) =
+                    dispatch_storage_jobs::<A, P, F>(make_provider, &job_tx, &result_tx)
+                {
+                    let _ = result_tx.send(Err(err));
+                }
+            });
+        }
+
+        for _ in 0..storage_workers {
+            let job_rx = Arc::clone(&job_rx);
+            let result_tx = result_tx.clone();
+
+            scope.spawn(move || loop {
+                let account = match job_rx.lock().expect("poisoned storage job receiver").recv() {
+                    Ok(account) => account,
+                    Err(_) => break,
+                };
+
+                let result = (|| -> eyre::Result<()> {
+                    let provider = make_provider()?.disable_long_read_transaction_safety();
+                    verify_storage_account::<A, _>(&provider, account, &result_tx)
+                })();
+
+                if let Err(err) = result {
+                    let _ = result_tx.send(Err(err));
+                    break;
+                }
+            });
+        }
+
+        drop(job_tx);
+        drop(result_tx);
+
+        verify_accounts::<A, _, _, _>(make_provider, &result_rx, &mut on_output)
+    })
+}
+
+fn dispatch_storage_jobs<A, P, F>(
+    make_provider: &F,
+    job_tx: &mpsc::SyncSender<B256>,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> eyre::Result<()>
+where
+    A: TrieTableAdapter,
+    P: DBProvider,
+    P::Tx: DbTx,
+    F: Fn() -> eyre::Result<P>,
+{
+    let provider = make_provider()?.disable_long_read_transaction_safety();
+    let tx = provider.tx_ref();
+    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
+    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+    let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+    let mut next_storage_account = storage_cursor.first()?.map(|entry| entry.0);
+    let mut next_account = account_cursor.first()?;
+
+    while let Some((account, _)) = next_account {
+        while next_storage_account.is_some_and(|storage_account| storage_account < account) {
+            next_storage_account = storage_cursor.next_no_dup()?.map(|entry| entry.0);
+        }
+
+        if next_storage_account == Some(account) {
+            job_tx.send(account).map_err(|_| eyre::eyre!("storage worker queue closed"))?;
+            next_storage_account = storage_cursor.next_no_dup()?.map(|entry| entry.0);
+        } else {
+            emit_empty_storage_inconsistencies(
+                account,
+                trie_cursor_factory.storage_trie_cursor(account)?,
+                result_tx,
+            )?;
+            result_tx
+                .send(Ok(StorageMessage::Root { account, root: EMPTY_ROOT_HASH }))
+                .map_err(|_| eyre::eyre!("storage results channel closed"))?;
+        }
+
+        next_account = account_cursor.next()?;
+    }
+
+    Ok(())
+}
+
+fn verify_storage_account<A, P>(
+    provider: &P,
+    account: B256,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> eyre::Result<()>
+where
+    A: TrieTableAdapter,
+    P: DBProvider,
+    P::Tx: DbTx,
+{
+    let tx = provider.tx_ref();
+    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
+    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
+
+    let (root, _, updates) = StorageRoot::new_hashed(
+        trie_cursor_factory.clone(),
+        hashed_cursor_factory,
+        account,
+        Default::default(),
+        TrieRootMetrics::new(TrieType::Storage),
+    )
+    .root_with_updates()?;
+
+    emit_storage_updates(
+        account,
+        trie_cursor_factory.storage_trie_cursor(account)?,
+        sorted_branch_nodes(updates.storage_nodes.into_iter()),
+        result_tx,
+    )?;
+
+    result_tx
+        .send(Ok(StorageMessage::Root { account, root }))
+        .map_err(|_| eyre::eyre!("storage results channel closed"))?;
+
+    Ok(())
+}
+
+fn verify_accounts<A, P, F, O>(
+    make_provider: &F,
+    result_rx: &mpsc::Receiver<StorageResult>,
+    on_output: &mut O,
+) -> eyre::Result<()>
+where
+    A: TrieTableAdapter,
+    P: DBProvider,
+    P::Tx: DbTx,
+    F: Fn() -> eyre::Result<P>,
+    O: FnMut(Output) -> eyre::Result<()>,
+{
+    let provider = make_provider()?.disable_long_read_transaction_safety();
+    let tx = provider.tx_ref();
+    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
+    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
+
+    let walker: TrieWalker<_> =
+        TrieWalker::state_trie(trie_cursor_factory.account_trie_cursor()?, Default::default())
+            .with_deletions_retained(true);
+    let mut account_node_iter =
+        TrieNodeIter::state_trie(walker, hashed_cursor_factory.hashed_account_cursor()?);
+    let mut hash_builder = HashBuilder::default().with_updates(true);
+    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+    let mut pending_roots = BTreeMap::new();
+    let mut pending_outputs = BTreeMap::new();
+
+    while let Some(node) = account_node_iter.try_next()? {
+        match node {
+            TrieElement::Branch(node) => {
+                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
+            }
+            TrieElement::Leaf(hashed_address, account) => {
+                let storage_root = wait_for_storage_root(
+                    hashed_address,
+                    result_rx,
+                    &mut pending_roots,
+                    &mut pending_outputs,
+                    on_output,
+                )?;
+
+                account_rlp.clear();
+                account.into_trie_account(storage_root).encode(&mut account_rlp as &mut dyn BufMut);
+                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
+                on_output(Output::Progress(Nibbles::unpack(hashed_address)))?;
+            }
+        }
+    }
+
+    let removed_keys = account_node_iter.walker.take_removed_keys();
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.finalize(hash_builder, removed_keys, Default::default());
+
+    let mut account_verifier =
+        RepairTrieCursorVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?;
+    for (path, node) in sorted_branch_nodes(trie_updates.account_nodes.into_iter()) {
+        for output in account_verifier.next(path, node)? {
+            on_output(output)?;
+        }
+    }
+    for output in account_verifier.finalize()? {
+        on_output(output)?;
+    }
+
+    Ok(())
+}
+
+fn wait_for_storage_root<O>(
+    account: B256,
+    result_rx: &mpsc::Receiver<StorageResult>,
+    pending_roots: &mut BTreeMap<B256, B256>,
+    pending_outputs: &mut BTreeMap<B256, Vec<Output>>,
+    on_output: &mut O,
+) -> eyre::Result<B256>
+where
+    O: FnMut(Output) -> eyre::Result<()>,
+{
+    if let Some(root) = pending_roots.remove(&account) {
+        flush_pending_outputs(account, pending_outputs, on_output)?;
+        return Ok(root)
+    }
+
+    loop {
+        // `Root` is the end-of-account marker: a producer must emit all storage inconsistencies
+        // for that account before its root, so flushing buffered outputs here is sufficient.
+        match result_rx.recv().map_err(|_| eyre::eyre!("storage results channel closed"))?? {
+            StorageMessage::Root { account: root_account, root } => {
+                if root_account == account {
+                    flush_pending_outputs(account, pending_outputs, on_output)?;
+                    return Ok(root)
+                }
+
+                pending_roots.insert(root_account, root);
+            }
+            StorageMessage::Output(output) => {
+                let output_account = output_storage_account(&output)
+                    .expect("storage worker emitted non-storage output");
+                if output_account == account {
+                    on_output(output)?;
+                } else {
+                    pending_outputs.entry(output_account).or_default().push(output);
+                }
+            }
+        }
+    }
+}
+
+fn flush_pending_outputs<O>(
+    account: B256,
+    pending_outputs: &mut BTreeMap<B256, Vec<Output>>,
+    on_output: &mut O,
+) -> eyre::Result<()>
+where
+    O: FnMut(Output) -> eyre::Result<()>,
+{
+    if let Some(outputs) = pending_outputs.remove(&account) {
+        for output in outputs {
+            on_output(output)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn emit_storage_updates<C>(
+    account: B256,
+    cursor: C,
+    expected_nodes: Vec<(Nibbles, BranchNodeCompact)>,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> eyre::Result<()>
+where
+    C: TrieCursor,
+{
+    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
+    for (path, node) in expected_nodes {
+        for output in verifier.next(path, node)? {
+            result_tx
+                .send(Ok(StorageMessage::Output(output)))
+                .map_err(|_| eyre::eyre!("storage results channel closed"))?;
+        }
+    }
+
+    for output in verifier.finalize()? {
+        result_tx
+            .send(Ok(StorageMessage::Output(output)))
+            .map_err(|_| eyre::eyre!("storage results channel closed"))?;
+    }
+
+    Ok(())
+}
+
+fn emit_empty_storage_inconsistencies<C>(
+    account: B256,
+    cursor: C,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> eyre::Result<()>
+where
+    C: TrieCursor,
+{
+    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
+    for output in verifier.finalize()? {
+        result_tx
+            .send(Ok(StorageMessage::Output(output)))
+            .map_err(|_| eyre::eyre!("storage results channel closed"))?;
+    }
+
+    Ok(())
+}
+
+fn sorted_branch_nodes<I>(nodes: I) -> Vec<(Nibbles, BranchNodeCompact)>
+where
+    I: IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
+{
+    let mut nodes = nodes.into_iter().collect::<Vec<_>>();
+    nodes.sort_unstable_by(|a, b| depth_first::cmp(&a.0, &b.0));
+    nodes
+}
+
+fn output_storage_account(output: &Output) -> Option<B256> {
+    match output {
+        Output::StorageExtra(account, ..) |
+        Output::StorageMissing(account, ..) |
+        Output::StorageWrong { account, .. } => Some(*account),
+        Output::AccountExtra(..) |
+        Output::AccountMissing(..) |
+        Output::AccountWrong { .. } |
+        Output::Progress(..) => None,
+    }
+}
+
+fn storage_worker_count() -> usize {
+    let available = thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
+    available.saturating_sub(2).max(1)
+}
+
 /// Output progress information based on the last seen account path.
 fn output_progress(last_account: Nibbles, start_time: Instant, inconsistent_nodes: u64) {
-    // Calculate percentage based on position in the trie path space
-    // For progress estimation, we'll use the first few nibbles as an approximation
-
-    // Convert the first 16 nibbles (8 bytes) to a u64 for progress calculation
     let mut current_value: u64 = 0;
     let nibbles_to_use = last_account.len().min(16);
 
     for i in 0..nibbles_to_use {
         current_value = (current_value << 4) | (last_account.get(i).unwrap_or(0) as u64);
     }
-    // Shift left to fill remaining bits if we have fewer than 16 nibbles
     if nibbles_to_use < 16 {
         current_value <<= (16 - nibbles_to_use) * 4;
     }
@@ -352,7 +757,6 @@ fn output_progress(last_account: Nibbles, start_time: Instant, inconsistent_node
     let progress_percent = current_value as f64 / u64::MAX as f64 * 100.0;
     let progress_percent_str = format!("{progress_percent:.2}");
 
-    // Calculate ETA based on current speed
     let elapsed = start_time.elapsed();
     let elapsed_secs = elapsed.as_secs_f64();
 
@@ -388,5 +792,72 @@ impl RepairTrieMetrics {
                 "type" => "storage"
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_for_storage_root_buffers_future_accounts() {
+        let target_account = B256::from([0x11; 32]);
+        let future_account = B256::from([0x22; 32]);
+        let target_root = B256::from([0xaa; 32]);
+        let future_root = B256::from([0xbb; 32]);
+        let target_output = Output::StorageExtra(
+            target_account,
+            Nibbles::from_nibbles([0x1]),
+            BranchNodeCompact::default(),
+        );
+        let future_output = Output::StorageExtra(
+            future_account,
+            Nibbles::from_nibbles([0x2]),
+            BranchNodeCompact::default(),
+        );
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Ok(StorageMessage::Output(future_output.clone()))).unwrap();
+        tx.send(Ok(StorageMessage::Root { account: future_account, root: future_root })).unwrap();
+        tx.send(Ok(StorageMessage::Output(target_output.clone()))).unwrap();
+        tx.send(Ok(StorageMessage::Root { account: target_account, root: target_root })).unwrap();
+
+        let mut pending_roots = BTreeMap::new();
+        let mut pending_outputs = BTreeMap::new();
+        let mut seen_outputs = Vec::new();
+
+        let root = wait_for_storage_root(
+            target_account,
+            &rx,
+            &mut pending_roots,
+            &mut pending_outputs,
+            &mut |output| {
+                seen_outputs.push(output);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(root, target_root);
+        assert_eq!(seen_outputs, vec![target_output]);
+
+        seen_outputs.clear();
+
+        let root = wait_for_storage_root(
+            future_account,
+            &rx,
+            &mut pending_roots,
+            &mut pending_outputs,
+            &mut |output| {
+                seen_outputs.push(output);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(root, future_root);
+        assert_eq!(seen_outputs, vec![future_output]);
+        assert!(pending_roots.is_empty());
+        assert!(pending_outputs.is_empty());
     }
 }

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -1,6 +1,3 @@
-use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::B256;
-use alloy_rlp::{BufMut, Encodable};
 use clap::Parser;
 use metrics::{self, Counter};
 use reth_chainspec::EthChainSpec;
@@ -8,7 +5,6 @@ use reth_cli_util::parse_socket_address;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::Database,
-    tables,
     transaction::{DbTx, DbTxMut},
 };
 use reth_db_common::DbTool;
@@ -22,30 +18,17 @@ use reth_node_metrics::{
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
 };
-use reth_provider::{providers::ProviderNodeTypes, ChainSpecProvider, StageCheckpointReader};
+use reth_provider::{
+    providers::ProviderNodeTypes, ChainSpecProvider, ProviderFactory, StageCheckpointReader,
+};
 use reth_stages::StageId;
-use reth_storage_api::{DBProvider, StorageSettingsCache};
+use reth_storage_api::StorageSettingsCache;
 use reth_tasks::TaskExecutor;
-use reth_trie::{
-    hashed_cursor::HashedCursorFactory,
-    metrics::TrieRootMetrics,
-    node_iter::{TrieElement, TrieNodeIter},
-    trie_cursor::{depth_first, DepthFirstTrieIterator, TrieCursor, TrieCursorFactory},
-    updates::TrieUpdates,
-    verify::Output,
-    walker::TrieWalker,
-    BranchNodeCompact, HashBuilder, Nibbles, StorageRoot, TrieType, TRIE_ACCOUNT_RLP_MAX_SIZE,
-};
-use reth_trie_db::{
-    DatabaseHashedCursorFactory, DatabaseTrieCursorFactory, StorageTrieEntryLike, TrieTableAdapter,
-};
+use reth_trie::{verify::Output, Nibbles};
+use reth_trie_db::{StorageTrieEntryLike, TrieTableAdapter};
+use reth_trie_parallel::ParallelTrieVerifier;
 use std::{
-    cmp::Ordering,
-    collections::BTreeMap,
     net::SocketAddr,
-    num::NonZeroUsize,
-    sync::{mpsc, Arc, Mutex},
-    thread,
     time::{Duration, Instant},
 };
 use tracing::{info, warn};
@@ -74,7 +57,6 @@ impl Command {
         task_executor: TaskExecutor,
         data_dir: &ChainPath<DataDirPath>,
     ) -> eyre::Result<()> {
-        // Set up metrics server if requested
         let _metrics_handle = if let Some(listen_addr) = self.metrics {
             let chain_name = tool.provider_factory.chain_spec().chain().to_string();
             let executor = task_executor.clone();
@@ -130,37 +112,32 @@ fn verify_only<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
     let start_time = Instant::now();
     let mut last_progress_time = Instant::now();
 
-    reth_trie_db::with_adapter!(tool.provider_factory, |A| {
-        parallel_verify::<A, _, _, _>(
-            &|| Ok(tool.provider_factory.provider()?.disable_long_read_transaction_safety()),
-            |output| {
-                if let Output::Progress(path) = output {
-                    if last_progress_time.elapsed() > PROGRESS_PERIOD {
-                        output_progress(path, start_time, inconsistent_nodes);
-                        last_progress_time = Instant::now();
-                    }
-                } else {
-                    warn!("Inconsistency found: {output:?}");
-                    inconsistent_nodes += 1;
+    ParallelTrieVerifier::new(tool.provider_factory.clone()).verify(|output| {
+        if let Output::Progress(path) = output {
+            if last_progress_time.elapsed() > PROGRESS_PERIOD {
+                output_progress(path, start_time, inconsistent_nodes);
+                last_progress_time = Instant::now();
+            }
+        } else {
+            warn!("Inconsistency found: {output:?}");
+            inconsistent_nodes += 1;
 
-                    match output {
-                        Output::AccountExtra(_, _) |
-                        Output::AccountWrong { .. } |
-                        Output::AccountMissing(_, _) => {
-                            metrics.account_inconsistencies.increment(1);
-                        }
-                        Output::StorageExtra(_, _, _) |
-                        Output::StorageWrong { .. } |
-                        Output::StorageMissing(_, _, _) => {
-                            metrics.storage_inconsistencies.increment(1);
-                        }
-                        Output::Progress(_) => unreachable!(),
-                    }
+            match output {
+                Output::AccountExtra(_, _) |
+                Output::AccountWrong { .. } |
+                Output::AccountMissing(_, _) => {
+                    metrics.account_inconsistencies.increment(1);
                 }
+                Output::StorageExtra(_, _, _) |
+                Output::StorageWrong { .. } |
+                Output::StorageMissing(_, _, _) => {
+                    metrics.storage_inconsistencies.increment(1);
+                }
+                Output::Progress(_) => unreachable!(),
+            }
+        }
 
-                Ok(())
-            },
-        )
+        Ok(())
     })?;
 
     info!("Found {} inconsistencies (dry run - no changes made)", inconsistent_nodes);
@@ -213,9 +190,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
     verify_checkpoints(provider_rw.as_ref())?;
 
     let inconsistent_nodes = reth_trie_db::with_adapter!(tool.provider_factory, |A| {
-        do_verify_and_repair::<_, A, _, _>(&mut provider_rw, &|| {
-            Ok(tool.provider_factory.provider()?.disable_long_read_transaction_safety())
-        })
+        do_verify_and_repair::<_, A>(tool.provider_factory.clone(), &mut provider_rw)
     })?;
 
     if inconsistent_nodes == 0 {
@@ -228,14 +203,11 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
     Ok(())
 }
 
-fn do_verify_and_repair<N: ProviderNodeTypes, A: TrieTableAdapter + Send, P, F>(
+fn do_verify_and_repair<N: ProviderNodeTypes, A: TrieTableAdapter>(
+    factory: ProviderFactory<N>,
     provider_rw: &mut reth_provider::DatabaseProviderRW<N::DB, N>,
-    make_provider: &F,
 ) -> eyre::Result<usize>
 where
-    P: DBProvider + Send,
-    P::Tx: DbTx,
-    F: Fn() -> eyre::Result<P> + Sync,
     <N::DB as Database>::TXMut: DbTxMut + DbTx,
 {
     let tx = provider_rw.tx_mut();
@@ -248,7 +220,7 @@ where
     let start_time = Instant::now();
     let mut last_progress_time = Instant::now();
 
-    parallel_verify::<A, _, _, _>(make_provider, |output| {
+    ParallelTrieVerifier::new(factory).verify(|output| {
         if !matches!(output, Output::Progress(_)) {
             warn!("Inconsistency found, will repair: {output:?}");
             inconsistent_nodes += 1;
@@ -279,7 +251,7 @@ where
                 let subkey: A::StorageSubKey = path.into();
                 if storage_trie_cursor
                     .seek_by_key_subkey(account, subkey.clone())?
-                    .filter(|e| *e.nibbles() == subkey)
+                    .filter(|entry| *entry.nibbles() == subkey)
                     .is_some()
                 {
                     storage_trie_cursor.delete_current()?;
@@ -296,7 +268,7 @@ where
                 let entry = A::StorageValue::new(subkey.clone(), node);
                 if storage_trie_cursor
                     .seek_by_key_subkey(account, subkey.clone())?
-                    .filter(|v| *v.nibbles() == subkey)
+                    .filter(|value| *value.nibbles() == subkey)
                     .is_some()
                 {
                     storage_trie_cursor.delete_current()?;
@@ -315,441 +287,6 @@ where
     })?;
 
     Ok(inconsistent_nodes as usize)
-}
-
-type StorageResult = eyre::Result<StorageMessage>;
-
-// Each account's storage result stream must come from exactly one producer, and that producer must
-// send every inconsistency before it sends the final root for the account. `wait_for_storage_root`
-// relies on that ordering when it buffers future-account messages.
-#[derive(Debug)]
-enum StorageMessage {
-    Root { account: B256, root: B256 },
-    Output(Output),
-}
-
-#[derive(Debug)]
-struct RepairTrieCursorVerifier<I> {
-    account: Option<B256>,
-    trie_iter: I,
-    curr: Option<(Nibbles, BranchNodeCompact)>,
-}
-
-impl<C: TrieCursor> RepairTrieCursorVerifier<DepthFirstTrieIterator<C>> {
-    fn new(account: Option<B256>, trie_cursor: C) -> eyre::Result<Self> {
-        let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
-        let curr = trie_iter.next().transpose()?;
-        Ok(Self { account, trie_iter, curr })
-    }
-
-    const fn output_extra(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
-        if let Some(account) = self.account {
-            Output::StorageExtra(account, path, node)
-        } else {
-            Output::AccountExtra(path, node)
-        }
-    }
-
-    const fn output_wrong(
-        &self,
-        path: Nibbles,
-        expected: BranchNodeCompact,
-        found: BranchNodeCompact,
-    ) -> Output {
-        if let Some(account) = self.account {
-            Output::StorageWrong { account, path, expected, found }
-        } else {
-            Output::AccountWrong { path, expected, found }
-        }
-    }
-
-    const fn output_missing(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
-        if let Some(account) = self.account {
-            Output::StorageMissing(account, path, node)
-        } else {
-            Output::AccountMissing(path, node)
-        }
-    }
-
-    fn next(&mut self, path: Nibbles, node: BranchNodeCompact) -> eyre::Result<Vec<Output>> {
-        let mut outputs = Vec::new();
-
-        loop {
-            if self.curr.is_none() {
-                outputs.push(self.output_missing(path, node));
-                return Ok(outputs)
-            }
-
-            let (curr_path, curr_node) = self.curr.as_ref().expect("not None");
-            match depth_first::cmp(&path, curr_path) {
-                Ordering::Less => {
-                    outputs.push(self.output_missing(path, node));
-                    return Ok(outputs)
-                }
-                Ordering::Equal => {
-                    if *curr_node != node {
-                        outputs.push(self.output_wrong(path, node, curr_node.clone()));
-                    }
-                    self.curr = self.trie_iter.next().transpose()?;
-                    return Ok(outputs)
-                }
-                Ordering::Greater => {
-                    outputs.push(self.output_extra(*curr_path, curr_node.clone()));
-                    self.curr = self.trie_iter.next().transpose()?;
-                }
-            }
-        }
-    }
-
-    fn finalize(&mut self) -> eyre::Result<Vec<Output>> {
-        let mut outputs = Vec::new();
-        while let Some((curr_path, curr_node)) = self.curr.take() {
-            outputs.push(self.output_extra(curr_path, curr_node));
-            self.curr = self.trie_iter.next().transpose()?;
-        }
-        Ok(outputs)
-    }
-}
-
-fn parallel_verify<A, P, F, O>(make_provider: &F, mut on_output: O) -> eyre::Result<()>
-where
-    A: TrieTableAdapter + Send,
-    P: DBProvider + Send,
-    P::Tx: DbTx,
-    F: Fn() -> eyre::Result<P> + Sync,
-    O: FnMut(Output) -> eyre::Result<()>,
-{
-    let storage_workers = storage_worker_count();
-    info!(storage_workers, "Verifying storage tries in parallel");
-
-    let (job_tx, job_rx) = mpsc::sync_channel(storage_workers.saturating_mul(2).max(1));
-    let job_rx = Arc::new(Mutex::new(job_rx));
-    let (result_tx, result_rx) = mpsc::channel();
-
-    thread::scope(|scope| -> eyre::Result<()> {
-        {
-            let result_tx = result_tx.clone();
-            let job_tx = job_tx.clone();
-            scope.spawn(move || {
-                if let Err(err) =
-                    dispatch_storage_jobs::<A, P, F>(make_provider, &job_tx, &result_tx)
-                {
-                    let _ = result_tx.send(Err(err));
-                }
-            });
-        }
-
-        for _ in 0..storage_workers {
-            let job_rx = Arc::clone(&job_rx);
-            let result_tx = result_tx.clone();
-
-            scope.spawn(move || {
-                let provider = match make_provider() {
-                    Ok(provider) => provider.disable_long_read_transaction_safety(),
-                    Err(err) => {
-                        let _ = result_tx.send(Err(err));
-                        return;
-                    }
-                };
-
-                loop {
-                    let account = match job_rx.lock().expect("poisoned storage job receiver").recv()
-                    {
-                        Ok(account) => account,
-                        Err(_) => break,
-                    };
-
-                    if let Err(err) = verify_storage_account::<A, _>(&provider, account, &result_tx)
-                    {
-                        let _ = result_tx.send(Err(err));
-                        break;
-                    }
-                }
-            });
-        }
-
-        drop(job_tx);
-        drop(result_tx);
-
-        verify_accounts::<A, _, _, _>(make_provider, &result_rx, &mut on_output)
-    })
-}
-
-fn dispatch_storage_jobs<A, P, F>(
-    make_provider: &F,
-    job_tx: &mpsc::SyncSender<B256>,
-    result_tx: &mpsc::Sender<StorageResult>,
-) -> eyre::Result<()>
-where
-    A: TrieTableAdapter,
-    P: DBProvider,
-    P::Tx: DbTx,
-    F: Fn() -> eyre::Result<P>,
-{
-    let provider = make_provider()?.disable_long_read_transaction_safety();
-    let tx = provider.tx_ref();
-    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
-    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
-    let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
-
-    let mut next_storage_account = storage_cursor.first()?.map(|entry| entry.0);
-    let mut next_account = account_cursor.first()?;
-
-    while let Some((account, _)) = next_account {
-        while next_storage_account.is_some_and(|storage_account| storage_account < account) {
-            next_storage_account = storage_cursor.next_no_dup()?.map(|entry| entry.0);
-        }
-
-        if next_storage_account == Some(account) {
-            job_tx.send(account).map_err(|_| eyre::eyre!("storage worker queue closed"))?;
-            next_storage_account = storage_cursor.next_no_dup()?.map(|entry| entry.0);
-        } else {
-            emit_empty_storage_inconsistencies(
-                account,
-                trie_cursor_factory.storage_trie_cursor(account)?,
-                result_tx,
-            )?;
-            result_tx
-                .send(Ok(StorageMessage::Root { account, root: EMPTY_ROOT_HASH }))
-                .map_err(|_| eyre::eyre!("storage results channel closed"))?;
-        }
-
-        next_account = account_cursor.next()?;
-    }
-
-    Ok(())
-}
-
-fn verify_storage_account<A, P>(
-    provider: &P,
-    account: B256,
-    result_tx: &mpsc::Sender<StorageResult>,
-) -> eyre::Result<()>
-where
-    A: TrieTableAdapter,
-    P: DBProvider,
-    P::Tx: DbTx,
-{
-    let tx = provider.tx_ref();
-    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
-    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
-
-    let (root, _, updates) = StorageRoot::new_hashed(
-        trie_cursor_factory.clone(),
-        hashed_cursor_factory,
-        account,
-        Default::default(),
-        TrieRootMetrics::new(TrieType::Storage),
-    )
-    .root_with_updates()?;
-
-    emit_storage_updates(
-        account,
-        trie_cursor_factory.storage_trie_cursor(account)?,
-        sorted_branch_nodes(updates.storage_nodes.into_iter()),
-        result_tx,
-    )?;
-
-    result_tx
-        .send(Ok(StorageMessage::Root { account, root }))
-        .map_err(|_| eyre::eyre!("storage results channel closed"))?;
-
-    Ok(())
-}
-
-fn verify_accounts<A, P, F, O>(
-    make_provider: &F,
-    result_rx: &mpsc::Receiver<StorageResult>,
-    on_output: &mut O,
-) -> eyre::Result<()>
-where
-    A: TrieTableAdapter,
-    P: DBProvider,
-    P::Tx: DbTx,
-    F: Fn() -> eyre::Result<P>,
-    O: FnMut(Output) -> eyre::Result<()>,
-{
-    let provider = make_provider()?.disable_long_read_transaction_safety();
-    let tx = provider.tx_ref();
-    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
-    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
-
-    let walker: TrieWalker<_> =
-        TrieWalker::state_trie(trie_cursor_factory.account_trie_cursor()?, Default::default())
-            .with_deletions_retained(true);
-    let mut account_node_iter =
-        TrieNodeIter::state_trie(walker, hashed_cursor_factory.hashed_account_cursor()?);
-    let mut hash_builder = HashBuilder::default().with_updates(true);
-    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
-    let mut pending_roots = BTreeMap::new();
-    let mut pending_outputs = BTreeMap::new();
-
-    while let Some(node) = account_node_iter.try_next()? {
-        match node {
-            TrieElement::Branch(node) => {
-                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
-            }
-            TrieElement::Leaf(hashed_address, account) => {
-                let storage_root = wait_for_storage_root(
-                    hashed_address,
-                    result_rx,
-                    &mut pending_roots,
-                    &mut pending_outputs,
-                    on_output,
-                )?;
-
-                account_rlp.clear();
-                account.into_trie_account(storage_root).encode(&mut account_rlp as &mut dyn BufMut);
-                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
-                on_output(Output::Progress(Nibbles::unpack(hashed_address)))?;
-            }
-        }
-    }
-
-    let removed_keys = account_node_iter.walker.take_removed_keys();
-    let mut trie_updates = TrieUpdates::default();
-    trie_updates.finalize(hash_builder, removed_keys, Default::default());
-
-    let mut account_verifier =
-        RepairTrieCursorVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?;
-    for (path, node) in sorted_branch_nodes(trie_updates.account_nodes.into_iter()) {
-        for output in account_verifier.next(path, node)? {
-            on_output(output)?;
-        }
-    }
-    for output in account_verifier.finalize()? {
-        on_output(output)?;
-    }
-
-    Ok(())
-}
-
-fn wait_for_storage_root<O>(
-    account: B256,
-    result_rx: &mpsc::Receiver<StorageResult>,
-    pending_roots: &mut BTreeMap<B256, B256>,
-    pending_outputs: &mut BTreeMap<B256, Vec<Output>>,
-    on_output: &mut O,
-) -> eyre::Result<B256>
-where
-    O: FnMut(Output) -> eyre::Result<()>,
-{
-    if let Some(root) = pending_roots.remove(&account) {
-        flush_pending_outputs(account, pending_outputs, on_output)?;
-        return Ok(root)
-    }
-
-    loop {
-        // `Root` is the end-of-account marker: a producer must emit all storage inconsistencies
-        // for that account before its root, so flushing buffered outputs here is sufficient.
-        match result_rx.recv().map_err(|_| eyre::eyre!("storage results channel closed"))?? {
-            StorageMessage::Root { account: root_account, root } => {
-                if root_account == account {
-                    flush_pending_outputs(account, pending_outputs, on_output)?;
-                    return Ok(root)
-                }
-
-                pending_roots.insert(root_account, root);
-            }
-            StorageMessage::Output(output) => {
-                let output_account = output_storage_account(&output)
-                    .expect("storage worker emitted non-storage output");
-                if output_account == account {
-                    on_output(output)?;
-                } else {
-                    pending_outputs.entry(output_account).or_default().push(output);
-                }
-            }
-        }
-    }
-}
-
-fn flush_pending_outputs<O>(
-    account: B256,
-    pending_outputs: &mut BTreeMap<B256, Vec<Output>>,
-    on_output: &mut O,
-) -> eyre::Result<()>
-where
-    O: FnMut(Output) -> eyre::Result<()>,
-{
-    if let Some(outputs) = pending_outputs.remove(&account) {
-        for output in outputs {
-            on_output(output)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn emit_storage_updates<C>(
-    account: B256,
-    cursor: C,
-    expected_nodes: Vec<(Nibbles, BranchNodeCompact)>,
-    result_tx: &mpsc::Sender<StorageResult>,
-) -> eyre::Result<()>
-where
-    C: TrieCursor,
-{
-    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
-    for (path, node) in expected_nodes {
-        for output in verifier.next(path, node)? {
-            result_tx
-                .send(Ok(StorageMessage::Output(output)))
-                .map_err(|_| eyre::eyre!("storage results channel closed"))?;
-        }
-    }
-
-    for output in verifier.finalize()? {
-        result_tx
-            .send(Ok(StorageMessage::Output(output)))
-            .map_err(|_| eyre::eyre!("storage results channel closed"))?;
-    }
-
-    Ok(())
-}
-
-fn emit_empty_storage_inconsistencies<C>(
-    account: B256,
-    cursor: C,
-    result_tx: &mpsc::Sender<StorageResult>,
-) -> eyre::Result<()>
-where
-    C: TrieCursor,
-{
-    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
-    for output in verifier.finalize()? {
-        result_tx
-            .send(Ok(StorageMessage::Output(output)))
-            .map_err(|_| eyre::eyre!("storage results channel closed"))?;
-    }
-
-    Ok(())
-}
-
-fn sorted_branch_nodes<I>(nodes: I) -> Vec<(Nibbles, BranchNodeCompact)>
-where
-    I: IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
-{
-    let mut nodes = nodes.into_iter().collect::<Vec<_>>();
-    nodes.sort_unstable_by(|a, b| depth_first::cmp(&a.0, &b.0));
-    nodes
-}
-
-fn output_storage_account(output: &Output) -> Option<B256> {
-    match output {
-        Output::StorageExtra(account, ..) |
-        Output::StorageMissing(account, ..) |
-        Output::StorageWrong { account, .. } => Some(*account),
-        Output::AccountExtra(..) |
-        Output::AccountMissing(..) |
-        Output::AccountWrong { .. } |
-        Output::Progress(..) => None,
-    }
-}
-
-fn storage_worker_count() -> usize {
-    let available = thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
-    available.saturating_sub(2).max(1)
 }
 
 /// Output progress information based on the last seen account path.
@@ -802,72 +339,5 @@ impl RepairTrieMetrics {
                 "type" => "storage"
             ),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn wait_for_storage_root_buffers_future_accounts() {
-        let target_account = B256::from([0x11; 32]);
-        let future_account = B256::from([0x22; 32]);
-        let target_root = B256::from([0xaa; 32]);
-        let future_root = B256::from([0xbb; 32]);
-        let target_output = Output::StorageExtra(
-            target_account,
-            Nibbles::from_nibbles([0x1]),
-            BranchNodeCompact::default(),
-        );
-        let future_output = Output::StorageExtra(
-            future_account,
-            Nibbles::from_nibbles([0x2]),
-            BranchNodeCompact::default(),
-        );
-
-        let (tx, rx) = mpsc::channel();
-        tx.send(Ok(StorageMessage::Output(future_output.clone()))).unwrap();
-        tx.send(Ok(StorageMessage::Root { account: future_account, root: future_root })).unwrap();
-        tx.send(Ok(StorageMessage::Output(target_output.clone()))).unwrap();
-        tx.send(Ok(StorageMessage::Root { account: target_account, root: target_root })).unwrap();
-
-        let mut pending_roots = BTreeMap::new();
-        let mut pending_outputs = BTreeMap::new();
-        let mut seen_outputs = Vec::new();
-
-        let root = wait_for_storage_root(
-            target_account,
-            &rx,
-            &mut pending_roots,
-            &mut pending_outputs,
-            &mut |output| {
-                seen_outputs.push(output);
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        assert_eq!(root, target_root);
-        assert_eq!(seen_outputs, vec![target_output]);
-
-        seen_outputs.clear();
-
-        let root = wait_for_storage_root(
-            future_account,
-            &rx,
-            &mut pending_roots,
-            &mut pending_outputs,
-            &mut |output| {
-                seen_outputs.push(output);
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        assert_eq!(root, future_root);
-        assert_eq!(seen_outputs, vec![future_output]);
-        assert!(pending_roots.is_empty());
-        assert!(pending_outputs.is_empty());
     }
 }

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -57,6 +57,7 @@ impl Command {
         task_executor: TaskExecutor,
         data_dir: &ChainPath<DataDirPath>,
     ) -> eyre::Result<()> {
+        // Set up metrics server if requested
         let _metrics_handle = if let Some(listen_addr) = self.metrics {
             let chain_name = tool.provider_factory.chain_spec().chain().to_string();
             let executor = task_executor.clone();
@@ -79,6 +80,7 @@ impl Command {
                     pprof_dump_dir,
                 );
 
+                // Spawn the metrics server
                 if let Err(e) = MetricServer::new(config).serve().await {
                     tracing::error!("Metrics server error: {}", e);
                 }
@@ -100,6 +102,7 @@ impl Command {
 }
 
 fn verify_only<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
+    // Log the database block tip from Finish stage checkpoint
     let finish_checkpoint = tool
         .provider_factory
         .provider()?
@@ -122,6 +125,7 @@ fn verify_only<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
             warn!("Inconsistency found: {output:?}");
             inconsistent_nodes += 1;
 
+            // Record metrics based on output type
             match output {
                 Output::AccountExtra(_, _) |
                 Output::AccountWrong { .. } |
@@ -182,11 +186,14 @@ fn verify_checkpoints(provider: impl StageCheckpointReader) -> eyre::Result<()> 
 }
 
 fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()> {
+    // Get a read-write database provider
     let mut provider_rw = tool.provider_factory.provider_rw()?;
 
+    // Log the database block tip from Finish stage checkpoint
     let finish_checkpoint = provider_rw.get_stage_checkpoint(StageId::Finish)?.unwrap_or_default();
     info!("Database block tip: {}", finish_checkpoint.block_number);
 
+    // Check that a pipeline sync isn't in progress.
     verify_checkpoints(provider_rw.as_ref())?;
 
     let inconsistent_nodes = reth_trie_db::with_adapter!(tool.provider_factory, |A| {
@@ -210,6 +217,7 @@ fn do_verify_and_repair<N: ProviderNodeTypes, A: TrieTableAdapter>(
 where
     <N::DB as Database>::TXMut: DbTxMut + DbTx,
 {
+    // Create cursors for making modifications with
     let tx = provider_rw.tx_mut();
     tx.disable_long_read_transaction_safety();
     let mut account_trie_cursor = tx.cursor_write::<A::AccountTrieTable>()?;
@@ -225,6 +233,7 @@ where
             warn!("Inconsistency found, will repair: {output:?}");
             inconsistent_nodes += 1;
 
+            // Record metrics based on output type
             match &output {
                 Output::AccountExtra(_, _) |
                 Output::AccountWrong { .. } |
@@ -242,12 +251,14 @@ where
 
         match output {
             Output::AccountExtra(path, _node) => {
+                // Extra account node in trie, remove it
                 let key: A::AccountKey = path.into();
                 if account_trie_cursor.seek_exact(key)?.is_some() {
                     account_trie_cursor.delete_current()?;
                 }
             }
             Output::StorageExtra(account, path, _node) => {
+                // Extra storage node in trie, remove it
                 let subkey: A::StorageSubKey = path.into();
                 if storage_trie_cursor
                     .seek_by_key_subkey(account, subkey.clone())?
@@ -259,11 +270,15 @@ where
             }
             Output::AccountWrong { path, expected: node, .. } |
             Output::AccountMissing(path, node) => {
+                // Wrong/missing account node value, upsert it
                 let key: A::AccountKey = path.into();
                 account_trie_cursor.upsert(key, &node)?;
             }
             Output::StorageWrong { account, path, expected: node, .. } |
             Output::StorageMissing(account, path, node) => {
+                // Wrong/missing storage node value, upsert it
+                // (We can't just use `upsert` method with a dup cursor, it's not properly
+                // supported)
                 let subkey: A::StorageSubKey = path.into();
                 let entry = A::StorageValue::new(subkey.clone(), node);
                 if storage_trie_cursor
@@ -291,12 +306,17 @@ where
 
 /// Output progress information based on the last seen account path.
 fn output_progress(last_account: Nibbles, start_time: Instant, inconsistent_nodes: u64) {
+    // Calculate percentage based on position in the trie path space
+    // For progress estimation, we'll use the first few nibbles as an approximation
+
+    // Convert the first 16 nibbles (8 bytes) to a u64 for progress calculation
     let mut current_value: u64 = 0;
     let nibbles_to_use = last_account.len().min(16);
 
     for i in 0..nibbles_to_use {
         current_value = (current_value << 4) | (last_account.get(i).unwrap_or(0) as u64);
     }
+    // Shift left to fill remaining bits if we have fewer than 16 nibbles
     if nibbles_to_use < 16 {
         current_value <<= (16 - nibbles_to_use) * 4;
     }
@@ -304,6 +324,7 @@ fn output_progress(last_account: Nibbles, start_time: Instant, inconsistent_node
     let progress_percent = current_value as f64 / u64::MAX as f64 * 100.0;
     let progress_percent_str = format!("{progress_percent:.2}");
 
+    // Calculate ETA based on current speed
     let elapsed = start_time.elapsed();
     let elapsed_secs = elapsed.as_secs_f64();
 

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -13,14 +13,18 @@ workspace = true
 
 [dependencies]
 # reth
+reth-db-api.workspace = true
 reth-primitives-traits = { workspace = true, features = ["dashmap", "std"] }
 reth-execution-errors.workspace = true
 reth-provider.workspace = true
+reth-storage-api = { workspace = true, features = ["db-api"] }
 reth-storage-errors.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-trie.workspace = true
+reth-trie-db.workspace = true
 
 # alloy
+alloy-consensus.workspace = true
 alloy-eip7928.workspace = true
 alloy-evm.workspace = true
 alloy-primitives.workspace = true
@@ -76,4 +80,5 @@ test-utils = [
     "reth-trie/test-utils",
     "reth-tasks/test-utils",
     "reth-trie-sparse?/test-utils",
+    "reth-db-api/test-utils",
 ]

--- a/crates/trie/parallel/src/lib.rs
+++ b/crates/trie/parallel/src/lib.rs
@@ -17,6 +17,9 @@ pub mod stats;
 /// Implementation of parallel state root computation.
 pub mod root;
 
+/// Implementation of parallel trie verification.
+pub mod verify;
+
 /// Implementation of parallel proof computation.
 pub mod proof_task;
 
@@ -33,3 +36,5 @@ pub mod metrics;
 /// Proof task manager metrics.
 #[cfg(feature = "metrics")]
 pub mod proof_task_metrics;
+
+pub use verify::{ParallelTrieVerifier, ParallelTrieVerifyError};

--- a/crates/trie/parallel/src/verify.rs
+++ b/crates/trie/parallel/src/verify.rs
@@ -1,6 +1,5 @@
 use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::B256;
-use alloy_rlp::{BufMut, Encodable};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
@@ -9,26 +8,20 @@ use reth_db_api::{
 use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_api::{DBProvider, StorageSettingsCache};
 use reth_storage_errors::db::DatabaseError;
-use reth_trie::{
-    hashed_cursor::HashedCursorFactory,
-    node_iter::{TrieElement, TrieNodeIter},
-    trie_cursor::{
-        depth_first, noop::NoopTrieCursorFactory, DepthFirstTrieIterator, TrieCursor,
-        TrieCursorFactory,
-    },
-    updates::TrieUpdates,
-    verify::Output,
-    walker::TrieWalker,
-    BranchNodeCompact, HashBuilder, Nibbles, StorageRoot, TRIE_ACCOUNT_RLP_MAX_SIZE,
-};
 #[cfg(feature = "metrics")]
 use reth_trie::{metrics::TrieRootMetrics, TrieType};
+use reth_trie::{
+    trie_cursor::{noop::NoopTrieCursorFactory, TrieCursor, TrieCursorFactory},
+    verify::{
+        rebuild_account_nodes_from_hashed_state, sorted_branch_nodes, Output, TrieCursorVerifier,
+    },
+    BranchNodeCompact, Nibbles, StorageRoot,
+};
 use reth_trie_db::{
     DatabaseHashedCursorFactory, DatabaseTrieCursorFactory, LegacyKeyAdapter, PackedKeyAdapter,
     TrieTableAdapter,
 };
 use std::{
-    cmp::Ordering,
     collections::BTreeMap,
     num::NonZeroUsize,
     sync::{mpsc, Arc, Mutex},
@@ -166,93 +159,6 @@ enum StorageMessage {
     Output(Output),
 }
 
-#[derive(Debug)]
-struct RepairTrieCursorVerifier<I> {
-    account: Option<B256>,
-    trie_iter: I,
-    curr: Option<(Nibbles, BranchNodeCompact)>,
-}
-
-impl<C: TrieCursor> RepairTrieCursorVerifier<DepthFirstTrieIterator<C>> {
-    fn new(account: Option<B256>, trie_cursor: C) -> Result<Self, DatabaseError> {
-        let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
-        let curr = trie_iter.next().transpose()?;
-        Ok(Self { account, trie_iter, curr })
-    }
-
-    const fn output_extra(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
-        if let Some(account) = self.account {
-            Output::StorageExtra(account, path, node)
-        } else {
-            Output::AccountExtra(path, node)
-        }
-    }
-
-    const fn output_wrong(
-        &self,
-        path: Nibbles,
-        expected: BranchNodeCompact,
-        found: BranchNodeCompact,
-    ) -> Output {
-        if let Some(account) = self.account {
-            Output::StorageWrong { account, path, expected, found }
-        } else {
-            Output::AccountWrong { path, expected, found }
-        }
-    }
-
-    const fn output_missing(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
-        if let Some(account) = self.account {
-            Output::StorageMissing(account, path, node)
-        } else {
-            Output::AccountMissing(path, node)
-        }
-    }
-
-    fn next(
-        &mut self,
-        path: Nibbles,
-        node: BranchNodeCompact,
-    ) -> Result<Vec<Output>, DatabaseError> {
-        let mut outputs = Vec::new();
-
-        loop {
-            if self.curr.is_none() {
-                outputs.push(self.output_missing(path, node));
-                return Ok(outputs)
-            }
-
-            let (curr_path, curr_node) = self.curr.as_ref().expect("not None");
-            match depth_first::cmp(&path, curr_path) {
-                Ordering::Less => {
-                    outputs.push(self.output_missing(path, node));
-                    return Ok(outputs)
-                }
-                Ordering::Equal => {
-                    if *curr_node != node {
-                        outputs.push(self.output_wrong(path, node, curr_node.clone()));
-                    }
-                    self.curr = self.trie_iter.next().transpose()?;
-                    return Ok(outputs)
-                }
-                Ordering::Greater => {
-                    outputs.push(self.output_extra(*curr_path, curr_node.clone()));
-                    self.curr = self.trie_iter.next().transpose()?;
-                }
-            }
-        }
-    }
-
-    fn finalize(&mut self) -> Result<Vec<Output>, DatabaseError> {
-        let mut outputs = Vec::new();
-        while let Some((curr_path, curr_node)) = self.curr.take() {
-            outputs.push(self.output_extra(curr_path, curr_node));
-            self.curr = self.trie_iter.next().transpose()?;
-        }
-        Ok(outputs)
-    }
-}
-
 fn open_provider<Factory>(factory: &Factory) -> Result<Factory::Provider, ParallelTrieVerifyError>
 where
     Factory: DatabaseProviderROFactory,
@@ -361,58 +267,37 @@ where
     let tx = provider.tx_ref();
     let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
     let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
-
-    // Rebuild the account trie from hashed state alone so the collected updates represent the
-    // full canonical trie, not an incremental diff against the current trie tables.
-    let walker: TrieWalker<_> = TrieWalker::state_trie(
-        NoopTrieCursorFactory::default().account_trie_cursor()?,
-        Default::default(),
-    )
-    .with_deletions_retained(true);
-    let mut account_node_iter =
-        TrieNodeIter::state_trie(walker, hashed_cursor_factory.hashed_account_cursor()?);
-    let mut hash_builder = HashBuilder::default().with_updates(true);
-    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
     let mut pending_roots = BTreeMap::new();
     let mut pending_outputs = BTreeMap::new();
 
-    while let Some(node) = account_node_iter.try_next()? {
-        match node {
-            TrieElement::Branch(node) => {
-                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
-            }
-            TrieElement::Leaf(hashed_address, account) => {
-                let storage_root = wait_for_storage_root(
-                    hashed_address,
-                    result_rx,
-                    &mut pending_roots,
-                    &mut pending_outputs,
-                    on_output,
-                )?;
-
-                account_rlp.clear();
-                account.into_trie_account(storage_root).encode(&mut account_rlp as &mut dyn BufMut);
-                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
-                on_output(Output::Progress(Nibbles::unpack(hashed_address)))?;
-            }
-        }
-    }
-
-    // Finalize the rebuilt trie so the hash builder flushes any remaining top-level branch nodes
-    // into its collected updates before we compare against the trie tables.
-    let _ = hash_builder.root();
-    let removed_keys = account_node_iter.walker.take_removed_keys();
-    let mut trie_updates = TrieUpdates::default();
-    trie_updates.finalize(hash_builder, removed_keys, Default::default());
+    let expected_account_nodes = rebuild_account_nodes_from_hashed_state(
+        hashed_cursor_factory,
+        |hashed_address| -> Result<B256, ParallelTrieVerifyError> {
+            let storage_root = wait_for_storage_root(
+                hashed_address,
+                result_rx,
+                &mut pending_roots,
+                &mut pending_outputs,
+                on_output,
+            )?;
+            on_output(Output::Progress(Nibbles::unpack(hashed_address)))?;
+            Ok(storage_root)
+        },
+    )?;
 
     let mut account_verifier =
-        RepairTrieCursorVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?;
-    for (path, node) in sorted_branch_nodes(trie_updates.account_nodes.into_iter()) {
-        for output in account_verifier.next(path, node)? {
+        TrieCursorVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?;
+    let mut outputs = Vec::new();
+    for (path, node) in expected_account_nodes {
+        outputs.clear();
+        account_verifier.next(&mut outputs, path, node)?;
+        for output in outputs.drain(..) {
             on_output(output)?;
         }
     }
-    for output in account_verifier.finalize()? {
+    outputs.clear();
+    account_verifier.finalize(&mut outputs)?;
+    for output in outputs {
         on_output(output)?;
     }
 
@@ -449,8 +334,8 @@ where
                 pending_roots.insert(root_account, root);
             }
             StorageMessage::Output(output) => {
-                let output_account = output_storage_account(&output)
-                    .expect("storage worker emitted non-storage output");
+                let output_account =
+                    output.storage_account().expect("storage worker emitted non-storage output");
                 if output_account == account {
                     on_output(output)?;
                 } else {
@@ -487,16 +372,21 @@ fn emit_storage_updates<C>(
 where
     C: TrieCursor,
 {
-    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
+    let mut verifier = TrieCursorVerifier::new(Some(account), cursor)?;
+    let mut outputs = Vec::new();
     for (path, node) in expected_nodes {
-        for output in verifier.next(path, node)? {
+        outputs.clear();
+        verifier.next(&mut outputs, path, node)?;
+        for output in outputs.drain(..) {
             result_tx.send(Ok(StorageMessage::Output(output))).map_err(|_| {
                 ParallelTrieVerifyError::Other("storage results channel closed".into())
             })?;
         }
     }
 
-    for output in verifier.finalize()? {
+    outputs.clear();
+    verifier.finalize(&mut outputs)?;
+    for output in outputs {
         result_tx
             .send(Ok(StorageMessage::Output(output)))
             .map_err(|_| ParallelTrieVerifyError::Other("storage results channel closed".into()))?;
@@ -513,35 +403,16 @@ fn emit_empty_storage_inconsistencies<C>(
 where
     C: TrieCursor,
 {
-    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
-    for output in verifier.finalize()? {
+    let mut verifier = TrieCursorVerifier::new(Some(account), cursor)?;
+    let mut outputs = Vec::new();
+    verifier.finalize(&mut outputs)?;
+    for output in outputs {
         result_tx
             .send(Ok(StorageMessage::Output(output)))
             .map_err(|_| ParallelTrieVerifyError::Other("storage results channel closed".into()))?;
     }
 
     Ok(())
-}
-
-fn sorted_branch_nodes<I>(nodes: I) -> Vec<(Nibbles, BranchNodeCompact)>
-where
-    I: IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
-{
-    let mut nodes = nodes.into_iter().collect::<Vec<_>>();
-    nodes.sort_unstable_by(|a, b| depth_first::cmp(&a.0, &b.0));
-    nodes
-}
-
-fn output_storage_account(output: &Output) -> Option<B256> {
-    match output {
-        Output::StorageExtra(account, ..) |
-        Output::StorageMissing(account, ..) |
-        Output::StorageWrong { account, .. } => Some(*account),
-        Output::AccountExtra(..) |
-        Output::AccountMissing(..) |
-        Output::AccountWrong { .. } |
-        Output::Progress(..) => None,
-    }
 }
 
 fn storage_worker_count() -> usize {

--- a/crates/trie/parallel/src/verify.rs
+++ b/crates/trie/parallel/src/verify.rs
@@ -12,7 +12,10 @@ use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory,
     node_iter::{TrieElement, TrieNodeIter},
-    trie_cursor::{depth_first, DepthFirstTrieIterator, TrieCursor, TrieCursorFactory},
+    trie_cursor::{
+        depth_first, noop::NoopTrieCursorFactory, DepthFirstTrieIterator, TrieCursor,
+        TrieCursorFactory,
+    },
     updates::TrieUpdates,
     verify::Output,
     walker::TrieWalker,
@@ -357,9 +360,13 @@ where
     let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
     let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
 
-    let walker: TrieWalker<_> =
-        TrieWalker::state_trie(trie_cursor_factory.account_trie_cursor()?, Default::default())
-            .with_deletions_retained(true);
+    // Rebuild the account trie from hashed state alone so the collected updates represent the
+    // full canonical trie, not an incremental diff against the current trie tables.
+    let walker: TrieWalker<_> = TrieWalker::state_trie(
+        NoopTrieCursorFactory::default().account_trie_cursor()?,
+        Default::default(),
+    )
+    .with_deletions_retained(true);
     let mut account_node_iter =
         TrieNodeIter::state_trie(walker, hashed_cursor_factory.hashed_account_cursor()?);
     let mut hash_builder = HashBuilder::default().with_updates(true);
@@ -542,9 +549,12 @@ mod tests {
     use super::*;
     use alloy_primitives::U256;
     use reth_primitives_traits::{Account, StorageEntry};
-    use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
-    use reth_trie::verify::Verifier;
-    use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
+    use reth_provider::{test_utils::create_test_provider_factory, HashingWriter, TrieWriter};
+    use reth_trie::{verify::Verifier, StateRoot};
+    use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory};
+
+    type DbStateRoot<'a, TX, A> =
+        StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 
     fn non_progress(outputs: Vec<Output>) -> Vec<String> {
         let mut outputs = outputs
@@ -704,6 +714,79 @@ mod tests {
                 .unwrap(),
             )
         };
+
+        let mut actual = Vec::new();
+        ParallelTrieVerifier::new(factory.clone())
+            .verify(|output| {
+                actual.push(output);
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(expected, non_progress(actual));
+    }
+
+    #[test]
+    fn parallel_verifier_uses_full_account_trie_on_populated_tables() {
+        let factory = create_test_provider_factory();
+        let address_with_storage = "0x1000000000000000000000000000000000000001".parse().unwrap();
+        let address_without_storage = "0x2000000000000000000000000000000000000002".parse().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .insert_account_for_hashing([
+                (
+                    address_with_storage,
+                    Some(Account { nonce: 1, balance: U256::from(10), bytecode_hash: None }),
+                ),
+                (
+                    address_without_storage,
+                    Some(Account { nonce: 2, balance: U256::from(20), bytecode_hash: None }),
+                ),
+            ])
+            .unwrap();
+        provider_rw
+            .insert_storage_for_hashing([(
+                address_with_storage,
+                [StorageEntry { key: B256::from([0x33; 32]), value: U256::from(1) }],
+            )])
+            .unwrap();
+
+        let updates = reth_trie_db::with_adapter!(provider_rw, |A| {
+            let (_root, updates) =
+                DbStateRoot::<_, A>::from_tx(provider_rw.tx_ref()).root_with_updates().unwrap();
+            updates
+        });
+        provider_rw.write_trie_updates(updates).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap().disable_long_read_transaction_safety();
+        let expected = if provider.cached_storage_settings().is_v2() {
+            let trie_cursor_factory =
+                DatabaseTrieCursorFactory::<_, PackedKeyAdapter>::new(provider.tx_ref());
+            non_progress(
+                Verifier::new(
+                    &trie_cursor_factory,
+                    DatabaseHashedCursorFactory::new(provider.tx_ref()),
+                )
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            )
+        } else {
+            let trie_cursor_factory =
+                DatabaseTrieCursorFactory::<_, LegacyKeyAdapter>::new(provider.tx_ref());
+            non_progress(
+                Verifier::new(
+                    &trie_cursor_factory,
+                    DatabaseHashedCursorFactory::new(provider.tx_ref()),
+                )
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            )
+        };
+        assert!(expected.is_empty());
 
         let mut actual = Vec::new();
         ParallelTrieVerifier::new(factory.clone())

--- a/crates/trie/parallel/src/verify.rs
+++ b/crates/trie/parallel/src/verify.rs
@@ -1,0 +1,718 @@
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_primitives::B256;
+use alloy_rlp::{BufMut, Encodable};
+use reth_db_api::{
+    cursor::{DbCursorRO, DbDupCursorRO},
+    tables,
+    transaction::DbTx,
+};
+use reth_provider::{DatabaseProviderROFactory, ProviderError};
+use reth_storage_api::{DBProvider, StorageSettingsCache};
+use reth_storage_errors::db::DatabaseError;
+use reth_trie::{
+    hashed_cursor::HashedCursorFactory,
+    node_iter::{TrieElement, TrieNodeIter},
+    trie_cursor::{depth_first, DepthFirstTrieIterator, TrieCursor, TrieCursorFactory},
+    updates::TrieUpdates,
+    verify::Output,
+    walker::TrieWalker,
+    BranchNodeCompact, HashBuilder, Nibbles, StorageRoot, TRIE_ACCOUNT_RLP_MAX_SIZE,
+};
+#[cfg(feature = "metrics")]
+use reth_trie::{metrics::TrieRootMetrics, TrieType};
+use reth_trie_db::{
+    DatabaseHashedCursorFactory, DatabaseTrieCursorFactory, LegacyKeyAdapter, PackedKeyAdapter,
+    TrieTableAdapter,
+};
+use std::{
+    cmp::Ordering,
+    collections::BTreeMap,
+    num::NonZeroUsize,
+    sync::{mpsc, Arc, Mutex},
+    thread,
+};
+use thiserror::Error;
+use tracing::info;
+
+/// Parallel trie verifier for `reth db repair-trie`-style consistency checks.
+#[derive(Debug)]
+pub struct ParallelTrieVerifier<Factory> {
+    factory: Factory,
+    storage_workers: usize,
+}
+
+impl<Factory> ParallelTrieVerifier<Factory> {
+    /// Create a new parallel trie verifier.
+    pub fn new(factory: Factory) -> Self {
+        Self { factory, storage_workers: storage_worker_count() }
+    }
+
+    /// Override the number of storage worker threads.
+    pub const fn with_storage_workers(mut self, storage_workers: usize) -> Self {
+        self.storage_workers = storage_workers;
+        self
+    }
+}
+
+impl<Factory> ParallelTrieVerifier<Factory>
+where
+    Factory: DatabaseProviderROFactory + StorageSettingsCache + Clone + Send + Sync,
+    Factory::Provider: DBProvider + Send,
+{
+    /// Verify the trie tables and stream outputs into the provided callback.
+    pub fn verify<O>(self, mut on_output: O) -> Result<(), ParallelTrieVerifyError>
+    where
+        O: FnMut(Output) -> Result<(), DatabaseError>,
+    {
+        if self.factory.cached_storage_settings().is_v2() {
+            self.verify_with_adapter::<PackedKeyAdapter, _>(&mut on_output)
+        } else {
+            self.verify_with_adapter::<LegacyKeyAdapter, _>(&mut on_output)
+        }
+    }
+
+    fn verify_with_adapter<A, O>(self, on_output: &mut O) -> Result<(), ParallelTrieVerifyError>
+    where
+        A: TrieTableAdapter + Send,
+        O: FnMut(Output) -> Result<(), DatabaseError>,
+    {
+        let storage_workers = self.storage_workers.max(1);
+        info!(storage_workers, "Verifying storage tries in parallel");
+
+        let (job_tx, job_rx) = mpsc::sync_channel(storage_workers.saturating_mul(2).max(1));
+        let job_rx = Arc::new(Mutex::new(job_rx));
+        let (result_tx, result_rx) = mpsc::channel();
+
+        thread::scope(|scope| -> Result<(), ParallelTrieVerifyError> {
+            {
+                let result_tx = result_tx.clone();
+                let job_tx = job_tx.clone();
+                let factory = self.factory.clone();
+
+                scope.spawn(move || {
+                    if let Err(err) = dispatch_storage_jobs::<A, _>(&factory, &job_tx, &result_tx) {
+                        let _ = result_tx.send(Err(err));
+                    }
+                });
+            }
+
+            for _ in 0..storage_workers {
+                let job_rx = Arc::clone(&job_rx);
+                let result_tx = result_tx.clone();
+                let factory = self.factory.clone();
+
+                scope.spawn(move || {
+                    let provider = match open_provider(&factory) {
+                        Ok(provider) => provider,
+                        Err(err) => {
+                            let _ = result_tx.send(Err(err));
+                            return;
+                        }
+                    };
+
+                    loop {
+                        let account =
+                            match job_rx.lock().expect("poisoned storage job receiver").recv() {
+                                Ok(account) => account,
+                                Err(_) => break,
+                            };
+
+                        if let Err(err) =
+                            verify_storage_account::<A, _>(&provider, account, &result_tx)
+                        {
+                            let _ = result_tx.send(Err(err));
+                            break;
+                        }
+                    }
+                });
+            }
+
+            drop(job_tx);
+            drop(result_tx);
+
+            verify_accounts::<A, _, _>(&self.factory, &result_rx, on_output)
+        })
+    }
+}
+
+/// Error returned by [`ParallelTrieVerifier`].
+#[derive(Error, Debug)]
+pub enum ParallelTrieVerifyError {
+    /// Provider error while opening or reading providers.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    /// Direct database error.
+    #[error(transparent)]
+    Database(#[from] DatabaseError),
+    /// Storage root computation error.
+    #[error(transparent)]
+    StorageRoot(#[from] reth_execution_errors::StorageRootError),
+    /// Generic error.
+    #[error("{0}")]
+    Other(String),
+}
+
+type StorageResult = Result<StorageMessage, ParallelTrieVerifyError>;
+
+// Each account's storage result stream must come from exactly one producer, and that producer must
+// send every inconsistency before it sends the final root. `wait_for_storage_root` relies on that
+// ordering when it buffers future-account messages.
+#[derive(Debug)]
+enum StorageMessage {
+    Root { account: B256, root: B256 },
+    Output(Output),
+}
+
+#[derive(Debug)]
+struct RepairTrieCursorVerifier<I> {
+    account: Option<B256>,
+    trie_iter: I,
+    curr: Option<(Nibbles, BranchNodeCompact)>,
+}
+
+impl<C: TrieCursor> RepairTrieCursorVerifier<DepthFirstTrieIterator<C>> {
+    fn new(account: Option<B256>, trie_cursor: C) -> Result<Self, DatabaseError> {
+        let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
+        let curr = trie_iter.next().transpose()?;
+        Ok(Self { account, trie_iter, curr })
+    }
+
+    const fn output_extra(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
+        if let Some(account) = self.account {
+            Output::StorageExtra(account, path, node)
+        } else {
+            Output::AccountExtra(path, node)
+        }
+    }
+
+    const fn output_wrong(
+        &self,
+        path: Nibbles,
+        expected: BranchNodeCompact,
+        found: BranchNodeCompact,
+    ) -> Output {
+        if let Some(account) = self.account {
+            Output::StorageWrong { account, path, expected, found }
+        } else {
+            Output::AccountWrong { path, expected, found }
+        }
+    }
+
+    const fn output_missing(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
+        if let Some(account) = self.account {
+            Output::StorageMissing(account, path, node)
+        } else {
+            Output::AccountMissing(path, node)
+        }
+    }
+
+    fn next(
+        &mut self,
+        path: Nibbles,
+        node: BranchNodeCompact,
+    ) -> Result<Vec<Output>, DatabaseError> {
+        let mut outputs = Vec::new();
+
+        loop {
+            if self.curr.is_none() {
+                outputs.push(self.output_missing(path, node));
+                return Ok(outputs)
+            }
+
+            let (curr_path, curr_node) = self.curr.as_ref().expect("not None");
+            match depth_first::cmp(&path, curr_path) {
+                Ordering::Less => {
+                    outputs.push(self.output_missing(path, node));
+                    return Ok(outputs)
+                }
+                Ordering::Equal => {
+                    if *curr_node != node {
+                        outputs.push(self.output_wrong(path, node, curr_node.clone()));
+                    }
+                    self.curr = self.trie_iter.next().transpose()?;
+                    return Ok(outputs)
+                }
+                Ordering::Greater => {
+                    outputs.push(self.output_extra(*curr_path, curr_node.clone()));
+                    self.curr = self.trie_iter.next().transpose()?;
+                }
+            }
+        }
+    }
+
+    fn finalize(&mut self) -> Result<Vec<Output>, DatabaseError> {
+        let mut outputs = Vec::new();
+        while let Some((curr_path, curr_node)) = self.curr.take() {
+            outputs.push(self.output_extra(curr_path, curr_node));
+            self.curr = self.trie_iter.next().transpose()?;
+        }
+        Ok(outputs)
+    }
+}
+
+fn open_provider<Factory>(factory: &Factory) -> Result<Factory::Provider, ParallelTrieVerifyError>
+where
+    Factory: DatabaseProviderROFactory,
+    Factory::Provider: DBProvider,
+{
+    Ok(factory.database_provider_ro()?.disable_long_read_transaction_safety())
+}
+
+fn dispatch_storage_jobs<A, Factory>(
+    factory: &Factory,
+    job_tx: &mpsc::SyncSender<B256>,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> Result<(), ParallelTrieVerifyError>
+where
+    Factory: DatabaseProviderROFactory,
+    Factory::Provider: DBProvider,
+    A: TrieTableAdapter,
+{
+    let provider = open_provider(factory)?;
+    let tx = provider.tx_ref();
+    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
+    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+    let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+    let mut next_storage_account = storage_cursor.first()?.map(|entry| entry.0);
+    let mut next_account = account_cursor.first()?;
+
+    while let Some((account, _)) = next_account {
+        while next_storage_account.is_some_and(|storage_account| storage_account < account) {
+            next_storage_account = storage_cursor.next_no_dup()?.map(|entry| entry.0);
+        }
+
+        if next_storage_account == Some(account) {
+            job_tx.send(account).map_err(|_| {
+                ParallelTrieVerifyError::Other("storage worker queue closed".into())
+            })?;
+            next_storage_account = storage_cursor.next_no_dup()?.map(|entry| entry.0);
+        } else {
+            emit_empty_storage_inconsistencies(
+                account,
+                trie_cursor_factory.storage_trie_cursor(account)?,
+                result_tx,
+            )?;
+            result_tx.send(Ok(StorageMessage::Root { account, root: EMPTY_ROOT_HASH })).map_err(
+                |_| ParallelTrieVerifyError::Other("storage results channel closed".into()),
+            )?;
+        }
+
+        next_account = account_cursor.next()?;
+    }
+
+    Ok(())
+}
+
+fn verify_storage_account<A, P>(
+    provider: &P,
+    account: B256,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> Result<(), ParallelTrieVerifyError>
+where
+    A: TrieTableAdapter,
+    P: DBProvider,
+{
+    let tx = provider.tx_ref();
+    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
+    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
+
+    let (root, _, updates) = StorageRoot::new_hashed(
+        trie_cursor_factory.clone(),
+        hashed_cursor_factory,
+        account,
+        Default::default(),
+        #[cfg(feature = "metrics")]
+        TrieRootMetrics::new(TrieType::Storage),
+    )
+    .root_with_updates()?;
+
+    emit_storage_updates(
+        account,
+        trie_cursor_factory.storage_trie_cursor(account)?,
+        sorted_branch_nodes(updates.storage_nodes.into_iter()),
+        result_tx,
+    )?;
+
+    result_tx
+        .send(Ok(StorageMessage::Root { account, root }))
+        .map_err(|_| ParallelTrieVerifyError::Other("storage results channel closed".into()))?;
+
+    Ok(())
+}
+
+fn verify_accounts<A, Factory, O>(
+    factory: &Factory,
+    result_rx: &mpsc::Receiver<StorageResult>,
+    on_output: &mut O,
+) -> Result<(), ParallelTrieVerifyError>
+where
+    Factory: DatabaseProviderROFactory,
+    Factory::Provider: DBProvider,
+    A: TrieTableAdapter,
+    O: FnMut(Output) -> Result<(), DatabaseError>,
+{
+    let provider = open_provider(factory)?;
+    let tx = provider.tx_ref();
+    let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
+    let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
+
+    let walker: TrieWalker<_> =
+        TrieWalker::state_trie(trie_cursor_factory.account_trie_cursor()?, Default::default())
+            .with_deletions_retained(true);
+    let mut account_node_iter =
+        TrieNodeIter::state_trie(walker, hashed_cursor_factory.hashed_account_cursor()?);
+    let mut hash_builder = HashBuilder::default().with_updates(true);
+    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+    let mut pending_roots = BTreeMap::new();
+    let mut pending_outputs = BTreeMap::new();
+
+    while let Some(node) = account_node_iter.try_next()? {
+        match node {
+            TrieElement::Branch(node) => {
+                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
+            }
+            TrieElement::Leaf(hashed_address, account) => {
+                let storage_root = wait_for_storage_root(
+                    hashed_address,
+                    result_rx,
+                    &mut pending_roots,
+                    &mut pending_outputs,
+                    on_output,
+                )?;
+
+                account_rlp.clear();
+                account.into_trie_account(storage_root).encode(&mut account_rlp as &mut dyn BufMut);
+                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
+                on_output(Output::Progress(Nibbles::unpack(hashed_address)))?;
+            }
+        }
+    }
+
+    let removed_keys = account_node_iter.walker.take_removed_keys();
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.finalize(hash_builder, removed_keys, Default::default());
+
+    let mut account_verifier =
+        RepairTrieCursorVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?;
+    for (path, node) in sorted_branch_nodes(trie_updates.account_nodes.into_iter()) {
+        for output in account_verifier.next(path, node)? {
+            on_output(output)?;
+        }
+    }
+    for output in account_verifier.finalize()? {
+        on_output(output)?;
+    }
+
+    Ok(())
+}
+
+fn wait_for_storage_root<O>(
+    account: B256,
+    result_rx: &mpsc::Receiver<StorageResult>,
+    pending_roots: &mut BTreeMap<B256, B256>,
+    pending_outputs: &mut BTreeMap<B256, Vec<Output>>,
+    on_output: &mut O,
+) -> Result<B256, ParallelTrieVerifyError>
+where
+    O: FnMut(Output) -> Result<(), DatabaseError>,
+{
+    if let Some(root) = pending_roots.remove(&account) {
+        flush_pending_outputs(account, pending_outputs, on_output)?;
+        return Ok(root)
+    }
+
+    loop {
+        // `Root` is the end-of-account marker: a producer must emit all storage inconsistencies
+        // for that account before its root, so flushing buffered outputs here is sufficient.
+        match result_rx.recv().map_err(|_| {
+            ParallelTrieVerifyError::Other("storage results channel closed".into())
+        })?? {
+            StorageMessage::Root { account: root_account, root } => {
+                if root_account == account {
+                    flush_pending_outputs(account, pending_outputs, on_output)?;
+                    return Ok(root)
+                }
+
+                pending_roots.insert(root_account, root);
+            }
+            StorageMessage::Output(output) => {
+                let output_account = output_storage_account(&output)
+                    .expect("storage worker emitted non-storage output");
+                if output_account == account {
+                    on_output(output)?;
+                } else {
+                    pending_outputs.entry(output_account).or_default().push(output);
+                }
+            }
+        }
+    }
+}
+
+fn flush_pending_outputs<O>(
+    account: B256,
+    pending_outputs: &mut BTreeMap<B256, Vec<Output>>,
+    on_output: &mut O,
+) -> Result<(), DatabaseError>
+where
+    O: FnMut(Output) -> Result<(), DatabaseError>,
+{
+    if let Some(outputs) = pending_outputs.remove(&account) {
+        for output in outputs {
+            on_output(output)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn emit_storage_updates<C>(
+    account: B256,
+    cursor: C,
+    expected_nodes: Vec<(Nibbles, BranchNodeCompact)>,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> Result<(), ParallelTrieVerifyError>
+where
+    C: TrieCursor,
+{
+    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
+    for (path, node) in expected_nodes {
+        for output in verifier.next(path, node)? {
+            result_tx.send(Ok(StorageMessage::Output(output))).map_err(|_| {
+                ParallelTrieVerifyError::Other("storage results channel closed".into())
+            })?;
+        }
+    }
+
+    for output in verifier.finalize()? {
+        result_tx
+            .send(Ok(StorageMessage::Output(output)))
+            .map_err(|_| ParallelTrieVerifyError::Other("storage results channel closed".into()))?;
+    }
+
+    Ok(())
+}
+
+fn emit_empty_storage_inconsistencies<C>(
+    account: B256,
+    cursor: C,
+    result_tx: &mpsc::Sender<StorageResult>,
+) -> Result<(), ParallelTrieVerifyError>
+where
+    C: TrieCursor,
+{
+    let mut verifier = RepairTrieCursorVerifier::new(Some(account), cursor)?;
+    for output in verifier.finalize()? {
+        result_tx
+            .send(Ok(StorageMessage::Output(output)))
+            .map_err(|_| ParallelTrieVerifyError::Other("storage results channel closed".into()))?;
+    }
+
+    Ok(())
+}
+
+fn sorted_branch_nodes<I>(nodes: I) -> Vec<(Nibbles, BranchNodeCompact)>
+where
+    I: IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
+{
+    let mut nodes = nodes.into_iter().collect::<Vec<_>>();
+    nodes.sort_unstable_by(|a, b| depth_first::cmp(&a.0, &b.0));
+    nodes
+}
+
+fn output_storage_account(output: &Output) -> Option<B256> {
+    match output {
+        Output::StorageExtra(account, ..) |
+        Output::StorageMissing(account, ..) |
+        Output::StorageWrong { account, .. } => Some(*account),
+        Output::AccountExtra(..) |
+        Output::AccountMissing(..) |
+        Output::AccountWrong { .. } |
+        Output::Progress(..) => None,
+    }
+}
+
+fn storage_worker_count() -> usize {
+    let available = thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
+    available.saturating_sub(2).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+    use reth_primitives_traits::{Account, StorageEntry};
+    use reth_provider::{test_utils::create_test_provider_factory, HashingWriter};
+    use reth_trie::verify::Verifier;
+    use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
+
+    fn non_progress(outputs: Vec<Output>) -> Vec<String> {
+        let mut outputs = outputs
+            .into_iter()
+            .filter(|output| !matches!(output, Output::Progress(_)))
+            .map(|output| format!("{output:?}"))
+            .collect::<Vec<_>>();
+        outputs.sort_unstable();
+        outputs
+    }
+
+    #[test]
+    fn wait_for_storage_root_buffers_future_accounts() {
+        let target_account = B256::from([0x11; 32]);
+        let future_account = B256::from([0x22; 32]);
+        let target_root = B256::from([0xaa; 32]);
+        let future_root = B256::from([0xbb; 32]);
+        let target_output = Output::StorageExtra(
+            target_account,
+            Nibbles::from_nibbles([0x1]),
+            BranchNodeCompact::default(),
+        );
+        let future_output = Output::StorageExtra(
+            future_account,
+            Nibbles::from_nibbles([0x2]),
+            BranchNodeCompact::default(),
+        );
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Ok(StorageMessage::Output(future_output.clone()))).unwrap();
+        tx.send(Ok(StorageMessage::Root { account: future_account, root: future_root })).unwrap();
+        tx.send(Ok(StorageMessage::Output(target_output.clone()))).unwrap();
+        tx.send(Ok(StorageMessage::Root { account: target_account, root: target_root })).unwrap();
+
+        let mut pending_roots = BTreeMap::new();
+        let mut pending_outputs = BTreeMap::new();
+        let mut seen_outputs = Vec::new();
+
+        let root = wait_for_storage_root(
+            target_account,
+            &rx,
+            &mut pending_roots,
+            &mut pending_outputs,
+            &mut |output| {
+                seen_outputs.push(output);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(root, target_root);
+        assert_eq!(seen_outputs, vec![target_output]);
+
+        seen_outputs.clear();
+
+        let root = wait_for_storage_root(
+            future_account,
+            &rx,
+            &mut pending_roots,
+            &mut pending_outputs,
+            &mut |output| {
+                seen_outputs.push(output);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(root, future_root);
+        assert_eq!(seen_outputs, vec![future_output]);
+        assert!(pending_roots.is_empty());
+        assert!(pending_outputs.is_empty());
+    }
+
+    #[test]
+    fn wait_for_storage_root_flushes_buffered_outputs_when_root_is_already_pending() {
+        let account = B256::from([0x11; 32]);
+        let root = B256::from([0xaa; 32]);
+        let output = Output::StorageExtra(
+            account,
+            Nibbles::from_nibbles([0x1]),
+            BranchNodeCompact::default(),
+        );
+
+        let (_tx, rx) = mpsc::channel();
+        let mut pending_roots = BTreeMap::from([(account, root)]);
+        let mut pending_outputs = BTreeMap::from([(account, vec![output.clone()])]);
+        let mut seen_outputs = Vec::new();
+
+        let returned_root = wait_for_storage_root(
+            account,
+            &rx,
+            &mut pending_roots,
+            &mut pending_outputs,
+            &mut |output| {
+                seen_outputs.push(output);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(returned_root, root);
+        assert_eq!(seen_outputs, vec![output]);
+        assert!(pending_roots.is_empty());
+        assert!(pending_outputs.is_empty());
+    }
+
+    #[test]
+    fn parallel_verifier_matches_sequential_outputs() {
+        let factory = create_test_provider_factory();
+        let address_with_storage = "0x1000000000000000000000000000000000000001".parse().unwrap();
+        let address_without_storage = "0x2000000000000000000000000000000000000002".parse().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .insert_account_for_hashing([
+                (
+                    address_with_storage,
+                    Some(Account { nonce: 1, balance: U256::from(10), bytecode_hash: None }),
+                ),
+                (
+                    address_without_storage,
+                    Some(Account { nonce: 2, balance: U256::from(20), bytecode_hash: None }),
+                ),
+            ])
+            .unwrap();
+        provider_rw
+            .insert_storage_for_hashing([(
+                address_with_storage,
+                [StorageEntry { key: B256::from([0x33; 32]), value: U256::from(1) }],
+            )])
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap().disable_long_read_transaction_safety();
+        let expected = if provider.cached_storage_settings().is_v2() {
+            let trie_cursor_factory =
+                DatabaseTrieCursorFactory::<_, PackedKeyAdapter>::new(provider.tx_ref());
+            non_progress(
+                Verifier::new(
+                    &trie_cursor_factory,
+                    DatabaseHashedCursorFactory::new(provider.tx_ref()),
+                )
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            )
+        } else {
+            let trie_cursor_factory =
+                DatabaseTrieCursorFactory::<_, LegacyKeyAdapter>::new(provider.tx_ref());
+            non_progress(
+                Verifier::new(
+                    &trie_cursor_factory,
+                    DatabaseHashedCursorFactory::new(provider.tx_ref()),
+                )
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            )
+        };
+
+        let mut actual = Vec::new();
+        ParallelTrieVerifier::new(factory.clone())
+            .verify(|output| {
+                actual.push(output);
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(expected, non_progress(actual));
+    }
+}

--- a/crates/trie/parallel/src/verify.rs
+++ b/crates/trie/parallel/src/verify.rs
@@ -320,8 +320,10 @@ where
     let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
     let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
 
+    // Rebuild the storage trie from hashed state alone so the collected updates represent the
+    // full canonical storage trie, not an incremental diff against the current trie tables.
     let (root, _, updates) = StorageRoot::new_hashed(
-        trie_cursor_factory.clone(),
+        NoopTrieCursorFactory::default(),
         hashed_cursor_factory,
         account,
         Default::default(),
@@ -396,6 +398,9 @@ where
         }
     }
 
+    // Finalize the rebuilt trie so the hash builder flushes any remaining top-level branch nodes
+    // into its collected updates before we compare against the trie tables.
+    let _ = hash_builder.root();
     let removed_keys = account_node_iter.walker.take_removed_keys();
     let mut trie_updates = TrieUpdates::default();
     trie_updates.finalize(hash_builder, removed_keys, Default::default());
@@ -748,7 +753,11 @@ mod tests {
         provider_rw
             .insert_storage_for_hashing([(
                 address_with_storage,
-                [StorageEntry { key: B256::from([0x33; 32]), value: U256::from(1) }],
+                [
+                    StorageEntry { key: B256::from([0x11; 32]), value: U256::from(1) },
+                    StorageEntry { key: B256::from([0x22; 32]), value: U256::from(2) },
+                    StorageEntry { key: B256::from([0x33; 32]), value: U256::from(3) },
+                ],
             )])
             .unwrap();
 

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -1,5 +1,6 @@
 use crate::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
+    node_iter::{TrieElement, TrieNodeIter},
     progress::{IntermediateStateRootState, StateRootProgress},
     trie::StateRoot,
     trie_cursor::{
@@ -7,9 +8,12 @@ use crate::{
         noop::NoopTrieCursorFactory,
         TrieCursor, TrieCursorFactory,
     },
-    Nibbles,
+    updates::TrieUpdates,
+    walker::TrieWalker,
+    HashBuilder, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use alloy_primitives::B256;
+use alloy_rlp::{BufMut, Encodable};
 use alloy_trie::BranchNodeCompact;
 use reth_execution_errors::StateRootError;
 use reth_storage_errors::db::DatabaseError;
@@ -185,17 +189,89 @@ pub enum Output {
     Progress(Nibbles),
 }
 
+impl Output {
+    /// Returns the hashed account for storage trie verification outputs.
+    pub const fn storage_account(&self) -> Option<B256> {
+        match self {
+            Self::StorageExtra(account, ..) |
+            Self::StorageMissing(account, ..) |
+            Self::StorageWrong { account, .. } => Some(*account),
+            Self::AccountExtra(..) |
+            Self::AccountMissing(..) |
+            Self::AccountWrong { .. } |
+            Self::Progress(..) => None,
+        }
+    }
+}
+
+/// Collects branch nodes into depth-first order so they can be compared against trie cursors.
+pub fn sorted_branch_nodes<I>(nodes: I) -> Vec<(Nibbles, BranchNodeCompact)>
+where
+    I: IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
+{
+    let mut nodes = nodes.into_iter().collect::<Vec<_>>();
+    nodes.sort_unstable_by(|a, b| depth_first::cmp(&a.0, &b.0));
+    nodes
+}
+
+/// Rebuilds the canonical account trie branch nodes from hashed state and externally supplied
+/// storage roots.
+pub fn rebuild_account_nodes_from_hashed_state<H, S, E>(
+    hashed_cursor_factory: H,
+    mut storage_root: S,
+) -> Result<Vec<(Nibbles, BranchNodeCompact)>, E>
+where
+    H: HashedCursorFactory,
+    S: FnMut(B256) -> Result<B256, E>,
+    E: From<DatabaseError>,
+{
+    let walker: TrieWalker<_> = TrieWalker::state_trie(
+        NoopTrieCursorFactory::default().account_trie_cursor().map_err(E::from)?,
+        Default::default(),
+    )
+    .with_deletions_retained(true);
+    let mut account_node_iter =
+        TrieNodeIter::state_trie(walker, hashed_cursor_factory.hashed_account_cursor()?);
+    let mut hash_builder = HashBuilder::default().with_updates(true);
+    let mut account_rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
+
+    while let Some(node) = account_node_iter.try_next()? {
+        match node {
+            TrieElement::Branch(node) => {
+                hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
+            }
+            TrieElement::Leaf(hashed_address, account) => {
+                let storage_root = storage_root(hashed_address)?;
+
+                account_rlp.clear();
+                account.into_trie_account(storage_root).encode(&mut account_rlp as &mut dyn BufMut);
+                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
+            }
+        }
+    }
+
+    // Finalize the rebuilt trie so the hash builder flushes any remaining top-level branch nodes
+    // into its collected updates before they are compared against the trie tables.
+    let _ = hash_builder.root();
+    let removed_keys = account_node_iter.walker.take_removed_keys();
+    let mut trie_updates = TrieUpdates::default();
+    trie_updates.finalize(hash_builder, removed_keys, Default::default());
+
+    Ok(sorted_branch_nodes(trie_updates.account_nodes.into_iter()))
+}
+
 /// Verifies the contents of a trie table against some other data source which is able to produce
 /// stored trie nodes.
 #[derive(Debug)]
-struct SingleVerifier<I> {
+pub struct TrieCursorVerifier<I> {
     account: Option<B256>, // None for accounts trie
     trie_iter: I,
     curr: Option<(Nibbles, BranchNodeCompact)>,
 }
 
-impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
-    fn new(account: Option<B256>, trie_cursor: C) -> Result<Self, DatabaseError> {
+impl<C: TrieCursor> TrieCursorVerifier<DepthFirstTrieIterator<C>> {
+    /// Creates a verifier for either the account trie or a specific storage trie.
+    pub fn new(account: Option<B256>, trie_cursor: C) -> Result<Self, DatabaseError> {
         let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
         let curr = trie_iter.next().transpose()?;
         Ok(Self { account, trie_iter, curr })
@@ -235,7 +311,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
     /// inconsistent with that given.
     ///
     /// `next` must be called with paths in depth-first order.
-    fn next(
+    pub fn next(
         &mut self,
         outputs: &mut Vec<Output>,
         path: Nibbles,
@@ -285,7 +361,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
 
     /// Must be called once there are no more calls to `next` to made. All further nodes produced
     /// by the iterator will be considered extraneous.
-    fn finalize(&mut self, outputs: &mut Vec<Output>) -> Result<(), DatabaseError> {
+    pub fn finalize(&mut self, outputs: &mut Vec<Output>) -> Result<(), DatabaseError> {
         loop {
             if let Some((curr_path, curr_node)) = self.curr.take() {
                 outputs.push(self.output_extra(curr_path, curr_node));
@@ -306,8 +382,8 @@ pub struct Verifier<'a, T: TrieCursorFactory, H> {
     hashed_cursor_factory: H,
     branch_node_iter: StateRootBranchNodesIter<H>,
     outputs: Vec<Output>,
-    account: SingleVerifier<DepthFirstTrieIterator<T::AccountTrieCursor<'a>>>,
-    storage: Option<(B256, SingleVerifier<DepthFirstTrieIterator<T::StorageTrieCursor<'a>>>)>,
+    account: TrieCursorVerifier<DepthFirstTrieIterator<T::AccountTrieCursor<'a>>>,
+    storage: Option<(B256, TrieCursorVerifier<DepthFirstTrieIterator<T::StorageTrieCursor<'a>>>)>,
     complete: bool,
 }
 
@@ -322,7 +398,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
             hashed_cursor_factory: hashed_cursor_factory.clone(),
             branch_node_iter: StateRootBranchNodesIter::new(hashed_cursor_factory),
             outputs: Default::default(),
-            account: SingleVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?,
+            account: TrieCursorVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?,
             storage: None,
             complete: false,
         })
@@ -337,7 +413,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
         node: BranchNodeCompact,
     ) -> Result<(), DatabaseError> {
         let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(account)?;
-        let mut storage = SingleVerifier::new(Some(account), trie_cursor)?;
+        let mut storage = TrieCursorVerifier::new(Some(account), trie_cursor)?;
         storage.next(&mut self.outputs, path, node)?;
         self.storage = Some((account, storage));
         Ok(())
@@ -375,17 +451,9 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
             if curr_account < next_account || (end_inclusive && curr_account == next_account) {
                 trace!(target: "trie::verify", account = ?curr_account, "Verifying account has empty storage");
 
-                let mut storage_cursor =
-                    self.trie_cursor_factory.storage_trie_cursor(curr_account)?;
-                let mut seeked = false;
-                while let Some((path, node)) = if seeked {
-                    storage_cursor.next()?
-                } else {
-                    seeked = true;
-                    storage_cursor.seek(Nibbles::new())?
-                } {
-                    self.outputs.push(Output::StorageExtra(curr_account, path, node));
-                }
+                let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(curr_account)?;
+                let mut verifier = TrieCursorVerifier::new(Some(curr_account), trie_cursor)?;
+                verifier.finalize(&mut self.outputs)?;
             } else {
                 return Ok(())
             }
@@ -663,14 +731,14 @@ mod tests {
 
     #[test]
     fn test_single_verifier_new() {
-        // Test creating a new SingleVerifier for account trie
+        // Test creating a new TrieCursorVerifier for account trie
         let trie_nodes = BTreeMap::from([(
             Nibbles::from_nibbles([0x1]),
             test_branch_node(0b1111, 0, 0, vec![]),
         )]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let verifier = SingleVerifier::new(None, cursor).unwrap();
+        let verifier = TrieCursorVerifier::new(None, cursor).unwrap();
 
         // Should have seeked to the beginning and found the first node
         assert!(verifier.curr.is_some());
@@ -688,7 +756,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with the exact node that exists
@@ -707,7 +775,7 @@ mod tests {
         let trie_nodes = BTreeMap::from([(Nibbles::from_nibbles([0x1]), node_in_trie.clone())]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with different node value
@@ -731,7 +799,7 @@ mod tests {
         let trie_nodes = BTreeMap::from([(Nibbles::from_nibbles([0x3]), node1)]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with a node that comes before any in the trie
@@ -763,7 +831,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces in post-order: 0x1, 0x2, 0x3, root
@@ -808,7 +876,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces in post-order: 0x1, 0x2, 0x3, root
@@ -836,14 +904,14 @@ mod tests {
 
     #[test]
     fn test_single_verifier_storage_trie() {
-        // Test SingleVerifier for storage trie (with account set)
+        // Test TrieCursorVerifier for storage trie (with account set)
         let account = B256::from([42u8; 32]);
         let node = test_branch_node(0b1111, 0, 0b1111, vec![B256::from([1u8; 32])]);
 
         let trie_nodes = BTreeMap::from([(Nibbles::from_nibbles([0x1]), node)]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(Some(account), cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(Some(account), cursor).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with missing node
@@ -864,7 +932,7 @@ mod tests {
         // Test with empty trie cursor
         let trie_nodes = BTreeMap::new();
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // Any node should be marked as missing
@@ -901,7 +969,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces nodes in post-order (children before parents)
@@ -941,7 +1009,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // Process in WRONG order (skip root, provide child before processing all nodes correctly)
@@ -981,7 +1049,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = TrieCursorVerifier::new(None, cursor).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces nodes in post-order (children before parents)


### PR DESCRIPTION
Parallelizes `reth db repair-trie` by pushing per-account storage verification into a worker pool while the main thread keeps the account trie walk ordered. A dispatcher thread handles empty-storage accounts directly, and the account worker buffers out-of-order storage roots and inconsistencies until each account is ready.

This keeps repair writes serialized on the main thread while removing the old per-account storage verification bottleneck from the account walk.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: Brian