### PR TITLE
chore: update rpc-compat expected failures

### DIFF
--- a/.github/scripts/hive/expected_failures.yaml
+++ b/.github/scripts/hive/expected_failures.yaml
@@ -2,7 +2,9 @@
 rpc-compat:
   - debug_getRawBlock/get-invalid-number (reth)
   - debug_getRawTransaction/get-invalid-hash (reth)
-
+  - debug_getRawReceipts/get-invalid-number (reth)
+  - debug_getRawHeader/get-invalid-number (reth)
+  - debug_getRawReceipts/get-block-n (reth)
   - eth_getStorageAt/get-storage-invalid-key-too-large (reth)
   - eth_getStorageAt/get-storage-invalid-key (reth)
   - eth_getTransactionReceipt/get-legacy-contract (reth)


### PR DESCRIPTION
These fail because jsonrpsee includes data in error and hive expects that data is empty
`"error": {
    "code": -32602,
    -- "data": "hex string without 0x prefix at line 1 column 3"
  },`