### PR TITLE
fix(payload): wire EIP-7928 BAL + EIP-7843 slot_number into Amsterdam blocks

### DIFF
--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -47,6 +47,7 @@ where
             transactions,
             output: BlockExecutionResult { receipts, requests, gas_used, blob_gas_used },
             state_root,
+            block_access_list_hash,
             ..
         } = input;
 
@@ -90,6 +91,10 @@ where
             };
         }
 
+        let is_amsterdam = self.chain_spec.is_amsterdam_active_at_timestamp(timestamp);
+        let bal_hash = if is_amsterdam { block_access_list_hash } else { None };
+        let slot_number = if is_amsterdam { ctx.slot_number } else { None };
+
         let header = Header {
             parent_hash: ctx.parent_hash,
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
@@ -112,8 +117,8 @@ where
             blob_gas_used: block_blob_gas_used,
             excess_blob_gas,
             requests_hash,
-            block_access_list_hash: None,
-            slot_number: None,
+            block_access_list_hash: bal_hash,
+            slot_number,
         };
 
         Ok(Block {

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -416,31 +416,31 @@ where
         return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }
 
-    let BlockBuilderOutcome { execution_result, block, .. } = if let Some(mut handle) = trie_handle
-    {
-        // Drop the state hook, which drops the StateHookSender and triggers
-        // FinishedStateUpdates via its Drop impl, signaling the trie task to finalize.
-        builder.executor_mut().set_state_hook(None);
+    let BlockBuilderOutcome { execution_result, block, block_access_list, .. } =
+        if let Some(mut handle) = trie_handle {
+            // Drop the state hook, which drops the StateHookSender and triggers
+            // FinishedStateUpdates via its Drop impl, signaling the trie task to finalize.
+            builder.executor_mut().set_state_hook(None);
 
-        // The sparse trie has been computing incrementally alongside tx execution.
-        // This recv() waits for the final root hash — most work is already done.
-        // Fall back to sync state root if the trie pipeline fails.
-        match handle.state_root() {
-            Ok(outcome) => {
-                debug!(target: "payload_builder", id=%payload_id, state_root=?outcome.state_root, "received state root from sparse trie");
-                builder.finish(
-                    state_provider.as_ref(),
-                    Some((outcome.state_root, Arc::unwrap_or_clone(outcome.trie_updates))),
-                )?
+            // The sparse trie has been computing incrementally alongside tx execution.
+            // This recv() waits for the final root hash — most work is already done.
+            // Fall back to sync state root if the trie pipeline fails.
+            match handle.state_root() {
+                Ok(outcome) => {
+                    debug!(target: "payload_builder", id=%payload_id, state_root=?outcome.state_root, "received state root from sparse trie");
+                    builder.finish(
+                        state_provider.as_ref(),
+                        Some((outcome.state_root, Arc::unwrap_or_clone(outcome.trie_updates))),
+                    )?
+                }
+                Err(err) => {
+                    warn!(target: "payload_builder", id=%payload_id, %err, "sparse trie failed, falling back to sync state root");
+                    builder.finish(state_provider.as_ref(), None)?
+                }
             }
-            Err(err) => {
-                warn!(target: "payload_builder", id=%payload_id, %err, "sparse trie failed, falling back to sync state root");
-                builder.finish(state_provider.as_ref(), None)?
-            }
-        }
-    } else {
-        builder.finish(state_provider.as_ref(), None)?
-    };
+        } else {
+            builder.finish(state_provider.as_ref(), None)?
+        };
 
     let requests = chain_spec
         .is_prague_active_at_timestamp(attributes.timestamp)
@@ -456,9 +456,14 @@ where
         }));
     }
 
-    let payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None)
-        // add blob sidecars from the executed txs
-        .with_sidecars(blob_sidecars);
+    // EIP-7928 (Amsterdam): the BAL extracted by the block builder is RLP-encoded into
+    // the V6 envelope by `EthBuiltPayload::try_into_v6`. Encode it here to match the
+    // `Option<Bytes>` field on the built payload.
+    let block_access_list_bytes = block_access_list.map(|bal| alloy_rlp::encode(&bal).into());
+    let payload =
+        EthBuiltPayload::new(sealed_block, total_fees, requests, block_access_list_bytes)
+            // add blob sidecars from the executed txs
+            .with_sidecars(blob_sidecars);
 
     Ok(BuildOutcome::Better { payload, cached_reads })
 }

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,7 +3,10 @@
 use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::eip2718::WithEncoded;
+use alloy_eips::{
+    eip2718::WithEncoded,
+    eip7928::{compute_block_access_list_hash, BlockAccessList},
+};
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
 use alloy_evm::{
     block::{CommitChanges, ExecutableTxParts},
@@ -205,6 +208,8 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
     pub state_provider: &'b dyn StateProvider,
     /// State root for this block.
     pub state_root: B256,
+    /// Block access list hash (EIP-7928, Amsterdam).
+    pub block_access_list_hash: Option<B256>,
 }
 
 impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
