### PR TITLE
refactor(evm): return gas output from block builder

### DIFF
--- a/crates/engine/util/src/reorg.rs
+++ b/crates/engine/util/src/reorg.rs
@@ -287,7 +287,7 @@ where
         let tx_recovered =
             tx.try_into_recovered().map_err(|_| ProviderError::SenderRecoveryError)?;
         let gas_used = match builder.execute_transaction(tx_recovered) {
-            Ok(gas_used) => gas_used,
+            Ok(gas_used) => gas_used.tx_gas_used(),
             Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                 hash,
                 error,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -342,7 +342,7 @@ where
         let tx_hash = *tx.tx_hash();
 
         let gas_used = match builder.execute_transaction(tx) {
-            Ok(gas_used) => gas_used,
+            Ok(gas_used) => gas_used.tx_gas_used(),
             Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                 error, ..
             })) => {

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -4,7 +4,7 @@ use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_eips::eip2718::WithEncoded;
-pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
+pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory, GasOutput};
 use alloy_evm::{
     block::{CommitChanges, ExecutableTxParts},
     Evm, EvmEnv, EvmFactory, RecoveredTx, ToTxEnv,
@@ -327,7 +327,7 @@ pub trait BlockBuilder {
         &mut self,
         tx: impl ExecutorTx<Self::Executor>,
         f: impl FnOnce(&<Self::Executor as BlockExecutor>::Result) -> CommitChanges,
-    ) -> Result<Option<u64>, BlockExecutionError>;
+    ) -> Result<Option<GasOutput>, BlockExecutionError>;
 
     /// Invokes [`BlockExecutor::execute_transaction_with_result_closure`] and saves the
     /// transaction in internal state.
@@ -335,7 +335,7 @@ pub trait BlockBuilder {
         &mut self,
         tx: impl ExecutorTx<Self::Executor>,
         f: impl FnOnce(&<Self::Executor as BlockExecutor>::Result),
-    ) -> Result<u64, BlockExecutionError> {
+    ) -> Result<GasOutput, BlockExecutionError> {
         self.execute_transaction_with_commit_condition(tx, |res| {
             f(res);
             CommitChanges::Yes
@@ -348,7 +348,7 @@ pub trait BlockBuilder {
     fn execute_transaction(
         &mut self,
         tx: impl ExecutorTx<Self::Executor>,
-    ) -> Result<u64, BlockExecutionError> {
+    ) -> Result<GasOutput, BlockExecutionError> {
         self.execute_transaction_with_result_closure(tx, |_| ())
     }
 
@@ -460,13 +460,13 @@ where
         &mut self,
         tx: impl ExecutorTx<Self::Executor>,
         f: impl FnOnce(&<Self::Executor as BlockExecutor>::Result) -> CommitChanges,
-    ) -> Result<Option<u64>, BlockExecutionError> {
+    ) -> Result<Option<GasOutput>, BlockExecutionError> {
         let (tx_env, tx) = tx.into_parts();
         if let Some(gas_used) =
             self.executor.execute_transaction_with_commit_condition((tx_env, &tx), f)?
         {
             self.transactions.push(tx);
-            Ok(Some(gas_used.tx_gas_used()))
+            Ok(Some(gas_used))
         } else {
             Ok(None)
         }

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -338,7 +338,7 @@ pub trait LoadPendingBlock:
                 }
 
                 let gas_used = match builder.execute_transaction(tx) {
-                    Ok(gas_used) => gas_used,
+                    Ok(gas_used) => gas_used.tx_gas_used(),
                     Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                         error,
                         ..

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -179,7 +179,7 @@ where
 
                     let tip = tx.effective_tip_per_gas(base_fee).unwrap_or_default();
                     let gas_used = match builder.execute_transaction(tx) {
-                        Ok(gas_used) => gas_used,
+                        Ok(gas_used) => gas_used.tx_gas_used(),
                         Err(err) => {
                             if skip_invalid_transactions {
                                 debug!(


### PR DESCRIPTION
Aligns Reth `BlockBuilder` transaction execution methods with the underlying `alloy-evm::BlockExecutor` API by returning `GasOutput` instead of collapsing it to `u64`.

Consumers that only need receipt gas now call `tx_gas_used()` explicitly. This lets follow-up payload builder changes use regular/state gas accounting without reaching around the wrapper.

Validated with `cargo +nightly fmt --all` and `cargo check -p reth-evm -p reth-engine-util -p reth-ethereum-payload-builder -p reth-rpc-eth-api -p reth-rpc`.