### PR TITLE
refactor(metrics): extract `VersionInfo::from_reth_metadata()` helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9319,6 +9319,7 @@ dependencies = [
  "reqwest 0.13.2",
  "reth-fs-util",
  "reth-metrics",
+ "reth-node-core",
  "reth-tasks",
  "socket2",
  "tempfile",

--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -8,10 +8,7 @@ use reth_db_api::{
     transaction::{DbTx, DbTxMut},
 };
 use reth_db_common::DbTool;
-use reth_node_core::{
-    dirs::{ChainPath, DataDirPath},
-    version::version_metadata,
-};
+use reth_node_core::dirs::{ChainPath, DataDirPath};
 use reth_node_metrics::{
     chain::ChainSpecInfo,
     hooks::Hooks,
@@ -68,14 +65,7 @@ impl Command {
             let handle = task_executor.spawn_critical_task("metrics server", async move {
                 let config = MetricServerConfig::new(
                     listen_addr,
-                    VersionInfo {
-                        version: version_metadata().cargo_pkg_version.as_ref(),
-                        build_timestamp: version_metadata().vergen_build_timestamp.as_ref(),
-                        cargo_features: version_metadata().vergen_cargo_features.as_ref(),
-                        git_sha: version_metadata().vergen_git_sha.as_ref(),
-                        target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
-                        build_profile: version_metadata().build_profile_name.as_ref(),
-                    },
+                    VersionInfo::from_reth_metadata(),
                     ChainSpecInfo { name: chain_name },
                     executor,
                     Hooks::builder().build(),

--- a/crates/cli/commands/src/prune.rs
+++ b/crates/cli/commands/src/prune.rs
@@ -6,7 +6,7 @@ use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
 use reth_cli_util::cancellation::CancellationToken;
 use reth_node_builder::common::metrics_hooks;
-use reth_node_core::{args::MetricArgs, version::version_metadata};
+use reth_node_core::args::MetricArgs;
 use reth_node_metrics::{
     chain::ChainSpecInfo,
     server::{MetricServer, MetricServerConfig},
@@ -43,14 +43,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> PruneComma
         if let Some(listen_addr) = self.metrics.prometheus {
             let config = MetricServerConfig::new(
                 listen_addr,
-                VersionInfo {
-                    version: version_metadata().cargo_pkg_version.as_ref(),
-                    build_timestamp: version_metadata().vergen_build_timestamp.as_ref(),
-                    cargo_features: version_metadata().vergen_cargo_features.as_ref(),
-                    git_sha: version_metadata().vergen_git_sha.as_ref(),
-                    target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
-                    build_profile: version_metadata().build_profile_name.as_ref(),
-                },
+                VersionInfo::from_reth_metadata(),
                 ChainSpecInfo { name: provider_factory.chain_spec().chain().to_string() },
                 ctx.task_executor.clone(),
                 metrics_hooks(&provider_factory),

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -19,10 +19,7 @@ use reth_exex::ExExManagerHandle;
 use reth_network::BlockDownloaderProvider;
 use reth_network_p2p::HeadersClient;
 use reth_node_builder::common::metrics_hooks;
-use reth_node_core::{
-    args::{NetworkArgs, StageEnum},
-    version::version_metadata,
-};
+use reth_node_core::args::{NetworkArgs, StageEnum};
 use reth_node_metrics::{
     chain::ChainSpecInfo,
     server::{MetricServer, MetricServerConfig},
@@ -130,14 +127,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         if let Some(listen_addr) = self.metrics {
             let config = MetricServerConfig::new(
                 listen_addr,
-                VersionInfo {
-                    version: version_metadata().cargo_pkg_version.as_ref(),
-                    build_timestamp: version_metadata().vergen_build_timestamp.as_ref(),
-                    cargo_features: version_metadata().vergen_cargo_features.as_ref(),
-                    git_sha: version_metadata().vergen_git_sha.as_ref(),
-                    target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
-                    build_profile: version_metadata().build_profile_name.as_ref(),
-                },
+                VersionInfo::from_reth_metadata(),
                 ChainSpecInfo { name: provider_factory.chain_spec().chain().to_string() },
                 ctx.task_executor,
                 metrics_hooks(&provider_factory),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -55,7 +55,6 @@ use reth_node_core::{
     dirs::{ChainPath, DataDirPath},
     node_config::NodeConfig,
     primitives::BlockHeader,
-    version::version_metadata,
 };
 use reth_node_metrics::{
     chain::ChainSpecInfo,
@@ -634,14 +633,7 @@ where
         if let Some(addr) = listen_addr {
             let config = MetricServerConfig::new(
                 addr,
-                VersionInfo {
-                    version: version_metadata().cargo_pkg_version.as_ref(),
-                    build_timestamp: version_metadata().vergen_build_timestamp.as_ref(),
-                    cargo_features: version_metadata().vergen_cargo_features.as_ref(),
-                    git_sha: version_metadata().vergen_git_sha.as_ref(),
-                    target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
-                    build_profile: version_metadata().build_profile_name.as_ref(),
-                },
+                VersionInfo::from_reth_metadata(),
                 ChainSpecInfo { name: self.chain_id().to_string() },
                 self.task_executor().clone(),
                 metrics_hooks(self.provider_factory()),

--- a/crates/node/metrics/Cargo.toml
+++ b/crates/node/metrics/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 reth-metrics.workspace = true
+reth-node-core.workspace = true
 reth-tasks.workspace = true
 
 metrics.workspace = true

--- a/crates/node/metrics/src/version.rs
+++ b/crates/node/metrics/src/version.rs
@@ -1,5 +1,6 @@
 //! This exposes reth's version information over prometheus.
 use metrics::gauge;
+use reth_node_core::version::version_metadata;
 
 /// Contains version information for the application.
 #[derive(Debug, Clone)]
@@ -19,6 +20,18 @@ pub struct VersionInfo {
 }
 
 impl VersionInfo {
+    /// Creates a new [`VersionInfo`] from the reth version metadata.
+    pub fn from_reth_metadata() -> Self {
+        Self {
+            version: version_metadata().cargo_pkg_version.as_ref(),
+            build_timestamp: version_metadata().vergen_build_timestamp.as_ref(),
+            cargo_features: version_metadata().vergen_cargo_features.as_ref(),
+            git_sha: version_metadata().vergen_git_sha.as_ref(),
+            target_triple: version_metadata().vergen_cargo_target_triple.as_ref(),
+            build_profile: version_metadata().build_profile_name.as_ref(),
+        }
+    }
+
     /// This exposes reth's version information over prometheus.
     pub fn register_version_metrics(&self) {
         let labels: [(&str, &str); 6] = [


### PR DESCRIPTION
Consolidates duplicate `VersionInfo` construction from 4 locations into a single `VersionInfo::from_reth_metadata()` method in `reth-node-metrics`. Net reduction of ~20 lines.