### PR TITLE
feat(net): add Basic in-memory BAL store

### DIFF
--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use reth_eth_wire::{EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandleProvider;
+use reth_storage_api::BalStoreHandle;
 use reth_transaction_pool::TransactionPool;
 use tokio::sync::mpsc;
 
@@ -64,11 +65,20 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
         self,
         client: Client,
     ) -> NetworkBuilder<Tx, EthRequestHandler<Client, N>, N> {
+        self.request_handler_with_bal_store(client, BalStoreHandle::default())
+    }
+
+    /// Creates a new [`EthRequestHandler`] with a BAL store and wires it to the network.
+    pub fn request_handler_with_bal_store<Client>(
+        self,
+        client: Client,
+        bal_store: BalStoreHandle,
+    ) -> NetworkBuilder<Tx, EthRequestHandler<Client, N>, N> {
         let Self { mut network, transactions, .. } = self;
         let (tx, rx) = mpsc::channel(ETH_REQUEST_CHANNEL_CAPACITY);
         network.set_eth_request_handler(tx);
         let peers = network.handle().peers_handle().clone();
-        let request_handler = EthRequestHandler::new(client, peers, rx);
+        let request_handler = EthRequestHandler::with_bal_store(client, peers, rx, bal_store);
         NetworkBuilder { network, request_handler, transactions }
     }
 

