### PR TITLE
feat(net): enforce BAL response soft limit

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -338,6 +338,7 @@ where
     }
 }
 
+/// Builds the error fallback response while still enforcing the BAL response soft limit.
 fn empty_block_access_lists_with_limit(count: usize, limit: GetBlockAccessListLimit) -> Vec<Bytes> {
     let mut out = Vec::with_capacity(count);
     let mut size = 0;

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -18,9 +18,7 @@ use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::error::RequestResult;
 use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
-use reth_storage_api::{
-    empty_block_access_list, BalProvider, BlockReader, GetBlockAccessListLimit, HeaderProvider,
-};
+use reth_storage_api::{BalProvider, BlockReader, GetBlockAccessListLimit, HeaderProvider};
 use std::{
     future::Future,
     pin::Pin,
@@ -343,7 +341,7 @@ fn empty_block_access_lists_with_limit(count: usize, limit: GetBlockAccessListLi
     let mut out = Vec::with_capacity(count);
     let mut size = 0;
     for _ in 0..count {
-        let bal = empty_block_access_list();
+        let bal = Bytes::from_static(&[0xc0]);
         size += bal.len();
         out.push(bal);
 

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -18,7 +18,9 @@ use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::error::RequestResult;
 use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
-use reth_storage_api::{BalProvider, BlockReader, HeaderProvider};
+use reth_storage_api::{
+    empty_block_access_list, BalProvider, BlockReader, GetBlockAccessListLimit, HeaderProvider,
+};
 use std::{
     future::Future,
     pin::Pin,
@@ -326,16 +328,29 @@ where
         request: GetBlockAccessLists,
         response: oneshot::Sender<RequestResult<BlockAccessLists>>,
     ) {
+        let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(SOFT_RESPONSE_LIMIT);
         let access_lists = self
             .client
             .bal_store()
-            .get_by_hashes(&request.0)
-            .unwrap_or_else(|_| request.0.iter().map(|_| None).collect())
-            .into_iter()
-            .map(|bal| bal.unwrap_or_else(|| Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE])))
-            .collect();
+            .get_by_hashes_with_limit(&request.0, limit)
+            .unwrap_or_else(|_| empty_block_access_lists_with_limit(request.0.len(), limit));
         let _ = response.send(Ok(BlockAccessLists(access_lists)));
     }
+}
+
+fn empty_block_access_lists_with_limit(count: usize, limit: GetBlockAccessListLimit) -> Vec<Bytes> {
+    let mut out = Vec::with_capacity(count);
+    let mut size = 0;
+    for _ in 0..count {
+        let bal = empty_block_access_list();
+        size += bal.len();
+        out.push(bal);
+
+        if limit.exceeds(size) {
+            break
+        }
+    }
+    out
 }
 
 /// An endless future.

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use parking_lot::RwLock;
-use reth_storage_api::BalStore;
+use reth_storage_api::{empty_block_access_list, BalStore, GetBlockAccessListLimit};
 use reth_storage_errors::provider::ProviderResult;
 use std::{collections::HashMap, sync::Arc};
 
@@ -32,6 +32,28 @@ impl BalStore for InMemoryBalStore {
         Ok(result)
     }
 
+    fn append_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+        out: &mut Vec<Bytes>,
+    ) -> ProviderResult<()> {
+        let entries = self.entries.read();
+        let mut size = 0;
+
+        for hash in block_hashes {
+            let bal = entries.get(hash).cloned().unwrap_or_else(empty_block_access_list);
+            size += bal.len();
+            out.push(bal);
+
+            if limit.exceeds(size) {
+                break
+            }
+        }
+
+        Ok(())
+    }
+
     fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
         Ok(Vec::new())
     }
