### PR TITLE
perf(engine): trim empty prewarm proof work

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -248,8 +248,12 @@ where
 
             if index > 0 {
                 let (targets, storage_targets) = multiproof_targets_from_state(res.state);
-                ctx.metrics.prefetch_storage_targets.record(storage_targets as f64);
-                if let Some(to_sparse_trie_task) = to_sparse_trie_task {
+                if !targets.is_empty() {
+                    ctx.metrics.prefetch_storage_targets.record(storage_targets as f64);
+                }
+                if !targets.is_empty() &&
+                    let Some(to_sparse_trie_task) = to_sparse_trie_task
+                {
                     let _ = to_sparse_trie_task.send(StateRootMessage::PrefetchProofs(targets));
                 }
             }
@@ -811,7 +815,11 @@ where
 /// Returns a set of [`MultiProofTargetsV2`] and the total amount of storage targets, based on the
 /// given state.
 fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize) {
+    let state_len = state.len();
     let mut targets = MultiProofTargetsV2::default();
+    targets.account_targets.reserve(state_len);
+    targets.storage_targets.reserve(state_len);
+
     let mut storage_target_count = 0;
     for (addr, account) in state {
         // if the account was not touched, or if the account was selfdestructed, do not
@@ -828,7 +836,8 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         let hashed_address = keccak256(addr);
         targets.account_targets.push(hashed_address.into());
 
-        let mut storage_slots = Vec::with_capacity(account.storage.len());
+        let storage_capacity = account.storage.len();
+        let mut storage_slots = None::<Vec<ProofV2Target>>;
         for (key, slot) in account.storage {
             // do nothing if unchanged
             if !slot.is_changed() {
@@ -836,11 +845,13 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
             }
 
             let hashed_slot = keccak256(B256::new(key.to_be_bytes()));
-            storage_slots.push(ProofV2Target::from(hashed_slot));
+            storage_slots
+                .get_or_insert_with(|| Vec::with_capacity(storage_capacity))
+                .push(ProofV2Target::from(hashed_slot));
         }
 
-        storage_target_count += storage_slots.len();
-        if !storage_slots.is_empty() {
+        if let Some(storage_slots) = storage_slots {
+            storage_target_count += storage_slots.len();
             targets.storage_targets.insert(hashed_address, storage_slots);
         }
     }


### PR DESCRIPTION
Avoid allocating per-account storage target buffers when a prewarm transaction did not change storage, reserve the proof target containers once up front, and skip no-op PrefetchProofs messages. This keeps the sparse-trie prefetch path focused on transactions that actually contribute proof targets.