### PR TITLE
ci(bench): update snapshots with `reth download`

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -18,7 +18,8 @@
 #   --tracy-filter F Tracy tracing filter (default: debug)
 #   --no-tune       Skip system tuning (useful on dev machines / macOS)
 #
-# Requires: the reth repo at RETH_REPO (default: ~/reth)
+# Requires: the reth repo at RETH_REPO (default: ~/reth) and
+# BENCH_SNAPSHOT_MANIFEST_URL pointing at the benchmark snapshot manifest.
 #
 # Dependencies (install before first run):
 #   schelk, cpupower, taskset, stdbuf, python3, curl,
@@ -240,14 +241,7 @@ echo "  Baseline src : $BASELINE_SRC"
 echo "  Feature src  : $FEATURE_SRC"
 echo
 
-# ── Step 3: Validate local snapshot ──────────────────────────────────
-echo "▸ Validating local snapshot..."
-cd "$RETH_REPO"
-"${SCRIPTS_DIR}/bench-reth-snapshot.sh"
-echo "  Snapshot is ready."
-echo
-
-# ── Step 4: Build binaries in parallel ───────────────────────────────
+# ── Step 3: Build binaries in parallel ───────────────────────────────
 echo "▸ Building binaries (parallel)..."
 cd "$RETH_REPO"
 
@@ -267,6 +261,12 @@ if [ $FAIL -ne 0 ]; then
   exit 1
 fi
 echo "  Binaries built successfully."
+echo
+
+# ── Step 4: Sync snapshot ────────────────────────────────────────────
+echo "▸ Syncing snapshot..."
+BENCH_RETH_BINARY="${FEATURE_SRC}/target/profiling/reth" "${SCRIPTS_DIR}/bench-reth-snapshot.sh"
+echo "  Snapshot is ready."
 echo
 
 # ── Step 5: System tuning (optional) ────────────────────────────────

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -130,6 +130,14 @@ RETH_ARGS=(
   --no-persist-peers
 )
 
+# Keep the engine in startup sync mode until the pipeline is idle. Older
+# baselines may not have this flag, so gate it on clap help output.
+SYNC_STATE_IDLE=false
+if "$BINARY" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
+  RETH_ARGS+=(--debug.startup-sync-state-idle)
+  SYNC_STATE_IDLE=true
+fi
+
 # Append per-label extra node args (baseline or feature)
 EXTRA_NODE_ARGS=""
 case "$LABEL" in
@@ -211,6 +219,26 @@ for i in $(seq 1 60); do
   fi
   sleep 1
 done
+
+if [ "$SYNC_STATE_IDLE" = "true" ]; then
+  for i in $(seq 1 300); do
+    SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
+      -H 'Content-Type: application/json' \
+      -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
+    if [ -n "$SYNC_RESULT" ] && jq -e '.result == false' <<< "$SYNC_RESULT" > /dev/null 2>&1; then
+      echo "reth (${LABEL}) pipeline finished after ${i}s, engine is live"
+      break
+    fi
+    if [ "$i" -eq 300 ]; then
+      echo "::error::reth (${LABEL}) pipeline did not finish within 300s"
+      cat "$LOG"
+      exit 1
+    fi
+    sleep 1
+  done
+else
+  echo "reth (${LABEL}) binary does not support --debug.startup-sync-state-idle, skipping sync wait"
+fi
 
 # Run reth-bench with high priority but as the current user so output
 # files are not root-owned (avoids EACCES on next checkout).

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -130,14 +130,6 @@ RETH_ARGS=(
   --no-persist-peers
 )
 
-# Gate flag on binary support (older baselines may not have it).
-# Uses --help which exits immediately via clap without node init.
-SYNC_STATE_IDLE=false
-if "$BINARY" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
-  RETH_ARGS+=(--debug.startup-sync-state-idle)
-  SYNC_STATE_IDLE=true
-fi
-
 # Append per-label extra node args (baseline or feature)
 EXTRA_NODE_ARGS=""
 case "$LABEL" in
@@ -219,29 +211,6 @@ for i in $(seq 1 60); do
   fi
   sleep 1
 done
