### PR TITLE
Add static-file storage for bytecodes

### DIFF
--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -2,8 +2,8 @@ use alloy_primitives::{hex, Address, BlockHash, B256};
 use clap::Parser;
 use reth_db::{
     static_file::{
-        AccountChangesetMask, ColumnSelectorOne, ColumnSelectorTwo, HeaderWithHashMask,
-        ReceiptMask, TransactionMask, TransactionSenderMask,
+        AccountChangesetMask, BytecodeMask, ColumnSelectorOne, ColumnSelectorTwo,
+        HeaderWithHashMask, ReceiptMask, TransactionMask, TransactionSenderMask,
     },
     RawDupSort,
 };
@@ -207,6 +207,9 @@ impl Command {
                     StaticFileSegment::StorageChangeSets => {
                         unreachable!("storage changesets handled above");
                     }
+                    StaticFileSegment::Bytecodes => {
+                        (serde_json::from_str::<u64>(&key)?, None, BytecodeMask::MASK)
+                    }
                 };
 
                 // handle account changesets differently if a subkey is provided.
@@ -284,6 +287,13 @@ impl Command {
                                 }
                                 StaticFileSegment::StorageChangeSets => {
                                     unreachable!("storage changeset static files are special cased before this match")
+                                }
+                                StaticFileSegment::Bytecodes => {
+                                    let bytecode =
+                                        <<tables::Bytecodes as Table>::Value>::decompress(
+                                            content[0].as_slice(),
+                                        )?;
+                                    println!("{}", serde_json::to_string_pretty(&bytecode)?);
                                 }
                             }
                         }

--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -178,6 +178,7 @@ pub(crate) fn config_for_selections(
             transaction_senders: blocks_per_file(SnapshotComponentType::TransactionSenders),
             account_change_sets: blocks_per_file(SnapshotComponentType::AccountChangesets),
             storage_change_sets: blocks_per_file(SnapshotComponentType::StorageChangesets),
+            bytecodes: None,
         },
     };
 

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -99,6 +99,7 @@ impl<C: ChainSpecParser> Command<C> {
                     StaticFileSegment::StorageChangeSets => {
                         writer.prune_storage_changesets(highest_block)?;
                     }
+                    StaticFileSegment::Bytecodes => unreachable!(),
                 }
             }
         }
@@ -145,6 +146,7 @@ impl<C: ChainSpecParser> Command<C> {
                 tx.clear::<tables::AccountChangeSets>()?;
                 tx.clear::<tables::StorageChangeSets>()?;
                 tx.clear::<tables::Bytecodes>()?;
+                tx.clear::<tables::BytecodeIds>()?;
                 tx.clear::<tables::Receipts<ReceiptTy<N>>>()?;
 
                 reset_prune_checkpoint(tx, PruneSegment::Receipts)?;

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -444,6 +444,8 @@ pub struct BlocksPerFileConfig {
     pub account_change_sets: Option<u64>,
     /// Number of blocks per file for the storage changesets segment.
     pub storage_change_sets: Option<u64>,
+    /// Number of bytecode IDs per file for the bytecodes segment.
+    pub bytecodes: Option<u64>,
 }
 
 impl StaticFilesConfig {
@@ -458,6 +460,7 @@ impl StaticFilesConfig {
             transaction_senders,
             account_change_sets,
             storage_change_sets,
+            bytecodes,
         } = self.blocks_per_file;
         eyre::ensure!(headers != Some(0), "Headers segment blocks per file must be greater than 0");
         eyre::ensure!(
@@ -480,6 +483,10 @@ impl StaticFilesConfig {
             storage_change_sets != Some(0),
             "Storage changesets segment blocks per file must be greater than 0"
         );
+        eyre::ensure!(
+            bytecodes != Some(0),
+            "Bytecodes segment bytecode IDs per file must be greater than 0"
+        );
         Ok(())
     }
 
@@ -492,6 +499,7 @@ impl StaticFilesConfig {
             transaction_senders,
             account_change_sets,
             storage_change_sets,
+            bytecodes,
         } = self.blocks_per_file;
 
         let mut map = StaticFileMap::default();
@@ -505,6 +513,7 @@ impl StaticFilesConfig {
                 StaticFileSegment::TransactionSenders => transaction_senders,
                 StaticFileSegment::AccountChangeSets => account_change_sets,
                 StaticFileSegment::StorageChangeSets => storage_change_sets,
+                StaticFileSegment::Bytecodes => bytecodes,
             };
 
             if let Some(blocks_per_file) = blocks_per_file {

--- a/crates/node/core/src/args/static_files.rs
+++ b/crates/node/core/src/args/static_files.rs
@@ -71,6 +71,7 @@ impl StaticFilesArgs {
                     .blocks_per_file_storage_change_sets
                     .or(minimal_blocks_per_file)
                     .or(config.blocks_per_file.storage_change_sets),
+                bytecodes: minimal_blocks_per_file.or(config.blocks_per_file.bytecodes),
             },
         }
     }

--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -61,6 +61,11 @@ pub enum StaticFileSegment {
     /// Storage changeset static files append block-by-block changesets sorted by address and
     /// storage slot.
     StorageChangeSets,
+    /// Static File segment responsible for bytecode blobs.
+    ///
+    /// Bytecode static files are indexed by monotonically increasing bytecode IDs. MDBX keeps the
+    /// hash-to-ID index, while this segment stores the bytecode payloads by ID.
+    Bytecodes,
 }
 
 impl StaticFileSegment {
@@ -78,6 +83,7 @@ impl StaticFileSegment {
             Self::TransactionSenders => "transaction-senders",
             Self::AccountChangeSets => "account-change-sets",
             Self::StorageChangeSets => "storage-change-sets",
+            Self::Bytecodes => "bytecodes",
         }
     }
 
@@ -92,6 +98,7 @@ impl StaticFileSegment {
             Self::TransactionSenders => "tx-senders",
             Self::AccountChangeSets => "account-changes",
             Self::StorageChangeSets => "storage-changes",
+            Self::Bytecodes => "bytecodes",
         }
     }
 
