### PR TITLE
perf(engine): skip redundant BAL account reads

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -664,42 +664,6 @@ where
             let _ = to_sparse_trie_task.send(StateRootMessage::HashedStateUpdate(hashed_state));
         }
 
-        if provider.is_none() {
-            let _span = debug_span!(
-                target: "engine::tree::payload_processor::prewarm",
-                parent: parent_span,
-                "bal_hashed_state_provider_init",
-                has_saved_cache = self.saved_cache.is_some(),
-            )
-            .entered();
-
-            let inner = match self.provider.build() {
-                Ok(p) => p,
-                Err(err) => {
-                    warn!(
-                        target: "engine::tree::payload_processor::prewarm",
-                        ?err,
-                        "Failed to build provider for BAL account reads"
-                    );
-                    return;
-                }
-            };
-            let boxed: Box<dyn AccountReader> = if let Some(saved) = &self.saved_cache {
-                let caches = saved.cache().clone();
-                Box::new(CachedStateProvider::new_prewarm(
-                    inner,
-                    caches,
-                    self.cache_metrics.clone().unwrap_or_default(),
-                ))
-            } else {
-                Box::new(inner)
-            };
-            *provider = Some(boxed);
-        }
-        let account_reader = provider.as_ref().expect("provider just initialized");
-
-        let existing_account = account_reader.basic_account(&address).ok().flatten();
-
         let balance = account_changes.balance_changes.last().map(|change| change.post_balance);
         let nonce = account_changes.nonce_changes.last().map(|change| change.new_nonce);
         let code_hash = account_changes.code_changes.last().map(|code_change| {
@@ -717,6 +681,52 @@ where
         {
             return;
         }
+
+        let needs_existing_account = balance.is_none() || nonce.is_none() || code_hash.is_none();
+
+        let existing_account = if needs_existing_account {
+            if provider.is_none() {
+                let _span = debug_span!(
+                    target: "engine::tree::payload_processor::prewarm",
+                    parent: parent_span,
+                    "bal_hashed_state_provider_init",
+                    has_saved_cache = self.saved_cache.is_some(),
+                )
+                .entered();
+
+                let inner = match self.provider.build() {
+                    Ok(p) => p,
+                    Err(err) => {
+                        warn!(
+                            target: "engine::tree::payload_processor::prewarm",
+                            ?err,
+                            "Failed to build provider for BAL account reads"
+                        );
+                        return;
+                    }
+                };
+                let boxed: Box<dyn AccountReader> = if let Some(saved) = &self.saved_cache {
+                    let caches = saved.cache().clone();
+                    Box::new(CachedStateProvider::new_prewarm(
+                        inner,
+                        caches,
+                        self.cache_metrics.clone().unwrap_or_default(),
+                    ))
+                } else {
+                    Box::new(inner)
+                };
+                *provider = Some(boxed);
+            }
+
+            provider
+                .as_ref()
+                .expect("provider just initialized")
+                .basic_account(&address)
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
 
         let account = reth_primitives_traits::Account {
             balance: balance.unwrap_or_else(|| {


### PR DESCRIPTION
BAL hashed-state emission only needs a provider fallback when balance, nonce, or code hash are missing from the BAL changes. Avoid building the reader and calling basic_account when the account update is already fully described by BAL data.