### PR TITLE
fix(engine): increase state root task timeout to 4s

### DIFF
--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -285,7 +285,7 @@ impl Default for DefaultEngineValues {
             sparse_trie_max_hot_accounts: DEFAULT_SPARSE_TRIE_MAX_HOT_ACCOUNTS,
             slow_block_threshold: None,
             disable_sparse_trie_cache_pruning: false,
-            state_root_task_timeout: Some("1s".to_string()),
+            state_root_task_timeout: Some("4s".to_string()),
             share_execution_cache_with_payload_builder: false,
             share_sparse_trie_with_payload_builder: false,
             suppress_persistence_during_build: false,
@@ -459,14 +459,14 @@ pub struct EngineArgs {
     /// If the state root task takes longer than this, a sequential computation starts in
     /// parallel and whichever finishes first is used.
     ///
-    /// --engine.state-root-task-timeout 1s
+    /// --engine.state-root-task-timeout 4s
     /// --engine.state-root-task-timeout 400ms
     ///
     /// Set to 0s to disable.
     #[arg(
         long = "engine.state-root-task-timeout",
         value_parser = humantime::parse_duration,
-        default_value = DefaultEngineValues::get_global().state_root_task_timeout.as_deref().unwrap_or("1s"),
+        default_value = DefaultEngineValues::get_global().state_root_task_timeout.as_deref().unwrap_or("4s"),
     )]
     pub state_root_task_timeout: Option<Duration>,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1056,11 +1056,11 @@ Engine:
       --engine.state-root-task-timeout <STATE_ROOT_TASK_TIMEOUT>
           Configure the timeout for the state root task before spawning a sequential fallback. If the state root task takes longer than this, a sequential computation starts in parallel and whichever finishes first is used.
 
-          --engine.state-root-task-timeout 1s --engine.state-root-task-timeout 400ms
+          --engine.state-root-task-timeout 4s --engine.state-root-task-timeout 400ms
 
           Set to 0s to disable.
 
-          [default: 1s]
+          [default: 4s]
 
       --engine.share-execution-cache-with-payload-builder
           Whether to share execution cache with the payload builder.


### PR DESCRIPTION
Updates the default `engine.state-root-task-timeout` from `1s` to `4s`, some blocks actually take this long for state root and the state root task getting truly stuck is unlikely