### PR TITLE
perf(engine): cap proof workers for payload validation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -270,6 +270,7 @@ where
             multiproof_provider_factory,
             env.parent_state_root,
             halve_workers,
+            Some(Self::proof_worker_limit(env.transaction_count)),
             config,
         );
         let install_state_hook = env.decoded_bal.is_none();
@@ -332,6 +333,7 @@ where
         multiproof_provider_factory: F,
         parent_state_root: B256,
         halve_workers: bool,
+        requested_workers: Option<usize>,
         config: &TreeConfig,
     ) -> StateRootHandle
     where
@@ -346,7 +348,8 @@ where
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
-        let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
+        let proof_handle =
+            ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers, requested_workers);
 
         let (state_root_tx, state_root_rx) = channel();
 
@@ -365,6 +368,12 @@ where
     /// produce fewer state changes and most workers would be idle overhead.
     const SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD: usize = 30;
 
+    /// Target amount of block work per proof worker when sizing the pool for payload validation.
+    ///
+    /// The state-root path already batches proof requests, so medium blocks do not need the full
+    /// proof pool just to stay ahead of execution.
+    const TARGET_TXS_PER_PROOF_WORKER: usize = 16;
+
     /// Transaction count threshold below which sequential conversion is used.
     ///
     /// For blocks with fewer than this many transactions, the rayon parallel iterator overhead
@@ -381,6 +390,10 @@ where
     /// a small head sequentially and sending it immediately, execution can start without
     /// waiting for rayon scheduling.
     const PARALLEL_PREFETCH_COUNT: usize = 4;
+
+    fn proof_worker_limit(transaction_count: usize) -> usize {
+        transaction_count.div_ceil(Self::TARGET_TXS_PER_PROOF_WORKER).max(1)
+    }
 
     /// Spawns a task advancing transaction env iterator and streaming updates through a channel.
     ///

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -994,7 +994,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false, None);
 
         let default_trie = RevealableSparseTrie::blind_from(ConfigurableSparseTrie::Arena(
             ArenaParallelSparseTrie::default(),

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -2038,6 +2038,7 @@ where
             parent_state_root,
             // Full proof workers — tx count unknown at FCU time (block built incrementally)
             false,
+            None,
             &self.config,
         ))
     }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -160,6 +160,7 @@ impl ProofWorkerHandle {
     /// - `runtime`: The centralized runtime used to spawn blocking worker tasks
     /// - `task_ctx`: Shared context with database view and prefix sets
     /// - `halve_workers`: Whether to halve the worker pool size (for small blocks)
+    /// - `requested_workers`: Optional cap for each proof worker pool
     #[instrument(
         name = "ProofWorkerHandle::new",
         level = "debug",
@@ -170,6 +171,7 @@ impl ProofWorkerHandle {
         runtime: &Runtime,
         task_ctx: ProofTaskCtx<Factory>,
         halve_workers: bool,
+        requested_workers: Option<usize>,
     ) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -183,11 +185,16 @@ impl ProofWorkerHandle {
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
-        let divisor = if halve_workers { 2 } else { 1 };
-        let storage_worker_count =
-            runtime.proof_storage_worker_pool().current_num_threads() / divisor;
-        let account_worker_count =
-            runtime.proof_account_worker_pool().current_num_threads() / divisor;
+        let storage_worker_count = Self::worker_count_for(
+            runtime.proof_storage_worker_pool().current_num_threads(),
+            halve_workers,
+            requested_workers,
+        );
+        let account_worker_count = Self::worker_count_for(
+            runtime.proof_account_worker_pool().current_num_threads(),
+            halve_workers,
+            requested_workers,
+        );
 
         let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
         let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
@@ -197,6 +204,7 @@ impl ProofWorkerHandle {
             storage_worker_count,
             account_worker_count,
             halve_workers,
+            ?requested_workers,
             "Spawning proof worker pools"
         );
 
@@ -288,6 +296,18 @@ impl ProofWorkerHandle {
             storage_worker_count,
             account_worker_count,
         }
+    }
+
+    fn worker_count_for(
+        available_workers: usize,
+        halve_workers: bool,
+        requested_workers: Option<usize>,
+    ) -> usize {
+        let available_workers =
+            if halve_workers { available_workers / 2 } else { available_workers }.max(1);
+
+        requested_workers
+            .map_or(available_workers, |requested| available_workers.min(requested.max(1)))
     }
 
     /// Returns `true` if more than one storage worker is currently idle.
@@ -1176,7 +1196,7 @@ mod tests {
         let ctx = test_ctx(factory);
 
         let runtime = reth_tasks::Runtime::test();
-        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false);
+        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false, None);
 
         // Verify handle can be cloned
         let _cloned_handle = proof_handle.clone();


### PR DESCRIPTION
Size payload-validation proof worker pools from the block transaction count instead of always spawning the full proof pool.
This keeps FCU and other unknown-size state-root paths on the existing behavior while reducing per-payload worker startup and provider initialization overhead for the common medium-block case.