### PR TITLE
perf(engine): skip eager prewarm init on small batches

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -141,13 +141,19 @@ where
 
             let ctx = &ctx;
             let pool = executor.prewarming_pool();
+            let eager_init_threshold = pool.current_num_threads().saturating_mul(2);
 
             let mut tx_count = 0usize;
             let to_sparse_trie_task = to_sparse_trie_task.as_ref();
             pool.in_place_scope(|s| {
-                s.spawn(|_| {
-                    pool.init::<PrewarmEvmState<Evm>>(|_| ctx.evm_for_ctx());
-                });
+                // Large batches usually fan out across the whole pool, so eagerly priming each
+                // worker still pays off. Smaller batches rely on the existing lazy get_or_init
+                // path and avoid paying the broadcast cost up front.
+                if ctx.env.transaction_count >= eager_init_threshold {
+                    s.spawn(|_| {
+                        pool.init::<PrewarmEvmState<Evm>>(|_| ctx.evm_for_ctx());
+                    });
+                }
 
                 while let Ok((index, tx)) = pending.recv() {
                     if ctx.should_stop() {


### PR DESCRIPTION
Only broadcast prewarm EVM initialization when the payload is large enough to likely use the full prewarming pool. Smaller batches already have a lazy get_or_init path, so this avoids paying the all-thread setup cost up front on medium and small blocks.