### PR TITLE
perf(engine): wait for persistence inline

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1669,27 +1669,11 @@ where
                                 let explicit_persistence_wait = if wait_for_persistence {
                                     let pending_persistence = self.persistence_state.rx.take();
                                     if let Some((rx, start_time, _action)) = pending_persistence {
-                                        let (persistence_tx, persistence_rx) =
-                                            std::sync::mpsc::channel();
-                                        self.runtime.spawn_blocking_named(
-                                            "wait-persist",
-                                            move || {
-                                                let start = Instant::now();
-                                                let result = rx
-                                                    .recv()
-                                                    .expect("persistence state channel closed");
-                                                let _ = persistence_tx.send((
-                                                    result,
-                                                    start_time,
-                                                    start.elapsed(),
-                                                ));
-                                            },
-                                        );
-                                        let (result, start_time, wait_duration) = persistence_rx
-                                            .recv()
-                                            .expect("persistence result channel closed");
+                                        let wait_start = Instant::now();
+                                        let result =
+                                            rx.recv().expect("persistence state channel closed");
                                         let _ = self.on_persistence_complete(result, start_time);
-                                        wait_duration
+                                        wait_start.elapsed()
                                     } else {
                                         Duration::ZERO
                                     }


### PR DESCRIPTION
Replace the helper thread and std::sync::mpsc hop in the explicit persistence wait path with a direct recv on the existing persistence channel. This keeps the same blocking behavior while trimming the extra thread handoff before newPayload execution resumes.