### PR TITLE
perf(trie): evict changeset cache in place

### DIFF
--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -847,18 +847,18 @@ impl ChangesetCacheInner {
             "Starting cache eviction"
         );
 
-        // Find all block numbers that should be evicted (< up_to_block)
-        let blocks_to_evict: Vec<u64> =
-            self.block_numbers.range(..up_to_block).map(|(num, _)| *num).collect();
-
         // Remove entries for each block number below threshold
         #[cfg(feature = "metrics")]
         let mut evicted_count = 0;
         #[cfg(not(feature = "metrics"))]
         let mut evicted_count = 0;
 
-        for block_number in &blocks_to_evict {
-            if let Some(hashes) = self.block_numbers.remove(block_number) {
+        while let Some((&block_number, _)) = self.block_numbers.first_key_value() {
+            if block_number >= up_to_block {
+                break;
+            }
+
+            if let Some((_, hashes)) = self.block_numbers.pop_first() {
                 debug!(
                     target: "trie::changeset_cache",
                     block_number,


### PR DESCRIPTION
Walk the changeset cache eviction index with  and  instead of collecting block numbers into a temporary vector first. This keeps the same eviction boundary while removing an allocation and an extra tree traversal from the steady-state persistence path.