### PR TITLE
refactor(trie): prepare verifier parallelization

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -124,7 +124,7 @@ fn do_verify_only<TX: DbTx, A: TrieTableAdapter>(tx: &TX) -> eyre::Result<()> {
     // Create the verifier
     let hashed_cursor_factory = DatabaseHashedCursorFactory::new(tx);
     let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
-    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory)?;
+    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory, Nibbles::new())?;
 
     let metrics = RepairTrieMetrics::new();
 
@@ -247,7 +247,7 @@ where
     let trie_cursor_factory = DatabaseTrieCursorFactory::<_, A>::new(tx);
 
     // Create the verifier
-    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory)?;
+    let verifier = Verifier::new(&trie_cursor_factory, hashed_cursor_factory, Nibbles::new())?;
 
     let metrics = RepairTrieMetrics::new();
 

--- a/crates/trie/trie/src/trie_cursor/depth_first.rs
+++ b/crates/trie/trie/src/trie_cursor/depth_first.rs
@@ -20,6 +20,10 @@ pub fn cmp(a: &Nibbles, b: &Nibbles) -> Ordering {
 pub struct DepthFirstTrieIterator<C: TrieCursor> {
     /// The underlying trie cursor.
     cursor: C,
+    /// The first lexicographical key to seek to.
+    lower_bound: Nibbles,
+    /// The exclusive upper bound for iteration, if any.
+    upper_bound: Option<Nibbles>,
     /// Set to true once the trie cursor has done its initial seek to the root node.
     initialized: bool,
     /// Stack of nodes which have been fetched. Each node's path is a prefix of the next's.
@@ -35,11 +39,20 @@ impl<C: TrieCursor> DepthFirstTrieIterator<C> {
     pub fn new(cursor: C) -> Self {
         Self {
             cursor,
+            lower_bound: Nibbles::new(),
+            upper_bound: None,
             initialized: false,
             stack: Default::default(),
             next: Default::default(),
             complete: false,
         }
+    }
+
+    /// Limit traversal to nodes whose paths start with the given prefix.
+    pub fn with_subtrie_prefix(mut self, subtrie_prefix: Nibbles) -> Self {
+        self.lower_bound = subtrie_prefix;
+        self.upper_bound = subtrie_prefix.next_without_prefix();
+        self
     }
 
     fn push(&mut self, path: Nibbles, node: BranchNodeCompact) {
@@ -80,7 +93,7 @@ impl<C: TrieCursor> DepthFirstTrieIterator<C> {
                 self.cursor.next()?
             } else {
                 self.initialized = true;
-                self.cursor.seek(Nibbles::new())?
+                self.cursor.seek(self.lower_bound)?
             }) else {
                 // Record that the cursor is empty and yield the stack. The stack is in reverse
                 // order of what we want to yield, but `next` is popped from, so we don't have to
@@ -89,6 +102,12 @@ impl<C: TrieCursor> DepthFirstTrieIterator<C> {
                 self.next = core::mem::take(&mut self.stack);
                 return Ok(())
             };
+
+            if self.upper_bound.as_ref().is_some_and(|upper_bound| &path >= upper_bound) {
+                self.complete = true;
+                self.next = core::mem::take(&mut self.stack);
+                return Ok(())
+            }
 
             trace!(
                 target: "trie::trie_cursor::depth_first",

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -1,5 +1,6 @@
 use crate::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
+    prefix_set::{PrefixSetMut, TriePrefixSets},
     progress::{IntermediateStateRootState, StateRootProgress},
     trie::StateRoot,
     trie_cursor::{
@@ -15,6 +16,105 @@ use reth_execution_errors::StateRootError;
 use reth_storage_errors::db::DatabaseError;
 use std::cmp::{Ordering, Reverse};
 use tracing::trace;
+
+fn state_root_prefix_sets(subtrie_prefix: Nibbles) -> TriePrefixSets {
+    if subtrie_prefix.is_empty() {
+        TriePrefixSets::default()
+    } else {
+        TriePrefixSets {
+            account_prefix_set: PrefixSetMut::from([subtrie_prefix]).freeze(),
+            ..Default::default()
+        }
+    }
+}
+
+fn nibbles_prefix_to_b256(prefix: &Nibbles) -> B256 {
+    B256::right_padding_from(&prefix.pack())
+}
+
+fn subtrie_account_bounds(subtrie_prefix: Nibbles) -> Option<(B256, Option<B256>)> {
+    (!subtrie_prefix.is_empty()).then(|| {
+        (
+            nibbles_prefix_to_b256(&subtrie_prefix),
+            subtrie_prefix.next_without_prefix().map(|prefix| nibbles_prefix_to_b256(&prefix)),
+        )
+    })
+}
+
+#[derive(Clone, Debug)]
+struct BoundedHashedCursorFactory<H> {
+    inner: H,
+    account_bounds: Option<(B256, Option<B256>)>,
+}
+
+impl<H> BoundedHashedCursorFactory<H> {
+    const fn new(inner: H, account_bounds: Option<(B256, Option<B256>)>) -> Self {
+        Self { inner, account_bounds }
+    }
+}
+
+impl<H: HashedCursorFactory> HashedCursorFactory for BoundedHashedCursorFactory<H> {
+    type AccountCursor<'a>
+        = BoundedHashedCursor<H::AccountCursor<'a>>
+    where
+        Self: 'a;
+    type StorageCursor<'a>
+        = H::StorageCursor<'a>
+    where
+        Self: 'a;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        Ok(BoundedHashedCursor::new(self.inner.hashed_account_cursor()?, self.account_bounds))
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        self.inner.hashed_storage_cursor(hashed_address)
+    }
+}
+
+#[derive(Debug)]
+struct BoundedHashedCursor<C> {
+    inner: C,
+    lower_bound: Option<B256>,
+    upper_bound: Option<B256>,
+}
+
+impl<C> BoundedHashedCursor<C> {
+    const fn new(inner: C, account_bounds: Option<(B256, Option<B256>)>) -> Self {
+        let (lower_bound, upper_bound) = if let Some((lower_bound, upper_bound)) = account_bounds {
+            (Some(lower_bound), upper_bound)
+        } else {
+            (None, None)
+        };
+        Self { inner, lower_bound, upper_bound }
+    }
+
+    fn filter_entry<V>(&self, entry: Option<(B256, V)>) -> Option<(B256, V)> {
+        entry.filter(|(key, _)| self.upper_bound.is_none_or(|upper_bound| *key < upper_bound))
+    }
+}
+
+impl<C: HashedCursor> HashedCursor for BoundedHashedCursor<C> {
+    type Value = C::Value;
+
+    fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        let key = self.lower_bound.map_or(key, |lower_bound| key.max(lower_bound));
+        let entry = self.inner.seek(key)?;
+        Ok(self.filter_entry(entry))
+    }
+
+    fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+        let entry = self.inner.next()?;
+        Ok(self.filter_entry(entry))
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset();
+    }
+}
 
 /// Used by [`StateRootBranchNodesIter`] to iterate over branch nodes in a state root.
 #[derive(Debug)]
@@ -38,6 +138,8 @@ enum BranchNode {
 struct StateRootBranchNodesIter<T, H> {
     trie_cursor_factory: T,
     hashed_cursor_factory: H,
+    subtrie_prefix: Option<Nibbles>,
+    subtrie_account_bounds: Option<(B256, Option<B256>)>,
     account_nodes: Vec<(Nibbles, BranchNodeCompact)>,
     storage_tries: Vec<(B256, Vec<(Nibbles, BranchNodeCompact)>)>,
     curr_storage: Option<(B256, Vec<(Nibbles, BranchNodeCompact)>)>,
@@ -50,12 +152,20 @@ impl<T, H> StateRootBranchNodesIter<T, H> {
         Self {
             trie_cursor_factory,
             hashed_cursor_factory,
+            subtrie_prefix: None,
+            subtrie_account_bounds: None,
             account_nodes: Default::default(),
             storage_tries: Default::default(),
             curr_storage: None,
             intermediate_state: None,
             complete: false,
         }
+    }
+
+    fn with_subtrie_prefix(mut self, subtrie_prefix: Nibbles) -> Self {
+        self.subtrie_prefix = Some(subtrie_prefix);
+        self.subtrie_account_bounds = subtrie_account_bounds(subtrie_prefix);
+        self
     }
 
     /// Sorts a Vec of updates such that it is ready to be yielded from the `next` method. We yield
@@ -107,8 +217,12 @@ impl<T: TrieCursorFactory + Clone, H: HashedCursorFactory + Clone> Iterator
 
             let state_root = StateRoot::new(
                 self.trie_cursor_factory.clone(),
-                self.hashed_cursor_factory.clone(),
+                BoundedHashedCursorFactory::new(
+                    self.hashed_cursor_factory.clone(),
+                    self.subtrie_account_bounds,
+                ),
             )
+            .with_prefix_sets(self.subtrie_prefix.map(state_root_prefix_sets).unwrap_or_default())
             .with_intermediate_state(self.intermediate_state.take().map(|s| *s));
 
             let updates = match state_root.root_with_progress() {
@@ -208,7 +322,10 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
         trie_cursor: C,
         subtrie_prefix: Option<Nibbles>,
     ) -> Result<Self, DatabaseError> {
-        let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
+        let mut trie_iter = match subtrie_prefix {
+            Some(prefix) => DepthFirstTrieIterator::new(trie_cursor).with_subtrie_prefix(prefix),
+            None => DepthFirstTrieIterator::new(trie_cursor),
+        };
         let curr = trie_iter.next().transpose()?;
         Ok(Self { account, trie_iter, curr, subtrie_prefix, canonical_branch_nodes: Vec::new() })
     }
@@ -340,6 +457,7 @@ pub struct Verifier<'a, T: TrieCursorFactory, H> {
     trie_cursor_factory: &'a T,
     hashed_cursor_factory: H,
     subtrie_prefix: Nibbles,
+    subtrie_account_bounds: Option<(B256, Option<B256>)>,
     branch_node_iter: StateRootBranchNodesIter<NoopTrieCursorFactory, H>,
     outputs: Vec<Output>,
     account: SingleVerifier<DepthFirstTrieIterator<T::AccountTrieCursor<'a>>>,
@@ -354,14 +472,17 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
         hashed_cursor_factory: H,
         subtrie_prefix: Nibbles,
     ) -> Result<Self, DatabaseError> {
+        let subtrie_account_bounds = subtrie_account_bounds(subtrie_prefix);
         Ok(Self {
             trie_cursor_factory,
             hashed_cursor_factory: hashed_cursor_factory.clone(),
             subtrie_prefix,
+            subtrie_account_bounds,
             branch_node_iter: StateRootBranchNodesIter::new(
                 NoopTrieCursorFactory,
                 hashed_cursor_factory,
-            ),
+            )
+            .with_subtrie_prefix(subtrie_prefix),
             outputs: Default::default(),
             account: SingleVerifier::new(
                 None,
@@ -380,7 +501,9 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
     }
 
     fn account_in_subtrie(&self, account: B256) -> bool {
-        Nibbles::unpack(account).starts_with(&self.subtrie_prefix)
+        self.subtrie_account_bounds.map_or(true, |(lower_bound, upper_bound)| {
+            account >= lower_bound && upper_bound.is_none_or(|upper_bound| account < upper_bound)
+        })
     }
 
     fn new_storage(
@@ -407,33 +530,44 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
         start_inclusive: bool,
         end_inclusive: bool,
     ) -> Result<(), DatabaseError> {
-        let mut account_cursor = self.hashed_cursor_factory.hashed_account_cursor()?;
-        let mut account_seeked = false;
+        let seek_account = self
+            .subtrie_account_bounds
+            .map(|(lower_bound, _)| lower_bound.max(last_account))
+            .unwrap_or(last_account);
 
-        if !start_inclusive {
-            account_seeked = true;
-            account_cursor.seek(last_account)?;
+        if self.subtrie_account_bounds.is_some_and(|(_, upper_bound)| {
+            upper_bound.is_some_and(|upper_bound| seek_account >= upper_bound)
+        }) || seek_account > next_account ||
+            (!end_inclusive && seek_account == next_account)
+        {
+            return Ok(())
+        }
+
+        let mut account_cursor = self.hashed_cursor_factory.hashed_account_cursor()?;
+        let mut curr_account = account_cursor.seek(seek_account)?;
+
+        if !start_inclusive &&
+            curr_account.as_ref().is_some_and(|(account, _)| *account == last_account)
+        {
+            curr_account = account_cursor.next()?;
         }
 
         loop {
-            let Some((curr_account, _)) = (if account_seeked {
-                account_cursor.next()?
-            } else {
-                account_seeked = true;
-                account_cursor.seek(last_account)?
-            }) else {
+            let Some((curr_account_key, _)) = curr_account.take() else { return Ok(()) };
+
+            if self.subtrie_account_bounds.is_some_and(|(_, upper_bound)| {
+                upper_bound.is_some_and(|upper_bound| curr_account_key >= upper_bound)
+            }) {
                 return Ok(())
-            };
+            }
 
-            if curr_account < next_account || (end_inclusive && curr_account == next_account) {
-                if !self.account_in_subtrie(curr_account) {
-                    continue
-                }
-
-                trace!(target: "trie::verify", account = ?curr_account, "Verifying account has empty storage");
+            if curr_account_key < next_account ||
+                (end_inclusive && curr_account_key == next_account)
+            {
+                trace!(target: "trie::verify", account = ?curr_account_key, "Verifying account has empty storage");
 
                 let mut storage_cursor =
-                    self.trie_cursor_factory.storage_trie_cursor(curr_account)?;
+                    self.trie_cursor_factory.storage_trie_cursor(curr_account_key)?;
                 let mut seeked = false;
                 while let Some((path, node)) = if seeked {
                     storage_cursor.next()?
@@ -441,8 +575,9 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
                     seeked = true;
                     storage_cursor.seek(Nibbles::new())?
                 } {
-                    self.outputs.push(Output::StorageExtra(curr_account, path, node));
+                    self.outputs.push(Output::StorageExtra(curr_account_key, path, node));
                 }
+                curr_account = account_cursor.next()?;
             } else {
                 return Ok(())
             }
@@ -540,6 +675,7 @@ mod tests {
     use super::*;
     use crate::{
         hashed_cursor::mock::MockHashedCursorFactory,
+        mock::{KeyVisit, KeyVisitType},
         trie_cursor::mock::{MockTrieCursor, MockTrieCursorFactory},
     };
     use alloy_primitives::{address, keccak256, map::B256Map, U256};
@@ -1129,5 +1265,163 @@ mod tests {
             Output::StorageWrong { account, .. } =>
                 Nibbles::unpack(*account).starts_with(&subtrie_prefix),
         }));
+    }
+
+    #[test]
+    fn test_single_verifier_subtrie_prefix_seeks_directly_to_prefix() {
+        let subtrie_prefix = Nibbles::from_nibbles([0x1]);
+        let in_prefix_parent = Nibbles::from_nibbles([0x1]);
+        let in_prefix_child = Nibbles::from_nibbles([0x1, 0x1]);
+        let first_out_of_prefix = Nibbles::from_nibbles([0x2]);
+        let later_out_of_prefix = Nibbles::from_nibbles([0x3]);
+
+        let trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::from([
+                (Nibbles::new(), test_branch_node(0b1110, 0, 0b1110, vec![])),
+                (in_prefix_parent, test_branch_node(0b0010, 0, 0b0010, vec![])),
+                (in_prefix_child, test_branch_node(0b0001, 0, 0b0001, vec![])),
+                (first_out_of_prefix, test_branch_node(0b0001, 0, 0b0001, vec![])),
+                (later_out_of_prefix, test_branch_node(0b0001, 0, 0b0001, vec![])),
+            ]),
+            B256Map::default(),
+        );
+
+        let mut verifier = SingleVerifier::new(
+            None,
+            trie_cursor_factory.account_trie_cursor().unwrap(),
+            Some(subtrie_prefix),
+        )
+        .unwrap();
+        let mut outputs = Vec::new();
+
+        verifier
+            .next(&mut outputs, in_prefix_child, test_branch_node(0b0001, 0, 0b0001, vec![]))
+            .unwrap();
+        verifier
+            .next(&mut outputs, in_prefix_parent, test_branch_node(0b0010, 0, 0b0010, vec![]))
+            .unwrap();
+        let _ = verifier.finalize(&mut outputs).unwrap();
+
+        assert!(outputs.is_empty());
+        assert_eq!(
+            *trie_cursor_factory.visited_account_keys(),
+            vec![
+                KeyVisit {
+                    visit_type: KeyVisitType::SeekNonExact(subtrie_prefix),
+                    visited_key: Some(in_prefix_parent),
+                },
+                KeyVisit { visit_type: KeyVisitType::Next, visited_key: Some(in_prefix_child) },
+                KeyVisit { visit_type: KeyVisitType::Next, visited_key: Some(first_out_of_prefix) },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_state_root_branch_nodes_iter_subtrie_prefix_seeks_hashed_accounts_to_prefix() {
+        let before_prefix = B256::right_padding_from(&[0x00]);
+        let first_in_prefix = B256::right_padding_from(&[0x10]);
+        let second_in_prefix = B256::right_padding_from(&[0x11]);
+        let first_out_of_prefix = B256::right_padding_from(&[0x20]);
+        let later_out_of_prefix = B256::right_padding_from(&[0x30]);
+
+        let empty_account = Account::default();
+        let factory = MockHashedCursorFactory::new(
+            BTreeMap::from([
+                (before_prefix, empty_account),
+                (first_in_prefix, empty_account),
+                (second_in_prefix, empty_account),
+                (first_out_of_prefix, empty_account),
+                (later_out_of_prefix, empty_account),
+            ]),
+            [
+                (before_prefix, BTreeMap::default()),
+                (first_in_prefix, BTreeMap::default()),
+                (second_in_prefix, BTreeMap::default()),
+                (first_out_of_prefix, BTreeMap::default()),
+                (later_out_of_prefix, BTreeMap::default()),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let iter = StateRootBranchNodesIter::new(NoopTrieCursorFactory, factory.clone())
+            .with_subtrie_prefix(Nibbles::from_nibbles([0x1]));
+
+        let outputs = iter.collect::<Result<Vec<_>, _>>().unwrap();
+        assert!(outputs.iter().all(|node| match node {
+            BranchNode::Account(path, _) => path.starts_with(&Nibbles::from_nibbles([0x1])),
+            BranchNode::Storage(account, _, _) =>
+                Nibbles::unpack(*account).starts_with(&Nibbles::from_nibbles([0x1])),
+        }));
+
+        let visits = factory.visited_account_keys().clone();
+        assert!(visits.iter().any(|visit| visit.visited_key == Some(first_in_prefix)));
+        assert!(visits.iter().any(|visit| visit.visited_key == Some(second_in_prefix)));
+        assert!(!visits.iter().any(|visit| visit.visited_key == Some(before_prefix)));
+        assert!(!visits.iter().any(|visit| visit.visited_key == Some(later_out_of_prefix)));
+    }
+
+    #[test]
+    fn test_verifier_subtrie_prefix_bounds_empty_storage_scan() {
+        let subtrie_prefix = Nibbles::from_nibbles([0x1, 0x2, 0x3]);
+        let before_prefix = B256::right_padding_from(&[0x12, 0x20]);
+        let first_in_prefix = B256::right_padding_from(&[0x12, 0x30]);
+        let second_in_prefix = B256::right_padding_from(&[0x12, 0x3f]);
+        let first_out_of_prefix = B256::right_padding_from(&[0x12, 0x40]);
+        let later_out_of_prefix = B256::right_padding_from(&[0x20]);
+
+        let trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::default(),
+            [
+                (before_prefix, BTreeMap::default()),
+                (first_in_prefix, BTreeMap::default()),
+                (second_in_prefix, BTreeMap::default()),
+                (first_out_of_prefix, BTreeMap::default()),
+                (later_out_of_prefix, BTreeMap::default()),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let hashed_cursor_factory = MockHashedCursorFactory::new(
+            BTreeMap::from([
+                (before_prefix, Account::default()),
+                (first_in_prefix, Account::default()),
+                (second_in_prefix, Account::default()),
+                (first_out_of_prefix, Account::default()),
+                (later_out_of_prefix, Account::default()),
+            ]),
+            [
+                (before_prefix, BTreeMap::default()),
+                (first_in_prefix, BTreeMap::default()),
+                (second_in_prefix, BTreeMap::default()),
+                (first_out_of_prefix, BTreeMap::default()),
+                (later_out_of_prefix, BTreeMap::default()),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let mut verifier =
+            Verifier::new(&trie_cursor_factory, hashed_cursor_factory.clone(), subtrie_prefix)
+                .unwrap();
+        verifier.branch_node_iter.complete = true;
+
+        let outputs = verifier.collect::<Result<Vec<_>, _>>().unwrap();
+        assert!(outputs.is_empty());
+        assert_eq!(
+            *hashed_cursor_factory.visited_account_keys(),
+            vec![
+                KeyVisit {
+                    visit_type: KeyVisitType::SeekNonExact(first_in_prefix),
+                    visited_key: Some(first_in_prefix),
+                },
+                KeyVisit { visit_type: KeyVisitType::Next, visited_key: Some(second_in_prefix) },
+                KeyVisit { visit_type: KeyVisitType::Next, visited_key: Some(first_out_of_prefix) },
+            ]
+        );
+        assert!(trie_cursor_factory.visited_storage_keys(before_prefix).is_empty());
+        assert_eq!(trie_cursor_factory.visited_storage_keys(first_in_prefix).len(), 1);
+        assert_eq!(trie_cursor_factory.visited_storage_keys(second_in_prefix).len(), 1);
+        assert!(trie_cursor_factory.visited_storage_keys(first_out_of_prefix).is_empty());
+        assert!(trie_cursor_factory.visited_storage_keys(later_out_of_prefix).is_empty());
     }
 }

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -198,14 +198,23 @@ struct SingleVerifier<I> {
     account: Option<B256>, // None for accounts trie
     trie_iter: I,
     curr: Option<(Nibbles, BranchNodeCompact)>,
+    subtrie_prefix: Option<Nibbles>,
     canonical_branch_nodes: Vec<(Nibbles, BranchNodeCompact)>,
 }
 
 impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
-    fn new(account: Option<B256>, trie_cursor: C) -> Result<Self, DatabaseError> {
+    fn new(
+        account: Option<B256>,
+        trie_cursor: C,
+        subtrie_prefix: Option<Nibbles>,
+    ) -> Result<Self, DatabaseError> {
         let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
         let curr = trie_iter.next().transpose()?;
-        Ok(Self { account, trie_iter, curr, canonical_branch_nodes: Vec::new() })
+        Ok(Self { account, trie_iter, curr, subtrie_prefix, canonical_branch_nodes: Vec::new() })
+    }
+
+    fn should_output_extra(&self, path: &Nibbles) -> bool {
+        self.subtrie_prefix.as_ref().is_none_or(|prefix| path.starts_with(prefix))
     }
 
     const fn output_extra(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
@@ -293,7 +302,9 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
                     // If the given path comes after the current path in depth-first order,
                     // it means the cursor's path was not found by the caller (otherwise it would
                     // have hit the equal case) and so is extraneous.
-                    outputs.push(self.output_extra(*curr_path, curr_node.clone()));
+                    if self.should_output_extra(curr_path) {
+                        outputs.push(self.output_extra(*curr_path, curr_node.clone()));
+                    }
                     self.curr = self.trie_iter.next().transpose()?;
                     // back to the top of the loop to check the latest `self.curr` value against the
                     // given path/node.
@@ -310,7 +321,9 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
     ) -> Result<Vec<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         loop {
             if let Some((curr_path, curr_node)) = self.curr.take() {
-                outputs.push(self.output_extra(curr_path, curr_node));
+                if self.should_output_extra(&curr_path) {
+                    outputs.push(self.output_extra(curr_path, curr_node));
+                }
                 self.curr = self.trie_iter.next().transpose()?;
             } else {
                 return Ok(core::mem::take(&mut self.canonical_branch_nodes))
@@ -326,6 +339,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
 pub struct Verifier<'a, T: TrieCursorFactory, H> {
     trie_cursor_factory: &'a T,
     hashed_cursor_factory: H,
+    subtrie_prefix: Nibbles,
     branch_node_iter: StateRootBranchNodesIter<NoopTrieCursorFactory, H>,
     outputs: Vec<Output>,
     account: SingleVerifier<DepthFirstTrieIterator<T::AccountTrieCursor<'a>>>,
@@ -338,16 +352,22 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
     pub fn new(
         trie_cursor_factory: &'a T,
         hashed_cursor_factory: H,
+        subtrie_prefix: Nibbles,
     ) -> Result<Self, DatabaseError> {
         Ok(Self {
             trie_cursor_factory,
             hashed_cursor_factory: hashed_cursor_factory.clone(),
+            subtrie_prefix,
             branch_node_iter: StateRootBranchNodesIter::new(
                 NoopTrieCursorFactory,
                 hashed_cursor_factory,
             ),
             outputs: Default::default(),
-            account: SingleVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?,
+            account: SingleVerifier::new(
+                None,
+                trie_cursor_factory.account_trie_cursor()?,
+                Some(subtrie_prefix),
+            )?,
             storage: None,
             complete: false,
         })
@@ -355,6 +375,14 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
 }
 
 impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H> {
+    fn matches_subtrie_prefix(&self, path: &Nibbles) -> bool {
+        path.starts_with(&self.subtrie_prefix)
+    }
+
+    fn account_in_subtrie(&self, account: B256) -> bool {
+        Nibbles::unpack(account).starts_with(&self.subtrie_prefix)
+    }
+
     fn new_storage(
         &mut self,
         account: B256,
@@ -362,7 +390,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
         node: BranchNodeCompact,
     ) -> Result<(), DatabaseError> {
         let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(account)?;
-        let mut storage = SingleVerifier::new(Some(account), trie_cursor)?;
+        let mut storage = SingleVerifier::new(Some(account), trie_cursor, None)?;
         storage.next(&mut self.outputs, path, node)?;
         self.storage = Some((account, storage));
         Ok(())
@@ -398,6 +426,10 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
             };
 
             if curr_account < next_account || (end_inclusive && curr_account == next_account) {
+                if !self.account_in_subtrie(curr_account) {
+                    continue
+                }
+
                 trace!(target: "trie::verify", account = ?curr_account, "Verifying account has empty storage");
 
                 let mut storage_cursor =
@@ -432,10 +464,17 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
                     let max_account = B256::from([0xFFu8; 32]);
 
                     self.verify_empty_storages(prev_account, max_account, false, true)?;
+                } else if !self.subtrie_prefix.is_empty() {
+                    let max_account = B256::from([0xFFu8; 32]);
+                    self.verify_empty_storages(B256::ZERO, max_account, true, true)?;
                 }
                 self.complete = true;
             }
             Some(BranchNode::Account(path, node)) => {
+                if !self.matches_subtrie_prefix(&path) {
+                    return Ok(())
+                }
+
                 trace!(target: "trie::verify", ?path, "Account node from state root");
                 self.account.next(&mut self.outputs, path, node)?;
                 // Push progress indicator
@@ -444,6 +483,10 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
                 }
             }
             Some(BranchNode::Storage(account, path, node)) => {
+                if !self.account_in_subtrie(account) {
+                    return Ok(())
+                }
+
                 trace!(target: "trie::verify", ?account, ?path, "Storage node from state root");
                 match self.storage.as_mut() {
                     None => {
@@ -695,7 +738,7 @@ mod tests {
         )]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let verifier = SingleVerifier::new(None, cursor).unwrap();
+        let verifier = SingleVerifier::new(None, cursor, None).unwrap();
 
         // Should have seeked to the beginning and found the first node
         assert!(verifier.curr.is_some());
@@ -713,7 +756,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with the exact node that exists
@@ -732,7 +775,7 @@ mod tests {
         let trie_nodes = BTreeMap::from([(Nibbles::from_nibbles([0x1]), node_in_trie.clone())]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with different node value
@@ -756,7 +799,7 @@ mod tests {
         let trie_nodes = BTreeMap::from([(Nibbles::from_nibbles([0x3]), node1)]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with a node that comes before any in the trie
@@ -788,7 +831,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces in post-order: 0x1, 0x2, 0x3, root
@@ -833,7 +876,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces in post-order: 0x1, 0x2, 0x3, root
@@ -872,7 +915,7 @@ mod tests {
         let trie_nodes = BTreeMap::from([(Nibbles::from_nibbles([0x1]), node)]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(Some(account), cursor).unwrap();
+        let mut verifier = SingleVerifier::new(Some(account), cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // Call next with missing node
@@ -893,7 +936,7 @@ mod tests {
         // Test with empty trie cursor
         let trie_nodes = BTreeMap::new();
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // Any node should be marked as missing
@@ -930,7 +973,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces nodes in post-order (children before parents)
@@ -971,7 +1014,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // Process in WRONG order (skip root, provide child before processing all nodes correctly)
@@ -1011,7 +1054,7 @@ mod tests {
         ]);
 
         let cursor = create_mock_cursor(trie_nodes);
-        let mut verifier = SingleVerifier::new(None, cursor).unwrap();
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
         let mut outputs = Vec::new();
 
         // The depth-first iterator produces nodes in post-order (children before parents)
@@ -1037,5 +1080,54 @@ mod tests {
             }
         }
         assert!(outputs.is_empty());
+    }
+
+    #[test]
+    fn test_verifier_subtrie_prefix_filters_account_outputs() {
+        let subtrie_prefix = Nibbles::from_nibbles([0x1]);
+        let in_prefix_path = Nibbles::from_nibbles([0x1]);
+        let out_of_prefix_path = Nibbles::from_nibbles([0x2]);
+
+        let root = test_branch_node(0b0110, 0, 0b0110, vec![]);
+        let expected_in_prefix = test_branch_node(0b0001, 0, 0b0001, vec![B256::from([1u8; 32])]);
+        let expected_out_of_prefix =
+            test_branch_node(0b0010, 0, 0b0010, vec![B256::from([2u8; 32])]);
+        let wrong_in_prefix = test_branch_node(0b0100, 0, 0b0100, vec![B256::from([3u8; 32])]);
+        let wrong_out_of_prefix = test_branch_node(0b1000, 0, 0b1000, vec![B256::from([4u8; 32])]);
+
+        let trie_cursor_factory = MockTrieCursorFactory::new(
+            BTreeMap::from([
+                (Nibbles::new(), root),
+                (in_prefix_path, wrong_in_prefix.clone()),
+                (out_of_prefix_path, wrong_out_of_prefix),
+            ]),
+            B256Map::default(),
+        );
+        let hashed_cursor_factory =
+            MockHashedCursorFactory::new(BTreeMap::new(), B256Map::default());
+
+        let mut verifier =
+            Verifier::new(&trie_cursor_factory, hashed_cursor_factory, subtrie_prefix).unwrap();
+        verifier.branch_node_iter.account_nodes = vec![
+            (out_of_prefix_path, expected_out_of_prefix),
+            (in_prefix_path, expected_in_prefix),
+        ];
+        verifier.branch_node_iter.complete = true;
+
+        let outputs = verifier.collect::<Result<Vec<_>, _>>().unwrap();
+
+        assert!(outputs.iter().any(|output| {
+            matches!(output, Output::AccountWrong { path, found, .. } if *path == in_prefix_path && *found == wrong_in_prefix)
+        }));
+        assert!(outputs.iter().all(|output| match output {
+            Output::AccountExtra(path, _) |
+            Output::AccountMissing(path, _) |
+            Output::Progress(path) => path.starts_with(&subtrie_prefix),
+            Output::AccountWrong { path, .. } => path.starts_with(&subtrie_prefix),
+            Output::StorageExtra(account, ..) |
+            Output::StorageMissing(account, ..) |
+            Output::StorageWrong { account, .. } =>
+                Nibbles::unpack(*account).starts_with(&subtrie_prefix),
+        }));
     }
 }

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -363,6 +363,27 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
         }
     }
 
+    fn retain_canonical_branch_node(&mut self, path: Nibbles, node: &BranchNodeCompact) {
+        let mut replaced_descendants = false;
+        self.canonical_branch_nodes.retain(|(existing_path, _)| {
+            let keep = !existing_path.starts_with(&path);
+            replaced_descendants |= !keep;
+            keep
+        });
+
+        if replaced_descendants {
+            self.canonical_branch_nodes.push((path, node.clone()));
+            return
+        }
+
+        let has_retained_ancestor = self.canonical_branch_nodes.iter().any(|(existing_path, _)| {
+            self.subtrie_prefix != Some(*existing_path) && path.starts_with(existing_path)
+        });
+        if !has_retained_ancestor {
+            self.canonical_branch_nodes.push((path, node.clone()));
+        }
+    }
+
     /// Called with the next path and node in the canonical sequence of stored trie nodes. Will
     /// append to the given `outputs` Vec if walking the trie cursor produces data
     /// inconsistent with that given.
@@ -374,17 +395,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
         path: Nibbles,
         node: BranchNodeCompact,
     ) -> Result<(), DatabaseError> {
-        match self.canonical_branch_nodes.first() {
-            Some((first_path, _)) if path.len() < first_path.len() => {
-                self.canonical_branch_nodes.clear();
-                self.canonical_branch_nodes.push((path, node.clone()));
-            }
-            Some((first_path, _)) if path.len() == first_path.len() => {
-                self.canonical_branch_nodes.push((path, node.clone()));
-            }
-            None => self.canonical_branch_nodes.push((path, node.clone())),
-            Some(_) => {}
-        }
+        self.retain_canonical_branch_node(path, &node);
 
         loop {
             // `curr` is None only if the end of the iterator has been reached. Any further nodes
@@ -1038,6 +1049,38 @@ mod tests {
         );
         assert_eq!(
             canonical_branch_nodes,
+            vec![(Nibbles::from_nibbles([0x1]), node1), (Nibbles::from_nibbles([0x2]), node2),]
+        );
+    }
+
+    #[test]
+    fn test_single_verifier_finalize_replaces_only_descendants() {
+        let node_root = test_branch_node(0b0110, 0, 0b0110, vec![]);
+        let node1 = test_branch_node(0b0110, 0, 0b0110, vec![]);
+        let node11 = test_branch_node(0b0001, 0, 0b0001, vec![]);
+        let node12 = test_branch_node(0b0010, 0, 0b0010, vec![]);
+        let node2 = test_branch_node(0b0100, 0, 0b0100, vec![]);
+
+        let trie_nodes = BTreeMap::from([
+            (Nibbles::new(), node_root.clone()),
+            (Nibbles::from_nibbles([0x1]), node1.clone()),
+            (Nibbles::from_nibbles([0x1, 0x1]), node11.clone()),
+            (Nibbles::from_nibbles([0x1, 0x2]), node12.clone()),
+            (Nibbles::from_nibbles([0x2]), node2.clone()),
+        ]);
+
+        let cursor = create_mock_cursor(trie_nodes);
+        let mut verifier = SingleVerifier::new(None, cursor, None).unwrap();
+        let mut outputs = Vec::new();
+
+        verifier.next(&mut outputs, Nibbles::from_nibbles([0x1, 0x1]), node11).unwrap();
+        verifier.next(&mut outputs, Nibbles::from_nibbles([0x1, 0x2]), node12).unwrap();
+        verifier.next(&mut outputs, Nibbles::from_nibbles([0x1]), node1.clone()).unwrap();
+        verifier.next(&mut outputs, Nibbles::from_nibbles([0x2]), node2.clone()).unwrap();
+
+        assert!(outputs.is_empty());
+        assert_eq!(
+            verifier.canonical_branch_nodes,
             vec![(Nibbles::from_nibbles([0x1]), node1), (Nibbles::from_nibbles([0x2]), node2),]
         );
     }

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -35,7 +35,8 @@ enum BranchNode {
 ///   started. In other words, if the current storage account is not equal to the previous, the
 ///   previous has no more nodes.
 #[derive(Debug)]
-struct StateRootBranchNodesIter<H> {
+struct StateRootBranchNodesIter<T, H> {
+    trie_cursor_factory: T,
     hashed_cursor_factory: H,
     account_nodes: Vec<(Nibbles, BranchNodeCompact)>,
     storage_tries: Vec<(B256, Vec<(Nibbles, BranchNodeCompact)>)>,
@@ -44,9 +45,10 @@ struct StateRootBranchNodesIter<H> {
     complete: bool,
 }
 
-impl<H> StateRootBranchNodesIter<H> {
-    fn new(hashed_cursor_factory: H) -> Self {
+impl<T, H> StateRootBranchNodesIter<T, H> {
+    fn new(trie_cursor_factory: T, hashed_cursor_factory: H) -> Self {
         Self {
+            trie_cursor_factory,
             hashed_cursor_factory,
             account_nodes: Default::default(),
             storage_tries: Default::default(),
@@ -66,7 +68,9 @@ impl<H> StateRootBranchNodesIter<H> {
     }
 }
 
-impl<H: HashedCursorFactory + Clone> Iterator for StateRootBranchNodesIter<H> {
+impl<T: TrieCursorFactory + Clone, H: HashedCursorFactory + Clone> Iterator
+    for StateRootBranchNodesIter<T, H>
+{
     type Item = Result<BranchNode, StateRootError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -101,9 +105,11 @@ impl<H: HashedCursorFactory + Clone> Iterator for StateRootBranchNodesIter<H> {
                 return None
             }
 
-            let state_root =
-                StateRoot::new(NoopTrieCursorFactory, self.hashed_cursor_factory.clone())
-                    .with_intermediate_state(self.intermediate_state.take().map(|s| *s));
+            let state_root = StateRoot::new(
+                self.trie_cursor_factory.clone(),
+                self.hashed_cursor_factory.clone(),
+            )
+            .with_intermediate_state(self.intermediate_state.take().map(|s| *s));
 
             let updates = match state_root.root_with_progress() {
                 Err(err) => return Some(Err(err)),
@@ -192,13 +198,14 @@ struct SingleVerifier<I> {
     account: Option<B256>, // None for accounts trie
     trie_iter: I,
     curr: Option<(Nibbles, BranchNodeCompact)>,
+    canonical_branch_nodes: Vec<(Nibbles, BranchNodeCompact)>,
 }
 
 impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
     fn new(account: Option<B256>, trie_cursor: C) -> Result<Self, DatabaseError> {
         let mut trie_iter = DepthFirstTrieIterator::new(trie_cursor);
         let curr = trie_iter.next().transpose()?;
-        Ok(Self { account, trie_iter, curr })
+        Ok(Self { account, trie_iter, curr, canonical_branch_nodes: Vec::new() })
     }
 
     const fn output_extra(&self, path: Nibbles, node: BranchNodeCompact) -> Output {
@@ -241,6 +248,18 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
         path: Nibbles,
         node: BranchNodeCompact,
     ) -> Result<(), DatabaseError> {
+        match self.canonical_branch_nodes.first() {
+            Some((first_path, _)) if path.len() < first_path.len() => {
+                self.canonical_branch_nodes.clear();
+                self.canonical_branch_nodes.push((path, node.clone()));
+            }
+            Some((first_path, _)) if path.len() == first_path.len() => {
+                self.canonical_branch_nodes.push((path, node.clone()));
+            }
+            None => self.canonical_branch_nodes.push((path, node.clone())),
+            Some(_) => {}
+        }
+
         loop {
             // `curr` is None only if the end of the iterator has been reached. Any further nodes
             // found must be considered missing.
@@ -285,13 +304,16 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
 
     /// Must be called once there are no more calls to `next` to made. All further nodes produced
     /// by the iterator will be considered extraneous.
-    fn finalize(&mut self, outputs: &mut Vec<Output>) -> Result<(), DatabaseError> {
+    fn finalize(
+        &mut self,
+        outputs: &mut Vec<Output>,
+    ) -> Result<Vec<(Nibbles, BranchNodeCompact)>, DatabaseError> {
         loop {
             if let Some((curr_path, curr_node)) = self.curr.take() {
                 outputs.push(self.output_extra(curr_path, curr_node));
                 self.curr = self.trie_iter.next().transpose()?;
             } else {
-                return Ok(())
+                return Ok(core::mem::take(&mut self.canonical_branch_nodes))
             }
         }
     }
@@ -304,7 +326,7 @@ impl<C: TrieCursor> SingleVerifier<DepthFirstTrieIterator<C>> {
 pub struct Verifier<'a, T: TrieCursorFactory, H> {
     trie_cursor_factory: &'a T,
     hashed_cursor_factory: H,
-    branch_node_iter: StateRootBranchNodesIter<H>,
+    branch_node_iter: StateRootBranchNodesIter<NoopTrieCursorFactory, H>,
     outputs: Vec<Output>,
     account: SingleVerifier<DepthFirstTrieIterator<T::AccountTrieCursor<'a>>>,
     storage: Option<(B256, SingleVerifier<DepthFirstTrieIterator<T::StorageTrieCursor<'a>>>)>,
@@ -320,7 +342,10 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
         Ok(Self {
             trie_cursor_factory,
             hashed_cursor_factory: hashed_cursor_factory.clone(),
-            branch_node_iter: StateRootBranchNodesIter::new(hashed_cursor_factory),
+            branch_node_iter: StateRootBranchNodesIter::new(
+                NoopTrieCursorFactory,
+                hashed_cursor_factory,
+            ),
             outputs: Default::default(),
             account: SingleVerifier::new(None, trie_cursor_factory.account_trie_cursor()?)?,
             storage: None,
@@ -395,9 +420,9 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
     fn try_next(&mut self) -> Result<(), StateRootError> {
         match self.branch_node_iter.next().transpose()? {
             None => {
-                self.account.finalize(&mut self.outputs)?;
+                let _ = self.account.finalize(&mut self.outputs)?;
                 if let Some((prev_account, storage)) = self.storage.as_mut() {
-                    storage.finalize(&mut self.outputs)?;
+                    let _ = storage.finalize(&mut self.outputs)?;
 
                     // If there was a previous storage account, and it is the final one, then we
                     // need to validate that all accounts coming after it have empty storages.
@@ -430,7 +455,7 @@ impl<'a, T: TrieCursorFactory, H: HashedCursorFactory + Clone> Verifier<'a, T, H
                         storage.next(&mut self.outputs, path, node)?;
                     }
                     Some((prev_account, storage)) => {
-                        storage.finalize(&mut self.outputs)?;
+                        let _ = storage.finalize(&mut self.outputs)?;
                         // Clear any storage entries between the previous account and the new one
                         let prev_account = *prev_account;
                         self.verify_empty_storages(prev_account, account, false, false)?;
@@ -516,7 +541,7 @@ mod tests {
     fn test_state_root_branch_nodes_iter_empty() {
         // Test with completely empty state
         let factory = MockHashedCursorFactory::new(BTreeMap::new(), B256Map::default());
-        let mut iter = StateRootBranchNodesIter::new(factory);
+        let mut iter = StateRootBranchNodesIter::new(NoopTrieCursorFactory, factory);
 
         // Collect all results - with empty state, should complete without producing nodes
         let mut count = 0;
@@ -554,7 +579,7 @@ mod tests {
         storage_tries.insert(addr1, storage1);
 
         let factory = MockHashedCursorFactory::new(accounts, storage_tries);
-        let mut iter = StateRootBranchNodesIter::new(factory);
+        let mut iter = StateRootBranchNodesIter::new(NoopTrieCursorFactory, factory);
 
         // Collect nodes and verify basic properties
         let mut account_paths = Vec::new();
@@ -627,7 +652,7 @@ mod tests {
         }
 
         let factory = MockHashedCursorFactory::new(accounts, storage_tries);
-        let mut iter = StateRootBranchNodesIter::new(factory);
+        let mut iter = StateRootBranchNodesIter::new(NoopTrieCursorFactory, factory);
 
         // Track what we see
         let mut seen_storage_accounts = Vec::new();
@@ -770,7 +795,7 @@ mod tests {
         // We only provide 0x1 and 0x3, skipping 0x2 and root
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x1]), node1).unwrap();
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x3]), node3).unwrap();
-        verifier.finalize(&mut outputs).unwrap();
+        let _ = verifier.finalize(&mut outputs).unwrap();
 
         // Should have two "extra" outputs for nodes in the trie that we skipped
         if outputs.len() != 2 {
@@ -813,12 +838,12 @@ mod tests {
 
         // The depth-first iterator produces in post-order: 0x1, 0x2, 0x3, root
         // Process first two nodes correctly
-        verifier.next(&mut outputs, Nibbles::from_nibbles([0x1]), node1).unwrap();
-        verifier.next(&mut outputs, Nibbles::from_nibbles([0x2]), node2).unwrap();
+        verifier.next(&mut outputs, Nibbles::from_nibbles([0x1]), node1.clone()).unwrap();
+        verifier.next(&mut outputs, Nibbles::from_nibbles([0x2]), node2.clone()).unwrap();
         assert!(outputs.is_empty());
 
         // Finalize - should mark remaining nodes (0x3 and root) as extra
-        verifier.finalize(&mut outputs).unwrap();
+        let canonical_branch_nodes = verifier.finalize(&mut outputs).unwrap();
 
         // Should have two extra nodes
         assert_eq!(outputs.len(), 2);
@@ -831,6 +856,10 @@ mod tests {
             &outputs[1],
             Output::AccountExtra(path, node)
                 if *path == Nibbles::new() && *node == node_root
+        );
+        assert_eq!(
+            canonical_branch_nodes,
+            vec![(Nibbles::from_nibbles([0x1]), node1), (Nibbles::from_nibbles([0x2]), node2),]
         );
     }
 
@@ -910,8 +939,8 @@ mod tests {
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x1, 0x2]), node12).unwrap();
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x1]), node1).unwrap();
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x2]), node2).unwrap();
-        verifier.next(&mut outputs, Nibbles::new(), node_root).unwrap();
-        verifier.finalize(&mut outputs).unwrap();
+        verifier.next(&mut outputs, Nibbles::new(), node_root.clone()).unwrap();
+        let canonical_branch_nodes = verifier.finalize(&mut outputs).unwrap();
 
         // All should match, no outputs
         if !outputs.is_empty() {
@@ -924,6 +953,7 @@ mod tests {
             }
         }
         assert!(outputs.is_empty());
+        assert_eq!(canonical_branch_nodes, vec![(Nibbles::new(), node_root)]);
     }
 
     #[test]
@@ -994,7 +1024,7 @@ mod tests {
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x2, 0x1]), node21).unwrap();
         verifier.next(&mut outputs, Nibbles::from_nibbles([0x2]), node2).unwrap();
         verifier.next(&mut outputs, Nibbles::new(), node_root).unwrap();
-        verifier.finalize(&mut outputs).unwrap();
+        let _ = verifier.finalize(&mut outputs).unwrap();
 
         // All should match, no outputs
         if !outputs.is_empty() {


### PR DESCRIPTION
Threads a trie cursor factory into `StateRootBranchNodesIter` while keeping current callers on `NoopTrieCursorFactory`, and has `SingleVerifier::finalize` return the shallowest canonical branch-node layer seen during verification.

This keeps the current verifier behavior intact while exposing the state we need for the next parallelization steps.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: Brian
