### PR TITLE
perf(trie): fuse hashed-state sorting with prefix sets

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -355,7 +355,7 @@ where
         // Validate block consensus rules which includes header validation
         if let Err(consensus_err) = self.validate_block_inner(&block, None) {
             // Header validation error takes precedence over execution error
-            return Err(InsertBlockError::new(block, consensus_err.into()).into())
+            return Err(InsertBlockError::new(block, consensus_err.into()).into());
         }
 
         // Also validate against the parent
@@ -363,7 +363,7 @@ where
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
             // Parent validation error takes precedence over execution error
-            return Err(InsertBlockError::new(block, consensus_err.into()).into())
+            return Err(InsertBlockError::new(block, consensus_err.into()).into());
         }
 
         // No header validation errors, return the original execution error
@@ -438,7 +438,7 @@ where
                     Ok(val) => val,
                     Err(e) => {
                         let block = convert_to_block(input)?;
-                        return Err(InsertBlockError::new(block, e.into()).into())
+                        return Err(InsertBlockError::new(block, e.into()).into());
                     }
                 }
             };
@@ -471,7 +471,7 @@ where
                 convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
-            .into())
+            .into());
         };
         let mut state_provider = ensure_ok!(provider_builder.build());
         drop(_enter);
@@ -484,7 +484,7 @@ where
                 convert_to_block(input)?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
-            .into())
+            .into());
         };
 
         let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm_env")
@@ -811,7 +811,7 @@ where
                 )
                 .into(),
             )
-            .into())
+            .into());
         }
 
         let timing_stats = state_provider_stats.map(|stats| {
@@ -873,14 +873,14 @@ where
     ) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
-            return Err(e)
+            return Err(e);
         }
 
         if let Err(e) =
             self.consensus.validate_block_pre_execution_with_tx_root(block, transaction_root)
         {
             error!(target: "engine::tree::payload_validator", ?block, "Failed to validate block {}: {e}", block.hash());
-            return Err(e)
+            return Err(e);
         }
 
         Ok(())
@@ -1105,13 +1105,14 @@ where
         let hashed_state = hashed_state.get();
         // The `hashed_state` argument will be taken into account as part of the overlay, but we
         // need to use the prefix sets which were generated from it to indicate to the
-        // ParallelStateRoot which parts of the trie need to be recomputed.
-        let prefix_sets = hashed_state.construct_prefix_sets().freeze();
+        // ParallelStateRoot which parts of the trie need to be recomputed. Build both derived
+        // views together so we only walk the hashed-state maps once on this hot path.
+        let (sorted_hashed_state, prefix_sets) = hashed_state.clone_into_sorted_with_prefix_sets();
         let overlay_factory = OverlayStateProviderFactory::new(
             provider_factory,
-            overlay_builder.with_extended_hashed_state_overlay(hashed_state.clone_into_sorted()),
+            overlay_builder.with_extended_hashed_state_overlay(sorted_hashed_state),
         );
-        ParallelStateRoot::new(overlay_factory, prefix_sets, self.runtime.clone())
+        ParallelStateRoot::new(overlay_factory, prefix_sets.freeze(), self.runtime.clone())
             .incremental_root_with_updates()
     }
 
@@ -1371,7 +1372,7 @@ where
         trace!(target: "engine::tree::payload_validator", block=?block.num_hash(), "Validating block consensus");
         // validate block consensus rules
         if let Err(e) = self.validate_block_inner(block, transaction_root) {
-            return Err(e.into())
+            return Err(e.into());
         }
 
         // now validate against the parent
@@ -1380,7 +1381,7 @@ where
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
             warn!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {} against parent: {e}", block.hash());
-            return Err(e.into())
+            return Err(e.into());
         }
         drop(_enter);
 
@@ -1393,7 +1394,7 @@ where
         {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into())
+            return Err(err.into());
         }
         drop(_enter);
 
@@ -1409,7 +1410,7 @@ where
         {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into())
+            return Err(err.into());
         }
 
         // record post-execution validation duration
@@ -1510,7 +1511,7 @@ where
                 self.provider.clone(),
                 historical,
                 Some(blocks),
-            )))
+            )));
         }
 
         // Check if the block is persisted
@@ -1518,7 +1519,7 @@ where
             debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)));
         }
 
         debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");
