### PR TITLE
perf(engine): trim prewarm proof target work

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -247,11 +247,14 @@ where
             }
 
             if index > 0 {
+                let Some(to_sparse_trie_task) = to_sparse_trie_task else {
+                    ctx.metrics.total_runtime.record(start.elapsed());
+                    return;
+                };
+
                 let (targets, storage_targets) = multiproof_targets_from_state(res.state);
                 ctx.metrics.prefetch_storage_targets.record(storage_targets as f64);
-                if let Some(to_sparse_trie_task) = to_sparse_trie_task {
-                    let _ = to_sparse_trie_task.send(StateRootMessage::PrefetchProofs(targets));
-                }
+                let _ = to_sparse_trie_task.send(StateRootMessage::PrefetchProofs(targets));
             }
 
             ctx.metrics.total_runtime.record(start.elapsed());
@@ -811,6 +814,10 @@ where
 /// Returns a set of [`MultiProofTargetsV2`] and the total amount of storage targets, based on the
 /// given state.
 fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize) {
+    if state.is_empty() {
+        return (MultiProofTargetsV2::default(), 0)
+    }
+
     let mut targets = MultiProofTargetsV2::default();
     let mut storage_target_count = 0;
     for (addr, account) in state {
@@ -828,7 +835,7 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         let hashed_address = keccak256(addr);
         targets.account_targets.push(hashed_address.into());
 
-        let mut storage_slots = Vec::with_capacity(account.storage.len());
+        let mut storage_slots = None;
         for (key, slot) in account.storage {
             // do nothing if unchanged
             if !slot.is_changed() {
@@ -836,11 +843,11 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
             }
 
             let hashed_slot = keccak256(B256::new(key.to_be_bytes()));
-            storage_slots.push(ProofV2Target::from(hashed_slot));
+            storage_target_count += 1;
+            storage_slots.get_or_insert_with(Vec::new).push(ProofV2Target::from(hashed_slot));
         }
 
-        storage_target_count += storage_slots.len();
-        if !storage_slots.is_empty() {
+        if let Some(storage_slots) = storage_slots {
             targets.storage_targets.insert(hashed_address, storage_slots);
         }
     }


### PR DESCRIPTION
Skip per-transaction proof-target construction when there is no sparse-trie consumer for prewarm results.
Build storage target vectors lazily so touched accounts without changed slots avoid unnecessary allocation in the prewarm hot path.