### PR TITLE
fix(rpc): set JWT `iat` to current time, not `now + 60s`

### DIFF
--- a/crates/rpc/rpc-layer/src/auth_client_layer.rs
+++ b/crates/rpc/rpc-layer/src/auth_client_layer.rs
@@ -2,7 +2,7 @@ use crate::{Claims, JwtSecret};
 use http::{header::AUTHORIZATION, HeaderValue};
 use std::{
     task::{Context, Poll},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 use tower::{Layer, Service};
 
@@ -66,9 +66,7 @@ pub fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
         "Bearer {}",
         secret
             .encode(&Claims {
-                iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() +
-                    Duration::from_secs(60))
-                .as_secs(),
+                iat: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
                 exp: None,
             })
             .unwrap()


### PR DESCRIPTION
`secret_to_bearer_header` was setting `iat` to `now + 60s`, which violates the JWT spec (issued-at must be the signing time) and inflated the effective validity window to ~120s under alloy's `abs_diff(now, iat) <= 60s` rule. Setting `iat = now` matches the doc comment ("valid for 60 seconds") and `Claims::new()`.

Before:
```rust
iat: (SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + Duration::from_secs(60)).as_secs()
// token accepted: now .. now+120s
```

After:
```rust
iat: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
// token accepted: now-60s .. now+60s
```