### PR TITLE
perf(provider): stream static-file changesets directly

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -47,6 +47,7 @@ use reth_storage_api::{
     StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult, StaticFileWriterError};
+use revm_database::states::reverts::AccountInfoRevert;
 use std::{
     collections::BTreeMap,
     fmt::Debug,
@@ -517,14 +518,36 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ) -> ProviderResult<()> {
         for block in blocks {
             let block_number = block.recovered_block().number();
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
+            let reverts = &block.execution_outcome().state.reverts;
+            let mut changeset = Vec::with_capacity(
+                reverts
+                    .iter()
+                    .map(|transition| {
+                        transition
+                            .iter()
+                            .filter(|(_, revert)| !matches!(revert.account, AccountInfoRevert::DoNothing))
+                            .count()
+                    })
+                    .sum(),
+            );
 
-            let changeset: Vec<_> = reverts
-                .accounts
-                .into_iter()
-                .flatten()
-                .map(|(address, info)| AccountBeforeTx { address, info: info.map(Into::into) })
-                .collect();
+            for transition in reverts.iter() {
+                for (address, revert) in transition {
+                    match &revert.account {
+                        AccountInfoRevert::RevertTo(info) => {
+                            changeset.push(AccountBeforeTx {
+                                address: *address,
+                                info: Some(info.clone().into()),
+                            });
+                        }
+                        AccountInfoRevert::DeleteIt => {
+                            changeset.push(AccountBeforeTx { address: *address, info: None });
+                        }
+                        AccountInfoRevert::DoNothing => {}
+                    }
+                }
+            }
+
             w.append_account_changeset(changeset, block_number)?;
         }
         Ok(())
@@ -538,22 +561,28 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     ) -> ProviderResult<()> {
         for block in blocks {
             let block_number = block.recovered_block().number();
-            let reverts = block.execution_outcome().state.reverts.to_plain_state_reverts();
-
-            let changeset: Vec<_> = reverts
-                .storage
-                .into_iter()
-                .flatten()
-                .flat_map(|revert| {
-                    revert.storage_revert.into_iter().map(move |(key, revert_to_slot)| {
-                        StorageBeforeTx {
-                            address: revert.address,
-                            key: B256::from(key.to_be_bytes()),
-                            value: revert_to_slot.to_previous_value(),
-                        }
+            let reverts = &block.execution_outcome().state.reverts;
+            let mut changeset = Vec::with_capacity(
+                reverts
+                    .iter()
+                    .map(|transition| {
+                        transition.iter().map(|(_, revert)| revert.storage.len()).sum::<usize>()
                     })
-                })
-                .collect();
+                    .sum(),
+            );
+
+            for transition in reverts.iter() {
+                for (address, revert) in transition {
+                    for (key, revert_to_slot) in revert.storage.iter() {
+                        changeset.push(StorageBeforeTx {
+                            address: *address,
+                            key: B256::from(key.to_be_bytes()),
+                            value: (*revert_to_slot).to_previous_value(),
+                        });
+                    }
+                }
+            }
+
             w.append_storage_changeset(changeset, block_number)?;
         }
         Ok(())


### PR DESCRIPTION
Build static-file account and storage changesets directly from bundle reverts instead of materializing PlainStateReverts first.
This keeps the storage_v2 static-file persistence path on a single flattening pass and avoids the intermediate account and storage revert vectors.