### PR TITLE
perf(engine): use Entry API in `insert_executed`

### DIFF
--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -165,11 +165,12 @@ impl<N: NodePrimitives> TreeState<N> {
         let parent_hash = executed.recovered_block().parent_hash();
         let block_number = executed.recovered_block().number();
 
-        if self.blocks_by_hash.contains_key(&hash) {
-            return;
+        match self.blocks_by_hash.entry(hash) {
+            hash_map::Entry::Occupied(_) => return,
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(executed.clone());
+            }
         }
-
-        self.blocks_by_hash.insert(hash, executed.clone());
 
         self.blocks_by_number.entry(block_number).or_default().push(executed);
 


### PR DESCRIPTION
Replace `contains_key` + `insert` in `TreeState::insert_executed` with a single `entry()` match, dropping the duplicate hash lookup on every block insertion. Matches the pattern already used in `remove_by_hash` and `block_buffer::insert_block`.