--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use reth_eth_wire::{EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandleProvider;
-use reth_storage_api::BalStoreHandle;
+use reth_storage_api::BalProvider;
 use reth_transaction_pool::TransactionPool;
 use tokio::sync::mpsc;
 
@@ -64,21 +64,15 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
     pub fn request_handler<Client>(
         self,
         client: Client,
-    ) -> NetworkBuilder<Tx, EthRequestHandler<Client, N>, N> {
-        self.request_handler_with_bal_store(client, BalStoreHandle::default())
-    }
-
-    /// Creates a new [`EthRequestHandler`] with a BAL store and wires it to the network.
-    pub fn request_handler_with_bal_store<Client>(
-        self,
-        client: Client,
-        bal_store: BalStoreHandle,
-    ) -> NetworkBuilder<Tx, EthRequestHandler<Client, N>, N> {
+    ) -> NetworkBuilder<Tx, EthRequestHandler<Client, N>, N>
+    where
+        Client: BalProvider,
+    {
         let Self { mut network, transactions, .. } = self;
         let (tx, rx) = mpsc::channel(ETH_REQUEST_CHANNEL_CAPACITY);
         network.set_eth_request_handler(tx);
         let peers = network.handle().peers_handle().clone();
-        let request_handler = EthRequestHandler::with_bal_store(client, peers, rx, bal_store);
+        let request_handler = EthRequestHandler::new(client, peers, rx);
         NetworkBuilder { network, request_handler, transactions }
     }
 

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -20,7 +20,9 @@ use reth_eth_wire_types::message::MAX_MESSAGE_SIZE;
 use reth_ethereum_forks::{ForkFilter, Head};
 use reth_network_peers::{mainnet_nodes, pk2id, sepolia_nodes, PeerId, TrustedPeer};
 use reth_network_types::{PeersConfig, SessionsConfig};
-use reth_storage_api::{noop::NoopProvider, BlockNumReader, BlockReader, HeaderProvider};
+use reth_storage_api::{
+    noop::NoopProvider, BalProvider, BlockNumReader, BlockReader, HeaderProvider,
+};
 use reth_tasks::Runtime;
 use secp256k1::SECP256K1;
 use std::{collections::HashSet, net::SocketAddr, sync::Arc};
@@ -157,7 +159,8 @@ where
 impl<C, N> NetworkConfig<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
+    C: BalProvider
+        + BlockReader<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
         + HeaderProvider
         + Clone
         + Unpin

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -20,9 +20,7 @@ use reth_eth_wire_types::message::MAX_MESSAGE_SIZE;
 use reth_ethereum_forks::{ForkFilter, Head};
 use reth_network_peers::{mainnet_nodes, pk2id, sepolia_nodes, PeerId, TrustedPeer};
 use reth_network_types::{PeersConfig, SessionsConfig};
-use reth_storage_api::{
-    noop::NoopProvider, BalProvider, BlockNumReader, BlockReader, HeaderProvider,
-};
+use reth_storage_api::{noop::NoopProvider, BlockNumReader, BlockReader, HeaderProvider};
 use reth_tasks::Runtime;
 use secp256k1::SECP256K1;
 use std::{collections::HashSet, net::SocketAddr, sync::Arc};
@@ -159,8 +157,7 @@ where
 impl<C, N> NetworkConfig<C, N>
 where
     N: NetworkPrimitives,
-    C: BalProvider
-        + BlockReader<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
+    C: BlockReader<Block = N::Block, Receipt = N::Receipt, Header = N::BlockHeader>
         + HeaderProvider
         + Clone
         + Unpin

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -18,7 +18,7 @@ use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::error::RequestResult;
 use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
-use reth_storage_api::{BalProvider, BlockReader, HeaderProvider};
+use reth_storage_api::{BalStoreHandle, BlockReader, HeaderProvider};
 use std::{
     future::Future,
     pin::Pin,
@@ -63,6 +63,8 @@ pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
     peers: PeersHandle,
     /// Incoming request from the [`NetworkManager`](crate::NetworkManager).
     incoming_requests: ReceiverStream<IncomingEthRequest<N>>,
+    /// Store for block access lists.
+    bal_store: BalStoreHandle,
     /// Metrics for the eth request handler.
     metrics: EthRequestHandlerMetrics,
 }
@@ -71,10 +73,21 @@ pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
 impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
     /// Create a new instance
     pub fn new(client: C, peers: PeersHandle, incoming: Receiver<IncomingEthRequest<N>>) -> Self {
+        Self::with_bal_store(client, peers, incoming, BalStoreHandle::default())
+    }
+
+    /// Create a new instance with the given BAL store.
+    pub fn with_bal_store(
+        client: C,
+        peers: PeersHandle,
+        incoming: Receiver<IncomingEthRequest<N>>,
+        bal_store: BalStoreHandle,
+    ) -> Self {
         Self {
             client,
             peers,
             incoming_requests: ReceiverStream::new(incoming),
+            bal_store,
             metrics: Default::default(),
         }
     }
@@ -83,7 +96,7 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
 impl<C, N> EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BalProvider + BlockReader,
+    C: BlockReader,
 {
     /// Returns the list of requested headers
     fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<C::Header> {
@@ -293,8 +306,7 @@ where
         response: oneshot::Sender<RequestResult<BlockAccessLists>>,
     ) {
         let access_lists = self
-            .client
-            .bal_store()
+            .bal_store
             .get_by_hashes(&request.0)
             .unwrap_or_else(|_| request.0.iter().map(|_| None).collect())
             .into_iter()
@@ -338,8 +350,7 @@ where
 impl<C, N> Future for EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BalProvider
-        + BlockReader<Block = N::Block, Receipt = N::Receipt>
+    C: BlockReader<Block = N::Block, Receipt = N::Receipt>
         + HeaderProvider<Header = N::BlockHeader>
         + Unpin,
 {

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -18,7 +18,7 @@ use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::error::RequestResult;
 use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
-use reth_storage_api::{BalStoreHandle, BlockReader, HeaderProvider};
+use reth_storage_api::{BalProvider, BlockReader, HeaderProvider};
 use std::{
     future::Future,
     pin::Pin,
@@ -63,8 +63,6 @@ pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
     peers: PeersHandle,
     /// Incoming request from the [`NetworkManager`](crate::NetworkManager).
     incoming_requests: ReceiverStream<IncomingEthRequest<N>>,
-    /// Store for block access lists.
-    bal_store: BalStoreHandle,
     /// Metrics for the eth request handler.
     metrics: EthRequestHandlerMetrics,
 }
@@ -73,21 +71,10 @@ pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
 impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
     /// Create a new instance
     pub fn new(client: C, peers: PeersHandle, incoming: Receiver<IncomingEthRequest<N>>) -> Self {
-        Self::with_bal_store(client, peers, incoming, BalStoreHandle::default())
-    }
-
-    /// Create a new instance with the given BAL store.
-    pub fn with_bal_store(
-        client: C,
-        peers: PeersHandle,
-        incoming: Receiver<IncomingEthRequest<N>>,
-        bal_store: BalStoreHandle,
-    ) -> Self {
         Self {
             client,
             peers,
             incoming_requests: ReceiverStream::new(incoming),
-            bal_store,
             metrics: Default::default(),
         }
     }
@@ -295,26 +282,6 @@ where
         let _ = response.send(Ok(Receipts70 { last_block_incomplete, receipts }));
     }
 
-    /// Handles [`GetBlockAccessLists`] queries.
-    ///
-    /// EIP-8159 defines the final `BlockAccessLists` response semantics:
-    /// <https://eips.ethereum.org/EIPS/eip-8159>
-    fn on_block_access_lists_request(
-        &self,
-        _peer_id: PeerId,
-        request: GetBlockAccessLists,
-        response: oneshot::Sender<RequestResult<BlockAccessLists>>,
-    ) {
-        let access_lists = self
-            .bal_store
-            .get_by_hashes(&request.0)
-            .unwrap_or_else(|_| request.0.iter().map(|_| None).collect())
-            .into_iter()
-            .map(|bal| bal.unwrap_or_else(|| Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE])))
-            .collect();
-        let _ = response.send(Ok(BlockAccessLists(access_lists)));
-    }
-
     #[inline]
     fn get_receipts_response<T, F>(&self, request: GetReceipts, transform_fn: F) -> Vec<Vec<T>>
     where
@@ -344,13 +311,41 @@ where
     }
 }
 
