### PR TITLE
perf(provider): stream rocksdb history reverts

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -24,6 +24,7 @@ use reth_storage_errors::{
     db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation, LogLevel},
     provider::{ProviderError, ProviderResult},
 };
+use revm_database::states::reverts::AccountInfoRevert;
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
     DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
@@ -1393,13 +1394,15 @@ impl RocksDBProvider {
 
         for (block_idx, block) in blocks.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let reverts = &block.execution_outcome().state.reverts;
 
             // Iterate through account reverts - these are exactly the accounts that have
             // changesets written, ensuring history indices match changeset entries.
-            for account_block_reverts in reverts.accounts {
-                for (address, _) in account_block_reverts {
-                    account_history.entry(address).or_default().push(block_number);
+            for transition in reverts.iter() {
+                for (address, revert) in transition {
+                    if !matches!(revert.account, AccountInfoRevert::DoNothing) {
+                        account_history.entry(*address).or_default().push(block_number);
+                    }
                 }
             }
         }
@@ -1426,18 +1429,15 @@ impl RocksDBProvider {
 
         for (block_idx, block) in blocks.iter().enumerate() {
             let block_number = ctx.first_block_number + block_idx as u64;
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let reverts = &block.execution_outcome().state.reverts;
 
             // Iterate through storage reverts - these are exactly the slots that have
             // changesets written, ensuring history indices match changeset entries.
-            for storage_block_reverts in reverts.storage {
-                for revert in storage_block_reverts {
-                    for (slot, _) in revert.storage_revert {
+            for transition in reverts.iter() {
+                for (address, revert) in transition {
+                    for (slot, _) in revert.storage.iter() {
                         let plain_key = B256::new(slot.to_be_bytes());
-                        storage_history
-                            .entry((revert.address, plain_key))
-                            .or_default()
-                            .push(block_number);
+                        storage_history.entry((*address, plain_key)).or_default().push(block_number);
                     }
                 }
             }


### PR DESCRIPTION
Walk bundle reverts directly when deriving RocksDB account and storage history shards.
This avoids materializing PlainStateReverts for the storage_v2 history path while leaving shard append behavior unchanged.