### PR TITLE
feat(net): enable ETH70 by default

### DIFF
--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -35,10 +35,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth70;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {


### PR DESCRIPTION
Sets eth/70 as the latest advertised eth protocol version and includes it in the default version list.

Validated with `cargo +nightly fmt --all --check` and `cargo test -p reth-eth-wire-types test_eth_version --lib`.