### PR TITLE
perf(engine): publish warmed cache after validation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -268,7 +268,9 @@ where
     /// This consumes the `SavedCache` held by the task, which releases its usage guard and allows
     /// the new, warmed cache to be inserted.
     ///
-    /// This method is called from `run()` only after all execution tasks are complete.
+    /// This method is called from `run()` only after all execution tasks are complete. It waits
+    /// for block validation before mutating the shared cache so the mutex is only held for the
+    /// final publish/cleanup step.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn save_cache(
         self,
@@ -286,33 +288,28 @@ where
 
         if let Some(saved_cache) = saved_cache {
             debug!(target: "engine::caching", parent_hash=?hash, "Updating execution cache");
+            if valid_block_rx.recv().is_err() {
+                debug!(target: "engine::caching", "skipping execution cache update for invalid block");
+                return;
+            }
+
+            // Keep the saved cache alive until the publish step so concurrent readers continue to
+            // see it as unavailable while we prepare the next snapshot.
+            let caches = saved_cache.cache().clone();
+            let new_cache = SavedCache::new(hash, caches);
+            if new_cache.cache().insert_state(&execution_outcome.state).is_err() {
+                execution_cache.update_with_guard(|cached| {
+                    *cached = None;
+                });
+                debug!(target: "engine::caching", "cleared execution cache on update error");
+                return;
+            }
+            new_cache.update_metrics(cache_metrics.as_ref());
+
             execution_cache.update_with_guard(|cached| {
-                // consumes the `SavedCache` held by the prewarming task, which releases its usage
-                // guard
-                let caches = saved_cache.cache().clone();
-                let new_cache = SavedCache::new(hash, caches);
-
-                // Insert state into cache while holding the lock
-                // Access the BundleState through the shared ExecutionOutcome
-                if new_cache.cache().insert_state(&execution_outcome.state).is_err() {
-                    // Clear the cache on error to prevent having a polluted cache
-                    *cached = None;
-                    debug!(target: "engine::caching", "cleared execution cache on update error");
-                    return;
-                }
-
-                new_cache.update_metrics(cache_metrics.as_ref());
-
-                if valid_block_rx.recv().is_ok() {
-                    // Replace the shared cache with the new one; the previous cache (if any) is
-                    // dropped.
-                    *cached = Some(new_cache);
-                } else {
-                    // Block was invalid; caches were already mutated by insert_state above,
-                    // so we must clear to prevent using polluted state
-                    *cached = None;
-                    debug!(target: "engine::caching", "cleared execution cache on invalid block");
-                }
+                // Replace the shared cache with the new one; the previous cache (if any) is
+                // dropped.
+                *cached = Some(new_cache);
             });
 
             let elapsed = start.elapsed();


### PR DESCRIPTION
Wait for block validation before mutating the shared execution cache and only hold the cache mutex for the final publish or cleanup step.

This keeps the parent cache unavailable while the next snapshot is prepared, but removes the validation wait and insert_state work from the critical section so the next payload spends less time blocked on cache access.