### PR TITLE
perf(engine): fast-path uncontended cache waits

### DIFF
--- a/crates/engine/execution-cache/src/lib.rs
+++ b/crates/engine/execution-cache/src/lib.rs
@@ -122,6 +122,16 @@ impl PayloadExecutionCache {
         elapsed
     }
 
+    /// Tries to acquire the cache lock without spawning any helper work.
+    ///
+    /// Returns `Some(wait_duration)` if the lock was immediately available and `None` when the
+    /// caller should fall back to the contended wait path.
+    pub fn try_wait_for_availability(&self) -> Option<Duration> {
+        let start = Instant::now();
+        let _guard = self.inner.try_lock()?;
+        Some(start.elapsed())
+    }
+
     /// Updates the cache with a closure that has exclusive access to the guard.
     /// This ensures that all cache operations happen atomically.
     ///
@@ -158,6 +168,7 @@ struct PayloadExecutionCacheMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn single_checkout_blocks_second() {
@@ -211,5 +222,32 @@ mod tests {
     fn empty_cache_returns_none() {
         let cache = PayloadExecutionCache::default();
         assert!(cache.get_cache_for(B256::ZERO).is_none());
+    }
+
+    #[test]
+    fn try_wait_for_availability_succeeds_when_uncontended() {
+        let cache = PayloadExecutionCache::default();
+
+        assert!(cache.try_wait_for_availability().is_some());
+    }
+
+    #[test]
+    fn try_wait_for_availability_reports_contention() {
+        let cache = Arc::new(PayloadExecutionCache::default());
+        let held_cache = Arc::clone(&cache);
+        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let _guard = held_cache.inner.lock();
+            locked_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        locked_rx.recv().unwrap();
+        assert!(cache.try_wait_for_availability().is_none());
+
+        release_tx.send(()).unwrap();
+        handle.join().unwrap();
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -177,6 +177,16 @@ where
     fn wait_for_caches(&self) -> CacheWaitDurations {
         debug!(target: "engine::tree::payload_processor", "Waiting for execution cache and sparse trie locks");
 
+        if let (Some(execution_cache_duration), Some(sparse_trie_duration)) = (
+            self.execution_cache.try_wait_for_availability(),
+            self.sparse_state_trie.try_wait_for_availability(),
+        ) {
+            return CacheWaitDurations {
+                execution_cache: execution_cache_duration,
+                sparse_trie: sparse_trie_duration,
+            }
+        }
+
         // Wait for both caches in parallel using std threads
         let execution_cache = self.execution_cache.clone();
         let sparse_trie = self.sparse_state_trie.clone();

--- a/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/preserved_sparse_trie.rs
@@ -50,6 +50,16 @@ impl SharedPreservedSparseTrie {
         }
         elapsed
     }
+
+    /// Tries to acquire the preserved trie lock without blocking.
+    ///
+    /// Returns `Some(wait_duration)` if the lock was immediately available and `None` when the
+    /// caller should fall back to the contended wait path.
+    pub(super) fn try_wait_for_availability(&self) -> Option<std::time::Duration> {
+        let start = Instant::now();
+        let _guard = self.0.try_lock()?;
+        Some(start.elapsed())
+    }
 }
 
 /// Guard that holds the lock on the preserved trie.
@@ -134,5 +144,38 @@ impl PreservedSparseTrie {
                 trie
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn try_wait_for_availability_succeeds_when_uncontended() {
+        let trie = SharedPreservedSparseTrie::default();
+
+        assert!(trie.try_wait_for_availability().is_some());
+    }
+
+    #[test]
+    fn try_wait_for_availability_reports_contention() {
+        let trie = Arc::new(SharedPreservedSparseTrie::default());
+        let held_trie = Arc::clone(&trie);
+        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let _guard = held_trie.0.lock();
+            locked_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        locked_rx.recv().unwrap();
+        assert!(trie.try_wait_for_availability().is_none());
+
+        release_tx.send(()).unwrap();
+        handle.join().unwrap();
     }
 }


### PR DESCRIPTION
Add non-blocking lock probes for the execution cache and preserved sparse trie. When both locks are immediately available, payload validation now avoids spawning helper blocking tasks and channel round-trips, while preserving the existing parallel wait path for contended locks.