### PR TITLE
perf(trie): walk sorted storage trie writes forward

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4364,6 +4364,16 @@ mod tests {
                     )),
                 ),
                 (Nibbles::from_nibbles([0x2, 0x0]), None), // Deletion of existing node
+                (
+                    Nibbles::from_nibbles([0x3, 0x0]),
+                    Some(BranchNodeCompact::new(
+                        0b0000_1111_0000_1111,
+                        0b0000_0000_0000_0000,
+                        0b0000_0000_0000_0000,
+                        vec![],
+                        None,
+                    )),
+                ),
             ],
         };
 
@@ -4381,9 +4391,9 @@ mod tests {
         // Write the sorted trie updates
         let num_entries = provider_rw.write_trie_updates_sorted(&trie_updates).unwrap();
 
-        // We should have 2 account insertions + 1 account deletion + 1 storage insertion + 1
-        // storage deletion = 5
-        assert_eq!(num_entries, 5);
+        // We should have 2 account insertions + 1 account deletion + 2 storage insertions + 1
+        // storage deletion = 6
+        assert_eq!(num_entries, 6);
 
         // Verify account trie updates were written correctly
         let tx = provider_rw.tx_ref();
@@ -4421,13 +4431,23 @@ mod tests {
             .unwrap();
         assert_eq!(
             storage_entries1.len(),
-            1,
-            "Storage address1 should have 1 entry after deletion"
+            2,
+            "Storage address1 should have 2 entries after the update batch"
         );
         assert_eq!(
             storage_entries1[0].1.nibbles.0,
             Nibbles::from_nibbles([0x1, 0x0]),
             "Remaining entry should be [0x1, 0x0]"
+        );
+        assert_eq!(
+            storage_entries1[1].1.nibbles.0,
+            Nibbles::from_nibbles([0x3, 0x0]),
+            "New entry should be [0x3, 0x0]"
+        );
+        assert_eq!(
+            storage_entries1[1].1.node.state_mask,
+            reth_trie::TrieMask::new(0b0000_1111_0000_1111),
+            "New entry should have the inserted state_mask"
         );
 
         // Check storage for address2 was wiped

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -276,6 +276,17 @@ where
         + DbDupCursorRO<A::StorageTrieTable>
         + DbDupCursorRW<A::StorageTrieTable>,
 {
+    fn current_value(&mut self) -> Result<Option<A::StorageValue>, DatabaseError> {
+        Ok(self
+            .cursor
+            .current()?
+            .and_then(|(key, value)| (key == self.hashed_address).then_some(value)))
+    }
+
+    fn next_value(&mut self) -> Result<Option<A::StorageValue>, DatabaseError> {
+        Ok(self.cursor.next_dup()?.map(|(_, value)| value))
+    }
+
     /// Writes storage updates that are already sorted
     pub fn write_storage_trie_updates_sorted(
         &mut self,
@@ -286,25 +297,37 @@ where
             self.cursor.delete_current_duplicates()?;
         }
 
+        let mut current: Option<A::StorageValue> = None;
         let mut num_entries = 0;
         for (nibbles, maybe_updated) in updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
         {
             num_entries += 1;
             let nibbles = A::StorageSubKey::from(*nibbles);
+
+            let needs_seek = match current.as_ref() {
+                Some(entry) => entry.nibbles() > &nibbles,
+                None => true,
+            };
+
+            if needs_seek {
+                current = self.cursor.seek_by_key_subkey(self.hashed_address, nibbles.clone())?;
+            } else {
+                while current.as_ref().is_some_and(|entry| entry.nibbles() < &nibbles) {
+                    current = self.next_value()?;
+                }
+            }
+
             // Delete the old entry if it exists.
-            if self
-                .cursor
-                .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
-                .as_ref()
-                .is_some_and(|e| *e.nibbles() == nibbles)
-            {
+            if current.as_ref().is_some_and(|entry| *entry.nibbles() == nibbles) {
                 self.cursor.delete_current()?;
+                current = self.current_value()?;
             }
 
             // There is an updated version of this node, insert new entry.
             if let Some(node) = maybe_updated {
-                self.cursor
-                    .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
+                let updated = A::StorageValue::new(nibbles.clone(), node.clone());
+                self.cursor.upsert(self.hashed_address, &updated)?;
+                current = Some(updated);
             }
         }
 


### PR DESCRIPTION
Carry the storage dup cursor across sorted trie updates instead of re-seeking every subkey before delete or replace. This keeps MDBX on the forward path for merged trie writes while preserving the existing delete-and-upsert semantics.\n\nExtend the provider regression test to cover an insertion after a deletion in the same storage trie update batch.