### PR TITLE
fix(reth-bb): renumber bal_index space at segment boundaries

### DIFF
--- a/bin/reth-bb/src/evm.rs
+++ b/bin/reth-bb/src/evm.rs
@@ -106,6 +106,28 @@ pub(crate) type BlockHashSeeder<DB> = fn(&mut DB, &[(u64, B256)]);
 /// Function pointer that reads the BAL index from the DB.
 pub(crate) type BalIndexReader<DB> = fn(&DB) -> u64;
 
+/// Function pointer that bumps the BAL index in the DB.
+///
+/// Injected from `ConfigureEvm::create_executor` like the other DB callbacks
+/// so `BbBlockExecutor` can advance `bal_index` between sub-events of a
+/// segment boundary (post-N's `finish()` and pre-N+1's
+/// `apply_pre_execution_changes()`) without requiring additional trait bounds
+/// on `DB`. The renumbering scheme places these on consecutive `bal_indexes` so
+/// workers reading the BAL overlay see post-N's writes via the strict
+/// less-than `BalWrites::get` semantic.
+pub(crate) type BalIndexBumper<DB> = fn(&mut DB);
+
+/// Function pointer that overwrites the BAL index in the DB.
+///
+/// Used in `BbBlockExecutor::initialize` to map a worker's incoming
+/// `bal_index = i + 1` (the standard "tx i + 1" convention from
+/// `execute_block_in_pool`) onto the renumbered space `i + 1 + 2k`, where
+/// `k` is the segment index containing tx `i`. Renumbering reserves two
+/// extra `bal_indexes` per segment boundary (one for each segment's
+/// post-execution and one for the next segment's pre-execution), so workers'
+/// strict less-than reads can see those boundary writes.
+pub(crate) type BalIndexSetter<DB> = fn(&mut DB, u64);
+
 /// Block executor that wraps [`EthBlockExecutor`] and handles segment-boundary
 /// changes for big-block execution.
 ///
@@ -143,6 +165,14 @@ where
     block_hash_seeder: Option<BlockHashSeeder<DB>>,
     /// Callback to read the BAL index from the DB.
     bal_index_reader: Option<BalIndexReader<DB>>,
+    /// Callback to bump `bal_index` on the DB. See [`BalIndexBumper`]. Used at
+    /// segment boundaries to put post-N's writes and pre-N+1's writes on
+    /// consecutive `bal_indexes`.
+    bal_index_bumper: Option<BalIndexBumper<DB>>,
+    /// Callback to set `bal_index` on the DB. See [`BalIndexSetter`]. Used in
+    /// [`Self::initialize`] to renumber a worker's incoming `bal_index` into
+    /// the boundary-padded space.
+    bal_index_setter: Option<BalIndexSetter<DB>>,
     /// Whether the executor has selected its starting segment.
     initialized: bool,
 }
@@ -163,6 +193,7 @@ where
     >,
     TxEnv: FromRecoveredTx<TransactionSigned> + FromTxWithEncoded<TransactionSigned>,
 {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         evm: EthEvm<DB, I, P>,
         ctx: EthBlockExecutionCtx<'a>,
@@ -171,6 +202,8 @@ where
         plan: Option<BbEvmPlan>,
         block_hash_seeder: Option<BlockHashSeeder<DB>>,
         bal_index_reader: Option<BalIndexReader<DB>>,
+        bal_index_bumper: Option<BalIndexBumper<DB>>,
+        bal_index_setter: Option<BalIndexSetter<DB>>,
     ) -> Self {
         let inner = EthBlockExecutor::new(evm, ctx, spec, receipt_builder);
         Self {
@@ -182,6 +215,8 @@ where
             shared_hook: Arc::new(Mutex::new(None)),
             block_hash_seeder,
             bal_index_reader,
+            bal_index_bumper,
+            bal_index_setter,
             initialized: false,
         }
     }
