### PR TITLE
perf(engine): lazily allocate prewarm storage targets

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -812,6 +812,7 @@ where
 /// given state.
 fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize) {
     let mut targets = MultiProofTargetsV2::default();
+    targets.account_targets.reserve(state.len());
     let mut storage_target_count = 0;
     for (addr, account) in state {
         // if the account was not touched, or if the account was selfdestructed, do not
@@ -828,7 +829,8 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         let hashed_address = keccak256(addr);
         targets.account_targets.push(hashed_address.into());
 
-        let mut storage_slots = Vec::with_capacity(account.storage.len());
+        let storage_capacity = account.storage.len();
+        let mut storage_slots = None;
         for (key, slot) in account.storage {
             // do nothing if unchanged
             if !slot.is_changed() {
@@ -836,11 +838,13 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
             }
 
             let hashed_slot = keccak256(B256::new(key.to_be_bytes()));
-            storage_slots.push(ProofV2Target::from(hashed_slot));
+            storage_slots
+                .get_or_insert_with(|| Vec::with_capacity(storage_capacity))
+                .push(ProofV2Target::from(hashed_slot));
         }
 
-        storage_target_count += storage_slots.len();
-        if !storage_slots.is_empty() {
+        if let Some(storage_slots) = storage_slots {
+            storage_target_count += storage_slots.len();
             targets.storage_targets.insert(hashed_address, storage_slots);
         }
     }


### PR DESCRIPTION
Reserve account proof targets up front and only allocate per-account storage target vectors once a changed slot is actually discovered. This trims needless heap work in the prewarm multiproof target builder for touched accounts with no changed storage.