### PR TITLE
fix(bench): remove stale persistence wait options

### DIFF
--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -31,17 +31,15 @@ Otherwise, running `make maxperf` at the root of the repo should be sufficient f
 `reth-bench` contains different commands to benchmark different patterns of engine API calls.
 The `reth-bench new-payload-fcu` command is the most representative of ethereum mainnet live sync, alternating between sending `engine_newPayload` calls and `engine_forkchoiceUpdated` calls.
 
-The `new-payload-fcu` command supports two optional waiting modes that can be used together or independently:
-- `--wait-time <duration>`: Fixed sleep interval between blocks (e.g., `--wait-time 100ms` or `--wait-time 400` for 400ms)
-- `--wait-for-persistence`: Waits for blocks to be persisted using the `reth_subscribePersistedBlock` subscription
+The `new-payload-fcu` command supports two optional waiting controls that can be used together or independently:
+- `--wait-time <duration>`: Minimum interval between block submissions (e.g., `--wait-time 100ms` or `--wait-time 400` for 400ms). If payload processing takes longer than the interval, the next block is submitted immediately.
+- `--wait-for-persistence <mode>`: Controls the `wait_for_persistence` parameter sent to `reth_newPayload`. Use `always`, `never`, or a block interval number.
 
 Both `new-payload-fcu` and `new-payload-only` support `--rpc-block-fetch-retries <RETRIES>`
 to control how many times block fetches are retried after an RPC failure. The default is `10`.
 Use `--rpc-block-fetch-retries forever` to keep retrying indefinitely.
 
-When using `--wait-for-persistence`, the benchmark waits after every `(threshold + 1)` blocks, where the threshold defaults to the engine's persistence threshold (2). This can be customized with `--persistence-threshold <N>`.
-
-By default, the WebSocket URL for persistence subscriptions is derived from `--engine-rpc-url` (converting to ws:// on port 8546). Use `--ws-rpc-url` to override this.
+When `--wait-for-persistence` is omitted, the benchmark does not request an explicit persistence wait. The server-side `persistence_wait` result still includes time spent waiting on persistence backpressure.
 
 Below is an overview of how to run a benchmark:
 

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -29,7 +29,6 @@ use clap::Parser;
 use eyre::{bail, ensure, Context, OptionExt};
 use futures::{stream, StreamExt, TryStreamExt};
 use reth_cli_runner::CliContext;
-use reth_engine_primitives::config::DEFAULT_PERSISTENCE_THRESHOLD;
 use reth_node_core::args::BenchmarkArgs;
 use reth_rpc_api::{RethNewPayloadInput, TestingBuildBlockRequestV1};
 use std::time::{Duration, Instant};
@@ -64,32 +63,6 @@ pub struct Command {
     /// milliseconds (e.g. `400`).
     #[arg(long, value_name = "WAIT_TIME", value_parser = parse_duration, verbatim_doc_comment)]
     wait_time: Option<Duration>,
-
-    /// Engine persistence threshold used for deciding when to wait for persistence.
-    ///
-    /// The benchmark waits after every `(threshold + 1)` blocks. By default this
-    /// matches the engine's `DEFAULT_PERSISTENCE_THRESHOLD` (2), so waits occur
-    /// at blocks 3, 6, 9, etc.
-    #[arg(
-        long = "persistence-threshold",
-        value_name = "PERSISTENCE_THRESHOLD",
-        default_value_t = DEFAULT_PERSISTENCE_THRESHOLD,
-        verbatim_doc_comment
-    )]
-    persistence_threshold: u64,
-
-    /// Timeout for waiting on persistence at each checkpoint.
-    ///
-    /// Must be long enough to account for the persistence thread being blocked
-    /// by pruning after the previous save.
-    #[arg(
-        long = "persistence-timeout",
-        value_name = "PERSISTENCE_TIMEOUT",
-        value_parser = parse_duration,
-        default_value = "120s",
-        verbatim_doc_comment
-    )]
-    persistence_timeout: Duration,
 
     /// The size of the block buffer (channel capacity) for prefetching blocks from the RPC
     /// endpoint.

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -55,14 +55,8 @@ pub struct BenchmarkArgs {
     )]
     pub local_rpc_url: String,
 
-    /// The `WebSocket` RPC URL to use for persistence subscriptions.
-    ///
-    /// If not provided, will attempt to derive from engine-rpc-url by:
-    /// - Converting http/https to ws/wss
-    /// - Using port 8546 (standard RPC `WebSocket` port)
-    ///
-    /// Example: `ws://localhost:8546`
-    #[arg(long, value_name = "WS_RPC_URL", verbatim_doc_comment)]
+    #[doc(hidden)]
+    #[arg(skip)]
     pub ws_rpc_url: Option<String>,
 
     /// The path to the output directory for granular benchmark results.
@@ -95,11 +89,8 @@ pub struct BenchmarkArgs {
     /// Use `reth_newPayload` endpoint instead of `engine_newPayload*`.
     ///
     /// The `reth_newPayload` endpoint is a reth-specific extension that takes `ExecutionData`
-    /// directly, waits for persistence and cache updates to complete before processing,
-    /// and returns server-side timing breakdowns (latency, persistence wait, cache wait).
-    ///
-    /// Cannot be used with `--wait-for-persistence` because `reth_newPayload` already
-    /// waits for persistence by default.
+    /// directly and returns server-side timing breakdowns for latency, persistence waits,
+    /// and cache waits.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub reth_new_payload: bool,
 


### PR DESCRIPTION
Removes inactive `new-payload-fcu` persistence threshold and timeout options, and stops exposing the unused `--ws-rpc-url` benchmark argument.

The README now describes the current `reth_newPayload` wait controls and server-side `persistence_wait` reporting.