### PR TITLE
chore(deps): bump alloy to 2.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,14 +121,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
+checksum = "7fc6be02eff1541c43b6115be20dfee1193866d5fefae1ba51ac5faf17f12fee"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -149,24 +149,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
+checksum = "5741ea7c31531d6a1078da476fcb5e72d79034e083434d08d02ac314a3c97ca6"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
+checksum = "778ace63866868316eafbc8e05359b30d90351bdf330a67097a3be840f104c77"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
+checksum = "3d9aa76a48b69ace6af111896ec0ec8feb6b18b333a4906b9bb472f4d8b888cb"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -297,7 +297,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -333,13 +333,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
+checksum = "18bec5b246e024798c358821ba211fac8ee614495aafae121817adaa29349e78"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "alloy-trie",
  "borsh",
  "serde",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
+checksum = "28006b7c6d1b9d92a3f42aaa671dcadd83d4cf04d44c7fde2a22367ac1d7c33e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -402,19 +402,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
+checksum = "e1bb3cc37b6290e3eb75ccadcd4c95fde0c4bc1195e06b3b52a5351a843717d2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -428,14 +428,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
+checksum = "3474ec5781f716cb4eafda767548a917ddc38106b0699da7583f990df2a2e255"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
 ]
 
@@ -494,13 +494,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
+checksum = "d159c614dc09636b817941f4b2e36ce1f89b346ac32d43a45914bbe9b8cceaa5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7b42e514613c717887dc77bb58d35e845557ebd63a18c3f92a77094e4891f"
+checksum = "949373f75e2126c13cdf1d3292d5692dd7109181ed01c8ed5e393c5cef394f61"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
+checksum = "64612675792955bc80c7dbb3795413b14dfb4fd77782196c4ab73b23e92bf513"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -609,22 +609,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
+checksum = "49d756101eb020906c00f2d8f00fb2be51f211ff57e6b2fbb595d5c9d1d5a4c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670b3a8e0d1b32e9886b7a419b8efe6754ea00b9fdd4c0ea3c7411b6c30431f4"
+checksum = "b0a27b6e7d7025d350e71e9ad81c78441e9d3478674b415c72c381a536276bee"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -634,38 +634,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
+checksum = "edcc1730de47b7205a2d9abad9a6f3f8428746ecb57e2ae8a2f035bb18535d1b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
+checksum = "b8e71dcffea0a936878c2d6b329f1354d0c00c47d79b84f848a56159388ab4e1"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5d68ddca890854fb78291cbde06115473ded00b2337d0f815e92c0c1f8003"
+checksum = "3064e0ac102d2566fae3f999a9d733704bb8cff854fa8e9095ed3e61d5837121"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea21739e232c221779741eba7e7b9bc19ad8ff777b72736647ae519f5c9f6f33"
+checksum = "dc3d9bce6ca89178d8197d9db89a4793c1fbefbaf5f63bb647749e1fdd1bf29e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -694,15 +694,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f05338cfb4ee5508ff76f01c88142cab8a4579db74b7d9432936c26e4f11374"
+checksum = "35e8fc81e388dfd3172048d38dddb9d928780aecf1e4f4d48e1b47376e90c783"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "arbitrary",
  "derive_more",
  "ethereum_ssz",
