### PR TITLE
feat(debug-client): pass execution data from providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7891,7 +7891,6 @@ dependencies = [
 name = "reth-consensus-debug-client"
 version = "2.2.0"
 dependencies = [
- "alloy-consensus",
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -7904,7 +7903,6 @@ dependencies = [
  "futures",
  "reqwest 0.13.2",
  "reth-node-api",
- "reth-primitives-traits",
  "reth-tracing",
  "ringbuffer",
  "serde",

--- a/crates/consensus/debug-client/Cargo.toml
+++ b/crates/consensus/debug-client/Cargo.toml
@@ -14,10 +14,8 @@ workspace = true
 # reth
 reth-node-api.workspace = true
 reth-tracing.workspace = true
-reth-primitives-traits.workspace = true
 
 # ethereum
-alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-eips.workspace = true
 alloy-provider = { workspace = true, features = ["ws"] }
 alloy-transport.workspace = true

--- a/crates/consensus/debug-client/src/client.rs
+++ b/crates/consensus/debug-client/src/client.rs
@@ -1,35 +1,34 @@
-use alloy_consensus::Sealable;
 use alloy_primitives::B256;
-use reth_node_api::{
-    BuiltPayload, ConsensusEngineHandle, ExecutionPayload, NodePrimitives, PayloadTypes,
-};
-use reth_primitives_traits::{Block, SealedBlock};
+use reth_node_api::{ConsensusEngineHandle, ExecutionPayload, PayloadTypes};
 use reth_tracing::tracing::warn;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use std::future::Future;
 use tokio::sync::mpsc;
 
-/// Supplies consensus client with new blocks sent in `tx` and a callback to find specific blocks
-/// by number to fetch past finalized and safe blocks.
+/// Supplies consensus client with new execution payloads sent in `tx` and a callback to find
+/// specific payloads by number to fetch past finalized and safe block hashes.
 #[auto_impl::auto_impl(&, Arc, Box)]
-pub trait BlockProvider: Send + Sync + 'static {
-    /// The block type.
-    type Block: Block;
+pub trait PayloadProvider: Send + Sync + 'static {
+    /// The execution payload data type.
+    type ExecutionData: ExecutionPayload;
 
-    /// Runs a block provider to send new blocks to the given sender.
+    /// Runs a provider to send new execution payloads to the given sender.
     ///
     /// Note: This is expected to be spawned in a separate task, and as such it should ignore
     /// errors.
-    fn subscribe_blocks(&self, tx: mpsc::Sender<Self::Block>) -> impl Future<Output = ()> + Send;
+    fn subscribe_payloads(
+        &self,
+        tx: mpsc::Sender<Self::ExecutionData>,
+    ) -> impl Future<Output = ()> + Send;
 
-    /// Get a past block by number.
-    fn get_block(
+    /// Get a past execution payload by block number.
+    fn get_payload(
         &self,
         block_number: u64,
-    ) -> impl Future<Output = eyre::Result<Self::Block>> + Send;
+    ) -> impl Future<Output = eyre::Result<Self::ExecutionData>> + Send;
 
     /// Get previous block hash using previous block hash buffer. If it isn't available (buffer
-    /// started more recently than `offset`), fetch it using `get_block`.
+    /// started more recently than `offset`), fetch it using `get_payload`.
     fn get_or_fetch_previous_block(
         &self,
         previous_block_hashes: &AllocRingBuffer<B256>,
@@ -46,23 +45,23 @@ pub trait BlockProvider: Send + Sync + 'static {
                 Some(number) => number,
                 None => return Ok(B256::default()),
             };
-            let block = self.get_block(previous_block_number).await?;
-            Ok(block.header().hash_slow())
+            let payload = self.get_payload(previous_block_number).await?;
+            Ok(payload.block_hash())
         }
     }
 }
 
-/// Debug consensus client that sends FCUs and new payloads using recent blocks from an external
+/// Debug consensus client that sends FCUs and new payloads using recent payloads from an external
 /// provider like Etherscan or an RPC endpoint.
 #[derive(Debug)]
