### PR TITLE
fix(db): move unix deps section after strum in Cargo.toml

### DIFF
--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -42,11 +42,11 @@ rustc-hash = { workspace = true, optional = true, features = ["std"] }
 sysinfo = { workspace = true, features = ["system"] }
 parking_lot = { workspace = true, optional = true }
 
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
-
 # arbitrary utils
 strum = { workspace = true, features = ["derive"], optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [dev-dependencies]
 # reth libs with arbitrary


### PR DESCRIPTION
Fixes placement of `[target.'cfg(unix)'.dependencies]` which was accidentally placed before `strum`, making it a unix-only dependency.

Follow-up to #23685.