### PR TITLE
fix(tree): prioritize BAL prewarm for state root task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -510,12 +510,12 @@ where
             let to_prewarm_task = to_prewarm_task.clone();
             let disable_bal_parallel_state_root = self.disable_bal_parallel_state_root;
             self.executor.spawn_blocking_named("prewarm", move || {
-                let mode = if skip_prewarm {
-                    PrewarmMode::Skipped
-                } else if let Some(decoded_bal) =
+                let mode = if let Some(decoded_bal) =
                     maybe_decoded_bal.filter(|_| !disable_bal_parallel_state_root)
                 {
                     PrewarmMode::BlockAccessList(decoded_bal)
+                } else if skip_prewarm {
+                    PrewarmMode::Skipped
                 } else {
                     PrewarmMode::Transactions(transactions)
                 };
@@ -801,7 +801,7 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
 
     /// Returns a state hook to stream execution state updates to the sparse trie cache task.
     ///
-    /// Returns `None` when execution should not send state updates, such as BAL-driven execution.
+    /// Returns `None` when BAL-driven hashed state streaming feeds the sparse trie task.
     pub fn state_hook(&self) -> Option<impl OnStateHook> {
         self.install_state_hook
             .then(|| self.state_root_handle.as_ref().map(|handle| handle.state_hook()))


### PR DESCRIPTION
BAL payloads with `transaction_count == 0` were selecting `PrewarmMode::Skipped` before the decoded BAL path. Since BAL was present, the normal EVM state hook was also not installed. That left the sparse-trie task with no BAL updates and no `FinishedStateUpdates`, so it sat waiting until the 1s timeout wrapper spawned the sequential fallback.

The StateRootTask path depends on one producer feeding the sparse-trie task and signaling completion. For non-BAL execution that producer is the EVM state hook. For BAL-backed state roots it is BAL prewarm, which streams hashed state updates and then sends `FinishedStateUpdates`. Skipping prewarm for small BAL payloads broke that contract.

Decoded BAL prewarm now takes precedence over the small-block skip when BAL state-root streaming is enabled, so the sparse-trie task receives the BAL updates and completion signal instead of timing out.