@@ -715,17 +715,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
+checksum = "4589a0fc81a22686ee46cde926c281c1f7b4c1ce123b71c95997420173183fb5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -737,28 +737,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df223478aec91d8fb0f8643234764042fa432e6111aca126774802b2618a3a5"
+checksum = "bf95f3080e53a12db2d306b2a99785cbbb22ae6fd974951f4feaf849b1e27b86"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5905ac3663b0859d67b82d912acce20887d20682a0cadde79c8a763b133a515"
+checksum = "b57caea9c114033c66e49e094ba960828650b9672fbe7970642cad1b0444ed2f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -766,13 +766,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fbf71892d4df9cae8d35dc96f15d522384bb93806205465e2c8c012b7f0a34"
+checksum = "7487a9554e881c21d50b87cefbb27de639617f5f8fb783d88932d5f17661717e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "serde",
 ]
 
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
+checksum = "ff6f96fdb0e2de87add103e3ab5831a85bae203c17a8e53f8a24406037830f62"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
+checksum = "7243b3538b80c55b7f92c6af22416a89790cb97fca79a1c510008187d03f3346"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
+checksum = "93e63f4de554e65dd8ce37047eef7600789ed54513e7271f8f82e3c12ecbb2af"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
+checksum = "b43b6eb5e46dbb8621f555806b0a98702cf731bd98b97377822d0be8263d5833"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
+checksum = "1892220ecae77044e5e693c9b65e6f5ac172857e54e6f43f750501d425a73d23"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfad7aa9206fcb831ae401b6a1c893a402b8eed74f9c8ffbb7a7323afb0d9a4c"
+checksum = "54c972ef890e78a6c057b3e939354d60e0b6166f490d5f0a3637acb016d35281"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aa8ff49386df3e008b73c7fb0a5479410e8493fdb86a8b916877a16e8aead9"
+checksum = "d3ead4d675dedafd779d14efd52e20cead1569e6fcf17ee71c64a8830fc48c59"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
+checksum = "acaf3e97aaf7196a7d7f8c837f8a94d422b51f56df467508455482dce8514585"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2833,7 +2833,7 @@ name = "custom-hardforks"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "reth-chainspec",
@@ -3279,7 +3279,7 @@ name = "ef-tests"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -3497,7 +3497,7 @@ name = "example-beacon-api-sidecar-fetcher"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-beacon",
  "clap",
