### PR TITLE
chore: default to min-trace-logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ maxperf: ## Builds `reth` with the most aggressive optimisations.
 
 .PHONY: maxperf-no-asm
 maxperf-no-asm: ## Builds `reth` with the most aggressive optimisations, minus the "asm-keccak" feature.
-	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --no-default-features --features jemalloc,min-debug-logs,otlp,otlp-logs,reth-revm/portable,js-tracer,keccak-cache-global,rocksdb
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf --no-default-features --features jemalloc,min-trace-logs,otlp,otlp-logs,reth-revm/portable,js-tracer,keccak-cache-global,rocksdb
 
 fmt:
 	cargo +nightly fmt

--- a/bin/reth-bb/Cargo.toml
+++ b/bin/reth-bb/Cargo.toml
@@ -70,7 +70,7 @@ default = [
     "reth-cli-util/jemalloc",
     "asm-keccak",
     "keccak-cache-global",
-    "min-debug-logs",
+    "min-trace-logs",
 ]
 
 jemalloc = [
@@ -100,6 +100,11 @@ min-debug-logs = [
     "tracing/release_max_level_debug",
     "reth-ethereum-cli/min-debug-logs",
     "reth-node-core/min-debug-logs",
+]
+min-trace-logs = [
+    "tracing/release_max_level_trace",
+    "reth-ethereum-cli/min-trace-logs",
+    "reth-node-core/min-trace-logs",
 ]
 
 [[bin]]

--- a/bin/reth-bench/README.md
+++ b/bin/reth-bench/README.md
@@ -86,7 +86,7 @@ RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --features "jem
 Finally, if the purpose of the benchmark is to profile the node when `snmalloc` is configured as the default allocator, it would be built with the following
 command:
 ```bash
-RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --no-default-features --features "snmalloc-native,asm-keccak,min-debug-logs"
+RUSTFLAGS="-C target-cpu=native" cargo build --profile profiling --no-default-features --features "snmalloc-native,asm-keccak,min-trace-logs"
 ```
 
 ### Run the Benchmark:

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -88,7 +88,7 @@ default = [
     "js-tracer",
     "keccak-cache-global",
     "asm-keccak",
-    "min-debug-logs",
+    "min-trace-logs",
 ]
 
 otlp = [

--- a/docs/vocs/docs/pages/installation/source.mdx
+++ b/docs/vocs/docs/pages/installation/source.mdx
@@ -110,11 +110,11 @@ RUSTFLAGS="-C target-cpu=native" cargo build --profile maxperf
 
 **Features**
 
-The following performance features are enabled by default: `jemalloc` (except on Windows), `asm-keccak`, and `min-debug-logs`.
+The following performance features are enabled by default: `jemalloc` (except on Windows), `asm-keccak`, and `min-trace-logs`.
 
 Some additional optional features are available:
 
--   `min-LEVEL-logs`, where `LEVEL` is one of `error`, `warn`, `info`, `debug`, `trace`: disables compilation of logs of lower level than the given one; `min-debug-logs` is enabled by default
+-   `min-LEVEL-logs`, where `LEVEL` is one of `error`, `warn`, `info`, `debug`, `trace`: disables compilation of logs of lower level than the given one; `min-trace-logs` is enabled by default
 
 You can build with maximum performance optimizations using:
 


### PR DESCRIPTION
Switches the default compile-time tracing filter from `min-debug-logs` to `min-trace-logs` for the reth binaries, and updates the no-default-features build paths and docs to match.

Without this feature, we can't use the `trace` filter for logs without recompiling the binary.