### PR TITLE
perf(provider): batch static-file tx appends

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -458,9 +458,11 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         for (block, &first_tx) in blocks.iter().zip(tx_nums) {
             let b = block.recovered_block();
             w.increment_block(b.number())?;
-            for (i, tx) in b.body().transactions().iter().enumerate() {
-                w.append_transaction(first_tx + i as u64, tx)?;
-            }
+            w.append_transactions(
+                b.body().transactions().iter().enumerate().map(|(i, tx)| {
+                    Ok((first_tx + i as u64, tx))
+                }),
+            )?;
         }
         Ok(())
     }
@@ -475,9 +477,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         for (block, &first_tx) in blocks.iter().zip(tx_nums) {
             let b = block.recovered_block();
             w.increment_block(b.number())?;
-            for (i, sender) in b.senders_iter().enumerate() {
-                w.append_transaction_sender(first_tx + i as u64, sender)?;
-            }
+            w.append_transaction_senders(
+                b.senders_iter().enumerate().map(|(i, sender)| (first_tx + i as u64, *sender)),
+            )?;
         }
         Ok(())
     }
@@ -502,9 +504,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 continue
             }
 
-            for (i, receipt) in block.execution_outcome().receipts.iter().enumerate() {
-                w.append_receipt(first_tx + i as u64, receipt)?;
-            }
+            w.append_receipts(block.execution_outcome().receipts.iter().enumerate().map(
+                |(i, receipt)| Ok((first_tx + i as u64, receipt)),
+            ))?;
         }
         Ok(())
     }

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -1208,6 +1208,42 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         Ok(())
     }
 
+    /// Appends multiple transactions to the static file.
+    pub fn append_transactions<I, Tx>(&mut self, txs: I) -> ProviderResult<()>
+    where
+        I: Iterator<Item = Result<(TxNumber, Tx), ProviderError>>,
+        Tx: Borrow<N::SignedTx>,
+        N::SignedTx: Compact,
+    {
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Transactions);
+
+        let mut txs_iter = txs.into_iter().peekable();
+        if txs_iter.peek().is_none() {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        let mut count: u64 = 0;
+        for tx_result in txs_iter {
+            let (tx_num, tx) = tx_result?;
+            self.append_with_tx_number(tx_num, tx.borrow())?;
+            count += 1;
+        }
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operations(
+                StaticFileSegment::Transactions,
+                StaticFileProviderOperation::Append,
+                count,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
     /// Appends receipt to static file.
     ///
     /// It **DOES NOT** call `increment_block()`, it should be handled elsewhere. There might be


### PR DESCRIPTION
Use per-block batch append APIs for static-file transactions, receipts, and transaction senders so the storage_v2 save path avoids per-entry writer setup and metrics work. This keeps the existing segment layout while reducing fixed writer overhead on persisted block batches.