### PR TITLE
fix(discv5): propagate `--nat extip:<IP>` to the local ENR

### DIFF
--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -192,7 +192,6 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
 
         let default_secret_key_path = data_dir.p2p_secret();
         let p2p_secret_key = self.network.secret_key(default_secret_key_path)?;
-        let rlpx_socket: SocketAddr = (self.network.addr, self.network.port).into();
         let advertised_ip =
             self.network.nat.clone().as_external_ip(self.network.port).unwrap_or(self.network.addr);
         let advertised_socket: SocketAddr = (advertised_ip, self.network.port).into();
@@ -211,8 +210,8 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
                 .apply(|builder| {
                     self.network.discovery.apply_to_builder(
                         builder,
-                        rlpx_socket,
                         advertised_socket,
+                        self.network.addr,
                         boot_nodes,
                     )
                 })

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -1,6 +1,6 @@
 //! P2P Debugging tool
 
-use std::{path::PathBuf, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use crate::common::CliNodeTypes;
 use alloy_eips::BlockHashOrNumber;
@@ -192,7 +192,10 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
 
         let default_secret_key_path = data_dir.p2p_secret();
         let p2p_secret_key = self.network.secret_key(default_secret_key_path)?;
-        let rlpx_socket = (self.network.addr, self.network.port).into();
+        let rlpx_socket: SocketAddr = (self.network.addr, self.network.port).into();
+        let advertised_ip =
+            self.network.nat.clone().as_external_ip(self.network.port).unwrap_or(self.network.addr);
+        let advertised_socket: SocketAddr = (advertised_ip, self.network.port).into();
         let boot_nodes = self
             .network
             .resolved_bootnodes()
@@ -206,7 +209,12 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
                 .network_id(self.network.network_id)
                 .boot_nodes(boot_nodes.clone())
                 .apply(|builder| {
-                    self.network.discovery.apply_to_builder(builder, rlpx_socket, boot_nodes)
+                    self.network.discovery.apply_to_builder(
+                        builder,
+                        rlpx_socket,
+                        advertised_socket,
+                        boot_nodes,
+                    )
                 })
                 .build_with_noop_provider(self.chain.clone())
                 .manager()

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -192,9 +192,8 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
 
         let default_secret_key_path = data_dir.p2p_secret();
         let p2p_secret_key = self.network.secret_key(default_secret_key_path)?;
-        let advertised_ip =
-            self.network.nat.clone().as_external_ip(self.network.port).unwrap_or(self.network.addr);
-        let advertised_socket: SocketAddr = (advertised_ip, self.network.port).into();
+        let bind_socket: SocketAddr = (self.network.addr, self.network.port).into();
+        let advertised_ip = self.network.nat.clone().as_external_ip(self.network.port);
         let boot_nodes = self
             .network
             .resolved_bootnodes()
@@ -210,8 +209,8 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
                 .apply(|builder| {
                     self.network.discovery.apply_to_builder(
                         builder,
-                        advertised_socket,
-                        self.network.addr,
+                        bind_socket,
+                        advertised_ip,
                         boot_nodes,
                     )
                 })

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -66,17 +66,13 @@ pub struct ConfigBuilder {
     ///
     /// Defaults to L1 mainnet if not set.
     fork: Option<(&'static [u8], ForkId)>,
-    /// `RLPx` TCP socket the OS binds to. Its port is what gets advertised in the local ENR
-    /// (`tcp4`/`tcp6`); its IP is used as the fallback advertised IP only when no explicit
-    /// advertised socket is set via [`ConfigBuilder::advertised_socket`] *and* the bind IP is
-    /// not unspecified.
+    /// `RLPx` TCP socket as **advertised** in the local [`Enr`](discv5::enr::Enr) — IP and port
+    /// peers will dial to open `RLPx` sessions. Distinct from the OS bind address, which lives in
+    /// [`discv5::ListenConfig`]: when the host is behind NAT (e.g. `--nat extip:<IP>`) the
+    /// advertised IP is the externally-resolved one, while the bind IP is the local interface.
+    /// An UNSPECIFIED IP (`0.0.0.0` / `::`) here means "no explicit advertised IP — let
+    /// `discv5::Discv5` populate it from observed addresses."
     tcp_socket: SocketAddr,
-    /// Explicit advertised IPv4 for the local ENR. When `Some`, this overrides the IPv4 derived
-    /// from `tcp_socket` when populating the ENR's `ip4` field. The discv5 [`ListenConfig`] is
-    /// kept untouched, so the OS continues to bind to the user-configured address.
-    advertised_ipv4: Option<Ipv4Addr>,
-    /// Explicit advertised IPv6 for the local ENR. See [`Self::advertised_ipv4`].
-    advertised_ipv6: Option<Ipv6Addr>,
     /// List of `(key, rlp-encoded-value)` tuples that should be advertised in local node record
     /// (in addition to tcp port, udp port and fork).
     other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -100,8 +96,6 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
-            advertised_ipv4,
-            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -114,8 +108,6 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork: fork.map(|(key, fork_id)| (key, fork_id.fork_id)),
             tcp_socket,
-            advertised_ipv4,
-            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval: Some(lookup_interval),
             bootstrap_lookup_interval: Some(bootstrap_lookup_interval),
@@ -178,28 +170,16 @@ impl ConfigBuilder {
         self
     }
 
-    /// Sets the `RLPx` TCP bind socket. Its port is what gets advertised in the local
-    /// [`Enr`](discv5::enr::Enr) (`tcp4`/`tcp6`); its IP is the fallback advertised IP only
-    /// when no explicit advertised socket is set via [`Self::advertised_socket`].
+    /// Sets the `RLPx` TCP socket to advertise in the local [`Enr`](discv5::enr::Enr).
+    ///
+    /// This is the IP and port peers will dial to open `RLPx` sessions — distinct from the OS bind
+    /// address (which lives in the inner [`discv5::ListenConfig`]). Behind NAT this should be
+    /// the externally-resolved address (e.g. from `--nat extip:<IP>`); the OS bind continues to
+    /// target the local interface configured on the [`ListenConfig`]. Pass an UNSPECIFIED IP
+    /// (`0.0.0.0` / `::`) to omit the IP from the ENR and let `discv5::Discv5` fill it in from
+    /// observed addresses.
     pub const fn tcp_socket(mut self, socket: SocketAddr) -> Self {
         self.tcp_socket = socket;
-        self
-    }
-
-    /// Sets an explicit advertised socket whose IP overrides the IP derived from `tcp_socket`
-    /// when populating the local ENR's `ip4`/`ip6` field.
-    ///
-    /// Used to advertise an externally-resolved address (e.g. from `--nat extip:<IP>`) while
-    /// continuing to bind discv5 to the locally-reachable address. The discv5 [`ListenConfig`]
-    /// is unaffected, so the OS bind keeps targeting the configured local interface.
-    ///
-    /// Only the IP portion of `socket` is used; ports come from the [`ListenConfig`] (UDP) and
-    /// `tcp_socket` (TCP).
-    pub const fn advertised_socket(mut self, socket: SocketAddr) -> Self {
-        match socket {
-            SocketAddr::V4(s) => self.advertised_ipv4 = Some(*s.ip()),
-            SocketAddr::V6(s) => self.advertised_ipv6 = Some(*s.ip()),
-        }
         self
     }
 
@@ -247,8 +227,6 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
-            advertised_ipv4,
-            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -258,19 +236,6 @@ impl ConfigBuilder {
 
         let discv5_config = discv5_config.unwrap_or_else(|| {
             discv5::ConfigBuilder::new(DEFAULT_DISCOVERY_V5_LISTEN_CONFIG).build()
-        });
-
-        // Default advertised IPs to the IP version of `tcp_socket` for callers that do not set
-        // an explicit advertised socket. UNSPECIFIED IPs (0.0.0.0 / ::) are not treated as a
-        // fallback so the ENR omits the corresponding field and `discv5::Discv5` populates it
-        // from observed addresses.
-        let advertised_ipv4 = advertised_ipv4.or_else(|| match tcp_socket {
-            SocketAddr::V4(s) if *s.ip() != Ipv4Addr::UNSPECIFIED => Some(*s.ip()),
-            _ => None,
-        });
-        let advertised_ipv6 = advertised_ipv6.or_else(|| match tcp_socket {
-            SocketAddr::V6(s) if *s.ip() != Ipv6Addr::UNSPECIFIED => Some(*s.ip()),
-            _ => None,
         });
 
         let fork = fork.map(|(key, fork_id)| (key, fork_id.into()));
@@ -289,8 +254,6 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
-            advertised_ipv4,
-            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -303,24 +266,20 @@ impl ConfigBuilder {
 /// Config used to bootstrap [`discv5::Discv5`].
 #[derive(Clone, Debug)]
 pub struct Config {
-    /// Config used by [`discv5::Discv5`]. Contains the [`ListenConfig`], with the discovery listen
-    /// socket. Drives where the OS binds; not used directly for ENR IP fields.
+    /// Config used by [`discv5::Discv5`]. Contains the [`ListenConfig`] (the OS bind config —
+    /// distinct from what gets advertised in the ENR's `ip` field).
     pub(super) discv5_config: discv5::Config,
     /// Nodes to boot from.
     pub(super) bootstrap_nodes: HashSet<BootNode>,
     /// Fork kv-pair to set in local node record. Identifies which network/chain/fork the node
     /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", [ForkId])`.
     pub(super) fork: Option<(&'static [u8], EnrForkIdEntry)>,
-    /// `RLPx` TCP socket the OS binds to. Its port is what gets advertised in the local ENR;
-    /// its IP is the fallback advertised IP only when [`Self::advertised_ipv4`] /
-    /// [`Self::advertised_ipv6`] are unset and the bind IP is not unspecified.
+    /// `RLPx` TCP socket as **advertised** in the local [`Enr`](discv5::enr::Enr). When the host
+    /// is behind NAT (e.g. `--nat extip:<IP>`) this is the externally-resolved address; the OS
+    /// bind continues to target the local interface configured on the [`ListenConfig`]. An
+    /// UNSPECIFIED IP (`0.0.0.0` / `::`) means "no explicit advertised IP — let
+    /// `discv5::Discv5` populate it from observed addresses."
     pub(super) tcp_socket: SocketAddr,
-    /// IPv4 address to advertise in the local ENR's `ip4` field. Decoupled from the bind
-    /// [`ListenConfig`] so an externally-resolved address (e.g. from `--nat extip:<IP>`) can be
-    /// advertised while discv5 binds to a locally-reachable address.
-    pub(super) advertised_ipv4: Option<Ipv4Addr>,
-    /// IPv6 address to advertise in the local ENR's `ip6` field. See [`Self::advertised_ipv4`].
-    pub(super) advertised_ipv6: Option<Ipv6Addr>,
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to
     /// peers by including in local node record.
     pub(super) other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -337,16 +296,15 @@ pub struct Config {
 }
 
 impl Config {
-    /// Returns a new [`ConfigBuilder`], with the `RLPx` TCP port and IP version configured w.r.t.
-    /// the given socket.
+    /// Returns a new [`ConfigBuilder`]. `rlpx_tcp_socket` is the **advertised** `RLPx` socket
+    /// (see [`ConfigBuilder::tcp_socket`]); the OS bind for discv5 lives on the inner
+    /// [`discv5::ListenConfig`].
     pub fn builder(rlpx_tcp_socket: SocketAddr) -> ConfigBuilder {
         ConfigBuilder {
             discv5_config: None,
             bootstrap_nodes: HashSet::default(),
             fork: None,
             tcp_socket: rlpx_tcp_socket,
-            advertised_ipv4: None,
-            advertised_ipv6: None,
             other_enr_kv_pairs: Vec::new(),
             lookup_interval: None,
             bootstrap_lookup_interval: None,
@@ -387,23 +345,11 @@ impl Config {
         }
     }
 
-    /// Returns the `RLPx` (TCP) bind socket. Its port is what gets advertised to peers in the
-    /// local [`Enr`](discv5::enr::Enr); its IP is only the fallback advertised IP when
-    /// [`Self::advertised_ipv4`] / [`Self::advertised_ipv6`] are unset.
+    /// Returns the `RLPx` (TCP) socket as **advertised** in the local [`Enr`](discv5::enr::Enr).
+    /// When the host is behind NAT this is the externally-resolved address; the OS bind for
+    /// discv5 lives on the inner [`discv5::ListenConfig`].
     pub const fn rlpx_socket(&self) -> &SocketAddr {
         &self.tcp_socket
-    }
-
-    /// Returns the explicit IPv4 advertised in the local ENR, if any. Falls back to the IPv4
-    /// derived from [`Self::rlpx_socket`] when not set.
-    pub const fn advertised_ipv4(&self) -> Option<Ipv4Addr> {
-        self.advertised_ipv4
-    }
-
-    /// Returns the explicit IPv6 advertised in the local ENR, if any. Falls back to the IPv6
-    /// derived from [`Self::rlpx_socket`] when not set.
-    pub const fn advertised_ipv6(&self) -> Option<Ipv6Addr> {
-        self.advertised_ipv6
     }
 }
 
@@ -522,36 +468,23 @@ mod test {
     }
 
     #[test]
-    fn rlpx_ip_is_default_advertised_ipv4() {
+    fn rlpx_ip_is_advertised_ipv4_and_listen_config_untouched() {
         let rlpx_addr: Ipv4Addr = "192.168.0.1".parse().unwrap();
         let config = Config::builder((rlpx_addr, 30303).into()).build();
 
-        // ENR-advertised IPv4 falls back to the RLPx IP when no explicit advertised socket set.
-        assert_eq!(config.advertised_ipv4(), Some(rlpx_addr));
-        assert_eq!(config.advertised_ipv6(), None);
-        // The discv5 ListenConfig is not touched by `tcp_socket`.
+        // The RLPx IP is the advertised IP — it ends up in the ENR's `ip4` field.
+        assert_eq!(*config.rlpx_socket(), SocketAddr::from((rlpx_addr, 30303)));
+        // The discv5 `ListenConfig` is not touched by the RLPx socket (no more pre-fix
+        // overwrite); the OS bind keeps targeting the configured local interface.
         assert_default_listen_ipv4(&config.discv5_config.listen_config);
     }
 
     #[test]
-    fn rlpx_ip_is_default_advertised_ipv6() {
+    fn rlpx_ip_is_advertised_ipv6_and_listen_config_untouched() {
         let rlpx_addr: Ipv6Addr = "fe80::1".parse().unwrap();
         let config = Config::builder((rlpx_addr, 30303).into()).build();
 
-        assert_eq!(config.advertised_ipv6(), Some(rlpx_addr));
-        assert_eq!(config.advertised_ipv4(), None);
-        assert_default_listen_ipv4(&config.discv5_config.listen_config);
-    }
-
-    #[test]
-    fn advertised_socket_overrides_rlpx_for_enr_ipv4() {
-        let rlpx_addr: Ipv4Addr = "10.0.0.1".parse().unwrap();
-        let advertised: SocketAddr = "1.2.3.4:30303".parse().unwrap();
-        let config =
-            Config::builder((rlpx_addr, 30303).into()).advertised_socket(advertised).build();
-
-        assert_eq!(config.advertised_ipv4(), Some(Ipv4Addr::new(1, 2, 3, 4)));
-        // Bind ListenConfig left at its (default) value.
+        assert_eq!(*config.rlpx_socket(), SocketAddr::from((rlpx_addr, 30303)));
         assert_default_listen_ipv4(&config.discv5_config.listen_config);
     }
 }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -66,9 +66,10 @@ pub struct ConfigBuilder {
     ///
     /// Defaults to L1 mainnet if not set.
     fork: Option<(&'static [u8], ForkId)>,
-    /// `RLPx` TCP socket. Its port is advertised in the local ENR; its IP is the default
-    /// advertised IP when no explicit advertised socket is set via
-    /// [`ConfigBuilder::advertised_socket`].
+    /// `RLPx` TCP socket the OS binds to. Its port is what gets advertised in the local ENR
+    /// (`tcp4`/`tcp6`); its IP is used as the fallback advertised IP only when no explicit
+    /// advertised socket is set via [`ConfigBuilder::advertised_socket`] *and* the bind IP is
+    /// not unspecified.
     tcp_socket: SocketAddr,
     /// Explicit advertised IPv4 for the local ENR. When `Some`, this overrides the IPv4 derived
     /// from `tcp_socket` when populating the ENR's `ip4` field. The discv5 [`ListenConfig`] is
@@ -177,9 +178,9 @@ impl ConfigBuilder {
         self
     }
 
-    /// Sets the tcp socket to advertise in the local [`Enr`](discv5::enr::Enr). Its port is the
-    /// `tcp4`/`tcp6` advertised in the ENR; its IP is the default advertised IP when no explicit
-    /// advertised socket is set via [`Self::advertised_socket`].
+    /// Sets the `RLPx` TCP bind socket. Its port is what gets advertised in the local
+    /// [`Enr`](discv5::enr::Enr) (`tcp4`/`tcp6`); its IP is the fallback advertised IP only
+    /// when no explicit advertised socket is set via [`Self::advertised_socket`].
     pub const fn tcp_socket(mut self, socket: SocketAddr) -> Self {
         self.tcp_socket = socket;
         self
@@ -310,8 +311,9 @@ pub struct Config {
     /// Fork kv-pair to set in local node record. Identifies which network/chain/fork the node
     /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", [ForkId])`.
     pub(super) fork: Option<(&'static [u8], EnrForkIdEntry)>,
-    /// `RLPx` TCP socket. Its port is advertised in the local ENR; its IP is the default
-    /// advertised IP when [`Self::advertised_ipv4`]/[`Self::advertised_ipv6`] is unset.
+    /// `RLPx` TCP socket the OS binds to. Its port is what gets advertised in the local ENR;
+    /// its IP is the fallback advertised IP only when [`Self::advertised_ipv4`] /
+    /// [`Self::advertised_ipv6`] are unset and the bind IP is not unspecified.
     pub(super) tcp_socket: SocketAddr,
     /// IPv4 address to advertise in the local ENR's `ip4` field. Decoupled from the bind
     /// [`ListenConfig`] so an externally-resolved address (e.g. from `--nat extip:<IP>`) can be
@@ -385,9 +387,9 @@ impl Config {
         }
     }
 
-    /// Returns the `RLPx` (TCP) socket contained in the [`discv5::Config`]. Its port is what gets
-    /// advertised to peers in the local [`Enr`](discv5::enr::Enr); its IP is the default
-    /// advertised IP when no explicit advertised IP is set.
+    /// Returns the `RLPx` (TCP) bind socket. Its port is what gets advertised to peers in the
+    /// local [`Enr`](discv5::enr::Enr); its IP is only the fallback advertised IP when
+    /// [`Self::advertised_ipv4`] / [`Self::advertised_ipv6`] are unset.
     pub const fn rlpx_socket(&self) -> &SocketAddr {
         &self.tcp_socket
     }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -14,7 +14,6 @@ use discv5::{
 };
 use reth_ethereum_forks::{EnrForkIdEntry, ForkId};
 use reth_network_peers::NodeRecord;
-use tracing::debug;
 
 use crate::{enr::discv4_id_to_multiaddr_id, filter::MustNotIncludeKeys, NetworkStackId};
 
@@ -67,11 +66,16 @@ pub struct ConfigBuilder {
     ///
     /// Defaults to L1 mainnet if not set.
     fork: Option<(&'static [u8], ForkId)>,
-    /// `RLPx` TCP socket to advertise.
-    ///
-    /// NOTE: IP address of `RLPx` socket overwrites IP address of same IP version in
-    /// [`discv5::ListenConfig`].
+    /// `RLPx` TCP socket. Its port is advertised in the local ENR; its IP is the default
+    /// advertised IP when no explicit advertised socket is set via
+    /// [`ConfigBuilder::advertised_socket`].
     tcp_socket: SocketAddr,
+    /// Explicit advertised IPv4 for the local ENR. When `Some`, this overrides the IPv4 derived
+    /// from `tcp_socket` when populating the ENR's `ip4` field. The discv5 [`ListenConfig`] is
+    /// kept untouched, so the OS continues to bind to the user-configured address.
+    advertised_ipv4: Option<Ipv4Addr>,
+    /// Explicit advertised IPv6 for the local ENR. See [`Self::advertised_ipv4`].
+    advertised_ipv6: Option<Ipv6Addr>,
     /// List of `(key, rlp-encoded-value)` tuples that should be advertised in local node record
     /// (in addition to tcp port, udp port and fork).
     other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -95,6 +99,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -107,6 +113,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork: fork.map(|(key, fork_id)| (key, fork_id.fork_id)),
             tcp_socket,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval: Some(lookup_interval),
             bootstrap_lookup_interval: Some(bootstrap_lookup_interval),
@@ -169,11 +177,28 @@ impl ConfigBuilder {
         self
     }
 
-    /// Sets the tcp socket to advertise in the local [`Enr`](discv5::enr::Enr). The IP address of
-    /// this socket will overwrite the discovery address of the same IP version, if one is
-    /// configured.
+    /// Sets the tcp socket to advertise in the local [`Enr`](discv5::enr::Enr). Its port is the
+    /// `tcp4`/`tcp6` advertised in the ENR; its IP is the default advertised IP when no explicit
+    /// advertised socket is set via [`Self::advertised_socket`].
     pub const fn tcp_socket(mut self, socket: SocketAddr) -> Self {
         self.tcp_socket = socket;
+        self
+    }
+
+    /// Sets an explicit advertised socket whose IP overrides the IP derived from `tcp_socket`
+    /// when populating the local ENR's `ip4`/`ip6` field.
+    ///
+    /// Used to advertise an externally-resolved address (e.g. from `--nat extip:<IP>`) while
+    /// continuing to bind discv5 to the locally-reachable address. The discv5 [`ListenConfig`]
+    /// is unaffected, so the OS bind keeps targeting the configured local interface.
+    ///
+    /// Only the IP portion of `socket` is used; ports come from the [`ListenConfig`] (UDP) and
+    /// `tcp_socket` (TCP).
+    pub const fn advertised_socket(mut self, socket: SocketAddr) -> Self {
+        match socket {
+            SocketAddr::V4(s) => self.advertised_ipv4 = Some(*s.ip()),
+            SocketAddr::V6(s) => self.advertised_ipv6 = Some(*s.ip()),
+        }
         self
     }
 
@@ -221,6 +246,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -228,12 +255,22 @@ impl ConfigBuilder {
             discovered_peer_filter,
         } = self;
 
-        let mut discv5_config = discv5_config.unwrap_or_else(|| {
+        let discv5_config = discv5_config.unwrap_or_else(|| {
             discv5::ConfigBuilder::new(DEFAULT_DISCOVERY_V5_LISTEN_CONFIG).build()
         });
 
-        discv5_config.listen_config =
-            amend_listen_config_wrt_rlpx(&discv5_config.listen_config, tcp_socket.ip());
+        // Default advertised IPs to the IP version of `tcp_socket` for callers that do not set
+        // an explicit advertised socket. UNSPECIFIED IPs (0.0.0.0 / ::) are not treated as a
+        // fallback so the ENR omits the corresponding field and `discv5::Discv5` populates it
+        // from observed addresses.
+        let advertised_ipv4 = advertised_ipv4.or_else(|| match tcp_socket {
+            SocketAddr::V4(s) if *s.ip() != Ipv4Addr::UNSPECIFIED => Some(*s.ip()),
+            _ => None,
+        });
+        let advertised_ipv6 = advertised_ipv6.or_else(|| match tcp_socket {
+            SocketAddr::V6(s) if *s.ip() != Ipv6Addr::UNSPECIFIED => Some(*s.ip()),
+            _ => None,
+        });
 
         let fork = fork.map(|(key, fork_id)| (key, fork_id.into()));
 
@@ -251,6 +288,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -264,18 +303,22 @@ impl ConfigBuilder {
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Config used by [`discv5::Discv5`]. Contains the [`ListenConfig`], with the discovery listen
-    /// socket.
+    /// socket. Drives where the OS binds; not used directly for ENR IP fields.
     pub(super) discv5_config: discv5::Config,
     /// Nodes to boot from.
     pub(super) bootstrap_nodes: HashSet<BootNode>,
     /// Fork kv-pair to set in local node record. Identifies which network/chain/fork the node
     /// belongs, e.g. `(b"opstack", ChainId)` or `(b"eth", [ForkId])`.
     pub(super) fork: Option<(&'static [u8], EnrForkIdEntry)>,
-    /// `RLPx` TCP socket to advertise.
-    ///
-    /// NOTE: IP address of `RLPx` socket overwrites IP address of same IP version in
-    /// [`discv5::ListenConfig`].
+    /// `RLPx` TCP socket. Its port is advertised in the local ENR; its IP is the default
+    /// advertised IP when [`Self::advertised_ipv4`]/[`Self::advertised_ipv6`] is unset.
     pub(super) tcp_socket: SocketAddr,
+    /// IPv4 address to advertise in the local ENR's `ip4` field. Decoupled from the bind
+    /// [`ListenConfig`] so an externally-resolved address (e.g. from `--nat extip:<IP>`) can be
+    /// advertised while discv5 binds to a locally-reachable address.
+    pub(super) advertised_ipv4: Option<Ipv4Addr>,
+    /// IPv6 address to advertise in the local ENR's `ip6` field. See [`Self::advertised_ipv4`].
+    pub(super) advertised_ipv6: Option<Ipv6Addr>,
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to
     /// peers by including in local node record.
     pub(super) other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -300,6 +343,8 @@ impl Config {
             bootstrap_nodes: HashSet::default(),
             fork: None,
             tcp_socket: rlpx_tcp_socket,
+            advertised_ipv4: None,
+            advertised_ipv6: None,
             other_enr_kv_pairs: Vec::new(),
             lookup_interval: None,
             bootstrap_lookup_interval: None,
@@ -340,10 +385,23 @@ impl Config {
         }
     }
 
-    /// Returns the `RLPx` (TCP) socket contained in the [`discv5::Config`]. This socket will be
-    /// advertised to peers in the local [`Enr`](discv5::enr::Enr).
+    /// Returns the `RLPx` (TCP) socket contained in the [`discv5::Config`]. Its port is what gets
+    /// advertised to peers in the local [`Enr`](discv5::enr::Enr); its IP is the default
+    /// advertised IP when no explicit advertised IP is set.
     pub const fn rlpx_socket(&self) -> &SocketAddr {
         &self.tcp_socket
+    }
+
+    /// Returns the explicit IPv4 advertised in the local ENR, if any. Falls back to the IPv4
+    /// derived from [`Self::rlpx_socket`] when not set.
+    pub const fn advertised_ipv4(&self) -> Option<Ipv4Addr> {
+        self.advertised_ipv4
+    }
+
+    /// Returns the explicit IPv6 advertised in the local ENR, if any. Falls back to the IPv6
+    /// derived from [`Self::rlpx_socket`] when not set.
+    pub const fn advertised_ipv6(&self) -> Option<Ipv6Addr> {
+        self.advertised_ipv6
     }
 }
 
@@ -365,85 +423,6 @@ pub const fn ipv6(listen_config: &ListenConfig) -> Option<SocketAddrV6> {
         ListenConfig::Ipv6 { ip, port } |
         ListenConfig::DualStack { ipv6: ip, ipv6_port: port, .. } => {
             Some(SocketAddrV6::new(*ip, *port, 0, 0))
-        }
-    }
-}
-
-/// Returns the amended [`discv5::ListenConfig`] based on the `RLPx` IP address. The ENR is limited
-/// to one IP address per IP version (atm, may become spec'd how to advertise different addresses).
-/// The `RLPx` address overwrites the discv5 address w.r.t. IP version.
-pub fn amend_listen_config_wrt_rlpx(
-    listen_config: &ListenConfig,
-    rlpx_addr: IpAddr,
-) -> ListenConfig {
-    let discv5_socket_ipv4 = ipv4(listen_config);
-    let discv5_socket_ipv6 = ipv6(listen_config);
-
-    let discv5_port_ipv4 =
-        discv5_socket_ipv4.map(|socket| socket.port()).unwrap_or(DEFAULT_DISCOVERY_V5_PORT);
-    let discv5_addr_ipv4 = discv5_socket_ipv4.map(|socket| *socket.ip());
-    let discv5_port_ipv6 =
-        discv5_socket_ipv6.map(|socket| socket.port()).unwrap_or(DEFAULT_DISCOVERY_V5_PORT);
-    let discv5_addr_ipv6 = discv5_socket_ipv6.map(|socket| *socket.ip());
-
-    let (discv5_socket_ipv4, discv5_socket_ipv6) = discv5_sockets_wrt_rlpx_addr(
-        rlpx_addr,
-        discv5_addr_ipv4,
-        discv5_port_ipv4,
-        discv5_addr_ipv6,
-        discv5_port_ipv6,
-    );
-
-    ListenConfig::from_two_sockets(discv5_socket_ipv4, discv5_socket_ipv6)
-}
-
-/// Returns the sockets that can be used for discv5 with respect to the `RLPx` address. ENR specs
-/// only acknowledge one address per IP version.
-pub fn discv5_sockets_wrt_rlpx_addr(
-    rlpx_addr: IpAddr,
-    discv5_addr_ipv4: Option<Ipv4Addr>,
-    discv5_port_ipv4: u16,
-    discv5_addr_ipv6: Option<Ipv6Addr>,
-    discv5_port_ipv6: u16,
-) -> (Option<SocketAddrV4>, Option<SocketAddrV6>) {
-    match rlpx_addr {
-        IpAddr::V4(rlpx_addr) => {
-            let discv5_socket_ipv6 =
-                discv5_addr_ipv6.map(|ip| SocketAddrV6::new(ip, discv5_port_ipv6, 0, 0));
-
-            if let Some(discv5_addr) = discv5_addr_ipv4 &&
-                discv5_addr != rlpx_addr
-            {
-                debug!(target: "net::discv5",
-                    %discv5_addr,
-                    %rlpx_addr,
-                    "Overwriting discv5 IPv4 address with RLPx IPv4 address, limited to one advertised IP address per IP version"
-                );
-            }
-
-            // overwrite discv5 ipv4 addr with RLPx address. this is since there is no
-            // spec'd way to advertise a different address for rlpx and discovery in the
-            // ENR.
-            (Some(SocketAddrV4::new(rlpx_addr, discv5_port_ipv4)), discv5_socket_ipv6)
-        }
-        IpAddr::V6(rlpx_addr) => {
-            let discv5_socket_ipv4 =
-                discv5_addr_ipv4.map(|ip| SocketAddrV4::new(ip, discv5_port_ipv4));
-
-            if let Some(discv5_addr) = discv5_addr_ipv6 &&
-                discv5_addr != rlpx_addr
-            {
-                debug!(target: "net::discv5",
-                    %discv5_addr,
-                    %rlpx_addr,
-                    "Overwriting discv5 IPv6 address with RLPx IPv6 address, limited to one advertised IP address per IP version"
-                );
-            }
-
-            // overwrite discv5 ipv6 addr with RLPx address. this is since there is no
-            // spec'd way to advertise a different address for rlpx and discovery in the
-            // ENR.
-            (discv5_socket_ipv4, Some(SocketAddrV6::new(rlpx_addr, discv5_port_ipv6, 0, 0)))
         }
     }
 }
@@ -533,33 +512,44 @@ mod test {
         }
     }
 
-    #[test]
-    fn overwrite_ipv4_addr() {
-        let rlpx_addr: Ipv4Addr = "192.168.0.1".parse().unwrap();
-
-        let listen_config = DEFAULT_DISCOVERY_V5_LISTEN_CONFIG;
-
-        let amended_config = amend_listen_config_wrt_rlpx(&listen_config, rlpx_addr.into());
-
-        let config_socket_ipv4 = ipv4(&amended_config).unwrap();
-
-        assert_eq!(*config_socket_ipv4.ip(), rlpx_addr);
-        assert_eq!(config_socket_ipv4.port(), DEFAULT_DISCOVERY_V5_PORT);
-        assert_eq!(ipv6(&amended_config), ipv6(&listen_config));
+    fn assert_default_listen_ipv4(listen_config: &ListenConfig) {
+        let bind = ipv4(listen_config).expect("default listen config is IPv4");
+        assert_eq!(*bind.ip(), DEFAULT_DISCOVERY_V5_ADDR);
+        assert_eq!(bind.port(), DEFAULT_DISCOVERY_V5_PORT);
+        assert!(ipv6(listen_config).is_none());
     }
 
     #[test]
-    fn overwrite_ipv6_addr() {
+    fn rlpx_ip_is_default_advertised_ipv4() {
+        let rlpx_addr: Ipv4Addr = "192.168.0.1".parse().unwrap();
+        let config = Config::builder((rlpx_addr, 30303).into()).build();
+
+        // ENR-advertised IPv4 falls back to the RLPx IP when no explicit advertised socket set.
+        assert_eq!(config.advertised_ipv4(), Some(rlpx_addr));
+        assert_eq!(config.advertised_ipv6(), None);
+        // The discv5 ListenConfig is not touched by `tcp_socket`.
+        assert_default_listen_ipv4(&config.discv5_config.listen_config);
+    }
+
+    #[test]
+    fn rlpx_ip_is_default_advertised_ipv6() {
         let rlpx_addr: Ipv6Addr = "fe80::1".parse().unwrap();
+        let config = Config::builder((rlpx_addr, 30303).into()).build();
 
-        let listen_config = DEFAULT_DISCOVERY_V5_LISTEN_CONFIG;
+        assert_eq!(config.advertised_ipv6(), Some(rlpx_addr));
+        assert_eq!(config.advertised_ipv4(), None);
+        assert_default_listen_ipv4(&config.discv5_config.listen_config);
+    }
 
-        let amended_config = amend_listen_config_wrt_rlpx(&listen_config, rlpx_addr.into());
+    #[test]
+    fn advertised_socket_overrides_rlpx_for_enr_ipv4() {
+        let rlpx_addr: Ipv4Addr = "10.0.0.1".parse().unwrap();
+        let advertised: SocketAddr = "1.2.3.4:30303".parse().unwrap();
+        let config =
+            Config::builder((rlpx_addr, 30303).into()).advertised_socket(advertised).build();
 
-        let config_socket_ipv6 = ipv6(&amended_config).unwrap();
-
-        assert_eq!(*config_socket_ipv6.ip(), rlpx_addr);
-        assert_eq!(config_socket_ipv6.port(), DEFAULT_DISCOVERY_V5_PORT);
-        assert_eq!(ipv4(&amended_config), ipv4(&listen_config));
+        assert_eq!(config.advertised_ipv4(), Some(Ipv4Addr::new(1, 2, 3, 4)));
+        // Bind ListenConfig left at its (default) value.
+        assert_default_listen_ipv4(&config.discv5_config.listen_config);
     }
 }

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -815,6 +815,48 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn advertised_ip_in_enr_while_bound_to_local_address() {
+        reth_tracing::init_test_tracing();
+
+        // Pick a real, locally-bindable port for discv5 to listen on.
+        let bind_udp_port = unused_udp_port();
+        let bind_listen: SocketAddr = format!("127.0.0.1:{bind_udp_port}").parse().unwrap();
+        let rlpx_bind: SocketAddr = "127.0.0.1:30303".parse().unwrap();
+        // Pretend the public/advertised address is something the host doesn't own.
+        let advertised: SocketAddr = "203.0.113.7:30303".parse().unwrap();
+        let advertised_ip = Ipv4Addr::new(203, 0, 113, 7);
+
+        // Build the inner discv5 config with `disable_enr_update()` so observations cannot
+        // overwrite the explicit advertised IP — same condition the CLI applies when an
+        // explicit advertised address is supplied.
+        let mut inner = discv5::ConfigBuilder::new(ListenConfig::from(bind_listen));
+        inner.disable_enr_update();
+
+        let secret_key = SecretKey::new(&mut thread_rng());
+        let config = Config::builder(rlpx_bind)
+            .advertised_socket(advertised)
+            .discv5_config(inner.build())
+            .build();
+
+        let (node, _events) =
+            Discv5::start(&secret_key, config).await.expect("should start discv5");
+
+        // (a) ENR contains the advertised IP, the RLPx tcp port, and the discv5 udp bind port.
+        let enr = node.with_discv5(|d| d.local_enr());
+        assert_eq!(enr.ip4(), Some(advertised_ip));
+        assert_eq!(enr.tcp4(), Some(30303));
+        assert_eq!(enr.udp4(), Some(bind_udp_port));
+
+        // (b) discv5 is genuinely bound to the local bind address: trying to bind another
+        // UdpSocket to the same address fails with `AddrInUse`.
+        let rebind = UdpSocket::bind(("127.0.0.1", bind_udp_port));
+        assert!(rebind.is_err(), "expected discv5 to hold the bind port, but rebinding succeeded");
+
+        drop(node);
+        wait_for_udp_port_release(bind_udp_port, Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn discv5_releases_port_on_drop() {
         reth_tracing::init_test_tracing();
 

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -470,40 +470,62 @@ pub fn build_local_enr(
 ) -> (Enr<SecretKey>, NodeRecord, Option<&'static [u8]>, IpMode) {
     let mut builder = discv5::enr::Enr::builder();
 
-    let Config { discv5_config, fork, tcp_socket, other_enr_kv_pairs, .. } = config;
+    let Config {
+        discv5_config,
+        fork,
+        tcp_socket,
+        advertised_ipv4,
+        advertised_ipv6,
+        other_enr_kv_pairs,
+        ..
+    } = config;
+
+    // Prefer the explicit advertised IP (e.g. resolved from `--nat extip:<IP>`); else fall back
+    // to the bind IP if it is a real address; else leave the ENR field unset and let
+    // `discv5::Discv5` populate it from observed addresses.
+    let enr_ipv4 = |bind: Ipv4Addr| -> Option<Ipv4Addr> {
+        advertised_ipv4.or_else(|| (bind != Ipv4Addr::UNSPECIFIED).then_some(bind))
+    };
+    let enr_ipv6 = |bind: Ipv6Addr| -> Option<Ipv6Addr> {
+        advertised_ipv6.or_else(|| (bind != Ipv6Addr::UNSPECIFIED).then_some(bind))
+    };
 
     let socket = match discv5_config.listen_config {
         ListenConfig::Ipv4 { ip, port } => {
-            if ip != Ipv4Addr::UNSPECIFIED {
-                builder.ip4(ip);
+            let advertised = enr_ipv4(ip);
+            if let Some(advertised) = advertised {
+                builder.ip4(advertised);
             }
             builder.udp4(port);
             builder.tcp4(tcp_socket.port());
 
-            (ip, port).into()
+            (advertised.unwrap_or(ip), port).into()
         }
         ListenConfig::Ipv6 { ip, port } => {
-            if ip != Ipv6Addr::UNSPECIFIED {
-                builder.ip6(ip);
+            let advertised = enr_ipv6(ip);
+            if let Some(advertised) = advertised {
+                builder.ip6(advertised);
             }
             builder.udp6(port);
             builder.tcp6(tcp_socket.port());
 
-            (ip, port).into()
+            (advertised.unwrap_or(ip), port).into()
         }
         ListenConfig::DualStack { ipv4, ipv4_port, ipv6, ipv6_port } => {
-            if ipv4 != Ipv4Addr::UNSPECIFIED {
-                builder.ip4(ipv4);
+            let advertised_v4 = enr_ipv4(ipv4);
+            if let Some(advertised) = advertised_v4 {
+                builder.ip4(advertised);
             }
             builder.udp4(ipv4_port);
             builder.tcp4(tcp_socket.port());
 
-            if ipv6 != Ipv6Addr::UNSPECIFIED {
-                builder.ip6(ipv6);
+            let advertised_v6 = enr_ipv6(ipv6);
+            if let Some(advertised) = advertised_v6 {
+                builder.ip6(advertised);
             }
             builder.udp6(ipv6_port);
 
-            (ipv6, ipv6_port).into()
+            (advertised_v6.unwrap_or(ipv6), ipv6_port).into()
         }
     };
 
@@ -1005,6 +1027,37 @@ mod test {
 
         assert_eq!(fork_id, decoded_fork_id);
         assert_eq!(TCP_PORT, enr.tcp4().unwrap()); // listen config is defaulting to ip mode ipv4
+    }
+
+    #[test]
+    fn build_local_enr_uses_advertised_ip_over_unspecified_bind() {
+        const TCP_PORT: u16 = 30303;
+        let bind: SocketAddr = (Ipv4Addr::UNSPECIFIED, TCP_PORT).into();
+        let advertised: SocketAddr = "1.2.3.4:30303".parse().unwrap();
+
+        let config = Config::builder(bind).advertised_socket(advertised).build();
+
+        let sk = SecretKey::new(&mut thread_rng());
+        let (enr, _, _, _) = build_local_enr(&sk, &config);
+
+        assert_eq!(enr.ip4(), Some(Ipv4Addr::new(1, 2, 3, 4)));
+        assert_eq!(enr.tcp4(), Some(TCP_PORT));
+    }
+
+    #[test]
+    fn build_local_enr_keeps_no_ip_for_unspecified_bind_without_advertised() {
+        const TCP_PORT: u16 = 30303;
+        let bind: SocketAddr = (Ipv4Addr::UNSPECIFIED, TCP_PORT).into();
+
+        // No `advertised_socket()` and the RLPx IP is also UNSPECIFIED. We expect the ENR to
+        // omit the `ip4` field so `discv5::Discv5` populates it from observed addresses.
+        let config = Config::builder(bind).build();
+
+        let sk = SecretKey::new(&mut thread_rng());
+        let (enr, _, _, _) = build_local_enr(&sk, &config);
+
+        assert_eq!(enr.ip4(), None);
+        assert_eq!(enr.tcp4(), Some(TCP_PORT));
     }
 
     #[test]

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -470,62 +470,52 @@ pub fn build_local_enr(
 ) -> (Enr<SecretKey>, NodeRecord, Option<&'static [u8]>, IpMode) {
     let mut builder = discv5::enr::Enr::builder();
 
-    let Config {
-        discv5_config,
-        fork,
-        tcp_socket,
-        advertised_ipv4,
-        advertised_ipv6,
-        other_enr_kv_pairs,
-        ..
-    } = config;
+    let Config { discv5_config, fork, tcp_socket, other_enr_kv_pairs, .. } = config;
 
-    // Prefer the explicit advertised IP (e.g. resolved from `--nat extip:<IP>`); else fall back
-    // to the bind IP if it is a real address; else leave the ENR field unset and let
-    // `discv5::Discv5` populate it from observed addresses.
-    let enr_ipv4 = |bind: Ipv4Addr| -> Option<Ipv4Addr> {
-        advertised_ipv4.or_else(|| (bind != Ipv4Addr::UNSPECIFIED).then_some(bind))
+    // The RLPx `tcp_socket` carries the advertised IP (and TCP port). UDP port comes from the
+    // bind `ListenConfig`. An UNSPECIFIED advertised IP means "omit from ENR" — peers will
+    // learn the address via observations.
+    let advertised_ip4 = match tcp_socket {
+        SocketAddr::V4(s) if *s.ip() != Ipv4Addr::UNSPECIFIED => Some(*s.ip()),
+        _ => None,
     };
-    let enr_ipv6 = |bind: Ipv6Addr| -> Option<Ipv6Addr> {
-        advertised_ipv6.or_else(|| (bind != Ipv6Addr::UNSPECIFIED).then_some(bind))
+    let advertised_ip6 = match tcp_socket {
+        SocketAddr::V6(s) if *s.ip() != Ipv6Addr::UNSPECIFIED => Some(*s.ip()),
+        _ => None,
     };
 
     let socket = match discv5_config.listen_config {
         ListenConfig::Ipv4 { ip, port } => {
-            let advertised = enr_ipv4(ip);
-            if let Some(advertised) = advertised {
-                builder.ip4(advertised);
+            if let Some(ip) = advertised_ip4 {
+                builder.ip4(ip);
             }
             builder.udp4(port);
             builder.tcp4(tcp_socket.port());
 
-            (advertised.unwrap_or(ip), port).into()
+            (advertised_ip4.unwrap_or(ip), port).into()
         }
         ListenConfig::Ipv6 { ip, port } => {
-            let advertised = enr_ipv6(ip);
-            if let Some(advertised) = advertised {
-                builder.ip6(advertised);
+            if let Some(ip) = advertised_ip6 {
+                builder.ip6(ip);
             }
             builder.udp6(port);
             builder.tcp6(tcp_socket.port());
 
-            (advertised.unwrap_or(ip), port).into()
+            (advertised_ip6.unwrap_or(ip), port).into()
         }
-        ListenConfig::DualStack { ipv4, ipv4_port, ipv6, ipv6_port } => {
-            let advertised_v4 = enr_ipv4(ipv4);
-            if let Some(advertised) = advertised_v4 {
-                builder.ip4(advertised);
+        ListenConfig::DualStack { ipv4: _, ipv4_port, ipv6, ipv6_port } => {
+            if let Some(ip) = advertised_ip4 {
+                builder.ip4(ip);
             }
             builder.udp4(ipv4_port);
             builder.tcp4(tcp_socket.port());
 
-            let advertised_v6 = enr_ipv6(ipv6);
-            if let Some(advertised) = advertised_v6 {
-                builder.ip6(advertised);
+            if let Some(ip) = advertised_ip6 {
+                builder.ip6(ip);
             }
             builder.udp6(ipv6_port);
 
-            (advertised_v6.unwrap_or(ipv6), ipv6_port).into()
+            (advertised_ip6.unwrap_or(ipv6), ipv6_port).into()
         }
     };
 
@@ -821,8 +811,7 @@ mod test {
         // Pick a real, locally-bindable port for discv5 to listen on.
         let bind_udp_port = unused_udp_port();
         let bind_listen: SocketAddr = format!("127.0.0.1:{bind_udp_port}").parse().unwrap();
-        let rlpx_bind: SocketAddr = "127.0.0.1:30303".parse().unwrap();
-        // Pretend the public/advertised address is something the host doesn't own.
+        // Pretend the public/advertised RLPx socket is something the host doesn't own.
         let advertised: SocketAddr = "203.0.113.7:30303".parse().unwrap();
         let advertised_ip = Ipv4Addr::new(203, 0, 113, 7);
 
@@ -833,10 +822,9 @@ mod test {
         inner.disable_enr_update();
 
         let secret_key = SecretKey::new(&mut thread_rng());
-        let config = Config::builder(rlpx_bind)
-            .advertised_socket(advertised)
-            .discv5_config(inner.build())
-            .build();
+        // The single `Config::builder(...)` arg is the advertised RLPx socket; the inner
+        // discv5 `ListenConfig` controls bind.
+        let config = Config::builder(advertised).discv5_config(inner.build()).build();
 
         let (node, _events) =
             Discv5::start(&secret_key, config).await.expect("should start discv5");
@@ -1074,10 +1062,10 @@ mod test {
     #[test]
     fn build_local_enr_uses_advertised_ip_over_unspecified_bind() {
         const TCP_PORT: u16 = 30303;
-        let bind: SocketAddr = (Ipv4Addr::UNSPECIFIED, TCP_PORT).into();
+        // Inner discv5 ListenConfig keeps the bind IP unspecified (i.e. 0.0.0.0); the
+        // advertised RLPx socket has a real public IP — that's what should land in the ENR.
         let advertised: SocketAddr = "1.2.3.4:30303".parse().unwrap();
-
-        let config = Config::builder(bind).advertised_socket(advertised).build();
+        let config = Config::builder(advertised).build();
 
         let sk = SecretKey::new(&mut thread_rng());
         let (enr, _, _, _) = build_local_enr(&sk, &config);

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -550,14 +550,8 @@ impl NetworkArgs {
             })
             // apply discovery settings
             .apply(|builder| {
-                let rlpx_socket = (addr, self.port).into();
                 let advertised_socket = (advertised_ip, self.port).into();
-                self.discovery.apply_to_builder(
-                    builder,
-                    rlpx_socket,
-                    advertised_socket,
-                    chain_bootnodes,
-                )
+                self.discovery.apply_to_builder(builder, advertised_socket, addr, chain_bootnodes)
             })
             .listener_addr(SocketAddr::new(
                 addr, // set discovery port based on instance number
@@ -795,15 +789,14 @@ pub struct DiscoveryArgs {
 impl DiscoveryArgs {
     /// Apply the discovery settings to the given [`NetworkConfigBuilder`].
     ///
-    /// `rlpx_tcp_socket` is the bind socket; `rlpx_advertised_socket` is the socket put into the
-    /// local ENR. They typically coincide; they differ only when `--nat extip:<IP>` (or
-    /// `extaddr:<DOMAIN>`) supplies an externally-resolved address. See
+    /// `rlpx_advertised_socket` is what gets advertised in the local ENR; `bind_ip` is the
+    /// locally-bindable IP used as the discv5 [`ListenConfig`] default. See
     /// [`Self::discovery_v5_builder`] for details.
     pub fn apply_to_builder<N>(
         &self,
         mut network_config_builder: NetworkConfigBuilder<N>,
-        rlpx_tcp_socket: SocketAddr,
         rlpx_advertised_socket: SocketAddr,
+        bind_ip: IpAddr,
         boot_nodes: impl IntoIterator<Item = NodeRecord>,
     ) -> NetworkConfigBuilder<N>
     where
@@ -824,7 +817,7 @@ impl DiscoveryArgs {
 
         if self.should_enable_discv5() {
             network_config_builder = network_config_builder.discovery_v5(
-                self.discovery_v5_builder(rlpx_tcp_socket, rlpx_advertised_socket, boot_nodes),
+                self.discovery_v5_builder(rlpx_advertised_socket, bind_ip, boot_nodes),
             );
         }
 
@@ -833,18 +826,15 @@ impl DiscoveryArgs {
 
     /// Creates a [`reth_discv5::ConfigBuilder`] filling it with the values from this struct.
     ///
-    /// `rlpx_tcp_socket` is the socket the OS binds `RLPx` to (`--addr` / `--port`). It is also
-    /// the default source of the discv5 [`ListenConfig`] IP when `--discovery.v5.addr` is not
-    /// set, so it must remain a locally-reachable address.
-    ///
-    /// `rlpx_advertised_socket` is the socket put into the local ENR. It typically equals
-    /// `rlpx_tcp_socket`, but when `--nat extip:<IP>` (or `extaddr:<DOMAIN>`) is set the IP comes
-    /// from there instead. Decoupling the two lets the node bind to a private address while
-    /// advertising the externally-resolved one.
+    /// `rlpx_advertised_socket` is the `RLPx` socket put into the local ENR. When the host is
+    /// behind NAT (e.g. `--nat extip:<IP>` / `extaddr:<DOMAIN>`) this is the externally-resolved
+    /// address; otherwise it is just the bind address. The OS bind for discv5 lives on the
+    /// inner [`discv5::ListenConfig`] and falls back to `bind_ip` when `--discovery.v5.addr` is
+    /// not set, so `bind_ip` must remain a locally-reachable address.
     pub fn discovery_v5_builder(
         &self,
-        rlpx_tcp_socket: SocketAddr,
         rlpx_advertised_socket: SocketAddr,
+        bind_ip: IpAddr,
         boot_nodes: impl IntoIterator<Item = NodeRecord>,
     ) -> reth_discv5::ConfigBuilder {
         let Self {
@@ -859,20 +849,20 @@ impl DiscoveryArgs {
         } = self;
 
         let has_discv5_addr_args = discv5_addr.is_some() || discv5_addr_ipv6.is_some();
-        // True when the user supplied an external advertised IP that differs from the bind IP
-        // (e.g. via `--nat extip:<IP>`). In that case we must not let `discv5::Discv5`
+        // True when the operator supplied an external advertised IP that differs from the bind
+        // IP (e.g. via `--nat extip:<IP>`). In that case we must not let `discv5::Discv5`
         // overwrite the explicitly advertised IP from observed addresses.
-        let advertised_differs_from_bind = rlpx_advertised_socket.ip() != rlpx_tcp_socket.ip();
+        let advertised_differs_from_bind = rlpx_advertised_socket.ip() != bind_ip;
 
         // The discv5 `ListenConfig` is the *bind* config: it must be a locally-reachable
         // address. Default to the RLPx bind IP, never the advertised IP.
-        let discv5_addr_ipv4 = discv5_addr.or(match rlpx_tcp_socket {
-            SocketAddr::V4(addr) => Some(*addr.ip()),
-            SocketAddr::V6(_) => None,
+        let discv5_addr_ipv4 = discv5_addr.or(match bind_ip {
+            IpAddr::V4(ip) => Some(ip),
+            IpAddr::V6(_) => None,
         });
-        let discv5_addr_ipv6 = discv5_addr_ipv6.or(match rlpx_tcp_socket {
-            SocketAddr::V4(_) => None,
-            SocketAddr::V6(addr) => Some(*addr.ip()),
+        let discv5_addr_ipv6 = discv5_addr_ipv6.or(match bind_ip {
+            IpAddr::V4(_) => None,
+            IpAddr::V6(ip) => Some(ip),
         });
 
         let mut discv5_config_builder =
@@ -886,11 +876,7 @@ impl DiscoveryArgs {
             // advertised address was supplied (we don't want it overwritten from observations).
             discv5_config_builder.disable_enr_update();
         }
-        // `tcp_socket` is the bind socket. The advertised IP is supplied separately via
-        // `.advertised_socket(...)`; this keeps `Config::rlpx_socket()` (and the
-        // `rlpx_ip_mode` derived from the same field) consistent with how the OS binds.
-        reth_discv5::Config::builder(rlpx_tcp_socket)
-            .advertised_socket(rlpx_advertised_socket)
+        reth_discv5::Config::builder(rlpx_advertised_socket)
             .discv5_config(discv5_config_builder.build())
             .add_unsigned_boot_nodes(boot_nodes)
             .lookup_interval(*discv5_lookup_interval)
@@ -1015,7 +1001,6 @@ mod tests {
         ])
         .args;
 
-        let bind_socket: SocketAddr = (args.addr, args.port).into();
         let advertised_ip =
             args.nat.clone().as_external_ip(args.port).expect("extip resolves synchronously");
         let advertised_socket: SocketAddr = (advertised_ip, args.port).into();
@@ -1023,11 +1008,12 @@ mod tests {
 
         let cfg = args
             .discovery
-            .discovery_v5_builder(bind_socket, advertised_socket, std::iter::empty())
+            .discovery_v5_builder(advertised_socket, args.addr, std::iter::empty())
             .build();
 
-        // Advertised IPv4 carried through to the discv5 Config (and eventually the ENR).
-        assert_eq!(cfg.advertised_ipv4(), Some(Ipv4Addr::new(1, 2, 3, 4)));
+        // The RLPx socket on the discv5 Config now carries the advertised IP (becomes the ENR
+        // `ip4` / `tcp4`).
+        assert_eq!(*cfg.rlpx_socket(), advertised_socket);
         // Bind side untouched: the host needs to bind to a locally-reachable address. The
         // `--discovery.v5.addr` default falls back to the RLPx bind IP (0.0.0.0), not the
         // external IP. UDP port stays at the discv5 default.

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -525,10 +525,10 @@ impl NetworkArgs {
             .with_enforce_enr_fork_id(self.enforce_enr_fork_id);
 
         // Resolve the synchronously-knowable external IP from `--nat extip:<IP>` /
-        // `--nat extaddr:<DOMAIN>` once. For `Upnp`/`PublicIp`/`NetIf`/`Any` this returns `None`
-        // and we fall back to the bind address; `discv5::Discv5` will populate the ENR's IP
-        // from observed addresses in those cases.
-        let advertised_ip = self.nat.clone().as_external_ip(self.port).unwrap_or(addr);
+        // `--nat extaddr:<DOMAIN>` once. `None` means no explicit advertised IP — the discv5
+        // builder will fall back to the bind socket and let `discv5::Discv5` populate the ENR
+        // from observed addresses.
+        let advertised_ip = self.nat.clone().as_external_ip(self.port);
 
         // Configure basic network stack
         NetworkConfigBuilder::<N>::new(secret_key, executor)
@@ -550,8 +550,13 @@ impl NetworkArgs {
             })
             // apply discovery settings
             .apply(|builder| {
-                let advertised_socket = (advertised_ip, self.port).into();
-                self.discovery.apply_to_builder(builder, advertised_socket, addr, chain_bootnodes)
+                let bind_socket = (addr, self.port).into();
+                self.discovery.apply_to_builder(
+                    builder,
+                    bind_socket,
+                    advertised_ip,
+                    chain_bootnodes,
+                )
             })
             .listener_addr(SocketAddr::new(
                 addr, // set discovery port based on instance number
@@ -789,14 +794,15 @@ pub struct DiscoveryArgs {
 impl DiscoveryArgs {
     /// Apply the discovery settings to the given [`NetworkConfigBuilder`].
     ///
-    /// `rlpx_advertised_socket` is what gets advertised in the local ENR; `bind_ip` is the
-    /// locally-bindable IP used as the discv5 [`ListenConfig`] default. See
-    /// [`Self::discovery_v5_builder`] for details.
+    /// `rlpx_bind_socket` is the `RLPx` bind address. `advertised_ip` is the explicit
+    /// externally-resolved advertised IP (from `--nat extip:<IP>` / `extaddr:<DOMAIN>`) when
+    /// the operator supplied one — `None` means "no explicit advertise; fall back to bind."
+    /// See [`Self::discovery_v5_builder`] for details.
     pub fn apply_to_builder<N>(
         &self,
         mut network_config_builder: NetworkConfigBuilder<N>,
-        rlpx_advertised_socket: SocketAddr,
-        bind_ip: IpAddr,
+        rlpx_bind_socket: SocketAddr,
+        advertised_ip: Option<IpAddr>,
         boot_nodes: impl IntoIterator<Item = NodeRecord>,
     ) -> NetworkConfigBuilder<N>
     where
@@ -817,7 +823,7 @@ impl DiscoveryArgs {
 
         if self.should_enable_discv5() {
             network_config_builder = network_config_builder.discovery_v5(
-                self.discovery_v5_builder(rlpx_advertised_socket, bind_ip, boot_nodes),
+                self.discovery_v5_builder(rlpx_bind_socket, advertised_ip, boot_nodes),
             );
         }
 
@@ -826,15 +832,20 @@ impl DiscoveryArgs {
 
     /// Creates a [`reth_discv5::ConfigBuilder`] filling it with the values from this struct.
     ///
-    /// `rlpx_advertised_socket` is the `RLPx` socket put into the local ENR. When the host is
-    /// behind NAT (e.g. `--nat extip:<IP>` / `extaddr:<DOMAIN>`) this is the externally-resolved
-    /// address; otherwise it is just the bind address. The OS bind for discv5 lives on the
-    /// inner [`discv5::ListenConfig`] and falls back to `bind_ip` when `--discovery.v5.addr` is
-    /// not set, so `bind_ip` must remain a locally-reachable address.
+    /// `rlpx_bind_socket` is the OS bind socket for `RLPx`; it is also the discv5
+    /// [`ListenConfig`] default when `--discovery.v5.addr` isn't set, so it must be a
+    /// locally-reachable address.
+    ///
+    /// `advertised_ip`, when `Some`, is the explicit externally-resolved IP from `--nat
+    /// extip:<IP>` / `extaddr:<DOMAIN>` — it goes into the local ENR's `ip4`/`ip6` and we call
+    /// `disable_enr_update()` to stop `discv5::Discv5` from overwriting it via observed
+    /// addresses (the operator has already told us the right answer). When `None`, the
+    /// advertised socket equals `rlpx_bind_socket` and observed-address updates are left
+    /// enabled.
     pub fn discovery_v5_builder(
         &self,
-        rlpx_advertised_socket: SocketAddr,
-        bind_ip: IpAddr,
+        rlpx_bind_socket: SocketAddr,
+        advertised_ip: Option<IpAddr>,
         boot_nodes: impl IntoIterator<Item = NodeRecord>,
     ) -> reth_discv5::ConfigBuilder {
         let Self {
@@ -849,20 +860,24 @@ impl DiscoveryArgs {
         } = self;
 
         let has_discv5_addr_args = discv5_addr.is_some() || discv5_addr_ipv6.is_some();
-        // True when the operator supplied an external advertised IP that differs from the bind
-        // IP (e.g. via `--nat extip:<IP>`). In that case we must not let `discv5::Discv5`
-        // overwrite the explicitly advertised IP from observed addresses.
-        let advertised_differs_from_bind = rlpx_advertised_socket.ip() != bind_ip;
+        // The operator supplied an explicit advertised IP via `--nat extip:`/`extaddr:`. Even
+        // if it happens to equal the bind IP, we must not let `discv5::Discv5` overwrite it
+        // from observed addresses — the operator has already told us the right answer.
+        let has_explicit_advertised_ip = advertised_ip.is_some();
+        let rlpx_advertised_socket: SocketAddr = match advertised_ip {
+            Some(ip) => (ip, rlpx_bind_socket.port()).into(),
+            None => rlpx_bind_socket,
+        };
 
         // The discv5 `ListenConfig` is the *bind* config: it must be a locally-reachable
         // address. Default to the RLPx bind IP, never the advertised IP.
-        let discv5_addr_ipv4 = discv5_addr.or(match bind_ip {
-            IpAddr::V4(ip) => Some(ip),
-            IpAddr::V6(_) => None,
+        let discv5_addr_ipv4 = discv5_addr.or(match rlpx_bind_socket {
+            SocketAddr::V4(addr) => Some(*addr.ip()),
+            SocketAddr::V6(_) => None,
         });
-        let discv5_addr_ipv6 = discv5_addr_ipv6.or(match bind_ip {
-            IpAddr::V4(_) => None,
-            IpAddr::V6(ip) => Some(ip),
+        let discv5_addr_ipv6 = discv5_addr_ipv6.or(match rlpx_bind_socket {
+            SocketAddr::V4(_) => None,
+            SocketAddr::V6(addr) => Some(*addr.ip()),
         });
 
         let mut discv5_config_builder =
@@ -871,7 +886,7 @@ impl DiscoveryArgs {
                 discv5_addr_ipv6.map(|addr| SocketAddrV6::new(addr, *discv5_port_ipv6, 0, 0)),
             ));
 
-        if has_discv5_addr_args || self.disable_nat || advertised_differs_from_bind {
+        if has_discv5_addr_args || self.disable_nat || has_explicit_advertised_ip {
             // disable native enr update if addresses manually set, nat disabled, or an explicit
             // advertised address was supplied (we don't want it overwritten from observations).
             discv5_config_builder.disable_enr_update();
@@ -1001,19 +1016,18 @@ mod tests {
         ])
         .args;
 
-        let advertised_ip =
-            args.nat.clone().as_external_ip(args.port).expect("extip resolves synchronously");
-        let advertised_socket: SocketAddr = (advertised_ip, args.port).into();
-        assert_eq!(advertised_ip, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+        let advertised_ip = args.nat.clone().as_external_ip(args.port);
+        assert_eq!(advertised_ip, Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))));
+        let bind_socket: SocketAddr = (args.addr, args.port).into();
 
         let cfg = args
             .discovery
-            .discovery_v5_builder(advertised_socket, args.addr, std::iter::empty())
+            .discovery_v5_builder(bind_socket, advertised_ip, std::iter::empty())
             .build();
 
-        // The RLPx socket on the discv5 Config now carries the advertised IP (becomes the ENR
+        // The RLPx socket on the discv5 Config carries the advertised IP (becomes the ENR
         // `ip4` / `tcp4`).
-        assert_eq!(*cfg.rlpx_socket(), advertised_socket);
+        assert_eq!(*cfg.rlpx_socket(), SocketAddr::from((Ipv4Addr::new(1, 2, 3, 4), 30303)));
         // Bind side untouched: the host needs to bind to a locally-reachable address. The
         // `--discovery.v5.addr` default falls back to the RLPx bind IP (0.0.0.0), not the
         // external IP. UDP port stays at the discv5 default.

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -524,6 +524,12 @@ impl NetworkArgs {
             .with_ip_filter(ip_filter)
             .with_enforce_enr_fork_id(self.enforce_enr_fork_id);
 
+        // Resolve the synchronously-knowable external IP from `--nat extip:<IP>` /
+        // `--nat extaddr:<DOMAIN>` once. For `Upnp`/`PublicIp`/`NetIf`/`Any` this returns `None`
+        // and we fall back to the bind address; `discv5::Discv5` will populate the ENR's IP
+        // from observed addresses in those cases.
+        let advertised_ip = self.nat.clone().as_external_ip(self.port).unwrap_or(addr);
+
         // Configure basic network stack
         NetworkConfigBuilder::<N>::new(secret_key, executor)
             .external_ip_resolver(self.nat.clone())
@@ -545,7 +551,13 @@ impl NetworkArgs {
             // apply discovery settings
             .apply(|builder| {
                 let rlpx_socket = (addr, self.port).into();
-                self.discovery.apply_to_builder(builder, rlpx_socket, chain_bootnodes)
+                let advertised_socket = (advertised_ip, self.port).into();
+                self.discovery.apply_to_builder(
+                    builder,
+                    rlpx_socket,
+                    advertised_socket,
+                    chain_bootnodes,
+                )
             })
             .listener_addr(SocketAddr::new(
                 addr, // set discovery port based on instance number
@@ -781,11 +793,17 @@ pub struct DiscoveryArgs {
 }
 
 impl DiscoveryArgs {
-    /// Apply the discovery settings to the given [`NetworkConfigBuilder`]
+    /// Apply the discovery settings to the given [`NetworkConfigBuilder`].
+    ///
+    /// `rlpx_tcp_socket` is the bind socket; `rlpx_advertised_socket` is the socket put into the
+    /// local ENR. They typically coincide; they differ only when `--nat extip:<IP>` (or
+    /// `extaddr:<DOMAIN>`) supplies an externally-resolved address. See
+    /// [`Self::discovery_v5_builder`] for details.
     pub fn apply_to_builder<N>(
         &self,
         mut network_config_builder: NetworkConfigBuilder<N>,
         rlpx_tcp_socket: SocketAddr,
+        rlpx_advertised_socket: SocketAddr,
         boot_nodes: impl IntoIterator<Item = NodeRecord>,
     ) -> NetworkConfigBuilder<N>
     where
@@ -805,17 +823,28 @@ impl DiscoveryArgs {
         }
 
         if self.should_enable_discv5() {
-            network_config_builder = network_config_builder
-                .discovery_v5(self.discovery_v5_builder(rlpx_tcp_socket, boot_nodes));
+            network_config_builder = network_config_builder.discovery_v5(
+                self.discovery_v5_builder(rlpx_tcp_socket, rlpx_advertised_socket, boot_nodes),
+            );
         }
 
         network_config_builder
     }
 
     /// Creates a [`reth_discv5::ConfigBuilder`] filling it with the values from this struct.
+    ///
+    /// `rlpx_tcp_socket` is the socket the OS binds `RLPx` to (`--addr` / `--port`). It is also
+    /// the default source of the discv5 [`ListenConfig`] IP when `--discovery.v5.addr` is not
+    /// set, so it must remain a locally-reachable address.
+    ///
+    /// `rlpx_advertised_socket` is the socket put into the local ENR. It typically equals
+    /// `rlpx_tcp_socket`, but when `--nat extip:<IP>` (or `extaddr:<DOMAIN>`) is set the IP comes
+    /// from there instead. Decoupling the two lets the node bind to a private address while
+    /// advertising the externally-resolved one.
     pub fn discovery_v5_builder(
         &self,
         rlpx_tcp_socket: SocketAddr,
+        rlpx_advertised_socket: SocketAddr,
         boot_nodes: impl IntoIterator<Item = NodeRecord>,
     ) -> reth_discv5::ConfigBuilder {
         let Self {
@@ -830,8 +859,13 @@ impl DiscoveryArgs {
         } = self;
 
         let has_discv5_addr_args = discv5_addr.is_some() || discv5_addr_ipv6.is_some();
+        // True when the user supplied an external advertised IP that differs from the bind IP
+        // (e.g. via `--nat extip:<IP>`). In that case we must not let `discv5::Discv5`
+        // overwrite the explicitly advertised IP from observed addresses.
+        let advertised_differs_from_bind = rlpx_advertised_socket.ip() != rlpx_tcp_socket.ip();
 
-        // Use rlpx address if none given
+        // The discv5 `ListenConfig` is the *bind* config: it must be a locally-reachable
+        // address. Default to the RLPx bind IP, never the advertised IP.
         let discv5_addr_ipv4 = discv5_addr.or(match rlpx_tcp_socket {
             SocketAddr::V4(addr) => Some(*addr.ip()),
             SocketAddr::V6(_) => None,
@@ -847,11 +881,13 @@ impl DiscoveryArgs {
                 discv5_addr_ipv6.map(|addr| SocketAddrV6::new(addr, *discv5_port_ipv6, 0, 0)),
             ));
 
-        if has_discv5_addr_args || self.disable_nat {
-            // disable native enr update if addresses manually set or nat disabled
+        if has_discv5_addr_args || self.disable_nat || advertised_differs_from_bind {
+            // disable native enr update if addresses manually set, nat disabled, or an explicit
+            // advertised address was supplied (we don't want it overwritten from observations).
             discv5_config_builder.disable_enr_update();
         }
-        reth_discv5::Config::builder(rlpx_tcp_socket)
+        reth_discv5::Config::builder(rlpx_advertised_socket)
+            .advertised_socket(rlpx_advertised_socket)
             .discv5_config(discv5_config_builder.build())
             .add_unsigned_boot_nodes(boot_nodes)
             .lookup_interval(*discv5_lookup_interval)
@@ -961,6 +997,41 @@ mod tests {
         let args =
             CommandParser::<NetworkArgs>::parse_from(["reth", "--nat", "extip:0.0.0.0"]).args;
         assert_eq!(args.nat, NatResolver::ExternalIp("0.0.0.0".parse().unwrap()));
+    }
+
+    #[test]
+    fn nat_extip_propagates_to_discv5_advertised_ip() {
+        let args = CommandParser::<NetworkArgs>::parse_from([
+            "reth",
+            "--addr",
+            "0.0.0.0",
+            "--port",
+            "30303",
+            "--nat",
+            "extip:1.2.3.4",
+        ])
+        .args;
+
+        let bind_socket: SocketAddr = (args.addr, args.port).into();
+        let advertised_ip =
+            args.nat.clone().as_external_ip(args.port).expect("extip resolves synchronously");
+        let advertised_socket: SocketAddr = (advertised_ip, args.port).into();
+        assert_eq!(advertised_ip, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+
+        let cfg = args
+            .discovery
+            .discovery_v5_builder(bind_socket, advertised_socket, std::iter::empty())
+            .build();
+
+        // Advertised IPv4 carried through to the discv5 Config (and eventually the ENR).
+        assert_eq!(cfg.advertised_ipv4(), Some(Ipv4Addr::new(1, 2, 3, 4)));
+        // Bind side untouched: the host needs to bind to a locally-reachable address. The
+        // `--discovery.v5.addr` default falls back to the RLPx bind IP (0.0.0.0), not the
+        // external IP. UDP port stays at the discv5 default.
+        assert_eq!(
+            cfg.discovery_socket(),
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, DEFAULT_DISCOVERY_V5_PORT))
+        );
     }
 
     #[test]

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -886,7 +886,10 @@ impl DiscoveryArgs {
             // advertised address was supplied (we don't want it overwritten from observations).
             discv5_config_builder.disable_enr_update();
         }
-        reth_discv5::Config::builder(rlpx_advertised_socket)
+        // `tcp_socket` is the bind socket. The advertised IP is supplied separately via
+        // `.advertised_socket(...)`; this keeps `Config::rlpx_socket()` (and the
+        // `rlpx_ip_mode` derived from the same field) consistent with how the OS binds.
+        reth_discv5::Config::builder(rlpx_tcp_socket)
             .advertised_socket(rlpx_advertised_socket)
             .discv5_config(discv5_config_builder.build())
             .add_unsigned_boot_nodes(boot_nodes)


### PR DESCRIPTION
The discv5 ENR was built from `discv5::ListenConfig` (the bind config) rather than from anything carrying the externally-resolved IP, so `--nat extip:<IP>` propagated to the enode URL but never to the ENR's `ip4`/`ip6` field. With `--nat extip:<IP> --addr 0.0.0.0` bootnodes accepted FINDNODE but never advertised the node back to peers (`connected_peers=0`). On top of that, an `amend_listen_config_wrt_rlpx` overwrite clobbered any explicit `--discovery.v5.addr` back to the RLPx bind IP.

Diagnosis: `reth_discv5::Config::tcp_socket`'s docs already said "RLPx TCP socket *to advertise*" — the field was just being passed the bind value (and then further clobbered). The fix is to make `tcp_socket` actually carry the advertised RLPx socket and to stop the overwrite. No new field is needed.

Changes:
- `discovery_v5_builder` / `DiscoveryArgs::apply_to_builder` now take `(rlpx_bind_socket: SocketAddr, advertised_ip: Option<IpAddr>)`. The bind socket is the OS bind (and the `discv5::ListenConfig` fallback when `--discovery.v5.addr` isn't set, so it must remain locally-reachable). `advertised_ip` is `Some(_)` when the operator explicitly supplied one via `--nat extip:<IP>` / `extaddr:<DOMAIN>`, and `None` otherwise.
- `Config::builder(...)` is fed the advertised socket; the inner `discv5::ListenConfig` is left untouched (the `amend_listen_config_wrt_rlpx` helper and the existing overwrite tests are removed).
- `build_local_enr` reads `tcp_socket.ip()` directly — UNSPECIFIED means "omit from ENR; let `discv5::Discv5` populate it from observed addresses."
- `disable_enr_update()` is now triggered whenever `advertised_ip.is_some()` (i.e. the operator explicitly stated the advertised IP), in addition to `--discovery.v5.addr` or `--disable-nat`. This also covers the case where an operator binds to a real public IP and sets `--nat extip:<same IP>` — observations can't improve on what they've told us.
- Async resolvers (`Upnp` / `PublicIp` / `NetIf` / `Any`) keep current behaviour: `as_external_ip` returns `None`, the advertised socket equals bind, and observations populate the ENR.

Tests: 5 new unit/integration tests across `reth-discv5` and `reth-node-core`, including a `tokio` end-to-end that spawns `Discv5` with bind = `127.0.0.1:<unused>` and advertised = `203.0.113.7:30303`, then asserts the ENR carries the advertised IP **and** another `UdpSocket::bind(...)` to the bind address fails (proving discv5 holds the OS socket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)