-
-# Wait for the pipeline to finish (eth_syncing returns false) so the
-# engine is in live mode and can accept newPayload calls.
-# Only possible when --debug.startup-sync-state-idle is supported.
-if [ "$SYNC_STATE_IDLE" = "true" ]; then
-  for i in $(seq 1 300); do
-    SYNC_RESULT=$(curl -sf http://127.0.0.1:8545 -X POST \
-      -H 'Content-Type: application/json' \
-      -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)
-    if [ -n "$SYNC_RESULT" ] && jq -e '.result == false' <<< "$SYNC_RESULT" > /dev/null 2>&1; then
-      echo "reth (${LABEL}) pipeline finished after ${i}s, engine is live"
-      break
-    fi
-    if [ "$i" -eq 300 ]; then
-      echo "::error::reth (${LABEL}) pipeline did not finish within 300s"
-      cat "$LOG"
-      exit 1
-    fi
-    sleep 1
-  done
-else
-  echo "reth (${LABEL}) binary does not support --debug.startup-sync-state-idle, skipping sync wait"
-fi
 
 # Run reth-bench with high priority but as the current user so output
 # files are not root-owned (avoids EACCES on next checkout).

--- a/.github/scripts/bench-reth-snapshot.sh
+++ b/.github/scripts/bench-reth-snapshot.sh
@@ -1,56 +1,138 @@
 #!/usr/bin/env bash
 #
-# Validates that the benchmark snapshot has already been populated into the
-# local schelk volume.
+# Ensures the benchmark snapshot in the schelk volume matches the configured
+# manifest. If the local manifest marker differs from the remote manifest, the
+# snapshot is replaced via `reth download` and promoted as the new schelk
+# baseline.
 #
 # Usage: bench-reth-snapshot.sh [--check]
-#   --check   Exit 0 if the local snapshot is ready, 10 if it is missing.
+#   --check   Exit 0 if the local snapshot is current, 10 if it needs refresh.
 #
 # Required env:
-#   SCHELK_MOUNT – schelk mount point (e.g. /reth-bench)
+#   SCHELK_MOUNT       - schelk mount point (e.g. /reth-bench)
+#   BENCH_SNAPSHOT_MANIFEST_URL - exact manifest URL to sync from
+#   BENCH_RETH_BINARY  - path to the reth-compatible binary (required to refresh)
+#
 # Optional env:
-#   BENCH_BIG_BLOCKS   – true when validating the big-blocks snapshot datadir
-#   BENCH_SNAPSHOT_NAME – expected snapshot label for log/error output
-set -euxo pipefail
+#   BENCH_BIG_BLOCKS            - true when syncing the big-blocks datadir
+set -euo pipefail
 
 : "${SCHELK_MOUNT:?SCHELK_MOUNT must be set}"