@@ -105,6 +112,7 @@ impl StaticFileSegment {
             Self::TransactionSenders,
             Self::AccountChangeSets,
             Self::StorageChangeSets,
+            Self::Bytecodes,
         ]
         .into_iter()
     }
@@ -122,7 +130,8 @@ impl StaticFileSegment {
             Self::Receipts |
             Self::TransactionSenders |
             Self::AccountChangeSets |
-            Self::StorageChangeSets => 1,
+            Self::StorageChangeSets |
+            Self::Bytecodes => 1,
         }
     }
 
@@ -184,7 +193,9 @@ impl StaticFileSegment {
     pub const fn is_tx_based(&self) -> bool {
         match self {
             Self::Receipts | Self::Transactions | Self::TransactionSenders => true,
-            Self::Headers | Self::AccountChangeSets | Self::StorageChangeSets => false,
+            Self::Headers | Self::AccountChangeSets | Self::StorageChangeSets | Self::Bytecodes => {
+                false
+            }
         }
     }
 
@@ -192,14 +203,18 @@ impl StaticFileSegment {
     pub const fn is_change_based(&self) -> bool {
         match self {
             Self::AccountChangeSets | Self::StorageChangeSets => true,
-            Self::Receipts | Self::Transactions | Self::Headers | Self::TransactionSenders => false,
+            Self::Receipts |
+            Self::Transactions |
+            Self::Headers |
+            Self::TransactionSenders |
+            Self::Bytecodes => false,
         }
     }
 
     /// Returns `true` if a segment row is linked to a block.
     pub const fn is_block_based(&self) -> bool {
         match self {
-            Self::Headers => true,
+            Self::Headers | Self::Bytecodes => true,
             Self::Receipts |
             Self::Transactions |
             Self::TransactionSenders |
@@ -222,6 +237,7 @@ impl StaticFileSegment {
             Self::Receipts | Self::AccountChangeSets | Self::StorageChangeSets => {
                 StageId::Execution
             }
+            Self::Bytecodes => StageId::Execution,
             Self::TransactionSenders => StageId::SenderRecovery,
         }
     }
@@ -715,6 +731,12 @@ mod tests {
                 None,
             ),
             (
+                StaticFileSegment::Bytecodes,
+                1_123_233..=11_223_233,
+                "static_file_bytecodes_1123233_11223233",
+                None,
+            ),
+            (
                 StaticFileSegment::Headers,
                 2..=30,
                 "static_file_headers_2_30_none_lz4",
@@ -804,6 +826,13 @@ mod tests {
                 segment: StaticFileSegment::StorageChangeSets,
                 changeset_offsets_len: 100,
             },
+            SegmentHeader {
+                expected_block_range: SegmentRangeInclusive::new(0, 200),
+                block_range: Some(SegmentRangeInclusive::new(0, 100)),
+                tx_range: None,
+                segment: StaticFileSegment::Bytecodes,
+                changeset_offsets_len: 0,
+            },
         ];
         // Check that we test all segments
         assert_eq!(
@@ -838,6 +867,7 @@ mod tests {
                 StaticFileSegment::TransactionSenders => "transaction-senders",
                 StaticFileSegment::AccountChangeSets => "account-change-sets",
                 StaticFileSegment::StorageChangeSets => "storage-change-sets",
+                StaticFileSegment::Bytecodes => "bytecodes",
             };
             assert_eq!(static_str, expected_str);
         }
@@ -857,6 +887,7 @@ mod tests {
                 StaticFileSegment::TransactionSenders => "TransactionSenders",
                 StaticFileSegment::AccountChangeSets => "AccountChangeSets",
                 StaticFileSegment::StorageChangeSets => "StorageChangeSets",
+                StaticFileSegment::Bytecodes => "Bytecodes",
             };
             assert_eq!(ser, format!("\"{expected_str}\""));
         }

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -386,6 +386,14 @@ tables! {
         type Value = Bytecode;
     }
 
+    /// Stores bytecode IDs by bytecode hash.
+    ///
+    /// Bytecode payloads for these IDs are stored in static files.
+    table BytecodeIds {
+        type Key = B256;
+        type Value = u64;
+    }
+
     /// Stores the current state of an [`Account`].
     table PlainAccountState {
         type Key = Address;

--- a/crates/storage/db/src/static_file/masks.rs
+++ b/crates/storage/db/src/static_file/masks.rs
@@ -4,7 +4,7 @@ use crate::{
     HeaderTerminalDifficulties,
 };
 use alloy_primitives::{Address, BlockHash};
-use reth_db_api::{models::StorageBeforeTx, table::Table, AccountChangeSets};
+use reth_db_api::{models::StorageBeforeTx, table::Table, AccountChangeSets, Bytecodes};
 
 // HEADER MASKS
 add_static_file_mask! {
@@ -59,4 +59,10 @@ add_static_file_mask! {
 add_static_file_mask! {
     #[doc = "Mask for selecting a single changeset from `StorageChangesets` static file segment"]
     StorageChangesetMask, StorageBeforeTx, 0b1
+}
+
+// BYTECODE MASKS
+add_static_file_mask! {
+    #[doc = "Mask for selecting a single bytecode from `Bytecodes` static file segment"]
+    BytecodeMask, <Bytecodes as Table>::Value, 0b1
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -901,14 +901,37 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         Ok(())
     }
 
-    /// Writes bytecodes to MDBX.
+    /// Writes bytecodes to static files and stores hash-to-ID pointers in MDBX.
     fn write_bytecodes(
         &self,
         bytecodes: impl IntoIterator<Item = (B256, Bytecode)>,
     ) -> ProviderResult<()> {
-        let mut bytecodes_cursor = self.tx_ref().cursor_write::<tables::Bytecodes>()?;
+        let mut next_bytecode_id = self
+            .static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::Bytecodes)
+            .map_or(0, |id| id + 1);
+
+        let mut ids_cursor = self.tx_ref().cursor_write::<tables::BytecodeIds>()?;
+        let mut legacy_bytecodes_cursor = self.tx_ref().cursor_read::<tables::Bytecodes>()?;
+        let mut bytecodes_writer = None;
+
         for (hash, bytecode) in bytecodes {
-            bytecodes_cursor.upsert(hash, &bytecode)?;
+            if ids_cursor.seek_exact(hash)?.is_some() ||
+                legacy_bytecodes_cursor.seek_exact(hash)?.is_some()
+            {
+                continue
+            }
+
+            let bytecode_id = next_bytecode_id;
+            next_bytecode_id += 1;
+
+            let writer = match bytecodes_writer.as_mut() {
+                Some(writer) => writer,
+                None => bytecodes_writer
+                    .insert(self.static_file_provider.latest_writer(StaticFileSegment::Bytecodes)?),
+            };
+            writer.append_bytecode(bytecode_id, &bytecode)?;
+            ids_cursor.upsert(hash, &bytecode_id)?;
         }
         Ok(())
     }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -2,6 +2,7 @@ use super::overlay::{Overlay, OverlayBuilder, OverlaySource};
 use crate::{
     AccountReader, BlockHashReader, ChangeSetReader, EitherReader, HashedPostStateProvider,
     ProviderError, RocksDBProviderFactory, StateProvider, StateRootProvider,
+    StaticFileProviderFactory,
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
@@ -659,6 +660,7 @@ where
         + StageCheckpointReader
         + StorageSettingsCache
         + RocksDBProviderFactory
+        + StaticFileProviderFactory
         + NodePrimitivesProvider<Primitives = N>,
     N: NodePrimitives,
 {
@@ -674,11 +676,18 @@ where
 
 impl<Provider, N> BytecodeReader for HistoricalStateProviderRef<'_, Provider, N>
 where
-    Provider: DBProvider + BlockNumReader + NodePrimitivesProvider<Primitives = N>,
+    Provider: DBProvider
+        + BlockNumReader
+        + StaticFileProviderFactory
+        + NodePrimitivesProvider<Primitives = N>,
     N: NodePrimitives,
 {
     /// Get account code by its hash
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        if let Some(bytecode_id) = self.tx().get_by_encoded_key::<tables::BytecodeIds>(code_hash)? {
+            return self.provider.static_file_provider().bytecode_by_id(bytecode_id)
+        }
+
         self.tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
     }
 }
@@ -754,7 +763,7 @@ impl<
 }
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
-reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provider> where [Provider: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader + StorageChangeSetReader + PruneCheckpointReader + StageCheckpointReader + StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider]);
+reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provider> where [Provider: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader + StorageChangeSetReader + PruneCheckpointReader + StageCheckpointReader + StorageSettingsCache + RocksDBProviderFactory + StaticFileProviderFactory + NodePrimitivesProvider]);
 
 /// Lowest blocks at which different parts of the state are available.
 /// They may be [Some] if pruning is enabled.
@@ -875,7 +884,7 @@ mod tests {
         providers::state::historical::{HistoryInfo, LowestAvailableBlocks},
         test_utils::create_test_provider_factory,
         AccountReader, HistoricalStateProvider, HistoricalStateProviderRef, RocksDBProviderFactory,
-        StateProvider,
+        StateProvider, StaticFileProviderFactory,
     };
     use alloy_primitives::{address, b256, Address, B256, U256};
     use reth_db_api::{
@@ -910,6 +919,7 @@ mod tests {
             + StageCheckpointReader
             + StorageSettingsCache
             + RocksDBProviderFactory
+            + StaticFileProviderFactory
             + NodePrimitivesProvider,
     >() {
         assert_state_provider::<HistoricalStateProvider<T>>();

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -1,5 +1,6 @@
 use crate::{
     AccountReader, BlockHashReader, HashedPostStateProvider, StateProvider, StateRootProvider,
+    StaticFileProviderFactory,
 };
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
@@ -257,8 +258,8 @@ impl<Provider: DBProvider> HashedPostStateProvider for LatestStateProviderRef<'_
     }
 }
 
-impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvider
-    for LatestStateProviderRef<'_, Provider>
+impl<Provider: DBProvider + BlockHashReader + StaticFileProviderFactory + StorageSettingsCache>
+    StateProvider for LatestStateProviderRef<'_, Provider>
 {
     /// Get storage by plain (unhashed) storage key slot.
     fn storage(
@@ -283,11 +284,15 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
     }
 }
 
-impl<Provider: DBProvider + BlockHashReader> BytecodeReader
+impl<Provider: DBProvider + BlockHashReader + StaticFileProviderFactory> BytecodeReader
     for LatestStateProviderRef<'_, Provider>
 {
     /// Get account code by its hash
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        if let Some(bytecode_id) = self.tx().get_by_encoded_key::<tables::BytecodeIds>(code_hash)? {
+            return self.0.static_file_provider().bytecode_by_id(bytecode_id)
+        }
+
         self.tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
     }
 }
@@ -310,7 +315,7 @@ impl<Provider: DBProvider> LatestStateProvider<Provider> {
 }
 
 // Delegates all provider impls to [LatestStateProviderRef]
-reth_storage_api::macros::delegate_provider_impls!(LatestStateProvider<Provider> where [Provider: DBProvider + BlockHashReader + StorageSettingsCache]);
+reth_storage_api::macros::delegate_provider_impls!(LatestStateProvider<Provider> where [Provider: DBProvider + BlockHashReader + StaticFileProviderFactory + StorageSettingsCache]);
 
 #[cfg(test)]
 mod tests {
@@ -328,7 +333,7 @@ mod tests {
     const fn assert_state_provider<T: StateProvider>() {}
     #[expect(dead_code)]
     const fn assert_latest_state_provider<
-        T: DBProvider + BlockHashReader + StorageSettingsCache,
+        T: DBProvider + BlockHashReader + StaticFileProviderFactory + StorageSettingsCache,
     >() {
         assert_state_provider::<LatestStateProvider<T>>();
     }

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -11,12 +11,12 @@ use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use reth_chainspec::ChainInfo;
 use reth_db::static_file::{
-    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TransactionMask,
-    TransactionSenderMask,
+    BlockHashMask, BytecodeMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor,
+    TransactionMask, TransactionSenderMask,
 };
 use reth_db_api::table::{Decompress, Value};
 use reth_node_types::NodePrimitives;
-use reth_primitives_traits::{SealedHeader, SignedTransaction};
+use reth_primitives_traits::{Bytecode, SealedHeader, SignedTransaction};
 use reth_static_file_types::ChangesetOffset;
 use reth_storage_api::range_size_hint;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
@@ -140,6 +140,11 @@ impl<'a, N: NodePrimitives> StaticFileJarProvider<'a, N> {
         } else {
             Ok(None)
         }
+    }
+
+    /// Reads bytecode by static-file bytecode ID.
+    pub fn bytecode_by_id(&self, bytecode_id: u64) -> ProviderResult<Option<Bytecode>> {
+        self.cursor()?.get_one::<BytecodeMask>(bytecode_id.into())
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -33,8 +33,8 @@ use reth_ethereum_primitives::{Receipt, TransactionSigned};
 use reth_nippy_jar::{NippyJar, NippyJarChecker};
 use reth_node_types::NodePrimitives;
 use reth_primitives_traits::{
-    dashmap::DashMap, AlloyBlockHeader as _, BlockBody as _, RecoveredBlock, SealedHeader,
-    SignedTransaction, StorageEntry,
+    dashmap::DashMap, AlloyBlockHeader as _, BlockBody as _, Bytecode, RecoveredBlock,
+    SealedHeader, SignedTransaction, StorageEntry,
 };
 use reth_prune_types::PruneSegment;
 use reth_stages_types::PipelineTarget;
@@ -686,6 +686,14 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 .ok_or(StaticFileWriterError::ThreadPanic("storage_changesets"))??;
         }
         Ok(())
+    }
+
+    /// Reads bytecode by static-file bytecode ID.
+    pub fn bytecode_by_id(&self, bytecode_id: u64) -> ProviderResult<Option<Bytecode>> {
+        self.get_maybe_segment_provider(StaticFileSegment::Bytecodes, bytecode_id)?
+            .map(|provider| provider.bytecode_by_id(bytecode_id))
+            .transpose()
+            .map(Option::flatten)
     }
 
     /// Gets the [`StaticFileJarProvider`] of the requested segment and start index that can be
@@ -1478,6 +1486,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 }
                 true
             }
