### PR TITLE
perf(trie): specialize forward overlay cursor seeks

### DIFF
--- a/crates/trie/trie/src/forward_cursor.rs
+++ b/crates/trie/trie/src/forward_cursor.rs
@@ -44,13 +44,6 @@ impl<'a, K, V> ForwardInMemoryCursor<'a, K, V> {
     pub const fn reset(&mut self) {
         self.idx = 0;
     }
-
-    #[inline]
-    fn next(&mut self) -> Option<&(K, V)> {
-        let entry = self.entries.get(self.idx)?;
-        self.idx += 1;
-        Some(entry)
-    }
 }
 
 /// Threshold for remaining entries above which binary search is used instead of linear scan.
@@ -61,33 +54,38 @@ impl<K: Ord, V> ForwardInMemoryCursor<'_, K, V> {
     /// Returns the first entry from the current cursor position that's greater or equal to the
     /// provided key. This method advances the cursor forward.
     pub fn seek(&mut self, key: &K) -> Option<&(K, V)> {
-        self.advance_while(|k| k < key)
+        let slice = &self.entries[self.idx..];
+        if slice.len() >= BINARY_SEARCH_THRESHOLD {
+            self.idx += slice.partition_point(|(entry_key, _)| entry_key < key);
+        } else {
+            while self.idx < self.entries.len() {
+                let (entry_key, _) = &self.entries[self.idx];
+                if entry_key >= key {
+                    break;
+                }
+                self.idx += 1;
+            }
+        }
+
+        self.current()
     }
 
     /// Returns the first entry from the current cursor position that's greater than the provided
     /// key. This method advances the cursor forward.
     pub fn first_after(&mut self, key: &K) -> Option<&(K, V)> {
-        self.advance_while(|k| k <= key)
-    }
-
-    /// Advances the cursor forward while `predicate` returns `true` or until the collection is
-    /// exhausted.
-    ///
-    /// Uses binary search for large remaining slices (>= 64 entries), linear scan for small ones.
-    ///
-    /// Returns the first entry for which `predicate` returns `false` or `None`. The cursor will
-    /// point to the returned entry.
-    fn advance_while(&mut self, predicate: impl Fn(&K) -> bool) -> Option<&(K, V)> {
-        let remaining = self.entries.len().saturating_sub(self.idx);
-        if remaining >= BINARY_SEARCH_THRESHOLD {
-            let slice = &self.entries[self.idx..];
-            let pos = slice.partition_point(|(k, _)| predicate(k));
-            self.idx += pos;
+        let slice = &self.entries[self.idx..];
+        if slice.len() >= BINARY_SEARCH_THRESHOLD {
+            self.idx += slice.partition_point(|(entry_key, _)| entry_key <= key);
         } else {
-            while self.current().is_some_and(|(k, _)| predicate(k)) {
-                self.next();
+            while self.idx < self.entries.len() {
+                let (entry_key, _) = &self.entries[self.idx];
+                if entry_key > key {
+                    break;
+                }
+                self.idx += 1;
             }
         }
+
         self.current()
     }
 }


### PR DESCRIPTION
Inline the seek and first_after fast paths in ForwardInMemoryCursor so trie overlay lookups no longer route through a generic predicate helper.
This trims closure and Option churn in a profile-hot path used by in-memory trie and hashed-state cursors.