### PR TITLE
feat(reth-bb): support out-of-band BALs

### DIFF
--- a/bin/reth-bb/src/main.rs
+++ b/bin/reth-bb/src/main.rs
@@ -7,7 +7,7 @@ static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::ne
 mod evm;
 mod evm_config;
 
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 
 use alloy_rpc_types::engine::{ExecutionData, ForkchoiceState, ForkchoiceUpdated};
 use async_trait::async_trait;
@@ -66,6 +66,7 @@ pub trait BbRethEngineApi {
         wait_for_persistence: Option<bool>,
         wait_for_caches: Option<bool>,
         big_block_data: Option<BigBlockData<ExecutionData>>,
+        oob_block_access_list: Option<Bytes>,
     ) -> RpcResult<RethPayloadStatus>;
 
     /// `reth_forkchoiceUpdated` – pass-through.
@@ -91,6 +92,7 @@ impl BbRethEngineApiServer for BbRethEngineApiHandler {
         wait_for_persistence: Option<bool>,
         wait_for_caches: Option<bool>,
         big_block_data: Option<BigBlockData<ExecutionData>>,
+        oob_block_access_list: Option<Bytes>,
     ) -> RpcResult<RethPayloadStatus> {
         let wait_for_persistence = wait_for_persistence.unwrap_or(true);
         let wait_for_caches = wait_for_caches.unwrap_or(true);
@@ -99,6 +101,7 @@ impl BbRethEngineApiServer for BbRethEngineApiHandler {
             wait_for_persistence,
             wait_for_caches,
             has_big_block_data = big_block_data.is_some(),
+            has_oob_bal = oob_block_access_list.is_some(),
             "Serving bb reth_newPayload"
         );
 
@@ -118,7 +121,7 @@ impl BbRethEngineApiServer for BbRethEngineApiHandler {
 
         let (status, timings) = self
             .engine
-            .reth_new_payload(payload, wait_for_persistence, wait_for_caches)
+            .reth_new_payload(payload, wait_for_persistence, wait_for_caches, oob_block_access_list)
             .await
             .map_err(EngineApiError::from)?;
 

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::BeaconForkChoiceUpdateError, BeaconOnNewPayloadError, ExecutionPayload, ForkchoiceStatus,
 };
+use alloy_primitives::Bytes;
 use alloy_rpc_types_engine::{
     ForkChoiceUpdateResult, ForkchoiceState, ForkchoiceUpdateError, ForkchoiceUpdated, PayloadId,
     PayloadStatus, PayloadStatusEnum,
@@ -206,6 +207,8 @@ pub enum BeaconEngineMessage<Payload: PayloadTypes> {
     RethNewPayload {
         /// The execution payload received by Engine API.
         payload: Payload::ExecutionData,
+        /// Optional out-of-band RLP-encoded block access list.
+        oob_block_access_list: Option<Bytes>,
         /// Whether to wait for in-flight persistence to complete before processing.
         wait_for_persistence: bool,
         /// Whether to wait for execution cache and sparse trie locks before processing.
@@ -303,10 +306,12 @@ where
         payload: Payload::ExecutionData,
         wait_for_persistence: bool,
         wait_for_caches: bool,
+        oob_block_access_list: Option<Bytes>,
     ) -> Result<(PayloadStatus, NewPayloadTimings), BeaconOnNewPayloadError> {
         let (tx, rx) = oneshot::channel();
         let _ = self.to_engine.send(BeaconEngineMessage::RethNewPayload {
             payload,
+            oob_block_access_list,
             wait_for_persistence,
             wait_for_caches,
             tx,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1898::BlockWithParent, merge::EPOCH_SLOTS, BlockNumHash, NumHash};
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
@@ -697,6 +697,9 @@ where
     ///
     /// This returns a [`PayloadStatus`] that represents the outcome of a processed new payload and
     /// returns an error if an internal error occurred.
+    ///
+    /// If provided, `oob_block_access_list` is an out-of-band RLP-encoded BAL supplied alongside
+    /// the payload. It takes precedence over the payload's inline BAL during validation.
     #[instrument(
         level = "debug",
         target = "engine::tree",
@@ -706,6 +709,7 @@ where
     fn on_new_payload(
         &mut self,
         payload: T::ExecutionData,
+        oob_block_access_list: Option<Bytes>,
     ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
         trace!(target: "engine::tree", "invoked new payload");
 
@@ -754,7 +758,7 @@ where
         self.metrics.block_validation.record_payload_validation(start.elapsed().as_secs_f64());
 
         let mut outcome = if self.backfill_sync_state.is_idle() {
-            self.try_insert_payload(payload)?.into_outcome()
+            self.try_insert_payload(payload, oob_block_access_list)?.into_outcome()
         } else {
             TreeOutcome::new(self.try_buffer_payload(payload)?)
         };
@@ -780,13 +784,14 @@ where
     fn try_insert_payload(
         &mut self,
         payload: T::ExecutionData,
+        oob_block_access_list: Option<Bytes>,
     ) -> Result<TryInsertPayloadResult, InsertBlockFatalError> {
         let block_hash = payload.block_hash();
         let num_hash = payload.num_hash();
         let parent_hash = payload.parent_hash();
         let mut latest_valid_hash = None;
 
-        match self.insert_payload(payload) {
+        match self.insert_payload(payload, oob_block_access_list) {
             Ok(status) => {
                 let (status, already_seen) = match status {
                     InsertPayloadOk::Inserted(BlockStatus::Valid) => {
@@ -1623,7 +1628,7 @@ where
                                 let start = Instant::now();
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
-                                let mut output = self.on_new_payload(payload);
+                                let mut output = self.on_new_payload(payload, None);
                                 self.metrics.engine.new_payload.update_response_metrics(
                                     start,
                                     &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
@@ -1652,6 +1657,7 @@ where
                             }
                             BeaconEngineMessage::RethNewPayload {
                                 payload,
+                                oob_block_access_list,
                                 wait_for_persistence,
                                 wait_for_caches,
                                 tx,
@@ -1703,7 +1709,8 @@ where
                                 let start = Instant::now();
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
-                                let mut output = self.on_new_payload(payload);
+                                let mut output =
+                                    self.on_new_payload(payload, oob_block_access_list);
                                 let latency = start.elapsed();
                                 self.metrics.engine.new_payload.update_response_metrics(
                                     start,
@@ -2832,14 +2839,20 @@ where
     ///
     /// Returns `InsertPayloadOk` if the payload was successfully inserted and executed,
     /// or `InsertPayloadError` if validation or execution failed.
+    ///
+    /// If provided, `oob_block_access_list` is an out-of-band RLP-encoded BAL supplied alongside
+    /// the payload. It takes precedence over the payload's inline BAL during validation.
     fn insert_payload(
         &mut self,
         payload: T::ExecutionData,
+        oob_block_access_list: Option<Bytes>,
     ) -> Result<InsertPayloadOk, InsertPayloadError<N::Block>> {
         self.insert_block_or_payload(
             payload.block_with_parent(),
             payload,
-            |validator, payload, ctx| validator.validate_payload(payload, ctx),
+            |validator, payload, ctx| {
+                validator.validate_payload(payload, ctx, oob_block_access_list)
+            },
             |this, payload| Ok(this.payload_validator.convert_payload_to_block(payload)?),
         )
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -48,13 +48,10 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{
-    bal::{Bal, DecodedBal},
-    BlockAccessList,
-};
+use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
-use alloy_primitives::{map::B256Set, B256};
+use alloy_primitives::{map::B256Set, Bytes, B256};
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 
@@ -377,6 +374,9 @@ where
     /// - Block execution
     /// - State root computation
     /// - Fork detection
+    ///
+    /// If provided, `decoded_bal` is the already-decoded BAL selected for this payload before
+    /// execution. `None` means no BAL was supplied or present.
     #[instrument(
         level = "debug",
         target = "engine::tree::payload_validator",
@@ -390,6 +390,7 @@ where
         &mut self,
         input: BlockOrPayload<T>,
         mut ctx: TreeCtx<'_, N>,
+        decoded_bal: Option<Arc<DecodedBal>>,
     ) -> InsertPayloadResult<N>
     where
         V: PayloadValidator<T, Block = N::Block> + Clone,
@@ -490,12 +491,6 @@ where
         let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm_env")
             .in_scope(|| self.evm_env_for(&input))
             .map_err(NewPayloadError::other)?;
-
-        // Extract the decoded BAL, if valid and available.
-        let decoded_bal = ensure_ok!(input
-            .try_decoded_access_list()
-            .map_err(|err| { Box::<dyn std::error::Error + Send + Sync>::from(err) }))
-        .map(Arc::new);
 
         let env = ExecutionEnv {
             evm_env,
@@ -1886,6 +1881,17 @@ enum StateRootStrategy {
     Synchronous,
 }
 
+/// Decodes the BAL for a payload, preferring out-of-band BAL bytes over the payload's inline BAL.
+fn decode_payload_access_list<P: ExecutionPayload>(
+    payload: &P,
+    oob_block_access_list: Option<Bytes>,
+) -> Result<Option<Arc<DecodedBal>>, alloy_rlp::Error> {
+    oob_block_access_list
+        .or_else(|| payload.block_access_list().cloned())
+        .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list).map(Arc::new))
+        .transpose()
+}
+
 /// Type that validates the payloads processed by the engine.
 ///
 /// This provides the necessary functions for validating/executing payloads/blocks.
@@ -1923,10 +1929,14 @@ pub trait EngineValidator<
     ) -> Result<SealedBlock<N::Block>, NewPayloadError>;
 
     /// Validates a payload received from engine API.
+    ///
+    /// If provided, `oob_block_access_list` is an out-of-band RLP-encoded BAL and is used instead
+    /// of the payload's inline BAL.
     fn validate_payload(
         &mut self,
         payload: Types::ExecutionData,
         ctx: TreeCtx<'_, N>,
+        oob_block_access_list: Option<Bytes>,
     ) -> ValidationOutcome<N>;
 
     /// Validates a block downloaded from the network.
@@ -1997,8 +2007,11 @@ where
         &mut self,
         payload: Types::ExecutionData,
         ctx: TreeCtx<'_, N>,
+        oob_block_access_list: Option<Bytes>,
     ) -> ValidationOutcome<N> {
-        self.validate_block_with_state(BlockOrPayload::Payload(payload), ctx)
+        let decoded_bal = decode_payload_access_list(&payload, oob_block_access_list)
+            .map_err(|err| NewPayloadError::Other(Box::new(err)))?;
+        self.validate_block_with_state(BlockOrPayload::Payload(payload), ctx, decoded_bal)
     }
 
     fn validate_block(
@@ -2006,7 +2019,7 @@ where
         block: SealedBlock<N::Block>,
         ctx: TreeCtx<'_, N>,
     ) -> ValidationOutcome<N> {
-        self.validate_block_with_state(BlockOrPayload::Block(block), ctx)
+        self.validate_block_with_state(BlockOrPayload::Block(block), ctx, None)
     }
 
     fn on_inserted_executed_block(&self, block: ExecutedBlock<N>) {
@@ -2099,27 +2112,6 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(_) => "payload",
             Self::Block(_) => "block",
-        }
-    }
-
-    /// Returns the block access list embedded in a payload, if present.
-    pub fn block_access_list(&self) -> Option<Result<BlockAccessList, alloy_rlp::Error>> {
-        match self {
-            Self::Payload(payload) => payload.block_access_list().map(|block_access_list| {
-                alloy_rlp::decode_exact::<Bal>(block_access_list.as_ref()).map(Bal::into_inner)
-            }),
-            Self::Block(_) => None,
-        }
-    }
-
-    /// Returns the decoded block access list, if present and successfully decoded.
-    pub fn try_decoded_access_list(&self) -> Result<Option<DecodedBal>, alloy_rlp::Error> {
-        match self {
-            Self::Payload(payload) => payload
-                .block_access_list()
-                .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
-                .transpose(),
-            Self::Block(_) => Ok(None),
         }
     }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -634,10 +634,10 @@ fn test_disconnected_payload() {
 
     let outcome = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
     assert!(outcome.outcome.is_syncing());
 
@@ -1218,10 +1218,10 @@ fn test_on_new_payload_canonical_insertion() {
     // Case 1: Submit payload when NOT sync target head - should be syncing (disconnected)
     let outcome1 = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload1.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload1.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
 
     // Since this is disconnected from genesis, it should be syncing
@@ -1273,10 +1273,10 @@ fn test_on_new_payload_invalid_ancestor() {
     // Submit payload 2 (child of invalid block 1)
     let outcome = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload2.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload2.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
 
     // Verify response is INVALID
@@ -1320,10 +1320,10 @@ fn test_on_new_payload_backfill_buffering() {
     // Submit payload during backfill
     let outcome = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
 
     // Verify response is SYNCING
@@ -1366,10 +1366,10 @@ fn test_on_new_payload_malformed_payload() {
     // Submit the malformed payload
     let outcome = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
 
     // For malformed payloads with incorrect hash, the current implementation
@@ -1415,10 +1415,10 @@ fn test_state_root_strategy_paths() {
     // Scenario 1: Test one strategy path
     let outcome1 = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload1.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload1.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
 
     assert!(
@@ -1437,10 +1437,10 @@ fn test_state_root_strategy_paths() {
     // Scenario 2: Test different strategy path (disconnected)
     let outcome2 = test_harness
         .tree
-        .on_new_payload(ExecutionData {
-            payload: payload2.into(),
-            sidecar: ExecutionPayloadSidecar::none(),
-        })
+        .on_new_payload(
+            ExecutionData { payload: payload2.into(), sidecar: ExecutionPayloadSidecar::none() },
+            None,
+        )
         .unwrap();
 
     assert!(outcome2.outcome.is_syncing(), "Second strategy path should work");
@@ -1733,7 +1733,7 @@ mod payload_execution_tests {
         };
 
         // Test the function directly
-        let result = test_harness.tree.try_insert_payload(payload);
+        let result = test_harness.tree.try_insert_payload(payload, None);
         // Should handle the payload gracefully
         assert!(result.is_ok(), "Should handle valid payload without error");
     }

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -49,7 +49,7 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
 
         let (status, timings) = self
             .beacon_engine_handle
-            .reth_new_payload(payload, wait_for_persistence, wait_for_caches)
+            .reth_new_payload(payload, wait_for_persistence, wait_for_caches, None)
             .await
             .map_err(EngineApiError::from)?;
         Ok(RethPayloadStatus {


### PR DESCRIPTION
Allows reth-bb to supply RLP-encoded BAL bytes alongside reth_newPayload instead of embedding them in the payload. This keeps replay payload bytes and block hashes untouched while still giving validation and prewarming access to the BAL data they need.

Threads the OOB BAL through the RethNewPayload message path, decodes it before payload validation, and prefers it over the payload's inline BAL when present. Normal reth_ payload handling passes None, so standard node behavior continues to read BALs from the payload unchanged.