### PR TITLE
refactor: expose executor transaction result type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.33.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f092eb6af80456e4ab41c9722e777d791335bc9c00b11bc3db7bf29a432dfd0"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,7 +450,7 @@ alloy-sol-types = { version = "1.5.6", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.4", default-features = false }
-alloy-evm = { version = "0.33.3", default-features = false }
+alloy-evm = { version = "0.34.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 

--- a/bin/reth-bb/src/evm.rs
+++ b/bin/reth-bb/src/evm.rs
@@ -7,15 +7,16 @@
 //! `execute_transaction` to apply segment-boundary changes.
 
 use crate::evm_config::BigBlockSegment;
+use alloy_consensus::TransactionEnvelope;
 use alloy_eips::eip7685::Requests;
 use alloy_evm::{
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        BlockExecutorFor, ExecutableTx, GasOutput, OnStateHook, StateChangeSource, StateDB,
+        ExecutableTx, GasOutput, OnStateHook, StateChangeSource, StateDB,
     },
     eth::{EthBlockExecutionCtx, EthBlockExecutor, EthEvmContext, EthTxResult},
     precompiles::PrecompilesMap,
-    Database, EthEvm, EthEvmFactory, Evm, FromRecoveredTx, FromTxWithEncoded,
+    Database, EthEvm, EthEvmFactory, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded,
 };
 use alloy_primitives::B256;
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
@@ -116,7 +117,8 @@ pub(crate) type BalIndexReader<DB> = fn(&DB) -> u64;
 /// Gas counters reset at each boundary so that each segment's real gas limit
 /// is used (preserving correct GASLIMIT opcode behavior). Accumulated offsets
 /// are applied to receipts and totals in `finish()`.
-pub(crate) struct BbBlockExecutor<'a, DB, I, P, Spec>
+#[expect(missing_debug_implementations)]
+pub struct BbBlockExecutor<'a, DB, I, P, Spec>
 where
     DB: Database,
 {
@@ -431,12 +433,11 @@ where
         self.inner_mut().execute_transaction_without_commit(tx)
     }
 
-    fn commit_transaction(
-        &mut self,
-        output: Self::Result,
-    ) -> Result<GasOutput, BlockExecutionError> {
-        self.maybe_apply_boundary()?;
-        let gas_used = self.inner_mut().commit_transaction(output)?;
+    fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
+        self.maybe_apply_boundary()
+            .expect("segment boundary application must succeed before committing transaction");
+
+        let gas_used = self.inner_mut().commit_transaction(output);
 
         // Fix up cumulative_gas_used on the just-committed receipt so that
         // the receipt root task (which reads receipts incrementally) sees
@@ -451,7 +452,7 @@ where
         if let Some(plan) = &mut self.plan {
             plan.tx_counter += 1;
         }
-        Ok(gas_used)
+        gas_used
     }
 
     fn finish(
@@ -613,6 +614,12 @@ where
     type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
     type Transaction = TransactionSigned;
     type Receipt = Receipt;
+    type TxExecutionResult = EthTxResult<
+        <EthEvmFactory as EvmFactory>::HaltReason,
+        <TransactionSigned as TransactionEnvelope>::TxType,
+    >;
+    type Executor<'a, DB: StateDB, I: Inspector<EthEvmContext<DB>>> =
+        BbBlockExecutor<'a, DB, I, PrecompilesMap, &'a Spec>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
@@ -622,10 +629,10 @@ where
         &'a self,
         evm: EthEvm<DB, I, PrecompilesMap>,
         ctx: EthBlockExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self, DB, I>
+    ) -> Self::Executor<'a, DB, I>
     where
