### PR TITLE
feat(storage): add in-memory BAL retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
+checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9456,6 +9456,7 @@ name = "reth-provider"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-sol-types = { version = "1.5.6", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.3.4", default-features = false }
+alloy-eip7928 = { version = "0.3.5", default-features = false }
 alloy-evm = { version = "0.34.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -35,6 +35,7 @@ reth-static-file-types = { workspace = true, features = ["std"] }
 reth-fs-util.workspace = true
 
 # ethereum
+alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-genesis.workspace = true
 alloy-primitives.workspace = true

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -69,7 +69,12 @@ impl InMemoryBalStoreInner {
     // Inserts a BAL and keeps the block-number index in sync.
     fn insert(&mut self, block_hash: BlockHash, block_number: BlockNumber, bal: Bytes) {
         if let Some(entry) = self.entries.insert(block_hash, BalEntry { block_number, bal }) {
-            self.remove_number_index(entry.block_number, block_hash);
+            if let Some(hashes) = self.hashes_by_number.get_mut(&entry.block_number) {
+                hashes.retain(|hash| *hash != block_hash);
+                if hashes.is_empty() {
+                    self.hashes_by_number.remove(&entry.block_number);
+                }
+            }
         }
 
         self.hashes_by_number.entry(block_number).or_default().push(block_hash);
@@ -92,15 +97,6 @@ impl InMemoryBalStoreInner {
             for hash in hashes {
                 self.entries.remove(&hash);
             }
-        }
-    }
-
-    // Drops a stale block-number index entry for a reinserted hash.
-    fn remove_number_index(&mut self, block_number: BlockNumber, block_hash: BlockHash) {
-        let Some(hashes) = self.hashes_by_number.get_mut(&block_number) else { return };
-        hashes.retain(|hash| *hash != block_hash);
-        if hashes.is_empty() {
-            self.hashes_by_number.remove(&block_number);
         }
     }
 }

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -64,13 +64,15 @@ struct InMemoryBalStoreInner {
 impl InMemoryBalStoreInner {
     // Inserts a BAL and keeps the block-number index in sync.
     fn insert(&mut self, block_hash: BlockHash, block_number: BlockNumber, bal: Bytes) {
-        if let Some(entry) = self.entries.insert(block_hash, BalEntry { block_number, bal }) {
-            if let Some(hashes) = self.hashes_by_number.get_mut(&entry.block_number) {
+        let empty_block_number =
+            self.entries.insert(block_hash, BalEntry { block_number, bal }).and_then(|entry| {
+                let hashes = self.hashes_by_number.get_mut(&entry.block_number)?;
                 hashes.retain(|hash| *hash != block_hash);
-                if hashes.is_empty() {
-                    self.hashes_by_number.remove(&entry.block_number);
-                }
-            }
+                hashes.is_empty().then_some(entry.block_number)
+            });
+
+        if let Some(block_number) = empty_block_number {
+            self.hashes_by_number.remove(&block_number);
         }
 
         self.hashes_by_number.entry(block_number).or_default().push(block_hash);

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -66,6 +66,7 @@ struct InMemoryBalStoreInner {
 }
 
 impl InMemoryBalStoreInner {
+    // Inserts a BAL and keeps the block-number index in sync.
     fn insert(&mut self, block_hash: BlockHash, block_number: BlockNumber, bal: Bytes) {
         if let Some(entry) = self.entries.insert(block_hash, BalEntry { block_number, bal }) {
             self.remove_number_index(entry.block_number, block_hash);
@@ -77,6 +78,7 @@ impl InMemoryBalStoreInner {
         );
     }
 
+    // Removes BALs outside the configured retention window.
     fn prune(&mut self, prune_mode: Option<PruneMode>) {
         let Some(prune_mode) = prune_mode else { return };
         let Some(tip) = self.highest_block_number else { return };
@@ -93,6 +95,7 @@ impl InMemoryBalStoreInner {
         }
     }
 
+    // Drops a stale block-number index entry for a reinserted hash.
     fn remove_number_index(&mut self, block_number: BlockNumber, block_hash: BlockHash) {
         let Some(hashes) = self.hashes_by_number.get_mut(&block_number) else { return };
         hashes.retain(|hash| *hash != block_hash);

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE: u64 = 100_000;
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct BalConfig {
     /// Retention policy for BALs kept in memory.
-    pub in_memory_retention: Option<PruneMode>,
+    in_memory_retention: Option<PruneMode>,
 }
 
 impl BalConfig {

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -1,3 +1,4 @@
+use alloy_eip7928::BAL_RETENTION_PERIOD_SLOTS;
 use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use parking_lot::RwLock;
 use reth_prune_types::PruneMode;
@@ -28,9 +29,6 @@ impl Default for InMemoryBalStore {
     }
 }
 
-/// Default in-memory BAL retention distance.
-pub const DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE: u64 = 100_000;
-
 /// Configuration for BAL storage.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct BalConfig {
@@ -52,9 +50,7 @@ impl BalConfig {
 
 impl Default for BalConfig {
     fn default() -> Self {
-        Self::with_in_memory_retention(PruneMode::Distance(
-            DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE,
-        ))
+        Self::with_in_memory_retention(PruneMode::Distance(BAL_RETENTION_PERIOD_SLOTS))
     }
 }
 
@@ -221,12 +217,8 @@ mod tests {
         let tip_bal = Bytes::from_static(b"tip");
 
         store.insert(old_hash, 1, old_bal).unwrap();
-        store
-            .insert(retained_hash, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE, retained_bal.clone())
-            .unwrap();
-        store
-            .insert(tip_hash, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE + 2, tip_bal.clone())
-            .unwrap();
+        store.insert(retained_hash, BAL_RETENTION_PERIOD_SLOTS, retained_bal.clone()).unwrap();
+        store.insert(tip_hash, BAL_RETENTION_PERIOD_SLOTS + 2, tip_bal.clone()).unwrap();
 
         assert_eq!(
             store.get_by_hashes(&[old_hash, retained_hash, tip_hash]).unwrap(),
@@ -243,9 +235,7 @@ mod tests {
         let tip_bal = Bytes::from_static(b"tip");
 
         store.insert(old_hash, 1, old_bal.clone()).unwrap();
-        store
-            .insert(tip_hash, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE + 1, tip_bal.clone())
-            .unwrap();
+        store.insert(tip_hash, BAL_RETENTION_PERIOD_SLOTS + 1, tip_bal.clone()).unwrap();
 
         assert_eq!(
             store.get_by_hashes(&[old_hash, tip_hash]).unwrap(),

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -1,32 +1,132 @@
 use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use parking_lot::RwLock;
+use reth_prune_types::PruneMode;
 use reth_storage_api::{BalStore, GetBlockAccessListLimit};
 use reth_storage_errors::provider::ProviderResult;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 /// Basic in-memory BAL store keyed by block hash.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct InMemoryBalStore {
-    entries: Arc<RwLock<HashMap<BlockHash, Bytes>>>,
+    config: BalConfig,
+    inner: Arc<RwLock<InMemoryBalStoreInner>>,
+}
+
+impl InMemoryBalStore {
+    /// Creates a new in-memory BAL store with the given config.
+    pub fn new(config: BalConfig) -> Self {
+        Self { config, inner: Arc::new(RwLock::new(InMemoryBalStoreInner::default())) }
+    }
+}
+
+impl Default for InMemoryBalStore {
+    fn default() -> Self {
+        Self::new(BalConfig::default())
+    }
+}
+
+/// Default in-memory BAL retention distance.
+pub const DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE: u64 = 100_000;
+
+/// Configuration for BAL storage.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct BalConfig {
+    /// Retention policy for BALs kept in memory.
+    pub in_memory_retention: Option<PruneMode>,
+}
+
+impl BalConfig {
+    /// Returns a config with no in-memory BAL retention limit.
+    pub const fn unbounded() -> Self {
+        Self { in_memory_retention: None }
+    }
+
+    /// Returns a config with the given in-memory BAL retention policy.
+    pub const fn with_in_memory_retention(in_memory_retention: PruneMode) -> Self {
+        Self { in_memory_retention: Some(in_memory_retention) }
+    }
+}
+
+impl Default for BalConfig {
+    fn default() -> Self {
+        Self::with_in_memory_retention(PruneMode::Distance(
+            DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE,
+        ))
+    }
+}
+
+#[derive(Debug, Default)]
+struct InMemoryBalStoreInner {
+    entries: HashMap<BlockHash, BalEntry>,
+    hashes_by_number: BTreeMap<BlockNumber, Vec<BlockHash>>,
+    highest_block_number: Option<BlockNumber>,
+}
+
+impl InMemoryBalStoreInner {
+    fn insert(&mut self, block_hash: BlockHash, block_number: BlockNumber, bal: Bytes) {
+        if let Some(entry) = self.entries.insert(block_hash, BalEntry { block_number, bal }) {
+            self.remove_number_index(entry.block_number, block_hash);
+        }
+
+        self.hashes_by_number.entry(block_number).or_default().push(block_hash);
+        self.highest_block_number = Some(
+            self.highest_block_number.map_or(block_number, |highest| highest.max(block_number)),
+        );
+    }
+
+    fn prune(&mut self, prune_mode: Option<PruneMode>) {
+        let Some(prune_mode) = prune_mode else { return };
+        let Some(tip) = self.highest_block_number else { return };
+
+        while let Some((&block_number, _)) = self.hashes_by_number.first_key_value() {
+            if !prune_mode.should_prune(block_number, tip) {
+                break
+            }
+
+            let Some((_, hashes)) = self.hashes_by_number.pop_first() else { break };
+            for hash in hashes {
+                self.entries.remove(&hash);
+            }
+        }
+    }
+
+    fn remove_number_index(&mut self, block_number: BlockNumber, block_hash: BlockHash) {
+        let Some(hashes) = self.hashes_by_number.get_mut(&block_number) else { return };
+        hashes.retain(|hash| *hash != block_hash);
+        if hashes.is_empty() {
+            self.hashes_by_number.remove(&block_number);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BalEntry {
+    block_number: BlockNumber,
+    bal: Bytes,
 }
 
 impl BalStore for InMemoryBalStore {
     fn insert(
         &self,
         block_hash: BlockHash,
-        _block_number: BlockNumber,
+        block_number: BlockNumber,
         bal: Bytes,
     ) -> ProviderResult<()> {
-        self.entries.write().insert(block_hash, bal);
+        let mut inner = self.inner.write();
+        inner.insert(block_hash, block_number, bal);
+        inner.prune(self.config.in_memory_retention);
         Ok(())
     }
 
     fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
-        let entries = self.entries.read();
+        let inner = self.inner.read();
         let mut result = Vec::with_capacity(block_hashes.len());
 
         for hash in block_hashes {
-            result.push(entries.get(hash).cloned());
+            result.push(inner.entries.get(hash).map(|entry| entry.bal.clone()));
         }
 
         Ok(result)
@@ -38,11 +138,15 @@ impl BalStore for InMemoryBalStore {
         limit: GetBlockAccessListLimit,
         out: &mut Vec<Bytes>,
     ) -> ProviderResult<()> {
-        let entries = self.entries.read();
+        let inner = self.inner.read();
         let mut size = 0;
 
         for hash in block_hashes {
-            let bal = entries.get(hash).cloned().unwrap_or_else(|| Bytes::from_static(&[0xc0]));
+            let bal = inner
+                .entries
+                .get(hash)
+                .map(|entry| entry.bal.clone())
+                .unwrap_or_else(|| Bytes::from_static(&[0xc0]));
             size += bal.len();
             out.push(bal);
 
@@ -105,5 +209,61 @@ mod tests {
             .unwrap();
 
         assert_eq!(limited, vec![bal0, bal1]);
+    }
+
+    #[test]
+    fn default_retention_prunes_old_bals() {
+        let store = InMemoryBalStore::default();
+        let old_hash = B256::random();
+        let retained_hash = B256::random();
+        let tip_hash = B256::random();
+        let old_bal = Bytes::from_static(b"old");
+        let retained_bal = Bytes::from_static(b"retained");
+        let tip_bal = Bytes::from_static(b"tip");
+
+        store.insert(old_hash, 1, old_bal).unwrap();
+        store
+            .insert(retained_hash, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE, retained_bal.clone())
+            .unwrap();
+        store
+            .insert(tip_hash, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE + 2, tip_bal.clone())
+            .unwrap();
+
+        assert_eq!(
+            store.get_by_hashes(&[old_hash, retained_hash, tip_hash]).unwrap(),
+            vec![None, Some(retained_bal), Some(tip_bal)]
+        );
+    }
+
+    #[test]
+    fn unbounded_retention_keeps_old_bals() {
+        let store = InMemoryBalStore::new(BalConfig::unbounded());
+        let old_hash = B256::random();
+        let tip_hash = B256::random();
+        let old_bal = Bytes::from_static(b"old");
+        let tip_bal = Bytes::from_static(b"tip");
+
+        store.insert(old_hash, 1, old_bal.clone()).unwrap();
+        store
+            .insert(tip_hash, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE + 1, tip_bal.clone())
+            .unwrap();
+
+        assert_eq!(
+            store.get_by_hashes(&[old_hash, tip_hash]).unwrap(),
+            vec![Some(old_bal), Some(tip_bal)]
+        );
+    }
+
+    #[test]
+    fn reinserting_hash_updates_number_index() {
+        let store =
+            InMemoryBalStore::new(BalConfig::with_in_memory_retention(PruneMode::Before(2)));
+        let hash = B256::random();
+        let bal = Bytes::from_static(b"bal");
+
+        store.insert(hash, 1, Bytes::from_static(b"old")).unwrap();
+        store.insert(hash, 2, bal.clone()).unwrap();
+
+        assert_eq!(store.get_by_hashes(&[hash]).unwrap(), vec![Some(bal)]);
     }
 }

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -39,7 +39,7 @@ pub mod either_writer;
 pub use either_writer::*;
 
 mod bal;
-pub use bal::InMemoryBalStore;
+pub use bal::{BalConfig, InMemoryBalStore, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE};
 
 pub use reth_chain_state::{
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotificationStream,

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -39,7 +39,7 @@ pub mod either_writer;
 pub use either_writer::*;
 
 mod bal;
-pub use bal::{BalConfig, InMemoryBalStore, DEFAULT_IN_MEMORY_BAL_RETENTION_DISTANCE};
+pub use bal::{BalConfig, InMemoryBalStore};
 
 pub use reth_chain_state::{
     CanonStateNotification, CanonStateNotificationSender, CanonStateNotificationStream,


### PR DESCRIPTION
Adds a configurable retention policy for the in-memory BAL store using BalConfig and PruneMode.

By default, the store now prunes older BALs after inserts instead of keeping every BAL forever. The config API stays small, and the store keeps a block-number index so pruning can remove old entries without scanning the whole map.

cc @mattsse 