### PR TITLE
fix(trie): account for heap-allocated blinded hashes in `SparseNode::memory_size`

### DIFF
--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -437,7 +437,10 @@ impl SparseNode {
     /// Returns the memory size of this node in bytes.
     pub const fn memory_size(&self) -> usize {
         match self {
-            Self::Empty | Self::Branch { .. } => core::mem::size_of::<Self>(),
+            Self::Empty => core::mem::size_of::<Self>(),
+            Self::Branch { .. } => {
+                core::mem::size_of::<Self>() + core::mem::size_of::<[B256; 16]>()
+            }
             Self::Leaf { key, .. } | Self::Extension { key, .. } => {
                 core::mem::size_of::<Self>() + key.len()
             }


### PR DESCRIPTION
`Branch` was only counting `size_of::<Self>()`, missing the 512 bytes held behind `Box<[B256; 16]>`. Before: a branch reports ~80 B; after: ~592 B, matching actual allocation and keeping `ParallelSparseTrie::memory_size` from undercounting by ~5 MB per 10k branches.