### PR TITLE
perf(tasks): detach fire-and-forget named workers

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1512,7 +1512,7 @@ where
         // Spawn a background task to trigger computation so it's ready when the next payload
         // arrives.
         if let Some(prepared) = self.state.tree_state.prepare_canonical_overlay() {
-            self.runtime.spawn_blocking_named("prepare-overlay", move || {
+            self.runtime.spawn_blocking_named_detached("prepare-overlay", move || {
                 let _ = prepared.overlay.get(prepared.anchor_hash);
             });
         }
@@ -1681,7 +1681,7 @@ where
                                     if let Some((rx, start_time, _action)) = pending_persistence {
                                         let (persistence_tx, persistence_rx) =
                                             std::sync::mpsc::channel();
-                                        self.runtime.spawn_blocking_named(
+                                        self.runtime.spawn_blocking_named_detached(
                                             "wait-persist",
                                             move || {
                                                 let start = Instant::now();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -185,10 +185,10 @@ where
         let (execution_tx, execution_rx) = std::sync::mpsc::channel();
         let (sparse_trie_tx, sparse_trie_rx) = std::sync::mpsc::channel();
 
-        self.executor.spawn_blocking_named("wait-exec-cache", move || {
+        self.executor.spawn_blocking_named_detached("wait-exec-cache", move || {
             let _ = execution_tx.send(execution_cache.wait_for_availability());
         });
-        self.executor.spawn_blocking_named("wait-sparse-tri", move || {
+        self.executor.spawn_blocking_named_detached("wait-sparse-tri", move || {
             let _ = sparse_trie_tx.send(sparse_trie.wait_for_availability());
         });
 
@@ -506,7 +506,7 @@ where
         {
             let to_prewarm_task = to_prewarm_task.clone();
             let disable_bal_parallel_execution = self.disable_bal_parallel_execution;
-            self.executor.spawn_blocking_named("prewarm", move || {
+            self.executor.spawn_blocking_named_detached("prewarm", move || {
                 let mode = if skip_prewarm {
                     PrewarmMode::Skipped
                 } else if let Some(decoded_bal) =
@@ -567,7 +567,7 @@ where
         let executor = self.executor.clone();
 
         let parent_span = Span::current();
-        self.executor.spawn_blocking_named("sparse-trie", move || {
+        self.executor.spawn_blocking_named_detached("sparse-trie", move || {
             reth_tasks::once!(increase_thread_priority);
 
             let _enter = debug_span!(target: "engine::tree::payload_processor", parent: parent_span, "sparse_trie_task")

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -131,7 +131,7 @@ where
         let ctx = self.ctx.clone();
         let span = Span::current();
 
-        self.executor.spawn_blocking_named("prewarm-txs", move || {
+        self.executor.spawn_blocking_named_detached("prewarm-txs", move || {
             let _enter = debug_span!(
                 target: "engine::tree::payload_processor::prewarm",
                 parent: &span,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -964,7 +964,7 @@ where
         let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
         self.payload_processor
             .executor()
-            .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
+            .spawn_blocking_named_detached("receipt-root", move || task_handle.run(receipts_len));
 
         let transaction_count = input.transaction_count();
         let executed_tx_index = Arc::clone(handle.executed_tx_index());

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -500,7 +500,7 @@ impl Runtime {
     /// and should not block the current task. Uses a persistent named thread (`"drop"`)
     /// to avoid thread creation overhead on hot paths.
     pub fn spawn_drop<T: Send + 'static>(&self, value: T) {
-        self.spawn_blocking_named("drop", move || drop(value));
+        self.spawn_blocking_named_detached("drop", move || drop(value));
     }
 
     /// Spawns a blocking closure on a dedicated, named OS thread.
@@ -520,6 +520,17 @@ impl Runtime {
         R: Send + 'static,
     {
         crate::LazyHandle::new(self.0.worker_map.spawn_on(name, func))
+    }
+
+    /// Spawns a blocking closure on a dedicated, named OS thread without creating a result handle.
+    ///
+    /// Use this for fire-and-forget work that already reports completion through some other
+    /// channel or side effect.
+    pub fn spawn_blocking_named_detached<F>(&self, name: &'static str, func: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.0.worker_map.spawn_on_detached(name, func)
     }
 
     /// Spawns the task onto the runtime.

--- a/crates/tasks/src/worker_map.rs
+++ b/crates/tasks/src/worker_map.rs
@@ -76,6 +76,18 @@ impl WorkerMap {
 
         result_rx
     }
+
+    /// Spawns a closure on the dedicated worker thread for the given name without allocating a
+    /// result channel.
+    pub(crate) fn spawn_on_detached<F>(&self, name: &'static str, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let task: BoxedTask = Box::new(f);
+
+        let worker = self.workers.entry(name).or_insert_with(|| WorkerThread::new(name));
+        let _ = worker.tx.send(task);
+    }
 }
 
 impl Drop for WorkerMap {
@@ -99,6 +111,7 @@ impl std::fmt::Debug for WorkerMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn worker_map_basic() {
@@ -162,5 +175,18 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(name, "custom-worker");
+    }
+
+    #[tokio::test]
+    async fn worker_map_detached_executes() {
+        let map = WorkerMap::new();
+        let (tx, rx) = oneshot::channel();
+
+        map.spawn_on_detached("detached-worker", move || {
+            let _ = tx.send(thread::current().name().unwrap().to_string());
+        });
+
+        let name = rx.await.unwrap();
+        assert_eq!(name, "detached-worker");
     }
 }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -207,7 +207,7 @@ impl ProofWorkerHandle {
         let storage_avail = storage_availability.clone();
         let storage_roots = cached_storage_roots.clone();
         let storage_parent_span = tracing::Span::current();
-        runtime.spawn_blocking_named("storage-workers", move || {
+        runtime.spawn_blocking_named_detached("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
             storage_rt.proof_storage_worker_pool().broadcast(storage_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
@@ -245,7 +245,7 @@ impl ProofWorkerHandle {
         let account_tx = storage_work_tx.clone();
         let account_avail = account_availability.clone();
         let account_parent_span = tracing::Span::current();
-        runtime.spawn_blocking_named("account-workers", move || {
+        runtime.spawn_blocking_named_detached("account-workers", move || {
             let worker_id = AtomicUsize::new(0);
             account_rt.proof_account_worker_pool().broadcast(account_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
Add a detached named-worker path for background jobs that already signal completion through other channels or side effects. Switch proof-worker startup and engine background tasks that ignored their LazyHandle results over to that path to avoid per-task oneshot and handle allocation.