### PR TITLE
perf(engine): lazily start proof workers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -27,10 +27,7 @@ use reth_provider::{
 use reth_revm::db::BundleState;
 use reth_tasks::{utils::increase_thread_priority, ForEachOrdered, Runtime};
 use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
-use reth_trie_parallel::{
-    proof_task::{ProofTaskCtx, ProofWorkerHandle},
-    root::ParallelStateRootError,
-};
+use reth_trie_parallel::{proof_task::ProofTaskCtx, root::ParallelStateRootError};
 use reth_trie_sparse::{
     ArenaParallelSparseTrie, ConfigurableSparseTrie, RevealableSparseTrie, SparseStateTrie,
 };
@@ -346,12 +343,12 @@ where
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
-        let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
 
         let (state_root_tx, state_root_rx) = channel();
 
         self.spawn_sparse_trie_task(
-            proof_handle,
+            task_ctx,
+            halve_workers,
             state_root_tx,
             from_multi_proof,
             parent_state_root,
@@ -551,14 +548,21 @@ where
     /// Spawns the [`SparseTrieCacheTask`] for this payload processor.
     ///
     /// The trie is preserved when the new payload is a child of the previous one.
-    fn spawn_sparse_trie_task(
+    fn spawn_sparse_trie_task<F>(
         &self,
-        proof_worker_handle: ProofWorkerHandle,
+        proof_task_ctx: ProofTaskCtx<F>,
+        halve_workers: bool,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
         from_multi_proof: CrossbeamReceiver<StateRootMessage>,
         parent_state_root: B256,
         chunk_size: usize,
-    ) {
+    ) where
+        F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+    {
         let preserved_sparse_trie = self.sparse_state_trie.clone();
         let trie_metrics = self.trie_metrics.clone();
         let max_hot_slots = self.sparse_trie_max_hot_slots;
@@ -603,7 +607,8 @@ where
             let mut task = SparseTrieCacheTask::new_with_trie(
                 &executor,
                 from_multi_proof,
-                proof_worker_handle,
+                proof_task_ctx,
+                halve_workers,
                 trie_metrics.clone(),
                 sparse_state_trie,
                 parent_state_root,

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -22,7 +22,8 @@ use reth_trie::{
 use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
 use reth_trie_parallel::{
     proof_task::{
-        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofTaskCtx,
+        ProofWorkerHandle,
     },
     root::ParallelStateRootError,
 };
@@ -37,6 +38,8 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 /// Maximum number of pending/prewarm updates that we accumulate in memory before actually applying.
 const MAX_PENDING_UPDATES: usize = 100;
 
+type ProofWorkerFactory = Box<dyn Fn() -> ProofWorkerHandle + Send + Sync>;
+
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = ConfigurableSparseTrie> {
     /// Sender for proof results.
@@ -49,8 +52,10 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     trie: SparseStateTrie<A, S>,
     /// The parent block's state root.
     parent_state_root: B256,
-    /// Handle to the proof worker pools (storage and account).
-    proof_worker_handle: ProofWorkerHandle,
+    /// Lazily-created handle to the proof worker pools (storage and account).
+    proof_worker_handle: Option<ProofWorkerHandle>,
+    /// Creates proof workers on first proof dispatch instead of at task startup.
+    make_proof_worker_handle: ProofWorkerFactory,
 
     /// The size of proof targets chunk to spawn in one calculation.
     /// If None, chunking is disabled and all targets are processed in a single proof.
@@ -117,15 +122,25 @@ where
     S: SparseTrie + Default + Clone,
 {
     /// Creates a new sparse trie, pre-populating with an existing [`SparseStateTrie`].
-    pub(super) fn new_with_trie(
+    pub(super) fn new_with_trie<Factory>(
         executor: &Runtime,
         updates: CrossbeamReceiver<StateRootMessage>,
-        proof_worker_handle: ProofWorkerHandle,
+        proof_task_ctx: ProofTaskCtx<Factory>,
+        halve_workers: bool,
         metrics: MultiProofTaskMetrics,
         trie: SparseStateTrie<A, S>,
         parent_state_root: B256,
         chunk_size: usize,
-    ) -> Self {
+    ) -> Self
+    where
+        Factory: reth_provider::DatabaseProviderROFactory<
+                Provider: reth_trie::trie_cursor::TrieCursorFactory
+                              + reth_trie::hashed_cursor::HashedCursorFactory,
+            > + Clone
+            + Send
+            + Sync
+            + 'static,
+    {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
 
@@ -136,11 +151,17 @@ where
             Self::run_hashing_task(updates, hashed_state_tx, hashing_metrics)
         });
 
+        let executor = executor.clone();
+        let make_proof_worker_handle = Box::new(move || {
+            ProofWorkerHandle::new(&executor, proof_task_ctx.clone(), halve_workers)
+        });
+
         Self {
             proof_result_tx,
             proof_result_rx,
             updates: hashed_state_rx,
-            proof_worker_handle,
+            proof_worker_handle: None,
+            make_proof_worker_handle,
             trie,
             parent_state_root,
             chunk_size,
@@ -800,20 +821,24 @@ where
 
         let _span = trace_span!("dispatch_pending_targets").entered();
         let (targets, chunking_length) = self.pending_targets.take();
+        let chunk_size = self.chunk_size;
+        let max_targets_for_chunking = self.max_targets_for_chunking;
+        let proof_result_tx = self.proof_result_tx.clone();
+        let proof_worker_handle = self.proof_worker_handle();
         dispatch_with_chunking(
             targets,
             chunking_length,
-            self.chunk_size,
-            self.max_targets_for_chunking,
-            self.proof_worker_handle.has_multiple_idle_account_workers(),
-            self.proof_worker_handle.has_multiple_idle_storage_workers(),
+            chunk_size,
+            max_targets_for_chunking,
+            proof_worker_handle.has_multiple_idle_account_workers(),
+            proof_worker_handle.has_multiple_idle_storage_workers(),
             MultiProofTargetsV2::chunks,
             |proof_targets| {
                 if let Err(e) =
-                    self.proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
+                    proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
                         targets: proof_targets,
                         proof_result_sender: ProofResultContext::new(
-                            self.proof_result_tx.clone(),
+                            proof_result_tx.clone(),
                             HashedPostState::default(),
                             Instant::now(),
                         ),
@@ -823,6 +848,14 @@ where
                 }
             },
         );
+    }
+
+    fn proof_worker_handle(&mut self) -> &ProofWorkerHandle {
+        if self.proof_worker_handle.is_none() {
+            self.proof_worker_handle = Some((self.make_proof_worker_handle)());
+        }
+
+        self.proof_worker_handle.as_ref().expect("proof worker handle is initialized")
     }
 }
 
@@ -993,9 +1026,6 @@ mod tests {
                 ChangesetCache::new(),
             ),
         );
-        let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
-
         let default_trie = RevealableSparseTrie::blind_from(ConfigurableSparseTrie::Arena(
             ArenaParallelSparseTrie::default(),
         ));
@@ -1009,7 +1039,8 @@ mod tests {
         let mut task = SparseTrieCacheTask::new_with_trie(
             &runtime,
             updates_rx,
-            proof_worker_handle,
+            ProofTaskCtx::new(overlay_factory),
+            false,
             MultiProofTaskMetrics::default(),
             trie,
             parent_state_root,
@@ -1024,5 +1055,6 @@ mod tests {
         assert_eq!(outcome.state_root, parent_state_root);
         assert!(outcome.trie_updates.is_empty());
         assert!(task.trie.state_trie_ref().is_none(), "blind trie should not be revealed");
+        assert!(task.proof_worker_handle.is_none(), "proof workers should stay lazy");
     }
 }


### PR DESCRIPTION
Defer proof worker pool creation until the sparse trie actually dispatches proof work. This avoids paying the worker startup cost for payloads that finish from preserved trie state without needing new proofs, while keeping the existing dispatch logic unchanged once proofs are needed.