+impl<C, N> EthRequestHandler<C, N>
+where
+    N: NetworkPrimitives,
+    C: BalProvider,
+{
+    /// Handles [`GetBlockAccessLists`] queries.
+    ///
+    /// EIP-8159 defines the final `BlockAccessLists` response semantics:
+    /// <https://eips.ethereum.org/EIPS/eip-8159>
+    fn on_block_access_lists_request(
+        &self,
+        _peer_id: PeerId,
+        request: GetBlockAccessLists,
+        response: oneshot::Sender<RequestResult<BlockAccessLists>>,
+    ) {
+        let access_lists = self
+            .client
+            .bal_store()
+            .get_by_hashes(&request.0)
+            .unwrap_or_else(|_| request.0.iter().map(|_| None).collect())
+            .into_iter()
+            .map(|bal| bal.unwrap_or_else(|| Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE])))
+            .collect();
+        let _ = response.send(Ok(BlockAccessLists(access_lists)));
+    }
+}
+
 /// An endless future.
 ///
 /// This should be spawned or used as part of `tokio::select!`.
 impl<C, N> Future for EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Block = N::Block, Receipt = N::Receipt>
+    C: BalProvider
+        + BlockReader<Block = N::Block, Receipt = N::Receipt>
         + HeaderProvider<Header = N::BlockHeader>
         + Unpin,
 {

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -18,7 +18,7 @@ use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::error::RequestResult;
 use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
-use reth_storage_api::{BlockReader, HeaderProvider};
+use reth_storage_api::{BalProvider, BlockReader, HeaderProvider};
 use std::{
     future::Future,
     pin::Pin,
@@ -83,7 +83,7 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
 impl<C, N> EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader,
+    C: BalProvider + BlockReader,
 {
     /// Returns the list of requested headers
     fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<C::Header> {
@@ -292,13 +292,13 @@ where
         request: GetBlockAccessLists,
         response: oneshot::Sender<RequestResult<BlockAccessLists>>,
     ) {
-        // TODO: BAL serving is not fully implemented yet. Per EIP-8159, unavailable BALs are
-        // returned as empty BAL entries while preserving request order, so we currently return
-        // one RLP-encoded empty BAL (`0xc0`) per requested hash.
-        let access_lists = request
-            .0
+        let access_lists = self
+            .client
+            .bal_store()
+            .get_by_hashes(&request.0)
+            .unwrap_or_else(|_| request.0.iter().map(|_| None).collect())
             .into_iter()
-            .map(|_| Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]))
+            .map(|bal| bal.unwrap_or_else(|| Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE])))
             .collect();
         let _ = response.send(Ok(BlockAccessLists(access_lists)));
     }