@@ -232,6 +267,17 @@ where
         self.reseed_block_hashes_for(block_number);
 
         if bal_index > 0 {
+            // Renumber the worker's bal_index from the raw "tx i + 1"
+            // convention to "tx i + 1 + 2k" where k is the segment index.
+            // This reserves two `bal_indexes` per crossed segment boundary
+            // (one for post-N's `finish()`, one for pre-N+1's
+            // `apply_pre_execution_changes`) so worker reads via
+            // `BalWrites::get` see those writes via the strict less-than
+            // semantic.
+            if let Some(setter) = self.bal_index_setter {
+                let renumbered = bal_index + 2 * segment_idx as u64;
+                setter(self.inner_mut().evm_mut().db_mut(), renumbered);
+            }
             self.plan = None;
         }
 
@@ -329,12 +375,21 @@ where
 
         // Finish the inner executor for the completed segment. This applies
         // post-execution system calls (EIP-7002/7251) and withdrawal balance
-        // increments via EthBlockExecutor::finish().
+        // increments via EthBlockExecutor::finish() at the current bal_index
+        // (= K, the boundary's "post-N slot").
         let mut inner = self.inner.take().expect("inner executor must exist");
         inner.ctx = prev_ctx;
         let spec = inner.spec.clone();
         let receipt_builder = inner.receipt_builder;
         let (mut evm, result) = inner.finish()?;
+
+        // Renumbering: bump bal_index so the new segment's
+        // `apply_pre_execution_changes` writes land at K+1 instead of colliding
+        // with post-N at K. Without this, BAL workers querying at K can't see
+        // either boundary write via `BalWrites::get`'s strict less-than.
+        if let Some(bumper) = self.bal_index_bumper {
+            bumper(evm.db_mut());
+        }
 
         // Receipts already have globally-correct cumulative_gas_used (fixed
         // up in commit_transaction). Update the offset with this segment's
@@ -387,8 +442,16 @@ where
             .saturating_to::<u64>();
         self.reseed_block_hashes_for(new_block_number);
 
-        // Apply pre-execution changes for the new segment (EIP-2935, EIP-4788).
+        // Apply pre-execution changes for the new segment (EIP-2935, EIP-4788)
+        // at bal_index K+1.
         self.inner_mut().apply_pre_execution_changes()?;
+
+        // Renumbering: bump bal_index so the upcoming `inner.commit_transaction`
+        // for tx 0 of this segment lands at K+2 (visible to its worker via
+        // strict less-than reads of K+2, which include both K and K+1).
+        if let Some(bumper) = self.bal_index_bumper {
+            bumper(self.inner_mut().evm_mut().db_mut());
+        }
 
         trace!(target: "engine::bb::evm", "Started segment {seg_idx}");
 
@@ -586,6 +649,8 @@ impl<Spec> BbBlockExecutorFactory<Spec> {
         ctx: EthBlockExecutionCtx<'a>,
         block_hash_seeder: Option<BlockHashSeeder<DB>>,
         bal_index_reader: Option<BalIndexReader<DB>>,
+        bal_index_bumper: Option<BalIndexBumper<DB>>,
+        bal_index_setter: Option<BalIndexSetter<DB>>,
     ) -> BbBlockExecutor<'a, DB, I, PrecompilesMap, &'a Spec>
     where
         Spec: alloy_evm::eth::spec::EthExecutorSpec,
@@ -601,6 +666,8 @@ impl<Spec> BbBlockExecutorFactory<Spec> {
             plan,
             block_hash_seeder,
             bal_index_reader,
+            bal_index_bumper,
+            bal_index_setter,
         )
     }
 }
@@ -635,6 +702,16 @@ where
         I: Inspector<EthEvmContext<DB>>,
     {
         let plan = self.peek_plan();
-        BbBlockExecutor::new(evm, ctx, &self.spec, self.receipt_builder, plan, None, None)
+        BbBlockExecutor::new(
+            evm,
+            ctx,
+            &self.spec,
+            self.receipt_builder,
+            plan,
+            None,
+            None,
+            None,
+            None,
+        )
     }
 }

--- a/bin/reth-bb/src/evm_config.rs
+++ b/bin/reth-bb/src/evm_config.rs
@@ -110,6 +110,27 @@ fn read_bal_index<DB>(state: &&mut revm::database::State<DB>) -> u64 {
     state.bal_state.bal_index()
 }
 
