### PR TITLE
perf(provider): reuse computed trie bundles during save_blocks merges

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -431,6 +431,18 @@ impl ComputedTrieData {
     }
 }
 
+impl AsRef<HashedPostStateSorted> for ComputedTrieData {
+    fn as_ref(&self) -> &HashedPostStateSorted {
+        self.hashed_state.as_ref()
+    }
+}
+
+impl AsRef<TrieUpdatesSorted> for ComputedTrieData {
+    fn as_ref(&self) -> &TrieUpdatesSorted {
+        self.trie_updates.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -718,19 +718,20 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Write all hashed state and trie updates in single batches.
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() {
-                // Blocks are oldest-to-newest, merge_batch expects newest-to-oldest.
+                // Compute each deferred trie bundle once, then reuse it for both merge passes.
+                // This keeps persistence from paying a second `wait_cloned()`/bundle clone pass
+                // just to switch from hashed state to trie updates.
+                let trie_data: Vec<_> = blocks.iter().rev().map(|block| block.trie_data()).collect();
+
                 let start = Instant::now();
-                let merged_hashed_state = HashedPostStateSorted::merge_batch(
-                    blocks.iter().rev().map(|b| b.trie_data().hashed_state),
-                );
+                let merged_hashed_state = HashedPostStateSorted::merge_slice(&trie_data);
                 if !merged_hashed_state.is_empty() {
                     self.write_hashed_state(&merged_hashed_state)?;
                 }
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                let merged_trie =
-                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
+                let merged_trie = TrieUpdatesSorted::merge_slice(&trie_data);
                 if !merged_trie.is_empty() {
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }


### PR DESCRIPTION
Collect each block's deferred trie data once during save_blocks and reuse the same computed bundle for both hashed-state and trie-update batch merges. This avoids paying a second wait_cloned/bundle-clone pass on the persistence path before the MDBX writes begin.