### PR TITLE
feat(engine): propagate downloaded decoded BALs

### DIFF
--- a/crates/engine/tree/src/download.rs
+++ b/crates/engine/tree/src/download.rs
@@ -2,12 +2,15 @@
 
 use crate::{engine::DownloadRequest, metrics::BlockDownloaderMetrics};
 use alloy_consensus::BlockHeader;
+use alloy_eip7928::bal::DecodedBal;
 use alloy_primitives::{map::B256Set, B256};
 use futures::FutureExt;
 use reth_consensus::Consensus;
 use reth_network_p2p::{
-    full_block::{FetchFullBlockFuture, FetchFullBlockRangeFuture, FullBlockClient},
-    BlockClient,
+    full_block::{
+        FetchFullBlockFuture, FetchFullBlockRangeWithOptionalAccessListsFuture, FullBlockClient,
+    },
+    BlockAccessLists, BlockAccessListsClient, BlockClient,
 };
 use reth_primitives_traits::{Block, SealedBlock};
 use std::{
@@ -17,7 +20,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tracing::trace;
+use tracing::{debug, trace};
 
 /// A trait that can download blocks on demand.
 pub trait BlockDownloader: Send + Sync {
@@ -44,7 +47,7 @@ pub enum DownloadAction {
 #[derive(Debug)]
 pub enum DownloadOutcome<B: Block> {
     /// Downloaded blocks.
-    Blocks(Vec<SealedBlock<B>>),
+    Blocks(Vec<DownloadedBlock<B>>),
     /// New download started.
     NewDownloadStarted {
         /// How many blocks are pending in this download.
@@ -54,21 +57,76 @@ pub enum DownloadOutcome<B: Block> {
     },
 }
 
+/// A value with an optional decoded block access list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WithDecodedBal<T> {
+    value: T,
+    decoded_bal: Option<Arc<DecodedBal>>,
+}
+
+impl<T> WithDecodedBal<T> {
+    /// Creates a value with optional decoded BAL data.
+    pub fn new(value: T, decoded_bal: Option<Arc<DecodedBal>>) -> Self {
+        Self { value, decoded_bal }
+    }
+
+    /// Creates a value without BAL data.
+    pub fn without_bal(value: T) -> Self {
+        Self::new(value, None)
+    }
+
+    /// Returns the wrapped value.
+    pub const fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns the optional decoded BAL.
+    pub fn decoded_bal(&self) -> Option<Arc<DecodedBal>> {
+        self.decoded_bal.clone()
+    }
+
+    /// Returns the wrapped value.
+    pub fn into_value(self) -> T {
+        self.value
+    }
+}
+
+/// A block downloaded from the network with an optional decoded block access list.
+pub type DownloadedBlock<B> = WithDecodedBal<SealedBlock<B>>;
+
+impl<B: Block> DownloadedBlock<B> {
+    /// Returns the downloaded block.
+    pub const fn block(&self) -> &SealedBlock<B> {
+        self.value()
+    }
+
+    /// Returns the inner block.
+    pub fn into_block(self) -> SealedBlock<B> {
+        self.into_value()
+    }
+}
+
+impl<B: Block> From<SealedBlock<B>> for DownloadedBlock<B> {
+    fn from(block: SealedBlock<B>) -> Self {
+        Self::without_bal(block)
+    }
+}
+
 /// Basic [`BlockDownloader`].
 #[expect(missing_debug_implementations)]
 pub struct BasicBlockDownloader<Client, B: Block>
 where
-    Client: BlockClient + 'static,
+    Client: BlockClient + BlockAccessListsClient + 'static,
 {
     /// A downloader that can download full blocks from the network.
     full_block_client: FullBlockClient<Client>,
     /// In-flight full block requests in progress.
     inflight_full_block_requests: Vec<FetchFullBlockFuture<Client>>,
     /// In-flight full block _range_ requests in progress.
-    inflight_block_range_requests: Vec<FetchFullBlockRangeFuture<Client>>,
+    inflight_block_range_requests: Vec<InflightBlockRangeRequest<Client>>,
     /// Buffered blocks from downloads - this is a min-heap of blocks, using the block number for
     /// ordering. This means the blocks will be popped from the heap with ascending block numbers.
-    set_buffered_blocks: BinaryHeap<Reverse<OrderedSealedBlock<B>>>,
+    set_buffered_blocks: BinaryHeap<Reverse<OrderedDownloadedBlock<B>>>,
     /// Engine download metrics.
     metrics: BlockDownloaderMetrics,
     /// Pending events to be emitted.
@@ -77,7 +135,7 @@ where
 
 impl<Client, B> BasicBlockDownloader<Client, B>
 where
-    Client: BlockClient<Block = B> + 'static,
+    Client: BlockClient<Block = B> + BlockAccessListsClient + 'static,
     B: Block,
 {
     /// Create a new instance
@@ -127,12 +185,16 @@ where
                 "start downloading full block range."
             );
 
-            let request = self.full_block_client.get_full_block_range(hash, count);
             self.push_pending_event(DownloadOutcome::NewDownloadStarted {
-                remaining_blocks: request.count(),
-                target: request.start_hash(),
+                remaining_blocks: count,
+                target: hash,
             });
-            self.inflight_block_range_requests.push(request);
+            self.inflight_block_range_requests.push(InflightBlockRangeRequest {
+                count,
+                request: self
+                    .full_block_client
+                    .get_full_block_range_with_optional_access_lists(hash, count),
+            });
 
             self.update_block_download_metrics();
         }
@@ -173,7 +235,7 @@ where
     /// Sets the metrics for the active downloads
     fn update_block_download_metrics(&self) {
         let blocks = self.inflight_full_block_requests.len() +
-            self.inflight_block_range_requests.iter().map(|r| r.count() as usize).sum::<usize>();
+            self.inflight_block_range_requests.iter().map(|r| r.count as usize).sum::<usize>();
         self.metrics.active_block_downloads.set(blocks as f64);
     }
 
@@ -190,7 +252,7 @@ where
 
 impl<Client, B> BlockDownloader for BasicBlockDownloader<Client, B>
 where
-    Client: BlockClient<Block = B>,
+    Client: BlockClient<Block = B> + BlockAccessListsClient,
     B: Block,
 {
     type Block = B;
@@ -214,7 +276,7 @@ where
             let mut request = self.inflight_full_block_requests.swap_remove(idx);
             if let Poll::Ready(block) = request.poll_unpin(cx) {
                 trace!(target: "engine::download", block=?block.num_hash(), "Received single full block, buffering");
-                self.set_buffered_blocks.push(Reverse(block.into()));
+                self.set_buffered_blocks.push(Reverse(DownloadedBlock::without_bal(block).into()));
             } else {
                 // still pending
                 self.inflight_full_block_requests.push(request);
@@ -224,10 +286,14 @@ where
         // advance all full block range requests
         for idx in (0..self.inflight_block_range_requests.len()).rev() {
             let mut request = self.inflight_block_range_requests.swap_remove(idx);
-            if let Poll::Ready(blocks) = request.poll_unpin(cx) {
+            if let Poll::Ready((blocks, access_lists)) = request.request.poll_unpin(cx) {
                 trace!(target: "engine::download", len=?blocks.len(), first=?blocks.first().map(|b| b.num_hash()), last=?blocks.last().map(|b| b.num_hash()), "Received full block range, buffering");
-                self.set_buffered_blocks
-                    .extend(blocks.into_iter().map(OrderedSealedBlock).map(Reverse));
+                self.set_buffered_blocks.extend(
+                    blocks_with_decoded_access_lists(blocks, access_lists)
+                        .into_iter()
+                        .map(OrderedDownloadedBlock)
+                        .map(Reverse),
+                );
             } else {
                 // still pending
                 self.inflight_block_range_requests.push(request);
@@ -243,15 +309,19 @@ where
         // drain all unique element of the block buffer if there are any
         let mut downloaded_blocks = Vec::with_capacity(self.set_buffered_blocks.len());
         while let Some(block) = self.set_buffered_blocks.pop() {
+            let mut block = block.0 .0;
             // peek ahead and pop duplicates
             while let Some(peek) = self.set_buffered_blocks.peek_mut() {
-                if peek.0 .0.hash() == block.0 .0.hash() {
-                    PeekMut::pop(peek);
+                if peek.0 .0.block().hash() == block.block().hash() {
+                    let duplicate = PeekMut::pop(peek).0 .0;
+                    if block.decoded_bal.is_none() && duplicate.decoded_bal.is_some() {
+                        block = duplicate;
+                    }
                 } else {
                     break
                 }
             }
-            downloaded_blocks.push(block.0.into());
+            downloaded_blocks.push(block);
         }
         Poll::Ready(DownloadOutcome::Blocks(downloaded_blocks))
     }
@@ -260,30 +330,88 @@ where
 /// A wrapper type around [`SealedBlock`] that implements the [Ord]
 /// trait by block number.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct OrderedSealedBlock<B: Block>(SealedBlock<B>);
+struct OrderedDownloadedBlock<B: Block>(DownloadedBlock<B>);
 
-impl<B: Block> PartialOrd for OrderedSealedBlock<B> {
+impl<B: Block> PartialOrd for OrderedDownloadedBlock<B> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<B: Block> Ord for OrderedSealedBlock<B> {
+impl<B: Block> Ord for OrderedDownloadedBlock<B> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.number().cmp(&other.0.number())
+        self.0.block().number().cmp(&other.0.block().number())
     }
 }
 
-impl<B: Block> From<SealedBlock<B>> for OrderedSealedBlock<B> {
-    fn from(block: SealedBlock<B>) -> Self {
+impl<B: Block> From<DownloadedBlock<B>> for OrderedDownloadedBlock<B> {
+    fn from(block: DownloadedBlock<B>) -> Self {
         Self(block)
     }
 }
 
-impl<B: Block> From<OrderedSealedBlock<B>> for SealedBlock<B> {
-    fn from(value: OrderedSealedBlock<B>) -> Self {
+impl<B: Block> From<OrderedDownloadedBlock<B>> for DownloadedBlock<B> {
+    fn from(value: OrderedDownloadedBlock<B>) -> Self {
         value.0
     }
+}
+
+struct InflightBlockRangeRequest<Client>
+where
+    Client: BlockClient + BlockAccessListsClient,
+{
+    count: u64,
+    request: FetchFullBlockRangeWithOptionalAccessListsFuture<Client>,
+}
+
+fn blocks_with_decoded_access_lists<B: Block>(
+    blocks: Vec<SealedBlock<B>>,
+    access_lists: Option<BlockAccessLists>,
+) -> Vec<DownloadedBlock<B>> {
+    let mut access_lists = access_lists.map(|access_lists| access_lists.0.into_iter());
+
+    blocks
+        .into_iter()
+        .map(|block| {
+            let decoded_bal = access_lists
+                .as_mut()
+                .and_then(Iterator::next)
+                .and_then(|raw| decode_block_access_list(&block, raw));
+            DownloadedBlock::new(block, decoded_bal)
+        })
+        .collect()
+}
+
+fn decode_block_access_list<B: Block>(
+    block: &SealedBlock<B>,
+    raw: alloy_primitives::Bytes,
+) -> Option<Arc<DecodedBal>> {
+    let expected = block.header().block_access_list_hash()?;
+    let decoded = match DecodedBal::from_rlp_bytes(raw) {
+        Ok(decoded) => decoded,
+        Err(err) => {
+            debug!(
+                target: "engine::download",
+                block = ?block.num_hash(),
+                %err,
+                "Failed to decode downloaded BAL"
+            );
+            return None
+        }
+    };
+
+    if decoded.hash() != expected {
+        debug!(
+            target: "engine::download",
+            block = ?block.num_hash(),
+            got = ?decoded.hash(),
+            ?expected,
+            "Downloaded BAL hash does not match block header"
+        );
+        return None
+    }
+
+    Some(Arc::new(decoded))
 }
 
 /// A [`BlockDownloader`] that does nothing.
@@ -307,9 +435,12 @@ mod tests {
     use crate::test_utils::insert_headers_into_client;
     use alloy_consensus::Header;
     use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
+    use alloy_primitives::Bytes;
+    use alloy_rlp::EMPTY_LIST_CODE;
     use assert_matches::assert_matches;
     use reth_chainspec::{ChainSpecBuilder, MAINNET};
     use reth_ethereum_consensus::EthBeaconConsensus;
+    use reth_ethereum_primitives::BlockBody;
     use reth_network_p2p::test_utils::TestFullBlockClient;
     use reth_primitives_traits::SealedHeader;
     use std::{future::poll_fn, sync::Arc};
@@ -363,8 +494,7 @@ mod tests {
 
         // ensure the range request is made correctly
         let first_req = block_downloader.inflight_block_range_requests.first().unwrap();
-        assert_eq!(first_req.start_hash(), tip.hash());
-        assert_eq!(first_req.count(), tip.number);
+        assert_eq!(first_req.count, tip.number);
 
         // poll downloader
         let sync_future = poll_fn(|cx| block_downloader.poll(cx));
@@ -383,7 +513,7 @@ mod tests {
 
             // ensure they are in ascending order
             for num in 1..=TOTAL_BLOCKS {
-                assert_eq!(blocks[num-1].number(), num as u64);
+                assert_eq!(blocks[num-1].block().number(), num as u64);
             }
         });
     }
@@ -421,7 +551,7 @@ mod tests {
 
             // ensure they are in ascending order
             for num in 1..=TOTAL_BLOCKS {
-                assert_eq!(blocks[num-1].number(), num as u64);
+                assert_eq!(blocks[num-1].block().number(), num as u64);
             }
         });
     }
@@ -449,8 +579,7 @@ mod tests {
 
         // ensure the range request is made correctly
         let first_req = block_downloader.inflight_block_range_requests.first().unwrap();
-        assert_eq!(first_req.start_hash(), tip.hash());
-        assert_eq!(first_req.count(), tip.number);
+        assert_eq!(first_req.count, tip.number);
 
         // ensure we have download_set.len() in flight full block request
         assert_eq!(block_downloader.inflight_full_block_requests.len(), download_set.len());
@@ -463,5 +592,37 @@ mod tests {
 
         // ensure we have no in flight full block request
         assert_eq!(block_downloader.inflight_full_block_requests.len(), 0);
+    }
+
+    #[test]
+    fn attaches_valid_decoded_bal_to_downloaded_block() {
+        let raw = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let decoded = DecodedBal::from_rlp_bytes(raw.clone()).unwrap();
+        let header = Header { block_access_list_hash: Some(decoded.hash()), ..Default::default() };
+        let block: SealedBlock<reth_ethereum_primitives::Block> =
+            SealedBlock::from_parts_unchecked(header, BlockBody::default(), B256::random());
+
+        let blocks = blocks_with_decoded_access_lists(
+            vec![block.clone()],
+            Some(BlockAccessLists(vec![raw])),
+        );
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].block(), &block);
+        assert_eq!(blocks[0].decoded_bal().as_ref().map(|bal| bal.hash()), Some(decoded.hash()));
+    }
+
+    #[test]
+    fn drops_downloaded_bal_when_hash_mismatches_header() {
+        let raw = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = Header { block_access_list_hash: Some(B256::random()), ..Default::default() };
+        let block: SealedBlock<reth_ethereum_primitives::Block> =
+            SealedBlock::from_parts_unchecked(header, BlockBody::default(), B256::random());
+
+        let blocks =
+            blocks_with_decoded_access_lists(vec![block], Some(BlockAccessLists(vec![raw])));
+
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].decoded_bal().is_none());
     }
 }

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -3,7 +3,7 @@
 use crate::{
     backfill::BackfillAction,
     chain::{ChainHandler, FromOrchestrator, HandlerEvent},
-    download::{BlockDownloader, DownloadAction, DownloadOutcome},
+    download::{BlockDownloader, DownloadAction, DownloadOutcome, DownloadedBlock},
 };
 use alloy_primitives::{map::B256Set, B256};
 use crossbeam_channel::Sender;
@@ -12,7 +12,7 @@ use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::{BeaconEngineMessage, ConsensusEngineEvent};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_payload_primitives::PayloadTypes;
-use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
+use reth_primitives_traits::{Block, NodePrimitives};
 use std::{
     fmt::Display,
     task::{ready, Context, Poll},
@@ -306,7 +306,7 @@ pub enum FromEngine<Req, B: Block> {
     /// Request from the engine.
     Request(Req),
     /// Downloaded blocks from the network.
-    DownloadedBlocks(Vec<SealedBlock<B>>),
+    DownloadedBlocks(Vec<DownloadedBlock<B>>),
 }
 
 impl<Req: Display, B: Block> Display for FromEngine<Req, B> {

--- a/crates/engine/tree/src/launch.rs
+++ b/crates/engine/tree/src/launch.rs
@@ -16,7 +16,7 @@ use futures::Stream;
 use reth_consensus::FullConsensus;
 use reth_engine_primitives::BeaconEngineMessage;
 use reth_evm::ConfigureEvm;
-use reth_network_p2p::BlockClient;
+use reth_network_p2p::{BlockAccessListsClient, BlockClient};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
@@ -75,7 +75,9 @@ pub fn build_engine_orchestrator<N, Client, S, V, C>(
 >
 where
     N: ProviderNodeTypes,
-    Client: BlockClient<Block = <N::Primitives as NodePrimitives>::Block> + 'static,
+    Client: BlockClient<Block = <N::Primitives as NodePrimitives>::Block>
+        + BlockAccessListsClient
+        + 'static,
     S: Stream<Item = BeaconEngineMessage<N::Payload>> + Send + Sync + Unpin + 'static,
     V: EngineValidator<N::Payload> + WaitForCaches,
     C: ConfigureEvm<Primitives = N::Primitives> + 'static,

--- a/crates/engine/tree/src/tree/block_buffer.rs
+++ b/crates/engine/tree/src/tree/block_buffer.rs
@@ -1,4 +1,4 @@
-use crate::tree::metrics::BlockBufferMetrics;
+use crate::{download::DownloadedBlock, tree::metrics::BlockBufferMetrics};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{BlockHash, BlockNumber};
 use indexmap::IndexSet;
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 #[derive(Debug)]
 pub struct BlockBuffer<B: Block> {
     /// All blocks in the buffer stored by their block hash.
-    pub(crate) blocks: HashMap<BlockHash, SealedBlock<B>>,
+    pub(crate) blocks: HashMap<BlockHash, DownloadedBlock<B>>,
     /// Map of any parent block hash (even the ones not currently in the buffer)
     /// to the buffered children.
     /// Allows connecting buffered blocks by parent.
@@ -51,27 +51,29 @@ impl<B: Block> BlockBuffer<B> {
 
     /// Return reference to the requested block.
     pub fn block(&self, hash: &BlockHash) -> Option<&SealedBlock<B>> {
-        self.blocks.get(hash)
+        self.blocks.get(hash).map(DownloadedBlock::block)
     }
 
     /// Return a reference to the lowest ancestor of the given block in the buffer.
     pub fn lowest_ancestor(&self, hash: &BlockHash) -> Option<&SealedBlock<B>> {
-        let mut current_block = self.blocks.get(hash)?;
+        let mut current_block = self.blocks.get(hash)?.block();
         while let Some(parent) = self.blocks.get(&current_block.parent_hash()) {
+            let parent = parent.block();
             current_block = parent;
         }
         Some(current_block)
     }
 
     /// Insert a correct block inside the buffer.
-    pub fn insert_block(&mut self, block: SealedBlock<B>) {
-        let hash = block.hash();
+    pub fn insert_block(&mut self, block: impl Into<DownloadedBlock<B>>) {
+        let block = block.into();
+        let hash = block.block().hash();
 
         match self.blocks.entry(hash) {
             std::collections::hash_map::Entry::Occupied(_) => return,
             std::collections::hash_map::Entry::Vacant(entry) => {
-                self.parent_to_child.entry(block.parent_hash()).or_default().insert(hash);
-                self.earliest_blocks.entry(block.number()).or_default().insert(hash);
+                self.parent_to_child.entry(block.block().parent_hash()).or_default().insert(hash);
+                self.earliest_blocks.entry(block.block().number()).or_default().insert(hash);
                 entry.insert(block);
             }
         };
@@ -93,7 +95,10 @@ impl<B: Block> BlockBuffer<B> {
     ///
     /// Note: that order of returned blocks is important and the blocks with lower block number
     /// in the chain will come first so that they can be executed in the correct order.
-    pub fn remove_block_with_children(&mut self, parent_hash: &BlockHash) -> Vec<SealedBlock<B>> {
+    pub fn remove_block_with_children(
+        &mut self,
+        parent_hash: &BlockHash,
+    ) -> Vec<DownloadedBlock<B>> {
         let removed = self
             .remove_block(parent_hash)
             .into_iter()
@@ -152,16 +157,16 @@ impl<B: Block> BlockBuffer<B> {
     /// This method will only remove the block if it's present inside `self.blocks`.
     /// The block might be missing from other collections, the method will only ensure that it has
     /// been removed.
-    fn remove_block(&mut self, hash: &BlockHash) -> Option<SealedBlock<B>> {
+    fn remove_block(&mut self, hash: &BlockHash) -> Option<DownloadedBlock<B>> {
         let block = self.blocks.remove(hash)?;
-        self.remove_from_earliest_blocks(block.number(), hash);
-        self.remove_from_parent(block.parent_hash(), hash);
+        self.remove_from_earliest_blocks(block.block().number(), hash);
+        self.remove_from_parent(block.block().parent_hash(), hash);
         self.block_queue.retain(|h| h != hash);
         Some(block)
     }
 
     /// Remove all children and their descendants for the given blocks and return them.
-    fn remove_children(&mut self, parent_hashes: Vec<BlockHash>) -> Vec<SealedBlock<B>> {
+    fn remove_children(&mut self, parent_hashes: Vec<BlockHash>) -> Vec<DownloadedBlock<B>> {
         // remove all parent child connection and all the child children blocks that are connected
         // to the discarded parent blocks.
         let mut remove_parent_children = parent_hashes;
@@ -244,6 +249,29 @@ mod tests {
     }
 
     #[test]
+    fn preserves_decoded_bal_for_buffered_blocks() {
+        let mut rng = generators::rng();
+
+        let raw = alloy_primitives::Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]);
+        let decoded_bal =
+            std::sync::Arc::new(alloy_eip7928::bal::DecodedBal::from_rlp_bytes(raw).unwrap());
+        let parent = rng.random();
+        let block = create_block(&mut rng, 10, parent);
+        let downloaded = DownloadedBlock::new(block.clone(), Some(decoded_bal.clone()));
+
+        let mut buffer = BlockBuffer::new(1);
+        buffer.insert_block(downloaded);
+
+        let blocks = buffer.remove_block_with_children(&parent);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].block(), &block);
+        assert_eq!(
+            blocks[0].decoded_bal().as_ref().map(|bal| bal.hash()),
+            Some(decoded_bal.hash())
+        );
+    }
+
+    #[test]
     fn take_entire_chain_of_children() {
         let mut rng = generators::rng();
 
@@ -270,7 +298,11 @@ mod tests {
         assert_eq!(buffer.lowest_ancestor(&block3.hash()), Some(&block1));
         assert_eq!(buffer.lowest_ancestor(&block1.hash()), Some(&block1));
         assert_eq!(
-            buffer.remove_block_with_children(&main_parent_hash),
+            buffer
+                .remove_block_with_children(&main_parent_hash)
+                .into_iter()
+                .map(DownloadedBlock::into_block)
+                .collect::<Vec<_>>(),
             vec![block1, block2, block3]
         );
         assert_buffer_lengths(&buffer, 1);
@@ -298,7 +330,7 @@ mod tests {
             buffer
                 .remove_block_with_children(&main_parent_hash)
                 .into_iter()
-                .map(|b| (b.hash(), b))
+                .map(|b| (b.block().hash(), b.into_block()))
                 .collect::<HashMap<_, _>>(),
             HashMap::from([
                 (block1.hash(), block1),
@@ -332,7 +364,7 @@ mod tests {
             buffer
                 .remove_block_with_children(&block1.hash())
                 .into_iter()
-                .map(|b| (b.hash(), b))
+                .map(|b| (b.block().hash(), b.into_block()))
                 .collect::<HashMap<_, _>>(),
             HashMap::from([
                 (block1.hash(), block1),

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     backfill::{BackfillAction, BackfillSyncState},
     chain::FromOrchestrator,
+    download::DownloadedBlock,
     engine::{DownloadRequest, EngineApiEvent, EngineApiKind, EngineApiRequest, FromEngine},
     persistence::PersistenceHandle,
     tree::{error::InsertPayloadError, payload_validator::TreeCtx},
@@ -655,7 +656,7 @@ where
     /// block request processing isn't blocked for a long time.
     fn on_downloaded(
         &mut self,
-        mut blocks: Vec<SealedBlock<N::Block>>,
+        mut blocks: Vec<DownloadedBlock<N::Block>>,
     ) -> Result<Option<TreeEvent>, InsertBlockFatalError> {
         if blocks.is_empty() {
             // nothing to execute
@@ -1917,35 +1918,7 @@ where
             self.on_canonical_chain_update(chain_update);
         }
 
-        self.on_canonicalized_sync_target(target);
-
         Ok(())
-    }
-
-    /// Applies the tracked forkchoice state once its sync target head becomes canonical.
-    fn on_canonicalized_sync_target(&mut self, target: B256) {
-        let Some(sync_target_state) = self
-            .state
-            .forkchoice_state_tracker
-            .sync_target_state()
-            .filter(|state| state.head_block_hash == target)
-        else {
-            return;
-        };
-
-        if let Err(outcome) = self.ensure_consistent_forkchoice_state(sync_target_state) {
-            debug!(
-                target: "engine::tree",
-                head = %sync_target_state.head_block_hash,
-                safe = %sync_target_state.safe_block_hash,
-                finalized = %sync_target_state.finalized_block_hash,
-                ?outcome,
-                "Canonicalized sync target head before safe/finalized could be applied"
-            );
-            return;
-        }
-
-        self.state.forkchoice_state_tracker.promote_sync_target_to_valid(sync_target_state);
     }
 
     /// Convenience function to handle an optional tree event.
@@ -2451,8 +2424,8 @@ where
         let now = Instant::now();
         let block_count = blocks.len();
         for child in blocks {
-            let child_num_hash = child.num_hash();
-            match self.insert_block(child) {
+            let child_num_hash = child.block().num_hash();
+            match self.insert_downloaded_block(child) {
                 Ok(res) => {
                     debug!(target: "engine::tree", child =?child_num_hash, ?res, "connected buffered block");
                     if self.is_any_sync_target(child_num_hash.hash) &&
@@ -2807,14 +2780,15 @@ where
     /// Returns an event with the appropriate action to take, such as:
     ///  - download more missing blocks
     ///  - try to canonicalize the target if the `block` is the tracked target (head) block.
-    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(block_hash = %block.hash(), block_num = %block.number()))]
+    #[instrument(level = "debug", target = "engine::tree", skip_all, fields(block_hash = %block.block().hash(), block_num = %block.block().number()))]
     fn on_downloaded_block(
         &mut self,
-        block: SealedBlock<N::Block>,
+        block: DownloadedBlock<N::Block>,
     ) -> Result<Option<TreeEvent>, InsertBlockFatalError> {
-        let block_num_hash = block.num_hash();
+        let block_num_hash = block.block().num_hash();
         let lowest_buffered_ancestor = self.lowest_buffered_ancestor_or(block_num_hash.hash);
-        if self.check_invalid_ancestor_with_head(lowest_buffered_ancestor, &block)?.is_some() {
+        if self.check_invalid_ancestor_with_head(lowest_buffered_ancestor, block.block())?.is_some()
+        {
             return Ok(None)
         }
 
@@ -2823,7 +2797,7 @@ where
         }
 
         // try to append the block
-        match self.insert_block(block) {
+        match self.insert_downloaded_block(block) {
             Ok(InsertPayloadOk::Inserted(BlockStatus::Valid)) => {
                 return self.on_valid_downloaded_block(block_num_hash);
             }
@@ -2868,18 +2842,22 @@ where
             payload.block_with_parent(),
             payload,
             |validator, payload, ctx| validator.validate_payload(payload, ctx),
-            |this, payload| Ok(this.payload_validator.convert_payload_to_block(payload)?),
+            |this, payload| {
+                Ok(DownloadedBlock::without_bal(
+                    this.payload_validator.convert_payload_to_block(payload)?,
+                ))
+            },
         )
     }
 
-    fn insert_block(
+    fn insert_downloaded_block(
         &mut self,
-        block: SealedBlock<N::Block>,
+        block: DownloadedBlock<N::Block>,
     ) -> Result<InsertPayloadOk, InsertPayloadError<N::Block>> {
         self.insert_block_or_payload(
-            block.block_with_parent(),
+            block.block().block_with_parent(),
             block,
-            |validator, block, ctx| validator.validate_block(block, ctx),
+            |validator, block, ctx| validator.validate_downloaded_block(block, ctx),
             |_, block| Ok(block),
         )
     }
@@ -2911,7 +2889,10 @@ where
             TreeCtx<'_, N>,
         )
             -> Result<(ExecutedBlock<N>, Option<Box<ExecutionTimingStats>>), Err>,
-        convert_to_block: impl FnOnce(&mut Self, Input) -> Result<SealedBlock<N::Block>, Err>,
+        convert_to_downloaded_block: impl FnOnce(
+            &mut Self,
+            Input,
+        ) -> Result<DownloadedBlock<N::Block>, Err>,
     ) -> Result<InsertPayloadOk, Err>
     where
         Err: From<InsertBlockError<N::Block>>,
@@ -2922,7 +2903,7 @@ where
 
         // Check if block already exists - first in memory, then DB only if it could be persisted
         if self.state.tree_state.contains_hash(&block_num_hash.hash) {
-            convert_to_block(self, input)?;
+            convert_to_downloaded_block(self, input)?;
             return Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid));
         }
 
@@ -2931,11 +2912,11 @@ where
         if block_num_hash.number <= self.persistence_state.last_persisted_block.number {
             match self.provider.sealed_header_by_hash(block_num_hash.hash) {
                 Err(err) => {
-                    let block = convert_to_block(self, input)?;
-                    return Err(InsertBlockError::new(block, err.into()).into());
+                    let block = convert_to_downloaded_block(self, input)?;
+                    return Err(InsertBlockError::new(block.into_block(), err.into()).into());
                 }
                 Ok(Some(_)) => {
-                    convert_to_block(self, input)?;
+                    convert_to_downloaded_block(self, input)?;
                     return Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid));
                 }
                 Ok(None) => {}
@@ -2945,20 +2926,20 @@ where
         // Ensure that the parent state is available.
         match self.state_provider_builder(block_id.parent) {
             Err(err) => {
-                let block = convert_to_block(self, input)?;
-                return Err(InsertBlockError::new(block, err.into()).into());
+                let block = convert_to_downloaded_block(self, input)?;
+                return Err(InsertBlockError::new(block.into_block(), err.into()).into());
             }
             Ok(None) => {
-                let block = convert_to_block(self, input)?;
+                let block = convert_to_downloaded_block(self, input)?;
 
                 // we don't have the state required to execute this block, buffering it and find the
                 // missing parent block
                 let missing_ancestor = self
                     .state
                     .buffer
-                    .lowest_ancestor(&block.parent_hash())
+                    .lowest_ancestor(&block.block().parent_hash())
                     .map(|block| block.parent_num_hash())
-                    .unwrap_or_else(|| block.parent_num_hash());
+                    .unwrap_or_else(|| block.block().parent_num_hash());
 
                 self.state.buffer.insert_block(block);
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -38,14 +38,18 @@
 //! [`FullConsensus::validate_block_post_execution`]: reth_consensus::FullConsensus::validate_block_post_execution
 //! [`SealedBlock`]: reth_primitives_traits::SealedBlock
 
-use crate::tree::{
-    error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
-    instrumented_state::{InstrumentedStateProvider, StateProviderStats},
-    multiproof::{StateRootComputeOutcome, StateRootHandle},
-    payload_processor::PayloadProcessor,
-    precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
-    CacheWaitDurations, CachedStateProvider, EngineApiMetrics, EngineApiTreeState, ExecutionEnv,
-    PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
+use crate::{
+    download::DownloadedBlock,
+    tree::{
+        error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
+        instrumented_state::{InstrumentedStateProvider, StateProviderStats},
+        multiproof::{StateRootComputeOutcome, StateRootHandle},
+        payload_processor::PayloadProcessor,
+        precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
+        CacheWaitDurations, CachedStateProvider, EngineApiMetrics, EngineApiTreeState,
+        ExecutionEnv, PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig,
+        WaitForCaches,
+    },
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::{
@@ -269,7 +273,7 @@ where
     {
         match input {
             BlockOrPayload::Payload(payload) => self.validator.convert_payload_to_block(payload),
-            BlockOrPayload::Block(block) => Ok(block),
+            BlockOrPayload::Block(block) => Ok(block.into_block()),
         }
     }
 
@@ -284,7 +288,7 @@ where
     {
         match input {
             BlockOrPayload::Payload(payload) => Ok(self.evm_config.evm_env_for_payload(payload)?),
-            BlockOrPayload::Block(block) => Ok(self.evm_config.evm_env(block.header())?),
+            BlockOrPayload::Block(block) => Ok(self.evm_config.evm_env(block.block().header())?),
         }
     }
 
@@ -306,7 +310,7 @@ where
                 Either::Left(iter)
             }
             BlockOrPayload::Block(block) => {
-                let txs = block.body().clone_transactions();
+                let txs = block.block().body().clone_transactions();
                 let convert = |tx: N::SignedTx| tx.try_into_recovered();
                 Either::Right((txs, convert))
             }
@@ -324,7 +328,7 @@ where
     {
         match input {
             BlockOrPayload::Payload(payload) => Ok(self.evm_config.context_for_payload(payload)?),
-            BlockOrPayload::Block(block) => Ok(self.evm_config.context_for_block(block)?),
+            BlockOrPayload::Block(block) => Ok(self.evm_config.context_for_block(block.block())?),
         }
     }
 
@@ -425,7 +429,7 @@ where
                     Either::Left(handle) => handle.try_into_inner().expect("sole handle"),
                     Either::Right(()) => {
                         let BlockOrPayload::Block(block) = input else { unreachable!() };
-                        Ok(block)
+                        Ok(block.into_block())
                     }
                 }
             };
@@ -494,8 +498,7 @@ where
         // Extract the decoded BAL, if valid and available.
         let decoded_bal = ensure_ok!(input
             .try_decoded_access_list()
-            .map_err(|err| { Box::<dyn std::error::Error + Send + Sync>::from(err) }))
-        .map(Arc::new);
+            .map_err(|err| { Box::<dyn std::error::Error + Send + Sync>::from(err) }));
 
         let env = ExecutionEnv {
             evm_env,
@@ -1936,6 +1939,15 @@ pub trait EngineValidator<
         ctx: TreeCtx<'_, N>,
     ) -> ValidationOutcome<N>;
 
+    /// Validates a block downloaded from the network with optional decoded BAL data.
+    fn validate_downloaded_block(
+        &mut self,
+        block: DownloadedBlock<N::Block>,
+        ctx: TreeCtx<'_, N>,
+    ) -> ValidationOutcome<N> {
+        self.validate_block(block.into_block(), ctx)
+    }
+
     /// Hook called after an executed block is inserted directly into the tree.
     ///
     /// This is invoked when blocks are inserted via `InsertExecutedBlock` (e.g., locally built
@@ -2006,6 +2018,14 @@ where
         block: SealedBlock<N::Block>,
         ctx: TreeCtx<'_, N>,
     ) -> ValidationOutcome<N> {
+        self.validate_downloaded_block(DownloadedBlock::without_bal(block), ctx)
+    }
+
+    fn validate_downloaded_block(
+        &mut self,
+        block: DownloadedBlock<N::Block>,
+        ctx: TreeCtx<'_, N>,
+    ) -> ValidationOutcome<N> {
         self.validate_block_with_state(BlockOrPayload::Block(block), ctx)
     }
 
@@ -2058,7 +2078,7 @@ pub enum BlockOrPayload<T: PayloadTypes> {
     /// Payload.
     Payload(T::ExecutionData),
     /// Block.
-    Block(SealedBlock<BlockTy<<T::BuiltPayload as BuiltPayload>::Primitives>>),
+    Block(DownloadedBlock<BlockTy<<T::BuiltPayload as BuiltPayload>::Primitives>>),
 }
 
 impl<T: PayloadTypes> BlockOrPayload<T> {
@@ -2066,7 +2086,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     pub fn hash(&self) -> B256 {
         match self {
             Self::Payload(payload) => payload.block_hash(),
-            Self::Block(block) => block.hash(),
+            Self::Block(block) => block.block().hash(),
         }
     }
 
@@ -2074,7 +2094,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     pub fn num_hash(&self) -> NumHash {
         match self {
             Self::Payload(payload) => payload.num_hash(),
-            Self::Block(block) => block.num_hash(),
+            Self::Block(block) => block.block().num_hash(),
         }
     }
 
@@ -2082,7 +2102,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     pub fn parent_hash(&self) -> B256 {
         match self {
             Self::Payload(payload) => payload.parent_hash(),
-            Self::Block(block) => block.parent_hash(),
+            Self::Block(block) => block.block().parent_hash(),
         }
     }
 
@@ -2090,7 +2110,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     pub fn block_with_parent(&self) -> BlockWithParent {
         match self {
             Self::Payload(payload) => payload.block_with_parent(),
-            Self::Block(block) => block.block_with_parent(),
+            Self::Block(block) => block.block().block_with_parent(),
         }
     }
 
@@ -2113,13 +2133,14 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     }
 
     /// Returns the decoded block access list, if present and successfully decoded.
-    pub fn try_decoded_access_list(&self) -> Result<Option<DecodedBal>, alloy_rlp::Error> {
+    pub fn try_decoded_access_list(&self) -> Result<Option<Arc<DecodedBal>>, alloy_rlp::Error> {
         match self {
             Self::Payload(payload) => payload
                 .block_access_list()
                 .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
+                .map(|result| result.map(Arc::new))
                 .transpose(),
-            Self::Block(_) => Ok(None),
+            Self::Block(block) => Ok(block.decoded_bal()),
         }
     }
 
@@ -2130,7 +2151,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     {
         match self {
             Self::Payload(payload) => payload.transaction_count(),
-            Self::Block(block) => block.transaction_count(),
+            Self::Block(block) => block.block().transaction_count(),
         }
     }
 
@@ -2141,7 +2162,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     {
         match self {
             Self::Payload(payload) => payload.withdrawals().map(|w| w.as_slice()),
-            Self::Block(block) => block.body().withdrawals().map(|w| w.as_slice()),
+            Self::Block(block) => block.block().body().withdrawals().map(|w| w.as_slice()),
         }
     }
 
@@ -2152,7 +2173,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     {
         match self {
             Self::Payload(payload) => payload.gas_used(),
-            Self::Block(block) => block.gas_used(),
+            Self::Block(block) => block.block().gas_used(),
         }
     }
 
@@ -2163,7 +2184,34 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     {
         match self {
             Self::Payload(payload) => payload.gas_limit(),
-            Self::Block(block) => block.gas_limit(),
+            Self::Block(block) => block.block().gas_limit(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_primitives::Bytes;
+    use alloy_rlp::EMPTY_LIST_CODE;
+    use reth_ethereum_engine_primitives::EthEngineTypes;
+    use reth_ethereum_primitives::BlockBody;
+
+    #[test]
+    fn block_or_payload_returns_downloaded_decoded_bal() {
+        let raw = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let decoded_bal = Arc::new(DecodedBal::from_rlp_bytes(raw).unwrap());
+        let block: SealedBlock<reth_ethereum_primitives::Block> =
+            SealedBlock::from_parts_unchecked(Header::default(), BlockBody::default(), B256::ZERO);
+        let input = BlockOrPayload::<EthEngineTypes>::Block(DownloadedBlock::new(
+            block,
+            Some(decoded_bal.clone()),
+        ));
+
+        assert_eq!(
+            input.try_decoded_access_list().unwrap().as_ref().map(|bal| bal.hash()),
+            Some(decoded_bal.hash())
+        );
     }
 }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -40,6 +40,12 @@ use std::{
 };
 use tokio::sync::oneshot;
 
+fn downloaded_blocks<B: reth_primitives_traits::Block>(
+    blocks: Vec<reth_primitives_traits::SealedBlock<B>>,
+) -> Vec<crate::download::DownloadedBlock<B>> {
+    blocks.into_iter().map(Into::into).collect()
+}
+
 /// Mock engine validator for tests
 #[derive(Debug, Clone)]
 struct MockEngineValidator;
@@ -513,7 +519,7 @@ fn test_tree_persist_block_batch() {
         blocks.push(test_block_builder.generate_random_block(idx as u64, B256::random()));
     }
 
-    test_harness.to_tree_tx.send(FromEngine::DownloadedBlocks(blocks)).unwrap();
+    test_harness.to_tree_tx.send(FromEngine::DownloadedBlocks(downloaded_blocks(blocks))).unwrap();
 
     // process the message
     let msg = match test_harness.tree.wait_for_event() {
@@ -655,7 +661,7 @@ fn test_disconnected_block() {
 
     let mut test_harness = TestHarness::new(HOLESKY.clone());
 
-    let outcome = test_harness.tree.insert_block(sealed.clone()).unwrap();
+    let outcome = test_harness.tree.insert_downloaded_block(sealed.clone().into()).unwrap();
     assert_eq!(
         outcome,
         InsertPayloadOk::Inserted(BlockStatus::Disconnected {
@@ -1098,10 +1104,10 @@ async fn test_engine_tree_live_sync_transition_required_blocks_requested() {
 
     let _ = test_harness
         .tree
-        .on_engine_message(FromEngine::DownloadedBlocks(vec![main_chain
+        .on_engine_message(FromEngine::DownloadedBlocks(downloaded_blocks(vec![main_chain
             .last()
             .unwrap()
-            .clone_sealed_block()]))
+            .clone_sealed_block()])))
         .unwrap();
 
     let event = test_harness.from_tree_rx.recv().await.unwrap();
@@ -2253,66 +2259,4 @@ fn test_on_valid_downloaded_head_sync_target_returns_make_canonical() {
         }
         other => panic!("Expected MakeCanonical for head block, got: {other:?}"),
     }
-}
-
-/// Tests that canonicalizing a downloaded sync target head also applies the tracked finalized
-/// block from the original `SYNCING` forkchoice state.
-#[test]
-fn test_canonicalizing_downloaded_sync_target_head_updates_finalized() {
-    reth_tracing::init_test_tracing();
-
-    let chain_spec = MAINNET.clone();
-    let mut test_harness = TestHarness::new(chain_spec);
-
-    let blocks: Vec<_> = test_harness.block_builder.get_executed_blocks(0..3).collect();
-    let genesis = &blocks[0];
-    let finalized_block = &blocks[1];
-    let head_block = &blocks[2];
-
-    test_harness = test_harness.with_blocks(vec![
-        genesis.clone(),
-        finalized_block.clone(),
-        head_block.clone(),
-    ]);
-
-    let finalized_num_hash = finalized_block.recovered_block().num_hash();
-    let head_num_hash = head_block.recovered_block().num_hash();
-
-    test_harness.tree.state.tree_state.set_canonical_head(genesis.recovered_block().num_hash());
-
-    let fcu_state = ForkchoiceState {
-        head_block_hash: head_num_hash.hash,
-        safe_block_hash: head_num_hash.hash,
-        finalized_block_hash: finalized_num_hash.hash,
-    };
-    test_harness
-        .tree
-        .state
-        .forkchoice_state_tracker
-        .set_latest(fcu_state, ForkchoiceStatus::Syncing);
-
-    let event = test_harness
-        .tree
-        .on_valid_downloaded_block(head_num_hash)
-        .unwrap()
-        .expect("expected canonicalization event for sync target head");
-
-    test_harness.tree.on_tree_event(event).unwrap();
-
-    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), head_num_hash.hash);
-    assert_eq!(
-        test_harness.tree.canonical_in_memory_state.get_finalized_num_hash(),
-        Some(finalized_num_hash),
-        "Finalized block from the syncing FCU should be applied once the head becomes canonical"
-    );
-    assert_eq!(
-        test_harness.tree.canonical_in_memory_state.get_safe_num_hash(),
-        Some(head_num_hash),
-        "Safe block from the syncing FCU should be applied once the head becomes canonical"
-    );
-    assert_eq!(
-        test_harness.tree.state.forkchoice_state_tracker.last_valid_state(),
-        Some(fcu_state)
-    );
-    assert!(test_harness.tree.state.forkchoice_state_tracker.sync_target_state().is_none());
 }

--- a/crates/net/network-api/src/downloaders.rs
+++ b/crates/net/network-api/src/downloaders.rs
@@ -3,16 +3,21 @@
 use std::fmt::Debug;
 
 use futures::Future;
-use reth_network_p2p::BlockClient;
+use reth_network_p2p::{BlockAccessListsClient, BlockClient};
 use tokio::sync::oneshot;
 
-/// Provides client for downloading blocks.
+/// Provides a client for downloading blocks and related block data.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockDownloaderProvider {
     /// The client this type can provide.
-    type Client: BlockClient<Header: Debug, Body: Debug> + Send + Sync + Clone + 'static;
+    type Client: BlockClient<Header: Debug, Body: Debug>
+        + BlockAccessListsClient
+        + Send
+        + Sync
+        + Clone
+        + 'static;
 
-    /// Returns a new [`BlockClient`], used for fetching blocks from peers.
+    /// Returns a new download client, used for fetching blocks from peers.
     ///
     /// The client is the entrypoint for sending block requests to the network.
     fn fetch_client(

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -1,6 +1,6 @@
 use super::headers::client::HeadersRequest;
 use crate::{
-    block_access_lists::client::BlockAccessListsClient,
+    block_access_lists::client::{BalRequirement, BlockAccessListsClient},
     bodies::client::{BodiesClient, SingleBodyRequest},
     download::DownloadClient,
     error::PeerRequestResult,
@@ -29,6 +29,10 @@ use std::{
     task::{ready, Context, Poll},
 };
 use tracing::debug;
+
+/// Response returned by [`FetchFullBlockRangeWithOptionalAccessListsFuture`].
+pub type FullBlockRangeWithOptionalAccessListsResponse<B> =
+    (Vec<SealedBlock<B>>, Option<BlockAccessLists>);
 
 /// A Client that can fetch full blocks from the network.
 #[derive(Debug, Clone)]
@@ -72,7 +76,7 @@ where
 
     /// Returns a future that fetches [`SealedBlock`]s for the given hash and count.
     ///
-    /// Note: this future is cancel safe
+    /// Note: this future is cancel safe.
     ///
     /// Caution: This does no validation of body (transactions) responses but guarantees that
     /// the starting [`SealedHeader`] matches the requested hash, and that the number of headers and
@@ -101,25 +105,6 @@ where
     }
 }
 
-impl<Client> FetchFullBlockFuture<Client>
-where
-    Client: BlockClient,
-{
-    fn new(client: Client, consensus: Arc<dyn Consensus<Client::Block>>, hash: B256) -> Self {
-        Self {
-            hash,
-            consensus,
-            request: FullBlockRequest {
-                header: Some(client.get_header(hash.into())),
-                body: Some(client.get_block_body(hash)),
-            },
-            client,
-            header: None,
-            body: None,
-        }
-    }
-}
-
 impl<Client> FullBlockClient<Client>
 where
     Client: BlockClient + BlockAccessListsClient,
@@ -140,6 +125,26 @@ where
             block: FetchFullBlockFuture::new(client.clone(), self.consensus.clone(), hash),
             block_result: None,
             bal_request_state: BalRequestState::Pending(client.get_block_access_lists(vec![hash])),
+        }
+    }
+
+    /// Returns a future that fetches [`SealedBlock`]s and optionally their [`BlockAccessLists`] for
+    /// the given hash and count.
+    ///
+    /// The block range is always the primary result. Access lists are requested after the block
+    /// range is downloaded. `Some` may contain a partial prefix when the peer truncates the BAL
+    /// response, while `None` means the optional BAL lookup failed or was unavailable.
+    pub fn get_full_block_range_with_optional_access_lists(
+        &self,
+        hash: B256,
+        count: u64,
+    ) -> FetchFullBlockRangeWithOptionalAccessListsFuture<Client> {
+        let client = self.client.clone();
+        FetchFullBlockRangeWithOptionalAccessListsFuture {
+            blocks: self.get_full_block_range(hash, count),
+            client,
+            block_result: None,
+            access_lists: OptionalBlockAccessListsState::WaitingForBlocks,
         }
     }
 }
@@ -165,6 +170,20 @@ impl<Client> FetchFullBlockFuture<Client>
 where
     Client: BlockClient,
 {
+    fn new(client: Client, consensus: Arc<dyn Consensus<Client::Block>>, hash: B256) -> Self {
+        Self {
+            hash,
+            consensus,
+            request: FullBlockRequest {
+                header: Some(client.get_header(hash.into())),
+                body: Some(client.get_block_body(hash)),
+            },
+            client,
+            header: None,
+            body: None,
+        }
+    }
+
     /// Returns the hash of the block being requested.
     pub const fn hash(&self) -> &B256 {
         &self.hash
@@ -435,6 +454,145 @@ impl<Req> BalRequestState<Req> {
     }
 }
 
+/// A future that downloads a range of full blocks and optionally their block access lists from the
+/// network.
+///
+/// This composes the existing full block range downloader with a follow-up optional block
+/// access-list request, so callers that only need blocks can keep using
+/// [`FetchFullBlockRangeFuture`].
+#[must_use = "futures do nothing unless polled"]
+#[expect(missing_debug_implementations)]
+pub struct FetchFullBlockRangeWithOptionalAccessListsFuture<Client>
+where
+    Client: BlockClient + BlockAccessListsClient,
+{
+    blocks: FetchFullBlockRangeFuture<Client>,
+    client: Client,
+    block_result: Option<Vec<SealedBlock<Client::Block>>>,
+    access_lists: OptionalBlockAccessListsState<<Client as BlockAccessListsClient>::Output>,
+}
+
+impl<Client> FetchFullBlockRangeWithOptionalAccessListsFuture<Client>
+where
+    Client: BlockClient<Header: Debug + BlockHeader + Sealable + Clone + Hash + Eq>
+        + BlockAccessListsClient,
+{
+    fn start_access_lists_request_if_possible(&mut self) {
+        if !matches!(self.access_lists, OptionalBlockAccessListsState::WaitingForBlocks) {
+            return
+        }
+
+        // BALs are requested by block hash, so wait until the block range is fully assembled.
+        let Some(blocks) = self.block_result.as_ref() else { return };
+        let hashes = blocks.iter().map(|block| block.hash()).collect::<Vec<_>>();
+        self.access_lists = OptionalBlockAccessListsState::Pending(
+            self.client.get_block_access_lists_with_requirement(hashes, BalRequirement::Optional),
+        );
+    }
+
+    fn on_access_lists_response(&mut self, response: WithPeerId<BlockAccessLists>) {
+        let (peer, access_lists) = response.split();
+        let expected =
+            self.block_result.as_ref().expect("blocks should be ready before BAL response").len();
+        let received = access_lists.0.len();
+
+        if received > expected {
+            debug!(
+                target: "downloaders",
+                start_hash = ?self.blocks.start_hash(),
+                expected,
+                received,
+                "Received wrong access list range response",
+            );
+            self.client.report_bad_message(peer);
+            self.access_lists = OptionalBlockAccessListsState::Ready(None);
+            return
+        }
+
+        // Short BAL responses are allowed by the wire protocol. Preserve the returned prefix and
+        // let callers decide whether they need to fetch the remaining entries.
+        self.access_lists = OptionalBlockAccessListsState::Ready(Some(access_lists));
+    }
+
+    /// Starts and polls the optional BAL request once, if it is ready to make progress.
+    fn poll_access_lists(&mut self, cx: &mut Context<'_>) {
+        self.start_access_lists_request_if_possible();
+
+        let poll = match &mut self.access_lists {
+            OptionalBlockAccessListsState::Pending(fut) => fut.poll_unpin(cx),
+            OptionalBlockAccessListsState::WaitingForBlocks |
+            OptionalBlockAccessListsState::Ready(_) => return,
+        };
+
+        match poll {
+            Poll::Pending => {}
+            Poll::Ready(Ok(access_lists)) => self.on_access_lists_response(access_lists),
+            Poll::Ready(Err(err)) => {
+                debug!(
+                    target: "downloaders",
+                    %err,
+                    start_hash = ?self.blocks.start_hash(),
+                    "Access list range download failed",
+                );
+
+                // Optional BAL lookup is best-effort: missing eth/71 support or request failures
+                // should not block returning the downloaded block range.
+                self.access_lists = OptionalBlockAccessListsState::Ready(None);
+            }
+        }
+    }
+
+    /// Returns the block range once blocks and the optional BAL lookup are both complete.
+    fn take_response(
+        &mut self,
+    ) -> Option<FullBlockRangeWithOptionalAccessListsResponse<Client::Block>> {
+        let OptionalBlockAccessListsState::Ready(access_lists) = &mut self.access_lists else {
+            return None
+        };
+
+        let blocks = self.block_result.take()?;
+        Some((blocks, access_lists.take()))
+    }
+}
+
+impl<Client> Future for FetchFullBlockRangeWithOptionalAccessListsFuture<Client>
+where
+    Client: BlockClient<Header: Debug + BlockHeader + Sealable + Clone + Hash + Eq>
+        + BlockAccessListsClient
+        + 'static,
+{
+    type Output = FullBlockRangeWithOptionalAccessListsResponse<Client::Block>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        // Complete the normal block range first, then issue a separate BAL hash-list request.
+        if this.block_result.is_none() &&
+            let Poll::Ready(blocks) = this.blocks.poll_unpin(cx)
+        {
+            this.block_result = Some(blocks);
+        }
+
+        this.poll_access_lists(cx);
+
+        if let Some(response) = this.take_response() {
+            return Poll::Ready(response)
+        }
+
+        Poll::Pending
+    }
+}
+
+/// Tracks an optional BAL range request and its completed result.
+enum OptionalBlockAccessListsState<Req> {
+    /// The block hashes needed for `GetBlockAccessLists` are not known yet.
+    WaitingForBlocks,
+    /// A `GetBlockAccessLists` request is in flight.
+    Pending(Req),
+    /// `None` means the block range is available but optional BAL data is not.
+    Ready(Option<BlockAccessLists>),
+}
+
 impl<Client> Debug for FetchFullBlockFuture<Client>
 where
     Client: BlockClient<Header: Debug, Body: Debug>,
@@ -534,11 +692,6 @@ impl<Client> FetchFullBlockRangeFuture<Client>
 where
     Client: BlockClient<Header: Debug + BlockHeader + Sealable + Clone + Hash + Eq>,
 {
-    /// Returns the block hashes for the given range, if they are available.
-    pub fn range_block_hashes(&self) -> Option<Vec<B256>> {
-        self.headers.as_ref().map(|h| h.iter().map(|h| h.hash()).collect())
-    }
-
     /// Returns whether or not the bodies map is fully populated with requested headers and bodies.
     fn is_bodies_complete(&self) -> bool {
         self.bodies.len() == self.count as usize
@@ -924,6 +1077,22 @@ where
     type Block = Net::Block;
 }
 
+impl<Net> BlockAccessListsClient for NoopFullBlockClient<Net>
+where
+    Net: NetworkPrimitives,
+{
+    type Output = futures::future::Ready<PeerRequestResult<BlockAccessLists>>;
+
+    fn get_block_access_lists_with_priority_and_requirement(
+        &self,
+        _hashes: Vec<B256>,
+        _priority: Priority,
+        _requirement: BalRequirement,
+    ) -> Self::Output {
+        futures::future::ready(Ok(WithPeerId::new(PeerId::random(), BlockAccessLists::default())))
+    }
+}
+
 impl<Net> Default for NoopFullBlockClient<Net> {
     fn default() -> Self {
         Self(PhantomData::<Net>)
@@ -1046,6 +1215,9 @@ mod tests {
         inner: TestFullBlockClient,
         access_lists: Arc<Mutex<HashMap<B256, Bytes>>>,
         access_list_requests: Arc<AtomicUsize>,
+        access_list_soft_limit: Arc<AtomicUsize>,
+        extra_access_list_entries: Arc<AtomicUsize>,
+        unsupported_access_lists: Arc<AtomicBool>,
         bad_messages: Arc<AtomicUsize>,
         empty_first_response: Arc<AtomicBool>,
     }
@@ -1056,6 +1228,9 @@ mod tests {
                 inner: TestFullBlockClient::default(),
                 access_lists: Arc::new(Mutex::new(HashMap::default())),
                 access_list_requests: Arc::new(AtomicUsize::new(0)),
+                access_list_soft_limit: Arc::new(AtomicUsize::new(usize::MAX)),
+                extra_access_list_entries: Arc::new(AtomicUsize::new(0)),
+                unsupported_access_lists: Arc::new(AtomicBool::new(false)),
                 bad_messages: Arc::new(AtomicUsize::new(0)),
                 empty_first_response: Arc::new(AtomicBool::new(false)),
             }
@@ -1067,6 +1242,39 @@ mod tests {
             self.inner.insert(header.clone(), body);
             self.access_lists.lock().insert(header.hash(), access_list);
         }
+
+        fn set_access_list_soft_limit(&self, limit: usize) {
+            self.access_list_soft_limit.store(limit, Ordering::SeqCst);
+        }
+
+        fn set_extra_access_list_entries(&self, count: usize) {
+            self.extra_access_list_entries.store(count, Ordering::SeqCst);
+        }
+
+        fn set_access_lists_unsupported(&self, unsupported: bool) {
+            self.unsupported_access_lists.store(unsupported, Ordering::SeqCst);
+        }
+    }
+
+    /// Inserts headers with block access lists and returns the last header and block body.
+    fn insert_headers_with_access_lists_into_client(
+        client: &FullBlockWithAccessListsClient,
+        range: Range<usize>,
+    ) -> (SealedHeader, BlockBody) {
+        let mut sealed_header: SealedHeader = SealedHeader::default();
+        let body = BlockBody::default();
+        for block_idx in range {
+            let (mut header, hash) = sealed_header.split();
+            header.parent_hash = hash;
+            header.number += 1;
+
+            sealed_header = SealedHeader::seal_slow(header);
+            let access_list = Bytes::from(vec![EMPTY_LIST_CODE, block_idx as u8]);
+
+            client.insert(sealed_header.clone(), body.clone(), access_list);
+        }
+
+        (sealed_header, body)
     }
 
     impl DownloadClient for FullBlockWithAccessListsClient {
@@ -1118,6 +1326,10 @@ mod tests {
         ) -> Self::Output {
             self.access_list_requests.fetch_add(1, Ordering::SeqCst);
 
+            if self.unsupported_access_lists.load(Ordering::SeqCst) {
+                return futures::future::ready(Err(RequestError::UnsupportedCapability))
+            }
+
             if self.empty_first_response.swap(false, Ordering::SeqCst) {
                 return futures::future::ready(Ok(WithPeerId::new(
                     PeerId::random(),
@@ -1125,8 +1337,9 @@ mod tests {
                 )))
             }
 
-            let access_lists = hashes
+            let mut access_lists: Vec<_> = hashes
                 .into_iter()
+                .take(self.access_list_soft_limit.load(Ordering::SeqCst))
                 .map(|hash| {
                     self.access_lists
                         .lock()
@@ -1135,6 +1348,9 @@ mod tests {
                         .unwrap_or_else(|| Bytes::from_static(&[EMPTY_LIST_CODE]))
                 })
                 .collect();
+            for _ in 0..self.extra_access_list_entries.load(Ordering::SeqCst) {
+                access_lists.push(Bytes::from_static(&[EMPTY_LIST_CODE]));
+            }
 
             futures::future::ready(Ok(WithPeerId::new(
                 PeerId::random(),
@@ -1260,6 +1476,131 @@ mod tests {
 
         assert_eq!(received.len(), 3);
         assert_eq!(body_requests.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists() {
+        let client = FullBlockWithAccessListsClient::default();
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+
+        let access_lists = Arc::clone(&client.access_lists);
+        let request_count = Arc::clone(&client.access_list_requests);
+        let client = FullBlockClient::test_client(client);
+
+        let response = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete");
+
+        let (blocks, received_access_lists) = response;
+        assert_eq!(blocks.len(), 3);
+        let expected = {
+            let access_lists = access_lists.lock();
+            blocks
+                .iter()
+                .map(|block| access_lists.get(&block.hash()).cloned().expect("access list exists"))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(received_access_lists, Some(BlockAccessLists(expected)));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_preserves_empty_response() {
+        let client = FullBlockWithAccessListsClient::default();
+        client.empty_first_response.store(true, Ordering::SeqCst);
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+
+        let request_count = Arc::clone(&client.access_list_requests);
+        let client = FullBlockClient::test_client(client);
+
+        let response = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete without access lists");
+
+        let (blocks, received_access_lists) = response;
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(received_access_lists, Some(BlockAccessLists(Vec::new())));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_preserves_short_response() {
+        let client = FullBlockWithAccessListsClient::default();
+        client.set_access_list_soft_limit(2);
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..5);
+
+        let access_lists = Arc::clone(&client.access_lists);
+        let request_count = Arc::clone(&client.access_list_requests);
+        let client = FullBlockClient::test_client(client);
+
+        let (blocks, received_access_lists) = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 5),
+        )
+        .await
+        .expect("range request should complete without access lists");
+
+        assert_eq!(blocks.len(), 5);
+        let expected = {
+            let access_lists = access_lists.lock();
+            blocks
+                .iter()
+                .take(2)
+                .map(|block| access_lists.get(&block.hash()).cloned().expect("access list exists"))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(received_access_lists, Some(BlockAccessLists(expected)));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_returns_none_when_unavailable() {
+        let client = FullBlockWithAccessListsClient::default();
+        client.set_access_lists_unsupported(true);
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+
+        let request_count = Arc::clone(&client.access_list_requests);
+        let client = FullBlockClient::test_client(client);
+
+        let (blocks, received_access_lists) = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete without access lists");
+
+        assert_eq!(blocks.len(), 3);
+        assert!(received_access_lists.is_none());
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_rejects_long_response() {
+        let client = FullBlockWithAccessListsClient::default();
+        client.set_extra_access_list_entries(1);
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+
+        let request_count = Arc::clone(&client.access_list_requests);
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let (blocks, received_access_lists) = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete without access lists");
+
+        assert_eq!(blocks.len(), 3);
+        assert!(received_access_lists.is_none());
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -58,6 +58,7 @@ pub use block_access_lists::client::{BalRequirement, BlockAccessListsClient};
 pub use bodies::client::BodiesClient;
 pub use headers::client::HeadersClient;
 pub use receipts::client::ReceiptsClient;
+pub use reth_eth_wire_types::BlockAccessLists;
 use reth_primitives_traits::Block;
 
 /// Helper trait that unifies network behaviour needed for fetching entire blocks.

--- a/crates/net/p2p/src/test_utils/full_block.rs
+++ b/crates/net/p2p/src/test_utils/full_block.rs
@@ -1,4 +1,5 @@
 use crate::{
+    block_access_lists::client::{BalRequirement, BlockAccessListsClient},
     bodies::client::BodiesClient,
     download::DownloadClient,
     error::PeerRequestResult,
@@ -10,7 +11,7 @@ use alloy_consensus::Header;
 use alloy_eips::{BlockHashOrNumber, BlockNumHash};
 use alloy_primitives::{map::B256Map, B256};
 use parking_lot::Mutex;
-use reth_eth_wire_types::HeadersDirection;
+use reth_eth_wire_types::{BlockAccessLists, HeadersDirection};
 use reth_ethereum_primitives::{Block, BlockBody};
 use reth_network_peers::{PeerId, WithPeerId};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
@@ -169,4 +170,17 @@ impl BodiesClient for TestFullBlockClient {
 
 impl BlockClient for TestFullBlockClient {
     type Block = reth_ethereum_primitives::Block;
+}
+
+impl BlockAccessListsClient for TestFullBlockClient {
+    type Output = futures::future::Ready<PeerRequestResult<BlockAccessLists>>;
+
+    fn get_block_access_lists_with_priority_and_requirement(
+        &self,
+        _hashes: Vec<B256>,
+        _priority: Priority,
+        _requirement: BalRequirement,
+    ) -> Self::Output {
+        futures::future::ready(Ok(WithPeerId::new(PeerId::random(), BlockAccessLists::default())))
+    }
 }


### PR DESCRIPTION
Adds optional BAL fetching to full block range downloads and carries any decoded BAL whose hash matches the block header through `DownloadedBlock`.
 
This lets the engine reuse downloaded BALs during block validation while still returning blocks when peers do not support BALs or the BAL response is invalid.

cc @mattsse 