### PR TITLE
perf(trie): reuse proof_v2 dirty child masks

### DIFF
--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -1,4 +1,4 @@
-use crate::Nibbles;
+use crate::{Nibbles, TrieMask};
 use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::map::{B256Map, B256Set};
 use core::ops::Range;
@@ -254,6 +254,41 @@ impl PrefixSet {
         }
 
         false
+    }
+
+    /// Returns a mask of the immediate child nibbles that have at least one changed descendant
+    /// below `prefix`.
+    #[inline]
+    pub fn child_mask(&mut self, prefix: &Nibbles) -> TrieMask {
+        if prefix.len() >= 64 {
+            return TrieMask::default()
+        }
+
+        if self.all {
+            return TrieMask::new(u16::MAX)
+        }
+
+        while self.index > 0 && &self.keys[self.index] > prefix {
+            self.index -= 1;
+        }
+
+        let mut mask = TrieMask::default();
+        for (idx, key) in self.keys[self.index..].iter().enumerate() {
+            if key.starts_with(prefix) {
+                self.index += idx;
+                if key.len() > prefix.len() {
+                    mask.set_bit(key.get_unchecked(prefix.len()));
+                }
+                continue
+            }
+
+            if key > prefix {
+                self.index += idx;
+                break
+            }
+        }
+
+        mask
     }
 
     /// Returns an iterator over reference to _all_ nibbles regardless of cursor position.

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -867,17 +867,8 @@ where
             return false
         }
 
-        let mut num_unmatched = 0u32;
-        let mut child_path = *cached_path;
-        for nibble in 0u8..16 {
-            if cached_branch.state_mask.is_bit_set(nibble) {
-                child_path.truncate(cached_path.len());
-                child_path.push_unchecked(nibble);
-                if !self.prefix_set.contains(&child_path) {
-                    num_unmatched += 1;
-                }
-            }
-        }
+        let dirty_child_nibbles = self.prefix_set.child_mask(cached_path);
+        let num_unmatched = (cached_branch.state_mask & !dirty_child_nibbles).count_ones();
 
         if num_unmatched <= 1 {
             trace!(
@@ -1095,17 +1086,8 @@ where
             // under this branch). Skip nibbles already set in `curr_state_mask` since those
             // children have already been constructed.
             if self.prefix_set.contains(&self.branch_path) {
-                let branch_path_len = self.branch_path.len();
-                let mut child_path = self.branch_path;
-                for nibble in 0u8..16 {
-                    if !curr_state_mask.is_bit_set(nibble) {
-                        child_path.truncate(branch_path_len);
-                        child_path.push_unchecked(nibble);
-                        if self.prefix_set.contains(&child_path) {
-                            next_child_nibbles.set_bit(nibble);
-                        }
-                    }
-                }
+                next_child_nibbles |=
+                    self.prefix_set.child_mask(&self.branch_path) & !curr_state_mask;
             }
 
             let _orig_next_child_nibbles = next_child_nibbles;


### PR DESCRIPTION
Add a PrefixSet helper that derives the immediate dirty child mask for a branch in one scan. ProofCalculator now uses that mask instead of probing the prefix set once per child when deciding which cached branches to skip or recalculate.