### PR TITLE
feat: avoid RLP-decoding `NewBlock` payloads

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -109,7 +109,7 @@ pub struct EthStreamInner<N> {
     /// Maximum allowed ETH message size.
     max_message_size: usize,
     /// When true, `NewBlock` (0x07) and `NewBlockHashes` (0x01) messages are rejected before RLP
-    /// decoding to avoid memory amplification from deserializing blocks that will be discarded.
+    /// decoding to avoid any memory impact for non-PoW networks.
     reject_block_announcements: bool,
     _pd: std::marker::PhantomData<N>,
 }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,7 +7,7 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, ProtocolBroadcastMessage, MAX_MESSAGE_SIZE},
+    message::{EthBroadcastMessage, EthMessageID, ProtocolBroadcastMessage, MAX_MESSAGE_SIZE},
     p2pstream::HANDSHAKE_TIMEOUT,
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     UnifiedStatus,
@@ -108,6 +108,9 @@ pub struct EthStreamInner<N> {
     version: EthVersion,
     /// Maximum allowed ETH message size.
     max_message_size: usize,
+    /// When true, `NewBlock` (0x07) and `NewBlockHashes` (0x01) messages are rejected before RLP
+    /// decoding to avoid memory amplification from deserializing blocks that will be discarded.
+    reject_block_announcements: bool,
     _pd: std::marker::PhantomData<N>,
 }
 
@@ -122,7 +125,12 @@ where
 
     /// Creates a new [`EthStreamInner`] with the given eth version and message size limit.
     pub const fn with_max_message_size(version: EthVersion, max_message_size: usize) -> Self {
-        Self { version, max_message_size, _pd: std::marker::PhantomData }
+        Self {
+            version,
+            max_message_size,
+            reject_block_announcements: false,
+            _pd: std::marker::PhantomData,
+        }
     }
 
     /// Returns the eth version
@@ -131,10 +139,24 @@ where
         self.version
     }
 
+    /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
+    /// RLP decoding.
+    pub const fn set_reject_block_announcements(&mut self, reject: bool) {
+        self.reject_block_announcements = reject;
+    }
+
     /// Decodes incoming bytes into an [`EthMessage`].
     pub fn decode_message(&self, bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
         if bytes.len() > self.max_message_size {
             return Err(EthStreamError::MessageTooBig(bytes.len()));
+        }
+
+        if self.reject_block_announcements
+            && let Some(&id) = bytes.first()
+            && (id == EthMessageID::NewBlock.to_u8() ||
+                id == EthMessageID::NewBlockHashes.to_u8())
+        {
+            return Err(EthStreamError::UnsupportedMessage { message_id: id });
         }
 
         let msg = match ProtocolMessage::decode_message(self.version, &mut bytes.as_ref()) {
@@ -206,6 +228,12 @@ impl<S, N: NetworkPrimitives> EthStream<S, N> {
     #[inline]
     pub const fn version(&self) -> EthVersion {
         self.eth.version()
+    }
+
+    /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
+    /// RLP decoding.
+    pub const fn set_reject_block_announcements(&mut self, reject: bool) {
+        self.eth.set_reject_block_announcements(reject);
     }
 
     /// Returns the underlying stream.

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -151,10 +151,9 @@ where
             return Err(EthStreamError::MessageTooBig(bytes.len()));
         }
 
-        if self.reject_block_announcements
-            && let Some(&id) = bytes.first()
-            && (id == EthMessageID::NewBlock.to_u8() ||
-                id == EthMessageID::NewBlockHashes.to_u8())
+        if self.reject_block_announcements &&
+            let Some(&id) = bytes.first() &&
+            (id == EthMessageID::NewBlock.to_u8() || id == EthMessageID::NewBlockHashes.to_u8())
         {
             return Err(EthStreamError::UnsupportedMessage { message_id: id });
         }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -329,8 +329,6 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
 
         let mut swarm = Swarm::new(incoming, sessions, state);
 
-        // On PoS networks, reject NewBlock/NewBlockHashes before RLP decoding to prevent
-        // memory amplification from deserialized blocks that would be immediately discarded.
         if network_mode.is_stake() {
             swarm.sessions_mut().set_reject_block_announcements(true);
         }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -318,6 +318,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             extra_protocols,
             handshake,
             eth_max_message_size,
+            network_mode.is_stake(),
         );
 
         let state = NetworkState::new(
@@ -327,11 +328,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             Arc::clone(&num_active_peers),
         );
 
-        let mut swarm = Swarm::new(incoming, sessions, state);
-
-        if network_mode.is_stake() {
-            swarm.sessions_mut().set_reject_block_announcements(true);
-        }
+        let swarm = Swarm::new(incoming, sessions, state);
 
         let (to_manager_tx, from_handle_rx) = mpsc::unbounded_channel();
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -327,7 +327,13 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             Arc::clone(&num_active_peers),
         );
 
