### PR TITLE
feat(engine): Enable running state root task in the background for external components

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -251,6 +251,7 @@ where
         multiproof_provider_factory: F,
         config: &TreeConfig,
         state_root_handle: Option<StateRootHandle>,
+        finalize_sparse_trie_task: bool,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
@@ -283,6 +284,7 @@ where
             prewarm_rx,
             provider_builder,
             Some(state_root_handle.updates_tx().clone()),
+            finalize_sparse_trie_task,
         );
 
         PayloadHandle {
@@ -309,7 +311,8 @@ where
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count);
-        let prewarm_handle = self.spawn_caching_with(env, prewarm_rx, provider_builder, None);
+        let prewarm_handle =
+            self.spawn_caching_with(env, prewarm_rx, provider_builder, None, false);
         PayloadHandle {
             state_root_handle: None,
             install_state_hook: false,
@@ -475,6 +478,7 @@ where
         transactions: mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
         provider_builder: StateProviderBuilder<N, P>,
         to_sparse_trie_task: Option<CrossbeamSender<StateRootMessage>>,
+        finalize_sparse_trie_task: bool,
     ) -> CacheTaskHandle<N::Receipt>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
@@ -521,7 +525,7 @@ where
                 } else {
                     PrewarmMode::Transactions(transactions)
                 };
-                prewarm_task.run(mode, to_prewarm_task);
+                prewarm_task.run(mode, to_prewarm_task, finalize_sparse_trie_task);
             });
         }
 
@@ -1279,6 +1283,7 @@ mod tests {
             ),
             &TreeConfig::default(),
             None,
+            false,
         );
 
         let mut state_hook = handle.state_hook().expect("state hook is None");

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -250,6 +250,7 @@ where
         provider_builder: StateProviderBuilder<N, P>,
         multiproof_provider_factory: F,
         config: &TreeConfig,
+        state_root_handle: Option<StateRootHandle>,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
@@ -265,13 +266,17 @@ where
 
         let span = Span::current();
 
-        let halve_workers = env.transaction_count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD;
-        let state_root_handle = self.spawn_state_root(
-            multiproof_provider_factory,
-            env.parent_state_root,
-            halve_workers,
-            config,
-        );
+        let state_root_handle = state_root_handle.unwrap_or_else(|| {
+            let halve_workers =
+                env.transaction_count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD;
+            self.spawn_state_root(
+                multiproof_provider_factory,
+                env.parent_state_root,
+                halve_workers,
+                config,
+            )
+        });
+
         let install_state_hook = env.decoded_bal.is_none();
         let prewarm_handle = self.spawn_caching_with(
             env,
@@ -805,9 +810,27 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
             .flatten()
     }
 
+    /// Returns a state hook that streams execution state updates to the sparse trie cache task
+    /// without sending [`StateRootMessage::FinishedStateUpdates`] when the hook is dropped.
+    ///
+    /// Returns `None` when execution should not send state updates, such as BAL-driven execution.
+    pub fn state_hook_persistent(&self) -> Option<impl OnStateHook> {
+        self.install_state_hook
+            .then(|| self.state_root_handle.as_ref().map(|handle| handle.state_hook_persistent()))
+            .flatten()
+    }
+
     /// Returns a clone of the caches used by prewarming
     pub fn caches(&self) -> Option<ExecutionCache> {
         self.prewarm_handle.saved_cache.as_ref().map(|cache| cache.cache().clone())
+    }
+
+    /// Takes the [`StateRootHandle`] out of this [`PayloadHandle`].
+    ///
+    /// Returns `None` when this handle was created without a state root pipeline (e.g. via
+    /// [`PayloadProcessor::spawn_cache_exclusive`]) or when the handle has already been taken.
+    pub fn take_state_root_handle(&mut self) -> Option<StateRootHandle> {
+        self.state_root_handle.take()
     }
 
     /// Returns engine cache metrics if a cache exists for prewarming.
