### PR TITLE
feat(payload): expose built payload block access list

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -202,6 +202,10 @@ impl<N: NodePrimitives> BuiltPayload for EthBuiltPayload<N> {
         self.fees
     }
 
+    fn block_access_list(&self) -> Option<&Bytes> {
+        self.block_access_list.as_ref()
+    }
+
     fn requests(&self) -> Option<Requests> {
         self.requests.clone()
     }

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -3,7 +3,7 @@ use crate::{
     PayloadConfig,
 };
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Bytes, B256, U256};
 use reth_payload_builder::PayloadId;
 use reth_payload_primitives::{BuiltPayload, PayloadAttributes};
 use reth_primitives_traits::{NodePrimitives, SealedBlock};
@@ -132,6 +132,13 @@ where
         match self {
             Self::Left(l) => l.fees(),
             Self::Right(r) => r.fees(),
+        }
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
+        match self {
+            Self::Left(l) => l.block_access_list(),
+            Self::Right(r) => r.block_access_list(),
         }
     }
 

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -3,7 +3,7 @@
 use crate::PayloadBuilderError;
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_eips::{eip4895::Withdrawal, eip7685::Requests};
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Bytes, B256, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadId};
 use core::fmt;
@@ -80,6 +80,13 @@ pub trait BuiltPayload: Send + Sync + fmt::Debug {
 
     /// Returns the total fees collected from all transactions in this block.
     fn fees(&self) -> U256;
+
+    /// Returns the EIP-7928 block access list included in this payload.
+    ///
+    /// Returns `None` for payloads that do not carry a block access list.
+    fn block_access_list(&self) -> Option<&Bytes> {
+        None
+    }
 
     /// Returns the complete execution result including state updates.
     ///


### PR DESCRIPTION
Adds a `BuiltPayload::block_access_list` accessor with a default `None` implementation, wires `EthBuiltPayload` to return its stored BAL bytes, and forwards through stacked payload builders.

Checked with `cargo check -p reth-payload-primitives -p reth-basic-payload-builder -p reth-ethereum-engine-primitives` and `cargo +nightly fmt --all --check`.