### PR TITLE
fix: skip already-known executed blocks

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1555,6 +1555,11 @@ where
                             return Ok(ops::ControlFlow::Continue(()))
                         }
 
+                        if self.state.tree_state.contains_hash(&block_num_hash.hash) {
+                            // block already known to the tree (e.g. delivered via newPayload first)
+                            return Ok(ops::ControlFlow::Continue(()))
+                        }
+
                         debug!(target: "engine::tree", block=?block_num_hash, "inserting already executed block");
                         let now = Instant::now();
 


### PR DESCRIPTION
Currently in `--dev` mode engine might panic in debug builds if `newPayload` arrives first https://github.com/paradigmxyz/reth/blob/0471a2b70a38f3036df686b8c524aca0aec7ad69/crates/trie/db/src/changesets.rs#L419