@@ -338,7 +338,8 @@ where
 impl<C, N> Future for EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Block = N::Block, Receipt = N::Receipt>
+    C: BalProvider
+        + BlockReader<Block = N::Block, Receipt = N::Receipt>
         + HeaderProvider<Header = N::BlockHeader>
         + Unpin,
 {

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -248,6 +248,7 @@ where
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
         > + HeaderProvider
+        + BalProvider
         + Clone
         + Unpin
         + 'static,
@@ -320,6 +321,7 @@ where
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
         > + HeaderProvider
+        + BalProvider
         + Unpin
         + 'static,
     Pool: TransactionPool<
@@ -470,12 +472,7 @@ where
         let (tx, rx) = channel(ETH_REQUEST_CHANNEL_CAPACITY);
         self.network.set_eth_request_handler(tx);
         let peers = self.network.peers_handle();
-        let request_handler = EthRequestHandler::with_bal_store(
-            self.client.clone(),
-            peers,
-            rx,
-            self.client.bal_store().clone(),
-        );
+        let request_handler = EthRequestHandler::new(self.client.clone(), peers, rx);
         self.request_handler = Some(request_handler);
     }
 
@@ -582,6 +579,7 @@ where
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
         > + HeaderProvider
+        + BalProvider
         + Unpin
         + 'static,
     Pool: TransactionPool<

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -243,8 +243,7 @@ where
 
 impl<C, Pool> Testnet<C, Pool>
 where
-    C: BalProvider
-        + BlockReader<
+    C: BlockReader<
             Block = reth_ethereum_primitives::Block,
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
@@ -316,8 +315,7 @@ impl<C, Pool> fmt::Debug for Testnet<C, Pool> {
 
 impl<C, Pool> Future for Testnet<C, Pool>
 where
-    C: BalProvider
-        + BlockReader<
+    C: BlockReader<
             Block = reth_ethereum_primitives::Block,
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
@@ -472,7 +470,12 @@ where
         let (tx, rx) = channel(ETH_REQUEST_CHANNEL_CAPACITY);
         self.network.set_eth_request_handler(tx);
         let peers = self.network.peers_handle();
-        let request_handler = EthRequestHandler::new(self.client.clone(), peers, rx);
+        let request_handler = EthRequestHandler::with_bal_store(
+            self.client.clone(),
+            peers,
+            rx,
+            self.client.bal_store().clone(),
+        );
         self.request_handler = Some(request_handler);
     }
 
@@ -574,8 +577,7 @@ where
 
 impl<C, Pool> Future for Peer<C, Pool>
 where
-    C: BalProvider
-        + BlockReader<
+    C: BlockReader<
             Block = reth_ethereum_primitives::Block,
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -27,7 +27,8 @@ use reth_network_api::{
 };
 use reth_network_peers::PeerId;
 use reth_storage_api::{
-    noop::NoopProvider, BlockReader, BlockReaderIdExt, HeaderProvider, StateProviderFactory,
+    noop::NoopProvider, BalProvider, BlockReader, BlockReaderIdExt, HeaderProvider,
+    StateProviderFactory,
 };
 use reth_tasks::Runtime;
 use reth_tokio_util::EventStream;
@@ -242,7 +243,8 @@ where
 
 impl<C, Pool> Testnet<C, Pool>
 where
-    C: BlockReader<
+    C: BalProvider
+        + BlockReader<
             Block = reth_ethereum_primitives::Block,
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
@@ -314,7 +316,8 @@ impl<C, Pool> fmt::Debug for Testnet<C, Pool> {
 
 impl<C, Pool> Future for Testnet<C, Pool>
 where
-    C: BlockReader<
+    C: BalProvider
+        + BlockReader<
             Block = reth_ethereum_primitives::Block,
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,
@@ -462,7 +465,10 @@ where
     }
 
     /// Set a new request handler that's connected to the peer's network
