### PR TITLE
fix(trie): handle inline root nodes in fast path

### DIFF
--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -446,9 +446,7 @@ impl SparseTrie for ParallelSparseTrie {
                 .get(&Nibbles::default())
                 .and_then(|node| node.cached_rlp_node())
         {
-            return rlp_node
-                .as_hash()
-                .expect("RLP-encoding of the root node cannot be less than 32 bytes")
+            return rlp_node.as_hash().unwrap_or(EMPTY_ROOT_HASH)
         }
 
         // Update all lower subtrie hashes


### PR DESCRIPTION
`ParallelSparseTrie::root()` fast path panics when root node RLP encoding is < 32 bytes. Aligned with normal path by using `unwrap_or(EMPTY_ROOT_HASH)` instead of `.expect()`.

Before:
```
rlp_node.as_hash().expect("RLP-encoding of the root node cannot be less than 32 bytes")
```

After:
```
rlp_node.as_hash().unwrap_or(EMPTY_ROOT_HASH)
```