### PR TITLE
feat(node, db-common): add --debug.skip-genesis-validation

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -172,10 +172,7 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             self.create_provider_factory(&config, db, sfp, rocksdb_provider, access, runtime)?;
         if access.is_read_write() {
             debug!(target: "reth::cli", chain=%self.chain.chain(), genesis=?self.chain.genesis_hash(), "Initializing genesis");
-            // Subcommands using EnvironmentArgs (init-state, init-db, etc.)
-            // do not carry DebugArgs and write genesis into an empty DB, so
-            // the validation gate is never tripped — pass false unconditionally.
-            init_genesis_with_settings(&provider_factory, self.storage_settings(), false)?;
+            init_genesis_with_settings(&provider_factory, self.storage_settings())?;
         }
 
         Ok(Environment { config, provider_factory, data_dir })

--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -172,7 +172,10 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             self.create_provider_factory(&config, db, sfp, rocksdb_provider, access, runtime)?;
         if access.is_read_write() {
             debug!(target: "reth::cli", chain=%self.chain.chain(), genesis=?self.chain.genesis_hash(), "Initializing genesis");
-            init_genesis_with_settings(&provider_factory, self.storage_settings())?;
+            // Subcommands using EnvironmentArgs (init-state, init-db, etc.)
+            // do not carry DebugArgs and write genesis into an empty DB, so
+            // the validation gate is never tripped — pass false unconditionally.
+            init_genesis_with_settings(&provider_factory, self.storage_settings(), false)?;
         }
 
         Ok(Environment { config, provider_factory, data_dir })

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -660,13 +660,21 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
-        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())?;
+        init_genesis_with_settings(
+            self.provider_factory(),
+            self.node_config().storage_settings(),
+            self.node_config().debug.skip_genesis_validation,
+        )?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())
+        init_genesis_with_settings(
+            self.provider_factory(),
+            self.node_config().storage_settings(),
+            self.node_config().debug.skip_genesis_validation,
+        )
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -43,7 +43,7 @@ use reth_config::{config::EtlConfig, PruneConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_db_common::init::{
-    init_genesis_with_settings, init_genesis_with_settings_and_hash_validation, InitStorageError,
+    init_genesis_with_settings, init_genesis_with_settings_and_validate, InitStorageError,
 };
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_engine_local::MiningMode;
@@ -662,7 +662,7 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
-        init_genesis_with_settings_and_hash_validation(
+        init_genesis_with_settings_and_validate(
             self.provider_factory(),
             self.node_config().storage_settings(),
             !self.node_config().debug.skip_genesis_validation,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -42,7 +42,9 @@ use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks};
 use reth_config::{config::EtlConfig, PruneConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
-use reth_db_common::init::{init_genesis_with_settings, InitStorageError};
+use reth_db_common::init::{
+    init_genesis_with_settings, init_genesis_with_settings_and_hash_validation, InitStorageError,
+};
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
 use reth_engine_local::MiningMode;
 use reth_evm::{noop::NoopEvmConfig, ConfigureEvm};
@@ -660,21 +662,17 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
-        init_genesis_with_settings(
+        init_genesis_with_settings_and_hash_validation(
             self.provider_factory(),
             self.node_config().storage_settings(),
-            self.node_config().debug.skip_genesis_validation,
+            !self.node_config().debug.skip_genesis_validation,
         )?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        init_genesis_with_settings(
-            self.provider_factory(),
-            self.node_config().storage_settings(),
-            self.node_config().debug.skip_genesis_validation,
-        )
+        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -58,7 +58,7 @@ pub struct DebugArgs {
     #[arg(long = "debug.skip-new-payload", help_heading = "Debug")]
     pub skip_new_payload: Option<usize>,
 
-    /// If set, bypasses the genesis-state-root mismatch check during init.
+    /// If set, bypasses genesis hash validation during init.
     /// Intended for tools that direct-write the database (e.g. snapshot
     /// importers, state-actor) and want reth to trust the DB-resident
     /// genesis state instead of recomputing it from the chainspec's alloc.

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -58,6 +58,15 @@ pub struct DebugArgs {
     #[arg(long = "debug.skip-new-payload", help_heading = "Debug")]
     pub skip_new_payload: Option<usize>,
 
+    /// If set, bypasses the genesis-state-root mismatch check during init.
+    /// Intended for tools that direct-write the database (e.g. snapshot
+    /// importers, state-actor) and want reth to trust the DB-resident
+    /// genesis state instead of recomputing it from the chainspec's alloc.
+    /// When the bypass fires, a structured `tracing::warn!` is emitted so
+    /// the divergence stays observable in operator logs.
+    #[arg(long = "debug.skip-genesis-validation", help_heading = "Debug")]
+    pub skip_genesis_validation: bool,
+
     /// If provided, the chain will be reorged at specified frequency.
     #[arg(long = "debug.reorg-frequency", help_heading = "Debug")]
     pub reorg_frequency: Option<usize>,
@@ -120,6 +129,7 @@ impl Default for DebugArgs {
             rpc_consensus_url: None,
             skip_fcu: None,
             skip_new_payload: None,
+            skip_genesis_validation: false,
             reorg_frequency: None,
             reorg_depth: None,
             engine_api_store: None,

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -161,12 +161,12 @@ where
         + AsRef<PF::ProviderRW>,
     PF::ChainSpec: EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
 {
-    init_genesis_with_settings_and_hash_validation(factory, genesis_storage_settings, true)
+    init_genesis_with_settings_and_validate(factory, genesis_storage_settings, true)
 }
 
 /// Write the genesis block if it has not already been written with [`StorageSettings`],
 /// optionally validating the DB-resident genesis hash against the chainspec hash.
-pub fn init_genesis_with_settings_and_hash_validation<PF>(
+pub fn init_genesis_with_settings_and_validate<PF>(
     factory: &PF,
     genesis_storage_settings: StorageSettings,
     validate_genesis_hash: bool,
@@ -1093,7 +1093,7 @@ mod tests {
         let rocksdb_provider = factory.rocksdb_provider();
         init_genesis(&factory).unwrap();
 
-        let result = init_genesis_with_settings_and_hash_validation(
+        let result = init_genesis_with_settings_and_validate(
             &ProviderFactory::<MockNodeTypesWithDB>::new(
                 factory.into_db(),
                 MAINNET.clone(),

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -130,20 +130,46 @@ where
         + AsRef<PF::ProviderRW>,
     PF::ChainSpec: EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
 {
-    init_genesis_with_settings(factory, StorageSettings::base(), false)
+    init_genesis_with_settings(factory, StorageSettings::base())
 }
 
 /// Write the genesis block if it has not already been written with [`StorageSettings`].
-///
-/// `skip_genesis_validation`: when `true`, a chainspec/DB genesis-hash mismatch
-/// is logged via [`tracing::warn`] and the DB-resident hash is returned instead
-/// of an error. Intended for tools that direct-write the database (e.g.
-/// snapshot importers, state-actor) and want reth to trust the DB-resident
-/// genesis state rather than recomputing it from the chainspec's `alloc`.
 pub fn init_genesis_with_settings<PF>(
     factory: &PF,
     genesis_storage_settings: StorageSettings,
-    skip_genesis_validation: bool,
+) -> Result<B256, InitStorageError>
+where
+    PF: DatabaseProviderFactory
+        + StaticFileProviderFactory<Primitives: NodePrimitives<BlockHeader: Compact>>
+        + ChainSpecProvider
+        + StageCheckpointReader
+        + BlockNumReader
+        + MetadataProvider
+        + StorageSettingsCache,
+    PF::ProviderRW: StaticFileProviderFactory<Primitives = PF::Primitives>
+        + StageCheckpointWriter
+        + HistoryWriter
+        + HeaderProvider
+        + HashingWriter
+        + StateWriter
+        + TrieWriter
+        + MetadataWriter
+        + ChainSpecProvider
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider
+        + AsRef<PF::ProviderRW>,
+    PF::ChainSpec: EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
+{
+    init_genesis_with_settings_and_hash_validation(factory, genesis_storage_settings, true)
+}
+
+/// Write the genesis block if it has not already been written with [`StorageSettings`],
+/// optionally validating the DB-resident genesis hash against the chainspec hash.
+pub fn init_genesis_with_settings_and_hash_validation<PF>(
+    factory: &PF,
+    genesis_storage_settings: StorageSettings,
+    validate_genesis_hash: bool,
 ) -> Result<B256, InitStorageError>
 where
     PF: DatabaseProviderFactory
@@ -203,7 +229,7 @@ where
                 return Ok(hash)
             }
 
-            if skip_genesis_validation {
+            if !validate_genesis_hash {
                 warn!(
                     target: "reth::storage",
                     chainspec_hash = %hash,
@@ -1061,19 +1087,13 @@ mod tests {
     }
 
     #[test]
-    fn skip_genesis_validation_accepts_mismatched_db() {
-        // Same setup as fail_init_inconsistent_db: write Sepolia genesis,
-        // then re-init against Mainnet chainspec. Without the bypass this
-        // returns GenesisHashMismatch (locked by the test above). With
-        // skip_genesis_validation = true, init should return Ok and the
-        // returned hash should be the DB-resident (Sepolia) hash, NOT the
-        // chainspec (Mainnet) hash — that's the contract this test pins.
+    fn skip_genesis_hash_validation_accepts_mismatched_db() {
         let factory = create_test_provider_factory_with_chain_spec(SEPOLIA.clone());
         let static_file_provider = factory.static_file_provider();
         let rocksdb_provider = factory.rocksdb_provider();
         init_genesis(&factory).unwrap();
 
-        let result = init_genesis_with_settings(
+        let result = init_genesis_with_settings_and_hash_validation(
             &ProviderFactory::<MockNodeTypesWithDB>::new(
                 factory.into_db(),
                 MAINNET.clone(),
@@ -1083,7 +1103,7 @@ mod tests {
             )
             .unwrap(),
             StorageSettings::base(),
-            true, // skip_genesis_validation
+            false,
         );
 
         let returned = result.expect("skip_genesis_validation should suppress mismatch error");
@@ -1175,10 +1195,10 @@ mod tests {
     #[test]
     fn warn_storage_settings_mismatch() {
         let factory = create_test_provider_factory_with_chain_spec(MAINNET.clone());
-        init_genesis_with_settings(&factory, StorageSettings::v1(), false).unwrap();
+        init_genesis_with_settings(&factory, StorageSettings::v1()).unwrap();
 
         // Request different settings - should warn but succeed
-        let result = init_genesis_with_settings(&factory, StorageSettings::v2(), false);
+        let result = init_genesis_with_settings(&factory, StorageSettings::v2());
 
         // Should succeed (warning is logged, not an error)
         assert!(result.is_ok());
@@ -1188,9 +1208,9 @@ mod tests {
     fn allow_same_storage_settings() {
         let factory = create_test_provider_factory_with_chain_spec(MAINNET.clone());
         let settings = StorageSettings::v2();
-        init_genesis_with_settings(&factory, settings, false).unwrap();
+        init_genesis_with_settings(&factory, settings).unwrap();
 
-        let result = init_genesis_with_settings(&factory, settings, false);
+        let result = init_genesis_with_settings(&factory, settings);
 
         assert!(result.is_ok());
     }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -1142,10 +1142,10 @@ mod tests {
     #[test]
     fn warn_storage_settings_mismatch() {
         let factory = create_test_provider_factory_with_chain_spec(MAINNET.clone());
-        init_genesis_with_settings(&factory, StorageSettings::v1()).unwrap();
+        init_genesis_with_settings(&factory, StorageSettings::v1(), false).unwrap();
 
         // Request different settings - should warn but succeed
-        let result = init_genesis_with_settings(&factory, StorageSettings::v2());
+        let result = init_genesis_with_settings(&factory, StorageSettings::v2(), false);
 
         // Should succeed (warning is logged, not an error)
         assert!(result.is_ok());
@@ -1155,9 +1155,9 @@ mod tests {
     fn allow_same_storage_settings() {
         let factory = create_test_provider_factory_with_chain_spec(MAINNET.clone());
         let settings = StorageSettings::v2();
-        init_genesis_with_settings(&factory, settings).unwrap();
+        init_genesis_with_settings(&factory, settings, false).unwrap();
 
-        let result = init_genesis_with_settings(&factory, settings);
+        let result = init_genesis_with_settings(&factory, settings, false);
 
         assert!(result.is_ok());
     }

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -130,13 +130,20 @@ where
         + AsRef<PF::ProviderRW>,
     PF::ChainSpec: EthChainSpec<Header = <PF::Primitives as NodePrimitives>::BlockHeader>,
 {
-    init_genesis_with_settings(factory, StorageSettings::base())
+    init_genesis_with_settings(factory, StorageSettings::base(), false)
 }
 
 /// Write the genesis block if it has not already been written with [`StorageSettings`].
+///
+/// `skip_genesis_validation`: when `true`, a chainspec/DB genesis-hash mismatch
+/// is logged via [`tracing::warn`] and the DB-resident hash is returned instead
+/// of an error. Intended for tools that direct-write the database (e.g.
+/// snapshot importers, state-actor) and want reth to trust the DB-resident
+/// genesis state rather than recomputing it from the chainspec's `alloc`.
 pub fn init_genesis_with_settings<PF>(
     factory: &PF,
     genesis_storage_settings: StorageSettings,
+    skip_genesis_validation: bool,
 ) -> Result<B256, InitStorageError>
 where
     PF: DatabaseProviderFactory
@@ -196,6 +203,15 @@ where
                 return Ok(hash)
             }
 
+            if skip_genesis_validation {
+                warn!(
+                    target: "reth::storage",
+                    chainspec_hash = %hash,
+                    storage_hash = %block_hash,
+                    "Genesis hash mismatch with chainspec; trusting DB per --debug.skip-genesis-validation"
+                );
+                return Ok(block_hash)
+            }
             return Err(InitStorageError::GenesisHashMismatch {
                 chainspec_hash: hash,
                 storage_hash: block_hash,

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -1061,6 +1061,39 @@ mod tests {
     }
 
     #[test]
+    fn skip_genesis_validation_accepts_mismatched_db() {
+        // Same setup as fail_init_inconsistent_db: write Sepolia genesis,
+        // then re-init against Mainnet chainspec. Without the bypass this
+        // returns GenesisHashMismatch (locked by the test above). With
+        // skip_genesis_validation = true, init should return Ok and the
+        // returned hash should be the DB-resident (Sepolia) hash, NOT the
+        // chainspec (Mainnet) hash — that's the contract this test pins.
+        let factory = create_test_provider_factory_with_chain_spec(SEPOLIA.clone());
+        let static_file_provider = factory.static_file_provider();
+        let rocksdb_provider = factory.rocksdb_provider();
+        init_genesis(&factory).unwrap();
+
+        let result = init_genesis_with_settings(
+            &ProviderFactory::<MockNodeTypesWithDB>::new(
+                factory.into_db(),
+                MAINNET.clone(),
+                static_file_provider,
+                rocksdb_provider,
+                reth_tasks::Runtime::test(),
+            )
+            .unwrap(),
+            StorageSettings::base(),
+            true, // skip_genesis_validation
+        );
+
+        let returned = result.expect("skip_genesis_validation should suppress mismatch error");
+        assert_eq!(
+            returned, SEPOLIA_GENESIS_HASH,
+            "bypass returns the DB-resident hash, not the chainspec hash",
+        );
+    }
+
+    #[test]
     fn init_genesis_history() {
         let address_with_balance = Address::with_last_byte(1);
         let address_with_storage = Address::with_last_byte(2);

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -753,6 +753,9 @@ Debug:
       --debug.skip-new-payload <SKIP_NEW_PAYLOAD>
           If provided, the engine will skip `n` consecutive new payloads
 
+      --debug.skip-genesis-validation
+          If set, bypasses genesis hash validation during init. Intended for tools that direct-write the database (e.g. snapshot importers, state-actor) and want reth to trust the DB-resident genesis state instead of recomputing it from the chainspec's alloc. When the bypass fires, a structured `tracing::warn!` is emitted so the divergence stays observable in operator logs
+
       --debug.reorg-frequency <REORG_FREQUENCY>
           If provided, the chain will be reorged at specified frequency
 


### PR DESCRIPTION
Tools that direct-write reth's database (snapshot importers, scratch-state generators, network bootstrap utilities) cannot easily ship a complete genesis `alloc` in chainspec.json. Today reth's `init_genesis_with_settings` strictly compares the chainspec-derived genesis hash against the DB-resident hash and aborts with `GenesisHashMismatch` when they differ, forcing those tools to embed every account in chainspec.json.

For one such tool ([state-actor](https://github.com/nerolation/state-actor) — a synthetic-state generator) this means a 351 MB chainspec at 3M accounts and OOM during `json.MarshalIndent` at ~5M, capping practical datadir size well below the 50 GB / ~38M-account targets we need.

This PR adds an opt-in `--debug.skip-genesis-validation` boolean to `DebugArgs` that bypasses the mismatch error. With the flag set, reth logs a structured `tracing::warn!` and trusts the DB-resident state — the chainspec can carry an empty alloc and the genesis state lives only in MDBX.

I tested this in my fork already (containing this flag) and successfully generated a 1TB DB for Reth in <1 day and bloated it with [spamoor](https://github.com/ethpandaops/spamoor/tree/master/) for more than 500blocks. No errors, intermediate trie nodes missing nor anything.
You can give it a ride at: https://github.com/nerolation/state-actor/pull/28

cc: @emmajam related to our discussion in Interop