-    pub fn install_request_handler(&mut self) {
+    pub fn install_request_handler(&mut self)
+    where
+        C: BalProvider,
+    {
         let (tx, rx) = channel(ETH_REQUEST_CHANNEL_CAPACITY);
         self.network.set_eth_request_handler(tx);
         let peers = self.network.peers_handle();
@@ -568,7 +574,8 @@ where
 
 impl<C, Pool> Future for Peer<C, Pool>
 where
-    C: BlockReader<
+    C: BalProvider
+        + BlockReader<
             Block = reth_ethereum_primitives::Block,
             Receipt = reth_ethereum_primitives::Receipt,
             Header = alloy_consensus::Header,

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -2,8 +2,9 @@
 //! Tests for eth related requests
 
 use alloy_consensus::Header;
+use alloy_primitives::Bytes;
 use rand::Rng;
-use reth_eth_wire::{EthVersion, HeadersDirection};
+use reth_eth_wire::{BlockAccessLists, EthVersion, GetBlockAccessLists, HeadersDirection};
 use reth_ethereum_primitives::Block;
 use reth_network::{
     test_utils::{NetworkEventStream, PeerConfig, Testnet},
@@ -14,7 +15,7 @@ use reth_network_p2p::{
     bodies::client::BodiesClient,
     headers::client::{HeadersClient, HeadersRequest},
 };
-use reth_provider::test_utils::MockEthProvider;
+use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore};
 use reth_transaction_pool::test_utils::{TestPool, TransactionGenerator};
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -525,4 +526,58 @@ async fn test_eth69_get_receipts() {
         assert_eq!(receipts_response.0[0][0].cumulative_gas_used, 21000);
         assert_eq!(receipts_response.0[0][1].cumulative_gas_used, 42000);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth71_get_block_access_lists() {
+    reth_tracing::init_test_tracing();
+    let mut rng = rand::rng();
+    let mut mock_provider = MockEthProvider::default();
+    let bal_store = BalStoreHandle::new(InMemoryBalStore::default());
+    mock_provider.bal_store = bal_store.clone();
+    let mock_provider = Arc::new(mock_provider);
+
+    let mut net: Testnet<Arc<MockEthProvider>, TestPool> = Testnet::default();
+
+    let p0 = PeerConfig::with_protocols(mock_provider.clone(), Some(EthVersion::Eth71.into()));
+    net.add_peer_with_config(p0).await.unwrap();
+
+    let p1 = PeerConfig::with_protocols(mock_provider.clone(), Some(EthVersion::Eth71.into()));
+    net.add_peer_with_config(p1).await.unwrap();
+
+    net.for_each_mut(|peer| peer.install_request_handler());
+
+    let handle0 = net.peers()[0].handle();
+    let mut events0 = NetworkEventStream::new(handle0.event_listener());
+    let handle1 = net.peers()[1].handle();
+
+    let _handle = net.spawn();
+
+    handle0.add_peer(*handle1.peer_id(), handle1.local_addr());
+    let connected = events0.next_session_established().await.unwrap();
+    assert_eq!(connected, *handle1.peer_id());
+
+    let hash0 = rng.random();
+    let hash1 = rng.random();
+    let hash2 = rng.random();
+    let bal0 = Bytes::from_static(&[0xc1, 0x01]);
+    let bal2 = Bytes::from_static(&[0xc1, 0x02]);
+
+    bal_store.insert(hash0, 1, bal0.clone()).unwrap();
+    bal_store.insert(hash2, 3, bal2.clone()).unwrap();
+
+    let (tx, rx) = oneshot::channel();
+    handle0.send_request(
+        *handle1.peer_id(),
+        reth_network::PeerRequest::GetBlockAccessLists {
+            request: GetBlockAccessLists(vec![hash0, hash1, hash2]),
+            response: tx,
+        },
+    );
+
+    let response = rx.await.unwrap().unwrap();
+    assert_eq!(
+        response,
+        BlockAccessLists(vec![bal0, Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]), bal2,])
+    );
 }

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -34,7 +34,7 @@ use reth_node_core::{
 };
 use reth_provider::{
     providers::{BlockchainProvider, NodeTypesForProvider, RocksDBProvider},
-    ChainSpecProvider, FullProvider,
+    BalProvider, ChainSpecProvider, FullProvider,
 };
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{PoolConfig, PoolTransaction, TransactionPool};
@@ -915,7 +915,10 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     {
         let (handle, network, txpool, eth) = builder
             .transactions_with_policies(pool, tx_config, propagation_policy, announcement_policy)
-            .request_handler(self.provider().clone())
+            .request_handler_with_bal_store(
+                self.provider().clone(),
+                self.provider().bal_store().clone(),
+            )
             .split_with_handle();
 
         self.executor.spawn_critical_blocking_task("p2p txpool", txpool);

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -34,7 +34,7 @@ use reth_node_core::{
 };
 use reth_provider::{
     providers::{BlockchainProvider, NodeTypesForProvider, RocksDBProvider},
-    BalProvider, ChainSpecProvider, FullProvider,
+    ChainSpecProvider, FullProvider,
 };
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{PoolConfig, PoolTransaction, TransactionPool};
@@ -915,10 +915,7 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
     {
         let (handle, network, txpool, eth) = builder
             .transactions_with_policies(pool, tx_config, propagation_policy, announcement_policy)
-            .request_handler_with_bal_store(
-                self.provider().clone(),
-                self.provider().bal_store().clone(),
-            )
+            .request_handler(self.provider().clone())
             .split_with_handle();
 
         self.executor.spawn_critical_blocking_task("p2p txpool", txpool);

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -1,0 +1,63 @@
+use alloy_primitives::{BlockHash, BlockNumber, Bytes};
+use parking_lot::RwLock;
+use reth_storage_api::BalStore;
+use reth_storage_errors::provider::ProviderResult;
+use std::{collections::HashMap, sync::Arc};
+
+/// Basic in-memory BAL store keyed by block hash.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryBalStore {
+    entries: Arc<RwLock<HashMap<BlockHash, Bytes>>>,
+}
+
+impl BalStore for InMemoryBalStore {
+    fn insert(
+        &self,
+        block_hash: BlockHash,
+        _block_number: BlockNumber,
+        bal: Bytes,
+    ) -> ProviderResult<()> {
+        self.entries.write().insert(block_hash, bal);
+        Ok(())
+    }
+
+    fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
+        let entries = self.entries.read();
+        let mut result = Vec::with_capacity(block_hashes.len());
+
+        for hash in block_hashes {
+            result.push(entries.get(hash).cloned());
+        }
+
+        Ok(result)
+    }
+
+    fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn insert_and_lookup_by_hash() {
+        let store = InMemoryBalStore::default();
+        let hash = B256::random();
+        let missing = B256::random();
+        let bal = Bytes::from_static(b"bal");
+
+        store.insert(hash, 1, bal.clone()).unwrap();
+
+        assert_eq!(store.get_by_hashes(&[hash, missing]).unwrap(), vec![Some(bal), None]);
+    }
+
+    #[test]
+    fn range_lookup_is_empty() {
+        let store = InMemoryBalStore::default();
+
+        assert!(store.get_by_range(1, 10).unwrap().is_empty());
+    }
+}

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -38,6 +38,9 @@ pub mod test_utils;
 pub mod either_writer;
 pub use either_writer::*;
 
+mod bal;
+pub use bal::InMemoryBalStore;
+
 pub use reth_chain_state::{
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotificationStream,
     CanonStateNotifications, CanonStateSubscriptions,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -6,8 +6,8 @@ use crate::{
     AccountReader, BalProvider, BalStoreHandle, BlockHashReader, BlockIdReader, BlockNumReader,
     BlockReader, BlockReaderIdExt, BlockSource, CanonChainTracker, CanonStateNotifications,
     CanonStateSubscriptions, ChainSpecProvider, ChainStateBlockReader, ChangeSetReader,
-    DatabaseProviderFactory, HashedPostStateProvider, HeaderProvider, ProviderError,
-    ProviderFactory, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
+    DatabaseProviderFactory, HashedPostStateProvider, HeaderProvider, InMemoryBalStore,
+    ProviderError, ProviderFactory, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
     RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateProviderFactory,
     StateReader, StaticFileProviderFactory, TransactionVariant, TransactionsProvider,
 };
@@ -111,7 +111,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
                 finalized_header,
                 safe_header,
             ),
-            bal_store: BalStoreHandle::default(),
+            bal_store: BalStoreHandle::new(InMemoryBalStore::default()),
         })
     }
 

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -5,11 +5,11 @@ use crate::{
     },
     to_range,
     traits::{BlockSource, ReceiptProvider},