+/// Bumps the BAL index on a `&mut State<DB>`.
+///
+/// Used as a [`BalIndexBumper`](crate::evm::BalIndexBumper) callback so the
+/// generic [`BbBlockExecutor`](crate::evm::BbBlockExecutor) can advance
+/// `bal_index` between sub-events of a segment boundary (post-N's `finish()`
+/// and pre-N+1's `apply_pre_execution_changes()`) without a trait bound on
+/// `DB`.
+fn bump_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>) {
+    state.bump_bal_index();
+}
+
+/// Sets the BAL index on a `&mut State<DB>`.
+///
+/// Used as a [`BalIndexSetter`](crate::evm::BalIndexSetter) callback so
+/// [`BbBlockExecutor::initialize`](crate::evm::BbBlockExecutor) can renumber
+/// a worker's incoming `bal_index = i + 1` into the boundary-padded space
+/// `i + 1 + 2*k` (where `k` is the worker's segment index).
+fn set_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>, index: u64) {
+    state.set_bal_index(index);
+}
+
 // ---------------------------------------------------------------------------
 // ConfigureEvm
 // ---------------------------------------------------------------------------
@@ -183,12 +204,15 @@ where
             Some(read_bal_index::<DB>);
 
         // Inject concrete function pointers that know the `State<DB>` type so
