### PR TITLE
perf(storage): defer static-file syncs until writes finish

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -561,8 +561,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
     /// Writes to a static file segment using the provided closure.
     ///
-    /// The closure receives a mutable reference to the segment writer. After the closure completes,
-    /// `sync_all()` is called to flush writes to disk.
+    /// The closure receives a mutable reference to the segment writer. Flushing is deferred until
+    /// all segment writes for the batch finish so storage threads only perform append work in the
+    /// parallel phase.
     #[instrument(level = "debug", target = "providers::static_file", skip_all, fields(?segment))]
     fn write_segment<F>(
         &self,
@@ -574,14 +575,13 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         F: FnOnce(&mut StaticFileProviderRWRefMut<'_, N>) -> ProviderResult<()>,
     {
         let mut w = self.get_writer(first_block_number, segment)?;
-        f(&mut w)?;
-        w.sync_all()
+        f(&mut w)
     }
 
     /// Writes all static file data for multiple blocks in parallel per-segment.
     ///
-    /// This spawns tasks on the storage thread pool for each segment type and each task calls
-    /// `sync_all()` on its writer when done.
+    /// This spawns tasks on the storage thread pool for each segment type, then flushes the batch
+    /// once all segment writers have finished appending.
     #[instrument(level = "debug", target = "providers::static_file", skip_all)]
     pub fn write_blocks_data(
         &self,
@@ -685,6 +685,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             r_storage_changesets
                 .ok_or(StaticFileWriterError::ThreadPanic("storage_changesets"))??;
         }
+        self.writers.sync_all()?;
         Ok(())
     }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -116,6 +116,33 @@ impl<N: NodePrimitives> StaticFileWriters<N> {
     }
 
     #[instrument(
+        name = "StaticFileWriters::sync_all",
+        level = "debug",
+        target = "providers::static_file",
+        skip_all
+    )]
+    pub(crate) fn sync_all(&self) -> ProviderResult<()> {
+        debug!(target: "providers::static_file", "Syncing all static file segments");
+
+        for writer_lock in [
+            &self.headers,
+            &self.transactions,
+            &self.receipts,
+            &self.transaction_senders,
+            &self.account_change_sets,
+            &self.storage_change_sets,
+        ] {
+            let mut writer = writer_lock.write();
+            if let Some(writer) = writer.as_mut() {
+                writer.sync_all()?;
+            }
+        }
+
+        debug!(target: "providers::static_file", "Synced all static file segments");
+        Ok(())
+    }
+
+    #[instrument(
         name = "StaticFileWriters::commit",
         level = "debug",
         target = "providers::static_file",


### PR DESCRIPTION
Keep per-segment static-file appends parallel, but move the sync_all phase out of the worker closures and into a single post-write pass. This shortens the storage pool's append phase without changing the written data or commit ordering.