-    BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider, DatabaseProviderFactory,
-    EitherWriterDestination, HashedPostStateProvider, HeaderProvider, HeaderSyncGapProvider,
-    MetadataProvider, ProviderError, PruneCheckpointReader, RocksDBProviderFactory,
-    StageCheckpointReader, StateProviderBox, StaticFileProviderFactory, StaticFileWriter,
-    TransactionVariant, TransactionsProvider,
+    BalProvider, BalStoreHandle, BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider,
+    DatabaseProviderFactory, EitherWriterDestination, HashedPostStateProvider, HeaderProvider,
+    HeaderSyncGapProvider, MetadataProvider, ProviderError, PruneCheckpointReader,
+    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StaticFileProviderFactory,
+    StaticFileWriter, TransactionVariant, TransactionsProvider,
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::BlockHashOrNumber;
@@ -90,6 +90,8 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     rocksdb_provider: RocksDBProvider,
     /// Changeset cache for trie unwinding
     changeset_cache: ChangesetCache,
+    /// Store for block access lists.
+    bal_store: BalStoreHandle,
     /// Task runtime for spawning parallel I/O work.
     runtime: reth_tasks::Runtime,
     /// Minimum distance from tip required before pruning can occur.
@@ -152,6 +154,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             storage_settings: Arc::new(RwLock::new(storage_settings)),
             rocksdb_provider,
             changeset_cache: ChangesetCache::new(),
