### PR TITLE
fix(cli): preserve `trusted_nodes_only` from config when `--trusted-only` is not set

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -188,7 +188,7 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
             )
         }
 
-        config.peers.trusted_nodes_only = self.network.trusted_only;
+        config.peers.trusted_nodes_only |= self.network.trusted_only;
 
         let default_secret_key_path = data_dir.p2p_secret();
         let p2p_secret_key = self.network.secret_key(default_secret_key_path)?;

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -210,7 +210,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     let consensus = Arc::new(components.consensus().clone());
 
                     let mut config = config;
-                    config.peers.trusted_nodes_only = self.network.trusted_only;
+                    config.peers.trusted_nodes_only |= self.network.trusted_only;
                     config.peers.trusted_nodes.extend(self.network.trusted_peers.clone());
 
                     let network_secret_path = self

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -167,8 +167,9 @@ impl LaunchContext {
 
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");
 
-        // Update the config with the command line arguments
-        toml_config.peers.trusted_nodes_only = config.network.trusted_only;
+        // Update the config with the command line arguments. Only override when the CLI flag is
+        // set, so the TOML value is preserved when the flag is not passed.
+        toml_config.peers.trusted_nodes_only |= config.network.trusted_only;
 
         // Merge static file CLI arguments with config file, giving priority to CLI
         toml_config.static_files =


### PR DESCRIPTION
`--trusted-only` is a clap flag that defaults to `false` when omitted. The three call sites wrote `config.peers.trusted_nodes_only = self.network.trusted_only` unconditionally, silently clobbering `connect_trusted_nodes_only = true` from the TOML config. Switched to `|=` so the CLI can still force it on while TOML values survive when the flag is absent.

Before:
```
$ cat reth.toml | grep trusted
connect_trusted_nodes_only = true
$ reth node --config reth.toml
# trusted_nodes_only silently becomes false
```

After:
```
$ cat reth.toml | grep trusted
connect_trusted_nodes_only = true
$ reth node --config reth.toml
# trusted_nodes_only stays true; --trusted-only on CLI still forces it on
```