-        DB: StateDB + 'a,
-        I: Inspector<EthEvmContext<DB>> + 'a,
+        DB: StateDB,
+        I: Inspector<EthEvmContext<DB>>,
     {
         let plan = self.peek_plan();
         BbBlockExecutor::new(evm, ctx, &self.spec, self.receipt_builder, plan, None, None)

--- a/bin/reth-bb/src/evm_config.rs
+++ b/bin/reth-bb/src/evm_config.rs
@@ -12,7 +12,10 @@ use crate::{
     BigBlockMap,
 };
 use alloy_consensus::Header;
-use alloy_evm::eth::EthBlockExecutionCtx;
+use alloy_evm::{
+    eth::{spec::EthExecutorSpec, EthBlockExecutionCtx},
+    EthEvmFactory,
+};
 use alloy_primitives::B256;
 use alloy_rpc_types::engine::ExecutionData;
 use core::convert::Infallible;
@@ -20,17 +23,14 @@ use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_ethereum_forks::Hardforks;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::{
-    ConfigureEngineEvm, ConfigureEvm, Database, EvmEnv, ExecutableTxIterator,
-    NextBlockEnvAttributes,
+    ConfigureEngineEvm, ConfigureEvm, Database, EvmEnv, EvmEnvFor, ExecutableTxIterator,
+    ExecutionCtxFor, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::{EthBlockAssembler, EthEvmConfig, RethReceiptBuilder};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use revm::primitives::hardfork::SpecId;
 use std::sync::Arc;
 use tracing::debug;
-
-use alloy_evm::{eth::spec::EthExecutorSpec, EthEvmFactory};
-use reth_evm::{EvmEnvFor, ExecutionCtxFor};
 
 // ---------------------------------------------------------------------------
 // Execution plan types
@@ -169,7 +169,7 @@ where
         &'a self,
         evm: reth_evm::EvmFor<Self, &'a mut revm::database::State<DB>, I>,
         ctx: EthBlockExecutionCtx<'a>,
-    ) -> impl alloy_evm::block::BlockExecutorFor<
+    ) -> alloy_evm::block::BlockExecutorFor<
         'a,
         Self::BlockExecutorFactory,
         &'a mut revm::database::State<DB>,

--- a/crates/evm/evm/src/aliases.rs
+++ b/crates/evm/evm/src/aliases.rs
@@ -1,8 +1,11 @@
 //! Helper aliases when working with [`ConfigureEvm`] and the traits in this crate.
 
 use crate::ConfigureEvm;
-use alloy_evm::{block::BlockExecutorFactory, Database, EvmEnv, EvmFactory};
-use revm::{inspector::NoOpInspector, Inspector};
+use alloy_evm::{
+    block::{BlockExecutorFactory, BlockExecutorFor},
+    Database, EvmEnv, EvmFactory,
+};
+use revm::{database::State, inspector::NoOpInspector, Inspector};
 
 /// Helper to access [`EvmFactory`] for a given [`ConfigureEvm`].
 pub type EvmFactoryFor<Evm> =
@@ -32,6 +35,10 @@ pub type TxEnvFor<Evm> = <EvmFactoryFor<Evm> as EvmFactory>::Tx;
 /// Helper to access [`BlockExecutorFactory::ExecutionCtx`] for a given [`ConfigureEvm`].
 pub type ExecutionCtxFor<'a, Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>;
+
+/// Helper to access [`alloy_evm::block::BlockExecutor`] for a given [`ConfigureEvm`].
+pub type BlockExecutorForEvm<'a, Evm, DB, I = NoOpInspector> =
+    BlockExecutorFor<'a, <Evm as ConfigureEvm>::BlockExecutorFactory, &'a mut State<DB>, I>;
 
 /// Type alias for [`EvmEnv`] for a given [`ConfigureEvm`].
 pub type EvmEnvFor<Evm> = EvmEnv<SpecFor<Evm>, BlockEnvFor<Evm>>;

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -20,10 +20,7 @@ extern crate alloc;
 use crate::execute::{BasicBlockBuilder, Executor};
 use alloc::vec::Vec;
 use alloy_eips::eip4895::Withdrawals;
-use alloy_evm::{
-    block::{BlockExecutorFactory, BlockExecutorFor},
-    precompiles::PrecompilesMap,
-};
+use alloy_evm::{block::BlockExecutorFactory, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes, B256};
 use core::{error::Error, fmt::Debug};
 use execute::{BasicBlockExecutor, BlockAssembler, BlockBuilder};
@@ -312,7 +309,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         &'a self,
         evm: EvmFor<Self, &'a mut State<DB>, I>,
         ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>, I>
+    ) -> BlockExecutorForEvm<'a, Self, DB, I>
     where
         DB: Database,
         I: InspectorFor<Self, &'a mut State<DB>> + 'a,
@@ -325,8 +322,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         &'a self,
         db: &'a mut State<DB>,
         block: &'a SealedBlock<<Self::Primitives as NodePrimitives>::Block>,