-        let swarm = Swarm::new(incoming, sessions, state);
+        let mut swarm = Swarm::new(incoming, sessions, state);
+
+        // On PoS networks, reject NewBlock/NewBlockHashes before RLP decoding to prevent
+        // memory amplification from deserialized blocks that would be immediately discarded.
+        if network_mode.is_stake() {
+            swarm.sessions_mut().set_reject_block_announcements(true);
+        }
 
         let (to_manager_tx, from_handle_rx) = mpsc::unbounded_channel();
 

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -93,6 +93,15 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
             Self::Satellite(conn) => conn.primary_mut().start_send_raw(msg),
         }
     }
+
+    /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
+    /// RLP decoding to avoid memory amplification from deserializing blocks that will be discarded.
+    pub fn set_reject_block_announcements(&mut self, reject: bool) {
+        match self {
+            Self::EthOnly(conn) => conn.set_reject_block_announcements(reject),
+            Self::Satellite(conn) => conn.primary_mut().set_reject_block_announcements(reject),
+        }
+    }
 }
 
 impl<N: NetworkPrimitives> From<EthPeerConnection<N>> for EthRlpxConnection<N> {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -123,6 +123,9 @@ pub struct SessionManager<N: NetworkPrimitives> {
     /// Shared local range information that gets propagated to active sessions.
     /// This represents the range of blocks that this node can serve to other peers.
     local_range_info: BlockRangeInfo,
+    /// When true, block announcement messages (`NewBlock`, `NewBlockHashes`) are rejected before
+    /// RLP decoding on new sessions to avoid memory amplification.
+    reject_block_announcements: bool,
 }
 
 // === impl SessionManager ===
@@ -176,7 +179,14 @@ impl<N: NetworkPrimitives> SessionManager<N> {
             handshake,
             eth_max_message_size,
             local_range_info,
+            reject_block_announcements: false,
         }
+    }
+
+    /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
+    /// RLP decoding on all future sessions.
+    pub const fn set_reject_block_announcements(&mut self, reject: bool) {
+        self.reject_block_announcements = reject;
     }
 
     /// Returns the currently tracked [`ForkId`].
@@ -496,7 +506,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 local_addr,
                 peer_id,
                 capabilities,
-                conn,
+                mut conn,
                 status,
                 direction,
                 client_id,
@@ -562,6 +572,10 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 let remote_range_info = status.block_range_update().map(|update| {
                     BlockRangeInfo::new(update.earliest, update.latest, update.latest_hash)
                 });
+
+                if self.reject_block_announcements {
+                    conn.set_reject_block_announcements(true);
+                }
 
                 let session = ActiveSession {
                     next_id: 0,

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -143,6 +143,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         extra_protocols: RlpxSubProtocols,
         handshake: Arc<dyn EthRlpxHandshake>,
         eth_max_message_size: usize,
+        reject_block_announcements: bool,
     ) -> Self {
         let (pending_sessions_tx, pending_sessions_rx) = mpsc::channel(config.session_event_buffer);
         let (active_session_tx, active_session_rx) = mpsc::channel(config.session_event_buffer);
@@ -179,14 +180,8 @@ impl<N: NetworkPrimitives> SessionManager<N> {
             handshake,
             eth_max_message_size,
             local_range_info,
-            reject_block_announcements: false,
+            reject_block_announcements,
         }
-    }
-
-    /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
-    /// RLP decoding on all future sessions.
-    pub const fn set_reject_block_announcements(&mut self, reject: bool) {
-        self.reject_block_announcements = reject;
     }
 
     /// Returns the currently tracked [`ForkId`].


### PR DESCRIPTION
Right now we already disconnect peers upon receiving `NewBlock` payload on PoW network: https://github.com/paradigmxyz/reth/blob/bd1c83b9c51b4416ba28af7550d68557ac7443a0/crates/net/network/src/manager.rs#L626-L634

This means that such payloads might occupy memory inside of `SessionManager` channel, and worst case memory usage for `NewBlock` messages might be quite big

This PR changes logic to reject `NewPayload` messaes ASAP and not even attempt decoding/handling when node is running PoS