### PR TITLE
refactor(generate-big-blocks): don't recompute receipts root

### DIFF
--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -5,14 +5,14 @@
 //! and saves the result to disk as a [`BigBlockPayload`] JSON file containing the merged
 //! [`ExecutionData`] and environment switches at each block boundary.
 
-use alloy_consensus::{TxEnvelope, TxReceipt};
+use alloy_consensus::{TxEnvelope};
 use alloy_eips::{
     eip1559::BaseFeeParams,
     eip7840::BlobParams,
     eip7928::{AccountChanges, BlockAccessList, SlotChanges},
     Typed2718,
 };
-use alloy_primitives::{Bloom, Bytes, B256};
+use alloy_primitives::{Bytes, B256};
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
 use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::{
@@ -28,7 +28,6 @@ use reth_cli_runner::CliContext;
 use reth_engine_primitives::BigBlockData;
 use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
 use reth_ethereum_primitives::Receipt;
-use reth_primitives_traits::proofs;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -354,7 +353,6 @@ impl Command {
 
             // Drain the prefetch stream until the gas target is reached for this big block.
             let mut blocks = Vec::new();
-            let mut block_receipts: Vec<Vec<Receipt>> = Vec::new();
             let mut block_access_lists: Vec<Option<BlockAccessList>> = Vec::new();
             let mut accumulated_block_gas: u64 = 0;
 
@@ -401,7 +399,6 @@ impl Command {
 
                 accumulated_block_gas += block_gas;
                 blocks.push(execution_data);
-                block_receipts.push(consensus_receipts);
                 block_access_lists.push(block_access_list);
                 next_block += 1;
             }
@@ -419,24 +416,8 @@ impl Command {
 
             // Block 0 is the base
             let mut base = blocks.remove(0);
-            let base_receipts = block_receipts.remove(0);
             let mut merged_block_access_list = block_access_lists.remove(0);
             let mut env_switches = Vec::new();
-
-            // Accumulate all receipts with corrected cumulative_gas_used.
-            // Each block's receipts have cumulative gas relative to that block;
-            // we add the prior blocks' total gas to make them globally correct.
-            let mut all_receipts: Vec<Receipt> = Vec::new();
-            let mut cumulative_gas_offset: u64 = 0;
-            {
-                // Base block receipts (block 0) — no offset needed
-                let base_block_gas = base.payload.as_v1().gas_used;
-                all_receipts.extend(base_receipts.into_iter().map(|mut r| {
-                    r.cumulative_gas_used += cumulative_gas_offset;
-                    r
-                }));
-                cumulative_gas_offset += base_block_gas;
-            }
 
             if !blocks.is_empty() {
                 // Store the original unmutated base block as env_switch at index 0.
@@ -456,8 +437,8 @@ impl Command {
                 let mut total_gas_limit = base.payload.as_v1().gas_limit;
 
                 // Concatenate transactions from subsequent blocks and build env_switches
-                for (block_idx, ((block_data, receipts), block_access_list)) in
-                    blocks.into_iter().zip(block_receipts).zip(block_access_lists).enumerate()
+                for (block_idx, (block_data, block_access_list)) in
+                    blocks.into_iter().zip(block_access_lists).enumerate()
                 {
                     // Segment index in the merged big block. The base block is
                     // segment 0; subsequent blocks are segments 1, 2, ...
@@ -476,13 +457,6 @@ impl Command {
                         );
                     }
 
-                    // Accumulate receipts with corrected cumulative_gas_used
-                    all_receipts.extend(receipts.into_iter().map(|mut r| {
-                        r.cumulative_gas_used += cumulative_gas_offset;
-                        r
-                    }));
-                    cumulative_gas_offset += block_gas;
-
                     // Record environment switch at this block boundary
                     env_switches.push((cumulative_tx_count, block_data.clone()));
 
@@ -492,21 +466,11 @@ impl Command {
                     base.payload.transactions_mut().extend(txs);
                 }
 
-                // Compute merged receipts_root and logs_bloom from all accumulated
-                // receipts (with globally-correct cumulative_gas_used).
-                let receipts_with_bloom: Vec<_> =
-                    all_receipts.iter().map(|r| r.with_bloom_ref()).collect();
-                let merged_receipts_root = proofs::calculate_receipt_root(&receipts_with_bloom);
-                let merged_logs_bloom =
-                    receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | *r.bloom_ref());
-
                 // Mutate the base payload header
                 let base_v1 = base.payload.as_v1_mut();
                 base_v1.state_root = final_state_root;
                 base_v1.gas_used = total_gas_used;
                 base_v1.gas_limit = total_gas_limit;
-                base_v1.receipts_root = merged_receipts_root;
-                base_v1.logs_bloom = merged_logs_bloom;
             }
 
             // Chain sequential big blocks: set parent_hash, block_number, basefee,

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -5,7 +5,7 @@
 //! and saves the result to disk as a [`BigBlockPayload`] JSON file containing the merged
 //! [`ExecutionData`] and environment switches at each block boundary.
 
-use alloy_consensus::{TxEnvelope};
+use alloy_consensus::TxEnvelope;
 use alloy_eips::{
     eip1559::BaseFeeParams,
     eip7840::BlobParams,


### PR DESCRIPTION
reth-bb skips receipt root validation so it's not necessary to precompute the receipts root with valid values