@@ -1550,7 +1551,7 @@ where
     ) {
         if state.invalid_headers.get(&block.hash()).is_some() {
             // we already marked this block as invalid
-            return
+            return;
         }
         self.invalid_block_hook.on_invalid_block(parent_header, block, output, trie_updates);
     }
@@ -1799,9 +1800,9 @@ where
             .sum();
 
         // Total time spent fetching state during execution
-        let state_read_duration = provider_stats.total_account_fetch_latency() +
-            provider_stats.total_storage_fetch_latency() +
-            provider_stats.total_code_fetch_latency();
+        let state_read_duration = provider_stats.total_account_fetch_latency()
+            + provider_stats.total_storage_fetch_latency()
+            + provider_stats.total_code_fetch_latency();
 
         // EIP-7702 delegation tracking from bytecode changes
         // Count new EIP-7702 bytecodes as delegations set

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -125,6 +125,40 @@ impl HashedPostState {
         TriePrefixSetsMut { account_prefix_set, storage_prefix_sets, destroyed_accounts }
     }
 
+    /// Converts hashed state into its sorted representation while constructing trie prefix sets in
+    /// the same pass.
+    pub fn into_sorted_with_prefix_sets(self) -> (HashedPostStateSorted, TriePrefixSetsMut) {
+        let accounts_len = self.accounts.len();
+        let storages_len = self.storages.len();
+
+        let mut accounts = Vec::with_capacity(accounts_len);
+        let mut account_prefix_set = PrefixSetMut::with_capacity(accounts_len + storages_len);
+        let mut destroyed_accounts = HashSet::default();
+        for (hashed_address, account) in self.accounts {
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            if account.is_none() {
+                destroyed_accounts.insert(hashed_address);
+            }
+            accounts.push((hashed_address, account));
+        }
+        accounts.sort_unstable_by_key(|(hashed_address, _)| *hashed_address);
+
+        let mut storages = B256Map::with_capacity_and_hasher(storages_len, Default::default());
+        let mut storage_prefix_sets =
+            HashMap::with_capacity_and_hasher(storages_len, Default::default());
+        for (hashed_address, storage) in self.storages {
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            let (sorted_storage, prefix_set) = storage.into_sorted_with_prefix_set();
+            storages.insert(hashed_address, sorted_storage);
+            storage_prefix_sets.insert(hashed_address, prefix_set);
+        }
+
+        (
+            HashedPostStateSorted { accounts, storages },
+            TriePrefixSetsMut { account_prefix_set, storage_prefix_sets, destroyed_accounts },
+        )
+    }
+
     /// Create multiproof targets for this state.
     pub fn multi_proof_targets(&self) -> MultiProofTargets {
         // Pre-allocate minimum capacity for the targets.
@@ -187,10 +221,10 @@ impl HashedPostState {
                 Some(storage_in_targets) => {
                     let mut storage_not_in_targets = HashedStorage::default();
                     storage.storage.retain(|&slot, value| {
-                        if storage_in_targets.contains(&slot) &&
-                            !storage_added_removed_keys.is_some_and(|k| k.is_removed(&slot))
+                        if storage_in_targets.contains(&slot)
+                            && !storage_added_removed_keys.is_some_and(|k| k.is_removed(&slot))
                         {
-                            return true
+                            return true;
                         }
 
                         storage_not_in_targets.storage.insert(slot, *value);
@@ -225,7 +259,7 @@ impl HashedPostState {
         });
         self.accounts.retain(|&address, account| {
             if targets.contains_key(&address) {
-                return true
+                return true;
             }
 
             state_updates_not_in_targets.accounts.insert(address, *account);
@@ -244,8 +278,9 @@ impl HashedPostState {
 
     /// Returns the number of items that will be considered during chunking in `[Self::chunks]`.
     pub fn chunking_length(&self) -> usize {
-        self.accounts.len() +
-            self.storages
+        self.accounts.len()
+            + self
+                .storages
                 .values()
                 .map(|storage| if storage.wiped { 1 } else { 0 } + storage.storage.len())
                 .sum::<usize>()
@@ -352,6 +387,42 @@ impl HashedPostState {
             .collect();
 
         HashedPostStateSorted { accounts, storages }
+    }
+
+    /// Creates a sorted copy and trie prefix sets without consuming self.
+    ///
+    /// More efficient than `construct_prefix_sets()` plus `clone_into_sorted()` as it only walks
+    /// the account and storage maps once.
+    pub fn clone_into_sorted_with_prefix_sets(&self) -> (HashedPostStateSorted, TriePrefixSetsMut) {
+        let accounts_len = self.accounts.len();
+        let storages_len = self.storages.len();
+
+        let mut accounts = Vec::with_capacity(accounts_len);
+        let mut account_prefix_set = PrefixSetMut::with_capacity(accounts_len + storages_len);
+        let mut destroyed_accounts = HashSet::default();
+        for (&hashed_address, &account) in &self.accounts {
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            if account.is_none() {
+                destroyed_accounts.insert(hashed_address);
+            }
+            accounts.push((hashed_address, account));
+        }
+        accounts.sort_unstable_by_key(|(hashed_address, _)| *hashed_address);
+
+        let mut storages = B256Map::with_capacity_and_hasher(storages_len, Default::default());
+        let mut storage_prefix_sets =
+            HashMap::with_capacity_and_hasher(storages_len, Default::default());
+        for (&hashed_address, storage) in &self.storages {
+            account_prefix_set.insert(Nibbles::unpack(hashed_address));
+            let (sorted_storage, prefix_set) = storage.clone_into_sorted_with_prefix_set();
+            storages.insert(hashed_address, sorted_storage);
+            storage_prefix_sets.insert(hashed_address, prefix_set);
+        }
+
+        (
+            HashedPostStateSorted { accounts, storages },
+            TriePrefixSetsMut { account_prefix_set, storage_prefix_sets, destroyed_accounts },
+        )
     }
 
     /// Clears the account and storage maps of this `HashedPostState`.
@@ -467,6 +538,30 @@ impl HashedStorage {
         }
     }
 
+    /// Converts hashed storage into its sorted representation while constructing the storage
+    /// prefix set in the same pass.
+    pub fn into_sorted_with_prefix_set(self) -> (HashedStorageSorted, PrefixSetMut) {
+        if self.wiped {
+            return (
+                HashedStorageSorted {
+                    storage_slots: self.storage.into_iter().collect(),
+                    wiped: true,
+                },
+                PrefixSetMut::all(),
+            );
+        }
+
+        let mut prefix_set = PrefixSetMut::with_capacity(self.storage.len());
+        let mut storage_slots = Vec::with_capacity(self.storage.len());
+        for (hashed_slot, value) in self.storage {
+            prefix_set.insert(Nibbles::unpack(hashed_slot));
+            storage_slots.push((hashed_slot, value));
+        }
+        storage_slots.sort_unstable_by_key(|(hashed_slot, _)| *hashed_slot);
+
+        (HashedStorageSorted { storage_slots, wiped: false }, prefix_set)
+    }
+
     /// Extend hashed storage with contents of other.
     /// The entries in second hashed storage take precedence.
     pub fn extend(&mut self, other: &Self) {
@@ -510,6 +605,29 @@ impl HashedStorage {
         storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
         HashedStorageSorted { storage_slots, wiped: self.wiped }
+    }
+
+    /// Creates a sorted copy and storage prefix set without consuming self.
+    pub fn clone_into_sorted_with_prefix_set(&self) -> (HashedStorageSorted, PrefixSetMut) {
+        if self.wiped {
+            return (
+                HashedStorageSorted {
+                    storage_slots: self.storage.iter().map(|(&k, &v)| (k, v)).collect(),
+                    wiped: true,
+                },
+                PrefixSetMut::all(),
+            );
+        }
+
+        let mut prefix_set = PrefixSetMut::with_capacity(self.storage.len());
+        let mut storage_slots = Vec::with_capacity(self.storage.len());
+        for (&hashed_slot, &value) in &self.storage {
+            prefix_set.insert(Nibbles::unpack(hashed_slot));
+            storage_slots.push((hashed_slot, value));
+        }
+        storage_slots.sort_unstable_by_key(|(hashed_slot, _)| *hashed_slot);
+
+        (HashedStorageSorted { storage_slots, wiped: false }, prefix_set)
     }
 }
 
@@ -1679,6 +1797,63 @@ mod tests {
 
         assert_eq!(sorted_via_clone, sorted_via_clone_into);
 
+        let (sorted_via_fused_clone, prefix_sets_via_fused_clone) =
+            state.clone_into_sorted_with_prefix_sets();
+        assert_eq!(sorted_via_clone, sorted_via_fused_clone);
+        let prefix_sets_via_construct = state.construct_prefix_sets().freeze();
+        let prefix_sets_via_fused_clone = prefix_sets_via_fused_clone.freeze();
+        assert_eq!(
+            prefix_sets_via_construct.account_prefix_set.iter().copied().collect::<Vec<_>>(),
+            prefix_sets_via_fused_clone.account_prefix_set.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            prefix_sets_via_construct.destroyed_accounts,
+            prefix_sets_via_fused_clone.destroyed_accounts
+        );
+        assert_eq!(
+            prefix_sets_via_construct.storage_prefix_sets.len(),
+            prefix_sets_via_fused_clone.storage_prefix_sets.len()
+        );
+        for (hashed_address, prefix_set) in &prefix_sets_via_construct.storage_prefix_sets {
+            let fused_prefix_set = prefix_sets_via_fused_clone
+                .storage_prefix_sets
+                .get(hashed_address)
+                .expect("missing fused storage prefix set");
+            assert_eq!(prefix_set.all(), fused_prefix_set.all());
+            assert_eq!(
+                prefix_set.iter().copied().collect::<Vec<_>>(),
+                fused_prefix_set.iter().copied().collect::<Vec<_>>()
+            );
+        }
+
+        let (sorted_via_fused_into, prefix_sets_via_fused_into) =
+            state.clone().into_sorted_with_prefix_sets();
+        assert_eq!(sorted_via_clone, sorted_via_fused_into);
+        let prefix_sets_via_fused_into = prefix_sets_via_fused_into.freeze();
+        assert_eq!(
+            prefix_sets_via_construct.account_prefix_set.iter().copied().collect::<Vec<_>>(),
+            prefix_sets_via_fused_into.account_prefix_set.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            prefix_sets_via_construct.destroyed_accounts,
+            prefix_sets_via_fused_into.destroyed_accounts
+        );
+        assert_eq!(
+            prefix_sets_via_construct.storage_prefix_sets.len(),
+            prefix_sets_via_fused_into.storage_prefix_sets.len()
+        );
+        for (hashed_address, prefix_set) in &prefix_sets_via_construct.storage_prefix_sets {
+            let fused_prefix_set = prefix_sets_via_fused_into
+                .storage_prefix_sets
+                .get(hashed_address)
+                .expect("missing fused storage prefix set");
+            assert_eq!(prefix_set.all(), fused_prefix_set.all());
+            assert_eq!(
+                prefix_set.iter().copied().collect::<Vec<_>>(),
+                fused_prefix_set.iter().copied().collect::<Vec<_>>()
+            );
+        }
+
         // Verify the original state is not consumed
         assert_eq!(state.accounts.len(), 3);
         assert_eq!(state.storages.len(), 2);
@@ -1704,6 +1879,27 @@ mod tests {
         let sorted_via_clone_into = storage.clone_into_sorted();
 
         assert_eq!(sorted_via_clone, sorted_via_clone_into);
+
+        let (sorted_via_fused_clone, prefix_set_via_fused_clone) =
+            storage.clone_into_sorted_with_prefix_set();
+        assert_eq!(sorted_via_clone, sorted_via_fused_clone);
+        let prefix_set_via_construct = storage.construct_prefix_set().freeze();
+        let prefix_set_via_fused_clone = prefix_set_via_fused_clone.freeze();
+        assert_eq!(prefix_set_via_construct.all(), prefix_set_via_fused_clone.all());
+        assert_eq!(
+            prefix_set_via_construct.iter().copied().collect::<Vec<_>>(),
+            prefix_set_via_fused_clone.iter().copied().collect::<Vec<_>>()
+        );
+
+        let (sorted_via_fused_into, prefix_set_via_fused_into) =
+            storage.clone().into_sorted_with_prefix_set();
+        assert_eq!(sorted_via_clone, sorted_via_fused_into);
+        let prefix_set_via_fused_into = prefix_set_via_fused_into.freeze();
+        assert_eq!(prefix_set_via_construct.all(), prefix_set_via_fused_into.all());
+        assert_eq!(
+            prefix_set_via_construct.iter().copied().collect::<Vec<_>>(),
+            prefix_set_via_fused_into.iter().copied().collect::<Vec<_>>()
+        );
 
         // Verify the original storage is not consumed
         assert_eq!(storage.storage.len(), 3);


### PR DESCRIPTION
Build the sorted hashed-state view and trie prefix sets in one pass instead of walking the account and storage maps twice on the parallel state-root path.\n\nThis keeps the existing state-root inputs unchanged while trimming duplicate derived-data work before ParallelStateRoot starts.