@@ -3576,7 +3576,7 @@ dependencies = [
 name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-sol-types",
  "eyre",
@@ -3631,7 +3631,7 @@ dependencies = [
 name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -3653,7 +3653,7 @@ dependencies = [
 name = "example-custom-payload-builder"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "eyre",
  "futures-util",
  "reth-basic-payload-builder",
@@ -7409,7 +7409,7 @@ name = "reth-basic-payload-builder"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -7435,7 +7435,7 @@ name = "reth-bb"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
@@ -7484,7 +7484,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -7531,7 +7531,7 @@ name = "reth-chain-state"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -7564,7 +7564,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -7596,7 +7596,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -7692,7 +7692,7 @@ dependencies = [
 name = "reth-cli-util"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -7717,7 +7717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -7777,7 +7777,7 @@ name = "reth-consensus-common"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "rand 0.9.4",
  "reth-chainspec",
@@ -7791,7 +7791,7 @@ name = "reth-consensus-debug-client"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -7910,7 +7910,7 @@ dependencies = [
 name = "reth-db-models"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8006,7 +8006,7 @@ name = "reth-downloaders"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
@@ -8044,7 +8044,7 @@ name = "reth-e2e-test-utils"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8149,7 +8149,7 @@ name = "reth-engine-primitives"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8174,7 +8174,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8272,7 +8272,7 @@ name = "reth-era"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -8350,7 +8350,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8389,7 +8389,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
@@ -8476,7 +8476,7 @@ name = "reth-ethereum-consensus"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8491,7 +8491,7 @@ dependencies = [
 name = "reth-ethereum-engine-primitives"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -8521,7 +8521,7 @@ name = "reth-ethereum-payload-builder"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8550,7 +8550,7 @@ name = "reth-ethereum-primitives"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
@@ -8581,7 +8581,7 @@ name = "reth-evm"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -8605,7 +8605,7 @@ name = "reth-evm-ethereum"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8657,7 +8657,7 @@ name = "reth-execution-types"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8678,7 +8678,7 @@ name = "reth-exex"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -8722,7 +8722,7 @@ dependencies = [
 name = "reth-exex-test-utils"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "eyre",
  "futures-util",
  "reth-chainspec",
@@ -8753,7 +8753,7 @@ dependencies = [
 name = "reth-exex-types"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "arbitrary",
  "bincode",
@@ -8780,7 +8780,7 @@ name = "reth-invalid-block-hooks"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -8894,7 +8894,7 @@ name = "reth-network"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -8980,7 +8980,7 @@ name = "reth-network-p2p"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9073,7 +9073,7 @@ name = "reth-node-builder"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9144,7 +9144,7 @@ name = "reth-node-core"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9201,7 +9201,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9283,7 +9283,7 @@ name = "reth-node-events"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9380,7 +9380,7 @@ name = "reth-payload-primitives"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9425,7 +9425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9456,7 +9456,7 @@ name = "reth-provider"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9507,7 +9507,7 @@ name = "reth-prune"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "assert_matches",
  "itertools 0.14.0",
@@ -9581,7 +9581,7 @@ version = "2.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -9597,7 +9597,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -9659,7 +9659,7 @@ dependencies = [
 name = "reth-rpc-api"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -9673,7 +9673,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -9689,7 +9689,7 @@ dependencies = [
 name = "reth-rpc-api-testing-util"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -9708,7 +9708,7 @@ dependencies = [
 name = "reth-rpc-builder"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -9806,7 +9806,7 @@ dependencies = [
 name = "reth-rpc-engine-api"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9845,7 +9845,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -9853,7 +9853,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -9888,7 +9888,7 @@ name = "reth-rpc-eth-types"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -9952,7 +9952,7 @@ dependencies = [
 name = "reth-rpc-server-types"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -9983,7 +9983,7 @@ name = "reth-stages"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10044,7 +10044,7 @@ dependencies = [
 name = "reth-stages-api"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "aquamarine",
  "assert_matches",
@@ -10136,7 +10136,7 @@ name = "reth-storage-api"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10158,7 +10158,7 @@ dependencies = [
 name = "reth-storage-errors"
 version = "2.1.0"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10176,7 +10176,7 @@ name = "reth-storage-rpc-provider"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -10225,7 +10225,7 @@ name = "reth-testing-utils"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10285,7 +10285,7 @@ name = "reth-transaction-pool"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10336,7 +10336,7 @@ name = "reth-trie"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips 2.0.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10373,7 +10373,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde 2.0.3",
  "alloy-trie",
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,33 +456,33 @@ alloy-trie = { version = "0.9.4", default-features = false }
 
 alloy-hardforks = "0.4.7"
 
-alloy-consensus = { version = "2.0.1", default-features = false }
-alloy-contract = { version = "2.0.1", default-features = false }
-alloy-eips = { version = "2.0.1", default-features = false }
-alloy-genesis = { version = "2.0.1", default-features = false }
-alloy-json-rpc = { version = "2.0.1", default-features = false }
-alloy-network = { version = "2.0.1", default-features = false }
-alloy-network-primitives = { version = "2.0.1", default-features = false }
-alloy-provider = { version = "2.0.1", features = ["reqwest", "debug-api"], default-features = false }
-alloy-pubsub = { version = "2.0.1", default-features = false }
-alloy-rpc-client = { version = "2.0.1", default-features = false }
-alloy-rpc-types = { version = "2.0.1", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "2.0.1", default-features = false }
-alloy-rpc-types-anvil = { version = "2.0.1", default-features = false }
-alloy-rpc-types-beacon = { version = "2.0.1", default-features = false }
-alloy-rpc-types-debug = { version = "2.0.1", default-features = false }
-alloy-rpc-types-engine = { version = "2.0.1", default-features = false }
-alloy-rpc-types-eth = { version = "2.0.1", default-features = false }
-alloy-rpc-types-mev = { version = "2.0.1", default-features = false }
-alloy-rpc-types-trace = { version = "2.0.1", default-features = false }
-alloy-rpc-types-txpool = { version = "2.0.1", default-features = false }
-alloy-serde = { version = "2.0.1", default-features = false }
-alloy-signer = { version = "2.0.1", default-features = false }
-alloy-signer-local = { version = "2.0.1", default-features = false }
-alloy-transport = { version = "2.0.1" }
-alloy-transport-http = { version = "2.0.1", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "2.0.1", default-features = false }
-alloy-transport-ws = { version = "2.0.1", default-features = false }
+alloy-consensus = { version = "2.0.3", default-features = false }
+alloy-contract = { version = "2.0.3", default-features = false }
+alloy-eips = { version = "2.0.3", default-features = false }
+alloy-genesis = { version = "2.0.3", default-features = false }
+alloy-json-rpc = { version = "2.0.3", default-features = false }
+alloy-network = { version = "2.0.3", default-features = false }
+alloy-network-primitives = { version = "2.0.3", default-features = false }
+alloy-provider = { version = "2.0.3", features = ["reqwest", "debug-api"], default-features = false }
+alloy-pubsub = { version = "2.0.3", default-features = false }
+alloy-rpc-client = { version = "2.0.3", default-features = false }
+alloy-rpc-types = { version = "2.0.3", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "2.0.3", default-features = false }
+alloy-rpc-types-anvil = { version = "2.0.3", default-features = false }
+alloy-rpc-types-beacon = { version = "2.0.3", default-features = false }
+alloy-rpc-types-debug = { version = "2.0.3", default-features = false }
+alloy-rpc-types-engine = { version = "2.0.3", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.3", default-features = false }
+alloy-rpc-types-mev = { version = "2.0.3", default-features = false }
+alloy-rpc-types-trace = { version = "2.0.3", default-features = false }
+alloy-rpc-types-txpool = { version = "2.0.3", default-features = false }
+alloy-serde = { version = "2.0.3", default-features = false }
+alloy-signer = { version = "2.0.3", default-features = false }
+alloy-signer-local = { version = "2.0.3", default-features = false }
+alloy-transport = { version = "2.0.3" }
+alloy-transport-http = { version = "2.0.3", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "2.0.3", default-features = false }
+alloy-transport-ws = { version = "2.0.3", default-features = false }
 
 # misc
 either = { version = "1.15.0", default-features = false }

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -611,19 +611,20 @@ fn build_block_request(
 
     let rpc_block = block.clone().into_inner();
 
-    Ok(TestingBuildBlockRequestV1 {
-        parent_block_hash,
-        payload_attributes: PayloadAttributes {
-            timestamp: block.header.timestamp,
-            prev_randao: block.header.mix_hash.unwrap_or_default(),
-            suggested_fee_recipient: block.header.beneficiary,
-            withdrawals: rpc_block.withdrawals.map(|withdrawals| withdrawals.into_inner()),
-            parent_beacon_block_root: block.header.parent_beacon_block_root,
-            slot_number: block.header.slot_number,
-        },
-        transactions,
-        extra_data: Some(block.header.extra_data.clone()),
-    })
+    let mut request = TestingBuildBlockRequestV1::default();
+    request.parent_block_hash = parent_block_hash;
+    request.payload_attributes = PayloadAttributes {
+        timestamp: block.header.timestamp,
+        prev_randao: block.header.mix_hash.unwrap_or_default(),
+        suggested_fee_recipient: block.header.beneficiary,
+        withdrawals: rpc_block.withdrawals.map(|withdrawals| withdrawals.into_inner()),
+        parent_beacon_block_root: block.header.parent_beacon_block_root,
+        slot_number: block.header.slot_number,
+    };
+    request.transactions = transactions;
+    request.extra_data = Some(block.header.extra_data.clone());
+
+    Ok(request)
 }
 
 fn parse_reorg_depth(value: &str) -> Result<usize, String> {

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -224,12 +224,11 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
         slot_number: None,
     };
 
-    let request = TestingBuildBlockRequestV1 {
-        parent_block_hash: genesis_hash,
-        payload_attributes,
-        transactions: vec![raw_tx],
-        extra_data: None,
-    };
+    let mut request = TestingBuildBlockRequestV1::default();
+    request.parent_block_hash = genesis_hash;
+    request.payload_attributes = payload_attributes;
+    request.transactions = vec![raw_tx];
+    request.extra_data = None;
 
     let envelope = node.testing_build_block_v1(request).await?;
 

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -59,12 +59,11 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
                 slot_number: None,
             };
 
-            let request = TestingBuildBlockRequestV1 {
-                parent_block_hash,
-                payload_attributes,
-                transactions: vec![],
-                extra_data: None,
-            };
+            let mut request = TestingBuildBlockRequestV1::default();
+            request.parent_block_hash = parent_block_hash;
+            request.payload_attributes = payload_attributes;
+            request.transactions = vec![];
+            request.extra_data = None;
 
             tokio::spawn(async move {
                 let res: eyre::Result<ExecutionPayloadEnvelopeV4> =


### PR DESCRIPTION
Updates the alloy 2.x workspace dependencies and lockfile to 2.0.3. Also adjusts testing_buildBlockV1 request construction to initialize from Default because TestingBuildBlockRequestV1 is now non-exhaustive.

Validated with cargo +nightly fmt --all --check, zepter, make lint-toml, cargo check -p reth-rpc-api, cargo check -p reth-bench, and cargo check -p reth-node-ethereum --tests.