### PR TITLE
chore: don't enforce non-empty blocks in e2e payload building

### DIFF
--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -53,27 +53,11 @@ impl<T: PayloadTypes> PayloadTestContext<T> {
     ///
     /// Panics if the payload builder does not produce a non-empty payload within 30 seconds.
     pub async fn wait_for_built_payload(&self, payload_id: PayloadId) {
-        let start = std::time::Instant::now();
-        loop {
-            let payload =
-                self.payload_builder.best_payload(payload_id).await.transpose().ok().flatten();
-            if payload.is_none_or(|p| p.block().body().transactions().is_empty()) {
-                assert!(
-                    start.elapsed() < std::time::Duration::from_secs(30),
-                    "timed out waiting for a non-empty payload for {payload_id} — \
-                     check that the chain spec supports all generated tx types"
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                continue
-            }
-            // Resolve payload once its built
-            self.payload_builder
-                .resolve_kind(payload_id, PayloadKind::Earliest)
-                .await
-                .unwrap()
-                .unwrap();
-            break;
-        }
+        self.payload_builder
+            .resolve_kind(payload_id, PayloadKind::WaitForPending)
+            .await
+            .unwrap()
+            .unwrap();
     }
 
     /// Expects the next event to be a built payload event or panics

--- a/crates/e2e-test-utils/src/payload.rs
+++ b/crates/e2e-test-utils/src/payload.rs
@@ -1,8 +1,8 @@
 use futures_util::StreamExt;
-use reth_node_api::{BlockBody, PayloadAttributes, PayloadKind};
+use reth_node_api::{PayloadAttributes, PayloadKind};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadId};
 use reth_payload_builder_primitives::Events;
-use reth_payload_primitives::{BuiltPayload, PayloadTypes};
+use reth_payload_primitives::PayloadTypes;
 use tokio_stream::wrappers::BroadcastStream;
 
 /// Helper for payload operations


### PR DESCRIPTION
Instead of waiting for a non-empty block we can just resolve with `WaitForPending` kind that would enforce the txs are drained from the pool