-        // the generic executor can reseed block hashes and read `bal_index`.
+        // the generic executor can manipulate `bal_index` and reseed block
+        // hashes without a trait bound on `DB`.
         self.executor_factory.create_executor_with_seeder(
             evm,
             ctx,
             Some(seed_state_block_hashes::<DB>),
             bal_index_reader,
+            Some(bump_bal_index::<DB>),
+            Some(set_bal_index::<DB>),
         )
     }
 }

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -456,9 +456,12 @@ impl Command {
                 let mut total_gas_limit = base.payload.as_v1().gas_limit;
 
                 // Concatenate transactions from subsequent blocks and build env_switches
-                for ((block_data, receipts), block_access_list) in
-                    blocks.into_iter().zip(block_receipts).zip(block_access_lists)
+                for (block_idx, ((block_data, receipts), block_access_list)) in
+                    blocks.into_iter().zip(block_receipts).zip(block_access_lists).enumerate()
                 {
+                    // Segment index in the merged big block. The base block is
+                    // segment 0; subsequent blocks are segments 1, 2, ...
+                    let segment_idx = (block_idx + 1) as u64;
                     let block_v1 = block_data.payload.as_v1();
                     let block_gas = block_v1.gas_used;
                     total_gas_used += block_gas;
@@ -469,6 +472,7 @@ impl Command {
                             merged_block_access_list.get_or_insert_with(Default::default),
                             block_access_list,
                             cumulative_tx_count as u64,
+                            segment_idx,
                         );
                     }
 
@@ -734,6 +738,7 @@ fn merge_block_access_list(
     merged: &mut BlockAccessList,
     incoming: BlockAccessList,
     tx_index_offset: u64,
+    segment_idx: u64,
 ) {
     let mut account_positions = merged
         .iter()
@@ -742,7 +747,7 @@ fn merge_block_access_list(
         .collect::<HashMap<_, _>>();
 
     for mut account_changes in incoming {
-        shift_account_changes(&mut account_changes, tx_index_offset);
+        shift_account_changes(&mut account_changes, tx_index_offset, segment_idx);
 
         if let Some(&idx) = account_positions.get(&account_changes.address) {
             merge_account_changes(&mut merged[idx], account_changes);
@@ -753,20 +758,37 @@ fn merge_block_access_list(
     }
 }
 
-fn shift_account_changes(account_changes: &mut AccountChanges, tx_index_offset: u64) {
+fn shift_account_changes(
+    account_changes: &mut AccountChanges,
+    tx_index_offset: u64,
+    segment_idx: u64,
+) {
+    // Per-block BALs use block_access_index = 0 for pre-execution writes
+    // (system contract calls before any tx), 1..tx_count for tx commits, and
+    // tx_count+1 for post-execution.
+    //
+    // Renumbering: each segment boundary reserves two distinct bal_indexes —
+    // one for the prior segment's `finish()` (post-execution withdrawals +
+    // EIP-7002/7251 system calls) and one for the new segment's
+    // `apply_pre_execution_changes()` (EIP-2935/EIP-4788). The renumbered
+    // bal_index for a block-local idx in segment `k` is
+    // `idx + tx_index_offset + 2*k`. This ensures BAL workers reading via
+    // `BalWrites::get` (strict less-than) see all prior segments' boundary
+    // writes.
+    let shift = tx_index_offset + 2 * segment_idx;
     for slot_changes in &mut account_changes.storage_changes {
         for change in &mut slot_changes.changes {
-            change.block_access_index += tx_index_offset;
+            change.block_access_index += shift;
         }
     }
     for change in &mut account_changes.balance_changes {
-        change.block_access_index += tx_index_offset;
+        change.block_access_index += shift;
     }
     for change in &mut account_changes.nonce_changes {
-        change.block_access_index += tx_index_offset;
+        change.block_access_index += shift;
     }
     for change in &mut account_changes.code_changes {
-        change.block_access_index += tx_index_offset;
+        change.block_access_index += shift;
     }
 }
 
@@ -865,7 +887,7 @@ mod tests {
             },
         ];
 
-        merge_block_access_list(&mut merged, incoming, 3);
+        merge_block_access_list(&mut merged, incoming, 3, 0);
 
         assert_eq!(merged.len(), 2);
 


### PR DESCRIPTION
## Summary

Fixes incorrect BAL indexing in `reth-bb generate-big-blocks` when execution crosses segment boundaries.

Before this PR, three different boundary events could be assigned the same `bal_index`:

- post-execution changes for segment N
- pre-execution changes for segment N+1
- transaction 0 of segment N+1

Because BAL writes collapse by index with last-write-wins behavior, some boundary writes could be hidden from workers. This is especially problematic because `BalWrites::get` only returns writes with indexes strictly less than the worker's current `bal_index`.

## Before

Boundary writes collided with the first transaction of the next segment:

| `bal_index` | Event(s) | Result |
|---|---|---|
| 0 | segment 0 pre-exec | visible to later txs |
| 1 | segment 0 tx 0 | |
| 2 | segment 0 tx 1 | |
| 3 | segment 0 tx 2 | |
| 4 | segment 0 post-exec, segment 1 pre-exec, segment 1 tx 0 | collision; worker at index 4 cannot see the post-exec or pre-exec writes |
| 5 | segment 1 tx 1 | |
| 6 | segment 1 post-exec, segment 2 pre-exec, segment 2 tx 0 | same collision at the next boundary |
| 7 | segment 2 post-exec | |

## After

Each boundary event gets its own slot:

| `bal_index` | Event(s) | Result |
|---|---|---|
| 0 | segment 0 pre-exec | |
| 1 | segment 0 tx 0 | |
| 2 | segment 0 tx 1 | |
| 3 | segment 0 tx 2 | |
| 4 | segment 0 post-exec | visible to segment 1 tx 0 |
| 5 | segment 1 pre-exec | visible to segment 1 tx 0 |
| 6 | segment 1 tx 0 | worker sees writes at indexes 4 and 5 |
| 7 | segment 1 tx 1 | |
| 8 | segment 1 post-exec | visible to segment 2 tx 0 |
| 9 | segment 2 pre-exec | visible to segment 2 tx 0 |
| 10 | segment 2 tx 0 | worker sees writes at indexes 8 and 9 |
| 11 | segment 2 post-exec | |

## Implementation

This PR renumbers BAL indexes for big-block execution by reserving two extra indexes per segment boundary:

- one index for the previous segment's post-execution writes
- one index for the next segment's pre-execution writes

Worker transaction indexes are remapped from the raw `tx_index + 1` convention into the padded index space.

The merged block access list generation now applies the same padding, so generated BAL indexes match the executor's runtime indexing scheme.
