### PR TITLE
fix(engine): do not install state hook if BAL is disabled

### DIFF
--- a/.github/scripts/hive/build_simulators.sh
+++ b/.github/scripts/hive/build_simulators.sh
@@ -5,8 +5,8 @@ fixture_variant="${1:-osaka}"
 
 case "${fixture_variant}" in
     amsterdam)
-        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/bal@v6.0.0/fixtures_bal.tar.gz"
-        eels_branch="devnets/snøbal/4"
+        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-5@v8037.0.0/fixtures_snobal-devnet-5.tar.gz"
+        eels_branch="devnets/snobal/5"
         ;;
     osaka)
         eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz"

--- a/.github/scripts/hive/build_simulators.sh
+++ b/.github/scripts/hive/build_simulators.sh
@@ -5,8 +5,8 @@ fixture_variant="${1:-osaka}"
 
 case "${fixture_variant}" in
     amsterdam)
-        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-5@v8037.0.0/fixtures_snobal-devnet-5.tar.gz"
-        eels_branch="devnets/snobal/5"
+        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/bal@v6.0.0/fixtures_bal.tar.gz"
+        eels_branch="devnets/snøbal/4"
         ;;
     osaka)
         eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz"

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -272,7 +272,7 @@ where
             halve_workers,
             config,
         );
-        let install_state_hook = env.decoded_bal.is_none();
+        let install_state_hook = env.decoded_bal.is_none() || self.disable_bal_parallel_state_root;
         let prewarm_handle = self.spawn_caching_with(
             env,
             prewarm_rx,
@@ -505,12 +505,12 @@ where
         );
         {
             let to_prewarm_task = to_prewarm_task.clone();
-            let disable_bal_parallel_execution = self.disable_bal_parallel_execution;
+            let disable_bal_parallel_state_root = self.disable_bal_parallel_state_root;
             self.executor.spawn_blocking_named("prewarm", move || {
                 let mode = if skip_prewarm {
                     PrewarmMode::Skipped
                 } else if let Some(decoded_bal) =
-                    maybe_decoded_bal.filter(|_| !disable_bal_parallel_execution)
+                    maybe_decoded_bal.filter(|_| !disable_bal_parallel_state_root)
                 {
                     PrewarmMode::BlockAccessList(decoded_bal)
                 } else {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -123,6 +123,7 @@ where
     /// Whether sparse trie cache pruning is fully disabled.
     disable_sparse_trie_cache_pruning: bool,
     /// Whether to disable BAL-based parallel execution (falls back to tx-based prewarming).
+    #[allow(unused)]
     disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
     disable_bal_parallel_state_root: bool,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -272,6 +272,8 @@ where
             halve_workers,
             config,
         );
+        // If no BALs are present or we have them explicitly disabled, we use sparse trie task and
+        // need to send the updates to it via state hook
         let install_state_hook = env.decoded_bal.is_none() || self.disable_bal_parallel_state_root;
         let prewarm_handle = self.spawn_caching_with(
             env,


### PR DESCRIPTION
We check the CLI flag here https://github.com/paradigmxyz/reth/blob/709485dcb7f76f55b882b5070f93c13b71bc1689/crates/engine/tree/src/tree/payload_processor/mod.rs#L510-L516 but we didn't check it when installing the state hook here https://github.com/paradigmxyz/reth/blob/709485dcb7f76f55b882b5070f93c13b71bc1689/crates/engine/tree/src/tree/payload_processor/mod.rs#L275