-pub struct DebugConsensusClient<P: BlockProvider, T: PayloadTypes> {
+pub struct DebugConsensusClient<P: PayloadProvider, T: PayloadTypes> {
     /// Handle to execution client.
     engine_handle: ConsensusEngineHandle<T>,
-    /// Provider to get consensus blocks from.
+    /// Provider to get consensus payloads from.
     block_provider: P,
 }
 
-impl<P: BlockProvider, T: PayloadTypes> DebugConsensusClient<P, T> {
+impl<P: PayloadProvider, T: PayloadTypes> DebugConsensusClient<P, T> {
     /// Create a new debug consensus client with the given handle to execution
     /// client and block provider.
     pub const fn new(engine_handle: ConsensusEngineHandle<T>, block_provider: P) -> Self {
@@ -72,25 +71,23 @@ impl<P: BlockProvider, T: PayloadTypes> DebugConsensusClient<P, T> {
 
 impl<P, T> DebugConsensusClient<P, T>
 where
-    P: BlockProvider + Clone,
-    T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives: NodePrimitives<Block = P::Block>>>,
+    P: PayloadProvider<ExecutionData = T::ExecutionData> + Clone,
+    T: PayloadTypes,
 {
     /// Spawn the client to start sending FCUs and new payloads by periodically fetching recent
-    /// blocks.
+    /// payloads.
     pub async fn run(self) {
         let mut previous_block_hashes = AllocRingBuffer::new(65);
-        let mut block_stream = {
-            let (tx, rx) = mpsc::channel::<P::Block>(64);
+        let mut payload_stream = {
+            let (tx, rx) = mpsc::channel::<P::ExecutionData>(64);
             let block_provider = self.block_provider.clone();
             tokio::spawn(async move {
-                block_provider.subscribe_blocks(tx).await;
+                block_provider.subscribe_payloads(tx).await;
             });
             rx
         };
 
-        while let Some(block) = block_stream.recv().await {
-            let payload = T::block_to_payload(SealedBlock::new_unhashed(block));
-
+        while let Some(payload) = payload_stream.recv().await {
             let block_hash = payload.block_hash();
             let block_number = payload.block_number();
 

--- a/crates/consensus/debug-client/src/lib.rs
+++ b/crates/consensus/debug-client/src/lib.rs
@@ -1,6 +1,6 @@
 //! Debug consensus client.
 //!
-//! This is a worker that sends FCUs and new payloads by fetching recent blocks from an external
+//! This is a worker that sends FCUs and new payloads by fetching recent payloads from an external
 //! provider like Etherscan or an RPC endpoint. This allows to quickly test the execution client
 //! without running a consensus node.
 
@@ -15,5 +15,5 @@
 mod client;
 mod providers;
 
-pub use client::{BlockProvider, DebugConsensusClient};
+pub use client::{DebugConsensusClient, PayloadProvider};
 pub use providers::{EtherscanBlockProvider, RpcBlockProvider};

--- a/crates/consensus/debug-client/src/providers/etherscan.rs
+++ b/crates/consensus/debug-client/src/providers/etherscan.rs
@@ -1,8 +1,8 @@
-use crate::BlockProvider;
-use alloy_consensus::BlockHeader;
+use crate::PayloadProvider;
 use alloy_eips::BlockNumberOrTag;
 use alloy_json_rpc::{Response, ResponsePayload};
 use reqwest::Client;
+use reth_node_api::ExecutionPayload;
 use reth_tracing::tracing::{debug, warn};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{sync::Arc, time::Duration};
@@ -10,17 +10,17 @@ use tokio::{sync::mpsc, time::interval};
 
 /// Block provider that fetches new blocks from Etherscan API.
 #[derive(derive_more::Debug, Clone)]
-pub struct EtherscanBlockProvider<RpcBlock, PrimitiveBlock> {
+pub struct EtherscanBlockProvider<RpcBlock, ExecutionData> {
     http_client: Client,
     base_url: String,
     api_key: String,
     chain_id: u64,
     interval: Duration,
     #[debug(skip)]
-    convert: Arc<dyn Fn(RpcBlock) -> PrimitiveBlock + Send + Sync>,
+    convert: Arc<dyn Fn(RpcBlock) -> ExecutionData + Send + Sync>,
 }
 
-impl<RpcBlock, PrimitiveBlock> EtherscanBlockProvider<RpcBlock, PrimitiveBlock>
+impl<RpcBlock, ExecutionData> EtherscanBlockProvider<RpcBlock, ExecutionData>
 where
     RpcBlock: Serialize + DeserializeOwned,
 {
@@ -29,7 +29,7 @@ where
         base_url: String,
         api_key: String,
         chain_id: u64,
-        convert: impl Fn(RpcBlock) -> PrimitiveBlock + Send + Sync + 'static,
+        convert: impl Fn(RpcBlock) -> ExecutionData + Send + Sync + 'static,
     ) -> Self {
         Self {
             http_client: Client::new(),
@@ -50,10 +50,10 @@ where
     /// Load block using Etherscan API. Note: only `BlockNumberOrTag::Latest`,
     /// `BlockNumberOrTag::Earliest`, `BlockNumberOrTag::Pending`, `BlockNumberOrTag::Number(u64)`
     /// are supported.
-    pub async fn load_block(
+    pub async fn load_payload(
         &self,
         block_number_or_tag: BlockNumberOrTag,
-    ) -> eyre::Result<PrimitiveBlock> {
+    ) -> eyre::Result<ExecutionData> {
         let tag = match block_number_or_tag {
             BlockNumberOrTag::Number(num) => format!("{num:#x}"),
             tag => tag.to_string(),
@@ -88,20 +88,20 @@ where
     }
 }
 
-impl<RpcBlock, PrimitiveBlock> BlockProvider for EtherscanBlockProvider<RpcBlock, PrimitiveBlock>
+impl<RpcBlock, ExecutionData> PayloadProvider for EtherscanBlockProvider<RpcBlock, ExecutionData>
 where
     RpcBlock: Serialize + DeserializeOwned + 'static,
-    PrimitiveBlock: reth_primitives_traits::Block + 'static,
+    ExecutionData: ExecutionPayload,
 {
-    type Block = PrimitiveBlock;
+    type ExecutionData = ExecutionData;
 
-    async fn subscribe_blocks(&self, tx: mpsc::Sender<Self::Block>) {
+    async fn subscribe_payloads(&self, tx: mpsc::Sender<Self::ExecutionData>) {
         let mut last_block_number: Option<u64> = None;
         let mut interval = interval(self.interval);
         loop {
             interval.tick().await;
-            let block = match self.load_block(BlockNumberOrTag::Latest).await {
-                Ok(block) => block,
+            let payload = match self.load_payload(BlockNumberOrTag::Latest).await {
+                Ok(payload) => payload,
                 Err(err) => {
                     warn!(
                         target: "consensus::debug-client",
@@ -111,12 +111,12 @@ where
                     continue
                 }
             };
-            let block_number = block.header().number();
+            let block_number = payload.block_number();
             if Some(block_number) == last_block_number {
                 continue;
             }
 
-            if tx.send(block).await.is_err() {
+            if tx.send(payload).await.is_err() {
                 // Channel closed.
                 break;
             }
@@ -125,7 +125,7 @@ where
         }
     }
 
-    async fn get_block(&self, block_number: u64) -> eyre::Result<Self::Block> {
-        self.load_block(BlockNumberOrTag::Number(block_number)).await
+    async fn get_payload(&self, block_number: u64) -> eyre::Result<Self::ExecutionData> {
+        self.load_payload(BlockNumberOrTag::Number(block_number)).await
     }
 }

--- a/crates/consensus/debug-client/src/providers/rpc.rs
+++ b/crates/consensus/debug-client/src/providers/rpc.rs
@@ -1,8 +1,8 @@
-use crate::BlockProvider;
+use crate::PayloadProvider;
 use alloy_provider::{ConnectionConfig, Network, Provider, ProviderBuilder, WebSocketConfig};
 use alloy_transport::TransportResult;
 use futures::{Stream, StreamExt};
-use reth_node_api::Block;
+use reth_node_api::ExecutionPayload;
 use reth_tracing::tracing::{debug, warn};
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
@@ -10,19 +10,19 @@ use tokio::sync::mpsc::Sender;
 /// Block provider that fetches new blocks from an RPC endpoint using a connection that supports
 /// RPC subscriptions.
 #[derive(derive_more::Debug, Clone)]
-pub struct RpcBlockProvider<N: Network, PrimitiveBlock> {
+pub struct RpcBlockProvider<N: Network, ExecutionData> {
     #[debug(skip)]
     provider: Arc<dyn Provider<N>>,
     url: String,
     #[debug(skip)]
-    convert: Arc<dyn Fn(N::BlockResponse) -> PrimitiveBlock + Send + Sync>,
+    convert: Arc<dyn Fn(N::BlockResponse) -> ExecutionData + Send + Sync>,
 }
 
-impl<N: Network, PrimitiveBlock> RpcBlockProvider<N, PrimitiveBlock> {
+impl<N: Network, ExecutionData> RpcBlockProvider<N, ExecutionData> {
     /// Create a new RPC block provider with the given RPC URL.
     pub async fn new(
         rpc_url: &str,
-        convert: impl Fn(N::BlockResponse) -> PrimitiveBlock + Send + Sync + 'static,
+        convert: impl Fn(N::BlockResponse) -> ExecutionData + Send + Sync + 'static,
     ) -> eyre::Result<Self> {
         Ok(Self {
             provider: Arc::new(
@@ -66,13 +66,13 @@ impl<N: Network, PrimitiveBlock> RpcBlockProvider<N, PrimitiveBlock> {
     }
 }
 
-impl<N: Network, PrimitiveBlock> BlockProvider for RpcBlockProvider<N, PrimitiveBlock>
+impl<N: Network, ExecutionData> PayloadProvider for RpcBlockProvider<N, ExecutionData>
 where
-    PrimitiveBlock: Block + 'static,
+    ExecutionData: ExecutionPayload,
 {
-    type Block = PrimitiveBlock;
+    type ExecutionData = ExecutionData;
 
-    async fn subscribe_blocks(&self, tx: Sender<Self::Block>) {
+    async fn subscribe_payloads(&self, tx: Sender<Self::ExecutionData>) {
         loop {
             let Ok(mut stream) = self.full_block_stream().await.inspect_err(|err| {
                 warn!(
@@ -94,7 +94,8 @@ where
             while let Some(res) = stream.next().await {
                 match res {
                     Ok(block) => {
-                        if tx.send((self.convert)(block)).await.is_err() {
+                        let payload = (self.convert)(block);
+                        if tx.send(payload).await.is_err() {
                             // Channel closed - receiver dropped, exit completely.
                             return;
                         }
@@ -118,7 +119,7 @@ where
         }
     }
 
-    async fn get_block(&self, block_number: u64) -> eyre::Result<Self::Block> {
+    async fn get_payload(&self, block_number: u64) -> eyre::Result<Self::ExecutionData> {
         let block = self
             .provider
             .get_block_by_number(block_number.into())

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -452,8 +452,12 @@ where
 impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for EthereumNode {
     type RpcBlock = alloy_rpc_types_eth::Block;
 
-    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> reth_ethereum_primitives::Block {
-        rpc_block.into_consensus().convert_transactions()
+    fn rpc_to_execution_data(rpc_block: Self::RpcBlock) -> ExecutionData {
+        let (block, hash) = rpc_block.into_consensus_sealed().into_parts();
+        ExecutionData::from_block_unchecked(
+            hash,
+            &block.convert_transactions::<TransactionSigned>(),
+        )
     }
 
     fn local_payload_attributes_builder(

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -5,12 +5,12 @@ use alloy_provider::network::AnyNetwork;
 use jsonrpsee::core::{DeserializeOwned, Serialize};
 use reth_chainspec::EthChainSpec;
 use reth_consensus_debug_client::{
-    BlockProvider, DebugConsensusClient, EtherscanBlockProvider, RpcBlockProvider,
+    DebugConsensusClient, EtherscanBlockProvider, PayloadProvider, RpcBlockProvider,
 };
 use reth_engine_local::{LocalMiner, MiningMode};
 use reth_node_api::{
-    BlockTy, FullNodeComponents, FullNodeTypes, HeaderTy, PayloadAttrTy, PayloadAttributesBuilder,
-    PayloadTypes,
+    FullNodeComponents, FullNodeTypes, HeaderTy, NodeTypes, PayloadAttrTy,
+    PayloadAttributesBuilder, PayloadTypes,
 };
 use std::{
     future::{Future, IntoFuture},
@@ -19,11 +19,14 @@ use std::{
 };
 use tracing::info;
 
+/// Helper adapter type for accessing [`PayloadTypes::ExecutionData`] on [`NodeTypes`].
+pub(crate) type PayloadDataTy<N> = <<N as NodeTypes>::Payload as PayloadTypes>::ExecutionData;
+
 /// [`Node`] extension with support for debugging utilities.
 ///
 /// This trait provides additional necessary conversion from RPC block type to the node's
-/// primitive block type, e.g. `alloy_rpc_types_eth::Block` to the node's internal block
-/// representation.
+/// execution payload data type, e.g. `alloy_rpc_types_eth::Block` to the node's Engine API
+/// payload representation.
 ///
 /// This is used in conjunction with the [`DebugNodeLauncher`] to enable debugging features such as:
 ///
@@ -38,7 +41,7 @@ use tracing::info;
 ///
 /// To implement this trait, you need to:
 /// 1. Define the RPC block type (typically `alloy_rpc_types_eth::Block`)
-/// 2. Implement the conversion from RPC format to your primitive block type
+/// 2. Implement the conversion from RPC format to your execution payload data type
 ///
 /// # Example
 ///
@@ -46,27 +49,28 @@ use tracing::info;
 /// impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for MyNode {
 ///     type RpcBlock = alloy_rpc_types_eth::Block;
 ///
-///     fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> BlockTy<Self> {
-///         // Convert from RPC format to primitive format by converting the transactions
-///         rpc_block.into_consensus().convert_transactions()
+///     fn rpc_to_execution_data(
+///         rpc_block: Self::RpcBlock,
+///     ) -> PayloadDataTy<Self> {
+///         // Convert from RPC format to the Engine API payload data expected by the node.
 ///     }
 /// }
 /// ```
 pub trait DebugNode<N: FullNodeComponents>: Node<N> {
-    /// RPC block type. Used by [`DebugConsensusClient`] to fetch blocks and submit them to the
-    /// engine. This is intended to match the block format returned by the external RPC endpoint.
+    /// RPC block type. This is intended to match the block format returned by the external RPC
+    /// endpoint.
     type RpcBlock: Serialize + DeserializeOwned + 'static;
 
-    /// Converts an RPC block to a primitive block.
+    /// Converts an RPC block to execution payload data.
     ///
-    /// This method handles the conversion between the RPC block format and the internal primitive
-    /// block format used by the node's consensus engine.
+    /// This method handles the conversion between the RPC block format and the internal Engine API
+    /// payload data used by the node's consensus engine.
     ///
     /// # Example
     ///
     /// For Ethereum nodes, this typically converts from `alloy_rpc_types_eth::Block`
-    /// to the node's internal block representation.
-    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> BlockTy<Self>;
+    /// to the node's internal execution payload data representation.
+    fn rpc_to_execution_data(rpc_block: Self::RpcBlock) -> PayloadDataTy<Self>;
 
     /// Creates a payload attributes builder for local mining in dev mode.
     ///
@@ -116,7 +120,7 @@ impl<L> DebugNodeLauncher<L> {
 /// bounds.
 pub type DefaultDebugBlockProvider<N> = EtherscanBlockProvider<
     <<N as FullNodeTypes>::Types as DebugNode<N>>::RpcBlock,
-    BlockTy<<N as FullNodeTypes>::Types>,
+    PayloadDataTy<<N as FullNodeTypes>::Types>,
 >;
 
 /// Future for the [`DebugNodeLauncher`].
@@ -140,7 +144,7 @@ where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N>,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>>,
-    B: BlockProvider<Block = BlockTy<N::Types>> + Clone,
+    B: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone,
 {
     /// Sets a custom payload attributes builder for local mining in dev mode.
     pub fn with_payload_attributes_builder(
@@ -181,7 +185,7 @@ where
         self
     }
 
-    /// Sets a custom block provider for the debug consensus client.
+    /// Sets a custom payload provider for the debug consensus client.
     ///
     /// When set, this provider will be used instead of creating an `EtherscanBlockProvider`
     /// or `RpcBlockProvider` from CLI arguments.
@@ -190,7 +194,7 @@ where
         provider: B2,
     ) -> DebugNodeLauncherFuture<L, Target, N, B2>
     where
-        B2: BlockProvider<Block = BlockTy<N::Types>> + Clone,
+        B2: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone,
     {
         DebugNodeLauncherFuture {
             inner: self.inner,
@@ -239,7 +243,7 @@ where
                         .expect("Block serialization cannot fail");
                     let rpc_block =
                         serde_json::from_value(json).expect("Block deserialization cannot fail");
-                    N::Types::rpc_to_primitive_block(rpc_block)
+                    N::Types::rpc_to_execution_data(rpc_block)
                 })
                 .await?;
 
@@ -270,7 +274,7 @@ where
                     )
                 })?,
                 chain.id(),
-                N::Types::rpc_to_primitive_block,
+                N::Types::rpc_to_execution_data,
             );
             let rpc_consensus_client = DebugConsensusClient::new(
                 handle.node.add_ons_handle.beacon_engine_handle.clone(),
@@ -339,7 +343,7 @@ where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N> + 'static,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>> + 'static,
-    B: BlockProvider<Block = BlockTy<N::Types>> + Clone + 'static,
+    B: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone + 'static,
 {
     type Output = eyre::Result<NodeHandle<N, AddOns>>;
     type IntoFuture = Pin<Box<dyn Future<Output = eyre::Result<NodeHandle<N, AddOns>>> + Send>>;
@@ -355,7 +359,7 @@ where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N> + 'static,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>> + 'static,
-    DefaultDebugBlockProvider<N>: BlockProvider<Block = BlockTy<N::Types>> + Clone,
+    DefaultDebugBlockProvider<N>: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone,
 {
     type Node = NodeHandle<N, AddOns>;
     type Future = DebugNodeLauncherFuture<L, Target, N>;


### PR DESCRIPTION
Refactors the debug consensus client to consume execution data from its providers instead of converting fetched blocks with `PayloadTypes::block_to_payload`.

This keeps block-to-payload conversion in the node-specific provider setup and lets the debug client forward `ExecutionData` directly to the engine.

cc @mattsse 