### PR TITLE
refactor(tree): reduce BAL cloning across validation and execution

### DIFF
--- a/.github/scripts/hive/build_simulators.sh
+++ b/.github/scripts/hive/build_simulators.sh
@@ -5,8 +5,8 @@ fixture_variant="${1:-osaka}"
 
 case "${fixture_variant}" in
     amsterdam)
-        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/bal@v6.0.0/fixtures_bal.tar.gz"
-        eels_branch="devnets/snøbal/4"
+        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz"
+        eels_branch="devnets/bal/3"
         ;;
     osaka)
         eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz"

--- a/.github/scripts/hive/expected_failures.yaml
+++ b/.github/scripts/hive/expected_failures.yaml
@@ -140,21 +140,6 @@ eels/consume-engine:
 #  this test inserts a chain via chain.rlp where the last block is invalid, but expects import to stop there, this doesn't work properly with our pipeline import approach hence the import fails when the invalid block is detected.
 #. In other words, if this test fails, this means we're correctly rejecting the block.
 #. The same test exists in the consume-engine simulator where it is passing as expected
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE2-non-empty-balance-correct-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Amsterdam-blockchain_test_engine_from_state_test]-reth
-  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_engine_from_state_test-initcode-with-deploy]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE2-non-empty-balance-revert-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_engine_from_state_test-empty-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_engine_from_state_test-sstore-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE-non-empty-balance-correct-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
-  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE-non-empty-balance-revert-initcode]-reth
-
 eels/consume-rlp:
   - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]-reth
   - tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py::test_system_contract_errors[fork_Prague-blockchain_test_engine-system_contract_reaches_gas_limit-system_contract_0x0000bbddc7ce488642fb579f8b00f3a590007251]-reth

--- a/.github/scripts/hive/expected_failures.yaml
+++ b/.github/scripts/hive/expected_failures.yaml
@@ -106,6 +106,21 @@ eels/consume-engine:
 #  this test inserts a chain via chain.rlp where the last block is invalid, but expects import to stop there, this doesn't work properly with our pipeline import approach hence the import fails when the invalid block is detected.
 #. In other words, if this test fails, this means we're correctly rejecting the block.
 #. The same test exists in the consume-engine simulator where it is passing as expected
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE2-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Amsterdam-blockchain_test_engine_from_state_test]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_engine_from_state_test-initcode-with-deploy]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE2-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_engine_from_state_test-empty-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_engine_from_state_test-sstore-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_engine_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_engine_from_state_test-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_engine_from_state_test-opcode_CREATE-non-empty-balance-revert-initcode]-reth
+
 eels/consume-rlp:
   - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]-reth
   - tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py::test_system_contract_errors[fork_Prague-blockchain_test_engine-system_contract_reaches_gas_limit-system_contract_0x0000bbddc7ce488642fb579f8b00f3a590007251]-reth
@@ -193,3 +208,17 @@ eels/consume-rlp:
   - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_1-blockchain_test_from_state_test-non-empty-balance-revert-initcode]-reth
   - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Prague-tx_type_2-blockchain_test_from_state_test-non-empty-balance-revert-initcode]-reth
   - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Shanghai-tx_type_0-blockchain_test_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_from_state_test-initcode-with-deploy]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_from_state_test-sstore-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_2-blockchain_test_from_state_test-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_from_state_test-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_collision_with_create2_revert_in_initcode[fork_Amsterdam-blockchain_test_from_state_test]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_1-blockchain_test_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_from_state_test-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_tx[fork_Amsterdam-tx_type_0-blockchain_test_from_state_test-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_from_state_test-opcode_CREATE-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_from_state_test-opcode_CREATE-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_from_state_test-opcode_CREATE2-non-empty-balance-correct-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_initcollision.py::test_init_collision_create_opcode[fork_Amsterdam-blockchain_test_from_state_test-opcode_CREATE2-non-empty-balance-revert-initcode]-reth
+  - tests/paris/eip7610_create_collision/test_revert_in_create.py::test_create2_collision_storage[fork_Amsterdam-blockchain_test_from_state_test-empty-initcode]-reth

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7765,6 +7765,7 @@ name = "reth-consensus"
 version = "2.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3438,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4203,8 +4203,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4728,7 +4728,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5092,7 +5092,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6068,7 +6068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8232,6 +8232,7 @@ dependencies = [
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm",
+ "revm-database-interface",
  "revm-primitives",
  "revm-state",
  "schnellru",
@@ -10922,7 +10923,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11002,7 +11003,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11591,7 +11592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11791,7 +11792,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13060,7 +13061,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bin/reth-bb/src/evm.rs
+++ b/bin/reth-bb/src/evm.rs
@@ -76,6 +76,7 @@ impl BbEvmPlan {
             .collect()
     }
 
+    /// Returns the segment that contains the transaction at `tx_index`.
     pub(crate) fn segment_index_for_tx(&self, tx_index: usize) -> usize {
         self.segments.partition_point(|segment| segment.start_tx <= tx_index).saturating_sub(1)
     }
@@ -104,6 +105,12 @@ impl std::fmt::Debug for BbEvmPlan {
 pub(crate) type BlockHashSeeder<DB> = fn(&mut DB, &[(u64, B256)]);
 
 /// Function pointer that reads the BAL index from the DB.
+///
+/// Injected from `ConfigureEvm::create_executor` where the concrete
+/// `State<DB>` type is known. `BbBlockExecutor` calls this lazily on first
+/// use to decide which segment to start at: `0` means canonical execution
+/// from segment 0, `n > 0` means a BAL worker that runs only the n-th
+/// transaction (in whichever segment contains it).
 pub(crate) type BalIndexReader<DB> = fn(&DB) -> u64;
 
 /// Block executor that wraps [`EthBlockExecutor`] and handles segment-boundary
@@ -141,9 +148,10 @@ where
     /// Callback to reseed block hashes into the DB's cache at segment
     /// boundaries. See [`BlockHashSeeder`].
     block_hash_seeder: Option<BlockHashSeeder<DB>>,
-    /// Callback to read the BAL index from the DB.
+    /// Callback to read `bal_index` from the DB. See [`BalIndexReader`].
     bal_index_reader: Option<BalIndexReader<DB>>,
-    /// Whether the executor has selected its starting segment.
+    /// Whether [`Self::initialize`] has run. Init swaps the inner executor's
+    /// env/ctx to the starting segment selected via `bal_index_reader`.
     initialized: bool,
 }
 
@@ -186,34 +194,40 @@ where
         }
     }
 
+    /// Idempotent first-use init. Reads `bal_index` from the DB to pick the
+    /// starting segment, swaps the inner executor's env/ctx to that segment,
+    /// and reseeds the block hash cache for its window.
+    ///
+    /// `bal_index == 0` selects segment 0 — canonical execution that walks
+    /// all segments via `maybe_apply_boundary`. `bal_index > 0` selects the
+    /// segment containing the `(bal_index - 1)`-th transaction and drops the
+    /// plan so segment boundaries don't fire — a BAL worker only runs one
+    /// transaction in its segment.
     fn initialize(&mut self) -> Result<(), BlockExecutionError> {
         if self.initialized {
             return Ok(());
         }
+        self.initialized = true;
 
         let plan = match &self.plan {
-            Some(plan) => plan,
+            Some(p) => p,
             None => return Ok(()),
         };
 
-        self.initialized = true;
-
         let bal_index =
             self.bal_index_reader.map(|reader| reader(self.inner().evm().db())).unwrap_or(0);
-        let segment_idx =
-            if bal_index == 0 { 0 } else { plan.segment_index_for_tx((bal_index - 1) as usize) };
+        let segment_idx = if bal_index == 0 {
+            0
+        } else {
+            let tx_index = (bal_index - 1) as usize;
+            plan.segment_index_for_tx(tx_index)
+        };
         let segment = &plan.segments[segment_idx];
-
-        // Swap the EVM's block_env and executor ctx to the selected segment's
-        // values so that EIP-2935/EIP-4788 system calls use the correct block
-        // number and parent hash. Without this, the outer big block header's
-        // block_number (which is synthetic) would be used, writing to wrong
-        // EIP-2935 slots and corrupting state.
         let block_env = segment.evm_env.block_env.clone();
         let block_number = block_env.number.saturating_to::<u64>();
         let mut cfg_env = segment.evm_env.cfg_env.clone();
         cfg_env.disable_base_fee = true;
-        let ctx = EthBlockExecutionCtx {
+        let segment_ctx = EthBlockExecutionCtx {
             parent_hash: segment.ctx.parent_hash,
             parent_beacon_block_root: segment.ctx.parent_beacon_block_root,
             ommers: segment.ctx.ommers,
@@ -227,7 +241,7 @@ where
         let evm_ctx = inner.evm.ctx_mut();
         evm_ctx.block = block_env;
         evm_ctx.cfg = cfg_env;
-        inner.ctx = ctx;
+        inner.ctx = segment_ctx;
 
         self.reseed_block_hashes_for(block_number);
 
@@ -418,8 +432,11 @@ where
     type Result = EthTxResult<HaltReason, alloy_consensus::TxType>;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
-        // The outer big-block header uses a synthetic block number, so start
-        // system calls must run against the selected real segment env.
+        // Init swaps the EVM's block_env and executor ctx to the starting
+        // segment's values so the EIP-2935/EIP-4788 system calls use the
+        // correct block number and parent hash. Without this the outer big
+        // block header's (synthetic) block_number would be used, writing to
+        // wrong EIP-2935 slots and corrupting state.
         self.initialize()?;
         self.inner_mut().apply_pre_execution_changes()
     }
@@ -543,7 +560,7 @@ pub struct BbBlockExecutorFactory<Spec> {
     receipt_builder: RethReceiptBuilder,
     spec: Spec,
     evm_factory: EthEvmFactory,
-    /// Staged plan cloned into each [`BbBlockExecutor`].
+    /// Staged plan consumed by the next [`BbBlockExecutor`].
     pub(crate) staged_plan: Arc<Mutex<Option<BbEvmPlan>>>,
 }
 
@@ -576,6 +593,10 @@ impl<Spec> BbBlockExecutorFactory<Spec> {
         *self.staged_plan.lock().unwrap() = None;
     }
 
+    /// Returns a clone of the currently staged plan without consuming it.
+    ///
+    /// Cloning lets multiple executors (canonical + N parallel BAL workers
+    /// for the same block) each own their own plan state.
     fn peek_plan(&self) -> Option<BbEvmPlan> {
         self.staged_plan.lock().unwrap().clone()
     }

--- a/bin/reth-bb/src/evm_config.rs
+++ b/bin/reth-bb/src/evm_config.rs
@@ -8,7 +8,7 @@
 pub(crate) use reth_engine_primitives::BigBlockData;
 
 use crate::{
-    evm::{BalIndexReader, BbBlockExecutorFactory, BbEvmPlan},
+    evm::{BbBlockExecutorFactory, BbEvmPlan},
     BigBlockMap,
 };
 use alloy_consensus::Header;
@@ -30,7 +30,6 @@ use reth_evm_ethereum::{EthBlockAssembler, EthEvmConfig, RethReceiptBuilder};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use revm::primitives::hardfork::SpecId;
 use std::sync::Arc;
-use tracing::debug;
 
 // ---------------------------------------------------------------------------
 // Execution plan types
@@ -55,7 +54,7 @@ pub(crate) struct BigBlockSegment {
 ///
 /// Wraps [`EthEvmConfig`] and a shared [`BigBlockMap`]. When a big-block
 /// payload is received, the plan is staged on the [`BbBlockExecutorFactory`]
-/// and cloned when executors are created. Block hashes for inter-segment
+/// and consumed when the executor is created. Block hashes for inter-segment
 /// BLOCKHASH resolution are reseeded into `State::block_hashes` at each
 /// segment boundary via a [`BlockHashSeeder`](crate::evm::BlockHashSeeder)
 /// callback injected in [`ConfigureEvm::create_executor`].
@@ -106,6 +105,11 @@ fn seed_state_block_hashes<DB>(state: &mut &mut revm::database::State<DB>, hashe
     }
 }
 
+/// Reads the BAL index from a `&mut State<DB>`.
+///
+/// Used as a [`BalIndexReader`](crate::evm::BalIndexReader) callback so the
+/// generic [`BbBlockExecutor`](crate::evm::BbBlockExecutor) can pick its
+/// starting segment without a trait bound on `DB`.
 fn read_bal_index<DB>(state: &&mut revm::database::State<DB>) -> u64 {
     state.bal_state.bal_index()
 }
@@ -144,19 +148,6 @@ where
         self.inner.next_evm_env(parent, attributes)
     }
 
-    fn context_for_block<'a>(
-        &self,
-        block: &'a SealedBlock<reth_ethereum_primitives::Block>,
-    ) -> Result<EthBlockExecutionCtx<'a>, Self::Error> {
-        if let Some(plan) = self.plan_for_payload_hash(&block.hash()) {
-            self.executor_factory.stage_plan(plan);
-        } else {
-            self.executor_factory.clear_staged_plan();
-        }
-
-        self.inner.context_for_block(block)
-    }
-
     fn context_for_next_block(
         &self,
         parent: &SealedHeader,
@@ -179,17 +170,31 @@ where
         DB: Database,
         I: reth_evm::InspectorFor<Self, &'a mut revm::database::State<DB>> + 'a,
     {
-        let bal_index_reader: Option<BalIndexReader<&'a mut revm::database::State<DB>>> =
-            Some(read_bal_index::<DB>);
-
-        // Inject concrete function pointers that know the `State<DB>` type so
-        // the generic executor can reseed block hashes and read `bal_index`.
+        // Inject concrete fn pointers that know the `State<DB>` type so the
+        // generic `BbBlockExecutor` can seed block hashes and read `bal_index`
+        // without trait bounds on `DB`.
         self.executor_factory.create_executor_with_seeder(
             evm,
             ctx,
             Some(seed_state_block_hashes::<DB>),
-            bal_index_reader,
+            Some(read_bal_index::<DB>),
         )
+    }
+
+    fn context_for_block<'a>(
+        &self,
+        block: &'a SealedBlock<reth_ethereum_primitives::Block>,
+    ) -> Result<EthBlockExecutionCtx<'a>, Self::Error> {
+        // Refresh the staged plan based on this block's hash so subsequent
+        // `create_executor` calls - both canonical and parallel BAL workers -
+        // see the right plan. Cleared explicitly when this block isn't a
+        // big-block payload, so a stale plan from a prior big block doesn't
+        // leak into a regular block.
+        match self.plan_for_payload_hash(&block.hash()) {
+            Some(plan) => self.executor_factory.stage_plan(plan),
+            None => self.executor_factory.clear_staged_plan(),
+        }
+        self.inner.context_for_block(block)
     }
 }
 
