### PR TITLE
fix(storage): `reth db migrate-v2` for pruned nodes

### DIFF
--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -255,6 +255,10 @@ impl Command {
             writer.commit()?;
         }
 
+        let before = sf_provider
+            .get_highest_static_file_tx(StaticFileSegment::Receipts)
+            .map_or(0, |tx| tx + 1);
+
         let block_range = first_block..=tip;
 
         let segment = reth_static_file::segments::Receipts;
@@ -262,7 +266,11 @@ impl Command {
 
         sf_provider.commit()?;
 
-        info!(target: "reth::cli", "Receipts migrated");
+        let after = sf_provider
+            .get_highest_static_file_tx(StaticFileSegment::Receipts)
+            .map_or(0, |tx| tx + 1);
+        let count = after - before;
+        info!(target: "reth::cli", count, "Receipts migrated");
         Ok(())
     }
 

--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -135,6 +135,14 @@ impl Command {
         let mut writer =
             sf_provider.get_writer(first_block, StaticFileSegment::AccountChangeSets)?;
 
+        // The writer starts at the fixed range boundary (e.g. 2500000) which may be
+        // earlier than first_block (e.g. 2603897 from prune checkpoint). Pad with
+        // empty changesets for pruned blocks so the writer is aligned.
+        let writer_start = writer.next_block_number();
+        for block in writer_start..first_block {
+            writer.append_account_changeset(vec![], block)?;
+        }
+
         let mut count = 0u64;
         let mut walker = cursor.walk(Some(first_block))?.peekable();
 
@@ -176,6 +184,12 @@ impl Command {
 
         let mut writer =
             sf_provider.get_writer(first_block, StaticFileSegment::StorageChangeSets)?;
+
+        // Pad with empty changesets for pruned blocks (same as account changesets above).
+        let writer_start = writer.next_block_number();
+        for block in writer_start..first_block {
+            writer.append_storage_changeset(vec![], block)?;
+        }
 
         let mut count = 0u64;
         let mut walker = cursor.walk(Some(Default::default()))?.peekable();
@@ -237,6 +251,18 @@ impl Command {
             .and_then(|cp| cp.block_number)
             .map_or(0, |b| b + 1);
         let first_block = prune_start.max(existing.map_or(0, |b| b + 1));
+
+        // Pad with empty blocks from the static file range boundary up to first_block
+        // so the writer is properly aligned (same as changeset migration).
+        {
+            let mut writer =
+                sf_provider.get_writer(first_block, StaticFileSegment::Receipts)?;
+            let writer_start = writer.next_block_number();
+            for block in writer_start..first_block {
+                writer.increment_block(block)?;
+            }
+            writer.commit()?;
+        }
 
         let block_range = first_block..=tip;
 

--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -185,7 +185,9 @@ impl Command {
         let mut writer =
             sf_provider.get_writer(first_block, StaticFileSegment::StorageChangeSets)?;
 
-        // Pad with empty changesets for pruned blocks (same as account changesets above).
+        // The writer starts at the fixed range boundary (e.g. 2500000) which may be
+        // earlier than first_block (e.g. 2603897 from prune checkpoint). Pad with
+        // empty changesets for pruned blocks so the writer is aligned.
         let writer_start = writer.next_block_number();
         for block in writer_start..first_block {
             writer.append_storage_changeset(vec![], block)?;
@@ -252,11 +254,11 @@ impl Command {
             .map_or(0, |b| b + 1);
         let first_block = prune_start.max(existing.map_or(0, |b| b + 1));
 
-        // Pad with empty blocks from the static file range boundary up to first_block
-        // so the writer is properly aligned (same as changeset migration).
+        // The writer starts at the fixed range boundary (e.g. 2500000) which may be
+        // earlier than first_block (e.g. 2603897 from prune checkpoint). Pad with
+        // empty blocks for pruned receipts so the writer is aligned.
         {
-            let mut writer =
-                sf_provider.get_writer(first_block, StaticFileSegment::Receipts)?;
+            let mut writer = sf_provider.get_writer(first_block, StaticFileSegment::Receipts)?;
             let writer_start = writer.next_block_number();
             for block in writer_start..first_block {
                 writer.increment_block(block)?;

--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -132,15 +132,11 @@ impl Command {
             .and_then(|cp| cp.block_number)
             .map_or(0, |b| b + 1);
 
-        let mut writer =
-            sf_provider.get_writer(first_block, StaticFileSegment::AccountChangeSets)?;
-
-        // The writer starts at the fixed range boundary (e.g. 2500000) which may be
-        // earlier than first_block (e.g. 2603897 from prune checkpoint). Pad with
-        // empty changesets for pruned blocks so the writer is aligned.
-        let writer_start = writer.next_block_number();
-        for block in writer_start..first_block {
-            writer.append_account_changeset(vec![], block)?;
+        // The writer always starts at the fixed range boundary (e.g. 2500000) which may be
+        // earlier than first_block (e.g. 2603897 from prune checkpoint).
+        let mut writer = sf_provider.latest_writer(StaticFileSegment::AccountChangeSets)?;
+        if first_block > 0 {
+            writer.ensure_at_block(first_block - 1)?;
         }
 
         let mut count = 0u64;
@@ -182,15 +178,11 @@ impl Command {
             .and_then(|cp| cp.block_number)
             .map_or(0, |b| b + 1);
 
-        let mut writer =
-            sf_provider.get_writer(first_block, StaticFileSegment::StorageChangeSets)?;
-
-        // The writer starts at the fixed range boundary (e.g. 2500000) which may be
-        // earlier than first_block (e.g. 2603897 from prune checkpoint). Pad with
-        // empty changesets for pruned blocks so the writer is aligned.
-        let writer_start = writer.next_block_number();
-        for block in writer_start..first_block {
-            writer.append_storage_changeset(vec![], block)?;
+        // The writer always starts at the fixed range boundary (e.g. 2500000) which may be
+        // earlier than first_block (e.g. 2603897 from prune checkpoint).
+        let mut writer = sf_provider.latest_writer(StaticFileSegment::StorageChangeSets)?;
+        if first_block > 0 {
+            writer.ensure_at_block(first_block - 1)?;
         }
 
         let mut count = 0u64;
@@ -254,15 +246,11 @@ impl Command {
             .map_or(0, |b| b + 1);
         let first_block = prune_start.max(existing.map_or(0, |b| b + 1));
 
-        // The writer starts at the fixed range boundary (e.g. 2500000) which may be
-        // earlier than first_block (e.g. 2603897 from prune checkpoint). Pad with
-        // empty blocks for pruned receipts so the writer is aligned.
-        {
-            let mut writer = sf_provider.get_writer(first_block, StaticFileSegment::Receipts)?;
-            let writer_start = writer.next_block_number();
-            for block in writer_start..first_block {
-                writer.increment_block(block)?;
-            }
+        // The writer always starts at the fixed range boundary (e.g. 2500000) which may be
+        // earlier than first_block (e.g. 2603897 from prune checkpoint).
+        if first_block > 0 {
+            let mut writer = sf_provider.latest_writer(StaticFileSegment::Receipts)?;
+            writer.ensure_at_block(first_block - 1)?;
             writer.commit()?;
         }
 

--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -5,6 +5,7 @@
 //! state), compacts MDBX, then runs the pipeline to rebuild them.
 
 use crate::common::CliNodeTypes;
+use alloy_primitives::Address;
 use clap::Parser;
 use reth_db::{
     mdbx::{self, ffi},
@@ -186,7 +187,7 @@ impl Command {
         }
 
         let mut count = 0u64;
-        let mut walker = cursor.walk(Some(Default::default()))?.peekable();
+        let mut walker = cursor.walk(Some((first_block, Address::ZERO).into()))?.peekable();
 
         for block in first_block..=tip {
             let mut entries = Vec::new();

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -696,14 +696,15 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
 
     /// Updates the `self.reader` internal index.
     fn update_index(&self) -> ProviderResult<()> {
+        let segment = self.writer.user_header().segment();
+
         // We find the maximum block of the segment by checking this writer's last block.
         //
         // However if there's no block range (because there's no data), we try to calculate it by
         // subtracting 1 from the expected block start, resulting on the last block of the
-        // previous file.
-        //
-        // If that expected block start is 0, then it means that there's no actual block data, and
-        // there's no block data in static files.
+        // previous file — but only if that file actually exists. If the previous file doesn't
+        // exist (e.g. first-ever file for a segment starting past range boundary), there's
+        // nothing to index.
         let segment_max_block = self
             .writer
             .user_header()
@@ -711,12 +712,19 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             .as_ref()
             .map(|block_range| block_range.end())
             .or_else(|| {
-                (self.writer.user_header().expected_block_start() >
-                    self.reader().genesis_block_number())
-                .then(|| self.writer.user_header().expected_block_start() - 1)
+                let expected_start = self.writer.user_header().expected_block_start();
+                if expected_start <= self.reader().genesis_block_number() {
+                    return None;
+                }
+
+                let prev_block = expected_start - 1;
+                let prev_range = self.reader().find_fixed_range(segment, prev_block);
+                let prev_path =
+                    self.reader().directory().join(segment.filename(&prev_range));
+                prev_path.exists().then_some(prev_block)
             });
 
-        self.reader().update_index(self.writer.user_header().segment(), segment_max_block)
+        self.reader().update_index(segment, segment_max_block)
     }
 
     /// Ensures that the writer is positioned at the specified block number.

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -719,8 +719,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
 
                 let prev_block = expected_start - 1;
                 let prev_range = self.reader().find_fixed_range(segment, prev_block);
-                let prev_path =
-                    self.reader().directory().join(segment.filename(&prev_range));
+                let prev_path = self.reader().directory().join(segment.filename(&prev_range));
                 prev_path.exists().then_some(prev_block)
             });
 

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -809,4 +809,78 @@ mod tests {
             "Should have 7 blocks * 5 changes = 35 rows"
         );
     }
+
+    /// Opening a writer for a block past the first range boundary should succeed
+    /// even when no previous static file exists for the segment.
+    #[test]
+    fn test_get_writer_no_previous_file() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Request a writer starting at block 250, which falls into range 200..=299.
+        // No file exists for range 100..=199 (the "previous" range).
+        // This must not panic or error.
+        let mut writer = provider
+            .get_writer(250, StaticFileSegment::AccountChangeSets)
+            .expect("get_writer should succeed without previous file");
+
+        // The index should have no entry for AccountChangeSets yet (empty jar).
+        assert!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).is_none(),
+            "Empty jar should not create an index entry"
+        );
+
+        // Writing data requires padding from the range start (200) to block 250,
+        // same as the migration code does.
+        let writer_start = writer.next_block_number();
+        for block in writer_start..250 {
+            writer.append_account_changeset(vec![], block).unwrap();
+        }
+        let changeset = generate_test_changeset(250, 2);
+        writer.append_account_changeset(changeset, 250).unwrap();
+        writer.commit().unwrap();
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).unwrap(),
+            250,
+            "After writing block 250, highest block should be 250"
+        );
+    }
+
+    /// When a previous file DOES exist, opening a new empty writer for the next
+    /// range should still update the index to point at the previous file.
+    #[test]
+    fn test_get_writer_with_previous_file() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // Write blocks 0..=99 to fill the first file completely.
+        {
+            let mut writer = provider.get_writer(0, StaticFileSegment::AccountChangeSets).unwrap();
+            for block in 0..100 {
+                writer.append_account_changeset(generate_test_changeset(block, 1), block).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).unwrap(),
+            99
+        );
+
+        // Now get a writer for block 100 (next range 100..=199).
+        // The previous file (0..=99) exists, so this should succeed.
+        let writer = provider
+            .get_writer(100, StaticFileSegment::AccountChangeSets)
+            .expect("get_writer should succeed with previous file");
+
+        // The index should still reflect the previous file's max block.
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets).unwrap(),
+            99,
+            "Index should still point at previous file's max block"
+        );
+
+        drop(writer);
+    }
 }


### PR DESCRIPTION
1. For a static file that has a range `0..=10` we can't write block `2` without writing blocks `0..=1 first`. The fix is to write empty data for these blocks, we do it already in Execution stage for receipts / changesets.
2. When we open a static files writer on block `500_001`, it creates a new empty jar for range `500_000..=999_999`, and tries to update the index with the max existing block being `499_999` (thinking that it exists), but it doesn't because it's a pruned node that shouldn't have this static file by design, so it crashes. The fix here is to not crash, skipping the index update.
3. When migrating storage changesets, we initialized the walker as `cursor.walk(Some(Default::default()))?.peekable()`, which is not correct if the first block is non-zero.

Drive-by: add `count` field to receipts migration log