### PR TITLE
feat(engine): add shared block accessor to EthBuiltPayload

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -62,6 +62,11 @@ impl<N: NodePrimitives> EthBuiltPayload<N> {
         &self.block
     }
 
+    /// Returns the built block with shared ownership.
+    pub const fn block_arc(&self) -> &Arc<SealedBlock<N::Block>> {
+        &self.block
+    }
+
     /// Fees of the block
     pub const fn fees(&self) -> U256 {
         self.fees


### PR DESCRIPTION
Adds `EthBuiltPayload::block_arc()` so callers can borrow the shared sealed block `Arc` without consuming the payload. The existing borrowed `block()` accessor remains unchanged. Validated with `cargo +nightly fmt --all --check` and `cargo nextest run -p reth-ethereum-engine-primitives`.