### PR TITLE
chore(deps): bump alloy to 2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,14 +121,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
+checksum = "5ba7927096abd6a0e97a5b65d38ec925434aa2d52a97f9827b758deade899a43"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -149,24 +149,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
+checksum = "4a93740debb79527a25c470a83917e09d52faff0305bb456ab2ab135e7746923"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
+checksum = "3cbe885a43cba4c59f9f6c7277a8cfe031e1c3d6c7ae045f62cb29793cd24977"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
+checksum = "ad7894cf51020fe00d1ad8240361dc7f8f38b63c227f619e2ed4cabb39b02bf6"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -297,7 +297,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -333,13 +333,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
+checksum = "82c363268d39da33999807ddeaab7dcfc0c52e27fca90f8cf42ffbbfd3aaa2b1"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "alloy-trie",
  "borsh",
  "serde",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
+checksum = "8fee7d684c4cb40e5ba4f5b8c75314cf59976ccf5cf56e1e5f82d2e7d02274e7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -402,19 +402,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
+checksum = "bd4d38702615cfa6eb8f35389ca06f57af6e7dcbe5b98ee41a7c40cbbddee227"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -428,14 +428,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
+checksum = "e9439d1544f8e6a75a8b11de163467c9797fb8028332f747ce53c89b06d378a4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
 ]
 
@@ -494,13 +494,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
+checksum = "7a0fb8ff3f2035e8cc911feb48189e5ec87edfdbf0e7006214f9ddbcb41ed9cb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7b42e514613c717887dc77bb58d35e845557ebd63a18c3f92a77094e4891f"
+checksum = "ffd128dcba6f87141b36b7af256e4a22550e8b25f482295960e9eef1b8b8bbe1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
+checksum = "2237433614c2f6c3fc0a6de4da4934621039fcdf27ffceb0f9e2c0d84aef6cb6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -609,22 +609,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
+checksum = "f0ab9e8c80c0021e1b425b65767a5592d920457fba092bd6b69f695cebf858a7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670b3a8e0d1b32e9886b7a419b8efe6754ea00b9fdd4c0ea3c7411b6c30431f4"
+checksum = "a5d3f552d804cc7f1e31a372244b830a59111d60b6a539851364c12d3e870fdd"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -634,38 +634,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
+checksum = "90b9a5f2d9eb05dc6a8c5bf5421a84cc8a9edd859221773f2e79d7078fc4fe1c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
+checksum = "a744a60a7570cf3671e030814b506d4964f3557dccc932ab8a2f4863dd4f929f"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5d68ddca890854fb78291cbde06115473ded00b2337d0f815e92c0c1f8003"
+checksum = "b1c59583ca0498f3ac2b5105d93bbb7ad6c201385b7315272b2ad1a95b6e9601"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea21739e232c221779741eba7e7b9bc19ad8ff777b72736647ae519f5c9f6f33"
+checksum = "e841acb939593623463c89c8fd435cd5b22923b717e65867a83d1ba61087cc26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -694,15 +694,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f05338cfb4ee5508ff76f01c88142cab8a4579db74b7d9432936c26e4f11374"
+checksum = "449a8bc017d3f4c8c661824d3ed79a85699ff06b233ac9ccfda36393fe0f0a25"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "arbitrary",
  "derive_more",
  "ethereum_ssz",
