### PR TITLE
feat: bound memory footprint of p2p messages

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -7,13 +7,14 @@ use alloy_primitives::{
     Bytes, TxHash, B256, U128,
 };
 use alloy_rlp::{
-    Decodable, Encodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
+    Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper,
 };
 use core::{fmt::Debug, mem};
 use derive_more::{Constructor, Deref, DerefMut, From, IntoIterator};
 use reth_codecs_derive::{add_arbitrary_tests, generate_tests};
 use reth_ethereum_primitives::TransactionSigned;
-use reth_primitives_traits::{Block, SignedTransaction};
+use reth_primitives_traits::{Block, InMemorySize, SignedTransaction};
 
 /// This informs peers of new blocks that have appeared on the network.
 #[derive(
@@ -141,6 +142,53 @@ impl<T> From<Transactions<T>> for Vec<T> {
     fn from(txs: Transactions<T>) -> Self {
         txs.0
     }
+}
+
+impl<T: Decodable + InMemorySize> Transactions<T> {
+    /// Decodes the RLP list of transactions, stopping once the cumulative
+    /// [`InMemorySize`] of decoded transactions exceeds `memory_budget` bytes.
+    /// Any remaining transactions in the payload are skipped.
+    pub fn decode_with_memory_budget(
+        buf: &mut &[u8],
+        memory_budget: usize,
+    ) -> alloy_rlp::Result<Self> {
+        decode_list_with_memory_budget(buf, memory_budget).map(Self)
+    }
+}
+
+/// Decodes an RLP list, stopping once the cumulative [`InMemorySize`] of decoded items exceeds
+/// `memory_budget` bytes. Any remaining items in the payload are skipped.
+pub fn decode_list_with_memory_budget<T: Decodable + InMemorySize>(
+    buf: &mut &[u8],
+    memory_budget: usize,
+) -> alloy_rlp::Result<Vec<T>> {
+    let header = Header::decode(buf)?;
+    if !header.list {
+        return Err(alloy_rlp::Error::UnexpectedString);
+    }
+    if buf.len() < header.payload_length {
+        return Err(alloy_rlp::Error::InputTooShort);
+    }
+
+    let (payload, rest) = buf.split_at(header.payload_length);
+    let mut payload = payload;
+
+    let mut txs = Vec::new();
+    let mut total_size = 0usize;
+
+    while !payload.is_empty() {
+        let item = T::decode(&mut payload)?;
+        total_size = total_size.saturating_add(item.size());
+
+        if total_size > memory_budget {
+            break;
+        }
+
+        txs.push(item);
+    }
+
+    *buf = rest;
+    Ok(txs)
 }
 
 /// Same as [`Transactions`] but this is intended as egress message send from local to _many_ peers.

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -33,7 +33,7 @@ pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
 ///
 /// Decoded transactions expand relative to their RLP encoding due to struct overhead and heap
 /// allocations. With many peers in flight this can cause significant memory pressure, so we
-/// stop decoding once the cumulative [`InMemorySize`] of decoded transactions exceeds
+/// stop decoding once the cumulative in-memory size of decoded transactions exceeds
 /// `max_message_size * TX_MEMORY_BUDGET_MULTIPLIER`. Remaining transactions are silently dropped.
 pub const TX_MEMORY_BUDGET_MULTIPLIER: usize = 2;
 
@@ -103,7 +103,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
     /// transactions in `Transactions` and `PooledTransactions` messages. Once exceeded,
     /// remaining transactions are silently dropped.
     ///
