### PR TITLE
refactor(payload): require built payload conversion

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -309,11 +309,7 @@ where
     /// Submits a payload to the engine.
     pub async fn submit_payload(&self, payload: Payload::BuiltPayload) -> eyre::Result<B256> {
         let block_hash = payload.block().hash();
-        self.inner
-            .add_ons_handle
-            .beacon_engine_handle
-            .new_payload(Payload::block_to_payload(payload.block().clone()))
-            .await?;
+        self.inner.add_ons_handle.beacon_engine_handle.new_payload(payload.into()).await?;
 
         Ok(block_hash)
     }

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -261,8 +261,7 @@ where
         };
 
         let header = payload.block().sealed_header().clone();
-        let payload = T::block_to_payload(payload.block().clone());
-        let res = self.to_engine.new_payload(payload).await?;
+        let res = self.to_engine.new_payload(payload.into()).await?;
 
         if !res.is_valid() {
             eyre::bail!("Invalid payload")

--- a/crates/ethereum/engine-primitives/src/lib.rs
+++ b/crates/ethereum/engine-primitives/src/lib.rs
@@ -34,14 +34,15 @@ pub struct EthEngineTypes<T: PayloadTypes = EthPayloadTypes> {
     _marker: core::marker::PhantomData<T>,
 }
 
-impl<
-        T: PayloadTypes<
-            ExecutionData = ExecutionData,
-            BuiltPayload: BuiltPayload<
-                Primitives: NodePrimitives<Block = reth_ethereum_primitives::Block>,
-            >,
+impl<T> PayloadTypes for EthEngineTypes<T>
+where
+    T: PayloadTypes<
+        ExecutionData = ExecutionData,
+        BuiltPayload: BuiltPayload<
+            Primitives: NodePrimitives<Block = reth_ethereum_primitives::Block>,
         >,
-    > PayloadTypes for EthEngineTypes<T>
+    >,
+    ExecutionData: From<T::BuiltPayload>,
 {
     type ExecutionData = T::ExecutionData;
     type BuiltPayload = T::BuiltPayload;
@@ -59,6 +60,7 @@ impl<
 impl<T> EngineTypes for EthEngineTypes<T>
 where
     T: PayloadTypes<ExecutionData = ExecutionData>,
+    ExecutionData: From<T::BuiltPayload>,
     T::BuiltPayload: BuiltPayload<Primitives: NodePrimitives<Block = reth_ethereum_primitives::Block>>
         + TryInto<ExecutionPayloadV1>
         + TryInto<ExecutionPayloadEnvelopeV2>

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -105,7 +105,10 @@ where
             payload_builder,
         );
         let (payload_service, payload_service_handle) =
-            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
+            PayloadBuilderService::<_, _, <Node::Types as NodeTypes>::Payload>::new(
+                payload_generator,
+                ctx.provider().canonical_state_stream(),
+            );
 
         ctx.task_executor().spawn_critical_task("payload builder service", payload_service);
 

--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -38,7 +38,7 @@ pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone + 'static
     ///
     /// This type represents the canonical format for block data that includes
     /// all necessary information for execution and validation.
-    type ExecutionData: ExecutionPayload;
+    type ExecutionData: ExecutionPayload + From<Self::BuiltPayload>;
     /// The type representing a successfully built payload/block.
     type BuiltPayload: BuiltPayload + Clone + Unpin;
 


### PR DESCRIPTION
Requires built payload types to convert into their execution data representation and uses that path when submitting locally built payloads.

This avoids reconstructing execution data from the sealed block when the richer built payload is already available.