### PR TITLE
perf: trim receipt root per-item overhead

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
+++ b/crates/engine/tree/src/tree/payload_processor/receipt_root_task.rs
@@ -66,6 +66,8 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
     /// * `receipts_len` - The total number of receipts expected. This is needed to correctly order
     ///   the trie keys according to RLP encoding rules.
     pub fn run(self, receipts_len: usize) {
+        const RECEIPT_BURST_SIZE: usize = 32;
+
         let _span = debug_span!(
             target: "engine::tree::payload_processor",
             "receipt_root",
@@ -78,7 +80,7 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
         let mut encode_buf = Vec::new();
         let mut received_count = 0usize;
 
-        for indexed_receipt in self.receipt_rx {
+        let mut process_receipt = |indexed_receipt: IndexedReceipt<R>| {
             let receipt_with_bloom = indexed_receipt.receipt.with_bloom_ref();
 
             encode_buf.clear();
@@ -100,6 +102,14 @@ impl<R: Receipt> ReceiptRootTaskHandle<R> {
                         "Receipt root task received invalid receipt index, skipping"
                     );
                 }
+            }
+        };
+
+        while let Ok(indexed_receipt) = self.receipt_rx.recv() {
+            process_receipt(indexed_receipt);
+
+            for indexed_receipt in self.receipt_rx.try_iter().take(RECEIPT_BURST_SIZE - 1) {
+                process_receipt(indexed_receipt);
             }
         }
 

--- a/crates/trie/common/src/ordered_root.rs
+++ b/crates/trie/common/src/ordered_root.rs
@@ -138,6 +138,8 @@ pub struct OrderedTrieRootEncodedBuilder {
     next_insert_i: usize,
     /// Buffer for pending items, indexed by execution index.
     pending: Vec<Option<Vec<u8>>>,
+    /// Precomputed flush order and trie leaf keys for each insertion slot.
+    flush_keys: Vec<(usize, Option<Nibbles>)>,
     /// The underlying hash builder.
     hb: HashBuilder,
 }
@@ -145,11 +147,19 @@ pub struct OrderedTrieRootEncodedBuilder {
 impl OrderedTrieRootEncodedBuilder {
     /// Creates a new builder for `len` pre-encoded items.
     pub fn new(len: usize) -> Self {
+        let mut flush_keys = Vec::with_capacity(len);
+        for insert_idx in 0..len {
+            let exec_index = adjust_index_for_rlp(insert_idx, len);
+            let index_buffer = alloy_rlp::encode_fixed_size(&exec_index);
+            flush_keys.push((exec_index, Some(Nibbles::unpack(&index_buffer))));
+        }
+
         Self {
             len,
             received: 0,
             next_insert_i: 0,
             pending: alloc::vec![None; len],
+            flush_keys,
             hb: HashBuilder::default(),
         }
     }
@@ -201,14 +211,17 @@ impl OrderedTrieRootEncodedBuilder {
     /// Attempts to flush pending items to the hash builder.
     fn flush(&mut self) {
         while self.next_insert_i < self.len {
-            let exec_index_needed = adjust_index_for_rlp(self.next_insert_i, self.len);
+            let (exec_index_needed, leaf_key) =
+                &mut self.flush_keys[self.next_insert_i];
 
-            let Some(value) = self.pending[exec_index_needed].take() else {
+            let Some(value) = self.pending[*exec_index_needed].take() else {
                 break;
             };
 
-            let index_buffer = alloy_rlp::encode_fixed_size(&exec_index_needed);
-            self.hb.add_leaf(Nibbles::unpack(&index_buffer), &value);
+            self.hb.add_leaf(
+                leaf_key.take().expect("flush key must be present until the slot is consumed"),
+                &value,
+            );
 
             self.next_insert_i += 1;
         }


### PR DESCRIPTION
Precompute the ordered-trie flush keys once per receipt-root builder so flushes stop re-encoding the same adjusted indices on every leaf.

Drain the receipt channel in short bursts inside the background worker so blocks with already-ready receipts spend less time bouncing through per-item recv overhead before hashing and inserting leaves.