### PR TITLE
perf(trie): skip redundant proof child commits

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -365,17 +365,14 @@ where
         &mut self,
         targets: &mut Option<TargetsCursor<'a>>,
     ) -> Result<(), StateProofError> {
+        if matches!(self.child_stack.last(), Some(ProofTrieBranchChild::RlpNode(_))) {
+            trace!(target: TRACE_TARGET, "Last child already committed");
+            return Ok(())
+        }
+
         let Some(child_path) = self.last_child_path() else { return Ok(()) };
         let child =
             self.child_stack.pop().expect("child_stack can't be empty if there's a child path");
-
-        // If the child is already an `RlpNode` then there is nothing to do, push it back on with no
-        // changes.
-        if let ProofTrieBranchChild::RlpNode(_rlp_node) = &child {
-            trace!(target: TRACE_TARGET, ?_rlp_node, "Already RlpNode, pushing onto stack");
-            self.child_stack.push(child);
-            return Ok(())
-        }
 
         // Only commit immediately if retained for the proof. Otherwise, defer conversion
         // to pop_branch() to give DeferredEncoder time for async work.


### PR DESCRIPTION
Return early when the last proof child is already an RLP node instead of popping and pushing it back through commit_last_child. This keeps pop_branch and leaf insertion on the cheaper fast path when sibling work has already committed the child.