### PR TITLE
fix: stop hive image loading from masking failures

### DIFF
--- a/.github/scripts/hive/load_images.sh
+++ b/.github/scripts/hive/load_images.sh
@@ -7,7 +7,6 @@ IMAGES=(
     "/tmp/devp2p.tar"
     "/tmp/engine.tar"
     "/tmp/rpc_compat.tar"
-    "/tmp/pyspec.tar"
     "/tmp/smoke_genesis.tar"
     "/tmp/smoke_network.tar"
     "/tmp/ethereum_sync.tar"
@@ -17,11 +16,23 @@ IMAGES=(
 )
 
 # Loop through the images and load them
+load_pids=( )
 for IMAGE_TAR in "${IMAGES[@]}"; do
     echo "Loading image $IMAGE_TAR..."
     docker load -i "$IMAGE_TAR" &
+    load_pids+=( "$!" )
 done
 
-wait
+failed=0
+for index in "${!load_pids[@]}"; do
+    if ! wait "${load_pids[$index]}"; then
+        echo "Failed to load image ${IMAGES[$index]}" >&2
+        failed=1
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi
 
 docker image ls -a


### PR DESCRIPTION
## Summary
- remove the stale `/tmp/pyspec.tar` entry from the Hive image loader
- track each background `docker load` process and fail the step if any image load fails
- prevent missing-image and disk-exhaustion errors from being hidden by a successful `wait`

## Testing
- `bash -n .github/scripts/hive/load_images.sh`
- `git diff --check -- .github/scripts/hive/load_images.sh`