@@ -715,17 +715,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
+checksum = "7357489697b0f2bb48a54ec049a97e88e74ade3415809c4dc7764e971b8ca3b9"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -737,28 +737,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df223478aec91d8fb0f8643234764042fa432e6111aca126774802b2618a3a5"
+checksum = "a1cf6089d6256f18eba59054b5e40e5d1b07d9195a4317adc546837e380d134e"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5905ac3663b0859d67b82d912acce20887d20682a0cadde79c8a763b133a515"
+checksum = "e39c597bd6328e0228e877676932cbaf6283fc6cce618713ea65a2daf65e8792"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -766,13 +766,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fbf71892d4df9cae8d35dc96f15d522384bb93806205465e2c8c012b7f0a34"
+checksum = "698c61412a9c058fadd3c088d86b46da126f0e534500cd7ca5916d7e3e669c67"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "serde",
 ]
 
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
+checksum = "93220b940e267b4b1d2974ebf906a4052d6ab731e2e2dc11e132a20bf3135a2c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
+checksum = "6b371be67aa8fb6d84057eb75a305ef09c3a89554c68981732b0345c9b3ddc1b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
+checksum = "653c69374e4cba9aa7f741a232a047799a914a349a8baac643e42cfefe6e7a69"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
+checksum = "db0a489d74eabeb32f597549f2c3926289599ab35a1a72afd21bc9fa3354b032"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
+checksum = "6ec9590f3fa3b8ef7453a9000126d1a616969b5ccdad35206e446bc5dd8f8bb0"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfad7aa9206fcb831ae401b6a1c893a402b8eed74f9c8ffbb7a7323afb0d9a4c"
+checksum = "b778f5a7cdb4e5faa7d7002386f9da97466bf40b98fac262d4efb58ee23775c5"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aa8ff49386df3e008b73c7fb0a5479410e8493fdb86a8b916877a16e8aead9"
+checksum = "d998445dc63066366cb7d06ed00452bd0afa67d97aaface7f89fd9dd9d024241"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
+checksum = "f2f83322fc68041e9f8190a370c0eee7738edcad2900e551f673cf3f4d6ca642"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2833,7 +2833,7 @@ name = "custom-hardforks"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "reth-chainspec",
@@ -3279,7 +3279,7 @@ name = "ef-tests"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -3497,7 +3497,7 @@ name = "example-beacon-api-sidecar-fetcher"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-beacon",
  "clap",
