### PR TITLE
fix(net): apply count cap to BlockAccessLists request handler

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -328,22 +328,17 @@ where
     fn on_block_access_lists_request(
         &self,
         _peer_id: PeerId,
-        request: GetBlockAccessLists,
+        mut request: GetBlockAccessLists,
         response: oneshot::Sender<RequestResult<BlockAccessLists>>,
     ) {
-        // Cap the number of hashes we look up per EIP-8159 implementation-defined limits.
-        let hashes = if request.0.len() > MAX_BLOCK_ACCESS_LISTS_SERVE {
-            &request.0[..MAX_BLOCK_ACCESS_LISTS_SERVE]
-        } else {
-            &request.0[..]
-        };
+        request.0.truncate(MAX_BLOCK_ACCESS_LISTS_SERVE);
 
         let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(SOFT_RESPONSE_LIMIT);
         let access_lists = self
             .client
             .bal_store()
-            .get_by_hashes_with_limit(hashes, limit)
-            .unwrap_or_else(|_| empty_block_access_lists_with_limit(hashes.len(), limit));
+            .get_by_hashes_with_limit(&request.0, limit)
+            .unwrap_or_else(|_| empty_block_access_lists_with_limit(request.0.len(), limit));
         let _ = response.send(Ok(BlockAccessLists(access_lists)));
     }
 }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -46,6 +46,11 @@ pub const MAX_HEADERS_SERVE: usize = 1024;
 /// `SOFT_RESPONSE_LIMIT`.
 pub const MAX_BODIES_SERVE: usize = 1024;
 
+/// Maximum number of block access lists to serve.
+///
+/// Used to limit lookups.
+pub const MAX_BLOCK_ACCESS_LISTS_SERVE: usize = 1024;
+
 /// Maximum size of replies to data retrievals: 2MB
 pub const SOFT_RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
 
@@ -326,12 +331,19 @@ where
         request: GetBlockAccessLists,
         response: oneshot::Sender<RequestResult<BlockAccessLists>>,
     ) {
+        // Cap the number of hashes we look up per EIP-8159 implementation-defined limits.
+        let hashes = if request.0.len() > MAX_BLOCK_ACCESS_LISTS_SERVE {
+            &request.0[..MAX_BLOCK_ACCESS_LISTS_SERVE]
+        } else {
+            &request.0[..]
+        };
+
         let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(SOFT_RESPONSE_LIMIT);
         let access_lists = self
             .client
             .bal_store()
-            .get_by_hashes_with_limit(&request.0, limit)
-            .unwrap_or_else(|_| empty_block_access_lists_with_limit(request.0.len(), limit));
+            .get_by_hashes_with_limit(hashes, limit)
+            .unwrap_or_else(|_| empty_block_access_lists_with_limit(hashes.len(), limit));
         let _ = response.send(Ok(BlockAccessLists(access_lists)));
     }
 }

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -7,7 +7,7 @@ use rand::Rng;
 use reth_eth_wire::{BlockAccessLists, EthVersion, GetBlockAccessLists, HeadersDirection};
 use reth_ethereum_primitives::Block;
 use reth_network::{
-    eth_requests::SOFT_RESPONSE_LIMIT,
+    eth_requests::{MAX_BLOCK_ACCESS_LISTS_SERVE, SOFT_RESPONSE_LIMIT},
     test_utils::{NetworkEventStream, PeerConfig, Testnet, TestnetHandle},
     BlockDownloaderProvider, NetworkEventListenerProvider,
 };
@@ -605,6 +605,26 @@ async fn test_eth71_get_block_access_lists_empty_request() {
     let response = request_block_access_lists(&net, Vec::new()).await;
 
     assert_eq!(response, BlockAccessLists(Vec::new()));
+}
+
+// Ensures BAL responses are capped at MAX_BLOCK_ACCESS_LISTS_SERVE entries.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth71_get_block_access_lists_caps_count() {
+    reth_tracing::init_test_tracing();
+    let (net, bal_store) = spawn_eth71_bal_testnet().await;
+
+    // Request more hashes than the count cap.
+    let request_count = MAX_BLOCK_ACCESS_LISTS_SERVE + 100;
+    let hashes: Vec<B256> = (0..request_count).map(|_| B256::random()).collect();
+
+    // Insert one BAL so the store isn't entirely empty (not strictly needed,
+    // but keeps the test path closer to real usage).
+    let bal = Bytes::from_static(&[0xc1, 0x01]);
+    bal_store.insert(hashes[0], 1, bal).unwrap();
+
+    let response = request_block_access_lists(&net, hashes).await;
+
+    assert_eq!(response.0.len(), MAX_BLOCK_ACCESS_LISTS_SERVE);
 }
 
 // Ensures the fetch client can request BALs through an eth/71 peer.


### PR DESCRIPTION
Mirrors MAX_RECEIPTS_SERVE, MAX_HEADERS_SERVE, and MAX_BODIES_SERVE.

#23725 added the response size soft limit, but a peer requesting many hashes can still force an unbounded number of allocations before the size cap triggers (each empty BAL is 1 byte).

Adds MAX_BLOCK_ACCESS_LISTS_SERVE = 1024 to align with sibling request handlers in this file.