### PR TITLE
chore: fix nightly clippy warnings

### DIFF
--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -194,7 +194,7 @@ where
     T: for<'a> Arbitrary<'a> + reth_codecs::Compact,
 {
     let type_name = type_name::<T>();
-    print!("{}", &type_name);
+    print!("{}", type_name);
 
     let mut bytes = std::iter::repeat_n(0u8, 256).collect::<Vec<u8>>();
     let mut compact_buffer = vec![];
@@ -230,7 +230,7 @@ where
 
     serde_json::to_writer(
         std::io::BufWriter::new(
-            std::fs::File::create(format!("{VECTORS_FOLDER}/{}.json", &type_name)).unwrap(),
+            std::fs::File::create(format!("{VECTORS_FOLDER}/{}.json", type_name)).unwrap(),
         ),
         &values,
     )?;
@@ -247,10 +247,10 @@ where
     T: reth_codecs::Compact,
 {
     let type_name = type_name::<T>();
-    print!("{}", &type_name);
+    print!("{}", type_name);
 
     // Read the file where the vectors are stored
-    let file_path = format!("{VECTORS_FOLDER}/{}.json", &type_name);
+    let file_path = format!("{VECTORS_FOLDER}/{}.json", type_name);
     let file =
         File::open(&file_path).wrap_err_with(|| format!("Failed to open vector {type_name}."))?;
     let reader = BufReader::new(file);

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -55,7 +55,7 @@ where
         block_number_or_tag: BlockNumberOrTag,
     ) -> eyre::Result<PrimitiveBlock> {
         let tag = match block_number_or_tag {
-            BlockNumberOrTag::Number(num) => format!("{num:#02x}"),
+            BlockNumberOrTag::Number(num) => format!("{num:#x}"),
             tag => tag.to_string(),
         };
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -441,7 +441,7 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> TransactionsProvider
     ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
         // init btreemap so we can return in order
         let mut map = BTreeMap::new();
-        for (_, block) in self.blocks.lock().iter() {
+        for block in self.blocks.lock().values() {
             if range.contains(&block.header().number()) {
                 map.insert(block.header().number(), block.body().clone_transactions());
             }

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -25,7 +25,7 @@ impl InMemoryBlobStore {
     ) -> Vec<Option<BlobAndProofV2>> {
         let mut result = vec![None; versioned_hashes.len()];
         let mut missing_count = result.len();
-        for (_tx_hash, blob_sidecar) in self.inner.store.read().iter() {
+        for blob_sidecar in self.inner.store.read().values() {
             if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
                 for (hash_idx, match_result) in
                     blob_sidecar.match_versioned_hashes(versioned_hashes)
@@ -181,7 +181,7 @@ impl BlobStore for InMemoryBlobStore {
         versioned_hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
         let mut result = vec![None; versioned_hashes.len()];
-        for (_tx_hash, blob_sidecar) in self.inner.store.read().iter() {
+        for blob_sidecar in self.inner.store.read().values() {
             if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
                 for (hash_idx, match_result) in
                     blob_sidecar.match_versioned_hashes(versioned_hashes)

--- a/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
+++ b/examples/beacon-api-sidecar-fetcher/src/mined_sidecar.rs
@@ -188,13 +188,13 @@ where
                 {
                     match notification {
                         CanonStateNotification::Commit { new } => {
-                            for (_, block) in new.blocks().iter() {
+                            for block in new.blocks().values() {
                                 this.process_block(block);
                             }
                         }
                         CanonStateNotification::Reorg { old, new } => {
                             // handle reorged blocks
-                            for (_, block) in old.blocks().iter() {
+                            for block in old.blocks().values() {
                                 let txs: Vec<BlobTransactionEvent> = block
                                     .body()
                                     .transactions()
@@ -215,7 +215,7 @@ where
                                 this.queued_actions.extend(txs);
                             }
 
-                            for (_, block) in new.blocks().iter() {
+                            for block in new.blocks().values() {
                                 this.process_block(block);
                             }
                         }


### PR DESCRIPTION
Removes patterns now warned by newer nightly clippy in map iteration and formatting. This keeps the all-features workspace clippy job clean on current nightly.

Validated with `cargo +nightly fmt --all`, `git diff --check`, and `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked`.