### PR TITLE
perf(trie): resume sparse branch scans by nibble

### DIFF
--- a/crates/trie/sparse/src/arena/branch_child_idx.rs
+++ b/crates/trie/sparse/src/arena/branch_child_idx.rs
@@ -1,8 +1,5 @@
-use alloy_trie::{TrieMask, TrieMaskIter};
-use core::{
-    iter::Enumerate,
-    ops::{Index, IndexMut},
-};
+use alloy_trie::TrieMask;
+use core::ops::{Index, IndexMut};
 use smallvec::SmallVec;
 
 /// A dense index into a branch node's children array.
@@ -68,13 +65,25 @@ impl<T> IndexMut<BranchChildIdx> for SmallVec<[T; 4]> {
 /// Wraps `TrieMask::iter().enumerate()` to produce [`BranchChildIdx`] values instead of raw
 /// `usize` indices.
 pub(super) struct BranchChildIter {
-    inner: Enumerate<TrieMaskIter>,
+    state_mask: TrieMask,
+    remaining: u16,
 }
 
 impl BranchChildIter {
     /// Creates a new iterator over the occupied children of the given `state_mask`.
     pub(super) fn new(state_mask: TrieMask) -> Self {
-        Self { inner: state_mask.iter().enumerate() }
+        Self::from_nibble(state_mask, 0)
+    }
+
+    /// Creates a new iterator over the occupied children starting at `start_nibble`.
+    pub(super) fn from_nibble(state_mask: TrieMask, start_nibble: u8) -> Self {
+        let remaining = if start_nibble >= u16::BITS as u8 {
+            0
+        } else {
+            state_mask.get() & !((1u16 << start_nibble) - 1)
+        };
+
+        Self { state_mask, remaining }
     }
 }
 
@@ -82,10 +91,41 @@ impl Iterator for BranchChildIter {
     type Item = (BranchChildIdx, u8);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|(dense, nibble)| (BranchChildIdx(dense as u8), nibble))
+        let nibble = self.remaining.trailing_zeros() as u8;
+        if nibble >= u16::BITS as u8 {
+            return None;
+        }
+
+        self.remaining &= self.remaining - 1;
+        Some((BranchChildIdx::new_unchecked(self.state_mask, nibble), nibble))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        let len = self.remaining.count_ones() as usize;
+        (len, Some(len))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iterates_children_in_dense_order() {
+        let mask = TrieMask::new(0b1010_0101);
+        let children =
+            BranchChildIter::new(mask).map(|(idx, nibble)| (idx.get(), nibble)).collect::<Vec<_>>();
+
+        assert_eq!(children, vec![(0, 0), (1, 2), (2, 5), (3, 7)]);
+    }
+
+    #[test]
+    fn resumes_iteration_from_nibble() {
+        let mask = TrieMask::new(0b1110_1101);
+        let children = BranchChildIter::from_nibble(mask, 4)
+            .map(|(idx, nibble)| (idx.get(), nibble))
+            .collect::<Vec<_>>();
+
+        assert_eq!(children, vec![(3, 5), (4, 6), (5, 7)]);
     }
 }

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -15,9 +15,9 @@ pub(super) struct ArenaCursorStackEntry {
     pub(super) index: Index,
     /// The absolute path of this node in the trie (not including its `short_key`).
     pub(super) path: Nibbles,
-    /// The dense index at which to resume child iteration in [`ArenaCursor::next`].
+    /// The nibble at which to resume child iteration in [`ArenaCursor::next`].
     /// Only meaningful when this entry's node is a branch.
-    pub(super) next_dense_idx: usize,
+    pub(super) next_child_nibble: u8,
 }
 
 /// Result of [`ArenaCursor::seek`] describing the state at the deepest ancestor node.
@@ -106,7 +106,7 @@ impl ArenaCursor {
     /// Pushes an entry onto the stack for the node at the given index and path.
     fn push(&mut self, arena: &NodeArena, idx: Index, path: Nibbles) {
         debug_assert!(arena.contains_key(idx), "push called with invalid arena index");
-        self.stack.push(ArenaCursorStackEntry { index: idx, path, next_dense_idx: 0 });
+        self.stack.push(ArenaCursorStackEntry { index: idx, path, next_child_nibble: 0 });
         trace!(target: TRACE_TARGET, entry = ?self.stack.last().expect("just pushed"), "Pushed stack entry");
     }
 
@@ -259,15 +259,12 @@ impl ArenaCursor {
             };
 
             let state_mask = branch.state_mask;
-            let start = head.next_dense_idx;
+            let start_nibble = head.next_child_nibble;
             let child_depth = self.stack.len();
 
             let mut descended = false;
-            for (branch_child_idx, nibble) in BranchChildIter::new(state_mask) {
-                if branch_child_idx.get() < start {
-                    continue;
-                }
-
+            for (branch_child_idx, nibble) in BranchChildIter::from_nibble(state_mask, start_nibble)
+            {
                 let child_idx = match &arena[head_idx].branch_ref().children[branch_child_idx] {
                     ArenaSparseNodeBranchChild::Revealed(child_idx) => *child_idx,
                     ArenaSparseNodeBranchChild::Blinded(_) => continue,
@@ -275,8 +272,7 @@ impl ArenaCursor {
 
                 if should_descend(child_depth, &arena[child_idx]) {
                     // Record where to resume iteration when we return to this entry.
-                    self.stack.last_mut().expect("head exists").next_dense_idx =
-                        branch_child_idx.get() + 1;
+                    self.stack.last_mut().expect("head exists").next_child_nibble = nibble + 1;
                     let path = self.child_path(arena, nibble);
                     self.push(arena, child_idx, path);
                     descended = true;


### PR DESCRIPTION
Carry the next child nibble on sparse-trie cursor stack entries and restart branch child iteration from that nibble instead of rebuilding an iterator and skipping previously visited children. This keeps depth-first sparse-trie walks on the forward path and adds focused iterator coverage for the new resume logic.