### PR TITLE
fix(cli): warn on failed bootnode resolution instead of silent drop

### DIFF
--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -44,7 +44,7 @@ use reth_network_peers::{mainnet_nodes, TrustedPeer};
 use reth_tasks::Runtime;
 use secp256k1::SecretKey;
 use std::str::FromStr;
-use tracing::error;
+use tracing::{error, warn};
 
 /// Global static network defaults
 static NETWORK_DEFAULTS: OnceLock<DefaultNetworkArgs> = OnceLock::new();
@@ -439,9 +439,21 @@ impl NetworkArgs {
     }
 
     /// Returns the resolved bootnodes if any are provided.
+    ///
+    /// Nodes that fail to resolve are skipped with a warning log so misconfigured
+    /// `--bootnodes` entries are visible instead of silently falling back to chain defaults.
     pub fn resolved_bootnodes(&self) -> Option<Vec<NodeRecord>> {
         self.bootnodes.clone().map(|bootnodes| {
-            bootnodes.into_iter().filter_map(|node| node.resolve_blocking().ok()).collect()
+            bootnodes
+                .into_iter()
+                .filter_map(|node| match node.resolve_blocking() {
+                    Ok(record) => Some(record),
+                    Err(err) => {
+                        warn!(target: "reth::cli", %node, %err, "Failed to resolve bootnode");
+                        None
+                    }
+                })
+                .collect()
         })
     }
 


### PR DESCRIPTION
`NetworkArgs::resolved_bootnodes` used `filter_map(|n| n.resolve_blocking().ok())`, which hid DNS/parse failures and let the node fall back to chain defaults without any hint. Replaced with an explicit `match` that logs each failure via `warn!` with the offending node and the underlying error.

Before:
```
$ reth node --bootnodes enode://abc@bad.host.example:30303
2026-04-24T10:12:04Z INFO reth::cli Starting reth
2026-04-24T10:12:04Z INFO net::peers Connected to mainnet bootnode enode://d860a01f...
```

After:
```
$ reth node --bootnodes enode://abc@bad.host.example:30303
2026-04-24T10:12:04Z INFO reth::cli Starting reth
2026-04-24T10:12:04Z WARN reth::cli Failed to resolve bootnode node=enode://abc@bad.host.example:30303 err="failed to lookup address information: Name or service not known"
```