@@ -3576,7 +3576,7 @@ dependencies = [
 name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-sol-types",
  "eyre",
@@ -3631,7 +3631,7 @@ dependencies = [
 name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -3653,7 +3653,7 @@ dependencies = [
 name = "example-custom-payload-builder"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "eyre",
  "futures-util",
  "reth-basic-payload-builder",
@@ -7409,7 +7409,7 @@ name = "reth-basic-payload-builder"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -7435,7 +7435,7 @@ name = "reth-bb"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
@@ -7484,7 +7484,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -7531,7 +7531,7 @@ name = "reth-chain-state"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -7564,7 +7564,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -7596,7 +7596,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -7692,7 +7692,7 @@ dependencies = [
 name = "reth-cli-util"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -7717,7 +7717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -7777,7 +7777,7 @@ name = "reth-consensus-common"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "rand 0.9.4",
  "reth-chainspec",
@@ -7791,7 +7791,7 @@ name = "reth-consensus-debug-client"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -7910,7 +7910,7 @@ dependencies = [
 name = "reth-db-models"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8006,7 +8006,7 @@ name = "reth-downloaders"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
@@ -8044,7 +8044,7 @@ name = "reth-e2e-test-utils"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8149,7 +8149,7 @@ name = "reth-engine-primitives"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8174,7 +8174,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8272,7 +8272,7 @@ name = "reth-era"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -8350,7 +8350,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8389,7 +8389,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
@@ -8476,7 +8476,7 @@ name = "reth-ethereum-consensus"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8491,7 +8491,7 @@ dependencies = [
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -8521,7 +8521,7 @@ name = "reth-ethereum-payload-builder"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8550,7 +8550,7 @@ name = "reth-ethereum-primitives"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
@@ -8581,7 +8581,7 @@ name = "reth-evm"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -8605,7 +8605,7 @@ name = "reth-evm-ethereum"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8657,7 +8657,7 @@ name = "reth-execution-types"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8678,7 +8678,7 @@ name = "reth-exex"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -8722,7 +8722,7 @@ dependencies = [
 name = "reth-exex-test-utils"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "eyre",
  "futures-util",
  "reth-chainspec",
@@ -8753,7 +8753,7 @@ dependencies = [
 name = "reth-exex-types"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "arbitrary",
  "bincode",
@@ -8780,7 +8780,7 @@ name = "reth-invalid-block-hooks"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -8894,7 +8894,7 @@ name = "reth-network"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -8980,7 +8980,7 @@ name = "reth-network-p2p"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9073,7 +9073,7 @@ name = "reth-node-builder"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9144,7 +9144,7 @@ name = "reth-node-core"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9201,7 +9201,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9283,7 +9283,7 @@ name = "reth-node-events"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9380,7 +9380,7 @@ name = "reth-payload-primitives"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9425,7 +9425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9456,7 +9456,7 @@ name = "reth-provider"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9507,7 +9507,7 @@ name = "reth-prune"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "assert_matches",
  "itertools 0.14.0",
@@ -9581,7 +9581,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -9597,7 +9597,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -9659,7 +9659,7 @@ dependencies = [
 name = "reth-rpc-api"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -9673,7 +9673,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -9689,7 +9689,7 @@ dependencies = [
 name = "reth-rpc-api-testing-util"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -9708,7 +9708,7 @@ dependencies = [
 name = "reth-rpc-builder"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -9806,7 +9806,7 @@ dependencies = [
 name = "reth-rpc-engine-api"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9845,7 +9845,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -9853,7 +9853,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -9888,7 +9888,7 @@ name = "reth-rpc-eth-types"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -9952,7 +9952,7 @@ dependencies = [
 name = "reth-rpc-server-types"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -9983,7 +9983,7 @@ name = "reth-stages"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10044,7 +10044,7 @@ dependencies = [
 name = "reth-stages-api"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "aquamarine",
  "assert_matches",
@@ -10136,7 +10136,7 @@ name = "reth-storage-api"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10158,7 +10158,7 @@ dependencies = [
 name = "reth-storage-errors"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10176,7 +10176,7 @@ name = "reth-storage-rpc-provider"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -10225,7 +10225,7 @@ name = "reth-testing-utils"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10285,7 +10285,7 @@ name = "reth-transaction-pool"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10336,7 +10336,7 @@ name = "reth-trie"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.2",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10373,7 +10373,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.2",
  "alloy-trie",
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,33 +456,33 @@ alloy-trie = { version = "0.9.4", default-features = false }
 
 alloy-hardforks = "0.4.7"
 
-alloy-consensus = { version = "2.0.1", default-features = false }
-alloy-contract = { version = "2.0.1", default-features = false }
-alloy-eips = { version = "2.0.1", default-features = false }
-alloy-genesis = { version = "2.0.1", default-features = false }
-alloy-json-rpc = { version = "2.0.1", default-features = false }
-alloy-network = { version = "2.0.1", default-features = false }
-alloy-network-primitives = { version = "2.0.1", default-features = false }
-alloy-provider = { version = "2.0.1", features = ["reqwest", "debug-api"], default-features = false }
-alloy-pubsub = { version = "2.0.1", default-features = false }
-alloy-rpc-client = { version = "2.0.1", default-features = false }
-alloy-rpc-types = { version = "2.0.1", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "2.0.1", default-features = false }
-alloy-rpc-types-anvil = { version = "2.0.1", default-features = false }
-alloy-rpc-types-beacon = { version = "2.0.1", default-features = false }
-alloy-rpc-types-debug = { version = "2.0.1", default-features = false }
-alloy-rpc-types-engine = { version = "2.0.1", default-features = false }
-alloy-rpc-types-eth = { version = "2.0.1", default-features = false }
-alloy-rpc-types-mev = { version = "2.0.1", default-features = false }
-alloy-rpc-types-trace = { version = "2.0.1", default-features = false }
-alloy-rpc-types-txpool = { version = "2.0.1", default-features = false }
-alloy-serde = { version = "2.0.1", default-features = false }
-alloy-signer = { version = "2.0.1", default-features = false }
-alloy-signer-local = { version = "2.0.1", default-features = false }
-alloy-transport = { version = "2.0.1" }
-alloy-transport-http = { version = "2.0.1", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "2.0.1", default-features = false }
-alloy-transport-ws = { version = "2.0.1", default-features = false }
+alloy-consensus = { version = "2.0.2", default-features = false }
+alloy-contract = { version = "2.0.2", default-features = false }
+alloy-eips = { version = "2.0.2", default-features = false }
+alloy-genesis = { version = "2.0.2", default-features = false }
+alloy-json-rpc = { version = "2.0.2", default-features = false }
+alloy-network = { version = "2.0.2", default-features = false }
+alloy-network-primitives = { version = "2.0.2", default-features = false }
+alloy-provider = { version = "2.0.2", features = ["reqwest", "debug-api"], default-features = false }
+alloy-pubsub = { version = "2.0.2", default-features = false }
+alloy-rpc-client = { version = "2.0.2", default-features = false }
+alloy-rpc-types = { version = "2.0.2", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "2.0.2", default-features = false }
+alloy-rpc-types-anvil = { version = "2.0.2", default-features = false }
+alloy-rpc-types-beacon = { version = "2.0.2", default-features = false }
+alloy-rpc-types-debug = { version = "2.0.2", default-features = false }
+alloy-rpc-types-engine = { version = "2.0.2", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.2", default-features = false }
+alloy-rpc-types-mev = { version = "2.0.2", default-features = false }
+alloy-rpc-types-trace = { version = "2.0.2", default-features = false }
+alloy-rpc-types-txpool = { version = "2.0.2", default-features = false }
+alloy-serde = { version = "2.0.2", default-features = false }
+alloy-signer = { version = "2.0.2", default-features = false }
+alloy-signer-local = { version = "2.0.2", default-features = false }
+alloy-transport = { version = "2.0.2" }
+alloy-transport-http = { version = "2.0.2", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "2.0.2", default-features = false }
+alloy-transport-ws = { version = "2.0.2", features = ["aws-lc-rs"], default-features = false }
 
 # misc
 either = { version = "1.15.0", default-features = false }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloy_consensus::TxEnvelope;
 use alloy_eips::Encodable2718;
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_provider::{
     ext::DebugApi,
     network::{AnyNetwork, AnyRpcBlock},
@@ -600,7 +600,7 @@ fn build_block_request(
             Ok(Some(tx.encoded_2718().into()))
         })
         .filter_map(|tx| tx.transpose())
-        .collect::<eyre::Result<Vec<_>>>()?;
+        .collect::<eyre::Result<Vec<Bytes>>>()?;
 
     // `testing_buildBlockV1` only takes raw transaction bytes, so we exclude blob transactions
     // from the synthetic fork blocks rather than trying to reconstruct their sidecars.
@@ -611,9 +611,9 @@ fn build_block_request(
 
     let rpc_block = block.clone().into_inner();
 
-    Ok(TestingBuildBlockRequestV1 {
-        parent_block_hash,
-        payload_attributes: PayloadAttributes {
+    Ok(serde_json::from_value(serde_json::json!({
+        "parentBlockHash": parent_block_hash,
+        "payloadAttributes": PayloadAttributes {
             timestamp: block.header.timestamp,
             prev_randao: block.header.mix_hash.unwrap_or_default(),
             suggested_fee_recipient: block.header.beneficiary,
@@ -621,9 +621,9 @@ fn build_block_request(
             parent_beacon_block_root: block.header.parent_beacon_block_root,
             slot_number: block.header.slot_number,
         },
-        transactions,
-        extra_data: Some(block.header.extra_data.clone()),
-    })
+        "transactions": transactions,
+        "extraData": Some(block.header.extra_data.clone()),
+    }))?)
 }
 
 fn parse_reorg_depth(value: &str) -> Result<usize, String> {

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -224,12 +224,12 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
         slot_number: None,
     };
 
-    let request = TestingBuildBlockRequestV1 {
-        parent_block_hash: genesis_hash,
-        payload_attributes,
-        transactions: vec![raw_tx],
-        extra_data: None,
-    };
+    let request: TestingBuildBlockRequestV1 = serde_json::from_value(serde_json::json!({
+        "parentBlockHash": genesis_hash,
+        "payloadAttributes": payload_attributes,
+        "transactions": vec![raw_tx],
+        "extraData": Option::<alloy_primitives::Bytes>::None,
+    }))?;
 
     let envelope = node.testing_build_block_v1(request).await?;
 

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -59,12 +59,12 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
                 slot_number: None,
             };
 
-            let request = TestingBuildBlockRequestV1 {
-                parent_block_hash,
-                payload_attributes,
-                transactions: vec![],
-                extra_data: None,
-            };
+            let request: TestingBuildBlockRequestV1 = serde_json::from_value(serde_json::json!({
+                "parentBlockHash": parent_block_hash,
+                "payloadAttributes": payload_attributes,
+                "transactions": Vec::<alloy_primitives::Bytes>::new(),
+                "extraData": Option::<alloy_primitives::Bytes>::None,
+            }))?;
 
             tokio::spawn(async move {
                 let res: eyre::Result<ExecutionPayloadEnvelopeV4> =


### PR DESCRIPTION
Updates the Alloy 2.0.x workspace dependencies to 2.0.2 and refreshes Cargo.lock. Keeps websocket TLS enabled explicitly after alloy-transport-ws moved TLS behind features, and adapts existing testing_buildBlockV1 request construction locally for Alloy's non-exhaustive request type.

Validation: cargo +nightly fmt --all --check; zepter; make lint-toml; cargo check --workspace --all-features --tests; cargo test --workspace --doc --all-features; cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features.