@@ -222,6 +227,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
         bundle_state: &'a BundleState,
         state_provider: &'b dyn StateProvider,
         state_root: B256,
+        block_access_list_hash: Option<B256>,
     ) -> Self {
         Self {
             evm_env,
@@ -232,6 +238,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
             bundle_state,
             state_provider,
             state_root,
+            block_access_list_hash,
         }
     }
 }
@@ -301,6 +308,8 @@ pub struct BlockBuilderOutcome<N: NodePrimitives> {
     pub trie_updates: TrieUpdates,
     /// The built block.
     pub block: RecoveredBlock<N::Block>,
+    /// Block access list built during execution (EIP-7928, Amsterdam).
+    pub block_access_list: Option<BlockAccessList>,
 }
 
 /// A type that knows how to execute and build a block.
@@ -483,6 +492,11 @@ where
         // merge all transitions into bundle state
         db.merge_transitions(BundleRetention::Reverts);
 
+        // extract the built block access list (EIP-7928, Amsterdam) and compute its hash
+        let block_access_list = db.take_built_alloy_bal();
+        let block_access_list_hash =
+            block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
+
         let hashed_state = state.hashed_post_state(&db.bundle_state);
         let (state_root, trie_updates) = match state_root_precomputed {
             Some(precomputed) => precomputed,
@@ -503,11 +517,18 @@ where
             bundle_state: &db.bundle_state,
             state_provider: &state,
             state_root,
+            block_access_list_hash,
         })?;
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 
-        Ok(BlockBuilderOutcome { execution_result: result, hashed_state, trie_updates, block })
+        Ok(BlockBuilderOutcome {
+            execution_result: result,
+            hashed_state,
+            trie_updates,
+            block,
+            block_access_list,
+        })
     }
 
     fn executor_mut(&mut self) -> &mut Self::Executor {


### PR DESCRIPTION
## Summary

The Amsterdam header fields `block_access_list_hash` and `slot_number` were hardcoded to `None` in `EthBlockAssembler::assemble_block`, and `block_access_list` was hardcoded to `None` when constructing `EthBuiltPayload` in `default_ethereum_payload`. Even though `EthereumPayloadBuilder` enabled `with_bal_builder_if(is_amsterdam)` on the state, the built BAL was never extracted from the executor or threaded through to the assembler / payload.

As a result, post-Amsterdam blocks were sealed with `block_access_list_hash: None` and `slot_number: None`. `EthBuiltPayload::try_into_v6` then failed with `BuiltPayloadConversionError::MissingBlockAccessList`, returning `-38001 "Unknown payload"` to the CL on every `engine_getPayloadV6` call. The chain stalled at the Amsterdam fork boundary because no proposer could publish.

Reproduction with the unfixed `bal-devnet-4` image: 3-node lighthouse+reth network on the bal-devnet-4 minimal preset hangs at the last pre-Amsterdam block (block 15 with the test config); reth logs spam `WARN reth_rpc_engine_api::engine_api: could not transform built payload version=V6` and the engine snooper shows lighthouse retrying `engine_getPayloadV6` indefinitely.

## Changes

- `crates/evm/evm/src/execute.rs` — add `block_access_list: Option<BlockAccessList>` to `BlockBuilderOutcome` and `block_access_list_hash: Option<B256>` to `BlockAssemblerInput`. In `BasicBlockBuilder::finish`, call `db.take_built_alloy_bal()` after merging transitions, compute the hash via `compute_block_access_list_hash`, and propagate both to the outcome and assembler input.
- `crates/ethereum/evm/src/build.rs` — in `EthBlockAssembler::assemble_block`, gate `block_access_list_hash` and `slot_number` on `is_amsterdam_active_at_timestamp`, reading the hash from the input and the slot from the execution context (rather than the previous hardcoded `None`).
- `crates/ethereum/payload/src/lib.rs` — destructure `block_access_list` from the `BlockBuilderOutcome`, RLP-encode it, and pass the resulting `Option<Bytes>` to `EthBuiltPayload::new`.

`BlockAssemblerInput::new` gains a trailing `block_access_list_hash: Option<B256>` parameter; the field is `pub` so any code constructing the struct via the literal form already destructures with `..` in the call sites I checked.

## Test plan

Verified end-to-end on a 3-node lighthouse + reth kurtosis network (minimal preset, devnet-4 genesis, `amsterdamTime` set to slot 16):

- [x] Before: chain stalls at block 15, reth logs spam V6 transform warning, snooper shows `-38001 Unknown payload` on every `engine_getPayloadV6`.
- [x] After: all three reth nodes cross the Amsterdam fork in lockstep and continue producing blocks; chain reached block 30+ healthily.
- [x] Block 16 (first Amsterdam block) now contains both Amsterdam-only header fields populated:
  - `blockAccessListHash: 0xeab072620169c7236529b9cb48cb6e81cfa58830ee1e6adde435da82ac2c5c05`
  - `slotNumber: 0x10`
- [x] `cargo check -p reth-evm -p reth-evm-ethereum -p reth-ethereum-payload-builder` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)