### PR TITLE
fix(ci): clean bench checkouts and lock cargo builds

### DIFF
--- a/.github/scripts/bench-reth-build.sh
+++ b/.github/scripts/bench-reth-build.sh
@@ -53,7 +53,7 @@ build_node_binary() {
 
   # shellcheck disable=SC2086
   RUSTFLAGS="-C target-cpu=native${EXTRA_RUSTFLAGS}" \
-    cargo build --profile profiling $NODE_PKG $workspace_arg $features_arg
+    cargo build --locked --profile profiling $NODE_PKG $workspace_arg $features_arg
 }
 
 case "$MODE" in

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -366,19 +366,24 @@ jobs:
 
       - name: Prepare source dirs
         run: |
-          if [ -d ../reth-baseline ]; then
-            git -C ../reth-baseline fetch origin "$BASELINE_REF"
-          else
-            git clone . ../reth-baseline
-          fi
-          git -C ../reth-baseline checkout "$BASELINE_REF"
+          prepare_source_dir() {
+            local dir="$1"
+            local ref="$2"
 
-          if [ -d ../reth-feature ]; then
-            git -C ../reth-feature fetch origin "$FEATURE_REF"
-          else
-            git clone . ../reth-feature
-          fi
-          git -C ../reth-feature checkout "$FEATURE_REF"
+            if [ -d "$dir" ]; then
+              git -C "$dir" reset --hard HEAD
+              git -C "$dir" clean -fdx
+              git -C "$dir" fetch origin "$ref"
+            else
+              git clone . "$dir"
+            fi
+
+            git -C "$dir" checkout --force "$ref"
+          }
+
+          prepare_source_dir ../reth-baseline "$BASELINE_REF"
+
+          prepare_source_dir ../reth-feature "$FEATURE_REF"
 
       - name: Build binaries
         id: build

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -802,21 +802,26 @@ jobs:
 
       - name: Prepare source dirs
         run: |
+          prepare_source_dir() {
+            local dir="$1"
+            local ref="$2"
+
+            if [ -d "$dir" ]; then
+              git -C "$dir" reset --hard HEAD
+              git -C "$dir" clean -fdx
+              git -C "$dir" fetch origin "$ref"
+            else
+              git clone . "$dir"
+            fi
+
+            git -C "$dir" checkout --force "$ref"
+          }
+
           BASELINE_REF="${{ steps.refs.outputs.baseline-ref }}"
-          if [ -d ../reth-baseline ]; then
-            git -C ../reth-baseline fetch origin "$BASELINE_REF"
-          else
-            git clone . ../reth-baseline
-          fi
-          git -C ../reth-baseline checkout "$BASELINE_REF"
+          prepare_source_dir ../reth-baseline "$BASELINE_REF"
 
           FEATURE_REF="${{ steps.refs.outputs.feature-ref }}"
-          if [ -d ../reth-feature ]; then
-            git -C ../reth-feature fetch origin "$FEATURE_REF"
-          else
-            git clone . ../reth-feature
-          fi
-          git -C ../reth-feature checkout "$FEATURE_REF"
+          prepare_source_dir ../reth-feature "$FEATURE_REF"
 
       - name: Build binaries
         id: build


### PR DESCRIPTION
Cleans the reused benchmark source clones before checkout in both bench workflows so stale state on the runner can't block new jobs.

Builds benchmark binaries with `cargo build --locked` so the harness doesn't rewrite `Cargo.lock` in those reused clones.