### PR TITLE
refactor: remove the unneeded bal hash check.

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -9,14 +9,6 @@ use alloy_primitives::B256;
 /// block error.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RejectReason {
-    /// `keccak256(rlp(received_bal))` disagrees with `header.block_access_list_hash`.
-    HeaderHashMismatch {
-        /// Hash computed from the received BAL bytes.
-        computed: B256,
-        /// Hash committed in the block header.
-        expected: B256,
-    },
-
     /// BAL fails the structural item-count gate:
     /// `(addresses + unique_storage_keys) * ITEM_COST > block_gas_limit`.
     ItemCountExceedsGasBudget {

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -8,7 +8,6 @@
 //!
 //! ### Checks performed
 //!
-//! - **A (structural hash)**: `check_bal_hash(received_bal, header_bal_hash)` at entry.
 //! - **B (item-count gate)**: `check_item_count(received_bal, block_gas_limit)` at entry.
 //! - **F (final hash)**: rebuilt composed BAL hashed against the header's commitment after
 //!   post-execution.
@@ -16,10 +15,7 @@
 //! Check E (per-tx fragment compare) is skipped — check F is authoritative, and a
 //! lightweight fragment compare isn't yet designed.
 
-use super::{
-    validation::{check_bal_hash, check_item_count},
-    RejectReason,
-};
+use super::{validation::check_item_count, RejectReason};
 use alloy_consensus::Transaction;
 use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
 use alloy_evm::{
@@ -67,7 +63,7 @@ pub struct BalExecutionOutput<Evm: ConfigureEvm> {
 /// Errors surfaced by [`BalPayloadExecutor::execute_block`].
 #[derive(Debug)]
 pub enum BalExecutionError {
-    /// BAL-specific rejection — structural or final-hash mismatch.
+    /// BAL-specific rejection.
     Reject(RejectReason),
     /// Worker or canonical EVM failure (including revm `BalError` for undeclared accesses,
     /// surfaced opaquely until upstream revm carries address/slot metadata).
@@ -166,7 +162,6 @@ impl<Evm: ConfigureEvm> BalPayloadExecutor<Evm> {
         DB: Database + Send,
         MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
     {
-        check_bal_hash(&received_bal, header_bal_hash)?;
         let bal = received_bal.as_bal();
         check_item_count(bal, block_gas_limit)?;
 
@@ -457,31 +452,6 @@ mod tests {
             },
         };
         block.seal_slow()
-    }
-
-    #[test]
-    fn rejects_bad_bal_hash_up_front() {
-        // Check A: the received BAL's hash must match the header's commitment.
-        let executor = BalPayloadExecutor::new(Runtime::test(), EthEvmConfig::mainnet());
-        let snapshot = Arc::new(BlockPreState::default());
-        let received_bal: BlockAccessList = Vec::new();
-        let wrong_hash = B256::repeat_byte(0xff);
-        let block = empty_amsterdam_block(wrong_hash);
-
-        let result = executor.execute_block(
-            snapshot_db(snapshot),
-            to_arc_decoded(received_bal),
-            &block,
-            Vec::<Recovered<TransactionSigned>>::new(),
-            wrong_hash,
-            30_000_000,
-        );
-
-        match result {
-            Err(BalExecutionError::Reject(RejectReason::HeaderHashMismatch { .. })) => {}
-            Err(e) => panic!("expected HeaderHashMismatch, got error {e:?}"),
-            Ok(_) => panic!("expected HeaderHashMismatch, got Ok"),
-        }
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -36,6 +36,6 @@ pub use pre_state::{BlockPreState, RequiredReads};
 pub use snapshot::build_pre_state;
 #[cfg(test)]
 pub use snapshot_db::{SnapshotDatabase, SnapshotDbError};
-pub use validation::{check_bal_hash, check_item_count};
+pub use validation::check_item_count;
 #[cfg(test)]
 pub use worker::{BalBlockExecutor, WorkerError};

--- a/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
@@ -1,26 +1,11 @@
-//! Structural BAL validation: the two cheapest checks in the validation chain.
+//! Structural BAL validation.
 //!
-//! Both run before any state I/O, letting us reject adversarial BALs without spending storage
-//! bandwidth. See `BAL.md` §Validation chain, checks A and B.
+//! These checks run before any state I/O, letting us reject adversarial BALs without spending
+//! storage bandwidth.
 
-use alloy_eip7928::{bal::DecodedBal, AccountChanges};
-use alloy_primitives::B256;
+use alloy_eip7928::AccountChanges;
 
 use super::RejectReason;
-
-/// Check A: `keccak256(raw_rlp_of_received_bal) == header.block_access_list_hash`.
-///
-/// Uses [`DecodedBal`]'s cached hash (`keccak256` of the raw RLP bytes captured at decode
-/// time) — the same pre-image the header commits to. Zero I/O; first call computes the hash,
-/// subsequent calls are free.
-pub fn check_bal_hash(bal: &DecodedBal, expected: B256) -> Result<(), RejectReason> {
-    let computed = bal.hash();
-    if computed == expected {
-        Ok(())
-    } else {
-        Err(RejectReason::HeaderHashMismatch { computed, expected })
-    }
-}
 
 /// Check B: `(addresses + unique_storage_keys) * ITEM_COST <= block_gas_limit`.
 ///
@@ -40,8 +25,8 @@ pub fn check_item_count(bal: &[AccountChanges], block_gas_limit: u64) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eip7928::{bal::Bal as AlloyBal, AccountChanges, SlotChanges, StorageChange};
-    use alloy_primitives::{b256, Address, U256};
+    use alloy_eip7928::{AccountChanges, SlotChanges, StorageChange};
+    use alloy_primitives::{Address, U256};
 
     fn addr(byte: u8) -> Address {
         let mut a = [0u8; 20];
@@ -52,50 +37,6 @@ mod tests {
     fn slot(byte: u8) -> U256 {
         U256::from(byte)
     }
-
-    /// Wraps a `Vec<AccountChanges>` into a `DecodedBal` by RLP-encoding the contents — same
-    /// path a real block takes through `DecodedBal::from_rlp_bytes`, so the cached hash stays
-    /// faithful to what the header would commit to.
-    fn to_decoded(bal: Vec<AccountChanges>) -> DecodedBal {
-        let alloy_bal: AlloyBal = bal.into();
-        let raw = alloy_rlp::encode(&alloy_bal).into();
-        DecodedBal::new(alloy_bal, raw)
-    }
-
-    // ---- check_bal_hash ----
-
-    #[test]
-    fn check_bal_hash_accepts_matching_hash() {
-        let decoded = to_decoded(vec![AccountChanges::new(addr(1))]);
-        let computed = decoded.hash();
-        assert_eq!(check_bal_hash(&decoded, computed), Ok(()));
-    }
-
-    #[test]
-    fn check_bal_hash_rejects_with_populated_fields() {
-        let decoded = to_decoded(vec![AccountChanges::new(addr(1))]);
-        let expected = b256!("0xdeadbeef00000000000000000000000000000000000000000000000000000000");
-
-        let err = check_bal_hash(&decoded, expected).unwrap_err();
-
-        match err {
-            RejectReason::HeaderHashMismatch { computed, expected: got } => {
-                assert_eq!(got, expected);
-                assert_eq!(computed, decoded.hash());
-                assert_ne!(computed, expected);
-            }
-            other => panic!("expected HeaderHashMismatch, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn check_bal_hash_handles_empty_bal() {
-        let decoded = to_decoded(Vec::new());
-        let computed = decoded.hash();
-        assert_eq!(check_bal_hash(&decoded, computed), Ok(()));
-    }
-
-    // ---- check_item_count ----
 
     #[test]
     fn check_item_count_accepts_empty_bal_with_zero_limit() {


### PR DESCRIPTION
This check is unneeded because it's already performed upstream.