@@ -203,16 +208,15 @@ where
 {
     fn evm_env_for_payload(&self, payload: &ExecutionData) -> Result<EvmEnvFor<Self>, Self::Error> {
         let payload_hash = payload.block_hash();
-        let has_plan = self.pending.lock().unwrap().contains_key(&payload_hash);
+        let first_exec_data = {
+            let pending = self.pending.lock().unwrap();
+            pending
+                .get(&payload_hash)
+                .and_then(|bb_data| bb_data.env_switches.first().map(|(_, data)| data.clone()))
+        };
 
-        if has_plan {
-            // Compute the env from the first segment BEFORE removing the
-            // entry (stage_plan_for_payload removes it).
-            let first_exec_data = {
-                let pending = self.pending.lock().unwrap();
-                let bb_data = pending.get(&payload_hash).unwrap();
-                bb_data.env_switches[0].1.clone()
-            };
+        if let Some(first_exec_data) = first_exec_data {
+            // Compute the env from the first segment before the executor is created.
             let mut env = self.inner.evm_env_for_payload(&first_exec_data)?;
 
             // Disable basefee validation: transactions from different
@@ -220,12 +224,8 @@ where
             // effective basefee.
             env.cfg_env.disable_base_fee = true;
 
-            // Now stage the plan on the factory (removes the entry).
-            self.stage_plan_for_payload(&payload_hash);
-
             Ok(env)
         } else {
-            self.executor_factory.clear_staged_plan();
             self.inner.evm_env_for_payload(payload)
         }
     }
@@ -246,61 +246,49 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// Plan construction and staging
+// Plan construction
 // ---------------------------------------------------------------------------
 
 impl<C> BbEvmConfig<C>
 where
     C: EthExecutorSpec + EthChainSpec<Header = Header> + Hardforks + 'static,
 {
-    /// Takes the big-block plan for a payload hash, builds a [`BbEvmPlan`],
-    /// and stages it on the factory.
-    ///
-    /// Must be called before `evm_with_env` is invoked for this payload.
-    /// In practice, this is called from `evm_env_for_payload` in the
-    /// engine pipeline.
-    pub fn stage_plan_for_payload(&self, payload_hash: &B256) {
-        let Some(plan) = self.plan_for_payload_hash(payload_hash) else { return };
-        self.executor_factory.stage_plan(plan);
+    fn plan_for_payload_hash(&self, payload_hash: &B256) -> Option<BbEvmPlan> {
+        let pending = self.pending.lock().unwrap();
+        self.build_plan(pending.get(payload_hash)?)
     }
 
-    fn plan_for_payload_hash(&self, payload_hash: &B256) -> Option<BbEvmPlan> {
-        let bb = self.pending.lock().unwrap().remove(payload_hash)?;
+    fn build_plan(&self, bb: &BigBlockData<ExecutionData>) -> Option<BbEvmPlan> {
+        if bb.env_switches.is_empty() {
+            return None;
+        }
 
         let segments: Vec<_> = bb
             .env_switches
-            .into_iter()
+            .iter()
             .map(|(start_tx, exec_data)| {
-                let evm_env = self.inner.evm_env_for_payload(&exec_data).unwrap();
-                let ctx = self.inner.context_for_payload(&exec_data).unwrap();
-                let ctx = EthBlockExecutionCtx {
-                    tx_count_hint: ctx.tx_count_hint,
-                    parent_hash: ctx.parent_hash,
-                    parent_beacon_block_root: ctx.parent_beacon_block_root,
-                    ommers: &[],
-                    withdrawals: ctx.withdrawals.map(|w| std::borrow::Cow::Owned(w.into_owned())),
-                    extra_data: ctx.extra_data,
-                    slot_number: ctx.slot_number,
-                };
-                BigBlockSegment { start_tx, evm_env, ctx }
+                let mut evm_env = self.inner.evm_env_for_payload(exec_data).unwrap();
+                evm_env.cfg_env.disable_base_fee = true;
+                let ctx = self.inner.context_for_payload(exec_data).unwrap();
+                BigBlockSegment { start_tx: *start_tx, evm_env, ctx: clone_ctx(&ctx) }
             })
             .collect();
 
-        debug!(
-            target: "engine::bb",
-            ?payload_hash,
-            segments = segments.len(),
-            seed_hashes = bb.prior_block_hashes.len(),
-            "Staging multi-segment plan"
-        );
-
         let mut plan = BbEvmPlan::new(segments);
-
-        // Add prior block hashes to the seeding list.
-        plan.block_hashes_to_seed.extend(bb.prior_block_hashes);
-
+        plan.block_hashes_to_seed.extend(bb.prior_block_hashes.iter().copied());
         plan.block_hashes_to_seed.sort_unstable_by_key(|(n, _)| *n);
-
         Some(plan)
+    }
+}
+
+fn clone_ctx<'a>(ctx: &EthBlockExecutionCtx<'_>) -> EthBlockExecutionCtx<'a> {
+    EthBlockExecutionCtx {
+        tx_count_hint: ctx.tx_count_hint,
+        parent_hash: ctx.parent_hash,
+        parent_beacon_block_root: ctx.parent_beacon_block_root,
+        ommers: &[],
+        withdrawals: ctx.withdrawals.clone().map(|w| std::borrow::Cow::Owned(w.into_owned())),
+        extra_data: ctx.extra_data.clone(),
+        slot_number: ctx.slot_number,
     }
 }

--- a/bin/reth-bb/src/main.rs
+++ b/bin/reth-bb/src/main.rs
@@ -33,6 +33,7 @@ use reth_node_builder::{
     },
     BuilderContext, Node,
 };
+use reth_node_core::args::DefaultEngineValues;
 use reth_node_ethereum::{
     EthEngineTypes, EthereumEngineValidatorBuilder, EthereumEthApiBuilder, EthereumNetworkBuilder,
     EthereumNode, EthereumPayloadBuilder, EthereumPoolBuilder,
@@ -356,8 +357,11 @@ fn main() {
 
     let pending: BigBlockMap = Arc::new(Mutex::new(HashMap::new()));
 
+    let _ = DefaultEngineValues::default().with_bal_parallel_execution_disabled(false).try_init();
+
     if let Err(err) = Cli::<EthereumChainSpecParser>::parse().run(async move |builder, _| {
         info!(target: "reth::cli", "Launching big block node");
+
         let handle = builder.launch_node(BbNode::new(pending.clone())).await?;
 
         handle.wait_for_node_exit().await

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -191,8 +191,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         };
 
+                        let bal= executor.take_bal();
+
                         if let Err(err) = consensus
-                            .validate_block_post_execution(&block, &result, None)
+                            .validate_block_post_execution(&block, &result, None,bal)
                             .wrap_err_with(|| {
                                 format!(
                                     "Failed to validate block {} {}",

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -191,10 +191,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         };
 
-                        let bal= executor.take_bal();
+                        let bal = executor.take_bal();
 
                         if let Err(err) = consensus
-                            .validate_block_post_execution(&block, &result, None,bal)
+                            .validate_block_post_execution(&block, &result, None, bal.as_deref())
                             .wrap_err_with(|| {
                                 format!(
                                     "Failed to validate block {} {}",

--- a/crates/consensus/consensus/Cargo.toml
+++ b/crates/consensus/consensus/Cargo.toml
@@ -18,6 +18,7 @@ reth-primitives-traits.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
+alloy-eip7928.workspace = true
 
 # misc
 auto_impl.workspace = true
@@ -29,10 +30,9 @@ std = [
     "reth-primitives-traits/std",
     "alloy-primitives/std",
     "alloy-consensus/std",
-    "reth-primitives-traits/std",
+    "alloy-eip7928/std",
     "reth-execution-types/std",
     "thiserror/std",
+    "alloy-eip7928/std",
 ]
-test-utils = [
-    "reth-primitives-traits/test-utils",
-]
+test-utils = ["reth-primitives-traits/test-utils"]

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -38,6 +38,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::Header;
+use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{BlockHash, BlockNumber, Bloom, B256};
 use core::{error::Error, fmt::Display};
 
@@ -85,6 +86,7 @@ pub trait FullConsensus<N: NodePrimitives>: Consensus<N::Block> {
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        block_access_list: Option<BlockAccessList>,
     ) -> Result<(), ConsensusError>;
 }
 
@@ -250,16 +252,6 @@ pub enum ConsensusError {
     /// hash.
     #[error("mismatched block requests hash: {0}")]
     BodyRequestsHashDiff(GotExpectedBoxed<B256>),
-
-    /// Error when the computed block access list hash does not match the hash committed in
-    /// the block header (EIP-7928).
-    #[error("mismatched block access list hash: {0}")]
-    BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
-
-    /// Error when the block's declared block access list contains more items than the
-    /// block's gas limit allows (EIP-7928 `ITEM_COST` gating).
-    #[error("block access list cost more than gas limit")]
-    BlockAccessListCostMoreThanGasLimit,
 
     /// Error when a block with a specific hash and number is already known.
     #[error("block with [hash={hash}, number={number}] is already known")]
@@ -484,6 +476,12 @@ pub enum ConsensusError {
     /// EIP-7825: Transaction gas limit exceeds maximum allowed
     #[error(transparent)]
     TransactionGasLimitTooHigh(Box<TxGasLimitTooHighErr>),
+    /// Error when an unexpected block access list cost is encountered.
+    #[error("block access list cost exceeds gas limit")]
+    BlockAccessListCostMoreThanGasLimit,
+    /// Error when the block access list hash doesn't match the expected value.
+    #[error("block access list hash mismatch: {0}")]
+    BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
     /// Any additional consensus error, for example L2-specific errors.
     #[error(transparent)]
     Other(#[from] Arc<dyn Error + Send + Sync>),
@@ -527,6 +525,23 @@ impl ConsensusError {
     pub fn is_other<T: Error + 'static>(&self) -> bool {
         self.as_other().map(|err| err.is::<T>()).unwrap_or(false)
     }
+}
+
+/// Validates the block access list against the gas limit.
+///
+/// EIP-7925 specifies that the total cost of the block access list items must not exceed
+/// the gas limit. Each item costs `ITEM_COST` gas.
+pub fn validate_block_access_list_gas(
+    block_access_list: Option<&alloy_eip7928::BlockAccessList>,
+    gas_limit: u64,
+) -> Result<(), ConsensusError> {
+    if let Some(bal) = block_access_list {
+        let bal_items = alloy_eip7928::total_bal_items(bal);
+        if bal_items > gas_limit / alloy_eip7928::ITEM_COST as u64 {
+            return Err(ConsensusError::BlockAccessListCostMoreThanGasLimit)
+        }
+    }
+    Ok(())
 }
 
 impl From<InvalidTransactionError> for ConsensusError {

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -251,6 +251,16 @@ pub enum ConsensusError {
     #[error("mismatched block requests hash: {0}")]
     BodyRequestsHashDiff(GotExpectedBoxed<B256>),
 
+    /// Error when the computed block access list hash does not match the hash committed in
+    /// the block header (EIP-7928).
+    #[error("mismatched block access list hash: {0}")]
+    BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
+
+    /// Error when the block's declared block access list contains more items than the
+    /// block's gas limit allows (EIP-7928 `ITEM_COST` gating).
+    #[error("block access list cost more than gas limit")]
+    BlockAccessListCostMoreThanGasLimit,
+
     /// Error when a block with a specific hash and number is already known.
     #[error("block with [hash={hash}, number={number}] is already known")]
     BlockKnown {

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -38,7 +38,6 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::Header;
-use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{BlockHash, BlockNumber, Bloom, B256};
 use core::{error::Error, fmt::Display};
 
@@ -86,7 +85,7 @@ pub trait FullConsensus<N: NodePrimitives>: Consensus<N::Block> {
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
-        block_access_list: Option<BlockAccessList>,
+        block_access_list: Option<&[alloy_eip7928::AccountChanges]>,
     ) -> Result<(), ConsensusError>;
 }
 
@@ -532,7 +531,7 @@ impl ConsensusError {
 /// EIP-7925 specifies that the total cost of the block access list items must not exceed
 /// the gas limit. Each item costs `ITEM_COST` gas.
 pub fn validate_block_access_list_gas(
-    block_access_list: Option<&alloy_eip7928::BlockAccessList>,
+    block_access_list: Option<&[alloy_eip7928::AccountChanges]>,
     gas_limit: u64,
 ) -> Result<(), ConsensusError> {
     if let Some(bal) = block_access_list {

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -20,6 +20,7 @@
 
 use crate::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
 use alloc::sync::Arc;
+use alloy_eip7928::BlockAccessList;
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
 
@@ -77,6 +78,7 @@ impl<N: NodePrimitives> FullConsensus<N> for NoopConsensus {
         _block: &RecoveredBlock<N::Block>,
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
+        _block_access_list: Option<BlockAccessList>,
     ) -> Result<(), ConsensusError> {
         Ok(())
     }

--- a/crates/consensus/consensus/src/noop.rs
+++ b/crates/consensus/consensus/src/noop.rs
@@ -20,7 +20,6 @@
 
 use crate::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
 use alloc::sync::Arc;
-use alloy_eip7928::BlockAccessList;
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
 
@@ -78,7 +77,7 @@ impl<N: NodePrimitives> FullConsensus<N> for NoopConsensus {
         _block: &RecoveredBlock<N::Block>,
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
-        _block_access_list: Option<BlockAccessList>,
+        _block_access_list: Option<&[alloy_eip7928::AccountChanges]>,
     ) -> Result<(), ConsensusError> {
         Ok(())
     }

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -1,4 +1,5 @@
 use crate::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
+use alloy_eip7928::BlockAccessList;
 use core::sync::atomic::{AtomicBool, Ordering};
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
@@ -52,6 +53,7 @@ impl<N: NodePrimitives> FullConsensus<N> for TestConsensus {
         _block: &RecoveredBlock<N::Block>,
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
+        _block_access_list: Option<BlockAccessList>,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {
             Err(ConsensusError::BaseFeeMissing)

--- a/crates/consensus/consensus/src/test_utils.rs
+++ b/crates/consensus/consensus/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
-use alloy_eip7928::BlockAccessList;
+use alloy_eip7928::AccountChanges;
 use core::sync::atomic::{AtomicBool, Ordering};
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{Block, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
@@ -53,7 +53,7 @@ impl<N: NodePrimitives> FullConsensus<N> for TestConsensus {
         _block: &RecoveredBlock<N::Block>,
         _result: &BlockExecutionResult<N::Receipt>,
         _receipt_root_bloom: Option<ReceiptRootBloom>,
-        _block_access_list: Option<BlockAccessList>,
+        _block_access_list: Option<&[AccountChanges]>,
     ) -> Result<(), ConsensusError> {
         if self.fail_validation() {
             Err(ConsensusError::BaseFeeMissing)

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -185,15 +185,14 @@ pub struct TreeConfig {
     /// with block building on latency-sensitive chains.
     suppress_persistence_during_build: bool,
     /// Whether to disable BAL (Block Access List, EIP-7928) based parallel execution.
-    /// When disabled, falls back to transaction-based prewarming even when a BAL is available.
+    /// When disabled, uses the sequential execution path even when a BAL is available.
     disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
-    /// When disabled, the BAL hashed post state is not sent to the multiproof task for
-    /// early parallel state root computation.
+    /// Only valid when BAL parallel execution is also disabled.
     disable_bal_parallel_state_root: bool,
-    /// Whether to disable BAL (Block Access List) batched IO during prewarming.
-    /// When disabled, falls back to individual per-slot storage reads instead of
-    /// batched cursor reads via `storage_range`.
+    /// Whether to disable BAL (Block Access List) state prefetching during prewarm.
+    /// When disabled, BAL executor workers fetch state on demand instead of consuming
+    /// BAL-declared cache prefetches.
     disable_bal_batch_io: bool,
     /// Maximum random jitter applied before each proof computation (trie-debug only).
     /// When set, each proof worker sleeps for a random duration up to this value
@@ -239,7 +238,7 @@ impl Default for TreeConfig {
             share_execution_cache_with_payload_builder: false,
             share_sparse_trie_with_payload_builder: false,
             suppress_persistence_during_build: false,
-            disable_bal_parallel_execution: true,
+            disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
             #[cfg(feature = "trie-debug")]
@@ -316,7 +315,7 @@ impl TreeConfig {
             share_execution_cache_with_payload_builder,
             share_sparse_trie_with_payload_builder,
             suppress_persistence_during_build: false,
-            disable_bal_parallel_execution: true,
+            disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
             #[cfg(feature = "trie-debug")]
@@ -738,12 +737,12 @@ impl TreeConfig {
         self
     }
 
-    /// Returns whether BAL batched IO is disabled.
+    /// Returns whether BAL state prefetching during prewarm is disabled.
     pub const fn disable_bal_batch_io(&self) -> bool {
         self.disable_bal_batch_io
     }
 
-    /// Setter for whether to disable BAL batched IO.
+    /// Setter for whether to disable BAL state prefetching during prewarm.
     pub const fn without_bal_batch_io(mut self, disable_bal_batch_io: bool) -> Self {
         self.disable_bal_batch_io = disable_bal_batch_io;
         self

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -48,6 +48,7 @@ alloy-rpc-types-engine.workspace = true
 
 revm.workspace = true
 revm-primitives.workspace = true
+revm-state.workspace = true
 
 # common
 futures.workspace = true
@@ -95,8 +96,7 @@ reth-tracing.workspace = true
 reth-node-ethereum.workspace = true
 reth-e2e-test-utils.workspace = true
 
-# revm
-revm-state.workspace = true
+revm-database-interface.workspace = true
 
 assert_matches.workspace = true
 eyre.workspace = true
@@ -131,9 +131,9 @@ test-utils = [
     "reth-trie-parallel/test-utils",
     "reth-ethereum-primitives/test-utils",
     "reth-node-ethereum/test-utils",
-    "reth-evm-ethereum/test-utils",
     "reth-tasks/test-utils",
     "reth-execution-cache/test-utils",
+    "reth-evm-ethereum/test-utils",
 ]
 trie-debug = [
     "reth-trie-sparse/trie-debug",

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -1,5 +1,6 @@
 //! Internal errors for the tree module.
 
+use crate::tree::payload_processor::bal::BalExecutionError;
 use alloy_consensus::BlockHeader;
 use reth_consensus::ConsensusError;
 use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
@@ -116,9 +117,25 @@ pub enum InsertBlockErrorKind {
     /// Provider error.
     #[error(transparent)]
     Provider(#[from] ProviderError),
+    /// BAL-driven block execution rejected the block. Covers structural BAL errors and the
+    /// final-hash mismatch.
+    #[error(transparent)]
+    InvalidBlockAccessList(BalExecutionError),
     /// Other errors.
     #[error(transparent)]
     Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
+}
+
+impl From<BalExecutionError> for InsertBlockErrorKind {
+    fn from(e: BalExecutionError) -> Self {
+        match e {
+            // Worker EVM errors flow through the standard execution-error path so existing
+            // metrics and routing apply.
+            BalExecutionError::Evm(inner) => Self::Execution(inner),
+            BalExecutionError::Provider(inner) => Self::Provider(inner),
+            other => Self::InvalidBlockAccessList(other),
+        }
+    }
 }
 
 impl InsertBlockErrorKind {
@@ -147,6 +164,9 @@ impl InsertBlockErrorKind {
                 }
             }
             Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
+            Self::InvalidBlockAccessList(err) => {
+                Ok(InsertBlockValidationError::InvalidBlockAccessList(err))
+            }
             Self::Other(err) => Err(InternalBlockExecutionError::Other(err).into()),
         }
     }
@@ -172,6 +192,10 @@ pub enum InsertBlockValidationError {
     /// Validation error, transparently wrapping [`BlockValidationError`]
     #[error(transparent)]
     Validation(#[from] BlockValidationError),
+    /// BAL-driven block execution rejected the block. Covers structural BAL errors and the
+    /// final-hash mismatch.
+    #[error(transparent)]
+    InvalidBlockAccessList(BalExecutionError),
 }
 
 /// Errors that may occur when inserting a payload.

--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -9,14 +9,6 @@ use alloy_primitives::B256;
 /// block error.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RejectReason {
-    /// `keccak256(rlp(received_bal))` disagrees with `header.block_access_list_hash`.
-    HeaderHashMismatch {
-        /// Hash computed from the received BAL bytes.
-        computed: B256,
-        /// Hash committed in the block header.
-        expected: B256,
-    },
-
     /// BAL fails the structural item-count gate:
     /// `(addresses + unique_storage_keys) * ITEM_COST > block_gas_limit`.
     ItemCountExceedsGasBudget {

--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -1,0 +1,54 @@
+//! Rejection reasons for the BAL execution path.
+
+use alloy_primitives::B256;
+
+/// Reasons a block may be rejected on the BAL execution path.
+///
+/// These correspond to the validation stages described in `BAL.md`. Each stage maps to a specific
+/// variant; producing an instance short-circuits block validation and propagates as an invalid
+/// block error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RejectReason {
+    /// `keccak256(rlp(received_bal))` disagrees with `header.block_access_list_hash`.
+    HeaderHashMismatch {
+        /// Hash computed from the received BAL bytes.
+        computed: B256,
+        /// Hash committed in the block header.
+        expected: B256,
+    },
+
+    /// BAL fails the structural item-count gate:
+    /// `(addresses + unique_storage_keys) * ITEM_COST > block_gas_limit`.
+    ItemCountExceedsGasBudget {
+        /// Count of addresses + unique storage keys.
+        bal_items: u64,
+        /// Block gas limit in gas units.
+        gas_limit: u64,
+    },
+
+    /// A worker accessed state not declared in the received BAL (surfaced as revm's
+    /// `BalError::AccountNotFound` or a storage-key miss).
+    ///
+    /// TODO: once revm's `BalError` carries the offending `address` / `slot`, thread those
+    /// through to aid diagnostics. For now we only know which tx triggered the miss.
+    UndeclaredAccess {
+        /// Tx index whose worker reported the miss.
+        tx_index: u64,
+    },
+
+    /// The canonical `bal_builder`'s entries for a tx disagree with the received BAL for the same
+    /// tx index. Caught per-tx immediately after `commit_transaction`.
+    FragmentMismatch {
+        /// Tx index whose fragment diverged.
+        tx_index: u64,
+    },
+
+    /// The rebuilt BAL's hash disagrees with `header.block_access_list_hash` at end-of-block.
+    /// Catches over-declared addresses and any divergence the per-tx fragment compares missed.
+    FinalHashMismatch {
+        /// Hash of the rebuilt BAL.
+        rebuilt: B256,
+        /// Hash committed in the block header.
+        expected: B256,
+    },
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -8,7 +8,6 @@
 //!
 //! ### Checks performed
 //!
-//! - **A (structural hash)**: `check_bal_hash(received_bal, header_bal_hash)` at entry.
 //! - **B (item-count gate)**: `check_item_count(received_bal, block_gas_limit)` at entry.
 //! - **F (final hash)**: rebuilt composed BAL hashed against the header's commitment after
 //!   post-execution.
@@ -16,10 +15,7 @@
 //! Check E (per-tx fragment compare) is skipped — check F is authoritative, and a
 //! lightweight fragment compare isn't yet designed.
 
-use super::{
-    validation::{check_bal_hash, check_item_count},
-    RejectReason,
-};
+use super::{validation::check_item_count, RejectReason};
 use alloy_consensus::Transaction;
 use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
 use alloy_evm::{
@@ -67,7 +63,7 @@ pub struct BalExecutionOutput<Evm: ConfigureEvm> {
 /// Errors surfaced by [`BalPayloadExecutor::execute_block`].
 #[derive(Debug)]
 pub enum BalExecutionError {
-    /// BAL-specific rejection — structural or final-hash mismatch.
+    /// BAL-specific rejection.
     Reject(RejectReason),
     /// Worker or canonical EVM failure (including revm `BalError` for undeclared accesses,
     /// surfaced opaquely until upstream revm carries address/slot metadata).
@@ -166,7 +162,6 @@ impl<Evm: ConfigureEvm> BalPayloadExecutor<Evm> {
         DB: Database + Send,
         MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
     {
-        check_bal_hash(&received_bal, header_bal_hash)?;
         let bal = received_bal.as_bal();
         check_item_count(bal, block_gas_limit)?;
 
@@ -457,31 +452,6 @@ mod tests {
             },
         };
         block.seal_slow()
-    }
-
-    #[test]
-    fn rejects_bad_bal_hash_up_front() {
-        // Check A: the received BAL's hash must match the header's commitment.
-        let executor = BalPayloadExecutor::new(Runtime::test(), EthEvmConfig::mainnet());
-        let snapshot = Arc::new(BlockPreState::default());
-        let received_bal: BlockAccessList = Vec::new();
-        let wrong_hash = B256::repeat_byte(0xff);
-        let block = empty_amsterdam_block(wrong_hash);
-
-        let result = executor.execute_block(
-            snapshot_db(snapshot),
-            to_arc_decoded(received_bal),
-            &block,
-            Vec::<Recovered<TransactionSigned>>::new(),
-            wrong_hash,
-            30_000_000,
-        );
-
-        match result {
-            Err(BalExecutionError::Reject(RejectReason::HeaderHashMismatch { .. })) => {}
-            Err(e) => panic!("expected HeaderHashMismatch, got error {e:?}"),
-            Ok(_) => panic!("expected HeaderHashMismatch, got Ok"),
-        }
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -1,0 +1,1211 @@
+//! BAL-path block execution — workers produce per-tx results in parallel and the canonical
+//! executor commits them in order while building the composed BAL.
+//!
+//! Workers and canonical execution use separate `revm::State`s over the same parent-state
+//! provider source. Workers layer revm's BAL state over that provider so declared in-block
+//! reads resolve at the worker's `bal_index`; the canonical executor commits worker outputs
+//! in order while rebuilding the composed BAL.
+//!
+//! ### Checks performed
+//!
+//! - **A (structural hash)**: `check_bal_hash(received_bal, header_bal_hash)` at entry.
+//! - **B (item-count gate)**: `check_item_count(received_bal, block_gas_limit)` at entry.
+//! - **F (final hash)**: rebuilt composed BAL hashed against the header's commitment after
+//!   post-execution.
+//!
+//! Check E (per-tx fragment compare) is skipped — check F is authoritative, and a
+//! lightweight fragment compare isn't yet designed.
+
+use super::{
+    validation::{check_bal_hash, check_item_count},
+    RejectReason,
+};
+use alloy_consensus::Transaction;
+use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
+use alloy_evm::{
+    block::{
+        BlockExecutionError, BlockExecutor, BlockExecutorFactory, BlockValidationError, TxResult,
+    },
+    Evm,
+};
+use alloy_primitives::B256;
+use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database};
+use reth_primitives_traits::{BlockTy, SealedBlock};
+use reth_provider::ProviderError;
+use reth_tasks::{pool::WorkerPool, Runtime};
+use revm::{
+    context::result::ResultAndState,
+    database::{states::bundle_state::BundleRetention, BundleState, State},
+    primitives::{eip7825::TX_GAS_LIMIT_CAP, hardfork::SpecId},
+};
+use revm_state::bal::Bal;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+/// Alias for the canonical receipt type produced by a given `ConfigureEvm`. Factory-level
+/// associated type — DB-independent.
+pub type ReceiptFor<Evm> =
+    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::Receipt;
+
+/// Output of a successful BAL-path block execution.
+#[expect(missing_debug_implementations)]
+pub struct BalExecutionOutput<Evm: ConfigureEvm> {
+    /// Accumulated state transitions from the canonical executor.
+    pub bundle_state: BundleState,
+    /// Receipts produced in order, one per committed tx.
+    pub receipts: Vec<ReceiptFor<Evm>>,
+    /// Total gas used by all transactions.
+    pub gas_used: u64,
+    /// Blob gas used by the block.
+    pub blob_gas_used: u64,
+    /// EIP-7685 withdrawal / deposit / consolidation requests.
+    pub requests: alloy_eips::eip7685::Requests,
+}
+
+/// Errors surfaced by [`BalPayloadExecutor::execute_block`].
+#[derive(Debug)]
+pub enum BalExecutionError {
+    /// BAL-specific rejection — structural or final-hash mismatch.
+    Reject(RejectReason),
+    /// Worker or canonical EVM failure (including revm `BalError` for undeclared accesses,
+    /// surfaced opaquely until upstream revm carries address/slot metadata).
+    Evm(BlockExecutionError),
+    /// Provider setup failed before EVM execution could start.
+    Provider(ProviderError),
+    /// The received BAL could not be converted from alloy-format to revm-format.
+    BalConversion(String),
+}
+
+impl From<RejectReason> for BalExecutionError {
+    fn from(r: RejectReason) -> Self {
+        Self::Reject(r)
+    }
+}
+
+impl From<BlockExecutionError> for BalExecutionError {
+    fn from(e: BlockExecutionError) -> Self {
+        Self::Evm(e)
+    }
+}
+
+impl From<ProviderError> for BalExecutionError {
+    fn from(e: ProviderError) -> Self {
+        Self::Provider(e)
+    }
+}
+
+impl core::fmt::Display for BalExecutionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Reject(r) => write!(f, "BAL rejection: {r:?}"),
+            Self::Evm(e) => write!(f, "evm execution failed: {e}"),
+            Self::Provider(e) => write!(f, "provider setup failed: {e}"),
+            Self::BalConversion(s) => write!(f, "alloy→revm BAL conversion failed: {s}"),
+        }
+    }
+}
+
+impl core::error::Error for BalExecutionError {}
+
+/// Top-level BAL-path block executor. Owns the `evm_config` so methods on `&self` give
+/// revm's lifetime unification the method-scoped `&'a self` it needs.
+#[expect(missing_debug_implementations)]
+pub struct BalPayloadExecutor<Evm: ConfigureEvm> {
+    evm_config: Evm,
+    runtime: Runtime,
+}
+
+impl<Evm: ConfigureEvm> BalPayloadExecutor<Evm> {
+    /// Wraps an `evm_config` together with the runtime that owns the persistent BAL worker pool.
+    pub const fn new(runtime: Runtime, evm_config: Evm) -> Self {
+        Self { evm_config, runtime }
+    }
+
+    /// Executes one block on the BAL path using the runtime's persistent BAL worker pool.
+    pub fn execute_block<Tx, DB, MakeDb>(
+        &self,
+        make_db: MakeDb,
+        received_bal: Arc<DecodedBal>,
+        block: &SealedBlock<BlockTy<Evm::Primitives>>,
+        txs: Vec<Tx>,
+        header_bal_hash: B256,
+        block_gas_limit: u64,
+    ) -> Result<BalExecutionOutput<Evm>, BalExecutionError>
+    where
+        Tx: ExecutableTxFor<Evm> + Send,
+        DB: Database + Send,
+        MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
+    {
+        self.execute_block_in_pool(
+            self.runtime.bal_streaming_pool(),
+            make_db,
+            received_bal,
+            block,
+            txs,
+            header_bal_hash,
+            block_gas_limit,
+        )
+    }
+
+    /// Executes one block on the BAL path using the provided worker pool.
+    #[expect(clippy::too_many_arguments)]
+    pub fn execute_block_in_pool<Tx, DB, MakeDb>(
+        &self,
+        worker_pool: &WorkerPool,
+        make_db: MakeDb,
+        received_bal: Arc<DecodedBal>,
+        block: &SealedBlock<BlockTy<Evm::Primitives>>,
+        txs: Vec<Tx>,
+        header_bal_hash: B256,
+        block_gas_limit: u64,
+    ) -> Result<BalExecutionOutput<Evm>, BalExecutionError>
+    where
+        Tx: ExecutableTxFor<Evm> + Send,
+        DB: Database + Send,
+        MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
+    {
+        check_bal_hash(&received_bal, header_bal_hash)?;
+        let bal = received_bal.as_bal();
+        check_item_count(bal, block_gas_limit)?;
+
+        let received_bal_revm: Arc<Bal> = Arc::new(
+            Bal::try_from(Vec::<_>::from(bal.clone()))
+                .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?,
+        );
+
+        let mut canonical_state = State::builder()
+            .with_database(make_db()?)
+            .with_bundle_update()
+            .with_bal_builder()
+            .build();
+        // NOTE: technically Amsterdam implies BAL (the current path) we are on.
+        // TODO: should we do this
+        let is_amsterdam = self
+            .evm_config
+            .evm_env(block.header())
+            .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?
+            .cfg_env
+            .spec
+            .into()
+            .is_enabled_in(SpecId::AMSTERDAM);
+        let tx_gas_limits: Vec<_> = txs.iter().map(|tx| tx.tx().gas_limit()).collect();
+
+        // Pre-load every BAL-declared address into canonical state's cache. `State::commit`
+        // (called by `commit_transaction`) panics at revm-database's
+        // `cache.rs:195` ("All accounts should be present inside cache") when it tries to
+        // apply a diff for an address not previously loaded. In the normal serial flow the
+        // EVM loads the account itself during execution, but here workers execute the tx EVM
+        // and the canonical loop only commits their outputs, so canonical may never have read
+        // those accounts itself.
+        for account_changes in bal {
+            canonical_state
+                .load_cache_account(account_changes.address)
+                .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+        }
+
+        let block_result = {
+            let worker_evm_config = self.evm_config.clone();
+            let mut canonical_executor = self
+                .evm_config
+                .executor_for_block(&mut canonical_state, block)
+                .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+
+            canonical_executor.apply_pre_execution_changes()?;
+
+            let mut gas_tracker = BlockGasTracker::new(block_gas_limit, is_amsterdam);
+            let abort = Arc::new(AtomicBool::new(false));
+            let tx_count = txs.len() as u64;
+            let make_db = &make_db;
+
+            worker_pool.in_place_scope(|scope| -> Result<(), BalExecutionError> {
+                let mut result_rxs = Vec::with_capacity(tx_count as usize);
+
+                for (i, tx) in txs.into_iter().enumerate() {
+                    let tx_index = i as u64 + 1;
+                    let abort = Arc::clone(&abort);
+                    let received_bal_revm = Arc::clone(&received_bal_revm);
+                    let evm_config = worker_evm_config.clone();
+                    let result_rx = spawn_worker(scope, abort, move || {
+                        let mut worker_state = State::builder()
+                            .with_database(make_db()?)
+                            .with_bal(received_bal_revm)
+                            .with_bundle_update()
+                            .build();
+                        worker_state.set_bal_index(tx_index);
+
+                        evm_config
+                            .executor_for_block(&mut worker_state, block)
+                            .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?
+                            .execute_transaction_without_commit(tx)
+                            .map_err(BalExecutionError::Evm)
+                    });
+                    result_rxs.push(result_rx);
+                }
+                for (i, result_rx) in result_rxs.into_iter().enumerate() {
+                    let worker_result = result_rx.recv().map_err(|_| {
+                        BalExecutionError::Evm(BlockExecutionError::msg(
+                            "BAL worker result channel closed before result arrived",
+                        ))
+                    })?;
+                    let worker_result = match worker_result {
+                        Ok(worker_result) => worker_result,
+                        Err(err) => {
+                            abort.store(true, Ordering::Relaxed);
+                            return Err(err);
+                        }
+                    };
+                    gas_tracker.validate_tx_limit(tx_gas_limits[i])?;
+                    gas_tracker.record_result(worker_result.result());
+                    canonical_executor.evm_mut().db_mut().bump_bal_index();
+                    commit_worker_result(&mut canonical_executor, worker_result);
+                }
+
+                Ok(())
+            })?;
+
+            canonical_executor.evm_mut().db_mut().bump_bal_index();
+            canonical_executor.apply_post_execution_changes()?
+        };
+
+        let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+        let rebuilt = compute_block_access_list_hash(&composed_alloy);
+        if rebuilt != header_bal_hash {
+            return Err(BalExecutionError::Reject(RejectReason::FinalHashMismatch {
+                rebuilt,
+                expected: header_bal_hash,
+            }));
+        }
+
+        canonical_state.merge_transitions(BundleRetention::Reverts);
+        Ok(BalExecutionOutput {
+            bundle_state: canonical_state.take_bundle(),
+            receipts: block_result.receipts,
+            gas_used: block_result.gas_used,
+            blob_gas_used: block_result.blob_gas_used,
+            requests: block_result.requests,
+        })
+    }
+}
+
+/// Mirrors `EthBlockExecutor`'s cumulative gas admission check in the ordered BAL commit loop.
+#[derive(Debug)]
+struct BlockGasTracker {
+    block_gas_limit: u64,
+    is_amsterdam: bool,
+    cumulative_tx_gas_used: u64,
+    block_regular_gas_used: u64,
+}
+
+impl BlockGasTracker {
+    const fn new(block_gas_limit: u64, is_amsterdam: bool) -> Self {
+        Self { block_gas_limit, is_amsterdam, cumulative_tx_gas_used: 0, block_regular_gas_used: 0 }
+    }
+
+    fn validate_tx_limit(&self, tx_gas_limit: u64) -> Result<(), BlockExecutionError> {
+        let block_gas_used = if self.is_amsterdam {
+            self.block_regular_gas_used
+        } else {
+            self.cumulative_tx_gas_used
+        };
+        let block_available_gas = self.block_gas_limit.saturating_sub(block_gas_used);
+        let tx_min_gas_limit = tx_gas_limit.min(TX_GAS_LIMIT_CAP);
+
+        if tx_min_gas_limit > block_available_gas {
+            return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                transaction_gas_limit: tx_gas_limit,
+                block_available_gas,
+            }
+            .into());
+        }
+
+        Ok(())
+    }
+
+    fn record_result<H>(&mut self, result: &ResultAndState<H>) {
+        let gas = result.result.gas();
+        self.cumulative_tx_gas_used = self.cumulative_tx_gas_used.saturating_add(gas.tx_gas_used());
+        self.block_regular_gas_used =
+            self.block_regular_gas_used.saturating_add(gas.block_regular_gas_used());
+    }
+}
+
+fn spawn_worker<'scope, R, F>(
+    scope: &rayon::Scope<'scope>,
+    abort: Arc<AtomicBool>,
+    run: F,
+) -> crossbeam_channel::Receiver<Result<R, BalExecutionError>>
+where
+    R: Send + 'scope,
+    F: FnOnce() -> Result<R, BalExecutionError> + Send + 'scope,
+{
+    let (result_tx, result_rx) = crossbeam_channel::bounded(1);
+
+    scope.spawn(move |_| {
+        if abort.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let _ = result_tx.send(run());
+    });
+
+    result_rx
+}
+
+fn commit_worker_result<E>(executor: &mut E, worker_result: E::Result)
+where
+    E: BlockExecutor,
+{
+    let _ = executor.commit_transaction(worker_result);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::payload_processor::bal::{BlockPreState, RequiredReads, SnapshotDatabase};
+    use alloy_consensus::{constants::KECCAK_EMPTY, Header};
+    use alloy_eip7928::{bal::Bal as AlloyBal, BlockAccessList};
+    use alloy_eips::{
+        eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE},
+        eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE},
+        eip7002::{WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_PREDEPLOY_CODE},
+    };
+    use alloy_primitives::{keccak256, B256, U256};
+    use reth_ethereum_primitives::{Block, BlockBody, TransactionSigned};
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_primitives_traits::{Block as _, Recovered, SealedBlock};
+    use reth_tasks::Runtime;
+    use revm::{
+        database::{CacheDB, EmptyDB},
+        state::{AccountInfo, Bytecode},
+        Database,
+    };
+
+    /// Wraps a `BlockAccessList` into an `Arc<DecodedBal>` by RLP-encoding the BAL.
+    fn to_arc_decoded(bal: BlockAccessList) -> Arc<DecodedBal> {
+        let alloy_bal: AlloyBal = bal.into();
+        let raw = alloy_rlp::encode(&alloy_bal).into();
+        Arc::new(DecodedBal::new(alloy_bal, raw))
+    }
+
+    /// Builds an in-memory canonical DB pre-populated with the post-Cancun system contracts
+    /// that `apply_pre_execution_changes` calls: beacon roots (EIP-4788), withdrawal requests
+    /// (EIP-7002), and historical block hashes (EIP-2935).
+    fn system_contracts_db() -> CacheDB<EmptyDB> {
+        let mut db = CacheDB::<EmptyDB>::new(Default::default());
+        db.insert_account_info(
+            BEACON_ROOTS_ADDRESS,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 1,
+                code_hash: keccak256(BEACON_ROOTS_CODE.clone()),
+                code: Some(Bytecode::new_raw(BEACON_ROOTS_CODE.clone())),
+                account_id: None,
+            },
+        );
+        db.insert_account_info(
+            WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 1,
+                code_hash: keccak256(WITHDRAWAL_REQUEST_PREDEPLOY_CODE.clone()),
+                code: Some(Bytecode::new_raw(WITHDRAWAL_REQUEST_PREDEPLOY_CODE.clone())),
+                account_id: None,
+            },
+        );
+        db.insert_account_info(
+            HISTORY_STORAGE_ADDRESS,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 1,
+                code_hash: keccak256(HISTORY_STORAGE_CODE.clone()),
+                code: Some(Bytecode::new_raw(HISTORY_STORAGE_CODE.clone())),
+                account_id: None,
+            },
+        );
+        db
+    }
+
+    /// Builds a minimal sealed block (empty body, Amsterdam-ready header) for tests.
+    fn empty_amsterdam_block(header_bal_hash: B256) -> SealedBlock<Block> {
+        empty_amsterdam_block_with_gas_limit(header_bal_hash, 30_000_000)
+    }
+
+    fn empty_amsterdam_block_with_gas_limit(
+        header_bal_hash: B256,
+        gas_limit: u64,
+    ) -> SealedBlock<Block> {
+        let header = Header {
+            timestamp: 1,
+            number: 1,
+            gas_limit,
+            parent_beacon_block_root: Some(B256::ZERO),
+            withdrawals_root: Some(alloy_consensus::EMPTY_ROOT_HASH),
+            requests_hash: Some(alloy_eips::eip7685::EMPTY_REQUESTS_HASH),
+            excess_blob_gas: Some(0),
+            blob_gas_used: Some(0),
+            block_access_list_hash: Some(header_bal_hash),
+            ..Header::default()
+        };
+        let block = Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: Some(vec![].into()),
+            },
+        };
+        block.seal_slow()
+    }
+
+    #[test]
+    fn rejects_bad_bal_hash_up_front() {
+        // Check A: the received BAL's hash must match the header's commitment.
+        let executor = BalPayloadExecutor::new(Runtime::test(), EthEvmConfig::mainnet());
+        let snapshot = Arc::new(BlockPreState::default());
+        let received_bal: BlockAccessList = Vec::new();
+        let wrong_hash = B256::repeat_byte(0xff);
+        let block = empty_amsterdam_block(wrong_hash);
+
+        let result = executor.execute_block(
+            snapshot_db(snapshot),
+            to_arc_decoded(received_bal),
+            &block,
+            Vec::<Recovered<TransactionSigned>>::new(),
+            wrong_hash,
+            30_000_000,
+        );
+
+        match result {
+            Err(BalExecutionError::Reject(RejectReason::HeaderHashMismatch { .. })) => {}
+            Err(e) => panic!("expected HeaderHashMismatch, got error {e:?}"),
+            Ok(_) => panic!("expected HeaderHashMismatch, got Ok"),
+        }
+    }
+
+    #[test]
+    fn rejects_item_count_exceeding_gas_budget() {
+        // Check B: (addrs + unique_slots) * 2000 must be <= gas_limit.
+        use alloy_eip7928::AccountChanges;
+
+        let executor = BalPayloadExecutor::new(Runtime::test(), EthEvmConfig::mainnet());
+        let snapshot = Arc::new(BlockPreState::default());
+
+        // 10 accounts × 2000 gas = 20,000. We set the limit to 10,000 → reject.
+        let received_bal: BlockAccessList = (0u8..10)
+            .map(|i| {
+                let mut addr_bytes = [0u8; 20];
+                addr_bytes[19] = i;
+                AccountChanges { address: addr_bytes.into(), ..Default::default() }
+            })
+            .collect();
+
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&received_bal);
+        let block = empty_amsterdam_block(bal_hash);
+
+        let result = executor.execute_block(
+            snapshot_db(snapshot),
+            to_arc_decoded(received_bal),
+            &block,
+            Vec::<Recovered<TransactionSigned>>::new(),
+            bal_hash,
+            10_000,
+        );
+
+        match result {
+            Err(BalExecutionError::Reject(RejectReason::ItemCountExceedsGasBudget { .. })) => {}
+            Err(e) => panic!("expected ItemCountExceedsGasBudget, got error {e:?}"),
+            Ok(_) => panic!("expected ItemCountExceedsGasBudget, got Ok"),
+        }
+    }
+
+    /// Runs only the canonical phases (pre-exec → post-exec, no txs) against a fresh
+    /// `system_contracts_db()` to compute the composed BAL a block produces. Used to build
+    /// the "reference" received BAL for the happy-path test below.
+    ///
+    /// This intentionally mirrors what `BalPayloadExecutor::execute_block` does internally,
+    /// but without any hash check — the output is the BAL itself, not a pass/fail signal.
+    fn reference_bal_for_empty_block(evm_config: &EthEvmConfig) -> BlockAccessList {
+        use revm::database::State as RevmState;
+
+        let db = system_contracts_db();
+        let mut state =
+            RevmState::builder().with_database(db).with_bundle_update().with_bal_builder().build();
+
+        // Any header_bal_hash on the reference block is fine — we don't check it here.
+        let block = empty_amsterdam_block(B256::ZERO);
+        {
+            let mut executor =
+                evm_config.executor_for_block(&mut state, &block).expect("build executor");
+            executor.apply_pre_execution_changes().expect("pre-exec");
+            executor.evm_mut().db_mut().bump_bal_index();
+            executor.apply_post_execution_changes().expect("post-exec");
+        }
+        state.take_built_alloy_bal().expect("with_bal_builder was set")
+    }
+
+    #[test]
+    fn empty_block_happy_path_round_trip() {
+        // Two-pass end-to-end:
+        //   1. Build the canonical BAL an empty Amsterdam block produces (via
+        //      `reference_bal_for_empty_block`).
+        //   2. Hash it, stamp the header, and run `BalPayloadExecutor::execute_block` with that
+        //      BAL. Every check must pass (A, B, D, F).
+        let evm_config = EthEvmConfig::mainnet();
+
+        let received_bal = reference_bal_for_empty_block(&evm_config);
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&received_bal);
+        // Sanity: reference BAL is non-empty (system calls populated it).
+        assert!(!received_bal.is_empty(), "empty BAL means system calls didn't record state");
+
+        let executor = BalPayloadExecutor::new(Runtime::test(), evm_config);
+        let block = empty_amsterdam_block(bal_hash);
+        let snapshot = snapshot_for_bal(system_contracts_db(), &received_bal, block.number);
+
+        let result = executor.execute_block(
+            snapshot_db(snapshot),
+            to_arc_decoded(received_bal),
+            &block,
+            Vec::<Recovered<TransactionSigned>>::new(),
+            bal_hash,
+            30_000_000,
+        );
+
+        match result {
+            Ok(output) => {
+                assert!(output.receipts.is_empty(), "empty block → no receipts");
+            }
+            Err(e) => panic!("expected success, got {e:?}"),
+        }
+    }
+
+    /// Inserts `AccountInfo { nonce: 0, balance }` for `addr` into the canonical DB.
+    fn insert_funded(db: &mut CacheDB<EmptyDB>, addr: alloy_primitives::Address, balance: U256) {
+        db.insert_account_info(
+            addr,
+            AccountInfo { nonce: 0, balance, code_hash: B256::ZERO, code: None, account_id: None },
+        );
+    }
+
+    /// Builds the BAL snapshot from the declared access list and a fresh pre-block DB.
+    fn snapshot_for_bal(
+        mut db: CacheDB<EmptyDB>,
+        bal: &BlockAccessList,
+        block_number: u64,
+    ) -> Arc<BlockPreState> {
+        let reads = RequiredReads::from_bal(bal);
+        let mut pre = BlockPreState::default();
+
+        // Empty-code lookups are legitimate and should resolve deterministically.
+        pre.code.insert(KECCAK_EMPTY, None);
+
+        for address in reads.addresses {
+            let account = db.basic(address).expect("snapshot account read succeeds");
+            pre.accounts.insert(
+                address,
+                account.as_ref().map(|info| reth_primitives_traits::Account {
+                    balance: info.balance,
+                    nonce: info.nonce,
+                    bytecode_hash: (info.code_hash != KECCAK_EMPTY).then_some(info.code_hash),
+                }),
+            );
+
+            if let Some(info) = account &&
+                info.code_hash != KECCAK_EMPTY
+            {
+                let code = info
+                    .code
+                    .unwrap_or_else(|| db.code_by_hash(info.code_hash).expect("snapshot code"));
+                pre.code.insert(info.code_hash, Some(reth_primitives_traits::Bytecode(code)));
+            }
+        }
+
+        for (address, slot) in reads.storage {
+            let value = db
+                .storage(address, U256::from_be_bytes(slot.0))
+                .expect("snapshot storage read succeeds");
+            pre.storage.insert((address, slot), value);
+        }
+
+        let start = block_number.saturating_sub(256);
+        for number in start..block_number {
+            let hash = db.block_hash(number).expect("snapshot block hash read succeeds");
+            pre.block_hashes.insert(number, hash);
+        }
+
+        Arc::new(pre)
+    }
+
+    fn snapshot_db(
+        snapshot: Arc<BlockPreState>,
+    ) -> impl Fn() -> Result<SnapshotDatabase, BalExecutionError> + Sync {
+        move || Ok(SnapshotDatabase::new(Arc::clone(&snapshot)))
+    }
+
+    /// Runs the canonical path on a block with real txs (no hash check) and returns the
+    /// composed BAL. Used to build the reference BAL for happy-path multi-tx tests.
+    fn reference_bal_for_block<Tx>(
+        evm_config: &EthEvmConfig,
+        mut db: CacheDB<EmptyDB>,
+        block: &SealedBlock<Block>,
+        txs: Vec<Tx>,
+    ) -> BlockAccessList
+    where
+        Tx: ExecutableTxFor<EthEvmConfig>,
+    {
+        use revm::database::State as RevmState;
+
+        let mut state = RevmState::builder()
+            .with_database(&mut db)
+            .with_bundle_update()
+            .with_bal_builder()
+            .build();
+
+        {
+            let mut executor =
+                evm_config.executor_for_block(&mut state, block).expect("build executor");
+            executor.apply_pre_execution_changes().expect("pre-exec");
+            for (i, tx) in txs.into_iter().enumerate() {
+                executor.evm_mut().db_mut().bump_bal_index();
+                executor
+                    .execute_transaction(tx)
+                    .unwrap_or_else(|e| panic!("tx {i} failed during reference build: {e:?}"));
+            }
+            executor.evm_mut().db_mut().bump_bal_index();
+            executor.apply_post_execution_changes().expect("post-exec");
+        }
+        state.take_built_alloy_bal().expect("with_bal_builder was set")
+    }
+
+    #[test]
+    fn multi_tx_happy_path_round_trip() {
+        // End-to-end with two value transfers from distinct senders to the same recipient.
+        //
+        // 1. Fund alice and bob in a fresh canonical DB + snapshot.
+        // 2. Sign tx1 (alice → carol, 100 wei) and tx2 (bob → carol, 200 wei).
+        // 3. Build the reference BAL by running the block through a canonical executor with
+        //    `with_bal_builder`.
+        // 4. Feed that BAL into `BalPayloadExecutor::execute_block` and assert 2 receipts + no
+        //    rejections.
+        use alloy_consensus::TxLegacy;
+        use alloy_primitives::TxKind;
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+
+        let evm_config = EthEvmConfig::mainnet();
+        let carol: alloy_primitives::Address = alloy_primitives::Address::from([0xCA; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+
+        // Generate keypairs + derive sender addresses.
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+        let bob_kp = generate_key(&mut rng());
+        let bob = public_key_to_address(bob_kp.public_key());
+
+        // Pre-block DB: system contracts + funded senders.
+        let mut pre_block_db = system_contracts_db();
+        insert_funded(&mut pre_block_db, alice, sender_balance);
+        insert_funded(&mut pre_block_db, bob, sender_balance);
+
+        // Sign txs.
+        let chain_id = MAINNET.chain.id();
+        let gas_price = 1u128; // flat low price; block has no base fee in our test header.
+        let tx1 = sign_tx_with_key_pair(
+            alice_kp,
+            Transaction::Legacy(TxLegacy {
+                chain_id: Some(chain_id),
+                nonce: 0,
+                gas_price,
+                gas_limit: 21_000,
+                to: TxKind::Call(carol),
+                value: U256::from(100u64),
+                input: Default::default(),
+            }),
+        );
+        let tx2 = sign_tx_with_key_pair(
+            bob_kp,
+            Transaction::Legacy(TxLegacy {
+                chain_id: Some(chain_id),
+                nonce: 0,
+                gas_price,
+                gas_limit: 21_000,
+                to: TxKind::Call(carol),
+                value: U256::from(200u64),
+                input: Default::default(),
+            }),
+        );
+        let recovered1 = Recovered::new_unchecked(tx1, alice);
+        let recovered2 = Recovered::new_unchecked(tx2, bob);
+
+        // Reference BAL: run the block canonically through a separate executor.
+        let block_for_ref = empty_amsterdam_block(B256::ZERO);
+        let reference_bal = reference_bal_for_block::<Recovered<TransactionSigned>>(
+            &evm_config,
+            {
+                // Separate fresh DB for the reference run so we don't pollute canonical_db.
+                let mut db = system_contracts_db();
+                db.insert_account_info(
+                    alice,
+                    AccountInfo {
+                        nonce: 0,
+                        balance: sender_balance,
+                        code_hash: B256::ZERO,
+                        code: None,
+                        account_id: None,
+                    },
+                );
+                db.insert_account_info(
+                    bob,
+                    AccountInfo {
+                        nonce: 0,
+                        balance: sender_balance,
+                        code_hash: B256::ZERO,
+                        code: None,
+                        account_id: None,
+                    },
+                );
+                db
+            },
+            &block_for_ref,
+            vec![recovered1.clone(), recovered2.clone()],
+        );
+        assert!(!reference_bal.is_empty(), "expected BAL entries from pre-exec + txs");
+
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let block = empty_amsterdam_block(bal_hash);
+        let snapshot = snapshot_for_bal(pre_block_db.clone(), &reference_bal, block.number);
+
+        let executor = BalPayloadExecutor::new(Runtime::test(), evm_config);
+        let result = executor.execute_block(
+            snapshot_db(snapshot),
+            to_arc_decoded(reference_bal),
+            &block,
+            vec![recovered1, recovered2],
+            bal_hash,
+            30_000_000,
+        );
+
+        match result {
+            Ok(output) => {
+                assert_eq!(output.receipts.len(), 2, "expected 2 receipts");
+                assert!(output.gas_used >= 2 * 21_000, "expected at least 42k gas used");
+            }
+            Err(e) => panic!("expected success, got {e:?}"),
+        }
+    }
+
+    // ============================================================================
+    // Shadow-mode harness — runs a block through the serial `BasicBlockExecutor`
+    // and the BAL-path `BalPayloadExecutor`, asserts byte-equal outputs.
+    // ============================================================================
+
+    /// Output of one path in a shadow run. Both serial and BAL paths produce this shape so
+    /// the harness can compare field-by-field.
+    #[derive(Debug)]
+    struct ShadowOutput {
+        bundle_state: BundleState,
+        receipts: Vec<reth_ethereum_primitives::Receipt>,
+        gas_used: u64,
+        requests: alloy_eips::eip7685::Requests,
+    }
+
+    /// Runs the block through the serial path and captures its full output.
+    ///
+    /// Uses a manual state + executor (not `BasicBlockExecutor::execute_one`) so we can both
+    /// (a) capture the composed BAL for the BAL-path input and (b) pull the bundle out after.
+    fn run_serial_path(
+        evm_config: &EthEvmConfig,
+        canonical_db: CacheDB<EmptyDB>,
+        block: &SealedBlock<Block>,
+        txs: &[Recovered<TransactionSigned>],
+    ) -> (ShadowOutput, BlockAccessList) {
+        use revm::database::State as RevmState;
+
+        let mut state = RevmState::builder()
+            .with_database(canonical_db)
+            .with_bundle_update()
+            .with_bal_builder()
+            .build();
+
+        let block_result = {
+            let mut executor =
+                evm_config.executor_for_block(&mut state, block).expect("build serial executor");
+            executor.apply_pre_execution_changes().expect("serial pre-exec");
+            for (i, tx) in txs.iter().cloned().enumerate() {
+                executor.evm_mut().db_mut().bump_bal_index();
+                executor
+                    .execute_transaction(tx)
+                    .unwrap_or_else(|e| panic!("serial tx {i} failed: {e:?}"));
+            }
+            executor.evm_mut().db_mut().bump_bal_index();
+            executor.apply_post_execution_changes().expect("serial post-exec")
+        };
+
+        let bal = state.take_built_alloy_bal().expect("with_bal_builder was set");
+        state.merge_transitions(BundleRetention::Reverts);
+        let bundle_state = state.take_bundle();
+
+        (
+            ShadowOutput {
+                bundle_state,
+                receipts: block_result.receipts,
+                gas_used: block_result.gas_used,
+                requests: block_result.requests,
+            },
+            bal,
+        )
+    }
+
+    /// Shadow harness. Runs the block through both paths; asserts byte-equal outputs.
+    fn assert_shadow_equal(
+        evm_config: EthEvmConfig,
+        canonical_db_template: CacheDB<EmptyDB>,
+        block_header_only: SealedBlock<Block>,
+        txs: Vec<Recovered<TransactionSigned>>,
+        gas_limit: u64,
+    ) {
+        // Serial run: also produces the reference BAL we'll feed to the BAL path.
+        let (serial, reference_bal) =
+            run_serial_path(&evm_config, canonical_db_template.clone(), &block_header_only, &txs);
+
+        // BAL path: stamp the hash of the reference BAL onto the header.
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let block = empty_amsterdam_block(bal_hash); // same shape, updated hash
+        let snapshot = snapshot_for_bal(canonical_db_template, &reference_bal, block.number);
+
+        let executor = BalPayloadExecutor::new(Runtime::test(), evm_config);
+        let bal_out = executor
+            .execute_block(
+                snapshot_db(snapshot),
+                to_arc_decoded(reference_bal),
+                &block,
+                txs,
+                bal_hash,
+                gas_limit,
+            )
+            .unwrap_or_else(|e| panic!("BAL path failed: {e:?}"));
+
+        // Byte-equal assertions. Any divergence surfaces the specific field that broke.
+        assert_eq!(
+            serial.receipts, bal_out.receipts,
+            "receipts diverge between serial and BAL paths",
+        );
+        assert_eq!(
+            serial.gas_used, bal_out.gas_used,
+            "gas_used differs: serial {} vs bal {}",
+            serial.gas_used, bal_out.gas_used,
+        );
+        assert_eq!(
+            serial.requests, bal_out.requests,
+            "requests (EIP-7685) diverge between serial and BAL paths",
+        );
+        assert_eq!(
+            serial.bundle_state, bal_out.bundle_state,
+            "bundle_state diverges — the canonical state transitions don't match",
+        );
+    }
+
+    #[test]
+    fn shadow_empty_block() {
+        // System calls only — no txs. Both paths should produce identical system-call
+        // side effects in their BundleState (beacon roots storage, history storage, etc.).
+        assert_shadow_equal(
+            EthEvmConfig::mainnet(),
+            system_contracts_db(),
+            empty_amsterdam_block(B256::ZERO),
+            Vec::new(),
+            30_000_000,
+        );
+    }
+
+    #[test]
+    fn shadow_multi_value_transfer() {
+        // Two senders → same recipient. Byte-equal across paths means: worker-produced
+        // diffs commit identically to a directly-executed serial path.
+        use alloy_consensus::TxLegacy;
+        use alloy_primitives::TxKind;
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+
+        let evm_config = EthEvmConfig::mainnet();
+        let carol: alloy_primitives::Address = alloy_primitives::Address::from([0xCA; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+        let bob_kp = generate_key(&mut rng());
+        let bob = public_key_to_address(bob_kp.public_key());
+
+        let mut db = system_contracts_db();
+        insert_funded(&mut db, alice, sender_balance);
+        insert_funded(&mut db, bob, sender_balance);
+
+        let chain_id = MAINNET.chain.id();
+        let make_tx = |kp, to, value, nonce: u64| {
+            sign_tx_with_key_pair(
+                kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(chain_id),
+                    nonce,
+                    gas_price: 1,
+                    gas_limit: 21_000,
+                    to: TxKind::Call(to),
+                    value: U256::from(value),
+                    input: Default::default(),
+                }),
+            )
+        };
+        let tx1 = Recovered::new_unchecked(make_tx(alice_kp, carol, 100u64, 0), alice);
+        let tx2 = Recovered::new_unchecked(make_tx(bob_kp, carol, 200u64, 0), bob);
+
+        assert_shadow_equal(
+            evm_config,
+            db,
+            empty_amsterdam_block(B256::ZERO),
+            vec![tx1, tx2],
+            30_000_000,
+        );
+    }
+
+    #[test]
+    fn rejects_tx_gas_limit_that_exceeds_remaining_block_gas() {
+        // Each worker sees an empty block, so both transactions fit individually. The ordered
+        // commit loop must still reject tx2 because tx1's committed gas leaves too little
+        // block gas for tx2's gas limit.
+        use alloy_consensus::TxLegacy;
+        use alloy_evm::block::BlockValidationError;
+        use alloy_primitives::TxKind;
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+
+        let evm_config = EthEvmConfig::mainnet();
+        let carol: alloy_primitives::Address = alloy_primitives::Address::from([0xCA; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+        let block_gas_limit = 1_000_000;
+        let tx_gas_limit = 990_000;
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+        let bob_kp = generate_key(&mut rng());
+        let bob = public_key_to_address(bob_kp.public_key());
+
+        let mut pre_block_db = system_contracts_db();
+        insert_funded(&mut pre_block_db, alice, sender_balance);
+        insert_funded(&mut pre_block_db, bob, sender_balance);
+
+        let chain_id = MAINNET.chain.id();
+        let make_tx = |kp, value| {
+            sign_tx_with_key_pair(
+                kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(chain_id),
+                    nonce: 0,
+                    gas_price: 1,
+                    gas_limit: tx_gas_limit,
+                    to: TxKind::Call(carol),
+                    value: U256::from(value),
+                    input: Default::default(),
+                }),
+            )
+        };
+        let tx1 = Recovered::new_unchecked(make_tx(alice_kp, 100u64), alice);
+        let tx2 = Recovered::new_unchecked(make_tx(bob_kp, 200u64), bob);
+
+        // Build the reference BAL under a generous gas limit so both workers can execute.
+        // Replaying the same BAL under `block_gas_limit` below should reject in the ordered
+        // commit loop before tx2 is committed.
+        let reference_block = empty_amsterdam_block(B256::ZERO);
+        let reference_bal = reference_bal_for_block(
+            &evm_config,
+            pre_block_db.clone(),
+            &reference_block,
+            vec![tx1.clone(), tx2.clone()],
+        );
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let low_gas_block = empty_amsterdam_block_with_gas_limit(bal_hash, block_gas_limit);
+        let snapshot = snapshot_for_bal(pre_block_db, &reference_bal, low_gas_block.number);
+
+        let executor = BalPayloadExecutor::new(Runtime::test(), evm_config);
+        let result = executor.execute_block(
+            snapshot_db(snapshot),
+            to_arc_decoded(reference_bal),
+            &low_gas_block,
+            vec![tx1, tx2],
+            bal_hash,
+            block_gas_limit,
+        );
+
+        match result {
+            Err(BalExecutionError::Evm(err)) => assert!(matches!(
+                err.as_validation(),
+                Some(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. })
+            )),
+            Err(err) => panic!("expected block gas validation error, got {err:?}"),
+            Ok(_) => panic!("expected block gas validation error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn shadow_tx_with_revert() {
+        // A tx that reverts in a deployed contract. Both paths must produce identical receipts
+        // (success = false, gas charged, state rolled back except for gas payment + nonce bump).
+        //
+        // Deploys `0x60006000fd` (PUSH1 0 PUSH1 0 REVERT) at `revert_contract`. Sender calls
+        // it; the call reverts; fees + nonce still apply.
+        use alloy_consensus::TxLegacy;
+        use alloy_primitives::{Bytes, TxKind};
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+        use revm::primitives::keccak256;
+
+        let evm_config = EthEvmConfig::mainnet();
+        let revert_contract: alloy_primitives::Address =
+            alloy_primitives::Address::from([0xDE; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+
+        // Deploy the revert contract bytecode.
+        let revert_code: Bytes = Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xfd]);
+        let code_hash = keccak256(&revert_code);
+        let mut db = system_contracts_db();
+        insert_funded(&mut db, alice, sender_balance);
+        db.insert_account_info(
+            revert_contract,
+            AccountInfo {
+                nonce: 1,
+                balance: U256::ZERO,
+                code_hash,
+                code: Some(Bytecode::new_raw(revert_code)),
+                account_id: None,
+            },
+        );
+
+        let tx = Recovered::new_unchecked(
+            sign_tx_with_key_pair(
+                alice_kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(MAINNET.chain.id()),
+                    nonce: 0,
+                    gas_price: 1,
+                    gas_limit: 50_000,
+                    to: TxKind::Call(revert_contract),
+                    value: U256::ZERO,
+                    input: Default::default(),
+                }),
+            ),
+            alice,
+        );
+
+        assert_shadow_equal(
+            evm_config,
+            db,
+            empty_amsterdam_block(B256::ZERO),
+            vec![tx],
+            30_000_000,
+        );
+    }
+
+    #[test]
+    fn shadow_tx_with_sstore() {
+        // Tx calls a deployed contract that does `SSTORE(0, 0x42)`. The storage write must
+        // commit identically across serial and BAL paths — this is the first scenario that
+        // exercises a real storage diff, validating that our account-only pre-load path
+        // (`load_cache_account` in execute_block) is sufficient even when commits include
+        // storage writes.
+        //
+        // Bytecode: PUSH1 0x42, PUSH1 0x00, SSTORE, STOP → `0x60 0x42 0x60 0x00 0x55 0x00`.
+        use alloy_consensus::TxLegacy;
+        use alloy_primitives::{Bytes, TxKind};
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+        use revm::primitives::keccak256;
+
+        let evm_config = EthEvmConfig::mainnet();
+        let sstore_contract: alloy_primitives::Address =
+            alloy_primitives::Address::from([0x55; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+
+        // Deploy the SSTORE contract.
+        let sstore_code: Bytes = Bytes::from_static(&[0x60, 0x42, 0x60, 0x00, 0x55, 0x00]);
+        let code_hash = keccak256(&sstore_code);
+        let mut db = system_contracts_db();
+        insert_funded(&mut db, alice, sender_balance);
+        db.insert_account_info(
+            sstore_contract,
+            AccountInfo {
+                nonce: 1,
+                balance: U256::ZERO,
+                code_hash,
+                code: Some(Bytecode::new_raw(sstore_code)),
+                account_id: None,
+            },
+        );
+
+        let tx = Recovered::new_unchecked(
+            sign_tx_with_key_pair(
+                alice_kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(MAINNET.chain.id()),
+                    nonce: 0,
+                    gas_price: 1,
+                    gas_limit: 100_000,
+                    to: TxKind::Call(sstore_contract),
+                    value: U256::ZERO,
+                    input: Default::default(),
+                }),
+            ),
+            alice,
+        );
+
+        assert_shadow_equal(
+            evm_config,
+            db,
+            empty_amsterdam_block(B256::ZERO),
+            vec![tx],
+            30_000_000,
+        );
+    }
+
+    #[test]
+    fn empty_snapshot_db_fails_before_final_hash() {
+        // Test harnesses can still supply a strict snapshot DB. With an empty snapshot,
+        // pre-execution system calls fail on their first missing read instead of reaching
+        // the final rebuilt-BAL hash comparison.
+        let executor = BalPayloadExecutor::new(Runtime::test(), EthEvmConfig::mainnet());
+        let snapshot = Arc::new(BlockPreState::default());
+        let received_bal: BlockAccessList = Vec::new();
+        let empty_bal_hash = alloy_eip7928::compute_block_access_list_hash(&received_bal);
+        let block = empty_amsterdam_block(empty_bal_hash);
+
+        let result = executor.execute_block(
+            snapshot_db(snapshot),
+            to_arc_decoded(received_bal),
+            &block,
+            Vec::<Recovered<TransactionSigned>>::new(),
+            empty_bal_hash,
+            30_000_000,
+        );
+
+        match result {
+            Err(BalExecutionError::Evm(_)) => {}
+            Err(e) => panic!("expected strict DB execution failure, got error {e:?}"),
+            Ok(_) => panic!("expected strict DB execution failure, got Ok"),
+        }
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -1,0 +1,41 @@
+//! BAL-driven parallel block execution.
+//!
+//! An alternative to the serial `execute_block` path, activated when a block carries a
+//! Block-Level Access List (EIP-7928). The BAL declares every storage slot, account field, and
+//! code access a block makes, which lets us:
+//!
+//! - Execute transactions in parallel on isolated EVM instances, each using the BAL to resolve
+//!   mid-block state lookups via revm's BAL state.
+//! - Commit worker outputs to a canonical `BlockExecutor` in tx order, preserving client-override
+//!   extension points (`apply_pre_execution_changes`, `commit_transaction`,
+//!   `apply_post_execution_changes`).
+//! - Feed sparse-trie state-root work from the BAL through the payload prewarm task.
+//!
+//! See `BAL.md` at the repo root for the full design.
+//!
+//! The core BAL executor and its validation/state-root helpers live here. Engine-thread
+//! integration remains gated elsewhere.
+
+pub mod error;
+pub mod execute;
+#[cfg(test)]
+pub mod pre_state;
+#[cfg(test)]
+pub mod snapshot;
+#[cfg(test)]
+pub mod snapshot_db;
+pub mod validation;
+#[cfg(test)]
+pub mod worker;
+
+pub use error::RejectReason;
+pub use execute::{BalExecutionError, BalExecutionOutput, BalPayloadExecutor, ReceiptFor};
+#[cfg(test)]
+pub use pre_state::{BlockPreState, RequiredReads};
+#[cfg(test)]
+pub use snapshot::build_pre_state;
+#[cfg(test)]
+pub use snapshot_db::{SnapshotDatabase, SnapshotDbError};
+pub use validation::{check_bal_hash, check_item_count, BAL_ITEM_COST};
+#[cfg(test)]
+pub use worker::{BalBlockExecutor, WorkerError};

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -36,6 +36,6 @@ pub use pre_state::{BlockPreState, RequiredReads};
 pub use snapshot::build_pre_state;
 #[cfg(test)]
 pub use snapshot_db::{SnapshotDatabase, SnapshotDbError};
-pub use validation::{check_bal_hash, check_item_count, BAL_ITEM_COST};
+pub use validation::{check_bal_hash, check_item_count};
 #[cfg(test)]
 pub use worker::{BalBlockExecutor, WorkerError};

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -36,6 +36,6 @@ pub use pre_state::{BlockPreState, RequiredReads};
 pub use snapshot::build_pre_state;
 #[cfg(test)]
 pub use snapshot_db::{SnapshotDatabase, SnapshotDbError};
-pub use validation::{check_bal_hash, check_item_count};
+pub use validation::check_item_count;
 #[cfg(test)]
 pub use worker::{BalBlockExecutor, WorkerError};

--- a/crates/engine/tree/src/tree/payload_processor/bal/pre_state.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/pre_state.rs
@@ -6,9 +6,11 @@
 
 use alloc::collections::BTreeSet;
 use alloy_eip7928::AccountChanges;
-use alloy_primitives::{map::B256HashMap, Address, StorageKey, StorageValue, B256, U256};
+use alloy_primitives::{
+    map::{AddressHashMap, B256HashMap, HashMap},
+    Address, StorageKey, StorageValue, B256, U256,
+};
 use reth_primitives_traits::{Account, Bytecode};
-use std::collections::HashMap;
 
 /// Immutable pre-block state materialized in memory for every key the block reads.
 ///
@@ -20,7 +22,7 @@ use std::collections::HashMap;
 #[derive(Debug, Default, Clone)]
 pub struct BlockPreState {
     /// Pre-block account state. `None` means the account did not exist pre-block.
-    pub accounts: HashMap<Address, Option<Account>>,
+    pub accounts: AddressHashMap<Option<Account>>,
 
     /// Pre-block storage values. Missing entries are treated as zero at lookup time only if the
     /// miss is legitimate; a miss while executing always indicates an undeclared access.

--- a/crates/engine/tree/src/tree/payload_processor/bal/pre_state.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/pre_state.rs
@@ -1,0 +1,227 @@
+//! In-memory pre-block state snapshot consumed by BAL workers.
+//!
+//! Workers run their EVMs against an immutable `Arc<BlockPreState>` rather than a live
+//! `StateProvider`. The snapshot is built once per block from the BAL's declared access set;
+//! every read a worker can legitimately perform is satisfied from it.
+
+use alloc::collections::BTreeSet;
+use alloy_eip7928::AccountChanges;
+use alloy_primitives::{map::B256HashMap, Address, StorageKey, StorageValue, B256, U256};
+use reth_primitives_traits::{Account, Bytecode};
+use std::collections::HashMap;
+
+/// Immutable pre-block state materialized in memory for every key the block reads.
+///
+/// Populated once per block by the snapshot-build phase (consulting the cross-block execution
+/// cache with fallback to the state provider). Shared across workers as `Arc<BlockPreState>`.
+///
+/// Storage keys are `(Address, StorageKey)`-indexed. Code is keyed by `code_hash`, populated
+/// after accounts are resolved (since `code_hash` comes from the basic account).
+#[derive(Debug, Default, Clone)]
+pub struct BlockPreState {
+    /// Pre-block account state. `None` means the account did not exist pre-block.
+    pub accounts: HashMap<Address, Option<Account>>,
+
+    /// Pre-block storage values. Missing entries are treated as zero at lookup time only if the
+    /// miss is legitimate; a miss while executing always indicates an undeclared access.
+    pub storage: HashMap<(Address, StorageKey), StorageValue>,
+
+    /// Pre-block code, keyed by `code_hash`. `None` denotes "no code" (EOA / empty account).
+    pub code: B256HashMap<Option<Bytecode>>,
+
+    /// Recent block hashes available via the `BLOCKHASH` opcode. Derived from headers, not BAL.
+    pub block_hashes: HashMap<u64, B256>,
+}
+
+impl BlockPreState {
+    /// Returns pre-block account data for `address`, or `None` if the address was not declared
+    /// in the BAL used to seed this snapshot.
+    #[inline]
+    pub fn account(&self, address: &Address) -> Option<&Option<Account>> {
+        self.accounts.get(address)
+    }
+
+    /// Returns pre-block storage value for `(address, slot)`, or `None` if not declared.
+    #[inline]
+    pub fn storage_value(&self, address: &Address, slot: &StorageKey) -> Option<StorageValue> {
+        self.storage.get(&(*address, *slot)).copied()
+    }
+
+    /// Returns pre-block code for `code_hash`, or `None` if not present.
+    #[inline]
+    pub fn code(&self, code_hash: &B256) -> Option<&Option<Bytecode>> {
+        self.code.get(code_hash)
+    }
+}
+
+/// The exhaustive set of pre-block keys the snapshot must materialize, derived from a BAL.
+///
+/// Fetching is two-phase because code lookups are keyed by `code_hash`, which comes from the
+/// basic account. Callers first fill `accounts` and `storage` in parallel, then use the resolved
+/// accounts to populate the set of `code_hashes` to fetch.
+///
+/// `block_hashes` are independent of BAL and populated directly from recent headers.
+#[derive(Debug, Default, Clone)]
+pub struct RequiredReads {
+    /// Addresses needing a basic-account fetch. Every address in the BAL appears here.
+    pub addresses: BTreeSet<Address>,
+
+    /// Storage slots needing a pre-block value fetch: the union of `storage_reads` and
+    /// `storage_changes` slots, per EIP-7928 (disjoint per account), across all BAL accounts.
+    pub storage: BTreeSet<(Address, StorageKey)>,
+}
+
+impl RequiredReads {
+    /// Derives the required-reads set from a BAL.
+    ///
+    /// Addresses and storage slots are collected into `BTreeSet`s for deterministic iteration
+    /// order (useful for reproducible tests and ordered parallel fill).
+    pub fn from_bal<'a, I>(bal: I) -> Self
+    where
+        I: IntoIterator<Item = &'a AccountChanges>,
+    {
+        let mut addresses = BTreeSet::new();
+        let mut storage = BTreeSet::new();
+
+        for account_changes in bal {
+            let address = account_changes.address;
+            addresses.insert(address);
+
+            for slot_changes in &account_changes.storage_changes {
+                storage.insert((address, storage_key_from_u256(slot_changes.slot)));
+            }
+            for slot in &account_changes.storage_reads {
+                storage.insert((address, storage_key_from_u256(*slot)));
+            }
+        }
+
+        Self { addresses, storage }
+    }
+}
+
+/// Converts a BAL `U256` slot identifier to the reth `StorageKey` (`B256`) representation.
+#[inline]
+fn storage_key_from_u256(slot: U256) -> StorageKey {
+    B256::from(slot.to_be_bytes::<32>())
+}
+
+// Import vec/alloc for no_std compatibility in tests below.
+extern crate alloc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eip7928::{BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange};
+    use alloy_primitives::{address, b256, Bytes, U256};
+
+    fn addr(byte: u8) -> Address {
+        let mut a = [0u8; 20];
+        a[19] = byte;
+        Address::from(a)
+    }
+
+    fn slot(byte: u8) -> U256 {
+        U256::from(byte)
+    }
+
+    #[test]
+    fn required_reads_collects_unique_addresses() {
+        let bal = vec![
+            AccountChanges::new(addr(1)),
+            AccountChanges::new(addr(2)),
+            AccountChanges::new(addr(1)),
+        ];
+
+        let reads = RequiredReads::from_bal(&bal);
+
+        assert_eq!(reads.addresses.len(), 2);
+        assert!(reads.addresses.contains(&addr(1)));
+        assert!(reads.addresses.contains(&addr(2)));
+    }
+
+    #[test]
+    fn required_reads_unions_storage_reads_and_writes() {
+        let account = AccountChanges::new(addr(1))
+            .with_storage_read(slot(10))
+            .with_storage_read(slot(11))
+            .with_storage_change(SlotChanges::new(
+                slot(20),
+                vec![StorageChange::new(1, U256::from(42))],
+            ))
+            .with_storage_change(SlotChanges::new(
+                slot(21),
+                vec![StorageChange::new(2, U256::from(43))],
+            ));
+
+        let reads = RequiredReads::from_bal(&[account]);
+
+        assert_eq!(reads.storage.len(), 4);
+        assert!(reads.storage.contains(&(addr(1), storage_key_from_u256(slot(10)))));
+        assert!(reads.storage.contains(&(addr(1), storage_key_from_u256(slot(20)))));
+    }
+
+    #[test]
+    fn required_reads_ignores_non_storage_changes() {
+        // Balance/nonce/code changes don't contribute to the required-reads storage set.
+        // They contribute only by virtue of their address appearing in `addresses`.
+        let account = AccountChanges::new(addr(1))
+            .with_balance_change(BalanceChange::new(1, U256::from(100)))
+            .with_nonce_change(NonceChange::new(1, 7))
+            .with_code_change(CodeChange::new(1, Bytes::from_static(&[0x00])));
+
+        let reads = RequiredReads::from_bal(&[account]);
+
+        assert_eq!(reads.addresses.len(), 1);
+        assert!(reads.storage.is_empty());
+    }
+
+    #[test]
+    fn required_reads_empty_bal() {
+        let reads = RequiredReads::from_bal(std::iter::empty::<&AccountChanges>());
+
+        assert!(reads.addresses.is_empty());
+        assert!(reads.storage.is_empty());
+    }
+
+    #[test]
+    fn required_reads_multi_account_storage() {
+        let bal = vec![
+            AccountChanges::new(addr(1)).with_storage_read(slot(10)),
+            AccountChanges::new(addr(2)).with_storage_read(slot(10)),
+        ];
+
+        let reads = RequiredReads::from_bal(&bal);
+
+        // Same slot for different addresses: both must appear.
+        assert_eq!(reads.storage.len(), 2);
+        assert!(reads.storage.contains(&(addr(1), storage_key_from_u256(slot(10)))));
+        assert!(reads.storage.contains(&(addr(2), storage_key_from_u256(slot(10)))));
+    }
+
+    #[test]
+    fn storage_key_conversion_is_big_endian() {
+        let s = slot(1);
+        let k = storage_key_from_u256(s);
+        assert_eq!(k, b256!("0x0000000000000000000000000000000000000000000000000000000000000001"));
+    }
+
+    #[test]
+    fn block_pre_state_lookups() {
+        let mut pre = BlockPreState::default();
+        pre.accounts.insert(
+            addr(1),
+            Some(Account { balance: U256::from(100), nonce: 1, bytecode_hash: None }),
+        );
+        pre.accounts.insert(addr(2), None);
+        pre.storage.insert((addr(1), storage_key_from_u256(slot(10))), U256::from(42));
+
+        assert!(pre.account(&addr(1)).and_then(|a| a.as_ref()).is_some());
+        assert!(pre.account(&addr(2)).is_some_and(|a| a.is_none()));
+        assert!(pre.account(&address!("0x0000000000000000000000000000000000000099")).is_none());
+        assert_eq!(
+            pre.storage_value(&addr(1), &storage_key_from_u256(slot(10))),
+            Some(U256::from(42))
+        );
+        assert_eq!(pre.storage_value(&addr(1), &storage_key_from_u256(slot(11))), None);
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/snapshot.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/snapshot.rs
@@ -1,0 +1,347 @@
+//! Parallel pre-block snapshot build.
+//!
+//! Populates a `BlockPreState` by fetching every key listed in `RequiredReads`, plus the
+//! recent-256 block hashes for `BLOCKHASH`. Reads route through a per-thread prewarming
+//! [`CachedStateProvider`], so cache misses are served from the underlying provider and written
+//! back in one pass — this is the sole cache-writer window per block (see `BAL.md`
+//! §`ExecutionCache` interactions).
+//!
+//! ### Per-thread provider construction
+//!
+//! `StateProviderBox` is `Box<dyn StateProvider + Send>` (no `Sync`), so it can't be Arc-shared
+//! across rayon workers. Instead we take a [`StateProviderBuilder`] (which IS `Send + Sync`
+//! through its Arc'd factory) and have each rayon worker lazily build its own
+//! `CachedStateProvider<StateProviderBox, true>` via [`rayon::iter::ParallelIterator::map_init`].
+//!
+//! A provider error in any phase aborts the whole build: a missing snapshot entry is
+//! unrecoverable here (workers would surface it as
+//! `BalError::AccountNotFound`).
+//!
+//! Structured in four phases:
+//! 1. 1a — parallel account fetch, 1b — parallel storage fetch (run concurrently).
+//! 2. Collect `code_hash` values from phase-1a output.
+//! 3. Parallel bytecode fetch keyed by `code_hash`.
+//! 4. Serial `canonical_hashes_range` for the `BLOCKHASH` window.
+
+use super::pre_state::{BlockPreState, RequiredReads};
+use crate::tree::{CachedStateMetrics, CachedStateProvider, SavedCache, StateProviderBuilder};
+use alloy_primitives::{
+    map::{B256HashMap, B256HashSet},
+    Address, BlockNumber, StorageKey, StorageValue, B256,
+};
+use rayon::prelude::*;
+use reth_errors::ProviderResult;
+use reth_primitives_traits::{Account, Bytecode, NodePrimitives};
+use reth_provider::{
+    AccountReader, BlockHashReader, BlockReader, BytecodeReader, StateProvider, StateProviderBox,
+    StateProviderFactory, StateReader,
+};
+use std::collections::HashMap;
+
+/// Size of the recent-block window exposed by the `BLOCKHASH` opcode.
+const BLOCK_HASH_WINDOW: u64 = 256;
+
+/// Per-thread prewarming-cached provider. Built lazily by each rayon worker on first use via
+/// `map_init`, then reused for every item that worker processes.
+type ThreadCachedProvider = CachedStateProvider<StateProviderBox, true>;
+
+/// Builds the pre-block snapshot in parallel.
+///
+/// `provider_builder` must produce a `Send`-able `StateProviderBox` per call to `.build()`. Each
+/// rayon worker calls it once and wraps the result in a thread-local prewarming
+/// `CachedStateProvider` so cache misses populate `saved_cache` for cross-block warmth.
+///
+/// Fails fast on the first [`reth_errors::ProviderError`]. The caller (engine tree) is
+/// responsible for ensuring the passed `saved_cache` is the exclusive cache handle for this
+/// block's execution (`BAL.md` §`ExecutionCache`: "snapshot build is the only writer to
+/// `ExecutionCache` during a block's execution").
+pub fn build_pre_state<N, P>(
+    provider_builder: StateProviderBuilder<N, P>,
+    saved_cache: SavedCache,
+    cache_metrics: CachedStateMetrics,
+    reads: &RequiredReads,
+    block_number: BlockNumber,
+) -> ProviderResult<BlockPreState>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+{
+    // Phases 1a + 1b: accounts and storage have no cross-dependency; run concurrently.
+    let (accounts_result, storage_result) = rayon::join(
+        || {
+            fetch_accounts(
+                &provider_builder,
+                &saved_cache,
+                &cache_metrics,
+                reads.addresses.iter().copied(),
+            )
+        },
+        || {
+            fetch_storage(
+                &provider_builder,
+                &saved_cache,
+                &cache_metrics,
+                reads.storage.iter().copied(),
+            )
+        },
+    );
+    let accounts = accounts_result?;
+    let storage = storage_result?;
+
+    // Phases 2 + 3: derive code_hashes from resolved accounts, then fetch bytecode in parallel.
+    let code = fetch_code(&provider_builder, &saved_cache, &cache_metrics, &accounts)?;
+
+    // Phase 4: BLOCKHASH window. Single provider on the calling thread — the slice is small
+    // (≤256 entries) and a single `canonical_hashes_range` call covers it.
+    let block_hashes = fetch_block_hashes(&provider_builder, block_number)?;
+
+    Ok(BlockPreState { accounts, storage, code, block_hashes })
+}
+
+/// Builds a fresh per-thread provider wrapped in the prewarming cache. Returns
+/// `ProviderResult` so an init failure on one thread propagates as the per-item error to every
+/// item that thread would have handled.
+fn init_thread_provider<N, P>(
+    builder: &StateProviderBuilder<N, P>,
+    saved_cache: &SavedCache,
+    cache_metrics: &CachedStateMetrics,
+) -> ProviderResult<ThreadCachedProvider>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+{
+    let built = builder.build()?;
+    Ok(CachedStateProvider::new_prewarm(built, saved_cache.cache().clone(), cache_metrics.clone()))
+}
+
+/// Parallel fetch of every declared address's basic account.
+pub(super) fn fetch_accounts<N, P>(
+    builder: &StateProviderBuilder<N, P>,
+    saved_cache: &SavedCache,
+    cache_metrics: &CachedStateMetrics,
+    addresses: impl IntoIterator<Item = Address>,
+) -> ProviderResult<HashMap<Address, Option<Account>>>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+{
+    let addrs: Vec<Address> = addresses.into_iter().collect();
+    addrs
+        .into_par_iter()
+        .map_init(
+            || init_thread_provider(builder, saved_cache, cache_metrics),
+            |provider_result, addr| {
+                let provider = provider_result.as_ref().map_err(Clone::clone)?;
+                provider.basic_account(&addr).map(|opt| (addr, opt))
+            },
+        )
+        .collect()
+}
+
+/// Parallel fetch of every `(address, slot)` pair's pre-block storage value. Missing entries
+/// (provider returns `Ok(None)`) are recorded as `StorageValue::ZERO`.
+pub(super) fn fetch_storage<N, P>(
+    builder: &StateProviderBuilder<N, P>,
+    saved_cache: &SavedCache,
+    cache_metrics: &CachedStateMetrics,
+    keys: impl IntoIterator<Item = (Address, StorageKey)>,
+) -> ProviderResult<HashMap<(Address, StorageKey), StorageValue>>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+{
+    let keys: Vec<(Address, StorageKey)> = keys.into_iter().collect();
+    keys.into_par_iter()
+        .map_init(
+            || init_thread_provider(builder, saved_cache, cache_metrics),
+            |provider_result, (addr, slot)| {
+                let provider = provider_result.as_ref().map_err(Clone::clone)?;
+                provider.storage(addr, slot).map(|opt| ((addr, slot), opt.unwrap_or_default()))
+            },
+        )
+        .collect()
+}
+
+/// Parallel fetch of every distinct bytecode referenced by the resolved accounts.
+pub(super) fn fetch_code<N, P>(
+    builder: &StateProviderBuilder<N, P>,
+    saved_cache: &SavedCache,
+    cache_metrics: &CachedStateMetrics,
+    accounts: &HashMap<Address, Option<Account>>,
+) -> ProviderResult<B256HashMap<Option<Bytecode>>>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+{
+    // Dedupe code hashes across accounts so we fetch each bytecode once even if multiple
+    // accounts share the same code (common for proxy / clone patterns).
+    let mut hashes = B256HashSet::with_capacity_and_hasher(accounts.len(), Default::default());
+    hashes.extend(accounts.values().filter_map(|opt| opt.as_ref().and_then(|a| a.bytecode_hash)));
+
+    let pairs: Vec<(B256, Option<Bytecode>)> = hashes
+        .into_par_iter()
+        .map_init(
+            || init_thread_provider(builder, saved_cache, cache_metrics),
+            |provider_result, hash| {
+                let provider = provider_result.as_ref().map_err(Clone::clone)?;
+                provider.bytecode_by_hash(&hash).map(|code| (hash, code))
+            },
+        )
+        .collect::<ProviderResult<_>>()?;
+
+    Ok(pairs.into_iter().collect())
+}
+
+/// Fetches `[block_number - 256, block_number)` canonical hashes on the main thread.
+///
+/// At genesis (`block_number < 256`) the window shrinks naturally via `saturating_sub`. Builds
+/// a single provider via `builder.build()` — no parallelism needed for ≤256 entries fetched in
+/// one `canonical_hashes_range` call.
+pub(super) fn fetch_block_hashes<N, P>(
+    builder: &StateProviderBuilder<N, P>,
+    block_number: BlockNumber,
+) -> ProviderResult<HashMap<u64, B256>>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+{
+    let provider = builder.build()?;
+    let start = block_number.saturating_sub(BLOCK_HASH_WINDOW);
+    let hashes = provider.canonical_hashes_range(start, block_number)?;
+    Ok(hashes.into_iter().enumerate().map(|(i, hash)| (start + i as u64, hash)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::ExecutionCache;
+    use alloy_primitives::{keccak256, Bytes, U256};
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use std::collections::BTreeSet;
+
+    fn addr(byte: u8) -> Address {
+        let mut a = [0u8; 20];
+        a[19] = byte;
+        Address::from(a)
+    }
+
+    fn slot_key(byte: u8) -> StorageKey {
+        let mut b = [0u8; 32];
+        b[31] = byte;
+        B256::from(b)
+    }
+
+    fn test_cache() -> (SavedCache, CachedStateMetrics) {
+        (SavedCache::new(B256::ZERO, ExecutionCache::new(1 << 20)), CachedStateMetrics::default())
+    }
+
+    /// Wraps a `MockEthProvider` in a `StateProviderBuilder` so the snapshot build can use
+    /// `.build()` per worker (see module-level docs on per-thread provider construction).
+    fn builder_for(
+        provider: MockEthProvider,
+    ) -> StateProviderBuilder<reth_ethereum_primitives::EthPrimitives, MockEthProvider> {
+        StateProviderBuilder::new(provider, B256::ZERO, None)
+    }
+
+    #[test]
+    fn happy_path_populates_all_maps() {
+        let tp: MockEthProvider = MockEthProvider::new();
+        let bytecode_bytes = Bytes::from_static(&[0x60, 0x00]);
+        let code_hash = keccak256(&bytecode_bytes);
+
+        tp.add_account(
+            addr(1),
+            ExtendedAccount::new(1, U256::from(100))
+                .with_bytecode(bytecode_bytes)
+                .extend_storage([(slot_key(10), U256::from(42))]),
+        );
+
+        let reads = RequiredReads {
+            addresses: BTreeSet::from([addr(1)]),
+            storage: BTreeSet::from([(addr(1), slot_key(10))]),
+        };
+
+        let (cache, metrics) = test_cache();
+        let pre =
+            build_pre_state(builder_for(tp), cache, metrics, &reads, 0).expect("build succeeds");
+
+        let acc = pre.accounts.get(&addr(1)).unwrap().as_ref().unwrap();
+        assert_eq!(acc.nonce, 1);
+        assert_eq!(acc.balance, U256::from(100));
+        assert_eq!(acc.bytecode_hash, Some(code_hash));
+        assert_eq!(pre.storage.get(&(addr(1), slot_key(10))).copied(), Some(U256::from(42)));
+        assert!(pre.code.contains_key(&code_hash));
+    }
+
+    #[test]
+    fn missing_account_produces_none_entry() {
+        let tp: MockEthProvider = MockEthProvider::new();
+        let reads = RequiredReads { addresses: BTreeSet::from([addr(99)]), ..Default::default() };
+        let (cache, metrics) = test_cache();
+        let pre = build_pre_state(builder_for(tp), cache, metrics, &reads, 0).unwrap();
+
+        // Present in map, but with a None value: "account doesn't exist pre-block".
+        assert_eq!(pre.accounts.get(&addr(99)), Some(&None));
+    }
+
+    #[test]
+    fn missing_storage_becomes_zero() {
+        let tp: MockEthProvider = MockEthProvider::new();
+        let reads = RequiredReads {
+            storage: BTreeSet::from([(addr(1), slot_key(10))]),
+            ..Default::default()
+        };
+        let (cache, metrics) = test_cache();
+        let pre = build_pre_state(builder_for(tp), cache, metrics, &reads, 0).unwrap();
+
+        assert_eq!(pre.storage.get(&(addr(1), slot_key(10))).copied(), Some(U256::ZERO));
+    }
+
+    #[test]
+    fn eoa_account_produces_no_code_entry() {
+        let tp: MockEthProvider = MockEthProvider::new();
+        tp.add_account(addr(1), ExtendedAccount::new(0, U256::from(1)));
+
+        let reads = RequiredReads { addresses: BTreeSet::from([addr(1)]), ..Default::default() };
+        let (cache, metrics) = test_cache();
+        let pre = build_pre_state(builder_for(tp), cache, metrics, &reads, 0).unwrap();
+
+        assert!(pre.code.is_empty());
+    }
+
+    #[test]
+    fn duplicate_code_hash_fetched_once() {
+        // Two accounts sharing bytecode → one code entry keyed by hash.
+        let tp: MockEthProvider = MockEthProvider::new();
+        let bytecode_bytes = Bytes::from_static(&[0xff]);
+        let code_hash = keccak256(&bytecode_bytes);
+
+        tp.add_account(
+            addr(1),
+            ExtendedAccount::new(0, U256::ZERO).with_bytecode(bytecode_bytes.clone()),
+        );
+        tp.add_account(addr(2), ExtendedAccount::new(0, U256::ZERO).with_bytecode(bytecode_bytes));
+
+        let reads =
+            RequiredReads { addresses: BTreeSet::from([addr(1), addr(2)]), ..Default::default() };
+        let (cache, metrics) = test_cache();
+        let pre = build_pre_state(builder_for(tp), cache, metrics, &reads, 0).unwrap();
+
+        assert_eq!(pre.code.len(), 1);
+        assert!(pre.code.contains_key(&code_hash));
+    }
+
+    #[test]
+    fn empty_reads_still_returns_ok() {
+        let tp: MockEthProvider = MockEthProvider::new();
+        let (cache, metrics) = test_cache();
+        let pre =
+            build_pre_state(builder_for(tp), cache, metrics, &RequiredReads::default(), 0).unwrap();
+
+        assert!(pre.accounts.is_empty());
+        assert!(pre.storage.is_empty());
+        assert!(pre.code.is_empty());
+        // block_hashes: MockEthProvider returns empty Vec for an uninitialized range — fine.
+        assert!(pre.block_hashes.is_empty());
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/snapshot.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/snapshot.rs
@@ -26,7 +26,7 @@
 use super::pre_state::{BlockPreState, RequiredReads};
 use crate::tree::{CachedStateMetrics, CachedStateProvider, SavedCache, StateProviderBuilder};
 use alloy_primitives::{
-    map::{B256HashMap, B256HashSet},
+    map::{AddressHashMap, B256HashMap, B256HashSet, HashMap},
     Address, BlockNumber, StorageKey, StorageValue, B256,
 };
 use rayon::prelude::*;
@@ -36,7 +36,6 @@ use reth_provider::{
     AccountReader, BlockHashReader, BlockReader, BytecodeReader, StateProvider, StateProviderBox,
     StateProviderFactory, StateReader,
 };
-use std::collections::HashMap;
 
 /// Size of the recent-block window exposed by the `BLOCKHASH` opcode.
 const BLOCK_HASH_WINDOW: u64 = 256;
@@ -120,7 +119,7 @@ pub(super) fn fetch_accounts<N, P>(
     saved_cache: &SavedCache,
     cache_metrics: &CachedStateMetrics,
     addresses: impl IntoIterator<Item = Address>,
-) -> ProviderResult<HashMap<Address, Option<Account>>>
+) -> ProviderResult<AddressHashMap<Option<Account>>>
 where
     N: NodePrimitives,
     P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
@@ -167,7 +166,7 @@ pub(super) fn fetch_code<N, P>(
     builder: &StateProviderBuilder<N, P>,
     saved_cache: &SavedCache,
     cache_metrics: &CachedStateMetrics,
-    accounts: &HashMap<Address, Option<Account>>,
+    accounts: &AddressHashMap<Option<Account>>,
 ) -> ProviderResult<B256HashMap<Option<Bytecode>>>
 where
     N: NodePrimitives,

--- a/crates/engine/tree/src/tree/payload_processor/bal/snapshot_db.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/snapshot_db.rs
@@ -1,0 +1,309 @@
+//! Revm [`Database`] adapter over an [`Arc<BlockPreState>`].
+//!
+//! `SnapshotDatabase` is the BAL path's pre-block read source. Workers layer revm's
+//! `BalDatabase` on top of it, while the canonical executor uses it directly. The worker read
+//! chain is:
+//!
+//! ```text
+//! EVM → State → BalDatabase(received_bal, fallback = SnapshotDatabase)
+//! ```
+//!
+//! `BalDatabase` resolves any slot/account the block legitimately touches — either from an
+//! earlier in-block write (`block_access_index < tx_i`) or by delegating to us for the
+//! pre-block value. Reads for keys not declared in the BAL short-circuit inside `BalDatabase`
+//! with `BalError::AccountNotFound` and never reach us.
+//!
+//! This means a miss here is always a snapshot-fill bug or an invalid BAL: the caller built a
+//! snapshot that didn't cover every key the block execution needs. We surface it as a
+//! [`SnapshotDbError`] rather than silently returning defaults.
+
+use super::pre_state::BlockPreState;
+use alloy_primitives::{Address, B256, U256};
+use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
+use revm_database_interface::DBErrorMarker;
+use std::sync::Arc;
+
+/// Revm `Database` / `DatabaseRef` impl backed by an immutable `BlockPreState` snapshot.
+#[derive(Debug, Clone)]
+pub struct SnapshotDatabase {
+    snapshot: Arc<BlockPreState>,
+}
+
+impl SnapshotDatabase {
+    /// Wraps a pre-built snapshot. Cheap; workers each hold their own `SnapshotDatabase` around
+    /// a clone of the `Arc`.
+    pub const fn new(snapshot: Arc<BlockPreState>) -> Self {
+        Self { snapshot }
+    }
+}
+
+impl Database for SnapshotDatabase {
+    type Error = SnapshotDbError;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.basic_ref(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.code_by_hash_ref(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.storage_ref(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.block_hash_ref(number)
+    }
+}
+
+impl DatabaseRef for SnapshotDatabase {
+    type Error = SnapshotDbError;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        match self.snapshot.accounts.get(&address) {
+            // Account existed pre-block. `Into::into` sets code=None so revm pulls bytecode
+            // lazily via code_by_hash_ref when it needs it.
+            Some(Some(account)) => Ok(Some((*account).into())),
+            // Negative entry: the BAL declared this address but it didn't exist pre-block (a
+            // CREATE target, or a touched-but-absent account). revm represents this as None.
+            Some(None) => Ok(None),
+            None => Err(SnapshotDbError::AccountMissing(address)),
+        }
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        match self.snapshot.code.get(&code_hash) {
+            // reth's Bytecode wraps revm's Bytecode in a newtype; .0 is the inner revm type.
+            Some(Some(bytecode)) => Ok(bytecode.0.clone()),
+            Some(None) => Ok(Bytecode::default()),
+            None => Err(SnapshotDbError::CodeMissing(code_hash)),
+        }
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let slot = B256::new(index.to_be_bytes());
+        self.snapshot
+            .storage
+            .get(&(address, slot))
+            .copied()
+            .ok_or(SnapshotDbError::StorageMissing { address, slot })
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.snapshot
+            .block_hashes
+            .get(&number)
+            .copied()
+            .ok_or(SnapshotDbError::BlockHashMissing(number))
+    }
+}
+
+/// Errors produced by [`SnapshotDatabase`].
+///
+/// Each variant means the snapshot was asked for a key it didn't contain. Since `BalDatabase`
+/// catches undeclared-access attempts upstream, every variant here indicates a snapshot-fill
+/// bug: the required-reads derivation missed a key the block legitimately needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnapshotDbError {
+    /// Basic-account lookup for an address the snapshot didn't materialize.
+    AccountMissing(Address),
+    /// Storage lookup for a `(address, slot)` pair the snapshot didn't materialize.
+    StorageMissing {
+        /// Address whose storage was queried.
+        address: Address,
+        /// 32-byte storage key the EVM asked for.
+        slot: B256,
+    },
+    /// Code lookup for a hash absent from the snapshot's code map.
+    CodeMissing(B256),
+    /// `BLOCKHASH` opcode read of a block number not covered by the snapshot's window.
+    BlockHashMissing(u64),
+}
+
+impl core::fmt::Display for SnapshotDbError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AccountMissing(addr) => {
+                write!(f, "account {addr} missing from BAL snapshot")
+            }
+            Self::StorageMissing { address, slot } => {
+                write!(f, "storage ({address}, {slot}) missing from BAL snapshot")
+            }
+            Self::CodeMissing(hash) => write!(f, "code {hash} missing from BAL snapshot"),
+            Self::BlockHashMissing(number) => {
+                write!(f, "block_hash {number} missing from BAL snapshot")
+            }
+        }
+    }
+}
+
+impl core::error::Error for SnapshotDbError {}
+
+impl DBErrorMarker for SnapshotDbError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::constants::KECCAK_EMPTY;
+    use alloy_primitives::{keccak256, Bytes, StorageKey};
+    use reth_primitives_traits::{Account, Bytecode as RethBytecode};
+
+    fn addr(byte: u8) -> Address {
+        let mut a = [0u8; 20];
+        a[19] = byte;
+        Address::from(a)
+    }
+
+    fn slot_key(byte: u8) -> StorageKey {
+        let mut b = [0u8; 32];
+        b[31] = byte;
+        B256::from(b)
+    }
+
+    fn snapshot_with<F: FnOnce(&mut BlockPreState)>(f: F) -> Arc<BlockPreState> {
+        let mut pre = BlockPreState::default();
+        f(&mut pre);
+        Arc::new(pre)
+    }
+
+    #[test]
+    fn basic_contract_account_returns_populated_info() {
+        let bytecode_bytes = Bytes::from_static(&[0x60, 0x00]);
+        let code_hash = keccak256(&bytecode_bytes);
+        let pre = snapshot_with(|p| {
+            p.accounts.insert(
+                addr(1),
+                Some(Account {
+                    balance: U256::from(123),
+                    nonce: 7,
+                    bytecode_hash: Some(code_hash),
+                }),
+            );
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        let info = db.basic(addr(1)).unwrap().expect("account present");
+        assert_eq!(info.balance, U256::from(123));
+        assert_eq!(info.nonce, 7);
+        assert_eq!(info.code_hash, code_hash);
+        // Bytecode is not eagerly loaded; revm fetches it lazily via code_by_hash.
+        assert!(info.code.is_none());
+    }
+
+    #[test]
+    fn basic_eoa_has_empty_code_hash() {
+        let pre = snapshot_with(|p| {
+            p.accounts.insert(
+                addr(1),
+                Some(Account { balance: U256::ZERO, nonce: 0, bytecode_hash: None }),
+            );
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        let info = db.basic(addr(1)).unwrap().expect("account present");
+        assert_eq!(info.code_hash, KECCAK_EMPTY);
+    }
+
+    #[test]
+    fn basic_negative_entry_is_ok_none() {
+        // BAL declared the address, but it didn't exist pre-block (e.g., CREATE target).
+        let pre = snapshot_with(|p| {
+            p.accounts.insert(addr(1), None);
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        assert_eq!(db.basic(addr(1)).unwrap(), None);
+    }
+
+    #[test]
+    fn basic_missing_is_error() {
+        let mut db = SnapshotDatabase::new(snapshot_with(|_| {}));
+        assert_eq!(db.basic(addr(1)).unwrap_err(), SnapshotDbError::AccountMissing(addr(1)));
+    }
+
+    #[test]
+    fn storage_hit() {
+        let pre = snapshot_with(|p| {
+            p.storage.insert((addr(1), slot_key(10)), U256::from(42));
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        assert_eq!(db.storage(addr(1), U256::from(10)).unwrap(), U256::from(42));
+    }
+
+    #[test]
+    fn storage_zero_entry_returns_zero_not_error() {
+        // A slot whose pre-block value is literally zero is a legitimate read; must not
+        // degrade to "missing".
+        let pre = snapshot_with(|p| {
+            p.storage.insert((addr(1), slot_key(10)), U256::ZERO);
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        assert_eq!(db.storage(addr(1), U256::from(10)).unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn storage_missing_populates_both_fields() {
+        let mut db = SnapshotDatabase::new(snapshot_with(|_| {}));
+        let err = db.storage(addr(1), U256::from(10)).unwrap_err();
+        assert_eq!(err, SnapshotDbError::StorageMissing { address: addr(1), slot: slot_key(10) });
+    }
+
+    #[test]
+    fn code_by_hash_hit() {
+        let bytecode_bytes = Bytes::from_static(&[0xfe, 0x01]);
+        let code_hash = keccak256(&bytecode_bytes);
+        let pre = snapshot_with(|p| {
+            p.code.insert(code_hash, Some(RethBytecode::new_raw(bytecode_bytes.clone())));
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        let got = db.code_by_hash(code_hash).unwrap();
+        assert_eq!(got.original_byte_slice(), &bytecode_bytes[..]);
+    }
+
+    #[test]
+    fn code_by_hash_empty_entry_is_default() {
+        // Account had bytecode_hash = KECCAK_EMPTY → snapshot stored Some(None) (empty code).
+        let pre = snapshot_with(|p| {
+            p.code.insert(KECCAK_EMPTY, None);
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        assert_eq!(db.code_by_hash(KECCAK_EMPTY).unwrap(), Bytecode::default());
+    }
+
+    #[test]
+    fn code_by_hash_missing_is_error() {
+        let hash = B256::repeat_byte(0xcc);
+        let mut db = SnapshotDatabase::new(snapshot_with(|_| {}));
+        assert_eq!(db.code_by_hash(hash).unwrap_err(), SnapshotDbError::CodeMissing(hash));
+    }
+
+    #[test]
+    fn block_hash_hit_and_miss() {
+        let pre = snapshot_with(|p| {
+            p.block_hashes.insert(5, B256::repeat_byte(0xaa));
+        });
+        let mut db = SnapshotDatabase::new(pre);
+
+        assert_eq!(db.block_hash(5).unwrap(), B256::repeat_byte(0xaa));
+        assert_eq!(db.block_hash(6).unwrap_err(), SnapshotDbError::BlockHashMissing(6));
+    }
+
+    #[test]
+    fn database_ref_impls_agree_with_database() {
+        // DatabaseRef methods share the same logic (Database forwards to them), but sanity
+        // check that &self access works without needing &mut.
+        let pre = snapshot_with(|p| {
+            p.accounts.insert(
+                addr(1),
+                Some(Account { balance: U256::from(1), nonce: 0, bytecode_hash: None }),
+            );
+        });
+        let db = SnapshotDatabase::new(pre);
+        assert!(db.basic_ref(addr(1)).unwrap().is_some());
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
@@ -1,26 +1,11 @@
-//! Structural BAL validation: the two cheapest checks in the validation chain.
+//! Structural BAL validation.
 //!
-//! Both run before any state I/O, letting us reject adversarial BALs without spending storage
-//! bandwidth. See `BAL.md` §Validation chain, checks A and B.
+//! These checks run before any state I/O, letting us reject adversarial BALs without spending
+//! storage bandwidth.
 
-use alloy_eip7928::{bal::DecodedBal, AccountChanges};
-use alloy_primitives::B256;
+use alloy_eip7928::AccountChanges;
 
 use super::RejectReason;
-
-/// Check A: `keccak256(raw_rlp_of_received_bal) == header.block_access_list_hash`.
-///
-/// Uses [`DecodedBal`]'s cached hash (`keccak256` of the raw RLP bytes captured at decode
-/// time) — the same pre-image the header commits to. Zero I/O; first call computes the hash,
-/// subsequent calls are free.
-pub fn check_bal_hash(bal: &DecodedBal, expected: B256) -> Result<(), RejectReason> {
-    let computed = bal.hash();
-    if computed == expected {
-        Ok(())
-    } else {
-        Err(RejectReason::HeaderHashMismatch { computed, expected })
-    }
-}
 
 /// Check B: `(addresses + unique_storage_keys) * ITEM_COST <= block_gas_limit`.
 ///
@@ -40,8 +25,8 @@ pub fn check_item_count(bal: &[AccountChanges], block_gas_limit: u64) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eip7928::{bal::Bal as AlloyBal, AccountChanges, SlotChanges, StorageChange};
-    use alloy_primitives::{b256, Address, U256};
+    use alloy_eip7928::{AccountChanges, SlotChanges, StorageChange};
+    use alloy_primitives::{Address, U256};
 
     fn addr(byte: u8) -> Address {
         let mut a = [0u8; 20];
@@ -52,50 +37,6 @@ mod tests {
     fn slot(byte: u8) -> U256 {
         U256::from(byte)
     }
-
-    /// Wraps a `Vec<AccountChanges>` into a `DecodedBal` by RLP-encoding the contents — same
-    /// path a real block takes through `DecodedBal::from_rlp_bytes`, so the cached hash stays
-    /// faithful to what the header would commit to.
-    fn to_decoded(bal: Vec<AccountChanges>) -> DecodedBal {
-        let alloy_bal: AlloyBal = bal.into();
-        let raw = alloy_rlp::encode(&alloy_bal).into();
-        DecodedBal::new(alloy_bal, raw)
-    }
-
-    // ---- check_bal_hash ----
-
-    #[test]
-    fn check_bal_hash_accepts_matching_hash() {
-        let decoded = to_decoded(vec![AccountChanges::new(addr(1))]);
-        let computed = decoded.hash();
-        assert_eq!(check_bal_hash(&decoded, computed), Ok(()));
-    }
-
-    #[test]
-    fn check_bal_hash_rejects_with_populated_fields() {
-        let decoded = to_decoded(vec![AccountChanges::new(addr(1))]);
-        let expected = b256!("0xdeadbeef00000000000000000000000000000000000000000000000000000000");
-
-        let err = check_bal_hash(&decoded, expected).unwrap_err();
-
-        match err {
-            RejectReason::HeaderHashMismatch { computed, expected: got } => {
-                assert_eq!(got, expected);
-                assert_eq!(computed, decoded.hash());
-                assert_ne!(computed, expected);
-            }
-            other => panic!("expected HeaderHashMismatch, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn check_bal_hash_handles_empty_bal() {
-        let decoded = to_decoded(Vec::new());
-        let computed = decoded.hash();
-        assert_eq!(check_bal_hash(&decoded, computed), Ok(()));
-    }
-
-    // ---- check_item_count ----
 
     #[test]
     fn check_item_count_accepts_empty_bal_with_zero_limit() {

--- a/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
@@ -1,0 +1,185 @@
+//! Structural BAL validation: the two cheapest checks in the validation chain.
+//!
+//! Both run before any state I/O, letting us reject adversarial BALs without spending storage
+//! bandwidth. See `BAL.md` §Validation chain, checks A and B.
+
+use alloy_eip7928::{bal::DecodedBal, total_bal_items, AccountChanges};
+use alloy_primitives::B256;
+
+use super::RejectReason;
+
+/// Per-item gas cost for the EIP-7928 structural budget. Deliberately set below a cold SLOAD's
+/// 2100 gas so the gate is tighter than raw opcode cost.
+pub const BAL_ITEM_COST: u64 = 2000;
+
+/// Check A: `keccak256(raw_rlp_of_received_bal) == header.block_access_list_hash`.
+///
+/// Uses [`DecodedBal`]'s cached hash (`keccak256` of the raw RLP bytes captured at decode
+/// time) — the same pre-image the header commits to. Zero I/O; first call computes the hash,
+/// subsequent calls are free.
+pub fn check_bal_hash(bal: &DecodedBal, expected: B256) -> Result<(), RejectReason> {
+    let computed = bal.hash();
+    if computed == expected {
+        Ok(())
+    } else {
+        Err(RejectReason::HeaderHashMismatch { computed, expected })
+    }
+}
+
+/// Check B: `(addresses + unique_storage_keys) * BAL_ITEM_COST <= block_gas_limit`.
+///
+/// `unique_storage_keys` dedupes `storage_reads ∪ storage_changes` per account (delegated to
+/// `alloy_eip7928::total_bal_items`). Saturating arithmetic defends against adversarial BALs
+/// whose raw item count would overflow `u64` — they reject cleanly instead of panicking.
+pub fn check_item_count(bal: &[AccountChanges], block_gas_limit: u64) -> Result<(), RejectReason> {
+    let bal_items = total_bal_items(bal);
+    let total_cost = bal_items.saturating_mul(BAL_ITEM_COST);
+    if total_cost <= block_gas_limit {
+        Ok(())
+    } else {
+        Err(RejectReason::ItemCountExceedsGasBudget { bal_items, gas_limit: block_gas_limit })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eip7928::{bal::Bal as AlloyBal, AccountChanges, SlotChanges, StorageChange};
+    use alloy_primitives::{b256, Address, U256};
+
+    fn addr(byte: u8) -> Address {
+        let mut a = [0u8; 20];
+        a[19] = byte;
+        Address::from(a)
+    }
+
+    fn slot(byte: u8) -> U256 {
+        U256::from(byte)
+    }
+
+    /// Wraps a `Vec<AccountChanges>` into a `DecodedBal` by RLP-encoding the contents — same
+    /// path a real block takes through `DecodedBal::from_rlp_bytes`, so the cached hash stays
+    /// faithful to what the header would commit to.
+    fn to_decoded(bal: Vec<AccountChanges>) -> DecodedBal {
+        let alloy_bal: AlloyBal = bal.into();
+        let raw = alloy_rlp::encode(&alloy_bal).into();
+        DecodedBal::new(alloy_bal, raw)
+    }
+
+    // ---- check_bal_hash ----
+
+    #[test]
+    fn check_bal_hash_accepts_matching_hash() {
+        let decoded = to_decoded(vec![AccountChanges::new(addr(1))]);
+        let computed = decoded.hash();
+        assert_eq!(check_bal_hash(&decoded, computed), Ok(()));
+    }
+
+    #[test]
+    fn check_bal_hash_rejects_with_populated_fields() {
+        let decoded = to_decoded(vec![AccountChanges::new(addr(1))]);
+        let expected = b256!("0xdeadbeef00000000000000000000000000000000000000000000000000000000");
+
+        let err = check_bal_hash(&decoded, expected).unwrap_err();
+
+        match err {
+            RejectReason::HeaderHashMismatch { computed, expected: got } => {
+                assert_eq!(got, expected);
+                assert_eq!(computed, decoded.hash());
+                assert_ne!(computed, expected);
+            }
+            other => panic!("expected HeaderHashMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_bal_hash_handles_empty_bal() {
+        let decoded = to_decoded(Vec::new());
+        let computed = decoded.hash();
+        assert_eq!(check_bal_hash(&decoded, computed), Ok(()));
+    }
+
+    // ---- check_item_count ----
+
+    #[test]
+    fn check_item_count_accepts_empty_bal_with_zero_limit() {
+        assert_eq!(check_item_count(&[], 0), Ok(()));
+    }
+
+    #[test]
+    fn check_item_count_counts_addresses_and_union_of_slots() {
+        // 2 addresses, disjoint read/write slots totalling 4 unique keys → 6 items.
+        let bal = vec![
+            AccountChanges {
+                address: addr(1),
+                storage_reads: vec![slot(10), slot(11)],
+                storage_changes: vec![SlotChanges::new(
+                    slot(20),
+                    vec![StorageChange::new(1, U256::from(1))],
+                )],
+                ..Default::default()
+            },
+            AccountChanges {
+                address: addr(2),
+                storage_changes: vec![SlotChanges::new(
+                    slot(30),
+                    vec![StorageChange::new(2, U256::from(2))],
+                )],
+                ..Default::default()
+            },
+        ];
+
+        // 6 items * 2000 = 12_000. Limit exactly at cost → Ok (spec is `<=`).
+        assert_eq!(check_item_count(&bal, 12_000), Ok(()));
+
+        // One gas under → rejects with the raw item count in the error.
+        let err = check_item_count(&bal, 11_999).unwrap_err();
+        assert_eq!(
+            err,
+            RejectReason::ItemCountExceedsGasBudget { bal_items: 6, gas_limit: 11_999 }
+        );
+    }
+
+    #[test]
+    fn check_item_count_dedups_slot_appearing_in_reads_and_changes() {
+        // Malformed BAL: same slot listed in both storage_reads and storage_changes.
+        // total_bal_items dedups, so this counts as 1 address + 1 slot = 2 items.
+        let bal = vec![AccountChanges {
+            address: addr(1),
+            storage_reads: vec![slot(10)],
+            storage_changes: vec![SlotChanges::new(
+                slot(10),
+                vec![StorageChange::new(1, U256::from(1))],
+            )],
+            ..Default::default()
+        }];
+
+        assert_eq!(check_item_count(&bal, 4_000), Ok(()));
+        let err = check_item_count(&bal, 3_999).unwrap_err();
+        assert!(matches!(err, RejectReason::ItemCountExceedsGasBudget { bal_items: 2, .. }));
+    }
+
+    #[test]
+    fn check_item_count_rejects_tightly_over_budget() {
+        let bal = vec![AccountChanges::new(addr(1))]; // 1 item.
+        assert_eq!(check_item_count(&bal, 2_000), Ok(()));
+        let err = check_item_count(&bal, 1_999).unwrap_err();
+        assert_eq!(err, RejectReason::ItemCountExceedsGasBudget { bal_items: 1, gas_limit: 1_999 });
+    }
+
+    #[test]
+    fn check_item_count_tolerates_near_u64_item_count() {
+        // We can't actually build a u64::MAX-sized Vec, but we can verify the arithmetic helper
+        // is saturating by confirming that for any realistic count the cost comparison is
+        // well-defined (no panic). This test is a smoke test for the saturating_mul path.
+        let bal: Vec<AccountChanges> = (0u8..=200).map(|i| AccountChanges::new(addr(i))).collect();
+        // 201 items * 2000 = 402_000, well inside u64 and under any realistic gas limit.
+        assert!(check_item_count(&bal, 402_000).is_ok());
+    }
+
+    #[test]
+    fn item_cost_constant_matches_spec() {
+        // EIP-7928 + BAL.md §Validation chain pin this at 2000.
+        assert_eq!(BAL_ITEM_COST, 2000);
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/validation.rs
@@ -3,14 +3,10 @@
 //! Both run before any state I/O, letting us reject adversarial BALs without spending storage
 //! bandwidth. See `BAL.md` §Validation chain, checks A and B.
 
-use alloy_eip7928::{bal::DecodedBal, total_bal_items, AccountChanges};
+use alloy_eip7928::{bal::DecodedBal, AccountChanges};
 use alloy_primitives::B256;
 
 use super::RejectReason;
-
-/// Per-item gas cost for the EIP-7928 structural budget. Deliberately set below a cold SLOAD's
-/// 2100 gas so the gate is tighter than raw opcode cost.
-pub const BAL_ITEM_COST: u64 = 2000;
 
 /// Check A: `keccak256(raw_rlp_of_received_bal) == header.block_access_list_hash`.
 ///
@@ -26,14 +22,14 @@ pub fn check_bal_hash(bal: &DecodedBal, expected: B256) -> Result<(), RejectReas
     }
 }
 
-/// Check B: `(addresses + unique_storage_keys) * BAL_ITEM_COST <= block_gas_limit`.
+/// Check B: `(addresses + unique_storage_keys) * ITEM_COST <= block_gas_limit`.
 ///
 /// `unique_storage_keys` dedupes `storage_reads ∪ storage_changes` per account (delegated to
 /// `alloy_eip7928::total_bal_items`). Saturating arithmetic defends against adversarial BALs
 /// whose raw item count would overflow `u64` — they reject cleanly instead of panicking.
 pub fn check_item_count(bal: &[AccountChanges], block_gas_limit: u64) -> Result<(), RejectReason> {
-    let bal_items = total_bal_items(bal);
-    let total_cost = bal_items.saturating_mul(BAL_ITEM_COST);
+    let bal_items = alloy_eip7928::total_bal_items(bal);
+    let total_cost = bal_items.saturating_mul(alloy_eip7928::ITEM_COST as u64);
     if total_cost <= block_gas_limit {
         Ok(())
     } else {
@@ -175,11 +171,5 @@ mod tests {
         let bal: Vec<AccountChanges> = (0u8..=200).map(|i| AccountChanges::new(addr(i))).collect();
         // 201 items * 2000 = 402_000, well inside u64 and under any realistic gas limit.
         assert!(check_item_count(&bal, 402_000).is_ok());
-    }
-
-    #[test]
-    fn item_cost_constant_matches_spec() {
-        // EIP-7928 + BAL.md §Validation chain pin this at 2000.
-        assert_eq!(BAL_ITEM_COST, 2000);
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -1,0 +1,183 @@
+//! BAL-path block executor — a `BasicBlockExecutor`-shaped wrapper that runs transactions
+//! against a snapshot-backed state with revm's `BalDatabase` layered on top.
+//!
+//! `BalBlockExecutor` owns the `Evm` config and the layered revm `State`, mirroring reth's
+//! `BasicBlockExecutor` pattern (see `crates/evm/evm/src/execute.rs:529`). Methods on
+//! `&mut self` hold both fields simultaneously, which lets revm's
+//! `ConfigureEvm::create_executor` unify its three lifetimes (`&self`, `&mut State`,
+//! `ExecutionCtx<'_>`) at the method boundary — the lifetime trick that made a standalone
+//! generic helper infeasible.
+//!
+//! ### Error classification (limited)
+//!
+//! revm's `BalError` is a unit variant with no address/slot metadata, wrapped inside
+//! `BlockExecutionError::Internal(InternalBlockExecutionError::EVM { error: Box<dyn Error>,
+//! .. })`. Reliably distinguishing "undeclared access" from other EVM failures requires
+//! downcasting through revm's `EVMError<DB::Error, TxError>`, which we defer until upstream
+//! revm carries the richer error. For now all EVM failures surface as [`WorkerError::Evm`].
+//! The main-thread commit loop (step 4c) still catches adversarial BALs via checks E and F.
+
+use super::{pre_state::BlockPreState, snapshot_db::SnapshotDatabase};
+use alloy_evm::block::{BlockExecutionError, BlockExecutor, TxResult};
+use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor, HaltReasonFor};
+use revm::{context::result::ResultAndState, database::State};
+use revm_state::bal::Bal;
+use std::sync::Arc;
+
+/// Errors emitted by a worker executing one transaction.
+#[derive(Debug)]
+pub enum WorkerError {
+    /// EVM execution failed. Covers revm `BalError` (undeclared access), internal EVM errors,
+    /// and transaction validation failures.
+    // TODO: once revm's `BalError` carries address/slot metadata, split out a dedicated
+    // `UndeclaredAccess` variant so the commit loop can emit `RejectReason::UndeclaredAccess`
+    // without downcasting through `Box<dyn Error>`.
+    Evm(BlockExecutionError),
+}
+
+impl core::fmt::Display for WorkerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Evm(e) => write!(f, "evm execution failed: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for WorkerError {}
+
+/// A `BlockExecutor`-shaped worker that executes one transaction per call against a
+/// snapshot-backed state with revm's `BalDatabase` layered on top.
+///
+/// Owns the `Evm` config (cloned from the engine's) and the layered `State<SnapshotDatabase>`.
+/// The `&mut self` receiver on [`execute_tx`](Self::execute_tx) lets revm's `create_executor`
+/// unify its lifetimes — the same pattern `BasicBlockExecutor::execute_one` uses.
+#[expect(missing_debug_implementations)]
+pub struct BalBlockExecutor<Evm: ConfigureEvm> {
+    evm_config: Evm,
+    state: State<SnapshotDatabase>,
+}
+
+impl<Evm: ConfigureEvm> BalBlockExecutor<Evm> {
+    /// Builds a new worker. The layered revm `State` is constructed once and reused across
+    /// `execute_tx` calls on this instance — suitable for sequential per-tx iteration on one
+    /// thread. Each thread in a pool holds its own instance.
+    pub fn new(evm_config: Evm, snapshot: Arc<BlockPreState>, received_bal: Arc<Bal>) -> Self {
+        let state = State::builder()
+            .with_database(SnapshotDatabase::new(snapshot))
+            .with_bal(received_bal)
+            .with_bundle_update()
+            .build();
+        Self { evm_config, state }
+    }
+
+    /// Executes one transaction. Returns its `ResultAndState` on success, or a
+    /// [`WorkerError`] otherwise. Sets `state.bal_index = tx_index` so revm's `BalDatabase`
+    /// resolves mid-block reads at the correct in-block position.
+    ///
+    /// The caller must ensure `tx_index` is 1-based (EIP-7928 reserves `0` for pre-exec and
+    /// `n+1` for post-exec).
+    pub fn execute_tx<'a, Tx>(
+        &'a mut self,
+        tx_index: u64,
+        tx: Tx,
+        evm_env: EvmEnvFor<Evm>,
+        execution_ctx: ExecutionCtxFor<'a, Evm>,
+    ) -> Result<ResultAndState<HaltReasonFor<Evm>>, WorkerError>
+    where
+        Tx: ExecutableTxFor<Evm>,
+    {
+        self.state.set_bal_index(tx_index);
+        let evm = self.evm_config.evm_with_env(&mut self.state, evm_env);
+        let mut executor = self.evm_config.create_executor(evm, execution_ctx);
+        executor
+            .execute_transaction_without_commit(tx)
+            .map(TxResult::into_result)
+            .map_err(WorkerError::Evm)
+    }
+
+    /// Consumes the worker and returns the underlying state. Useful once all txs are done
+    /// and the caller wants the accumulated `BundleState` (e.g., for diagnostics).
+    pub fn into_state(self) -> State<SnapshotDatabase> {
+        self.state
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, U256};
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_primitives_traits::Account;
+    use revm::Database;
+
+    fn addr(byte: u8) -> Address {
+        let mut a = [0u8; 20];
+        a[19] = byte;
+        Address::from(a)
+    }
+
+    /// BAL with given addresses declared so `BalDatabase` falls through to our snapshot.
+    fn bal_declaring(addrs: &[Address]) -> Arc<Bal> {
+        let mut bal = Bal::new();
+        for a in addrs {
+            bal.accounts.insert(*a, Default::default());
+        }
+        Arc::new(bal)
+    }
+
+    #[test]
+    fn new_builds_state_that_reads_through_bal_to_snapshot() {
+        // Verifies: the three-layer stack (EVM → State → BalDatabase → SnapshotDatabase) is
+        // wired correctly. A declared address passes through the BAL layer and resolves from
+        // our snapshot.
+        let mut pre = BlockPreState::default();
+        pre.accounts.insert(
+            addr(1),
+            Some(Account { balance: U256::from(42), nonce: 0, bytecode_hash: None }),
+        );
+        let snapshot = Arc::new(pre);
+
+        let mut exec =
+            BalBlockExecutor::new(EthEvmConfig::mainnet(), snapshot, bal_declaring(&[addr(1)]));
+
+        let info = exec.state.basic(addr(1)).unwrap().unwrap();
+        assert_eq!(info.balance, U256::from(42));
+    }
+
+    #[test]
+    fn execute_tx_compiles_with_eth_evm_config() {
+        // Type-check smoke test: `execute_tx` is callable with the full `EthEvmConfig`-bound
+        // generic machinery (EvmEnvFor, ExecutionCtxFor, HaltReasonFor). Actual end-to-end
+        // execution of a real signed tx belongs with step 4c's integration harness, where
+        // the commit loop gives us real block data to construct SealedHeader +
+        // NextBlockEnvAttributes + a properly-signed Recovered<Tx>.
+        //
+        // This reference proves the lifetimes on `execute_tx` resolve for a concrete Evm
+        // type — the whole point of moving from the standalone generic function to the
+        // struct-method form.
+        fn _ty_check<Tx>(
+            worker: &mut BalBlockExecutor<EthEvmConfig>,
+            tx_index: u64,
+            tx: Tx,
+            evm_env: EvmEnvFor<EthEvmConfig>,
+            ctx: ExecutionCtxFor<'_, EthEvmConfig>,
+        ) -> Result<ResultAndState<HaltReasonFor<EthEvmConfig>>, WorkerError>
+        where
+            Tx: ExecutableTxFor<EthEvmConfig>,
+        {
+            worker.execute_tx(tx_index, tx, evm_env, ctx)
+        }
+        // Ensure the compiler actually realizes it.
+        let _ = _ty_check::<
+            reth_primitives_traits::Recovered<reth_ethereum_primitives::TransactionSigned>,
+        >;
+    }
+
+    #[test]
+    fn worker_error_displays() {
+        let err = WorkerError::Evm(BlockExecutionError::msg("boom"));
+        let s = format!("{err}");
+        assert!(s.contains("evm execution failed"));
+        assert!(s.contains("boom"));
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -123,6 +123,7 @@ where
     /// Whether sparse trie cache pruning is fully disabled.
     disable_sparse_trie_cache_pruning: bool,
     /// Whether to disable BAL-based parallel execution (falls back to tx-based prewarming).
+    #[allow(unused)]
     disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
     disable_bal_parallel_state_root: bool,
@@ -272,7 +273,9 @@ where
             halve_workers,
             config,
         );
-        let install_state_hook = env.decoded_bal.is_none();
+        // If no BALs are present or we have them explicitly disabled, we use sparse trie task and
+        // need to send the updates to it via state hook
+        let install_state_hook = env.decoded_bal.is_none() || self.disable_bal_parallel_state_root;
         let prewarm_handle = self.spawn_caching_with(
             env,
             prewarm_rx,
@@ -505,12 +508,12 @@ where
         );
         {
             let to_prewarm_task = to_prewarm_task.clone();
-            let disable_bal_parallel_execution = self.disable_bal_parallel_execution;
+            let disable_bal_parallel_state_root = self.disable_bal_parallel_state_root;
             self.executor.spawn_blocking_named("prewarm", move || {
                 let mode = if skip_prewarm {
                     PrewarmMode::Skipped
                 } else if let Some(decoded_bal) =
-                    maybe_decoded_bal.filter(|_| !disable_bal_parallel_execution)
+                    maybe_decoded_bal.filter(|_| !disable_bal_parallel_state_root)
                 {
                     PrewarmMode::BlockAccessList(decoded_bal)
                 } else {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -510,12 +510,12 @@ where
             let to_prewarm_task = to_prewarm_task.clone();
             let disable_bal_parallel_state_root = self.disable_bal_parallel_state_root;
             self.executor.spawn_blocking_named("prewarm", move || {
-                let mode = if skip_prewarm {
-                    PrewarmMode::Skipped
-                } else if let Some(decoded_bal) =
+                let mode = if let Some(decoded_bal) =
                     maybe_decoded_bal.filter(|_| !disable_bal_parallel_state_root)
                 {
                     PrewarmMode::BlockAccessList(decoded_bal)
+                } else if skip_prewarm {
+                    PrewarmMode::Skipped
                 } else {
                     PrewarmMode::Transactions(transactions)
                 };
@@ -801,7 +801,7 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
 
     /// Returns a state hook to stream execution state updates to the sparse trie cache task.
     ///
-    /// Returns `None` when execution should not send state updates, such as BAL-driven execution.
+    /// Returns `None` when BAL-driven hashed state streaming feeds the sparse trie task.
     pub fn state_hook(&self) -> Option<impl OnStateHook> {
         self.install_state_hook
             .then(|| self.state_root_handle.as_ref().map(|handle| handle.state_hook()))

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -44,6 +44,7 @@ use std::{
 };
 use tracing::{debug, debug_span, instrument, trace, warn, Span};
 
+pub mod bal;
 pub mod multiproof;
 mod preserved_sparse_trie;
 pub mod prewarm;
@@ -122,12 +123,10 @@ where
     sparse_trie_max_hot_accounts: usize,
     /// Whether sparse trie cache pruning is fully disabled.
     disable_sparse_trie_cache_pruning: bool,
-    /// Whether to disable BAL-based parallel execution (falls back to tx-based prewarming).
-    #[allow(unused)]
-    disable_bal_parallel_execution: bool,
     /// Whether to disable BAL-driven parallel state root computation.
+    /// Only valid when BAL parallel execution is also disabled.
     disable_bal_parallel_state_root: bool,
-    /// Whether BAL batched IO is disabled.
+    /// Whether BAL state prefetching during prewarm is disabled.
     disable_bal_batch_io: bool,
 }
 
@@ -164,7 +163,6 @@ where
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             cache_metrics: (!config.disable_cache_metrics())
                 .then(|| CachedStateMetrics::zeroed(CachedStateMetricsSource::Engine)),
-            disable_bal_parallel_execution: config.disable_bal_parallel_execution(),
             disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
             disable_bal_batch_io: config.disable_bal_batch_io(),
         }
@@ -273,14 +271,22 @@ where
             halve_workers,
             config,
         );
-        // If no BALs are present or we have them explicitly disabled, we use sparse trie task and
-        // need to send the updates to it via state hook
-        let install_state_hook = env.decoded_bal.is_none() || self.disable_bal_parallel_state_root;
+        // BAL blocks only bypass the normal execution state hook when the parallel BAL executor
+        // consumes the BAL. If BAL execution is disabled, treat the BAL as absent here so the
+        // block follows today's sequential execution and transaction-prewarm path.
+        //
+        // In the parallel BAL path, prewarm owns BAL-derived sparse-trie updates and optional
+        // BAL state prefetching. `disable_bal_batch_io` controls the prefetch half inside
+        // prewarm, not this dispatch decision.
+        let parallel_bal_execution =
+            !config.disable_bal_parallel_execution() && env.decoded_bal.is_some();
+        let install_state_hook = !parallel_bal_execution;
         let prewarm_handle = self.spawn_caching_with(
             env,
             prewarm_rx,
             provider_builder,
             Some(state_root_handle.updates_tx().clone()),
+            parallel_bal_execution,
         );
 
         PayloadHandle {
@@ -307,7 +313,8 @@ where
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count);
-        let prewarm_handle = self.spawn_caching_with(env, prewarm_rx, provider_builder, None);
+        let prewarm_handle =
+            self.spawn_caching_with(env, prewarm_rx, provider_builder, None, false);
         PayloadHandle {
             state_root_handle: None,
             install_state_hook: false,
@@ -461,29 +468,36 @@ where
     }
 
     /// Spawn prewarming optionally wired to the sparse trie task for target updates.
-    #[instrument(
-        level = "debug",
-        target = "engine::tree::payload_processor",
-        skip_all,
-        fields(bal=%env.decoded_bal.is_some())
-    )]
+    ///
+    /// `parallel_bal_execution` is true when the BAL execute path will execute this block. In
+    /// that case prewarm runs in BAL mode: it streams BAL-derived sparse-trie updates and,
+    /// unless `disable_bal_batch_io` is set, prefetches BAL-declared state into the shared cache.
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     fn spawn_caching_with<P>(
         &self,
         env: ExecutionEnv<Evm>,
         transactions: mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
         provider_builder: StateProviderBuilder<N, P>,
         to_sparse_trie_task: Option<CrossbeamSender<StateRootMessage>>,
+        parallel_bal_execution: bool,
     ) -> CacheTaskHandle<N::Receipt>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
     {
-        let skip_prewarm =
-            self.disable_transaction_prewarming || env.transaction_count < SMALL_BLOCK_TX_THRESHOLD;
-
+        let mode = if parallel_bal_execution {
+            PrewarmMode::BlockAccessList(
+                env.decoded_bal.clone().expect("BAL dispatch implies decoded BAL"),
+            )
+        } else if self.disable_transaction_prewarming ||
+            env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
+        {
+            PrewarmMode::Skipped
+        } else {
+            PrewarmMode::Transactions(transactions)
+        };
         let saved_cache = self.disable_state_cache.not().then(|| self.cache_for(env.parent_hash));
 
         let executed_tx_index = Arc::new(AtomicUsize::new(0));
-        let maybe_decoded_bal = env.decoded_bal.clone();
         // configure prewarming
         let prewarm_ctx = PrewarmContext {
             env,
@@ -508,17 +522,7 @@ where
         );
         {
             let to_prewarm_task = to_prewarm_task.clone();
-            let disable_bal_parallel_state_root = self.disable_bal_parallel_state_root;
             self.executor.spawn_blocking_named("prewarm", move || {
-                let mode = if let Some(decoded_bal) =
-                    maybe_decoded_bal.filter(|_| !disable_bal_parallel_state_root)
-                {
-                    PrewarmMode::BlockAccessList(decoded_bal)
-                } else if skip_prewarm {
-                    PrewarmMode::Skipped
-                } else {
-                    PrewarmMode::Transactions(transactions)
-                };
                 prewarm_task.run(mode, to_prewarm_task);
             });
         }
@@ -806,6 +810,13 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
         self.install_state_hook
             .then(|| self.state_root_handle.as_ref().map(|handle| handle.state_hook()))
             .flatten()
+    }
+
+    /// Returns a clone of the sender that streams updates into the sparse-trie task. The BAL
+    /// execute path uses this to spawn its own sparse-trie streaming task fed from the
+    /// snapshot.
+    pub fn sparse_trie_updates_tx(&self) -> Option<CrossbeamSender<StateRootMessage>> {
+        self.state_root_handle.as_ref().map(|handle| handle.updates_tx().clone())
     }
 
     /// Returns a clone of the caches used by prewarming

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -325,9 +325,10 @@ where
     /// Runs BAL-based prewarming and sparse-trie work inline.
     ///
     /// Spawns two halves concurrently on separate pools, then waits for both to complete:
-    /// 1. Storage prefetch on the prewarming pool to populate the execution cache.
-    /// 2. Hashed state streaming on the BAL streaming pool so storage updates can reach the sparse
+    /// 1. Hashed state streaming on the BAL streaming pool so storage updates can reach the sparse
     ///    trie before account reads finish.
+    /// 2. Storage prefetch on the prewarming pool to populate the execution cache, unless BAL batch
+    ///    I/O is disabled.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn run_bal_prewarm(
         &self,
@@ -398,7 +399,7 @@ where
             let _ = stream_tx.send(());
         }
 
-        if ctx.saved_cache.is_some() {
+        if ctx.saved_cache.is_some() && !ctx.disable_bal_batch_io {
             executor.prewarming_pool().spawn(move || {
                 let branch_span = debug_span!(
                     target: "engine::tree::payload_processor::prewarm",
@@ -544,8 +545,9 @@ where
     /// The precompile cache map.
     pub precompile_cache_map: PrecompileCacheMap<SpecFor<Evm>>,
     /// Whether to disable BAL-driven parallel state root computation.
+    /// Only valid when BAL parallel execution is also disabled.
     pub disable_bal_parallel_state_root: bool,
-    /// Whether BAL batched IO is disabled.
+    /// Whether BAL state prefetching during prewarm is disabled.
     pub disable_bal_batch_io: bool,
 }
 
@@ -669,7 +671,7 @@ where
                 target: "engine::tree::payload_processor::prewarm",
                 parent: parent_span,
                 "bal_hashed_state_provider_init",
-                has_saved_cache = self.saved_cache.is_some(),
+                has_saved_cache = !self.disable_bal_batch_io && self.saved_cache.is_some(),
             )
             .entered();
 
@@ -684,15 +686,17 @@ where
                     return;
                 }
             };
-            let boxed: Box<dyn AccountReader> = if let Some(saved) = &self.saved_cache {
-                let caches = saved.cache().clone();
-                Box::new(CachedStateProvider::new_prewarm(
-                    inner,
-                    caches,
-                    self.cache_metrics.clone().unwrap_or_default(),
-                ))
-            } else {
-                Box::new(inner)
+            let boxed: Box<dyn AccountReader> = match (self.disable_bal_batch_io, &self.saved_cache)
+            {
+                (false, Some(saved)) => {
+                    let caches = saved.cache().clone();
+                    Box::new(CachedStateProvider::new_prewarm(
+                        inner,
+                        caches,
+                        self.cache_metrics.clone().unwrap_or_default(),
+                    ))
+                }
+                _ => Box::new(inner),
             };
             *provider = Some(boxed);
         }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -50,7 +50,7 @@ use crate::tree::{
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::{
     bal::{Bal, DecodedBal},
-    compute_block_access_list_hash, total_bal_items, BlockAccessList, ITEM_COST,
+    BlockAccessList,
 };
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
@@ -62,7 +62,9 @@ use crate::tree::payload_processor::receipt_root_task::{IndexedReceipt, ReceiptR
 use reth_chain_state::{
     CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, ExecutionTimingStats, LazyOverlay,
 };
-use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
+use reth_consensus::{
+    validate_block_access_list_gas, ConsensusError, FullConsensus, ReceiptRootBloom,
+};
 use reth_engine_primitives::{
     ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
 };
@@ -649,8 +651,8 @@ where
                 &mut ctx,
                 transaction_root,
                 receipt_root_bloom,
-                built_bal.as_ref(),
                 hashed_state,
+                built_bal
             ),
             block
         );
@@ -915,25 +917,24 @@ where
         S: StateProvider + Send,
         Err: core::error::Error + Send + Sync + 'static,
         V: PayloadValidator<T, Block = N::Block>,
-        T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
+        T: PayloadTypes<
+            BuiltPayload: BuiltPayload<Primitives = N>,
+            ExecutionData: ExecutionPayload,
+        >,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        // EIP-7928 pre-check: reject blocks whose declared BAL exceeds the gas-limit budget
-        // (each BAL item costs ITEM_COST gas).
-        let has_bal = if let Some(bal_result) = input.block_access_list() {
-            let bal = bal_result.map_err(BlockExecutionError::other)?;
-            if total_bal_items(&bal) > input.gas_limit() / ITEM_COST as u64 {
-                return Err(InsertBlockErrorKind::Consensus(
-                    ConsensusError::BlockAccessListCostMoreThanGasLimit,
-                ));
-            }
-            true
-        } else {
-            false
-        };
+        if let Some(bal_opt) = input.block_access_list() {
+            let bal = bal_opt.map_err(BlockExecutionError::other)?;
+            validate_block_access_list_gas(Some(&bal), input.gas_limit())
+                .map_err(|e| {
+                    debug!(target: "engine::tree::payload_validator", "BAL is invalid since it contains more items than the gas limit allows");
+                    InsertBlockErrorKind::Consensus(e)
+                })?
+        }
 
+        let has_bal = input.block_access_list().is_some();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
@@ -997,6 +998,7 @@ where
             handle.iter_transactions(),
             &receipt_tx,
             &executed_tx_index,
+            has_bal,
         )?;
         drop(receipt_tx);
 
@@ -1011,9 +1013,10 @@ where
         debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
-        // Capture the BAL produced by the BAL builder before consuming the bundle. Only set
-        // when the State was constructed with `with_bal_builder_if(true)` above.
-        let built_bal = db.take_built_alloy_bal();
+        // Extract the built bal if payload has bal
+        let built_bal = if has_bal { db.take_built_alloy_bal() } else { None };
+
+        tracing::info!("Built Bal is {:?}", built_bal);
 
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
@@ -1034,18 +1037,20 @@ where
     /// - Collecting transaction senders for later use
     ///
     /// Returns the executor (for finalization) and the collected senders.
-    fn execute_transactions<E, Tx, InnerTx, Err>(
+    fn execute_transactions<'a, E, Tx, InnerTx, Err, DB>(
         &self,
         mut executor: E,
         transaction_count: usize,
         transactions: impl Iterator<Item = Result<Tx, Err>>,
         receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
         executed_tx_index: &AtomicUsize,
+        has_bal: bool,
     ) -> Result<(E, Vec<Address>), BlockExecutionError>
     where
-        E: BlockExecutor<Receipt = N::Receipt>,
+        E: BlockExecutor<Receipt = N::Receipt, Evm: alloy_evm::Evm<DB = &'a mut State<DB>>>,
         Tx: alloy_evm::block::ExecutableTx<E> + alloy_evm::RecoveredTx<InnerTx>,
         InnerTx: TxHashRef,
+        DB: revm::Database + 'a,
         Err: core::error::Error + Send + Sync + 'static,
     {
         let mut senders = Vec::with_capacity(transaction_count);
@@ -1055,6 +1060,11 @@ where
         debug_span!(target: "engine::tree", "pre_execution")
             .in_scope(|| executor.apply_pre_execution_changes())?;
         self.metrics.record_pre_execution(pre_exec_start.elapsed());
+
+        // Bump BAL index after pre-execution changes (EIP-7928: index 0 is pre-execution)
+        if has_bal {
+            executor.evm_mut().db_mut().bump_bal_index();
+        }
 
         // Execute transactions
         let exec_span = debug_span!(target: "engine::tree", "execution").entered();
@@ -1100,7 +1110,12 @@ where
                     let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
                 }
             }
+            // Bump BAL index after each transaction (EIP-7928)
+            if has_bal {
+                executor.evm_mut().db_mut().bump_bal_index();
+            }
         }
+
         drop(exec_span);
 
         Ok((executor, senders))
@@ -1382,8 +1397,8 @@ where
         ctx: &mut TreeCtx<'_, N>,
         transaction_root: Option<B256>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
-        built_bal: Option<&BlockAccessList>,
         hashed_state: LazyHashedPostState,
+        built_bal: Option<BlockAccessList>,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1410,29 +1425,18 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
-        if let Err(err) =
-            self.consensus.validate_block_post_execution(block, output, receipt_root_bloom)
-        {
+
+        if let Err(err) = self.consensus.validate_block_post_execution(
+            block,
+            output,
+            receipt_root_bloom,
+            built_bal,
+        ) {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
             return Err(err.into())
         }
         drop(_enter);
-
-        // EIP-7928: validate the produced BAL matches the hash committed in the header.
-        // Only checked when the header carries a BAL hash (post-Amsterdam) and the executor
-        // tracked execution into a BAL.
-        if let Some(header_bal_hash) = block.header().block_access_list_hash() {
-            let computed_hash =
-                built_bal.map(|bal| compute_block_access_list_hash(bal)).unwrap_or_default();
-            if computed_hash != header_bal_hash {
-                self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-                return Err(ConsensusError::BlockAccessListHashMismatch(
-                    GotExpected { got: computed_hash, expected: header_bal_hash }.into(),
-                )
-                .into())
-            }
-        }
 
         // Wait for the background keccak256 hashing task to complete. This blocks until
         // all changed addresses and storage slots have been hashed.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -50,7 +50,7 @@ use crate::tree::{
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::{
     bal::{Bal, DecodedBal},
-    BlockAccessList,
+    compute_block_access_list_hash, total_bal_items, BlockAccessList, ITEM_COST,
 };
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
@@ -569,7 +569,7 @@ where
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
-        let (output, senders, receipt_root_rx) =
+        let (output, senders, receipt_root_rx, built_bal) =
             match self.execute_block(state_provider, env, &input, &mut handle) {
                 Ok(output) => output,
                 Err(err) => return self.handle_execution_error(input, err, &parent_block),
@@ -650,6 +650,7 @@ where
                 &mut ctx,
                 transaction_root,
                 receipt_root_bloom,
+                built_bal.as_ref(),
                 hashed_state,
             ),
             block
@@ -907,6 +908,7 @@ where
             BlockExecutionOutput<N::Receipt>,
             Vec<Address>,
             tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>,
+            Option<BlockAccessList>,
         ),
         InsertBlockErrorKind,
     >
@@ -919,10 +921,25 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
+        // EIP-7928 pre-check: reject blocks whose declared BAL exceeds the gas-limit budget
+        // (each BAL item costs ITEM_COST gas).
+        let has_bal = if let Some(bal_result) = input.block_access_list() {
+            let bal = bal_result.map_err(BlockExecutionError::other)?;
+            if total_bal_items(&bal) > input.gas_limit() / ITEM_COST as u64 {
+                return Err(InsertBlockErrorKind::Consensus(
+                    ConsensusError::BlockAccessListCostMoreThanGasLimit,
+                ));
+            }
+            true
+        } else {
+            false
+        };
+
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
                 .with_bundle_update()
+                .with_bal_builder_if(has_bal)
                 .build()
         });
 
@@ -995,6 +1012,10 @@ where
         debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
+        // Capture the BAL produced by the BAL builder before consuming the bundle. Only set
+        // when the State was constructed with `with_bal_builder_if(true)` above.
+        let built_bal = db.take_built_alloy_bal();
+
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
         let execution_duration = execution_start.elapsed();
@@ -1002,7 +1023,7 @@ where
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
 
-        Ok((output, senders, result_rx))
+        Ok((output, senders, result_rx, built_bal))
     }
 
     /// Executes transactions and collects senders, streaming receipts to a background task.
@@ -1362,6 +1383,7 @@ where
         ctx: &mut TreeCtx<'_, N>,
         transaction_root: Option<B256>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        built_bal: Option<&BlockAccessList>,
         hashed_state: LazyHashedPostState,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
@@ -1397,6 +1419,21 @@ where
             return Err(err.into())
         }
         drop(_enter);
+
+        // EIP-7928: validate the produced BAL matches the hash committed in the header.
+        // Only checked when the header carries a BAL hash (post-Amsterdam) and the executor
+        // tracked execution into a BAL.
+        if let Some(header_bal_hash) = block.header().block_access_list_hash() {
+            let computed_hash =
+                built_bal.map(|bal| compute_block_access_list_hash(bal)).unwrap_or_default();
+            if computed_hash != header_bal_hash {
+                self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
+                return Err(ConsensusError::BlockAccessListHashMismatch(
+                    GotExpected { got: computed_hash, expected: header_bal_hash }.into(),
+                )
+                .into())
+            }
+        }
 
         // Wait for the background keccak256 hashing task to complete. This blocks until
         // all changed addresses and storage slots have been hashed.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1041,8 +1041,6 @@ where
         // Extract the built bal if payload has bal
         let built_bal = if has_bal { db.take_built_alloy_bal() } else { None };
 
-        tracing::info!("Built Bal is {:?}", built_bal);
-
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
         let execution_duration = execution_start.elapsed();

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -334,25 +334,18 @@ where
     ///
     /// When an execution error occurs, this function checks if there are any header validation
     /// errors that should be reported instead, as header validation errors have higher priority.
-    fn handle_execution_error<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
+    fn handle_execution_error_with_block(
         &self,
-        input: BlockOrPayload<T>,
+        block: SealedBlock<N::Block>,
         execution_err: InsertBlockErrorKind,
         parent_block: &SealedHeader<N::BlockHeader>,
-    ) -> InsertPayloadResult<N>
-    where
-        V: PayloadValidator<T, Block = N::Block>,
-    {
+    ) -> InsertPayloadResult<N> {
         debug!(
             target: "engine::tree::payload_validator",
             ?execution_err,
-            block = ?input.num_hash(),
+            block = ?block.num_hash(),
             "Block execution failed, checking for header validation errors"
         );
-
-        // If execution failed, we should first check if there are any header validation
-        // errors that take precedence over the execution error
-        let block = self.convert_to_block(input)?;
 
         // Validate block consensus rules which includes header validation
         if let Err(consensus_err) = self.validate_block_inner(&block, None) {
@@ -534,6 +527,11 @@ where
         let overlay_factory =
             OverlayStateProviderFactory::new(provider_factory.clone(), overlay_builder.clone());
 
+        // BAL execute path eligibility. Computed up front because the BAL arm needs a clone of
+        // `provider_builder` (consumed by `spawn_payload_processor` below).
+        let bal_eligible = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
+        let bal_provider_builder = bal_eligible.then(|| provider_builder.clone());
+
         // Spawn the appropriate processor based on strategy
         let mut handle = ensure_ok!(self.spawn_payload_processor(
             env.clone(),
@@ -570,11 +568,39 @@ where
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
-        let (output, senders, receipt_root_rx, built_bal) =
+        let (output, senders, receipt_root_rx, built_bal, block) = if bal_eligible {
+            let block = convert_to_block(input)?;
+            let decoded_bal = env.decoded_bal.clone().expect("eligibility implies BAL is present");
+            let built_bal = Some(decoded_bal.as_bal().clone().into());
+            let provider_builder =
+                bal_provider_builder.expect("eligibility implies builder was cloned");
+            match self.execute_block_bal(
+                state_provider,
+                env,
+                &block,
+                &mut handle,
+                decoded_bal,
+                provider_builder,
+            ) {
+                Ok((output, senders, receipt_root_rx)) => {
+                    (output, senders, receipt_root_rx, built_bal, block)
+                }
+                Err(err) => {
+                    return self.handle_execution_error_with_block(block, err, &parent_block)
+                }
+            }
+        } else {
             match self.execute_block(state_provider, env, &input, &mut handle) {
-                Ok(output) => output,
-                Err(err) => return self.handle_execution_error(input, err, &parent_block),
-            };
+                Ok((output, senders, receipt_root_rx, built_bal)) => {
+                    let block = convert_to_block(input)?;
+                    (output, senders, receipt_root_rx, built_bal, block)
+                }
+                Err(err) => {
+                    let block = convert_to_block(input)?;
+                    return self.handle_execution_error_with_block(block, err, &parent_block)
+                }
+            }
+        };
         let execution_duration = execute_block_start.elapsed();
 
         // After executing the block we can stop prewarming transactions
@@ -604,7 +630,6 @@ where
                 hashed_state_provider.hashed_post_state(&hashed_state_output.state)
             });
 
-        let block = convert_to_block(input)?;
         let transaction_root = is_payload.then(|| {
             let body = block.body().clone();
             let parent_span = Span::current();
@@ -1026,6 +1051,151 @@ where
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
 
         Ok((output, senders, result_rx, built_bal))
+    }
+
+    /// Returns true when the BAL execute path should be used for this block.
+    // TODO: extend with stronger gating before enabling on mainnet:
+    //   - Fork check: `Amsterdam.active_at_timestamp(env.evm_env.timestamp)`. Today a BAL only
+    //     exists post-Amsterdam, so the BAL-presence check is a sufficient proxy. It is a proxy,
+    //     not a guarantee.
+    //   - Tx-count threshold (`bal_execute_path_min_tx_count`): below the parallelism break-even
+    //     point, provider setup and worker scheduling overhead can exceed the gain. Tune
+    //     empirically once workers are parallel; meaningless while the commit loop is sequential.
+    fn bal_path_eligible(&self, bal: Option<&DecodedBal>) -> Result<bool, InsertBlockErrorKind> {
+        let has_bal = bal.is_some();
+        let parallel_execution = has_bal && !self.config.disable_bal_parallel_execution();
+        if parallel_execution && self.config.disable_bal_parallel_state_root() {
+            return Err(InsertBlockErrorKind::Other(
+                "disabling parallel state root is impossible when parallel execution is enabled"
+                    .into(),
+            ));
+        }
+
+        Ok(parallel_execution)
+    }
+
+    /// Executes the block on the BAL path. Mirrors the return shape of [`Self::execute_block`]
+    /// so the dispatch site stays uniform.
+    ///
+    /// Inside, this:
+    /// 1. Creates a shared parent-state cache handle for provider-backed workers.
+    /// 2. Relies on BAL prewarm to stream sparse-trie updates and optional state prefetches.
+    /// 3. Spawns the receipt-root task.
+    /// 4. Calls [`crate::tree::payload_processor::bal::BalPayloadExecutor::execute_block`].
+    /// 5. Adapts the BAL output to a [`BlockExecutionOutput`] and forwards receipts to the
+    ///    receipt-root channel.
+    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
+    #[expect(clippy::type_complexity)]
+    fn execute_block_bal<S, Tx, InnerTx, Err, BalP>(
+        &self,
+        _state_provider: S,
+        env: ExecutionEnv<Evm>,
+        block: &SealedBlock<N::Block>,
+        handle: &mut PayloadHandle<Tx, Err, N::Receipt>,
+        decoded_bal: Arc<DecodedBal>,
+        provider_builder: StateProviderBuilder<N, BalP>,
+    ) -> Result<
+        (
+            BlockExecutionOutput<N::Receipt>,
+            Vec<Address>,
+            tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>,
+        ),
+        InsertBlockErrorKind,
+    >
+    where
+        S: StateProvider + Send,
+        Tx: ExecutableTxFor<Evm> + alloy_evm::RecoveredTx<InnerTx> + Send,
+        InnerTx: TxHashRef,
+        Err: core::error::Error + Send + Sync + 'static,
+        BalP: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+        Evm: ConfigureEvm<Primitives = N>,
+    {
+        debug!(target: "engine::tree::payload_validator", "Executing block via BAL path");
+
+        let header_bal_hash = block.header().block_access_list_hash().ok_or_else(|| {
+            InsertBlockErrorKind::Other(
+                "BAL execute path: header missing block_access_list_hash".into(),
+            )
+        })?;
+
+        let cache = handle.caches().ok_or_else(|| {
+            InsertBlockErrorKind::Other("BAL execute path: no execution cache available".into())
+        })?;
+        let cache_metrics = handle.cache_metrics().unwrap_or_default();
+        let saved_cache = SavedCache::new(env.parent_hash, cache);
+
+        // Spawn the receipt-root task.
+        let receipts_len = env.transaction_count;
+        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
+        self.payload_processor
+            .executor()
+            .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
+
+        // Collect txs from the handle's iterator. The BAL executor needs a `Vec<Tx>` because it
+        // owns each tx for the (currently sequential) commit loop.
+        //
+        // TODO: this can be optimized so that transactions are streamed directly to the BAL
+        // executor.
+        let txs: Vec<Tx> = handle
+            .iter_transactions()
+            .collect::<Result<Vec<Tx>, Err>>()
+            .map_err(BlockExecutionError::other)?;
+        let senders: Vec<Address> =
+            txs.iter().map(|tx| *<Tx as alloy_evm::RecoveredTx<InnerTx>>::signer(tx)).collect();
+
+        let block_gas_limit = block.header().gas_limit();
+        let make_db = move || {
+            let provider = provider_builder
+                .build()
+                .map_err(crate::tree::payload_processor::bal::BalExecutionError::Provider)?;
+            Ok(StateProviderDatabase::new(CachedStateProvider::new_prewarm(
+                provider,
+                saved_cache.cache().clone(),
+                cache_metrics.clone(),
+            )))
+        };
+        let execution_start = Instant::now();
+        let bal_output = crate::tree::payload_processor::bal::BalPayloadExecutor::new(
+            self.runtime.clone(),
+            self.evm_config.clone(),
+        )
+        .execute_block(
+            make_db,
+            decoded_bal,
+            block,
+            txs,
+            header_bal_hash,
+            block_gas_limit,
+        )?;
+        let execution_duration = execution_start.elapsed();
+
+        // Forward all receipts to the receipt-root task, in order. Drop the sender so the task
+        // knows the stream is closed.
+        for (i, receipt) in bal_output.receipts.iter().enumerate() {
+            let _ = receipt_tx.send(IndexedReceipt::new(i, receipt.clone()));
+        }
+        drop(receipt_tx);
+
+        // Adapt BalExecutionOutput → BlockExecutionOutput.
+        let result = alloy_evm::block::BlockExecutionResult {
+            receipts: bal_output.receipts,
+            requests: bal_output.requests,
+            gas_used: bal_output.gas_used,
+            blob_gas_used: bal_output.blob_gas_used,
+        };
+        let output = BlockExecutionOutput { result, state: bal_output.bundle_state };
+
+        self.metrics.record_block_execution(&output, execution_duration);
+        self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
+        debug!(
+            target: "engine::tree::payload_validator",
+            elapsed = ?execution_duration,
+            "Executed block via BAL path",
+        );
+
+        Ok((output, senders, result_rx))
     }
 
     /// Executes transactions and collects senders, streaming receipts to a background task.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -48,10 +48,7 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{
-    bal::{Bal, DecodedBal},
-    BlockAccessList,
-};
+use alloy_eip7928::{bal::DecodedBal, AccountChanges, BlockAccessList};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -530,6 +527,9 @@ where
         // BAL execute path eligibility. Computed up front because the BAL arm needs a clone of
         // `provider_builder` (consumed by `spawn_payload_processor` below).
         let bal_eligible = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
+        let bal_for_validation = bal_eligible.then(|| {
+            Arc::clone(env.decoded_bal.as_ref().expect("eligibility implies BAL is present"))
+        });
         let bal_provider_builder = bal_eligible.then(|| provider_builder.clone());
 
         // Spawn the appropriate processor based on strategy
@@ -570,8 +570,9 @@ where
         let execute_block_start = Instant::now();
         let (output, senders, receipt_root_rx, built_bal, block) = if bal_eligible {
             let block = convert_to_block(input)?;
-            let decoded_bal = env.decoded_bal.clone().expect("eligibility implies BAL is present");
-            let built_bal = Some(decoded_bal.as_bal().clone().into());
+            let decoded_bal = Arc::clone(
+                bal_for_validation.as_ref().expect("eligibility implies BAL is present"),
+            );
             let provider_builder =
                 bal_provider_builder.expect("eligibility implies builder was cloned");
             match self.execute_block_bal(
@@ -583,7 +584,7 @@ where
                 provider_builder,
             ) {
                 Ok((output, senders, receipt_root_rx)) => {
-                    (output, senders, receipt_root_rx, built_bal, block)
+                    (output, senders, receipt_root_rx, None, block)
                 }
                 Err(err) => {
                     return self.handle_execution_error_with_block(block, err, &parent_block)
@@ -666,6 +667,9 @@ where
                 debug_span!(target: "engine::tree::payload_validator", "wait_payload_tx_root")
                     .entered();
             handle.try_into_inner().expect("sole handle")
+        });
+        let built_bal = built_bal.as_deref().or_else(|| {
+            bal_for_validation.as_ref().map(|decoded_bal| decoded_bal.as_bal().as_slice())
         });
 
         let hashed_state = ensure_ok_post_block!(
@@ -950,16 +954,15 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        if let Some(bal_opt) = input.block_access_list() {
-            let bal = bal_opt.map_err(BlockExecutionError::other)?;
-            validate_block_access_list_gas(Some(&bal), input.gas_limit())
+        if let Some(decoded_bal) = env.decoded_bal.as_deref() {
+            validate_block_access_list_gas(Some(decoded_bal.as_bal().as_slice()), input.gas_limit())
                 .map_err(|e| {
                     debug!(target: "engine::tree::payload_validator", "BAL is invalid since it contains more items than the gas limit allows");
                     InsertBlockErrorKind::Consensus(e)
                 })?
         }
 
-        let has_bal = input.block_access_list().is_some();
+        let has_bal = env.decoded_bal.is_some();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
@@ -1566,7 +1569,7 @@ where
         transaction_root: Option<B256>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
         hashed_state: LazyHashedPostState,
-        built_bal: Option<BlockAccessList>,
+        built_bal: Option<&[AccountChanges]>,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -2308,16 +2311,6 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(_) => "payload",
             Self::Block(_) => "block",
-        }
-    }
-
-    /// Returns the block access list embedded in a payload, if present.
-    pub fn block_access_list(&self) -> Option<Result<BlockAccessList, alloy_rlp::Error>> {
-        match self {
-            Self::Payload(payload) => payload.block_access_list().map(|block_access_list| {
-                alloy_rlp::decode_exact::<Bal>(block_access_list.as_ref()).map(Bal::into_inner)
-            }),
-            Self::Block(_) => None,
         }
     }
 

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 
 use alloc::{fmt::Debug, sync::Arc};
 use alloy_consensus::{constants::MAXIMUM_EXTRA_DATA_SIZE, EMPTY_OMMER_ROOT_HASH};
-use alloy_eips::eip7840::BlobParams;
+use alloy_eips::{eip7840::BlobParams, eip7928::BlockAccessList};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::{
     Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom, TransactionRoot,
@@ -108,9 +108,15 @@ where
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
+        block_access_list: Option<BlockAccessList>,
     ) -> Result<(), ConsensusError> {
-        let res =
-            validate_block_post_execution(block, &self.chain_spec, result, receipt_root_bloom);
+        let res = validate_block_post_execution(
+            block,
+            &self.chain_spec,
+            result,
+            receipt_root_bloom,
+            block_access_list,
+        );
 
         if self.skip_requests_hash_check &&
             let Err(ConsensusError::BodyRequestsHashDiff(_)) = &res

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -13,7 +13,7 @@ extern crate alloc;
 
 use alloc::{fmt::Debug, sync::Arc};
 use alloy_consensus::{constants::MAXIMUM_EXTRA_DATA_SIZE, EMPTY_OMMER_ROOT_HASH};
-use alloy_eips::{eip7840::BlobParams, eip7928::BlockAccessList};
+use alloy_eips::{eip7840::BlobParams, eip7928::AccountChanges};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_consensus::{
     Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom, TransactionRoot,
@@ -108,7 +108,7 @@ where
         block: &RecoveredBlock<N::Block>,
         result: &BlockExecutionResult<N::Receipt>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
-        block_access_list: Option<BlockAccessList>,
+        block_access_list: Option<&[AccountChanges]>,
     ) -> Result<(), ConsensusError> {
         let res = validate_block_post_execution(
             block,

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -1,6 +1,9 @@
 use alloc::vec::Vec;
 use alloy_consensus::{proofs::calculate_receipt_root, BlockHeader, TxReceipt};
-use alloy_eips::Encodable2718;
+use alloy_eips::{
+    eip7928::{compute_block_access_list_hash, BlockAccessList},
+    Encodable2718,
+};
 use alloy_primitives::{Bloom, Bytes, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_consensus::ConsensusError;
@@ -21,6 +24,7 @@ pub fn validate_block_post_execution<B, R, ChainSpec>(
     chain_spec: &ChainSpec,
     result: &BlockExecutionResult<R>,
     receipt_root_bloom: Option<(B256, Bloom)>,
+    block_access_list: Option<BlockAccessList>,
 ) -> Result<(), ConsensusError>
 where
     B: Block,
@@ -75,6 +79,21 @@ where
         if requests_hash != header_requests_hash {
             return Err(ConsensusError::BodyRequestsHashDiff(
                 GotExpected::new(requests_hash, header_requests_hash).into(),
+            ))
+        }
+    }
+
+    // Validate that the block access list hash matches the calculated block access list hash
+    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
+        block_access_list.is_some()
+    {
+        let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
+        let default_bal = BlockAccessList::default();
+        let block_access_list_hash =
+            compute_block_access_list_hash(block_access_list.as_ref().unwrap_or(&default_bal));
+        if block_access_list_hash != block_bal_hash {
+            return Err(ConsensusError::BlockAccessListHashMismatch(
+                (block_access_list_hash, block_bal_hash).into(),
             ))
         }
     }

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use alloy_consensus::{proofs::calculate_receipt_root, BlockHeader, TxReceipt};
 use alloy_eips::{
-    eip7928::{compute_block_access_list_hash, BlockAccessList},
+    eip7928::{compute_block_access_list_hash, AccountChanges},
     Encodable2718,
 };
 use alloy_primitives::{Bloom, Bytes, B256};
@@ -24,7 +24,7 @@ pub fn validate_block_post_execution<B, R, ChainSpec>(
     chain_spec: &ChainSpec,
     result: &BlockExecutionResult<R>,
     receipt_root_bloom: Option<(B256, Bloom)>,
-    block_access_list: Option<BlockAccessList>,
+    block_access_list: Option<&[AccountChanges]>,
 ) -> Result<(), ConsensusError>
 where
     B: Block,
@@ -84,13 +84,10 @@ where
     }
 
     // Validate that the block access list hash matches the calculated block access list hash
-    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
-        block_access_list.is_some()
-    {
+    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) {
+        let Some(block_access_list) = block_access_list else { return Ok(()) };
         let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
-        let default_bal = BlockAccessList::default();
-        let block_access_list_hash =
-            compute_block_access_list_hash(block_access_list.as_ref().unwrap_or(&default_bal));
+        let block_access_list_hash = compute_block_access_list_hash(block_access_list);
         if block_access_list_hash != block_bal_hash {
             return Err(ConsensusError::BlockAccessListHashMismatch(
                 (block_access_list_hash, block_bal_hash).into(),

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -47,6 +47,7 @@ where
             transactions,
             output: BlockExecutionResult { receipts, requests, gas_used, blob_gas_used },
             state_root,
+            block_access_list_hash,
             ..
         } = input;
 
@@ -90,6 +91,12 @@ where
             };
         }
 
+        let bal_hash = if self.chain_spec.is_amsterdam_active_at_timestamp(timestamp) {
+            block_access_list_hash
+        } else {
+            None
+        };
+
         let header = Header {
             parent_hash: ctx.parent_hash,
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
@@ -112,8 +119,8 @@ where
             blob_gas_used: block_blob_gas_used,
             excess_blob_gas,
             requests_hash,
-            block_access_list_hash: None,
-            slot_number: None,
+            block_access_list_hash: bal_hash,
+            slot_number: ctx.slot_number,
         };
 
         Ok(Block {

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use alloy_consensus::Transaction;
-use alloy_primitives::U256;
+use alloy_primitives::{Bytes, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes as EthPayloadAttributes;
 use reth_basic_payload_builder::{
@@ -446,7 +446,9 @@ where
         return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }
 
-    let BlockBuilderOutcome { execution_result, block, .. } = if let Some(mut handle) = trie_handle
+    let BlockBuilderOutcome { execution_result, block, block_access_list, .. } = if let Some(
+        mut handle,
+    ) = trie_handle
     {
         // Drop the state hook, which drops the StateHookSender and triggers
         // FinishedStateUpdates via its Drop impl, signaling the trie task to finalize.
@@ -486,7 +488,12 @@ where
         }));
     }
 
-    let payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None)
+    let block_access_list: Option<Bytes> = if let Some(block_access_list) = block_access_list {
+        Some(alloy_rlp::encode(&block_access_list).into())
+    } else {
+        None
+    };
+    let payload = EthBuiltPayload::new(sealed_block, total_fees, requests, block_access_list)
         // add blob sidecars from the executed txs
         .with_sidecars(blob_sidecars);
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -488,11 +488,8 @@ where
         }));
     }
 
-    let block_access_list: Option<Bytes> = if let Some(block_access_list) = block_access_list {
-        Some(alloy_rlp::encode(&block_access_list).into())
-    } else {
-        None
-    };
+    let block_access_list: Option<Bytes> =
+        block_access_list.map(|block_access_list| alloy_rlp::encode(&block_access_list).into());
     let payload = EthBuiltPayload::new(sealed_block, total_fees, requests, block_access_list)
         // add blob sidecars from the executed txs
         .with_sidecars(blob_sidecars);

--- a/crates/evm/evm/src/either.rs
+++ b/crates/evm/evm/src/either.rs
@@ -79,4 +79,11 @@ where
             Self::Right(b) => b.size_hint(),
         }
     }
+
+    fn take_bal(&mut self) -> Option<alloy_eips::eip7928::BlockAccessList> {
+        match self {
+            Self::Left(a) => a.take_bal(),
+            Self::Right(b) => b.take_bal(),
+        }
+    }
 }

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,7 +3,10 @@
 use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::eip2718::WithEncoded;
+use alloy_eips::{
+    eip2718::WithEncoded,
+    eip7928::{compute_block_access_list_hash, BlockAccessList},
+};
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory, GasOutput};
 use alloy_evm::{
     block::{CommitChanges, ExecutableTxParts},
@@ -21,7 +24,10 @@ use reth_primitives_traits::{
 use reth_storage_api::StateProvider;
 pub use reth_storage_errors::provider::ProviderError;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::database::{states::bundle_state::BundleRetention, BundleState, State};
+use revm::{
+    database::{states::bundle_state::BundleRetention, BundleState, State},
+    state::bal::Bal,
+};
 
 /// A type that knows how to execute a block. It is assumed to operate on a
 /// [`crate::Evm`] internally and use [`State`] as database.
@@ -145,6 +151,9 @@ pub trait Executor<DB: Database>: Sized {
     ///
     /// This is used to optimize DB commits depending on the size of the state.
     fn size_hint(&self) -> usize;
+
+    /// Takes built [`BlockAccessList`] from executor.
+    fn take_bal(&mut self) -> Option<BlockAccessList>;
 }
 
 /// Input for block building. Consumed by [`BlockAssembler`].
@@ -162,6 +171,7 @@ pub trait Executor<DB: Database>: Sized {
 /// - `bundle_state`: Accumulated state changes from all transactions
 /// - `state_provider`: Access to the current state for additional lookups
 /// - `state_root`: The calculated state root after all changes
+/// - `block_access_list_hash`: Block access list hash (EIP-7928, Amsterdam)
 ///
 /// # Usage
 ///
@@ -178,6 +188,7 @@ pub trait Executor<DB: Database>: Sized {
 ///     bundle_state: &state_changes,
 ///     state_provider: &state,
 ///     state_root: calculated_root,
+///     block_access_list_hash: Some(calculated_bal_hash),
 /// };
 ///
 /// let block = assembler.assemble_block(input)?;
@@ -205,6 +216,8 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory, H = Header> {
     pub state_provider: &'b dyn StateProvider,
     /// State root for this block.
     pub state_root: B256,
+    /// Block access list hash (EIP-7928, Amsterdam).
+    pub block_access_list_hash: Option<B256>,
 }
 
 impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
@@ -222,6 +235,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
         bundle_state: &'a BundleState,
         state_provider: &'b dyn StateProvider,
         state_root: B256,
+        block_access_list_hash: Option<B256>,
     ) -> Self {
         Self {
             evm_env,
@@ -232,6 +246,7 @@ impl<'a, 'b, F: BlockExecutorFactory, H> BlockAssemblerInput<'a, 'b, F, H> {
             bundle_state,
             state_provider,
             state_root,
+            block_access_list_hash,
         }
     }
 }
@@ -301,6 +316,8 @@ pub struct BlockBuilderOutcome<N: NodePrimitives> {
     pub trie_updates: TrieUpdates,
     /// The built block.
     pub block: RecoveredBlock<N::Block>,
+    /// Block access list built during execution (EIP-7928, Amsterdam).
+    pub block_access_list: Option<BlockAccessList>,
 }
 
 /// A type that knows how to execute and build a block.
@@ -453,7 +470,10 @@ where
     type Executor = Executor;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
-        self.executor.apply_pre_execution_changes()
+        self.executor.apply_pre_execution_changes()?;
+        self.executor.evm_mut().db_mut().bump_bal_index();
+
+        Ok(())
     }
 
     fn execute_transaction_with_commit_condition(
@@ -466,6 +486,7 @@ where
             self.executor.execute_transaction_with_commit_condition((tx_env, &tx), f)?
         {
             self.transactions.push(tx);
+            self.executor.evm_mut().db_mut().bump_bal_index();
             Ok(Some(gas_used))
         } else {
             Ok(None)
@@ -482,6 +503,10 @@ where
 
         // merge all transitions into bundle state
         db.merge_transitions(BundleRetention::Reverts);
+
+        let block_access_list = db.take_built_alloy_bal();
+        let block_access_list_hash =
+            block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal));
 
         let hashed_state = state.hashed_post_state(&db.bundle_state);
         let (state_root, trie_updates) = match state_root_precomputed {
@@ -503,11 +528,18 @@ where
             bundle_state: &db.bundle_state,
             state_provider: &state,
             state_root,
+            block_access_list_hash,
         })?;
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 
-        Ok(BlockBuilderOutcome { execution_result: result, hashed_state, trie_updates, block })
+        Ok(BlockBuilderOutcome {
+            execution_result: result,
+            hashed_state,
+            trie_updates,
+            block,
+            block_access_list,
+        })
     }
 
     fn executor_mut(&mut self) -> &mut Self::Executor {
@@ -554,11 +586,33 @@ where
         block: &RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
     ) -> Result<BlockExecutionResult<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
     {
-        let result = self
+        let mut executor = self
             .strategy_factory
             .executor_for_block(&mut self.db, block)
-            .map_err(BlockExecutionError::other)?
-            .execute_block(block.transactions_recovered())?;
+            .map_err(BlockExecutionError::other)?;
+
+        let has_bal = block.header().block_access_list_hash().is_some();
+
+        if has_bal {
+            executor.evm_mut().db_mut().bal_state.bal_builder = Some(Bal::new());
+        } else {
+            executor.evm_mut().db_mut().bal_state.bal_builder = None;
+        }
+
+        executor.apply_pre_execution_changes()?;
+
+        if has_bal {
+            executor.evm_mut().db_mut().bump_bal_index();
+        }
+
+        for tx in block.transactions_recovered() {
+            executor.execute_transaction(tx)?;
+            if has_bal {
+                executor.evm_mut().db_mut().bump_bal_index();
+            }
+        }
+
+        let result = executor.apply_post_execution_changes()?;
 
         self.db.merge_transitions(BundleRetention::Reverts);
 
@@ -591,6 +645,10 @@ where
 
     fn size_hint(&self) -> usize {
         self.db.bundle_state.size_hint()
+    }
+
+    fn take_bal(&mut self) -> Option<BlockAccessList> {
+        self.db.take_built_alloy_bal()
     }
 }
 
@@ -696,6 +754,10 @@ mod tests {
 
         fn size_hint(&self) -> usize {
             0
+        }
+
+        fn take_bal(&mut self) -> Option<BlockAccessList> {
+            None
         }
     }
 

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -35,10 +35,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth70;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -289,7 +289,7 @@ impl Default for DefaultEngineValues {
             share_execution_cache_with_payload_builder: false,
             share_sparse_trie_with_payload_builder: false,
             suppress_persistence_during_build: false,
-            bal_parallel_execution_disabled: true,
+            bal_parallel_execution_disabled: false,
             bal_parallel_state_root_disabled: false,
         }
     }
@@ -511,18 +511,17 @@ pub struct EngineArgs {
     )]
     pub suppress_persistence_during_build: bool,
 
-    /// Disable BAL (Block Access List, EIP-7928) based parallel execution. Defaults to disabled,
-    /// falling back to transaction-based prewarming even when a BAL is available.
+    /// Disable BAL (Block Access List, EIP-7928) based parallel execution.
     #[arg(long = "engine.disable-bal-parallel-execution", default_value_t = DefaultEngineValues::get_global().bal_parallel_execution_disabled)]
     pub bal_parallel_execution_disabled: bool,
 
-    /// Disable BAL-driven parallel state root computation. When set, the BAL hashed post state
-    /// is not sent to the multiproof task for early parallel state root computation.
+    /// Disable BAL-driven parallel state root computation. This is only valid together with
+    /// `--engine.disable-bal-parallel-execution`.
     #[arg(long = "engine.disable-bal-parallel-state-root", default_value_t = DefaultEngineValues::get_global().bal_parallel_state_root_disabled)]
     pub bal_parallel_state_root_disabled: bool,
 
-    /// Disable BAL (Block Access List) batched IO during prewarming. When set, falls back
-    /// to individual per-slot storage reads instead of batched cursor reads.
+    /// Disable BAL (Block Access List) state prefetching during prewarm. When set, BAL executor
+    /// workers fetch state on demand instead of consuming BAL-declared cache prefetches.
     #[arg(long = "engine.disable-bal-batch-io", default_value_t = false)]
     pub disable_bal_batch_io: bool,
 
@@ -629,6 +628,10 @@ impl EngineArgs {
             "--engine.persistence-backpressure-threshold ({}) must be greater than --engine.persistence-threshold ({})",
             self.persistence_backpressure_threshold,
             self.persistence_threshold
+        );
+        ensure!(
+            self.bal_parallel_execution_disabled || !self.bal_parallel_state_root_disabled,
+            "--engine.disable-bal-parallel-state-root requires --engine.disable-bal-parallel-execution because BAL parallel execution depends on BAL prewarm state-root updates"
         );
         Ok(())
     }
@@ -799,6 +802,19 @@ mod tests {
         let err = args.validate().unwrap_err().to_string();
         assert!(err.contains("engine.persistence-backpressure-threshold"));
         assert!(err.contains("engine.persistence-threshold"));
+    }
+
+    #[test]
+    fn validate_rejects_bal_parallel_execution_without_bal_parallel_state_root() {
+        let args = EngineArgs {
+            bal_parallel_execution_disabled: false,
+            bal_parallel_state_root_disabled: true,
+            ..EngineArgs::default()
+        };
+
+        let err = args.validate().unwrap_err().to_string();
+        assert!(err.contains("engine.disable-bal-parallel-state-root"));
+        assert!(err.contains("engine.disable-bal-parallel-execution"));
     }
 
     #[test]

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -202,7 +202,7 @@ where
         // update the cached reads
         self.update_cached_reads(parent_header_hash, request_cache).await;
 
-        self.consensus.validate_block_post_execution(&block, &output, None)?;
+        self.consensus.validate_block_post_execution(&block, &output, None, None)?;
 
         self.ensure_payment(&block, &output, &message)?;
 

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -4,7 +4,7 @@ use alloy_primitives::BlockNumber;
 use num_traits::Zero;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_config::config::ExecutionConfig;
-use reth_consensus::FullConsensus;
+use reth_consensus::{validate_block_access_list_gas, FullConsensus};
 use reth_db::{static_file::HeaderMask, tables};
 use reth_evm::{execute::Executor, metrics::ExecutorMetrics, ConfigureEvm};
 use reth_execution_types::Chain;
@@ -357,7 +357,19 @@ where
                 })
             })?;
 
-            if let Err(err) = self.consensus.validate_block_post_execution(&block, &result, None) {
+            let bal = executor.take_bal().unwrap_or_default();
+            if block.header().block_access_list_hash().is_some() &&
+                let Err(err) = validate_block_access_list_gas(Some(&bal), block.gas_limit())
+            {
+                return Err(StageError::Block {
+                    block: Box::new(block.block_with_parent()),
+                    error: BlockErrorKind::Validation(err),
+                })
+            }
+
+            if let Err(err) =
+                self.consensus.validate_block_post_execution(&block, &result, None, Some(bal))
+            {
                 return Err(StageError::Block {
                     block: Box::new(block.block_with_parent()),
                     error: BlockErrorKind::Validation(err),

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -359,7 +359,8 @@ where
 
             let bal = executor.take_bal().unwrap_or_default();
             if block.header().block_access_list_hash().is_some() &&
-                let Err(err) = validate_block_access_list_gas(Some(&bal), block.gas_limit())
+                let Err(err) =
+                    validate_block_access_list_gas(Some(bal.as_slice()), block.gas_limit())
             {
                 return Err(StageError::Block {
                     block: Box::new(block.block_with_parent()),
@@ -367,9 +368,12 @@ where
                 })
             }
 
-            if let Err(err) =
-                self.consensus.validate_block_post_execution(&block, &result, None, Some(bal))
-            {
+            if let Err(err) = self.consensus.validate_block_post_execution(
+                &block,
+                &result,
+                None,
+                Some(bal.as_slice()),
+            ) {
                 return Err(StageError::Block {
                     block: Box::new(block.block_with_parent()),
                     error: BlockErrorKind::Validation(err),

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1084,13 +1084,13 @@ Engine:
           When enabled, persistence cycles are deferred from the moment an FCU with payload attributes arrives until the next FCU clears the build. Useful on chains with short block times where persistence I/O can interfere with block building latency.
 
       --engine.disable-bal-parallel-execution
-          Disable BAL (Block Access List, EIP-7928) based parallel execution. Defaults to disabled, falling back to transaction-based prewarming even when a BAL is available
+          Disable BAL (Block Access List, EIP-7928) based parallel execution
 
       --engine.disable-bal-parallel-state-root
-          Disable BAL-driven parallel state root computation. When set, the BAL hashed post state is not sent to the multiproof task for early parallel state root computation
+          Disable BAL-driven parallel state root computation. This is only valid together with `--engine.disable-bal-parallel-execution`
 
       --engine.disable-bal-batch-io
-          Disable BAL (Block Access List) batched IO during prewarming. When set, falls back to individual per-slot storage reads instead of batched cursor reads
+          Disable BAL (Block Access List) state prefetching during prewarm. When set, BAL executor workers fetch state on demand instead of consuming BAL-declared cache prefetches
 
 ERA:
       --era.enable

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -252,7 +252,7 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
             .map_err(|err| Error::block_failed(block_number, err))?;
 
         // Consensus checks after block execution
-        validate_block_post_execution(block, &chain_spec, &output, None)
+        validate_block_post_execution(block, &chain_spec, &output, None, None)
             .map_err(|err| Error::block_failed(block_number, err))?;
 
         // Compute and check the post state root


### PR DESCRIPTION
Adds a broader BAL plumbing cleanup across engine tree, consensus, execution, and re-execution paths so the block access list is borrowed where possible instead of repeatedly cloned or re-decoded.

The main changes move BAL validation over to borrowed slices, thread decoded BAL state through the tree validator and post-execution consensus checks, and tighten the BAL execution/prewarm path so the same decoded data can be shared by the processor, prewarm workers, and final validation without materializing extra owned copies. The surrounding BAL executor, snapshot, and error-path updates keep the new ownership model consistent across the engine and related callers.

Testing:
- `cargo +nightly fmt --all`
- `cargo check -p reth-engine-tree -p reth-consensus -p reth-ethereum-consensus -p reth-stages -p reth-cli-commands`