### PR TITLE
[autoopt] 20260428-3-sparse-dirty-update-gate

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1275,7 +1275,11 @@ impl ArenaParallelSparseTrie {
 
             // Record trie updates for dirty branches only.
             // Skip the root node (empty logical path) as PST does.
-            if let Some(trie_updates) = updates.as_mut().filter(|_| was_dirty) {
+            if was_dirty {
+                let Some(trie_updates) = updates.as_mut() else {
+                    continue;
+                };
+
                 let mut logical_path = head_path;
                 logical_path.extend(&short_key);
 


### PR DESCRIPTION
# Skip sparse-trie update bookkeeping on clean branches
## Evidence
- The `25003175897` sparse-trie profile still shows noticeable self time in `ArenaParallelSparseTrie::update_cached_rlp`, including a few thousand weighted samples in `core::option::Option::filter` inside the per-branch caching loop.
- In `crates/trie/sparse/src/arena/mod.rs`, that hot loop called `updates.as_mut().filter(|_| was_dirty)` for every cached branch, even though only dirty branches can emit trie updates.
- Clean branches dominate steady-state cached-RLP walks after the trie has largely converged, so paying an extra `Option` closure and branch-update gate on every one is pure overhead.

## Hypothesis
If we gate sparse-trie update recording with a direct `was_dirty` check before touching the optional updates buffer, gas throughput improves by ~0.05-0.2% because cached-RLP walks stop spending work on update bookkeeping for already-clean branches.

## Success Metric
- gas_per_second (mgas_s.pct in summary.json) improves by >0.05%

## Plan
- Update `crates/trie/sparse/src/arena/mod.rs` so `update_cached_rlp` only looks up the optional trie-update buffer after confirming the branch was dirty.
- Leave the cached node and branch mask logic unchanged.
- Verify with `cargo check -p reth-trie-sparse` and `cargo test -p reth-trie-sparse update_leaves`.