### PR TITLE
fix(execution-types): set first_block on extend, fix split_at requests

### DIFF
--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -330,7 +330,7 @@ impl<T> ExecutionOutcome<T> {
         higher_state.receipts = higher_state.receipts.split_off(at_idx);
         // Ensure that there are enough requests to truncate.
         // Sometimes we just have receipts and no requests.
-        if at_idx < higher_state.requests.len() {
+        if at_idx <= higher_state.requests.len() {
             higher_state.requests = higher_state.requests.split_off(at_idx);
         }
         higher_state.bundle.take_n_reverts(at_idx);


### PR DESCRIPTION
- When extend()ing an empty ExecutionOutcome, copy other.first_block so block range metadata matches the merged state.
- In split_at, use at_idx <= requests.len() so requests are truncated when the split index matches the list length (same edge case as receipts).