### PR TITLE
docs(engine): clarify BAL storage prefetch flag

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -191,9 +191,9 @@ pub struct TreeConfig {
     /// When disabled, the BAL hashed post state is not sent to the multiproof task for
     /// early parallel state root computation.
     disable_bal_parallel_state_root: bool,
-    /// Whether to disable BAL (Block Access List) batched IO during prewarming.
-    /// When disabled, falls back to individual per-slot storage reads instead of
-    /// batched cursor reads via `storage_range`.
+    /// Whether to disable BAL (Block Access List) storage prefetch IO during prewarming.
+    /// When set, BAL storage slots are not read into the execution cache. BAL hashed-state
+    /// streaming for parallel state-root computation is controlled separately.
     disable_bal_batch_io: bool,
     /// Maximum random jitter applied before each proof computation (trie-debug only).
     /// When set, each proof worker sleeps for a random duration up to this value

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -521,8 +521,8 @@ pub struct EngineArgs {
     #[arg(long = "engine.disable-bal-parallel-state-root", default_value_t = DefaultEngineValues::get_global().bal_parallel_state_root_disabled)]
     pub bal_parallel_state_root_disabled: bool,
 
-    /// Disable BAL (Block Access List) batched IO during prewarming. When set, falls back
-    /// to individual per-slot storage reads instead of batched cursor reads.
+    /// Disable BAL (Block Access List) storage prefetch IO during prewarming. When set, BAL
+    /// storage slots are not read into the execution cache.
     #[arg(long = "engine.disable-bal-batch-io", default_value_t = false)]
     pub disable_bal_batch_io: bool,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1090,7 +1090,7 @@ Engine:
           Disable BAL-driven parallel state root computation. When set, the BAL hashed post state is not sent to the multiproof task for early parallel state root computation
 
       --engine.disable-bal-batch-io
-          Disable BAL (Block Access List) batched IO during prewarming. When set, falls back to individual per-slot storage reads instead of batched cursor reads
+          Disable BAL (Block Access List) storage prefetch IO during prewarming. When set, BAL storage slots are not read into the execution cache
 
 ERA:
       --era.enable


### PR DESCRIPTION
Clarifies `--engine.disable-bal-batch-io` to say it disables BAL storage prefetch IO instead of falling back to per-slot storage reads.

The old wording made the flag sound like it only disabled a batching strategy while preserving BAL storage prewarming, which confused this clanker during review. The generated CLI docs were refreshed with `make update-book-cli`.