@@ -1255,6 +1278,7 @@ mod tests {
                 OverlayBuilder::<EthPrimitives>::new(genesis_hash, ChangesetCache::new()),
             ),
             &TreeConfig::default(),
+            None,
         );
 
         let mut state_hook = handle.state_hook().expect("state hook is None");

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -333,10 +333,13 @@ where
         &self,
         decoded_bal: Arc<DecodedBal>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
+        finalize_sparse_trie_task: bool,
     ) {
         let bal = decoded_bal.as_bal();
         if bal.is_empty() {
-            if let Some(to_sparse_trie_task) = self.to_sparse_trie_task.as_ref() {
+            if finalize_sparse_trie_task &&
+                let Some(to_sparse_trie_task) = self.to_sparse_trie_task.as_ref()
+            {
                 let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
             }
             let _ =
@@ -391,7 +394,9 @@ where
                     },
                 );
 
-                let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
+                if finalize_sparse_trie_task {
+                    let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
+                }
                 let _ = stream_tx.send(());
             });
         } else {
@@ -452,8 +457,12 @@ where
         name = "prewarm and caching",
         skip_all
     )]
-    pub fn run<Tx>(self, mode: PrewarmMode<Tx>, actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>)
-    where
+    pub fn run<Tx>(
+        self,
+        mode: PrewarmMode<Tx>,
+        actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
+        finalize_sparse_trie_task: bool,
+    ) where
         Tx: ExecutableTxFor<Evm> + Send + 'static,
     {
         // Spawn execution tasks based on mode
@@ -462,7 +471,7 @@ where
                 self.spawn_txs_prewarm(pending, actions_tx, self.to_sparse_trie_task.clone());
             }
             PrewarmMode::BlockAccessList(bal) => {
-                self.run_bal_prewarm(bal, actions_tx);
+                self.run_bal_prewarm(bal, actions_tx, finalize_sparse_trie_task);
             }
             PrewarmMode::Skipped => {
                 let _ = actions_tx

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1468,6 +1468,7 @@ where
                     provider_builder,
                     overlay_factory,
                     &self.config,
+                    None,
                 );
 
                 // record prewarming initialization duration

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1469,6 +1469,7 @@ where
                     overlay_factory,
                     &self.config,
                     None,
+                    true,
                 );
 
                 // record prewarming initialization duration

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -120,6 +120,20 @@ impl StateRootHandle {
         }
     }
 
+    /// Returns a state hook that streams state updates to the background state root task
+    /// without sending [`StateRootMessage::FinishedStateUpdates`] when the hook is dropped.
+    ///
+    /// Use this for non-terminal executions when the same state root pipeline will be
+    /// reused for subsequent executions (e.g. flashblocks). Use [`Self::state_hook`] for
+    /// the final execution so the task finalizes on hook drop.
+    pub fn state_hook_persistent(&self) -> impl alloy_evm::block::OnStateHook {
+        let sender = self.updates_tx.clone();
+
+        move |source: StateChangeSource, state: &EvmState| {
+            let _ = sender.send(StateRootMessage::StateUpdate(source.into(), state.clone()));
+        }
+    }
+
     /// Awaits the state root computation result.
     ///
     /// # Panics


### PR DESCRIPTION
## Summary

This PR enables the reth engine payload processor to optionally allow state root task to run in the background, while exposing interfaces so callers are able to choose when state updates are completed. This is an add on PR similar to the context mentioned in - https://github.com/paradigmxyz/reth/pull/23354#issuecomment-4384850673, allowing more control over when do we want to finalize the sparse trie task handle.

1. Adds the new optional state root handle to the payload processor spawn interface, so callers can optionally pass the handler to an already running state root task to the new payload processing instance
2. Adds the new `state_hook_persistent` which does not send `StateRootMessage::FinishedStateUpdates` when state hook is dropped - used on optimistic transaction prewarming pipeline
3. Adds the new `finalize_sparse_trie_task` for state root task on BAL pipeline, to optionally not send `StateRootMessage::FinishedStateUpdates` if specified