@@ -59,5 +81,29 @@ mod tests {
         let store = InMemoryBalStore::default();
 
         assert!(store.get_by_range(1, 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn limited_lookup_returns_prefix() {
+        let store = InMemoryBalStore::default();
+        let hash0 = B256::random();
+        let hash1 = B256::random();
+        let hash2 = B256::random();
+        let bal0 = Bytes::from_static(&[0xc1, 0x01]);
+        let bal1 = Bytes::from_static(&[0xc1, 0x02]);
+        let bal2 = Bytes::from_static(&[0xc1, 0x03]);
+
+        store.insert(hash0, 1, bal0.clone()).unwrap();
+        store.insert(hash1, 2, bal1.clone()).unwrap();
+        store.insert(hash2, 3, bal2).unwrap();
+
+        let limited = store
+            .get_by_hashes_with_limit(
+                &[hash0, hash1, hash2],
+                GetBlockAccessListLimit::ResponseSizeSoftLimit(2),
+            )
+            .unwrap();
+
+        assert_eq!(limited, vec![bal0, bal1]);
     }
 }

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use parking_lot::RwLock;
-use reth_storage_api::{empty_block_access_list, BalStore, GetBlockAccessListLimit};
+use reth_storage_api::{BalStore, GetBlockAccessListLimit};
 use reth_storage_errors::provider::ProviderResult;
 use std::{collections::HashMap, sync::Arc};
 
@@ -42,7 +42,7 @@ impl BalStore for InMemoryBalStore {
         let mut size = 0;
 
         for hash in block_hashes {
-            let bal = entries.get(hash).cloned().unwrap_or_else(empty_block_access_list);
+            let bal = entries.get(hash).cloned().unwrap_or_else(|| Bytes::from_static(&[0xc0]));
             size += bal.len();
             out.push(bal);
 

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -51,9 +51,9 @@ pub use revm_database::states::OriginalValuesKnown;
 // reexport traits to avoid breaking changes
 pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
-    empty_block_access_list, BalProvider, BalStore, BalStoreHandle, GetBlockAccessListLimit,
-    HistoryWriter, MetadataProvider, MetadataWriter, NoopBalStore, StateWriteConfig, StatsReader,
-    StorageSettings, StorageSettingsCache,
+    BalProvider, BalStore, BalStoreHandle, GetBlockAccessListLimit, HistoryWriter,
+    MetadataProvider, MetadataWriter, NoopBalStore, StateWriteConfig, StatsReader, StorageSettings,
+    StorageSettingsCache,
 };
 /// Re-export provider error.
 pub use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -51,8 +51,9 @@ pub use revm_database::states::OriginalValuesKnown;
 // reexport traits to avoid breaking changes
 pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
-    BalProvider, BalStore, BalStoreHandle, HistoryWriter, MetadataProvider, MetadataWriter,
-    NoopBalStore, StateWriteConfig, StatsReader, StorageSettings, StorageSettingsCache,
+    empty_block_access_list, BalProvider, BalStore, BalStoreHandle, GetBlockAccessListLimit,
+    HistoryWriter, MetadataProvider, MetadataWriter, NoopBalStore, StateWriteConfig, StatsReader,
+    StorageSettings, StorageSettingsCache,
 };
 /// Re-export provider error.
 pub use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -2,6 +2,8 @@ use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use reth_storage_errors::provider::ProviderResult;
 
+const EMPTY_BLOCK_ACCESS_LIST_CODE: u8 = 0xc0;
+
 /// Store for Block Access Lists (BALs).
 ///
 /// This abstraction intentionally does not prescribe where BALs live. Implementations may keep
@@ -22,10 +24,74 @@ pub trait BalStore: Send + Sync + 'static {
     /// The returned vector must align with `block_hashes`.
     fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>>;
 
+    /// Fetch BAL response entries for the given block hashes, stopping after the soft limit is
+    /// exceeded.
+    ///
+    /// Entries are returned in request order. Unavailable BALs are represented as an RLP-encoded
+    /// empty list (`0xc0`). The limit is soft: the entry that exceeds the limit is included.
+    fn get_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+    ) -> ProviderResult<Vec<Bytes>> {
+        let mut out = Vec::new();
+        self.append_by_hashes_with_limit(block_hashes, limit, &mut out)?;
+        out.shrink_to_fit();
+        Ok(out)
+    }
+
+    /// Extends the given vector with BAL response entries for the given hashes.
+    ///
+    /// This adheres to the expected behavior of [`Self::get_by_hashes_with_limit`].
+    fn append_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+        out: &mut Vec<Bytes>,
+    ) -> ProviderResult<()> {
+        let mut size = 0;
+        for bal in self.get_by_hashes(block_hashes)? {
+            let bal = bal.unwrap_or_else(empty_block_access_list);
+            size += bal.len();
+            out.push(bal);
+
+            if limit.exceeds(size) {
+                break
+            }
+        }
+        Ok(())
+    }
+
     /// Fetch BALs for the requested range.
     ///
     /// Implementations may stop at the first gap and return the contiguous prefix.
     fn get_by_range(&self, start: BlockNumber, count: u64) -> ProviderResult<Vec<Bytes>>;
+}
+
+/// The limit to enforce for [`BalStore::get_by_hashes_with_limit`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GetBlockAccessListLimit {
+    /// No limit, return all BALs.
+    None,
+    /// Enforce a size limit on the returned BALs, for example 2MB.
+    ResponseSizeSoftLimit(usize),
+}
+
+impl GetBlockAccessListLimit {
+    /// Returns true if the given size exceeds the limit.
+    #[inline]
+    pub const fn exceeds(&self, size: usize) -> bool {
+        match self {
+            Self::None => false,
+            Self::ResponseSizeSoftLimit(limit) => size > *limit,
+        }
+    }
+}
+
+/// Returns the RLP-encoded empty BAL entry.
+#[inline]
+pub fn empty_block_access_list() -> Bytes {
+    Bytes::from_static(&[EMPTY_BLOCK_ACCESS_LIST_CODE])
 }
 
 /// Clone-friendly façade around a BAL store implementation.
