### PR TITLE
fix(txpool): log failed transaction re-injection on reorg

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -428,7 +428,19 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                 // Because the transactions are not finalized, the corresponding blobs are still in
                 // blob store (if we previously received them from the network)
                 metrics.inc_reinserted_transactions(pruned_old_transactions.len());
-                let _ = pool.add_external_transactions(pruned_old_transactions).await;
+                let outcomes = pool.add_external_transactions(pruned_old_transactions).await;
+                let failed = outcomes.iter().filter(|r| r.is_err()).count();
+                if failed > 0 {
+                    warn!(
+                        target: "txpool",
+                        failed,
+                        total = outcomes.len(),
+                        "failed to re-inject transactions after reorg",
+                    );
+                    for err in outcomes.iter().filter_map(|r| r.as_ref().err()) {
+                        debug!(target: "txpool", %err, "reorg re-injection error");
+                    }
+                }
 
                 // keep track of new mined blob transactions
                 blob_store_tracker.add_new_chain_blocks(&new_blocks);


### PR DESCRIPTION
Reorg path discarded the `Vec<Result<…>>` from `add_external_transactions`, so re-injection failures were silent while `metrics.inc_reinserted_transactions` had already counted them pre-call.

Before:
```rust
let _ = pool.add_external_transactions(pruned_old_transactions).await;
```

After: count errors and emit `warn!` with failed/total, plus `debug!` per error.
```
WARN txpool: failed=3 total=12 failed to re-inject transactions after reorg
```