### PR TITLE
perf(trie): cache sparse branch child positions

### DIFF
--- a/crates/trie/sparse/src/arena/branch_child_idx.rs
+++ b/crates/trie/sparse/src/arena/branch_child_idx.rs
@@ -14,21 +14,9 @@ use smallvec::SmallVec;
 pub(super) struct BranchChildIdx(u8);
 
 impl BranchChildIdx {
-    /// Returns the dense index for `nibble` within the children array of a branch whose
-    /// occupied slots are described by `state_mask`.
-    ///
-    /// Returns `None` if the nibble's bit is not set in `state_mask`.
-    pub(super) const fn new(state_mask: TrieMask, nibble: u8) -> Option<Self> {
-        if !state_mask.is_bit_set(nibble) {
-            return None;
-        }
-        Some(Self::new_unchecked(state_mask, nibble))
-    }
-
     /// Returns the dense insertion point for `nibble` — the number of occupied child slots
-    /// below `nibble`. Unlike [`Self::new`], this does **not** require the nibble's bit to be
-    /// set, making it suitable for computing the position at which a new child should be
-    /// inserted.
+    /// below `nibble`. This does not require the nibble's bit to be set, making it suitable for
+    /// computing the position at which a new child should be inserted.
     pub(super) const fn insertion_point(state_mask: TrieMask, nibble: u8) -> Self {
         Self(Self::count_below(state_mask, nibble))
     }
@@ -38,14 +26,14 @@ impl BranchChildIdx {
         self.0 as usize
     }
 
+    /// Creates an index from an already-computed dense child position.
+    pub(super) const fn from_dense(dense: u8) -> Self {
+        Self(dense)
+    }
+
     /// Counts the number of occupied child slots below `nibble` in the dense children array.
     const fn count_below(state_mask: TrieMask, nibble: u8) -> u8 {
         (state_mask.get() & ((1u16 << nibble) - 1)).count_ones() as u8
-    }
-
-    /// Computes the dense index for `nibble` without checking whether the bit is set.
-    const fn new_unchecked(state_mask: TrieMask, nibble: u8) -> Self {
-        Self(Self::count_below(state_mask, nibble))
     }
 }
 

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -1,6 +1,6 @@
 use super::{
-    branch_child_idx::{BranchChildIdx, BranchChildIter},
-    ArenaSparseNode, ArenaSparseNodeBranchChild, ArenaSparseNodeState, Index, NodeArena,
+    branch_child_idx::BranchChildIter, ArenaSparseNode, ArenaSparseNodeBranchChild,
+    ArenaSparseNodeState, Index, NodeArena,
 };
 use alloc::vec::Vec;
 use reth_trie_common::Nibbles;
