### PR TITLE
fix(rpc): relax forkchoice update error match

### DIFF
--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -195,6 +195,15 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                             None::<()>,
                         )
                     }
+                    // Map future alloy forkchoice errors as internal until handled.
+                    #[allow(unreachable_patterns, clippy::needless_return)]
+                    _ => {
+                        return jsonrpsee_types::error::ErrorObject::owned(
+                            INTERNAL_ERROR_CODE,
+                            SERVER_ERROR_MSG,
+                            Some(ErrorData::new(error)),
+                        );
+                    }
                 },
                 BeaconForkChoiceUpdateError::EngineUnavailable |
                 BeaconForkChoiceUpdateError::Internal(_) => {


### PR DESCRIPTION
Prepares reth for alloy-rs/alloy#3935 by adding a wildcard fallback for future `ForkchoiceUpdateError` variants. Unknown variants now return the existing internal Engine API error response instead of making the match exhaustiveness-sensitive.

Validated with `cargo +nightly fmt --all --check`, `cargo nextest run -p reth-rpc-engine-api engine_error_rpc_error_test`, and `cargo +nightly clippy -p reth-rpc-engine-api --all-features --tests`.