### PR TITLE
fix(net): retain active session buffer capacity

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -79,6 +79,9 @@ const TIMEOUT_SCALING: u32 = 3;
 /// before reading any more messages from the remote peer, throttling the peer.
 const MAX_QUEUED_OUTGOING_RESPONSES: usize = 4;
 
+/// Minimum capacity to retain for buffered incoming requests from the remote peer.
+const MIN_RECEIVED_REQUESTS_CAPACITY: usize = 1;
+
 /// Soft limit for the total number of buffered outgoing broadcast items (e.g. transaction hashes).
 ///
 /// Many small broadcast messages carrying a single tx hash each are equivalent in cost to one
@@ -204,8 +207,8 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
     /// Shrinks the capacity of the internal buffers.
     pub fn shrink_to_fit(&mut self) {
-        self.received_requests_from_remote.shrink_to_fit();
-        self.queued_outgoing.shrink_to_fit();
+        self.received_requests_from_remote.shrink_to(MIN_RECEIVED_REQUESTS_CAPACITY);
+        self.queued_outgoing.shrink_to(MAX_QUEUED_OUTGOING_RESPONSES);
     }
 
     /// Returns how many responses we've currently queued up.
@@ -1090,8 +1093,8 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
         self.count.increment(1);
     }
 
-    pub(crate) fn shrink_to_fit(&mut self) {
-        self.messages.shrink_to_fit();
+    pub(crate) fn shrink_to(&mut self, min_capacity: usize) {
+        self.messages.shrink_to(min_capacity);
     }
 }
 


### PR DESCRIPTION
Avoid shrinking active session buffers to zero on every poll.

`ActiveSession::shrink_to_fit()` runs unconditionally at the end of the poll loop, so the next remote request or outgoing response burst immediately has to allocate again. This keeps one incoming request slot warm and retains the existing `MAX_QUEUED_OUTGOING_RESPONSES` window for queued outgoing messages instead.

This preserves the current backpressure behavior while reducing needless allocation churn in steady state.

Validation:
- `cargo +nightly fmt --all`