@@ -208,7 +208,8 @@ impl ArenaCursor {
             child_nibble.expect("if cursor has a parent then the head path can't be empty");
 
         let parent_branch = arena[parent.index].branch_mut();
-        let child_idx = BranchChildIdx::new(parent_branch.state_mask, child_nibble)
+        let child_idx = parent_branch
+            .child_idx(child_nibble)
             .expect("child nibble not found in parent state_mask");
 
         debug_assert!(
@@ -340,8 +341,7 @@ impl ArenaCursor {
             }
 
             let child_nibble = full_path.get_unchecked(head_branch_logical_path.len());
-            let Some(branch_child_idx) = BranchChildIdx::new(head_branch.state_mask, child_nibble)
-            else {
+            let Some(branch_child_idx) = head_branch.child_idx(child_nibble) else {
                 return SeekResult::NoChild { child_nibble };
             };
 

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2,7 +2,7 @@ mod branch_child_idx;
 mod cursor;
 mod nodes;
 
-use branch_child_idx::{BranchChildIdx, BranchChildIter};
+use branch_child_idx::BranchChildIter;
 use cursor::{ArenaCursor, NextResult, SeekResult};
 use nodes::{
     ArenaSparseNode, ArenaSparseNodeBranch, ArenaSparseNodeBranchChild, ArenaSparseNodeState,
@@ -906,13 +906,7 @@ impl ArenaParallelSparseTrie {
 
         trace!(target: TRACE_TARGET, "Unwrapping empty subtrie, removing child slot");
         let parent_branch = self.upper_arena[parent_idx].branch_mut();
-        let child_idx = BranchChildIdx::new(parent_branch.state_mask, child_nibble)
-            .expect("child nibble not found in parent state_mask");
-
-        parent_branch.children.remove(child_idx.get());
-        parent_branch.unset_child_bit(child_nibble);
-        // The branch structure changed (child removed), so any cached RLP is stale.
-        parent_branch.state = parent_branch.state.to_dirty();
+        parent_branch.remove_child(child_nibble);
 
         self.maybe_collapse_or_remove_branch(cursor);
     }
@@ -978,11 +972,7 @@ impl ArenaParallelSparseTrie {
                 self.upper_arena.remove(branch_idx);
                 let parent_idx = cursor.head().expect("cursor is non-empty").index;
                 let parent_branch = self.upper_arena[parent_idx].branch_mut();
-                let child_idx = BranchChildIdx::new(parent_branch.state_mask, branch_nibble)
-                    .expect("child nibble not found in parent state_mask");
-                parent_branch.children.remove(child_idx.get());
-                parent_branch.unset_child_bit(branch_nibble);
-                parent_branch.state = parent_branch.state.to_dirty();
+                parent_branch.remove_child(branch_nibble);
                 continue; // re-check the parent
             }
 
@@ -1323,7 +1313,7 @@ impl ArenaParallelSparseTrie {
                     }
 
                     let child_nibble = full_path.get_unchecked(logical_end);
-                    let child_idx = BranchChildIdx::new(b.state_mask, child_nibble)?;
+                    let child_idx = b.child_idx(child_nibble)?;
                     match &b.children[child_idx] {
                         ArenaSparseNodeBranchChild::Blinded(_) => return None,
                         ArenaSparseNodeBranchChild::Revealed(child_idx) => {
@@ -1388,7 +1378,7 @@ impl ArenaParallelSparseTrie {
                     }
 
                     let child_nibble = full_path.get_unchecked(logical_end);
-                    let Some(child_idx) = BranchChildIdx::new(b.state_mask, child_nibble) else {
+                    let Some(child_idx) = b.child_idx(child_nibble) else {
                         return Ok(LeafLookup::NonExistent);
                     };
 
@@ -1522,13 +1512,13 @@ impl ArenaParallelSparseTrie {
         children.push(ArenaSparseNodeBranchChild::Revealed(first_child));
         children.push(ArenaSparseNodeBranchChild::Revealed(second_child));
 
-        let new_branch_idx = arena.insert(ArenaSparseNode::Branch(ArenaSparseNodeBranch {
-            state: ArenaSparseNodeState::Dirty,
+        let new_branch_idx = arena.insert(ArenaSparseNode::Branch(ArenaSparseNodeBranch::new(
+            ArenaSparseNodeState::Dirty,
             children,
             state_mask,
             short_key,
-            branch_masks: BranchNodeMasks::default(),
-        }));
+            BranchNodeMasks::default(),
+        )));
 
         cursor.replace_head_index(arena, root, new_branch_idx);
         newly_dirtied_existing
@@ -2066,7 +2056,8 @@ impl ArenaParallelSparseTrie {
             let parent_idx = cursor.parent().expect("pruned child has parent").index;
             let child_nibble = nibble.expect("non-root child");
             let parent_branch = arena[parent_idx].branch_mut();
-            let child_idx = BranchChildIdx::new(parent_branch.state_mask, child_nibble)
+            let child_idx = parent_branch
+                .child_idx(child_nibble)
                 .expect("child nibble not found in parent state_mask");
             parent_branch.children[child_idx] = ArenaSparseNodeBranchChild::Blinded(rlp_node);
         }
@@ -2109,7 +2100,8 @@ impl ArenaParallelSparseTrie {
 
         let child_nibble = node.path.get_unchecked(head_branch_logical_path.len());
         let head_branch = arena[head_idx].branch_ref();
-        let dense_child_idx = BranchChildIdx::new(head_branch.state_mask, child_nibble)
+        let dense_child_idx = head_branch
+            .child_idx(child_nibble)
             .expect("Blinded result but child nibble not in state_mask");
 
         let cached_rlp = match &head_branch.children[dense_child_idx] {
@@ -2257,13 +2249,13 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         .push(ArenaSparseNodeBranchChild::Blinded(branch.stack[stack_ptr].clone()));
                 }
 
-                self.upper_arena[self.root] = ArenaSparseNode::Branch(ArenaSparseNodeBranch {
-                    state: ArenaSparseNodeState::Revealed,
+                self.upper_arena[self.root] = ArenaSparseNode::Branch(ArenaSparseNodeBranch::new(
+                    ArenaSparseNodeState::Revealed,
                     children,
-                    state_mask: branch.state_mask,
-                    short_key: branch.key,
-                    branch_masks: masks.unwrap_or_default(),
-                });
+                    branch.state_mask,
+                    branch.key,
+                    masks.unwrap_or_default(),
+                ));
             }
             TrieNodeV2::Extension(_) => {
                 panic!("set_root does not support Extension nodes; extensions are represented as branches with a short_key")

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -8,6 +8,8 @@ use alloy_trie::{BranchNodeCompact, TrieMask};
 use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNodeV2, RlpNode, TrieNodeV2};
 use smallvec::SmallVec;
 
+const MISSING_CHILD_IDX: u8 = u8::MAX;
+
 /// Tracks whether a node's RLP encoding is cached or needs recomputation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ArenaSparseNodeState {
@@ -61,6 +63,8 @@ pub(super) struct ArenaSparseNodeBranch {
     /// Revealed or blinded children, packed densely. The `state_mask` tracks which
     /// nibble positions have entries in this `SmallVec`.
     pub(super) children: SmallVec<[ArenaSparseNodeBranchChild; 4]>,
+    /// Dense child index per nibble, or `u8::MAX` when the nibble is absent.
+    pub(super) child_lookup: [u8; 16],
     /// Bitmask indicating which of the 16 child slots are occupied (have an entry
     /// in `children`).
     pub(super) state_mask: TrieMask,
@@ -72,6 +76,37 @@ pub(super) struct ArenaSparseNodeBranch {
 }
 
 impl ArenaSparseNodeBranch {
+    pub(super) fn new(
+        state: ArenaSparseNodeState,
+        children: SmallVec<[ArenaSparseNodeBranchChild; 4]>,
+        state_mask: TrieMask,
+        short_key: Nibbles,
+        branch_masks: BranchNodeMasks,
+    ) -> Self {
+        let mut branch = Self {
+            state,
+            children,
+            child_lookup: [MISSING_CHILD_IDX; 16],
+            state_mask,
+            short_key,
+            branch_masks,
+        };
+        branch.rebuild_child_lookup();
+        branch
+    }
+
+    fn rebuild_child_lookup(&mut self) {
+        self.child_lookup.fill(MISSING_CHILD_IDX);
+        for (idx, nibble) in BranchChildIter::new(self.state_mask) {
+            self.child_lookup[nibble as usize] = idx.get() as u8;
+        }
+    }
+
+    pub(super) fn child_idx(&self, nibble: u8) -> Option<BranchChildIdx> {
+        let dense = self.child_lookup[nibble as usize];
+        (dense != MISSING_CHILD_IDX).then(|| BranchChildIdx::from_dense(dense))
+    }
+
     /// Unsets the bit for `nibble` in `state_mask`, `hash_mask`, and `tree_mask`.
     pub(super) const fn unset_child_bit(&mut self, nibble: u8) {
         self.state_mask.unset_bit(nibble);
@@ -83,6 +118,7 @@ impl ArenaSparseNodeBranch {
         let insert_pos = BranchChildIdx::insertion_point(self.state_mask, nibble);
         self.state_mask.set_bit(nibble);
         self.children.insert(insert_pos.get(), child);
+        self.rebuild_child_lookup();
         self.state = ArenaSparseNodeState::Dirty;
     }
 
@@ -93,10 +129,10 @@ impl ArenaSparseNodeBranch {
     ///
     /// Panics if `nibble` is not set in the state mask.
     pub(super) fn remove_child(&mut self, nibble: u8) {
-        let child_idx =
-            BranchChildIdx::new(self.state_mask, nibble).expect("nibble not found in state_mask");
+        let child_idx = self.child_idx(nibble).expect("nibble not found in state_mask");
         self.children.remove(child_idx.get());
         self.unset_child_bit(nibble);
+        self.rebuild_child_lookup();
         self.state = ArenaSparseNodeState::Dirty;
     }
 
@@ -111,8 +147,7 @@ impl ArenaSparseNodeBranch {
             2,
             "sibling_child requires exactly 2 children"
         );
-        let child_idx =
-            BranchChildIdx::new(self.state_mask, nibble).expect("nibble not found in state_mask");
+        let child_idx = self.child_idx(nibble).expect("nibble not found in state_mask");
         // With exactly 2 children the dense array has indices 0 and 1.
         &self.children[1 - child_idx.get()]
     }
@@ -309,13 +344,13 @@ impl ArenaSparseNode {
                     .iter()
                     .map(|rlp| ArenaSparseNodeBranchChild::Blinded(rlp.clone()))
                     .collect();
-                Self::Branch(ArenaSparseNodeBranch {
-                    state: ArenaSparseNodeState::Revealed,
+                Self::Branch(ArenaSparseNodeBranch::new(
+                    ArenaSparseNodeState::Revealed,
                     children,
-                    state_mask: branch.state_mask,
-                    short_key: branch.key,
-                    branch_masks: masks.unwrap_or_default(),
-                })
+                    branch.state_mask,
+                    branch.key,
+                    masks.unwrap_or_default(),
+                ))
             }
             TrieNodeV2::Extension(_) => {
                 panic!("Extension nodes should be merged into branches by TrieNodeV2")
@@ -332,5 +367,43 @@ impl ArenaSparseNode {
             }
             _ => 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn branch_child_lookup_tracks_insertions_and_removals() {
+        let mut children = SmallVec::new();
+        children.push(ArenaSparseNodeBranchChild::Blinded(RlpNode::word_rlp(&B256::ZERO)));
+        children
+            .push(ArenaSparseNodeBranchChild::Blinded(RlpNode::word_rlp(&B256::repeat_byte(0x11))));
+
+        let mut branch = ArenaSparseNodeBranch::new(
+            ArenaSparseNodeState::Revealed,
+            children,
+            TrieMask::from((1u16 << 1) | (1u16 << 5)),
+            Nibbles::default(),
+            BranchNodeMasks::default(),
+        );
+
+        assert_eq!(branch.child_idx(1).unwrap().get(), 0);
+        assert_eq!(branch.child_idx(5).unwrap().get(), 1);
+        assert!(branch.child_idx(3).is_none());
+
+        branch.set_child(
+            3,
+            ArenaSparseNodeBranchChild::Blinded(RlpNode::word_rlp(&B256::repeat_byte(0x22))),
+        );
+        assert_eq!(branch.child_idx(1).unwrap().get(), 0);
+        assert_eq!(branch.child_idx(3).unwrap().get(), 1);
+        assert_eq!(branch.child_idx(5).unwrap().get(), 2);
+
+        branch.remove_child(3);
+        assert_eq!(branch.child_idx(1).unwrap().get(), 0);
+        assert_eq!(branch.child_idx(5).unwrap().get(), 1);
+        assert!(branch.child_idx(3).is_none());
     }
 }


### PR DESCRIPTION
Store a nibble-to-dense-child lookup on arena branch nodes and reuse it in the sparse trie seek and mutation paths. This removes repeated rank calculations from hot leaf-update traversals while rebuilding the lookup only when branch structure changes.