### PR TITLE
perf(chain-state): compute lazy overlays off-lock

### DIFF
--- a/crates/chain-state/src/lazy_overlay.rs
+++ b/crates/chain-state/src/lazy_overlay.rs
@@ -104,10 +104,15 @@ impl<N: NodePrimitives> LazyOverlay<N> {
     /// The first call triggers computation (which may block waiting for deferred data).
     /// Subsequent calls for the same anchor return the cached result immediately.
     pub fn get(&self, anchor_hash: B256) -> Arc<TrieInputSorted> {
+        if let Some(input) = self.inner.get(&anchor_hash) {
+            return Arc::clone(input.value())
+        }
+
+        let input = self.compute(anchor_hash);
+
         match self.inner.entry(anchor_hash) {
             dashmap::Entry::Occupied(entry) => Arc::clone(entry.get()),
             dashmap::Entry::Vacant(entry) => {
-                let input = self.compute(anchor_hash);
                 entry.insert(Arc::clone(&input));
                 input
             }


### PR DESCRIPTION
Avoid holding the LazyOverlay cache entry lock while building a missing overlay. The cache still deduplicates the stored result, but concurrent readers no longer serialize behind the full overlay computation path.