### PR TITLE
perf: use k-way overlay merges for large batches

### DIFF
--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -628,7 +628,8 @@ impl HashedPostStateSorted {
     /// For small batches, uses `extend_ref_and_sort` loop.
     /// For large batches, uses k-way merge for O(n log k) complexity.
     pub fn merge_slice<T: AsRef<Self>>(items: &[T]) -> Self {
-        const THRESHOLD: usize = 30;
+        const SMALL_BATCH_THRESHOLD: usize = 4;
+        const SMALL_TOTAL_LEN_THRESHOLD: usize = 4_096;
 
         let k = items.len();
 
@@ -639,7 +640,8 @@ impl HashedPostStateSorted {
             return items[0].as_ref().clone();
         }
 
-        if k < THRESHOLD {
+        let total_len = items.iter().map(|item| item.as_ref().total_len()).sum::<usize>();
+        if k <= SMALL_BATCH_THRESHOLD && total_len <= SMALL_TOTAL_LEN_THRESHOLD {
             // Small k: extend loop, oldest-to-newest so newer overrides older.
             let mut iter = items.iter().rev();
             let mut acc = iter.next().expect("k > 0").as_ref().clone();
@@ -658,6 +660,7 @@ impl HashedPostStateSorted {
             slices: Vec<&'a [(B256, U256)]>,
         }
 
+        let slices_capacity = k.min(SMALL_BATCH_THRESHOLD);
         let mut acc: B256Map<StorageAcc<'_>> = B256Map::default();
 
         for item in items {
@@ -665,7 +668,7 @@ impl HashedPostStateSorted {
                 let entry = acc.entry(*addr).or_insert_with(|| StorageAcc {
                     wiped: false,
                     sealed: false,
-                    slices: Vec::new(),
+                    slices: Vec::with_capacity(slices_capacity),
                 });
 
                 if entry.sealed {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -646,7 +646,8 @@ impl TrieUpdatesSorted {
     /// For small batches, uses `extend_ref_and_sort` loop.
     /// For large batches, uses k-way merge for O(n log k) complexity.
     pub fn merge_slice<T: AsRef<Self>>(items: &[T]) -> Self {
-        const THRESHOLD: usize = 30;
+        const SMALL_BATCH_THRESHOLD: usize = 4;
+        const SMALL_TOTAL_LEN_THRESHOLD: usize = 4_096;
 
         let k = items.len();
 
@@ -657,7 +658,8 @@ impl TrieUpdatesSorted {
             return items[0].as_ref().clone();
         }
 
-        if k < THRESHOLD {
+        let total_len = items.iter().map(|item| item.as_ref().total_len()).sum::<usize>();
+        if k <= SMALL_BATCH_THRESHOLD && total_len <= SMALL_TOTAL_LEN_THRESHOLD {
             // Small k: extend loop, oldest-to-newest so newer overrides older.
             let mut iter = items.iter().rev();
             let mut acc = iter.next().expect("k > 0").as_ref().clone();
@@ -677,6 +679,7 @@ impl TrieUpdatesSorted {
             slices: Vec<&'a [(Nibbles, Option<BranchNodeCompact>)]>,
         }
 
+        let slices_capacity = k.min(SMALL_BATCH_THRESHOLD);
         let mut acc: B256Map<StorageAcc<'_>> = B256Map::default();
 
         for item in items {
@@ -684,7 +687,7 @@ impl TrieUpdatesSorted {
                 let entry = acc.entry(*addr).or_insert_with(|| StorageAcc {
                     is_deleted: false,
                     sealed: false,
-                    slices: Vec::new(),
+                    slices: Vec::with_capacity(slices_capacity),
                 });
 
                 if entry.sealed {


### PR DESCRIPTION
Retune the sorted overlay merge heuristic to consider total update volume, not just the number of blocks in the batch. This keeps tiny overlays on the existing extend-and-sort path while moving large lazy-overlay merges onto the existing k-way merge implementation that does less repeated cloning.

Pre-size the per-account storage slice accumulators in both hashed-state and trie-update merges so the large-batch path avoids a second layer of small Vec growth.