+            StaticFileSegment::Bytecodes => false,
         }
     }
 
@@ -1614,6 +1623,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     highest_block,
                     |key| key.block_number(),
                 ),
+            StaticFileSegment::Bytecodes => Ok(None),
         }
     }
 
@@ -1742,7 +1752,8 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         }
                         StaticFileSegment::Headers |
                         StaticFileSegment::AccountChangeSets |
-                        StaticFileSegment::StorageChangeSets => {
+                        StaticFileSegment::StorageChangeSets |
+                        StaticFileSegment::Bytecodes => {
                             unreachable!()
                         }
                     }
@@ -1756,6 +1767,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             StaticFileSegment::StorageChangeSets => {
                 writer.prune_storage_changesets(checkpoint_block_number)?;
             }
+            StaticFileSegment::Bytecodes => unreachable!(),
         }
 
         debug!(target: "reth::providers::static_file", "Committing writer after pruning");

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -91,20 +91,21 @@ mod tests {
         test_utils::create_test_provider_factory, HeaderProvider, StaticFileProviderFactory,
     };
     use alloy_consensus::{Header, SignableTransaction, Transaction, TxLegacy};
-    use alloy_primitives::{Address, BlockHash, Signature, TxNumber, B256, U160, U256};
+    use alloy_primitives::{Address, BlockHash, Bytes, Signature, TxNumber, B256, U160, U256};
     use rand::seq::SliceRandom;
     use reth_db::{
         models::{AccountBeforeTx, StorageBeforeTx},
         test_utils::create_test_static_files_dir,
     };