+: "${BENCH_SNAPSHOT_MANIFEST_URL:?BENCH_SNAPSHOT_MANIFEST_URL must be set}"
+
+if [ "${1:-}" != "" ] && [ "${1:-}" != "--check" ]; then
+  echo "Usage: $0 [--check]"
+  exit 1
+fi
+
+CHECK_ONLY=false
+if [ "${1:-}" = "--check" ]; then
+  CHECK_ONLY=true
+fi
 
 DATADIR_NAME="datadir"
 if [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
   DATADIR_NAME="datadir-big-blocks"
 fi
 DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
+LOCAL_MANIFEST="$DATADIR/manifest.json"
 
-describe_snapshot() {
-  if [ -n "${BENCH_SNAPSHOT_NAME:-}" ]; then
-    printf '%s' "${BENCH_SNAPSHOT_NAME}"
-  elif [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
-    printf '%s' 'big-block weekly snapshot'
-  else
-    printf '%s' 'benchmark snapshot'
-  fi
-}
+MANIFEST_URL="$BENCH_SNAPSHOT_MANIFEST_URL"
+MANIFEST_BASE_URL="${MANIFEST_URL%/*}"
+
+REMOTE_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/reth-bench-remote-manifest.XXXXXX")"
+REMOTE_CANONICAL="$(mktemp "${TMPDIR:-/tmp}/reth-bench-remote-canonical.XXXXXX")"
+LOCAL_CANONICAL="$(mktemp "${TMPDIR:-/tmp}/reth-bench-local-canonical.XXXXXX")"
+DOWNLOAD_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/reth-bench-download-manifest.XXXXXX")"
+trap 'rm -f "$REMOTE_MANIFEST" "$REMOTE_CANONICAL" "$LOCAL_CANONICAL" "$DOWNLOAD_MANIFEST"' EXIT
 
 snapshot_ready() {
   [ -d "$DATADIR/db" ] && [ -d "$DATADIR/static_files" ]
 }
 
-EXPECTED_SNAPSHOT="$(describe_snapshot)"
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+echo "Using snapshot manifest from BENCH_SNAPSHOT_MANIFEST_URL"
+
+if ! curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 "$MANIFEST_URL" -o "$REMOTE_MANIFEST"; then
+  echo "::error::Failed to fetch snapshot manifest from BENCH_SNAPSHOT_MANIFEST_URL"
+  exit 2
+fi
+
+if ! jq -S . "$REMOTE_MANIFEST" > "$REMOTE_CANONICAL"; then
+  echo "::error::Snapshot manifest is not valid JSON"
+  exit 2
+fi
+REMOTE_HASH="$(sha256_file "$REMOTE_CANONICAL")"
 
 sudo schelk recover -y --kill || sudo schelk full-recover -y || true
-sudo schelk mount -y || true
+sudo schelk mount -y
 
-if snapshot_ready; then
-  echo "Found local ${EXPECTED_SNAPSHOT} at ${DATADIR}"
+LOCAL_HASH=""
+LOCAL_MATCH=false
+if [ -f "$LOCAL_MANIFEST" ] && jq -S . "$LOCAL_MANIFEST" > "$LOCAL_CANONICAL"; then
+  LOCAL_HASH="$(sha256_file "$LOCAL_CANONICAL")"
+  if cmp -s "$REMOTE_CANONICAL" "$LOCAL_CANONICAL"; then
+    LOCAL_MATCH=true
+  fi
+fi
+
+if [ "$LOCAL_MATCH" = true ] && snapshot_ready; then
+  echo "Snapshot is up-to-date (manifest hash: ${REMOTE_HASH:0:16})"
   exit 0
 fi
 
-echo "::error::Missing local ${EXPECTED_SNAPSHOT} at ${DATADIR}. Benchmarks no longer download snapshots; pre-populate the local schelk data first."
-ls -la "$SCHELK_MOUNT" || true
-ls -la "$DATADIR" || true
+if ! snapshot_ready; then
+  echo "Snapshot needs refresh: missing expected db/ or static_files/ under ${DATADIR}"
+elif [ ! -f "$LOCAL_MANIFEST" ]; then
+  echo "Snapshot needs refresh: missing local manifest marker at ${LOCAL_MANIFEST}"
+elif [ -z "$LOCAL_HASH" ]; then
+  echo "Snapshot needs refresh: local manifest marker is not valid JSON"
+else
+  echo "Snapshot needs refresh (local: ${LOCAL_HASH:0:16}, remote: ${REMOTE_HASH:0:16})"
+fi
 
-if [ "${1:-}" = "--check" ]; then
+if [ "$CHECK_ONLY" = true ]; then
   exit 10
 fi
 
-exit 1
+RETH="${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set when refreshing the snapshot}"
+if [ ! -x "$RETH" ]; then
+  echo "::error::reth binary not found or not executable at ${RETH}"
+  exit 1
+fi
+
+# Force archive URLs to resolve relative to the configured manifest endpoint.
+# Some published manifests carry a base_url that is valid for publishers but
+# not for benchmark runners.
+jq --arg base "$MANIFEST_BASE_URL" '.base_url = $base' "$REMOTE_MANIFEST" > "$DOWNLOAD_MANIFEST"
+
+sudo rm -rf "$DATADIR"
+sudo mkdir -p "$DATADIR"
+# reth download runs as the current user and needs write access.
+sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
+
+"$RETH" download \
+  --manifest-path "$DOWNLOAD_MANIFEST" \
+  -y \
+  --minimal \
+  --datadir "$DATADIR"
+
+if ! snapshot_ready; then
+  echo "::error::Snapshot download did not produce expected directory layout (missing db/ or static_files/)"
+  ls -la "$DATADIR" || true
+  exit 1
+fi
+
+cp "$REMOTE_MANIFEST" "$LOCAL_MANIFEST"
+
+sync
+sudo schelk promote -y
+
+echo "Snapshot promoted to schelk baseline (manifest hash: ${REMOTE_HASH:0:16})"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -272,6 +272,7 @@ jobs:
       BENCH_ABBA: "true"
       BENCH_COMMENT_ID: ""
       BENCH_SLACK: ${{ github.event_name == 'workflow_dispatch' && inputs.slack || 'always' }}
+      BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9100"
       BENCH_OTLP_DISABLED: "true"
       BASELINE_REF: ${{ needs.resolve-refs.outputs.baseline-ref }}
@@ -372,10 +373,6 @@ jobs:
           echo "feature-name=${BENCH_MODE}-${FEATURE_SHORT}" >> "$GITHUB_OUTPUT"
           echo "feature-ref=$FEATURE_REF" >> "$GITHUB_OUTPUT"
 
-      - name: Validate local snapshot
-        id: snapshot-check
-        run: .github/scripts/bench-reth-snapshot.sh
-
       - name: Prepare source dirs
         run: |
           prepare_source_dir() {
@@ -418,6 +415,12 @@ jobs:
             echo "::error::One or more build tasks failed"
             exit 1
           fi
+
+      - name: Sync snapshot
+        id: snapshot-check
+        run: |
+          BENCH_RETH_BINARY="$(pwd)/../reth-feature/target/profiling/reth" \
+            .github/scripts/bench-reth-snapshot.sh
 
       # System tuning for reproducible benchmarks
       - name: System setup
@@ -919,8 +922,8 @@ jobs:
             if (!token || !channel) return;
 
             const steps_status = [
-              ['validating local snapshot', '${{ steps.snapshot-check.outcome }}'],
               ['building binaries', '${{ steps.build.outcome }}'],
+              ['syncing snapshot', '${{ steps.snapshot-check.outcome }}'],
               ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
               ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
               ['running feature benchmark (2/2)', '${{ steps.run-feature-2.outcome }}'],

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -555,6 +555,7 @@ jobs:
       BENCH_COMMENT_ID: ${{ needs.reth-bench-ack.outputs.comment-id }}
       BENCH_SLACK: ${{ needs.reth-bench-ack.outputs.slack }}
       BENCH_NODE_BIN: ${{ needs.reth-bench-ack.outputs.big-blocks == 'true' && 'reth-bb' || 'reth' }}
+      BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9100"
       BENCH_OTLP_TRACES_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_TRACES_ENDPOINT || '' }}
       BENCH_OTLP_LOGS_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_LOGS_ENDPOINT || '' }}