+            bal_store: BalStoreHandle::default(),
             runtime,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             read_only_sync: None,
@@ -583,6 +586,12 @@ impl<N: NodeTypesWithDB> NodePrimitivesProvider for ProviderFactory<N> {
     type Primitives = N::Primitives;
 }
 
+impl<N: NodeTypesWithDB> BalProvider for ProviderFactory<N> {
+    fn bal_store(&self) -> &BalStoreHandle {
+        &self.bal_store
+    }
+}
+
 impl<N: ProviderNodeTypes> DatabaseProviderFactory for ProviderFactory<N> {
     type DB = N::DB;
     type Provider = DatabaseProvider<<N::DB as Database>::TX, N>;
@@ -955,6 +964,7 @@ where
             storage_settings,
             rocksdb_provider,
             changeset_cache,
+            bal_store,
             runtime,
             minimum_pruning_distance,
             read_only_sync,
@@ -968,6 +978,7 @@ where
             .field("storage_settings", &*storage_settings.read())
             .field("rocksdb_provider", &rocksdb_provider)
             .field("changeset_cache", &changeset_cache)
+            .field("bal_store", &bal_store)
             .field("runtime", &runtime)
             .field("minimum_pruning_distance", &minimum_pruning_distance)
             .field(
@@ -989,6 +1000,7 @@ impl<N: NodeTypesWithDB> Clone for ProviderFactory<N> {
             storage_settings: self.storage_settings.clone(),
             rocksdb_provider: self.rocksdb_provider.clone(),
             changeset_cache: self.changeset_cache.clone(),
+            bal_store: self.bal_store.clone(),
             runtime: self.runtime.clone(),
             minimum_pruning_distance: self.minimum_pruning_distance,
             read_only_sync: self.read_only_sync.clone(),


### PR DESCRIPTION
 Adds a basic in-memory BAL store and wires it into P2P `GetBlockAccessLists` serving.

The network request handler now reads BALs from the provider's `BalStore` and preserves EIP-8159 fallback semantics by returning an RLP empty BAL (`0xc0`) for missing entries. 

This keeps the first implementation intentionally simple: hash-based in-memory lookup only, with no Engine API changes, persistence, range lookup, or retention policy.
  
cc @mattsse 
