### PR TITLE
chore(db): derive Eq for IntegerList

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10790,9 +10790,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/storage/db-api/src/models/integer_list.rs
+++ b/crates/storage/db-api/src/models/integer_list.rs
@@ -17,7 +17,7 @@ use roaring::RoaringTreemap;
 /// - Direct access: elements can be accessed or queried without needing to decode the entire list.
 /// - [`RoaringTreemap`] backing: internally backed by [`RoaringTreemap`], which supports 64-bit
 ///   integers.
-#[derive(Clone, PartialEq, Default, Deref)]
+#[derive(Clone, PartialEq, Eq, Default, Deref)]
 pub struct IntegerList(pub RoaringTreemap);
 
 impl fmt::Debug for IntegerList {


### PR DESCRIPTION
Bumps `roaring` to 0.11.4 in the lockfile so `RoaringTreemap` satisfies `Eq`, then derives `Eq` for `IntegerList`.

Validated with `cargo +nightly fmt --all --check`, `zepter`, `make lint-toml`, and `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked -- -D warnings`.
