### PR TITLE
perf(trie): skip no-op storage trie rewrites

### DIFF
--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -289,18 +289,26 @@ where
         let mut num_entries = 0;
         for (nibbles, maybe_updated) in updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
         {
-            num_entries += 1;
             let nibbles = A::StorageSubKey::from(*nibbles);
+            let existing_matches =
+                match self.cursor.seek_by_key_subkey(self.hashed_address, nibbles.clone())? {
+                    Some(existing) if *existing.nibbles() == nibbles => {
+                        if maybe_updated.as_ref().is_some_and(|node| existing.node() == node) {
+                            continue;
+                        }
+                        true
+                    }
+                    _ => false,
+                };
+
             // Delete the old entry if it exists.
-            if self
-                .cursor
-                .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
-                .as_ref()
-                .is_some_and(|e| *e.nibbles() == nibbles)
-            {
+            if existing_matches {
                 self.cursor.delete_current()?;
+            } else if maybe_updated.is_none() {
+                continue;
             }
 
+            num_entries += 1;
             // There is an updated version of this node, insert new entry.
             if let Some(node) = maybe_updated {
                 self.cursor

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -126,6 +126,49 @@ fn branch_node_child_changes() {
 }
 
 #[test]
+fn reapplying_identical_storage_trie_updates_is_noop() {
+    let factory = create_test_provider_factory();
+    let tx = factory.provider_rw().unwrap();
+    let hashed_address = B256::with_last_byte(7);
+
+    let mut hashed_storage_cursor =
+        tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+    for key in [
+        "1000000000000000000000000000000000000000000000000000000000000000",
+        "1100000000000000000000000000000000000000000000000000000000000000",
+        "1110000000000000000000000000000000000000000000000000000000000000",
+        "1200000000000000000000000000000000000000000000000000000000000000",
+        "1220000000000000000000000000000000000000000000000000000000000000",
+        "1320000000000000000000000000000000000000000000000000000000000000",
+    ]
+    .into_iter()
+    .map(|key| B256::from_str(key).unwrap())
+    {
+        hashed_storage_cursor
+            .upsert(hashed_address, &StorageEntry { key, value: U256::ZERO })
+            .unwrap();
+    }
+
+    reth_trie_db::with_adapter!(tx, |A| {
+        let (_, _, trie_updates) =
+            DbStorageRoot::<_, A>::from_tx_hashed(tx.tx_ref(), hashed_address)
+                .root_with_updates()
+                .unwrap();
+        let trie_updates = trie_updates.into_sorted();
+
+        let first_write = tx
+            .write_storage_trie_updates_sorted(core::iter::once((&hashed_address, &trie_updates)))
+            .unwrap();
+        assert!(first_write > 0);
+
+        let second_write = tx
+            .write_storage_trie_updates_sorted(core::iter::once((&hashed_address, &trie_updates)))
+            .unwrap();
+        assert_eq!(second_write, 0);
+    });
+}
+
+#[test]
 fn arbitrary_storage_root() {
     proptest!(ProptestConfig::with_cases(10), |(item in arb::<(Address, std::collections::BTreeMap<B256, U256>)>())| {
         let (address, storage) = item;


### PR DESCRIPTION
Treat an exact storage trie entry with an identical branch node as a true no-op instead of deleting and reinserting it. The integration test now reapplies the same trie updates twice and verifies the second pass reports no modified entries.