### PR TITLE
test(bench): cover payload version encoding

### DIFF
--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -550,3 +550,29 @@ fn upgrade_to_v4(
         slot_number: 0,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
+    use reth_ethereum_primitives::Block;
+
+    fn payload_v3() -> ExecutionPayloadV3 {
+        let payload_inner = ExecutionPayloadV2 {
+            payload_inner: ExecutionPayloadV1::from_block_slow(&Block::default()),
+            withdrawals: Vec::new(),
+        };
+        ExecutionPayloadV3 { payload_inner, blob_gas_used: 0, excess_blob_gas: 0 }
+    }
+
+    #[test]
+    fn upgrade_to_v4_adds_block_access_list_to_v3_payload() {
+        let block_access_list = alloy_primitives::Bytes::from_static(b"bal");
+
+        let payload = upgrade_to_v4(ExecutionPayload::V3(payload_v3()), block_access_list.clone());
+
+        let ExecutionPayload::V4(payload) = payload else { panic!("expected V4 payload") };
+        assert_eq!(payload.block_access_list, block_access_list);
+        assert_eq!(payload.slot_number, 0);
+    }
+}

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -492,3 +492,93 @@ pub(crate) async fn call_forkchoice_updated_with_reth<
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, B256};
+    use alloy_rpc_types_engine::{
+        CancunPayloadFields, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
+        ExecutionPayloadV4, PraguePayloadFields,
+    };
+    use reth_ethereum_primitives::Block;
+
+    fn payload_v3() -> ExecutionPayloadV3 {
+        let payload_inner = ExecutionPayloadV2 {
+            payload_inner: ExecutionPayloadV1::from_block_slow(&Block::default()),
+            withdrawals: Vec::new(),
+        };
+        ExecutionPayloadV3 { payload_inner, blob_gas_used: 0, excess_blob_gas: 0 }
+    }
+
+    fn cancun_fields() -> CancunPayloadFields {
+        CancunPayloadFields {
+            versioned_hashes: vec![B256::with_last_byte(1)],
+            parent_beacon_block_root: B256::with_last_byte(2),
+        }
+    }
+
+    fn prague_fields() -> PraguePayloadFields {
+        PraguePayloadFields { requests: Default::default() }
+    }
+
+    #[test]
+    fn encodes_v3_payload_as_new_payload_v3_without_prague_sidecar() {
+        let (version, params, execution_data) = payload_to_new_payload(
+            ExecutionPayload::V3(payload_v3()),
+            ExecutionPayloadSidecar::v3(cancun_fields()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(version, EngineApiMessageVersion::V3);
+        assert_eq!(params.as_array().expect("params are encoded as an array").len(), 3);
+        assert!(matches!(execution_data.payload, ExecutionPayload::V3(_)));
+    }
+
+    #[test]
+    fn encodes_v3_payload_as_new_payload_v4_with_prague_sidecar() {
+        let (version, params, execution_data) = payload_to_new_payload(
+            ExecutionPayload::V3(payload_v3()),
+            ExecutionPayloadSidecar::v4(cancun_fields(), prague_fields()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(version, EngineApiMessageVersion::V4);
+        assert_eq!(params.as_array().expect("params are encoded as an array").len(), 4);
+        assert!(matches!(execution_data.payload, ExecutionPayload::V3(_)));
+    }
+
+    #[test]
+    fn encodes_v4_payload_as_new_payload_v6_by_default() {
+        let payload = ExecutionPayload::V4(ExecutionPayloadV4 {
+            payload_inner: payload_v3(),
+            block_access_list: Bytes::from_static(b"bal"),
+            slot_number: 1,
+        });
+
+        let (version, params, execution_data) = payload_to_new_payload(
+            payload,
+            ExecutionPayloadSidecar::v4(cancun_fields(), prague_fields()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(version, EngineApiMessageVersion::V6);
+        assert_eq!(params.as_array().expect("params are encoded as an array").len(), 4);
+        assert!(matches!(execution_data.payload, ExecutionPayload::V4(_)));
+    }
+
+    #[test]
+    fn rejects_v3_payload_without_cancun_sidecar() {
+        let err = payload_to_new_payload(
+            ExecutionPayload::V3(payload_v3()),
+            ExecutionPayloadSidecar::none(),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("missing cancun sidecar for V3 payload"));
+    }
+}


### PR DESCRIPTION
Adds focused regression tests for reth-bench payload conversion across Cancun, Prague, and Amsterdam payload shapes. The tests cover V3 encoding, V4-request encoding, V4 payload defaulting to the latest engine message version, and the missing Cancun sidecar error path.