@@ -802,10 +803,6 @@ jobs:
           echo "Payload files: $PAYLOAD_COUNT"
           echo "BENCH_SNAPSHOT_NAME=${BASE_SNAPSHOT}" >> "$GITHUB_ENV"
 
-      - name: Validate local snapshot
-        id: snapshot-check
-        run: .github/scripts/bench-reth-snapshot.sh
-
       - name: Prepare source dirs
         run: |
           prepare_source_dir() {
@@ -850,6 +847,12 @@ jobs:
             echo "::error::One or more build tasks failed"
             exit 1
           fi
+
+      - name: Sync snapshot
+        id: snapshot-check
+        run: |
+          BENCH_RETH_BINARY="$(pwd)/../reth-feature/target/profiling/${BENCH_NODE_BIN}" \
+            .github/scripts/bench-reth-snapshot.sh
 
       # System tuning for reproducible benchmarks
       - name: System setup
@@ -1340,8 +1343,8 @@ jobs:
             const bigBlocks = process.env.BENCH_BIG_BLOCKS === 'true';
             const steps_status = [
               ...(bigBlocks ? [['validating local big-block data', '${{ steps.big-blocks-check.outcome }}']] : []),
-              ['validating local snapshot', '${{ steps.snapshot-check.outcome }}'],
               ['building binaries', '${{ steps.build.outcome }}'],
+              ['syncing snapshot', '${{ steps.snapshot-check.outcome }}'],
               ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
               ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
               ...(abba ? [['running baseline benchmark (2/2)', '${{ steps.run-baseline-2.outcome }}']] : []),
@@ -1378,8 +1381,8 @@ jobs:
             const bigBlocks = process.env.BENCH_BIG_BLOCKS === 'true';
             const steps_status = [
               ...(bigBlocks ? [['validating local big-block data', '${{ steps.big-blocks-check.outcome }}']] : []),
-              ['validating local snapshot', '${{ steps.snapshot-check.outcome }}'],
               ['building binaries', '${{ steps.build.outcome }}'],
+              ['syncing snapshot', '${{ steps.snapshot-check.outcome }}'],
               ['running feature benchmark (1/2)', '${{ steps.run-feature-1.outcome }}'],
               ['running baseline benchmark (1/2)', '${{ steps.run-baseline-1.outcome }}'],
               ...(abba ? [['running baseline benchmark (2/2)', '${{ steps.run-baseline-2.outcome }}']] : []),


### PR DESCRIPTION
- Switch benchmark snapshot management back to an automatic sync flow that compares the local manifest marker against the configured remote manifest.
- Download refreshed snapshots with `reth download --manifest-path` only when the manifest changes, and promote the result into schelk.
- Source the manifest URL from `BENCH_SNAPSHOT_MANIFEST_URL` in both benchmark workflows instead of hardcoding the endpoint.