### PR TITLE
perf(engine): bound the receipt root queue

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -957,9 +957,10 @@ where
         }
 
         // Spawn background task to compute receipt root and logs bloom incrementally.
-        // Unbounded channel is used since tx count bounds capacity anyway (max ~30k txs per block).
+        // A per-block bounded queue avoids per-receipt linked-node allocations while still
+        // leaving enough room for the entire block's receipt stream.
         let receipts_len = input.transaction_count();
-        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
+        let (receipt_tx, receipt_rx) = crossbeam_channel::bounded(receipts_len.max(1));
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
         self.payload_processor


### PR DESCRIPTION
Use a bounded crossbeam channel sized for the block's receipt stream when handing receipts to the background receipt-root task.

This avoids per-receipt linked-queue allocations in the execute path while preserving the existing streaming receipt root computation.