-    ) -> Result<impl BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>>, Self::Error>
-    {
+    ) -> Result<BlockExecutorForEvm<'a, Self, DB>, Self::Error> {
         let evm = self.evm_for_block(db, block.header())?;
         let ctx = self.context_for_block(block)?;
         Ok(self.create_executor(evm, ctx))
@@ -352,10 +348,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         evm: EvmFor<Self, &'a mut State<DB>, I>,
         parent: &'a SealedHeader<HeaderTy<Self::Primitives>>,
         ctx: <Self::BlockExecutorFactory as BlockExecutorFactory>::ExecutionCtx<'a>,
-    ) -> impl BlockBuilder<
-        Primitives = Self::Primitives,
-        Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>, I>,
-    >
+    ) -> impl BlockBuilder<Primitives = Self::Primitives, Executor = BlockExecutorForEvm<'a, Self, DB, I>>
     where
         DB: Database,
         I: InspectorFor<Self, &'a mut State<DB>> + 'a,
@@ -404,10 +397,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
         attributes: Self::NextBlockEnvCtx,
     ) -> Result<
-        impl BlockBuilder<
-            Primitives = Self::Primitives,
-            Executor: BlockExecutorFor<'a, Self::BlockExecutorFactory, &'a mut State<DB>>,
-        >,
+        impl BlockBuilder<Primitives = Self::Primitives, Executor = BlockExecutorForEvm<'a, Self, DB>>,
         Self::Error,
     > {
         let evm_env = self.next_evm_env(parent, &attributes)?;

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -5,11 +5,11 @@
 
 use alloy_eips::eip4895::Withdrawal;
 use alloy_evm::{
-    block::{BlockExecutorFactory, BlockExecutorFor, ExecutableTx, GasOutput},
+    block::{BlockExecutorFactory, ExecutableTx, GasOutput},
     eth::{EthBlockExecutionCtx, EthBlockExecutor, EthTxResult},
     precompiles::PrecompilesMap,
     revm::context::Block as _,
-    EthEvm, EthEvmFactory,
+    EthEvm, EthEvmFactory, EvmFactory,
 };
 use alloy_sol_types::{sol, SolCall};
 use reth_ethereum::{
@@ -94,6 +94,9 @@ impl BlockExecutorFactory for CustomEvmConfig {
     type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
     type Transaction = TransactionSigned;
     type Receipt = Receipt;
+    type TxExecutionResult = EthTxResult<<EthEvmFactory as EvmFactory>::HaltReason, TxType>;
+    type Executor<'a, DB: StateDB, I: InspectorFor<Self, DB>> =
+        CustomBlockExecutor<'a, EthEvm<DB, I, PrecompilesMap>>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         self.inner.evm_factory()
@@ -103,10 +106,10 @@ impl BlockExecutorFactory for CustomEvmConfig {
         &'a self,
         evm: EthEvm<DB, I, PrecompilesMap>,
         ctx: EthBlockExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self, DB, I>
+    ) -> Self::Executor<'a, DB, I>
     where
-        DB: StateDB + 'a,
-        I: InspectorFor<Self, DB> + 'a,
+        DB: StateDB,
+        I: InspectorFor<Self, DB>,
     {
         CustomBlockExecutor {
             inner: EthBlockExecutor::new(
@@ -211,10 +214,7 @@ where
         self.inner.execute_transaction_without_commit(tx)
     }
 
-    fn commit_transaction(
-        &mut self,
-        output: Self::Result,
-    ) -> Result<GasOutput, BlockExecutionError> {
+    fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
         self.inner.commit_transaction(output)
     }
 


### PR DESCRIPTION
This is compile-time API plumbing for BAL.

BAL executes transactions on worker executors with `execute_transaction_without_commit`, then commits the produced results later on a canonical executor with `commit_transaction`. For this to work generically, all executors created by a `ConfigureEvm` must have one nameable transaction result type.

Before this change, `executor_for_block` returned only `impl BlockExecutorFor<...>`, and generic code could not name or rely on the executor's `BlockExecutor::Result` type. That is fine for serial execution, where the same executor executes and commits internally, but not for passing transaction results between executors.

`ConfigureEvm::TxExecutionResult` gives that result type a stable name, requires it to be `Send`, and ties it to the configured executor factory. This lets BAL be written generically over `ConfigureEvm` instead of hard-coding Ethereum executor types.

> [!NOTE]
> depends on alloy-rs/evm change posted here https://github.com/alloy-rs/evm/pull/349