-    /// Use [`TRANSACTIONS_DECODED_SIZE_BUDGET`] for a reasonable default.
+    /// Use [`TX_MEMORY_BUDGET_MULTIPLIER`] to derive a reasonable default.
     pub fn decode_message_with_tx_memory_budget(
         version: EthVersion,
         buf: &mut &[u8],

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -28,6 +28,15 @@ use core::fmt::Debug;
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
 
+/// Multiplier applied to `max_message_size` to derive the in-memory budget for decoding
+/// `Transactions` and `PooledTransactions` messages.
+///
+/// Decoded transactions expand relative to their RLP encoding due to struct overhead and heap
+/// allocations. With many peers in flight this can cause significant memory pressure, so we
+/// stop decoding once the cumulative [`InMemorySize`] of decoded transactions exceeds
+/// `max_message_size * TX_MEMORY_BUDGET_MULTIPLIER`. Remaining transactions are silently dropped.
+pub const TX_MEMORY_BUDGET_MULTIPLIER: usize = 2;
+
 /// Error when sending/receiving a message
 #[derive(thiserror::Error, Debug)]
 pub enum MessageError {
@@ -87,6 +96,19 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
     ///
     /// This will enforce decoding according to the given [`EthVersion`] of the connection.
     pub fn decode_message(version: EthVersion, buf: &mut &[u8]) -> Result<Self, MessageError> {
+        Self::decode_message_with_tx_memory_budget(version, buf, usize::MAX)
+    }
+
+    /// Like [`Self::decode_message`], but caps the cumulative in-memory size of decoded
+    /// transactions in `Transactions` and `PooledTransactions` messages. Once exceeded,
+    /// remaining transactions are silently dropped.
+    ///
+    /// Use [`TRANSACTIONS_DECODED_SIZE_BUDGET`] for a reasonable default.
+    pub fn decode_message_with_tx_memory_budget(
+        version: EthVersion,
+        buf: &mut &[u8],
+        tx_memory_budget: usize,
+    ) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
 
         // For EIP-7642 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md):
@@ -103,7 +125,9 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
             EthMessageID::NewBlock => {
                 EthMessage::NewBlock(Box::new(N::NewBlockPayload::decode(buf)?))
             }
-            EthMessageID::Transactions => EthMessage::Transactions(Transactions::decode(buf)?),
+            EthMessageID::Transactions => EthMessage::Transactions(
+                Transactions::decode_with_memory_budget(buf, tx_memory_budget)?,
+            ),
             EthMessageID::NewPooledTransactionHashes => {
                 if version >= EthVersion::Eth68 {
                     EthMessage::NewPooledTransactionHashes68(NewPooledTransactionHashes68::decode(
@@ -123,7 +147,9 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 EthMessage::GetPooledTransactions(RequestPair::decode(buf)?)
             }
             EthMessageID::PooledTransactions => {
-                EthMessage::PooledTransactions(RequestPair::decode(buf)?)
+                EthMessage::PooledTransactions(RequestPair::decode_with(buf, |buf| {
+                    PooledTransactions::decode_with_memory_budget(buf, tx_memory_budget)
+                })?)
             }
             EthMessageID::GetNodeData => {
                 if version >= EthVersion::Eth67 {
@@ -731,6 +757,25 @@ impl<T> RequestPair<T> {
     {
         let Self { request_id, message } = self;
         RequestPair { request_id, message: f(message) }
+    }
+
+    /// Decodes the request id and then decodes the message payload using `decode_msg`.
+    pub fn decode_with<F>(buf: &mut &[u8], decode_msg: F) -> alloy_rlp::Result<Self>
+    where
+        F: FnOnce(&mut &[u8]) -> alloy_rlp::Result<T>,
+    {
+        let header = Header::decode(buf)?;
+
+        let initial_length = buf.len();
+        let request_id = u64::decode(buf)?;
+        let message = decode_msg(buf)?;
+
+        let consumed_len = initial_length - buf.len();
+        if consumed_len != header.payload_length {
+            return Err(alloy_rlp::Error::UnexpectedLength)
+        }
+
+        Ok(Self { request_id, message })
     }
 }
 

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -1,12 +1,14 @@
 //! Implements the `GetPooledTransactions` and `PooledTransactions` message types.
 
+use crate::broadcast::decode_list_with_memory_budget;
 use alloc::vec::Vec;
 use alloy_consensus::transaction::PooledTransaction;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::B256;
-use alloy_rlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use alloy_rlp::{Decodable, RlpDecodableWrapper, RlpEncodableWrapper};
 use derive_more::{Constructor, Deref, IntoIterator};
 use reth_codecs_derive::add_arbitrary_tests;
+use reth_primitives_traits::InMemorySize;
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
 #[derive(
@@ -61,6 +63,18 @@ pub struct PooledTransactions<T = PooledTransaction>(
     /// The transaction bodies, each of which should correspond to a requested hash.
     pub Vec<T>,
 );
+
+impl<T: Decodable + InMemorySize> PooledTransactions<T> {
+    /// Decodes the RLP list of transactions, stopping once the cumulative
+    /// [`InMemorySize`] of decoded transactions exceeds `memory_budget` bytes.
+    /// Any remaining transactions in the payload are skipped.
+    pub fn decode_with_memory_budget(
+        buf: &mut &[u8],
+        memory_budget: usize,
+    ) -> alloy_rlp::Result<Self> {
+        decode_list_with_memory_budget(buf, memory_budget).map(Self)
+    }
+}
 
 impl<T: Encodable2718> PooledTransactions<T> {
     /// Returns an iterator over the transaction hashes in this response.

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -5,7 +5,7 @@
 
 use super::message::MAX_MESSAGE_SIZE;
 use crate::{
-    message::{EthBroadcastMessage, ProtocolBroadcastMessage},
+    message::{EthBroadcastMessage, ProtocolBroadcastMessage, TX_MEMORY_BUDGET_MULTIPLIER},
     EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion, NetworkPrimitives, ProtocolMessage,
     RawCapabilityMessage, SnapProtocolMessage, SnapVersion,
 };
@@ -298,7 +298,11 @@ where
         // See also <https://github.com/paradigmxyz/reth/blob/main/crates/net/eth-wire/src/capability.rs#L272-L283>.
         if message_id <= EthMessageID::max(self.eth_version) {
             let mut buf = bytes.as_ref();
-            match ProtocolMessage::decode_message(self.eth_version, &mut buf) {
+            match ProtocolMessage::decode_message_with_tx_memory_budget(
+                self.eth_version,
+                &mut buf,
+                self.max_message_size * TX_MEMORY_BUDGET_MULTIPLIER,
+            ) {
                 Ok(protocol_msg) => {
                     if matches!(protocol_msg.message, EthMessage::Status(_)) {
                         return Err(EthSnapStreamError::StatusNotInHandshake);

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,7 +7,10 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, EthMessageID, ProtocolBroadcastMessage, MAX_MESSAGE_SIZE},
+    message::{
+        EthBroadcastMessage, ProtocolBroadcastMessage, MAX_MESSAGE_SIZE,
+        TX_MEMORY_BUDGET_MULTIPLIER,
+    },
     p2pstream::HANDSHAKE_TIMEOUT,
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     UnifiedStatus,
@@ -16,7 +19,7 @@ use alloy_primitives::bytes::{Bytes, BytesMut};
 use alloy_rlp::Encodable;
 use futures::{ready, Sink, SinkExt};
 use pin_project::pin_project;
-use reth_eth_wire_types::{NetworkPrimitives, RawCapabilityMessage};
+use reth_eth_wire_types::{EthMessageID, NetworkPrimitives, RawCapabilityMessage};
 use reth_ethereum_forks::ForkFilter;
 use std::{
     future::Future,
@@ -158,7 +161,11 @@ where
             return Err(EthStreamError::UnsupportedMessage { message_id: id });
         }
 
-        let msg = match ProtocolMessage::decode_message(self.version, &mut bytes.as_ref()) {
+        let msg = match ProtocolMessage::decode_message_with_tx_memory_budget(
+            self.version,
+            &mut bytes.as_ref(),
+            self.max_message_size * TX_MEMORY_BUDGET_MULTIPLIER,
+        ) {
             Ok(m) => m,
             Err(err) => {
                 let msg = if bytes.len() > 50 {


### PR DESCRIPTION
Even though we do enforce 10Mb limit on p2p message size, due to RLP encoding being pretty compact, memory footprint of messages might be up to 20x bigger, meaning that a 10MB `Transactions` payload would in fact occupy 200MB of memory, making worst case of a DOS from multiple peers quite bad

This PR adds an extra measure applied when decoding p2p messages which is that while decoding a `Vec` from RLP we track memory footprint of elements decoded so far, and skip decoding the rest once the threshold is exceeded.

For now this is only applied to `Transactions` and `PooledTransactions` messages as RLP-encoded transactions tend to have highest potential amplifiers of RLP vs mem footprint. The current limit of memory usage is set to 2x the message size