-    use reth_db_api::{transaction::DbTxMut, CanonicalHeaders, HeaderNumbers, Headers};
+    use reth_db_api::{tables, transaction::DbTxMut, CanonicalHeaders, HeaderNumbers, Headers};
     use reth_ethereum_primitives::{EthPrimitives, Receipt, TransactionSigned};
-    use reth_primitives_traits::Account;
+    use reth_primitives_traits::{Account, Bytecode};
     use reth_static_file_types::{
         find_fixed_range, SegmentRangeInclusive, DEFAULT_BLOCKS_PER_STATIC_FILE,
     };
     use reth_storage_api::{
-        ChangeSetReader, ReceiptProvider, StorageChangeSetReader, TransactionsProvider,
+        BytecodeReader, ChangeSetReader, ReceiptProvider, StorageChangeSetReader,
+        TransactionsProvider,
     };
     use reth_testing_utils::generators::{self, random_header_range};
     use std::{collections::BTreeMap, fmt::Debug, fs, ops::Range, path::Path};
@@ -182,6 +183,57 @@ mod tests {
                 assert_eq!(header, jar_provider.header_by_number(header.number).unwrap().unwrap());
             }
         }
+    }
+
+    #[test]
+    fn test_bytecodes_static_file_by_id() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let sf_rw: StaticFileProvider<EthPrimitives> =
+            StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(2)
+                .build()
+                .expect("static file provider");
+
+        let bytecode0 = Bytecode::new_raw(Bytes::from(vec![0x60, 0x00]));
+        let bytecode1 = Bytecode::new_raw(Bytes::from(vec![0x60, 0x01]));
+        let bytecode2 = Bytecode::new_raw(Bytes::from(vec![0x60, 0x02]));
+
+        {
+            let mut writer = sf_rw.latest_writer(StaticFileSegment::Bytecodes).unwrap();
+            writer.append_bytecode(0, &bytecode0).unwrap();
+            writer.append_bytecode(1, &bytecode1).unwrap();
+            writer.append_bytecode(2, &bytecode2).unwrap();
+            writer.commit().unwrap();
+        }
+
+        assert_eq!(sf_rw.get_highest_static_file_block(StaticFileSegment::Bytecodes), Some(2));
+        assert_eq!(sf_rw.bytecode_by_id(0).unwrap(), Some(bytecode0));
+        assert_eq!(sf_rw.bytecode_by_id(1).unwrap(), Some(bytecode1));
+        assert_eq!(sf_rw.bytecode_by_id(2).unwrap(), Some(bytecode2));
+        assert_eq!(sf_rw.bytecode_by_id(3).unwrap(), None);
+    }
+
+    #[test]
+    fn test_latest_state_reads_bytecode_from_static_file_id() {
+        let factory = create_test_provider_factory();
+        let bytecode = Bytecode::new_raw(Bytes::from(vec![0x60, 0x42]));
+        let hash = bytecode.hash_slow();
+
+        {
+            let mut provider_rw = factory.provider_rw().unwrap();
+            {
+                let static_file_provider = provider_rw.static_file_provider();
+                let mut writer =
+                    static_file_provider.latest_writer(StaticFileSegment::Bytecodes).unwrap();
+                writer.append_bytecode(0, &bytecode).unwrap();
+            }
+
+            provider_rw.tx_mut().put::<tables::BytecodeIds>(hash, 0).unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        let provider = factory.provider().unwrap();
+        assert_eq!(provider.latest().bytecode_by_hash(&hash).unwrap(), Some(bytecode));
     }
 
     #[test]
@@ -352,7 +404,8 @@ mod tests {
                     match segment {
                         StaticFileSegment::Headers |
                         StaticFileSegment::AccountChangeSets |
-                        StaticFileSegment::StorageChangeSets => {
+                        StaticFileSegment::StorageChangeSets |
+                        StaticFileSegment::Bytecodes => {
                             panic!("non tx based segment")
                         }
                         StaticFileSegment::Transactions => {
@@ -471,7 +524,8 @@ mod tests {
             match segment {
                 StaticFileSegment::Headers |
                 StaticFileSegment::AccountChangeSets |
-                StaticFileSegment::StorageChangeSets => {
+                StaticFileSegment::StorageChangeSets |
+                StaticFileSegment::Bytecodes => {
                     panic!("non tx based segment")
                 }
                 StaticFileSegment::Transactions => {
@@ -498,7 +552,8 @@ mod tests {
                 match segment {
                     StaticFileSegment::Headers |
                     StaticFileSegment::AccountChangeSets |
-                    StaticFileSegment::StorageChangeSets => {
+                    StaticFileSegment::StorageChangeSets |
+                    StaticFileSegment::Bytecodes => {
                         panic!("non tx based segment")
                     }
                     StaticFileSegment::Transactions => assert_eyre(

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -10,7 +10,7 @@ use reth_db::models::{AccountBeforeTx, StorageBeforeTx};
 use reth_db_api::models::CompactU256;
 use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
 use reth_node_types::NodePrimitives;
-use reth_primitives_traits::FastInstant as Instant;
+use reth_primitives_traits::{Bytecode, FastInstant as Instant};
 use reth_static_file_types::{
     ChangesetOffset, ChangesetOffsetReader, ChangesetOffsetWriter, SegmentHeader,
     SegmentRangeInclusive, StaticFileSegment,
@@ -78,6 +78,7 @@ pub(crate) struct StaticFileWriters<N> {
     transaction_senders: RwLock<Option<StaticFileProviderRW<N>>>,
     account_change_sets: RwLock<Option<StaticFileProviderRW<N>>>,
     storage_change_sets: RwLock<Option<StaticFileProviderRW<N>>>,
+    bytecodes: RwLock<Option<StaticFileProviderRW<N>>>,
 }
 
 impl<N> Default for StaticFileWriters<N> {
@@ -89,6 +90,7 @@ impl<N> Default for StaticFileWriters<N> {
             transaction_senders: Default::default(),
             account_change_sets: Default::default(),
             storage_change_sets: Default::default(),
+            bytecodes: Default::default(),
         }
     }
 }
@@ -106,6 +108,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             StaticFileSegment::TransactionSenders => self.transaction_senders.write(),
             StaticFileSegment::AccountChangeSets => self.account_change_sets.write(),
             StaticFileSegment::StorageChangeSets => self.storage_change_sets.write(),
+            StaticFileSegment::Bytecodes => self.bytecodes.write(),
         };
 
         if write_guard.is_none() {
@@ -131,6 +134,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             &self.transaction_senders,
             &self.account_change_sets,
             &self.storage_change_sets,
+            &self.bytecodes,
         ] {
             let mut writer = writer_lock.write();
             if let Some(writer) = writer.as_mut() {
@@ -150,6 +154,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             &self.transaction_senders,
             &self.account_change_sets,
             &self.storage_change_sets,
+            &self.bytecodes,
         ] {
             let writer = writer_lock.read();
             if let Some(writer) = writer.as_ref() &&
@@ -181,6 +186,7 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
             &self.transaction_senders,
             &self.account_change_sets,
             &self.storage_change_sets,
+            &self.bytecodes,
         ] {
             let mut writer = writer_lock.write();
             if let Some(writer) = writer.as_mut() {
@@ -1399,6 +1405,27 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 StaticFileSegment::StorageChangeSets,
                 StaticFileProviderOperation::Append,
                 count,
+                Some(start.elapsed()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Appends bytecode to the static file by its bytecode ID.
+    pub fn append_bytecode(&mut self, bytecode_id: u64, bytecode: &Bytecode) -> ProviderResult<()> {
+        let start = Instant::now();
+        self.ensure_no_queued_prune()?;
+
+        debug_assert!(self.writer.user_header().segment() == StaticFileSegment::Bytecodes);
+
+        self.increment_block(bytecode_id)?;
+        self.append_column(bytecode)?;
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_segment_operation(
+                StaticFileSegment::Bytecodes,
+                StaticFileProviderOperation::Append,
                 Some(start.elapsed()),
             );
         }


### PR DESCRIPTION
## Summary
- Store bytecode payloads in static files, indexed by bytecode ID.
- Keep the MDBX hash-to-ID mapping as the lookup entrypoint, with legacy MDBX bytecodes as a fallback.
- Add CLI and config support for the new bytecode static-file segment, plus pruning and read-path updates.

## Testing
- Added unit tests for bytecode static-file reads by ID.
- Added unit tests covering latest-state bytecode lookup through the new hash-to-ID path.
- Ran focused `cargo test` coverage and a targeted `cargo check` across the affected crates.