### PR TITLE
fix(cli): verify repaired trie state root before commit

### DIFF
--- a/crates/cli/commands/src/db/repair_trie.rs
+++ b/crates/cli/commands/src/db/repair_trie.rs
@@ -1,3 +1,4 @@
+use alloy_consensus::BlockHeader as AlloyBlockHeader;
 use clap::Parser;
 use metrics::{self, Counter};
 use reth_chainspec::EthChainSpec;
@@ -18,7 +19,9 @@ use reth_node_metrics::{
     server::{MetricServer, MetricServerConfig},
     version::VersionInfo,
 };
-use reth_provider::{providers::ProviderNodeTypes, ChainSpecProvider, StageCheckpointReader};
+use reth_provider::{
+    providers::ProviderNodeTypes, ChainSpecProvider, HeaderProvider, StageCheckpointReader,
+};
 use reth_stages::StageId;
 use reth_storage_api::StorageSettingsCache;
 use reth_tasks::TaskExecutor;
@@ -27,7 +30,8 @@ use reth_trie::{
     Nibbles,
 };
 use reth_trie_db::{
-    DatabaseHashedCursorFactory, DatabaseTrieCursorFactory, StorageTrieEntryLike, TrieTableAdapter,
+    DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory,
+    StorageTrieEntryLike, TrieTableAdapter,
 };
 use std::{
     net::SocketAddr,
@@ -215,7 +219,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
     verify_checkpoints(provider_rw.as_ref())?;
 
     let inconsistent_nodes = reth_trie_db::with_adapter!(tool.provider_factory, |A| {
-        do_verify_and_repair::<_, A>(&mut provider_rw)?
+        do_verify_and_repair::<_, A>(&mut provider_rw, finish_checkpoint.block_number)?
     });
 
     if inconsistent_nodes == 0 {
@@ -230,6 +234,7 @@ fn verify_and_repair<N: ProviderNodeTypes>(tool: &DbTool<N>) -> eyre::Result<()>
 
 fn do_verify_and_repair<N: ProviderNodeTypes, A: TrieTableAdapter>(
     provider_rw: &mut reth_provider::DatabaseProviderRW<N::DB, N>,
+    block_number: u64,
 ) -> eyre::Result<usize>
 where
     <N::DB as reth_db_api::database::Database>::TXMut: DbTxMut + DbTx,
@@ -329,7 +334,46 @@ where
         }
     }
 
+    drop(account_trie_cursor);
+    drop(storage_trie_cursor);
+
+    if inconsistent_nodes > 0 {
+        // Refuse to commit repaired trie tables unless they reproduce the canonical tip state
+        // root.
+        verify_repaired_state_root::<_, A>(provider_rw, block_number)?;
+    }
+
     Ok(inconsistent_nodes as usize)
+}
+
+fn verify_repaired_state_root<N: ProviderNodeTypes, A: TrieTableAdapter>(
+    provider_rw: &reth_provider::DatabaseProviderRW<N::DB, N>,
+    block_number: u64,
+) -> eyre::Result<()>
+where
+    <N::DB as reth_db_api::database::Database>::TXMut: DbTxMut + DbTx,
+{
+    type DbStateRoot<'a, TX, A> = reth_trie::StateRoot<
+        DatabaseTrieCursorFactory<&'a TX, A>,
+        DatabaseHashedCursorFactory<&'a TX>,
+    >;
+
+    let expected_state_root = provider_rw
+        .header_by_number(block_number)?
+        .ok_or_else(|| {
+            eyre::eyre!("Missing canonical header at database block tip {block_number}")
+        })?
+        .state_root();
+
+    let computed_state_root = DbStateRoot::<_, A>::from_tx(provider_rw.tx_ref()).root()?;
+
+    if computed_state_root != expected_state_root {
+        return Err(eyre::eyre!(
+            "Repaired trie state root mismatch at block {block_number}: computed {computed_state_root}, header {expected_state_root}",
+        ))
+    }
+
+    Ok(())
 }
 
 /// Output progress information based on the last seen account path.


### PR DESCRIPTION
Adds a full state root recomputation to `reth db repair-trie` before repaired trie tables are committed. The command now compares the recomputed root from the RW transaction against the canonical header state root at the finish checkpoint and aborts if they differ.