@@ -60,6 +126,28 @@ impl BalStoreHandle {
     #[inline]
     pub fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
         self.inner.get_by_hashes(block_hashes)
+    }
+
+    /// Fetch BAL response entries for the given block hashes, stopping after the soft limit is
+    /// exceeded.
+    #[inline]
+    pub fn get_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+    ) -> ProviderResult<Vec<Bytes>> {
+        self.inner.get_by_hashes_with_limit(block_hashes, limit)
+    }
+
+    /// Extends the given vector with BAL response entries for the given hashes.
+    #[inline]
+    pub fn append_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+        out: &mut Vec<Bytes>,
+    ) -> ProviderResult<()> {
+        self.inner.append_by_hashes_with_limit(block_hashes, limit, out)
     }
 
     /// Fetch BALs for the requested range.
@@ -106,6 +194,25 @@ impl BalStore for NoopBalStore {
         Ok(block_hashes.iter().map(|_| None).collect())
     }
 
+    fn append_by_hashes_with_limit(
+        &self,
+        block_hashes: &[BlockHash],
+        limit: GetBlockAccessListLimit,
+        out: &mut Vec<Bytes>,
+    ) -> ProviderResult<()> {
+        let mut size = 0;
+        for _ in block_hashes {
+            let bal = empty_block_access_list();
+            size += bal.len();
+            out.push(bal);
+
+            if limit.exceeds(size) {
+                break
+            }
+        }
+        Ok(())
+    }
+
     fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
         Ok(Vec::new())
     }
@@ -126,5 +233,28 @@ mod tests {
 
         assert_eq!(by_hash, vec![None, None]);
         assert!(by_range.is_empty());
+    }
+
+    #[test]
+    fn noop_store_limited_lookup_returns_prefix() {
+        let store = BalStoreHandle::default();
+        let hashes = [B256::random(), B256::random(), B256::random()];
+
+        let limited = store
+            .get_by_hashes_with_limit(&hashes, GetBlockAccessListLimit::ResponseSizeSoftLimit(1))
+            .unwrap();
+
+        assert_eq!(limited, vec![empty_block_access_list(), empty_block_access_list()]);
+    }
+
+    #[test]
+    fn block_access_list_limit() {
+        let limit_none = GetBlockAccessListLimit::None;
+        assert!(!limit_none.exceeds(usize::MAX));
+
+        let size_limit_2mb = GetBlockAccessListLimit::ResponseSizeSoftLimit(2 * 1024 * 1024);
+        assert!(!size_limit_2mb.exceeds(1024 * 1024));
+        assert!(!size_limit_2mb.exceeds(2 * 1024 * 1024));
+        assert!(size_limit_2mb.exceeds(3 * 1024 * 1024));
     }
 }

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -49,7 +49,7 @@ pub trait BalStore: Send + Sync + 'static {
     ) -> ProviderResult<()> {
         let mut size = 0;
         for bal in self.get_by_hashes(block_hashes)? {
-            let bal = bal.unwrap_or_else(empty_block_access_list);
+            let bal = bal.unwrap_or_else(|| Bytes::from_static(&[0xc0]));
             size += bal.len();
             out.push(bal);
 
@@ -84,12 +84,6 @@ impl GetBlockAccessListLimit {
             Self::ResponseSizeSoftLimit(limit) => size > *limit,
         }
     }
-}
-
-/// Returns the RLP-encoded empty BAL entry.
-#[inline]
-pub fn empty_block_access_list() -> Bytes {
-    Bytes::from_static(&[0xc0])
 }
 
 /// Clone-friendly façade around a BAL store implementation.
@@ -200,7 +194,7 @@ impl BalStore for NoopBalStore {
     ) -> ProviderResult<()> {
         let mut size = 0;
         for _ in block_hashes {
-            let bal = empty_block_access_list();
+            let bal = Bytes::from_static(&[0xc0]);
             size += bal.len();
             out.push(bal);
 
@@ -242,7 +236,7 @@ mod tests {
             .get_by_hashes_with_limit(&hashes, GetBlockAccessListLimit::ResponseSizeSoftLimit(1))
             .unwrap();
 
-        assert_eq!(limited, vec![empty_block_access_list(), empty_block_access_list()]);
+        assert_eq!(limited, vec![Bytes::from_static(&[0xc0]), Bytes::from_static(&[0xc0])]);
     }
 
     #[test]

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -2,8 +2,6 @@ use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use reth_storage_errors::provider::ProviderResult;
 
-const EMPTY_BLOCK_ACCESS_LIST_CODE: u8 = 0xc0;
-
 /// Store for Block Access Lists (BALs).
 ///
 /// This abstraction intentionally does not prescribe where BALs live. Implementations may keep
@@ -91,7 +89,7 @@ impl GetBlockAccessListLimit {
 /// Returns the RLP-encoded empty BAL entry.
 #[inline]
 pub fn empty_block_access_list() -> Bytes {
-    Bytes::from_static(&[EMPTY_BLOCK_ACCESS_LIST_CODE])
+    Bytes::from_static(&[0xc0])
 }
 
 /// Clone-friendly façade around a BAL store implementation.


### PR DESCRIPTION
Adds a soft response size limit to BAL store lookups used by `GetBlockAccessLists`.

The network handler now requests BAL entries through a limited store API with the standard 2MB response limit, so large BAL responses stop after the first entry that exceeds the limit. Missing BALs still fall back to the RLP empty-list entry.