### PR TITLE
fix(bench): preserve absent cache wait timings

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -322,14 +322,8 @@ impl Command {
                     .as_ref()
                     .map(|t| t.persistence_wait)
                     .unwrap_or_default(),
-                execution_cache_wait: server_timings
-                    .as_ref()
-                    .map(|t| t.execution_cache_wait)
-                    .unwrap_or_default(),
-                sparse_trie_wait: server_timings
-                    .as_ref()
-                    .map(|t| t.sparse_trie_wait)
-                    .unwrap_or_default(),
+                execution_cache_wait: server_timings.as_ref().and_then(|t| t.execution_cache_wait),
+                sparse_trie_wait: server_timings.as_ref().and_then(|t| t.sparse_trie_wait),
             };
 
             let fcu_start = Instant::now();

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -155,14 +155,8 @@ impl Command {
                     .as_ref()
                     .map(|t| t.persistence_wait)
                     .unwrap_or_default(),
-                execution_cache_wait: server_timings
-                    .as_ref()
-                    .map(|t| t.execution_cache_wait)
-                    .unwrap_or_default(),
-                sparse_trie_wait: server_timings
-                    .as_ref()
-                    .map(|t| t.sparse_trie_wait)
-                    .unwrap_or_default(),
+                execution_cache_wait: server_timings.as_ref().and_then(|t| t.execution_cache_wait),
+                sparse_trie_wait: server_timings.as_ref().and_then(|t| t.sparse_trie_wait),
             };
             blocks_processed += 1;
             let progress = match total_blocks {

--- a/bin/reth-bench/src/bench/output.rs
+++ b/bin/reth-bench/src/bench/output.rs
@@ -28,9 +28,9 @@ pub(crate) struct NewPayloadResult {
     /// Time spent waiting on persistence (backpressure + explicit wait).
     pub(crate) persistence_wait: Duration,
     /// Time spent waiting for execution cache lock.
-    pub(crate) execution_cache_wait: Duration,
+    pub(crate) execution_cache_wait: Option<Duration>,
     /// Time spent waiting for sparse trie lock.
-    pub(crate) sparse_trie_wait: Duration,
+    pub(crate) sparse_trie_wait: Option<Duration>,
 }
 
 impl NewPayloadResult {
@@ -65,8 +65,14 @@ impl Serialize for NewPayloadResult {
         state.serialize_field("gas_used", &self.gas_used)?;
         state.serialize_field("latency", &time)?;
         state.serialize_field("persistence_wait", &self.persistence_wait.as_micros())?;
-        state.serialize_field("execution_cache_wait", &self.execution_cache_wait.as_micros())?;
-        state.serialize_field("sparse_trie_wait", &self.sparse_trie_wait.as_micros())?;
+        state.serialize_field(
+            "execution_cache_wait",
+            &self.execution_cache_wait.map(|wait| wait.as_micros()),
+        )?;
+        state.serialize_field(
+            "sparse_trie_wait",
+            &self.sparse_trie_wait.map(|wait| wait.as_micros()),
+        )?;
         state.end()
     }
 }
@@ -110,11 +116,15 @@ impl std::fmt::Display for CombinedResult {
             self.fcu_latency,
             np.latency,
         )?;
-        if !np.execution_cache_wait.is_zero() {
-            write!(f, ", execution cache wait: {:?}", np.execution_cache_wait)?;
+        if let Some(wait) = np.execution_cache_wait &&
+            !wait.is_zero()
+        {
+            write!(f, ", execution cache wait: {:?}", wait)?;
         }
-        if !np.sparse_trie_wait.is_zero() {
-            write!(f, ", trie cache wait: {:?}", np.sparse_trie_wait)?;
+        if let Some(wait) = np.sparse_trie_wait &&
+            !wait.is_zero()
+        {
+            write!(f, ", trie cache wait: {:?}", wait)?;
         }
         if !np.persistence_wait.is_zero() {
             write!(f, ", persistence wait: {:?}", np.persistence_wait)?;
@@ -150,11 +160,11 @@ impl Serialize for CombinedResult {
         )?;
         state.serialize_field(
             "execution_cache_wait",
-            &self.new_payload_result.execution_cache_wait.as_micros(),
+            &self.new_payload_result.execution_cache_wait.map(|wait| wait.as_micros()),
         )?;
         state.serialize_field(
             "sparse_trie_wait",
-            &self.new_payload_result.sparse_trie_wait.as_micros(),
+            &self.new_payload_result.sparse_trie_wait.map(|wait| wait.as_micros()),
         )?;
         state.end()
     }

--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -337,14 +337,8 @@ impl Command {
                     .as_ref()
                     .map(|t| t.persistence_wait)
                     .unwrap_or_default(),
-                execution_cache_wait: server_timings
-                    .as_ref()
-                    .map(|t| t.execution_cache_wait)
-                    .unwrap_or_default(),
-                sparse_trie_wait: server_timings
-                    .as_ref()
-                    .map(|t| t.sparse_trie_wait)
-                    .unwrap_or_default(),
+                execution_cache_wait: server_timings.as_ref().and_then(|t| t.execution_cache_wait),
+                sparse_trie_wait: server_timings.as_ref().and_then(|t| t.sparse_trie_wait),
             };
 
             let fcu_state = ForkchoiceState {

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -356,9 +356,9 @@ struct RethPayloadStatus {
     #[serde(default)]
     persistence_wait_us: u64,
     #[serde(default)]
-    execution_cache_wait_us: u64,
+    execution_cache_wait_us: Option<u64>,
     #[serde(default)]
-    sparse_trie_wait_us: u64,
+    sparse_trie_wait_us: Option<u64>,
 }
 
 /// Server-side timing breakdown from `reth_newPayload` endpoint.
@@ -369,9 +369,9 @@ pub(crate) struct NewPayloadTimingBreakdown {
     /// Time spent waiting on persistence (backpressure + explicit wait).
     pub(crate) persistence_wait: Duration,
     /// Time spent waiting for execution cache lock.
-    pub(crate) execution_cache_wait: Duration,
+    pub(crate) execution_cache_wait: Option<Duration>,
     /// Time spent waiting for sparse trie lock.
-    pub(crate) sparse_trie_wait: Duration,
+    pub(crate) sparse_trie_wait: Option<Duration>,
 }
 
 /// Calls either `engine_newPayload*` or `reth_newPayload` depending on whether
@@ -416,8 +416,8 @@ pub(crate) async fn call_new_payload_with_reth<N: Network, P: Provider<N>>(
     Ok(Some(NewPayloadTimingBreakdown {
         latency: Duration::from_micros(resp.latency_us),
         persistence_wait: Duration::from_micros(resp.persistence_wait_us),
-        execution_cache_wait: Duration::from_micros(resp.execution_cache_wait_us),
-        sparse_trie_wait: Duration::from_micros(resp.sparse_trie_wait_us),
+        execution_cache_wait: resp.execution_cache_wait_us.map(Duration::from_micros),
+        sparse_trie_wait: resp.sparse_trie_wait_us.map(Duration::from_micros),
     }))
 }
 
@@ -490,5 +490,26 @@ pub(crate) async fn call_forkchoice_updated_with_reth<
                 ))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn preserves_absent_optional_cache_wait_fields() {
+        let resp: RethPayloadStatus = serde_json::from_value(serde_json::json!({
+            "status": "VALID",
+            "latestValidHash": B256::ZERO,
+            "validationError": null,
+            "latency_us": 7,
+            "persistence_wait_us": 3
+        }))
+        .unwrap();
+
+        assert_eq!(resp.execution_cache_wait_us, None);
+        assert_eq!(resp.sparse_trie_wait_us, None);
     }
 }

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -75,3 +75,31 @@ pub trait RethEngineApi<ExecutionData> {
         forkchoice_state: ForkchoiceState,
     ) -> RpcResult<ForkchoiceUpdated>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn serializes_absent_and_zero_cache_waits_differently() {
+        let status = serde_json::from_value(serde_json::json!({
+            "status": "VALID",
+            "latestValidHash": B256::ZERO,
+            "validationError": null
+        }))
+        .unwrap();
+        let payload_status = RethPayloadStatus {
+            status,
+            latency_us: 1,
+            persistence_wait_us: 0,
+            execution_cache_wait_us: None,
+            sparse_trie_wait_us: Some(0),
+        };
+
+        let value = serde_json::to_value(payload_status).unwrap();
+        let object = value.as_object().unwrap();
+        assert!(!object.contains_key("execution_cache_wait_us"));
+        assert_eq!(object.get("sparse_trie_wait_us").unwrap().as_u64(), Some(0));
+    }
+}


### PR DESCRIPTION
Preserves the difference between absent cache wait timings and zero-duration waits in reth-bench. Optional `reth_newPayload` wait fields now remain optional through deserialization, in-memory results, and CSV serialization.