### PR TITLE
fix(execution-types): set first_block when extending empty ExecutionOutcome

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -345,6 +345,10 @@ impl<T> ExecutionOutcome<T> {
     /// we know that other state was build on top of this one.
     /// In most cases this would be true.
     pub fn extend(&mut self, other: Self) {
+        if self.is_empty() {
+            *self = other;
+            return;
+        }
         self.bundle.extend(other.bundle);
         self.receipts.extend(other.receipts);
         self.requests.extend(other.requests);


### PR DESCRIPTION
When extend() is called on an empty outcome, first_block was left unchanged while bundle, receipts, and requests were merged from the other value. Copy other.first_block so block range metadata stays consistent.