### PR TITLE
fix(era): force ERA1 type for import sources

### DIFF
--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -6,6 +6,7 @@ use eyre::eyre;
 use reqwest::{Client, Url};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
+use reth_era::common::file_ops::EraFileType;
 use reth_era_downloader::{read_dir, EraClient, EraStream, EraStreamConfig};
 use reth_era_utils as era;
 use reth_etl::Collector;
@@ -96,7 +97,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             fs::create_dir_all(&folder)?;
 
             let config = EraStreamConfig::default().start_from(next_block);
-            let client = EraClient::new(Client::new(), url, folder);
+            let client =
+                EraClient::new(Client::new(), url, folder).with_era_type(EraFileType::Era1);
             let stream = EraStream::new(client, config);
 
             era::import(stream, &provider_factory, &mut hash_collector)?;

--- a/crates/era/src/common/file_ops.rs
+++ b/crates/era/src/common/file_ops.rs
@@ -225,10 +225,19 @@ impl EraFileType {
         }
     }
 
-    /// Detect file type from URL
-    /// By default, it assumes `Era` type
+    /// Detect file type from URL.
+    ///
+    /// This is only a heuristic. Prefer an explicit override when the caller knows the expected
+    /// file type.
     pub fn from_url(url: &str) -> Self {
-        if url.contains("era1") {
+        if let Some(file_type) = Self::from_filename(url.rsplit('/').next().unwrap_or_default()) {
+            return file_type;
+        }
+
+        if url
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .any(|part| part.eq_ignore_ascii_case("era1"))
+        {
             Self::Era1
         } else {
             Self::Era
@@ -241,5 +250,26 @@ pub fn format_hash(hash: Option<[u8; 4]>) -> String {
     match hash {
         Some(h) => format!("{:02x}{:02x}{:02x}{:02x}", h[0], h[1], h[2], h[3]),
         None => "00000000".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EraFileType;
+
+    #[test]
+    fn detects_era1_urls_from_filenames_and_tokens() {
+        assert_eq!(
+            EraFileType::from_url("https://mirror.example.com/mainnet-00000-deadbeef.era1"),
+            EraFileType::Era1
+        );
+        assert_eq!(
+            EraFileType::from_url("https://mirror.example.com/snapshots/sepolia-era1/index.html"),
+            EraFileType::Era1
+        );
+        assert_eq!(
+            EraFileType::from_url("https://mirror.example.com/snapshots/notera1/index.html"),
+            EraFileType::Era
+        );
     }
 }

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -4,7 +4,10 @@ use futures_util::{Stream, StreamExt};
 use reqwest::{Client, Url};
 use reth_config::config::EtlConfig;
 use reth_db_api::{table::Value, transaction::DbTxMut};
-use reth_era::{common::file_ops::StreamReader, era1::file::Era1Reader};
+use reth_era::{
+    common::file_ops::{EraFileType, StreamReader},
+    era1::file::Era1Reader,
+};
 use reth_era_downloader::{read_dir, EraClient, EraMeta, EraStream, EraStreamConfig};
 use reth_era_utils as era;
 use reth_etl::Collector;
@@ -60,7 +63,8 @@ where
             ),
             Self::Url(url, folder) => {
                 let _ = reth_fs_util::create_dir_all(&folder);
-                let client = EraClient::new(Client::new(), url, folder);
+                let client =
+                    EraClient::new(Client::new(), url, folder).with_era_type(EraFileType::Era1);
 
                 Self::convert(EraStream::new(
                     client,


### PR DESCRIPTION
Uses the existing ERA file type override for ERA1 import paths and narrows URL-based type inference to filename or token matches. Custom ERA1 hosts no longer depend on a broad `era1` substring heuristic in the main CLI and stage import paths.