### PR TITLE
feat(engine): handle canonical ancestor forkchoice updates

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -36,6 +36,11 @@ pub const DEFAULT_SPARSE_TRIE_PRUNE_DEPTH: usize = 4;
 /// Default timeout for the state root task before spawning a sequential fallback.
 pub const DEFAULT_STATE_ROOT_TASK_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Default maximum depth for canonical chain reorgs requested through forkchoice updates.
+///
+/// This matches Geth's default. A value of zero disables the limit.
+pub const DEFAULT_MAX_REORG_DEPTH: u64 = 32;
+
 const DEFAULT_BLOCK_BUFFER_LIMIT: u32 = EPOCH_SLOTS as u32 * 2;
 const DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH: u32 = 256;
 const DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE: usize = 4;
@@ -154,6 +159,8 @@ pub struct TreeConfig {
     always_process_payload_attributes_on_canonical_head: bool,
     /// Whether to unwind canonical header to ancestor during forkchoice updates.
     allow_unwind_canonical_header: bool,
+    /// Maximum canonical chain reorg depth. A value of zero disables the limit.
+    max_reorg_depth: u64,
     /// Whether to disable cache metrics recording (can be expensive with large cached state).
     disable_cache_metrics: bool,
     /// Depth for sparse trie pruning after state root computation.
@@ -228,6 +235,7 @@ impl Default for TreeConfig {
             state_root_fallback: false,
             always_process_payload_attributes_on_canonical_head: false,
             allow_unwind_canonical_header: false,
+            max_reorg_depth: DEFAULT_MAX_REORG_DEPTH,
             disable_cache_metrics: false,
             sparse_trie_prune_depth: DEFAULT_SPARSE_TRIE_PRUNE_DEPTH,
             slow_block_threshold: None,
@@ -301,6 +309,7 @@ impl TreeConfig {
             state_root_fallback,
             always_process_payload_attributes_on_canonical_head,
             allow_unwind_canonical_header,
+            max_reorg_depth: DEFAULT_MAX_REORG_DEPTH,
             disable_cache_metrics,
             sparse_trie_prune_depth,
             slow_block_threshold,
@@ -431,6 +440,13 @@ impl TreeConfig {
     /// Returns true if canonical header should be unwound to ancestor during forkchoice updates.
     pub const fn unwind_canonical_header(&self) -> bool {
         self.allow_unwind_canonical_header
+    }
+
+    /// Returns the maximum canonical chain reorg depth.
+    ///
+    /// A value of zero disables the limit.
+    pub const fn max_reorg_depth(&self) -> u64 {
+        self.max_reorg_depth
     }
 
     /// Setter for persistence threshold.
@@ -584,6 +600,14 @@ impl TreeConfig {
     /// Setter for whether to unwind canonical header to ancestor during forkchoice updates.
     pub const fn with_unwind_canonical_header(mut self, unwind_canonical_header: bool) -> Self {
         self.allow_unwind_canonical_header = unwind_canonical_header;
+        self
+    }
+
+    /// Sets the maximum canonical chain reorg depth.
+    ///
+    /// A value of zero disables the limit.
+    pub const fn with_max_reorg_depth(mut self, max_reorg_depth: u64) -> Self {
+        self.max_reorg_depth = max_reorg_depth;
         self
     }
 

--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -33,6 +33,9 @@ pub enum BeaconForkChoiceUpdateError {
     /// Thrown when a forkchoice update resulted in an error.
     #[error("forkchoice update error: {0}")]
     ForkchoiceUpdateError(#[from] ForkchoiceUpdateError),
+    /// Thrown when the requested canonical chain reorg exceeds the configured depth limit.
+    #[error("too deep reorg")]
+    TooDeepReorg,
     /// Thrown when the engine task is unavailable/stopped.
     #[error("beacon consensus engine task stopped")]
     EngineUnavailable,

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -4,8 +4,8 @@ use crate::{
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_engine::{
-    ExecutionData, ForkChoiceUpdateResult, ForkchoiceState, ForkchoiceUpdateError,
-    ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
+    ExecutionData, ForkchoiceState, ForkchoiceUpdateError, ForkchoiceUpdated, PayloadId,
+    PayloadStatus, PayloadStatusEnum,
 };
 use core::{
     fmt::{self, Display},
@@ -19,6 +19,8 @@ use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadTypes;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
+
+type ForkChoiceUpdateResult = Result<ForkchoiceUpdated, BeaconForkChoiceUpdateError>;
 
 /// Type alias for backwards compat
 #[deprecated(note = "Use ConsensusEngineHandle instead")]
@@ -79,7 +81,20 @@ impl OnForkChoiceUpdated {
     pub fn invalid_state() -> Self {
         Self {
             forkchoice_status: ForkchoiceStatus::Invalid,
-            fut: Either::Left(futures::future::ready(Err(ForkchoiceUpdateError::InvalidState))),
+            fut: Either::Left(futures::future::ready(Err(
+                ForkchoiceUpdateError::InvalidState.into()
+            ))),
+        }
+    }
+
+    /// Creates a new instance of `OnForkChoiceUpdated` if the requested reorg exceeds the
+    /// configured depth limit.
+    pub fn too_deep_reorg() -> Self {
+        Self {
+            forkchoice_status: ForkchoiceStatus::Invalid,
+            fut: Either::Left(futures::future::ready(Err(
+                BeaconForkChoiceUpdateError::TooDeepReorg,
+            ))),
         }
     }
 
@@ -90,7 +105,7 @@ impl OnForkChoiceUpdated {
             // This is valid because this is only reachable if the state and payload is valid
             forkchoice_status: ForkchoiceStatus::Valid,
             fut: Either::Left(futures::future::ready(Err(
-                ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes,
+                ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes.into(),
             ))),
         }
     }
@@ -139,7 +154,7 @@ impl Future for PendingPayloadId {
             })),
             Err(_) | Ok(Err(_)) => {
                 // failed to initiate a payload build job
-                Poll::Ready(Err(ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes))
+                Poll::Ready(Err(ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes.into()))
             }
         }
     }
@@ -370,12 +385,11 @@ where
         state: ForkchoiceState,
         payload_attrs: Option<Payload::PayloadAttributes>,
     ) -> Result<ForkchoiceUpdated, BeaconForkChoiceUpdateError> {
-        Ok(self
-            .send_fork_choice_updated(state, payload_attrs)
+        self.send_fork_choice_updated(state, payload_attrs)
             .map_err(|_| BeaconForkChoiceUpdateError::EngineUnavailable)
             .await?
             .map_err(BeaconForkChoiceUpdateError::internal)?
-            .await?)
+            .await
     }
 
     /// Sends a forkchoice update message to the beacon consensus engine and returns the receiver to

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1018,9 +1018,6 @@ where
         let new_head_number = canonical_header.number();
         let new_head_hash = canonical_header.hash();
 
-        // Update tree state with the new canonical head
-        self.state.tree_state.set_canonical_head(canonical_header.num_hash());
-
         // Handle the state update based on whether this is an unwind scenario
         if new_head_number < current_head_number {
             debug!(
@@ -1040,14 +1037,16 @@ where
                 new_head_hash = ?new_head_hash,
                 "Advancing latest block to canonical ancestor"
             );
-            self.handle_chain_advance_or_same_height(canonical_header)
+            self.handle_chain_advance_or_same_height(canonical_header)?;
+            self.state.tree_state.set_canonical_head(canonical_header.num_hash());
+            Ok(())
         }
     }
 
     /// Handles chain unwind scenarios by collecting blocks to remove and performing an unwind back
     /// to the canonical header
     fn handle_canonical_chain_unwind(
-        &self,
+        &mut self,
         current_head_number: u64,
         canonical_header: &SealedHeader<N::BlockHeader>,
     ) -> ProviderResult<()> {
@@ -1100,7 +1099,7 @@ where
 
     /// Applies the canonical ancestor block via a reorg operation.
     fn apply_canonical_ancestor_via_reorg(
-        &self,
+        &mut self,
         canonical_header: &SealedHeader<N::BlockHeader>,
         old_blocks: Vec<ExecutedBlock<N>>,
     ) -> ProviderResult<()> {
@@ -1109,13 +1108,10 @@ where
 
         // Load the canonical ancestor's block
         let executed_block = self.canonical_block_by_hash(new_head_hash)?;
-        // Perform the reorg to properly handle the unwind
-        self.canonical_in_memory_state
-            .update_chain(NewCanonicalChain::Reorg { new: vec![executed_block], old: old_blocks });
-
-        // CRITICAL: Update the canonical head after the reorg
-        // This ensures get_canonical_head() returns the correct block
-        self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
+        self.on_canonical_chain_update(NewCanonicalChain::Reorg {
+            new: vec![executed_block],
+            old: old_blocks,
+        });
 
         debug!(
             target: "engine::tree",
@@ -1311,42 +1307,63 @@ where
         attrs: &Option<T::PayloadAttributes>,
     ) -> ProviderResult<Option<TreeOutcome<OnForkChoiceUpdated>>> {
         // Check if the head is already part of the canonical chain
-        if let Ok(Some(canonical_header)) = self.find_canonical_header(state.head_block_hash) {
+        if let Some(canonical_header) = self.find_canonical_header(state.head_block_hash)? {
             debug!(target: "engine::tree", head = canonical_header.number(), "fcu head block is already canonical");
 
             // For OpStack, or if explicitly configured, the proposers are allowed to reorg their
             // own chain at will, so we need to always trigger a new payload job if requested.
-            if self.engine_kind.is_opstack() ||
-                self.config.always_process_payload_attributes_on_canonical_head()
-            {
+            let always_trigger_payload_job = self.engine_kind.is_opstack() ||
+                self.config.always_process_payload_attributes_on_canonical_head();
+
+            if !always_trigger_payload_job {
+                // A finalized canonical ancestor is already valid. The Engine API permits
+                // returning it without changing forkchoice state or starting a payload build.
+                if self
+                    .canonical_in_memory_state
+                    .get_finalized_num_hash()
+                    .is_some_and(|finalized| canonical_header.number() <= finalized.number)
+                {
+                    return Ok(Some(Self::valid_outcome(state)))
+                }
+
+                if !self.forkchoice_state_is_consistent_with_head(state, &canonical_header)? {
+                    return Ok(Some(TreeOutcome::new(OnForkChoiceUpdated::invalid_state())))
+                }
+
+                let reorg_depth = self
+                    .state
+                    .tree_state
+                    .canonical_block_number()
+                    .saturating_sub(canonical_header.number());
+                let max_reorg_depth = self.config.max_reorg_depth();
+                if max_reorg_depth != 0 && reorg_depth > max_reorg_depth {
+                    return Ok(Some(TreeOutcome::new(OnForkChoiceUpdated::too_deep_reorg())))
+                }
+            }
+
+            if !always_trigger_payload_job || self.config.unwind_canonical_header() {
                 // We need to effectively unwind the _canonical_ chain to the FCU's head, which is
                 // part of the canonical chain. We need to update the latest block state to reflect
                 // the canonical ancestor. This ensures that state providers and the transaction
                 // pool operate with the correct chain state after forkchoice update processing, and
                 // new payloads built on the reorg'd head will be added to the tree immediately.
-                if self.config.unwind_canonical_header() {
-                    self.update_latest_block_to_canonical_ancestor(&canonical_header)?;
-                }
+                self.update_latest_block_to_canonical_ancestor(&canonical_header)?;
 
-                if let Some(attr) = attrs {
-                    debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
-                    // Clone only when we actually need to process the attributes
-                    let updated =
-                        self.process_payload_attributes(attr.clone(), &canonical_header, state);
-                    return Ok(Some(TreeOutcome::new(updated)));
+                if !always_trigger_payload_job &&
+                    let Err(outcome) = self.ensure_consistent_forkchoice_state(state)
+                {
+                    return Ok(Some(TreeOutcome::new(outcome)))
                 }
             }
 
-            // According to the Engine API specification, client software MAY skip an update of the
-            // forkchoice state and MUST NOT begin a payload build process if
-            // `forkchoiceState.headBlockHash` references a `VALID` ancestor of the head
-            // of canonical chain, i.e. the ancestor passed payload validation process
-            // and deemed `VALID`. In the case of such an event, client software MUST
-            // return `{payloadStatus: {status: VALID, latestValidHash:
-            // forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`
+            if let Some(attr) = attrs {
+                debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
+                // Clone only when we actually need to process the attributes
+                let updated =
+                    self.process_payload_attributes(attr.clone(), &canonical_header, state);
+                return Ok(Some(TreeOutcome::new(updated)))
+            }
 
-            // The head block is already canonical and we're not processing payload attributes,
-            // so we're not triggering a payload job and can return right away
             return Ok(Some(Self::valid_outcome(state)));
         }
 
@@ -1371,6 +1388,27 @@ where
         }
 
         Ok(None)
+    }
+
+    /// Returns whether the safe and finalized hashes belong to the canonical chain at or below
+    /// `head`.
+    fn forkchoice_state_is_consistent_with_head(
+        &self,
+        state: ForkchoiceState,
+        head: &SealedHeader<N::BlockHeader>,
+    ) -> ProviderResult<bool> {
+        for hash in [state.finalized_block_hash, state.safe_block_hash] {
+            if hash.is_zero() {
+                continue
+            }
+
+            let Some(header) = self.find_canonical_header(hash)? else { return Ok(false) };
+            if header.number() > head.number() {
+                return Ok(false)
+            }
+        }
+
+        Ok(true)
     }
 
     /// Handles the case where the head block is missing and needs to be downloaded.
@@ -3194,13 +3232,18 @@ where
         &self,
         hash: B256,
     ) -> Result<Option<SealedHeader<N::BlockHeader>>, ProviderError> {
-        let mut canonical = self.canonical_in_memory_state.header_by_hash(hash);
-
-        if canonical.is_none() {
-            canonical = self.provider.header(hash)?.map(|header| SealedHeader::new(header, hash));
+        if let Some(header) = self.canonical_in_memory_state.header_by_hash(hash) {
+            return Ok(Some(header))
         }
 
-        Ok(canonical)
+        let Some(header) = self.provider.header(hash)? else { return Ok(None) };
+        let canonical_hash = self
+            .canonical_in_memory_state
+            .hash_by_number(header.number())
+            .map(Some)
+            .unwrap_or(self.provider.block_hash(header.number())?);
+
+        Ok((canonical_hash == Some(hash)).then(|| SealedHeader::new(header, hash)))
     }
 
     /// Updates the tracked finalized block if we have it.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -17,11 +17,14 @@ use alloy_primitives::{
 use alloy_rlp::Decodable;
 use alloy_rpc_types_engine::{
     ExecutionData, ExecutionPayloadSidecar, ExecutionPayloadV1, ForkchoiceState,
+    ForkchoiceUpdateError,
 };
 use assert_matches::assert_matches;
 use reth_chain_state::{test_utils::TestBlockBuilder, BlockState};
 use reth_chainspec::{ChainSpec, HOLESKY, MAINNET};
-use reth_engine_primitives::{EngineApiValidator, ForkchoiceStatus, NoopInvalidBlockHook};
+use reth_engine_primitives::{
+    BeaconForkChoiceUpdateError, EngineApiValidator, ForkchoiceStatus, NoopInvalidBlockHook,
+};
 use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_ethereum_engine_primitives::{EthEngineTypes, EthPayloadAttributes};
 use reth_ethereum_primitives::{Block, EthPrimitives};
@@ -1304,18 +1307,11 @@ async fn test_engine_tree_live_sync_transition_required_blocks_requested() {
 
 #[tokio::test]
 async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
-    // Test for issue where FCU with canonical ancestor doesn't update Latest block state
-    // This was causing "nonce too low" errors when discard_reorged_transactions is enabled
-
     reth_tracing::init_test_tracing();
     let chain_spec = MAINNET.clone();
 
-    // Create test harness
-    let mut test_harness = TestHarness::new(chain_spec.clone());
-
-    // Set engine kind to OpStack and enable unwind_canonical_header to ensure the fix is triggered
-    test_harness.tree.engine_kind = EngineApiKind::OpStack;
-    test_harness.tree.config = test_harness.tree.config.clone().with_unwind_canonical_header(true);
+    let config = TreeConfig::default().with_has_enough_parallelism(true).with_max_reorg_depth(2);
+    let mut test_harness = TestHarness::with_config(chain_spec.clone(), config);
     let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
 
     // Create a chain of blocks
@@ -1334,6 +1330,8 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
 
     // Now perform FCU to a canonical ancestor (block 2)
     let ancestor_block = blocks[1].recovered_block().clone(); // Block 2 (0-indexed as blocks[1])
+    let mut canonical_state_notifications =
+        test_harness.tree.canonical_in_memory_state.subscribe_canon_state();
 
     // Send FCU to the canonical ancestor
     let (tx, rx) = oneshot::channel();
@@ -1381,6 +1379,198 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
         ancestor_block.hash(),
         "In-memory state: Latest block hash should be updated to canonical ancestor"
     );
+
+    let notification = canonical_state_notifications.recv().await.unwrap();
+    assert!(notification.reverted().is_some());
+}
+
+#[tokio::test]
+async fn test_opstack_fcu_with_canonical_ancestor_keeps_existing_behavior() {
+    let chain_spec = MAINNET.clone();
+    let config = TreeConfig::default()
+        .with_has_enough_parallelism(true)
+        .with_unwind_canonical_header(true)
+        .with_max_reorg_depth(1);
+    let mut test_harness = TestHarness::with_config(chain_spec.clone(), config);
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+    test_harness.tree.engine_kind = EngineApiKind::OpStack;
+
+    let ancestor = blocks[0].recovered_block();
+    let outcome = test_harness
+        .tree
+        .on_forkchoice_updated(
+            ForkchoiceState {
+                head_block_hash: ancestor.hash(),
+                safe_block_hash: B256::ZERO,
+                finalized_block_hash: B256::ZERO,
+            },
+            None,
+        )
+        .unwrap()
+        .outcome
+        .await
+        .unwrap();
+
+    assert!(outcome.payload_status.is_valid());
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), ancestor.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        ancestor.hash()
+    );
+}
+
+#[tokio::test]
+async fn test_fcu_with_finalized_canonical_ancestor_is_noop() {
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+
+    let current_head = blocks[3].recovered_block();
+    let finalized = blocks[1].recovered_block();
+    let ancestor = blocks[0].recovered_block();
+    test_harness.tree.canonical_in_memory_state.set_finalized(finalized.clone_sealed_header());
+    for head in [finalized, ancestor] {
+        let payload_attributes = EthPayloadAttributes {
+            timestamp: head.timestamp() + 1,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: Default::default(),
+            withdrawals: None,
+            parent_beacon_block_root: None,
+            slot_number: None,
+            target_gas_limit: None,
+        };
+
+        let outcome = test_harness
+            .tree
+            .on_forkchoice_updated(
+                ForkchoiceState {
+                    head_block_hash: head.hash(),
+                    safe_block_hash: head.hash(),
+                    finalized_block_hash: head.hash(),
+                },
+                Some(payload_attributes),
+            )
+            .unwrap()
+            .outcome
+            .await
+            .unwrap();
+
+        assert!(outcome.payload_status.is_valid());
+        assert!(outcome.payload_id.is_none());
+    }
+
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), current_head.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_finalized_num_hash(),
+        Some(finalized.num_hash())
+    );
+    assert!(test_harness.payload_command_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn test_fcu_rejects_reorg_beyond_depth_limit_atomically() {
+    let chain_spec = MAINNET.clone();
+    let config = TreeConfig::default().with_has_enough_parallelism(true).with_max_reorg_depth(2);
+    let mut test_harness = TestHarness::with_config(chain_spec.clone(), config);
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+
+    let current_head = blocks[3].recovered_block();
+    let ancestor = blocks[0].recovered_block();
+    let state = ForkchoiceState {
+        head_block_hash: ancestor.hash(),
+        safe_block_hash: B256::ZERO,
+        finalized_block_hash: B256::ZERO,
+    };
+    let err =
+        test_harness.tree.on_forkchoice_updated(state, None).unwrap().outcome.await.unwrap_err();
+
+    assert_matches!(err, BeaconForkChoiceUpdateError::TooDeepReorg);
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), current_head.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        current_head.hash()
+    );
+
+    test_harness.tree.config = test_harness.tree.config.clone().with_max_reorg_depth(0);
+    let outcome =
+        test_harness.tree.on_forkchoice_updated(state, None).unwrap().outcome.await.unwrap();
+    assert!(outcome.payload_status.is_valid());
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), ancestor.hash());
+}
+
+#[tokio::test]
+async fn test_fcu_rejects_inconsistent_ancestor_state_atomically() {
+    let chain_spec = MAINNET.clone();
+    let config = TreeConfig::default().with_has_enough_parallelism(true).with_max_reorg_depth(1);
+    let mut test_harness = TestHarness::with_config(chain_spec.clone(), config);
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+
+    let current_head = blocks[3].recovered_block();
+    let ancestor = blocks[1].recovered_block();
+    let marker = blocks[2].recovered_block().hash();
+    for (safe_block_hash, finalized_block_hash) in [(marker, B256::ZERO), (B256::ZERO, marker)] {
+        let err = test_harness
+            .tree
+            .on_forkchoice_updated(
+                ForkchoiceState {
+                    head_block_hash: ancestor.hash(),
+                    safe_block_hash,
+                    finalized_block_hash,
+                },
+                None,
+            )
+            .unwrap()
+            .outcome
+            .await
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            BeaconForkChoiceUpdateError::ForkchoiceUpdateError(ForkchoiceUpdateError::InvalidState)
+        );
+    }
+
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), current_head.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        current_head.hash()
+    );
+}
+
+#[test]
+fn test_find_canonical_header_verifies_provider_header() {
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..4).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+
+    let canonical = blocks[1].recovered_block();
+    let persisted_only = TestHarness::new(chain_spec).with_blocks(blocks.clone());
+    persisted_only.tree.canonical_in_memory_state.clear_state();
+    assert_eq!(
+        persisted_only.tree.find_canonical_header(canonical.hash()).unwrap(),
+        Some(canonical.clone_sealed_header())
+    );
+
+    let mut stale_header = canonical.clone_sealed_header().clone_header();
+    stale_header.extra_data = Bytes::from_static(b"stale");
+    let stale_header = SealedHeader::seal_slow(stale_header);
+    test_harness.provider.add_header(stale_header.hash(), stale_header.clone_header());
+
+    assert_eq!(
+        test_harness.tree.find_canonical_header(canonical.hash()).unwrap(),
+        Some(canonical.clone_sealed_header())
+    );
+    assert!(test_harness.tree.find_canonical_header(stale_header.hash()).unwrap().is_none());
 }
 
 /// Test that verifies the happy path where a new payload extends the canonical chain

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -7,8 +7,8 @@ use clap::{
 use eyre::ensure;
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
 use reth_engine_primitives::{
-    TreeConfig, DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
-    DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+    TreeConfig, DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD, DEFAULT_MAX_REORG_DEPTH,
+    DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE, DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -43,6 +43,7 @@ pub struct DefaultEngineValues {
     state_root_fallback: bool,
     always_process_payload_attributes_on_canonical_head: bool,
     allow_unwind_canonical_header: bool,
+    max_reorg_depth: u64,
     storage_worker_count: Option<usize>,
     account_worker_count: Option<usize>,
     prewarming_threads: Option<usize>,
@@ -179,6 +180,12 @@ impl DefaultEngineValues {
         self
     }
 
+    /// Set the maximum canonical chain reorg depth
+    pub const fn with_max_reorg_depth(mut self, v: u64) -> Self {
+        self.max_reorg_depth = v;
+        self
+    }
+
     /// Set the default storage worker count
     pub const fn with_storage_worker_count(mut self, v: Option<usize>) -> Self {
         self.storage_worker_count = v;
@@ -273,6 +280,7 @@ impl Default for DefaultEngineValues {
             state_root_fallback: false,
             always_process_payload_attributes_on_canonical_head: false,
             allow_unwind_canonical_header: false,
+            max_reorg_depth: DEFAULT_MAX_REORG_DEPTH,
             storage_worker_count: None,
             account_worker_count: None,
             prewarming_threads: None,
@@ -437,6 +445,10 @@ pub struct EngineArgs {
     #[arg(long = "engine.allow-unwind-canonical-header", default_value_t = DefaultEngineValues::get_global().allow_unwind_canonical_header)]
     pub allow_unwind_canonical_header: bool,
 
+    /// Maximum canonical chain reorg depth. Set to zero to disable the limit.
+    #[arg(long = "engine.max-reorg-depth", default_value_t = DefaultEngineValues::get_global().max_reorg_depth)]
+    pub max_reorg_depth: u64,
+
     /// Configure the number of storage proof workers in the Tokio blocking pool.
     /// If not specified, defaults to 2x available parallelism.
     #[arg(long = "engine.storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_count.map(|v| v.to_string().into())))]
@@ -579,6 +591,7 @@ impl Default for EngineArgs {
             state_root_fallback,
             always_process_payload_attributes_on_canonical_head,
             allow_unwind_canonical_header,
+            max_reorg_depth,
             storage_worker_count,
             account_worker_count,
             prewarming_threads,
@@ -616,6 +629,7 @@ impl Default for EngineArgs {
             state_root_fallback,
             always_process_payload_attributes_on_canonical_head,
             allow_unwind_canonical_header,
+            max_reorg_depth,
             storage_worker_count,
             account_worker_count,
             prewarming_threads,
@@ -705,6 +719,7 @@ impl EngineArgs {
                 self.always_process_payload_attributes_on_canonical_head,
             )
             .with_unwind_canonical_header(self.allow_unwind_canonical_header)
+            .with_max_reorg_depth(self.max_reorg_depth)
             .without_cache_metrics(self.cache_metrics_disabled)
             .with_slow_block_threshold(self.slow_block_threshold)
             .with_disable_sparse_trie_cache_pruning(self.disable_sparse_trie_cache_pruning)
@@ -865,6 +880,7 @@ mod tests {
             state_root_fallback: true,
             always_process_payload_attributes_on_canonical_head: true,
             allow_unwind_canonical_header: true,
+            max_reorg_depth: 5,
             storage_worker_count: Some(16),
             account_worker_count: Some(8),
             prewarming_threads: Some(4),
@@ -909,6 +925,8 @@ mod tests {
             "--engine.state-root-fallback",
             "--engine.always-process-payload-attributes-on-canonical-head",
             "--engine.allow-unwind-canonical-header",
+            "--engine.max-reorg-depth",
+            "5",
             "--engine.storage-worker-count",
             "16",
             "--engine.account-worker-count",

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -20,9 +20,13 @@ pub const UNSUPPORTED_FORK_CODE: i32 = -38005;
 pub const UNKNOWN_PAYLOAD_CODE: i32 = -38001;
 /// Request too large error code.
 pub const REQUEST_TOO_LARGE_CODE: i32 = -38004;
+/// Requested forkchoice reorg exceeds the configured depth limit.
+pub const TOO_DEEP_REORG_CODE: i32 = -38006;
 
 /// Error message for the request too large error.
 const REQUEST_TOO_LARGE_MESSAGE: &str = "Too large request";
+/// Error message for a forkchoice reorg that exceeds the configured depth limit.
+const TOO_DEEP_REORG_MESSAGE: &str = "Too deep reorg";
 
 /// Error returned by [`EngineApi`][crate::EngineApi]
 ///
@@ -205,6 +209,13 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                         );
                     }
                 },
+                BeaconForkChoiceUpdateError::TooDeepReorg => {
+                    jsonrpsee_types::error::ErrorObject::owned(
+                        TOO_DEEP_REORG_CODE,
+                        TOO_DEEP_REORG_MESSAGE,
+                        None::<()>,
+                    )
+                }
                 BeaconForkChoiceUpdateError::EngineUnavailable |
                 BeaconForkChoiceUpdateError::Internal(_) => {
                     jsonrpsee_types::error::ErrorObject::owned(
@@ -277,6 +288,12 @@ mod tests {
             EngineApiError::ForkChoiceUpdate(BeaconForkChoiceUpdateError::ForkchoiceUpdateError(
                 ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes,
             )),
+        );
+
+        ensure_engine_rpc_error(
+            TOO_DEEP_REORG_CODE,
+            TOO_DEEP_REORG_MESSAGE,
+            EngineApiError::ForkChoiceUpdate(BeaconForkChoiceUpdateError::TooDeepReorg),
         );
 
         ensure_engine_rpc_error(

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1059,6 +1059,11 @@ Engine:
       --engine.allow-unwind-canonical-header
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
+      --engine.max-reorg-depth <MAX_REORG_DEPTH>
+          Maximum canonical chain reorg depth. Set to zero to disable the limit
+
+          [default: 32]
+
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
           Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
 


### PR DESCRIPTION
Implements https://github.com/ethereum/execution-apis/pull/786 by applying canonical-ancestor forkchoice updates above the latest finalized block and returning -38006: Too deep reorg when they exceed the configured depth. Keeps finalized-prefix replay as a VALID no-op, validates safe/finalized ancestry before mutation, and preserves OpStack behavior.