### PR TITLE
perf: offload prometheus upkeep from runtime workers

### DIFF
--- a/crates/node/metrics/src/recorder.rs
+++ b/crates/node/metrics/src/recorder.rs
@@ -94,7 +94,8 @@ impl PrometheusRecorder {
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                handle.run_upkeep();
+                let handle = handle.clone();
+                let _ = tokio::task::spawn_blocking(move || handle.run_upkeep()).await;
             }
         });
     }


### PR DESCRIPTION
Run Prometheus histogram upkeep through spawn_blocking while keeping the existing five-second cadence. This keeps metrics draining off the shared Tokio runtime workers so exporter maintenance does not contend with engine and validation tasks on the runtime thread pool.