### PR TITLE
feat(BAL): restructure the loop

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -20,7 +20,10 @@ use super::{
     BalExecutionError, RejectReason,
 };
 use alloy_consensus::BlockHeader;
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
+use alloy_eip7928::{
+    bal::{Bal as AlloyBal, DecodedBal},
+    compute_block_access_list_hash,
+};
 use alloy_evm::{
     block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
     Evm,
@@ -35,7 +38,7 @@ use revm::{
     database::{states::bundle_state::BundleRetention, BundleState, State},
     primitives::{eip7825::TX_GAS_LIMIT_CAP, hardfork::SpecId},
 };
-use revm_state::bal::Bal;
+use revm_state::bal::Bal as RevmBal;
 use std::sync::Arc;
 
 use crate::tree::payload_processor::receipt_root_task::IndexedReceipt;
@@ -115,13 +118,11 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let bal = received_bal.as_bal();
-    let received_bal_revm: Arc<Bal> = Arc::new(
-        Bal::try_from(Vec::<_>::from(bal.clone()))
+    let received_bal_revm: Arc<RevmBal> = Arc::new(
+        RevmBal::try_from(Vec::<_>::from(bal.clone()))
             .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?,
     );
 
-    let mut canonical_state =
-        State::builder().with_database(make_db()?).with_bundle_update().with_bal_builder().build();
     // NOTE: technically Amsterdam implies BAL (the current path) we are on.
     // TODO: should we do this
     let is_amsterdam = evm_config
@@ -132,19 +133,9 @@ where
         .into()
         .is_enabled_in(SpecId::AMSTERDAM);
     let block_gas_limit = block.header().gas_limit();
-
-    // Pre-load every BAL-declared address into canonical state's cache. `State::commit`
-    // (called by `commit_transaction`) panics at revm-database's
-    // `cache.rs:195` ("All accounts should be present inside cache") when it tries to
-    // apply a diff for an address not previously loaded. In the normal serial flow the
-    // EVM loads the account itself during execution, but here workers execute the tx EVM
-    // and the canonical loop only commits their outputs, so canonical may never have read
-    // those accounts itself.
-    for account_changes in bal {
-        canonical_state
-            .load_cache_account(account_changes.address)
-            .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
-    }
+    let mut canonical_state =
+        State::builder().with_database(make_db()?).with_bundle_update().with_bal_builder().build();
+    load_bal_accounts(&mut canonical_state, bal)?;
 
     let (block_result, senders) = {
         let worker_evm_config = evm_config.clone();
@@ -171,42 +162,35 @@ where
             .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
 
         canonical_executor.apply_pre_execution_changes()?;
-        let senders = commit_ordered_worker_outputs(
-            &result_rx,
-            transaction_count,
-            &mut canonical_executor,
-            &mut gas_tracker,
-            &receipt_tx,
-        );
+        let mut senders = Vec::with_capacity(transaction_count);
+        let mut last_sent_len = 0usize;
+        for output in OrderedWorkerOutputs::new(&result_rx, transaction_count) {
+            let output = output?;
+
+            gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
+            gas_tracker.record_result(output.result.result());
+            canonical_executor.evm_mut().db_mut().bump_bal_index();
+
+            let _ = canonical_executor.commit_transaction(output.result);
+            senders.push(output.signer);
+
+            let current_len = canonical_executor.receipts().len();
+            if current_len > last_sent_len {
+                last_sent_len = current_len;
+                if let Some(receipt) = canonical_executor.receipts().last() {
+                    let tx_index = current_len - 1;
+                    let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
+                }
+            }
+        }
         drop(abort_guard);
-        let senders = senders?;
 
         canonical_executor.evm_mut().db_mut().bump_bal_index();
         let block_result = canonical_executor.apply_post_execution_changes()?;
         (block_result, senders)
     };
 
-    let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
-    let rebuilt = compute_block_access_list_hash(&composed_alloy);
-    if rebuilt != header_bal_hash {
-        if tracing::enabled!(
-            target: "engine::tree::payload_processor::bal",
-            tracing::Level::DEBUG
-        ) {
-            let div = debug::first_bal_divergence(bal, &composed_alloy);
-            tracing::debug!(
-                target: "engine::tree::payload_processor::bal",
-                %rebuilt,
-                expected = %header_bal_hash,
-                ?div,
-                "first BAL divergence",
-            );
-        }
-        return Err(BalExecutionError::Reject(RejectReason::FinalHashMismatch {
-            rebuilt,
-            expected: header_bal_hash,
-        }));
-    }
+    validate_bal_hash(&mut canonical_state, bal, header_bal_hash)?;
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
     Ok((
@@ -219,6 +203,63 @@ where
         },
         senders,
     ))
+}
+
+fn load_bal_accounts<DB>(
+    canonical_state: &mut State<DB>,
+    bal: &AlloyBal,
+) -> Result<(), BalExecutionError>
+where
+    DB: Database,
+{
+    // Pre-load every BAL-declared address into canonical state's cache. `State::commit`
+    // (called by `commit_transaction`) panics at revm-database's
+    // `cache.rs:195` ("All accounts should be present inside cache") when it tries to
+    // apply a diff for an address not previously loaded. In the normal serial flow the
+    // EVM loads the account itself during execution, but here workers execute the tx EVM
+    // and the canonical loop only commits their outputs, so canonical may never have read
+    // those accounts itself.
+    for account_changes in bal {
+        canonical_state
+            .load_cache_account(account_changes.address)
+            .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+    }
+
+    Ok(())
+}
+
+fn validate_bal_hash<DB>(
+    canonical_state: &mut State<DB>,
+    received_bal: &AlloyBal,
+    header_bal_hash: B256,
+) -> Result<(), BalExecutionError>
+where
+    DB: Database,
+{
+    let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+    let rebuilt = compute_block_access_list_hash(&composed_alloy);
+    if rebuilt == header_bal_hash {
+        return Ok(());
+    }
+
+    if tracing::enabled!(
+        target: "engine::tree::payload_processor::bal",
+        tracing::Level::DEBUG
+    ) {
+        let div = debug::first_bal_divergence(received_bal, &composed_alloy);
+        tracing::debug!(
+            target: "engine::tree::payload_processor::bal",
+            %rebuilt,
+            expected = %header_bal_hash,
+            ?div,
+            "first BAL divergence",
+        );
+    }
+
+    Err(BalExecutionError::Reject(RejectReason::FinalHashMismatch {
+        rebuilt,
+        expected: header_bal_hash,
+    }))
 }
 
 /// Closes the abort channel on drop, waking scoped workers before the scope exits.
@@ -275,74 +316,76 @@ impl BlockGasTracker {
     }
 }
 
-fn commit_ordered_worker_outputs<'a, E, DB>(
-    result_rx: &Receiver<Result<BalWorkerOutput<E::Result>, BalExecutionError>>,
-    transaction_count: usize,
-    canonical_executor: &mut E,
-    gas_tracker: &mut BlockGasTracker,
-    receipt_tx: &Sender<IndexedReceipt<E::Receipt>>,
-) -> Result<Vec<Address>, BalExecutionError>
-where
-    E: BlockExecutor<Evm: Evm<DB = &'a mut State<DB>>>,
-    E::Receipt: Clone,
-    DB: Database + 'a,
-{
-    let mut pending = (0..transaction_count).map(|_| None).collect::<Vec<_>>();
-    let mut next_commit = 0usize;
-    let mut senders = Vec::with_capacity(transaction_count);
-
-    while next_commit < transaction_count {
-        let output = result_rx.recv().map_err(|_| {
-            BalExecutionError::Evm(BlockExecutionError::msg(
-                "BAL worker result channel closed before all results arrived",
-            ))
-        })??;
-
-        let index = output.index;
-        if index >= transaction_count {
-            return Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                "BAL worker returned out-of-bounds transaction index",
-            )));
-        }
-        if pending[index].is_some() {
-            return Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                "BAL worker returned duplicate transaction index",
-            )));
-        }
-        pending[index] = Some(output);
-
-        loop {
-            if next_commit >= transaction_count {
-                break;
-            }
-            let Some(output) = pending[next_commit].take() else {
-                break;
-            };
-
-            gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
-            gas_tracker.record_result(output.result.result());
-            canonical_executor.evm_mut().db_mut().bump_bal_index();
-
-            let previous_receipts_len = canonical_executor.receipts().len();
-            canonical_executor.commit_transaction(output.result);
-            senders.push(output.signer);
-
-            let receipts = canonical_executor.receipts();
-            if receipts.len() > previous_receipts_len {
-                if let Some(receipt) = receipts.last() {
-                    let _ =
-                        receipt_tx.send(IndexedReceipt::new(receipts.len() - 1, receipt.clone()));
-                }
-            }
-
-            next_commit += 1;
-        }
-    }
-
-    Ok(senders)
+struct OrderedWorkerOutputs<'a, R> {
+    result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+    pending: Vec<Option<BalWorkerOutput<R>>>,
+    next: usize,
+    total: usize,
+    failed: bool,
 }
 
+impl<'a, R> OrderedWorkerOutputs<'a, R> {
+    fn new(
+        result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+        total: usize,
+    ) -> Self {
+        Self {
+            result_rx,
+            pending: (0..total).map(|_| None).collect(),
+            next: 0,
+            total,
+            failed: false,
+        }
+    }
+}
 
+impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
+    type Item = Result<BalWorkerOutput<R>, BalExecutionError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.failed || self.next >= self.total {
+            return None;
+        }
+
+        loop {
+            if let Some(output) = self.pending[self.next].take() {
+                self.next += 1;
+                return Some(Ok(output));
+            }
+
+            let output = match self.result_rx.recv() {
+                Ok(Ok(output)) => output,
+                Ok(Err(err)) => {
+                    self.failed = true;
+                    return Some(Err(err));
+                }
+                Err(_) => {
+                    self.failed = true;
+                    return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                        "BAL worker result channel closed before all results arrived",
+                    ))));
+                }
+            };
+
+            let index = output.index;
+            if index >= self.total {
+                self.failed = true;
+                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                    "BAL worker returned out-of-bounds transaction index",
+                ))));
+            }
+
+            if index < self.next || self.pending[index].is_some() {
+                self.failed = true;
+                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                    "BAL worker returned duplicate transaction index",
+                ))));
+            }
+
+            self.pending[index] = Some(output);
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -2,9 +2,9 @@
 //!
 //! Read `execute_block` as two execution paths over the same parent state.
 //!
-//! Worker states run transactions speculatively. Each worker gets a fresh database from
-//! `make_db`, installs the received BAL, sets its transaction BAL index, and returns an
-//! uncommitted transaction result.
+//! Worker states run transactions speculatively. Each worker gets one fresh database from
+//! `make_db`, installs the received BAL, sets the transaction BAL index for each streamed
+//! transaction, and returns uncommitted transaction results.
 //!
 //! The canonical state owns block effects. It runs the normal pre/post block hooks, commits
 //! worker results in transaction order, tracks block gas admission, and builds the BAL that this
@@ -14,14 +14,19 @@
 //! validator still handles consensus checks, receipt-root validation, state-root work, and block
 //! insertion.
 
-use super::{debug, BalExecutionError, RejectReason};
-use alloy_consensus::{BlockHeader, Transaction};
+use super::{
+    debug,
+    worker::{self, BalWorkerOutput},
+    BalExecutionError, RejectReason,
+};
+use alloy_consensus::BlockHeader;
 use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
 use alloy_evm::{
     block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
     Evm,
 };
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
+use crossbeam_channel::{Receiver, Sender};
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database};
 use reth_primitives_traits::{BlockTy, ReceiptTy, SealedBlock};
 use reth_tasks::Runtime;
@@ -31,10 +36,9 @@ use revm::{
     primitives::{eip7825::TX_GAS_LIMIT_CAP, hardfork::SpecId},
 };
 use revm_state::bal::Bal;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::Arc;
+
+use crate::tree::payload_processor::receipt_root_task::IndexedReceipt;
 
 /// Output of a successful BAL-path block execution.
 #[expect(missing_debug_implementations)]
@@ -52,22 +56,64 @@ pub struct BalExecutionOutput<Evm: ConfigureEvm> {
 }
 
 /// Executes one block on the BAL path using the runtime's persistent BAL worker pool.
-pub fn execute_block<Evm, Tx, DB, MakeDb>(
+pub fn execute_block<Evm, Tx, Err, DB, MakeDb>(
     runtime: &Runtime,
     evm_config: Evm,
     make_db: MakeDb,
     received_bal: Arc<DecodedBal>,
     block: &SealedBlock<BlockTy<Evm::Primitives>>,
-    txs: Vec<Tx>,
+    transaction_count: usize,
+    txs: Receiver<(usize, Result<Tx, Err>)>,
+    receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
     header_bal_hash: B256,
-) -> Result<BalExecutionOutput<Evm>, BalExecutionError>
+) -> Result<(BalExecutionOutput<Evm>, Vec<Address>), BalExecutionError>
 where
     Evm: ConfigureEvm,
     Tx: ExecutableTxFor<Evm> + Send,
+    Err: core::error::Error + Send + Sync + 'static,
     DB: Database + Send,
     MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
+    ReceiptTy<Evm::Primitives>: Clone,
 {
     let worker_pool = runtime.bal_streaming_pool();
+    let worker_count = worker_pool.current_num_threads().max(1).min(transaction_count);
+
+    worker_pool.in_place_scope(|scope| {
+        execute_block_inner(
+            scope,
+            evm_config,
+            &make_db,
+            received_bal,
+            block,
+            transaction_count,
+            txs,
+            receipt_tx,
+            header_bal_hash,
+            worker_count,
+        )
+    })
+}
+
+fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
+    scope: &rayon::Scope<'scope>,
+    evm_config: Evm,
+    make_db: &'scope MakeDb,
+    received_bal: Arc<DecodedBal>,
+    block: &'scope SealedBlock<BlockTy<Evm::Primitives>>,
+    transaction_count: usize,
+    txs: Receiver<(usize, Result<Tx, Err>)>,
+    receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
+    header_bal_hash: B256,
+    worker_count: usize,
+) -> Result<(BalExecutionOutput<Evm>, Vec<Address>), BalExecutionError>
+where
+    Evm: ConfigureEvm + 'scope,
+    Tx: ExecutableTxFor<Evm> + Send + 'scope,
+    Err: core::error::Error + Send + Sync + 'static,
+    DB: Database + Send + 'scope,
+    MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'scope,
+    ReceiptTy<Evm::Primitives>: Clone,
+{
     let bal = received_bal.as_bal();
     let received_bal_revm: Arc<Bal> = Arc::new(
         Bal::try_from(Vec::<_>::from(bal.clone()))
@@ -86,7 +132,6 @@ where
         .into()
         .is_enabled_in(SpecId::AMSTERDAM);
     let block_gas_limit = block.header().gas_limit();
-    let tx_gas_limits: Vec<_> = txs.iter().map(|tx| tx.tx().gas_limit()).collect();
 
     // Pre-load every BAL-declared address into canonical state's cache. `State::commit`
     // (called by `commit_transaction`) panics at revm-database's
@@ -101,67 +146,44 @@ where
             .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
     }
 
-    let block_result = {
+    let (block_result, senders) = {
         let worker_evm_config = evm_config.clone();
+        let (result_tx, result_rx) = crossbeam_channel::unbounded();
+        let (abort_guard, abort_rx) = AbortGuard::new();
+
+        for _ in 0..worker_count {
+            worker::spawn_worker(
+                scope,
+                txs.clone(),
+                abort_rx.clone(),
+                result_tx.clone(),
+                worker_evm_config.clone(),
+                make_db,
+                Arc::clone(&received_bal_revm),
+                block,
+            );
+        }
+        drop(result_tx);
+
+        let mut gas_tracker = BlockGasTracker::new(block_gas_limit, is_amsterdam);
         let mut canonical_executor = evm_config
             .executor_for_block(&mut canonical_state, block)
             .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
 
         canonical_executor.apply_pre_execution_changes()?;
-
-        let mut gas_tracker = BlockGasTracker::new(block_gas_limit, is_amsterdam);
-        let abort = Arc::new(AtomicBool::new(false));
-        let tx_count = txs.len() as u64;
-        let make_db = &make_db;
-
-        worker_pool.in_place_scope(|scope| -> Result<(), BalExecutionError> {
-            let mut result_rxs = Vec::with_capacity(tx_count as usize);
-
-            for (i, tx) in txs.into_iter().enumerate() {
-                let tx_index = i as u64 + 1;
-                let abort = Arc::clone(&abort);
-                let received_bal_revm = Arc::clone(&received_bal_revm);
-                let evm_config = worker_evm_config.clone();
-                let result_rx = spawn_worker(scope, abort, move || {
-                    let mut worker_state = State::builder()
-                        .with_database(make_db()?)
-                        .with_bal(received_bal_revm)
-                        .with_bundle_update()
-                        .build();
-                    worker_state.set_bal_index(tx_index);
-
-                    evm_config
-                        .executor_for_block(&mut worker_state, block)
-                        .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?
-                        .execute_transaction_without_commit(tx)
-                        .map_err(BalExecutionError::Evm)
-                });
-                result_rxs.push(result_rx);
-            }
-            for (i, result_rx) in result_rxs.into_iter().enumerate() {
-                let worker_result = result_rx.recv().map_err(|_| {
-                    BalExecutionError::Evm(BlockExecutionError::msg(
-                        "BAL worker result channel closed before result arrived",
-                    ))
-                })?;
-                let worker_result = match worker_result {
-                    Ok(worker_result) => worker_result,
-                    Err(err) => {
-                        abort.store(true, Ordering::Relaxed);
-                        return Err(err);
-                    }
-                };
-                gas_tracker.validate_tx_limit(tx_gas_limits[i])?;
-                gas_tracker.record_result(worker_result.result());
-                canonical_executor.evm_mut().db_mut().bump_bal_index();
-                commit_worker_result(&mut canonical_executor, worker_result);
-            }
-
-            Ok(())
-        })?;
+        let senders = commit_ordered_worker_outputs(
+            &result_rx,
+            transaction_count,
+            &mut canonical_executor,
+            &mut gas_tracker,
+            &receipt_tx,
+        );
+        drop(abort_guard);
+        let senders = senders?;
 
         canonical_executor.evm_mut().db_mut().bump_bal_index();
-        canonical_executor.apply_post_execution_changes()?
+        let block_result = canonical_executor.apply_post_execution_changes()?;
+        (block_result, senders)
     };
 
     let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
@@ -187,13 +209,28 @@ where
     }
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
-    Ok(BalExecutionOutput {
-        bundle_state: canonical_state.take_bundle(),
-        receipts: block_result.receipts,
-        gas_used: block_result.gas_used,
-        blob_gas_used: block_result.blob_gas_used,
-        requests: block_result.requests,
-    })
+    Ok((
+        BalExecutionOutput {
+            bundle_state: canonical_state.take_bundle(),
+            receipts: block_result.receipts,
+            gas_used: block_result.gas_used,
+            blob_gas_used: block_result.blob_gas_used,
+            requests: block_result.requests,
+        },
+        senders,
+    ))
+}
+
+/// Closes the abort channel on drop, waking scoped workers before the scope exits.
+struct AbortGuard {
+    _tx: Sender<()>,
+}
+
+impl AbortGuard {
+    fn new() -> (Self, Receiver<()>) {
+        let (tx, rx) = crossbeam_channel::bounded(0);
+        (Self { _tx: tx }, rx)
+    }
 }
 
 /// Mirrors `EthBlockExecutor`'s cumulative gas admission check in the ordered BAL commit loop.
@@ -238,34 +275,74 @@ impl BlockGasTracker {
     }
 }
 
-fn spawn_worker<'scope, R, F>(
-    scope: &rayon::Scope<'scope>,
-    abort: Arc<AtomicBool>,
-    run: F,
-) -> crossbeam_channel::Receiver<Result<R, BalExecutionError>>
+fn commit_ordered_worker_outputs<'a, E, DB>(
+    result_rx: &Receiver<Result<BalWorkerOutput<E::Result>, BalExecutionError>>,
+    transaction_count: usize,
+    canonical_executor: &mut E,
+    gas_tracker: &mut BlockGasTracker,
+    receipt_tx: &Sender<IndexedReceipt<E::Receipt>>,
+) -> Result<Vec<Address>, BalExecutionError>
 where
-    R: Send + 'scope,
-    F: FnOnce() -> Result<R, BalExecutionError> + Send + 'scope,
+    E: BlockExecutor<Evm: Evm<DB = &'a mut State<DB>>>,
+    E::Receipt: Clone,
+    DB: Database + 'a,
 {
-    let (result_tx, result_rx) = crossbeam_channel::bounded(1);
+    let mut pending = (0..transaction_count).map(|_| None).collect::<Vec<_>>();
+    let mut next_commit = 0usize;
+    let mut senders = Vec::with_capacity(transaction_count);
 
-    scope.spawn(move |_| {
-        if abort.load(Ordering::Relaxed) {
-            return;
+    while next_commit < transaction_count {
+        let output = result_rx.recv().map_err(|_| {
+            BalExecutionError::Evm(BlockExecutionError::msg(
+                "BAL worker result channel closed before all results arrived",
+            ))
+        })??;
+
+        let index = output.index;
+        if index >= transaction_count {
+            return Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                "BAL worker returned out-of-bounds transaction index",
+            )));
         }
+        if pending[index].is_some() {
+            return Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                "BAL worker returned duplicate transaction index",
+            )));
+        }
+        pending[index] = Some(output);
 
-        let _ = result_tx.send(run());
-    });
+        loop {
+            if next_commit >= transaction_count {
+                break;
+            }
+            let Some(output) = pending[next_commit].take() else {
+                break;
+            };
 
-    result_rx
+            gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
+            gas_tracker.record_result(output.result.result());
+            canonical_executor.evm_mut().db_mut().bump_bal_index();
+
+            let previous_receipts_len = canonical_executor.receipts().len();
+            canonical_executor.commit_transaction(output.result);
+            senders.push(output.signer);
+
+            let receipts = canonical_executor.receipts();
+            if receipts.len() > previous_receipts_len {
+                if let Some(receipt) = receipts.last() {
+                    let _ =
+                        receipt_tx.send(IndexedReceipt::new(receipts.len() - 1, receipt.clone()));
+                }
+            }
+
+            next_commit += 1;
+        }
+    }
+
+    Ok(senders)
 }
 
-fn commit_worker_result<E>(executor: &mut E, worker_result: E::Result)
-where
-    E: BlockExecutor,
-{
-    let _ = executor.commit_transaction(worker_result);
-}
+
 
 #[cfg(test)]
 mod tests {
@@ -286,6 +363,7 @@ mod tests {
         database::{CacheDB, EmptyDB},
         state::{AccountInfo, Bytecode},
     };
+    use std::convert::Infallible;
 
     /// Wraps a `BlockAccessList` into an `Arc<DecodedBal>` by RLP-encoding the BAL.
     fn to_arc_decoded(bal: BlockAccessList) -> Arc<DecodedBal> {
@@ -405,7 +483,7 @@ mod tests {
 
         let block = empty_amsterdam_block(bal_hash);
 
-        let result = execute_block(
+        let result = run_execute_block(
             &Runtime::test(),
             evm_config,
             db_factory(system_contracts_db()),
@@ -427,6 +505,44 @@ mod tests {
         db: CacheDB<EmptyDB>,
     ) -> impl Fn() -> Result<CacheDB<EmptyDB>, BalExecutionError> + Sync {
         move || Ok(db.clone())
+    }
+
+    fn tx_stream<Tx>(txs: Vec<Tx>) -> Receiver<(usize, Result<Tx, Infallible>)> {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        for (index, transaction) in txs.into_iter().enumerate() {
+            tx.send((index, Ok(transaction))).unwrap();
+        }
+        rx
+    }
+
+    fn run_execute_block<Tx, DB, MakeDb>(
+        runtime: &Runtime,
+        evm_config: EthEvmConfig,
+        make_db: MakeDb,
+        received_bal: Arc<DecodedBal>,
+        block: &SealedBlock<Block>,
+        txs: Vec<Tx>,
+        bal_hash: B256,
+    ) -> Result<BalExecutionOutput<EthEvmConfig>, BalExecutionError>
+    where
+        Tx: ExecutableTxFor<EthEvmConfig> + Send,
+        DB: Database + Send,
+        MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
+    {
+        let transaction_count = txs.len();
+        let (receipt_tx, _receipt_rx) = crossbeam_channel::unbounded();
+        execute_block(
+            runtime,
+            evm_config,
+            make_db,
+            received_bal,
+            block,
+            transaction_count,
+            tx_stream(txs),
+            receipt_tx,
+            bal_hash,
+        )
+        .map(|(output, _)| output)
     }
 
     /// Inserts `AccountInfo { nonce: 0, balance }` for `addr` into the canonical DB.
@@ -570,7 +686,7 @@ mod tests {
         let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
         let block = empty_amsterdam_block(bal_hash);
 
-        let result = execute_block(
+        let result = run_execute_block(
             &Runtime::test(),
             evm_config,
             db_factory(pre_block_db),
@@ -667,7 +783,7 @@ mod tests {
         let block =
             empty_amsterdam_block_with_gas_limit(bal_hash, block_header_only.header().gas_limit());
 
-        let bal_out = execute_block(
+        let bal_out = run_execute_block(
             &Runtime::test(),
             evm_config,
             db_factory(canonical_db_template),
@@ -814,7 +930,7 @@ mod tests {
         let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
         let low_gas_block = empty_amsterdam_block_with_gas_limit(bal_hash, block_gas_limit);
 
-        let result = execute_block(
+        let result = run_execute_block(
             &Runtime::test(),
             evm_config,
             db_factory(pre_block_db),

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -15,9 +15,7 @@
 //! insertion.
 
 use super::{
-    debug,
-    worker::{self, BalWorkerOutput},
-    BalExecutionError, RejectReason,
+    debug, ordered_outputs::ordered_worker_outputs, worker, BalExecutionError, RejectReason,
 };
 use alloy_consensus::BlockHeader;
 use alloy_eip7928::{
@@ -164,7 +162,7 @@ where
         canonical_executor.apply_pre_execution_changes()?;
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
-        for output in OrderedWorkerOutputs::new(&result_rx, transaction_count) {
+        for output in ordered_worker_outputs(&result_rx, transaction_count) {
             let output = output?;
 
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
@@ -313,77 +311,6 @@ impl BlockGasTracker {
         self.cumulative_tx_gas_used = self.cumulative_tx_gas_used.saturating_add(gas.tx_gas_used());
         self.block_regular_gas_used =
             self.block_regular_gas_used.saturating_add(gas.block_regular_gas_used());
-    }
-}
-
-struct OrderedWorkerOutputs<'a, R> {
-    result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
-    pending: Vec<Option<BalWorkerOutput<R>>>,
-    next: usize,
-    total: usize,
-    failed: bool,
-}
-
-impl<'a, R> OrderedWorkerOutputs<'a, R> {
-    fn new(
-        result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
-        total: usize,
-    ) -> Self {
-        Self {
-            result_rx,
-            pending: (0..total).map(|_| None).collect(),
-            next: 0,
-            total,
-            failed: false,
-        }
-    }
-}
-
-impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
-    type Item = Result<BalWorkerOutput<R>, BalExecutionError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.failed || self.next >= self.total {
-            return None;
-        }
-
-        loop {
-            if let Some(output) = self.pending[self.next].take() {
-                self.next += 1;
-                return Some(Ok(output));
-            }
-
-            let output = match self.result_rx.recv() {
-                Ok(Ok(output)) => output,
-                Ok(Err(err)) => {
-                    self.failed = true;
-                    return Some(Err(err));
-                }
-                Err(_) => {
-                    self.failed = true;
-                    return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                        "BAL worker result channel closed before all results arrived",
-                    ))));
-                }
-            };
-
-            let index = output.index;
-            if index >= self.total {
-                self.failed = true;
-                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                    "BAL worker returned out-of-bounds transaction index",
-                ))));
-            }
-
-            if index < self.next || self.pending[index].is_some() {
-                self.failed = true;
-                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                    "BAL worker returned duplicate transaction index",
-                ))));
-            }
-
-            self.pending[index] = Some(output);
-        }
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -9,6 +9,7 @@
 //! fragment checks. It does not yet report rich undeclared-access diagnostics.
 
 mod debug;
+mod worker;
 
 pub mod error;
 pub mod execute;

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -9,6 +9,7 @@
 //! fragment checks. It does not yet report rich undeclared-access diagnostics.
 
 mod debug;
+mod ordered_outputs;
 mod worker;
 
 pub mod error;

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -1,0 +1,192 @@
+//! Ordering adapter for speculative BAL worker results.
+
+use super::{worker::BalWorkerOutput, BalExecutionError};
+use alloy_evm::block::BlockExecutionError;
+use crossbeam_channel::Receiver;
+
+/// Returns a blocking iterator over worker outputs in transaction order.
+///
+/// Workers may finish transactions out of order. This adapter buffers future-indexed outputs and
+/// yields each output only when every earlier transaction has been yielded. It owns no execution
+/// state and performs no canonical commit work.
+///
+/// Contract for callers:
+/// - each yielded `Ok` output has the next transaction index
+/// - worker errors are forwarded unchanged
+/// - closed channels before `total` outputs, out-of-bounds indices, and duplicate indices yield
+///   `Err`
+/// - after the first error, the iterator is exhausted
+///
+/// Callers that intentionally abort workers must stop polling this iterator after initiating
+/// abort. Before `total` outputs are yielded, channel closure is treated as an execution error.
+pub(super) fn ordered_worker_outputs<R>(
+    result_rx: &Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+    total: usize,
+) -> impl Iterator<Item = Result<BalWorkerOutput<R>, BalExecutionError>> + '_ {
+    OrderedWorkerOutputs::new(result_rx, total)
+}
+
+struct OrderedWorkerOutputs<'a, R> {
+    result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+    pending: Vec<Option<BalWorkerOutput<R>>>,
+    next: usize,
+    total: usize,
+    failed: bool,
+}
+
+impl<'a, R> OrderedWorkerOutputs<'a, R> {
+    fn new(
+        result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+        total: usize,
+    ) -> Self {
+        Self {
+            result_rx,
+            pending: (0..total).map(|_| None).collect(),
+            next: 0,
+            total,
+            failed: false,
+        }
+    }
+}
+
+impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
+    type Item = Result<BalWorkerOutput<R>, BalExecutionError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.failed || self.next >= self.total {
+            return None;
+        }
+
+        loop {
+            if let Some(output) = self.pending[self.next].take() {
+                self.next += 1;
+                return Some(Ok(output));
+            }
+
+            let output = match self.result_rx.recv() {
+                Ok(Ok(output)) => output,
+                Ok(Err(err)) => {
+                    self.failed = true;
+                    return Some(Err(err));
+                }
+                Err(_) => {
+                    self.failed = true;
+                    return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                        "BAL worker result channel closed while waiting for ordered outputs",
+                    ))));
+                }
+            };
+
+            let index = output.index;
+            if index >= self.total {
+                self.failed = true;
+                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                    "BAL worker returned out-of-bounds transaction index",
+                ))));
+            }
+
+            if index < self.next || self.pending[index].is_some() {
+                self.failed = true;
+                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
+                    "BAL worker returned duplicate transaction index",
+                ))));
+            }
+
+            self.pending[index] = Some(output);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Address;
+
+    fn output(index: usize, result: u64) -> BalWorkerOutput<u64> {
+        BalWorkerOutput { index, signer: Address::ZERO, tx_gas_limit: 0, result }
+    }
+
+    fn expect_err_contains<R>(result: Result<BalWorkerOutput<R>, BalExecutionError>, text: &str) {
+        let Err(err) = result else {
+            panic!("expected ordered worker output error");
+        };
+        assert!(err.to_string().contains(text), "expected `{err}` to contain `{text}`");
+    }
+
+    #[test]
+    fn yields_outputs_in_transaction_order() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Ok(output(2, 20))).unwrap();
+        tx.send(Ok(output(0, 0))).unwrap();
+        tx.send(Ok(output(1, 10))).unwrap();
+        drop(tx);
+
+        let results = ordered_worker_outputs(&rx, 3)
+            .map(|output| output.expect("ordered output").result)
+            .collect::<Vec<_>>();
+
+        assert_eq!(results, vec![0, 10, 20]);
+    }
+
+    #[test]
+    fn forwards_worker_errors_and_then_stops() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Err(BalExecutionError::Evm(BlockExecutionError::msg("worker failed")))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs::<u64>(&rx, 1);
+
+        expect_err_contains(outputs.next().expect("first item"), "worker failed");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn rejects_closed_channel_before_all_outputs_arrive() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs::<u64>(&rx, 1);
+
+        expect_err_contains(outputs.next().expect("first item"), "waiting for ordered outputs");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_index() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Ok(output(1, 10))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs(&rx, 1);
+
+        expect_err_contains(outputs.next().expect("first item"), "out-of-bounds");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn rejects_duplicate_pending_index() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Ok(output(1, 10))).unwrap();
+        tx.send(Ok(output(1, 11))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs(&rx, 2);
+
+        expect_err_contains(outputs.next().expect("first item"), "duplicate");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn rejects_duplicate_already_yielded_index() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Ok(output(0, 0))).unwrap();
+        tx.send(Ok(output(0, 1))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs(&rx, 2);
+
+        assert_eq!(outputs.next().expect("first item").expect("first output").result, 0);
+        expect_err_contains(outputs.next().expect("second item"), "duplicate");
+        assert!(outputs.next().is_none());
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -11,7 +11,7 @@ use crossbeam_channel::{Receiver, Sender};
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database};
 use reth_primitives_traits::{BlockTy, SealedBlock};
 use revm::database::State;
-use revm_state::bal::Bal;
+use revm_state::bal::Bal as RevmBal;
 use std::sync::Arc;
 
 pub(super) struct BalWorkerOutput<R> {
@@ -35,7 +35,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
     >,
     evm_config: Evm,
     make_db: &'scope MakeDb,
-    received_bal_revm: Arc<Bal>,
+    received_bal_revm: Arc<RevmBal>,
     block: &'scope SealedBlock<BlockTy<Evm::Primitives>>,
 ) where
     Evm: ConfigureEvm + 'scope,

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -1,0 +1,90 @@
+//! Speculative BAL worker execution.
+
+use super::BalExecutionError;
+use alloy_consensus::Transaction;
+use alloy_evm::{
+    block::{BlockExecutionError, BlockExecutor},
+    Evm,
+};
+use alloy_primitives::Address;
+use crossbeam_channel::{Receiver, Sender};
+use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database};
+use reth_primitives_traits::{BlockTy, SealedBlock};
+use revm::database::State;
+use revm_state::bal::Bal;
+use std::sync::Arc;
+
+pub(super) struct BalWorkerOutput<R> {
+    pub(super) index: usize,
+    pub(super) signer: Address,
+    pub(super) tx_gas_limit: u64,
+    pub(super) result: R,
+}
+
+pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
+    scope: &rayon::Scope<'scope>,
+    tx_rx: Receiver<(usize, Result<Tx, Err>)>,
+    abort_rx: Receiver<()>,
+    result_tx: Sender<
+        Result<
+            BalWorkerOutput<
+                <reth_evm::BlockExecutorForEvm<'scope, Evm, DB> as alloy_evm::block::BlockExecutor>::Result,
+            >,
+            BalExecutionError,
+        >,
+    >,
+    evm_config: Evm,
+    make_db: &'scope MakeDb,
+    received_bal_revm: Arc<Bal>,
+    block: &'scope SealedBlock<BlockTy<Evm::Primitives>>,
+) where
+    Evm: ConfigureEvm + 'scope,
+    Tx: ExecutableTxFor<Evm> + Send + 'scope,
+    Err: core::error::Error + Send + Sync + 'static,
+    DB: Database + Send + 'scope,
+    MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'scope,
+{
+    scope.spawn(move |_| {
+        let worker_result = (|| -> Result<(), BalExecutionError> {
+            let mut worker_state = State::builder()
+                .with_database(make_db()?)
+                .with_bal(received_bal_revm)
+                .with_bundle_update()
+                .build();
+            let mut executor = evm_config
+                .executor_for_block(&mut worker_state, block)
+                .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+
+            loop {
+                let (index, tx) = crossbeam_channel::select_biased! {
+                    recv(abort_rx) -> _ => break,
+                    recv(tx_rx) -> msg => match msg {
+                        Ok(ix_tx) => ix_tx,
+                        Err(_) => break,
+                    },
+                };
+                let tx = tx.map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+                let signer = *tx.signer();
+                let tx_gas_limit = tx.tx().gas_limit();
+
+                executor.evm_mut().db_mut().set_bal_index(index as u64 + 1);
+                let result = executor
+                    .execute_transaction_without_commit(tx)
+                    .map_err(BalExecutionError::Evm)?;
+
+                if result_tx
+                    .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }))
+                    .is_err()
+                {
+                    break;
+                }
+            }
+
+            Ok(())
+        })();
+
+        if let Err(err) = worker_result {
+            let _ = result_tx.send(Err(err));
+        }
+    });
+}

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -406,10 +406,10 @@ where
         transaction_count: usize,
     ) -> (
         mpsc::Receiver<(usize, WithTxEnv<TxEnvFor<Evm>, I::Recovered>)>,
-        mpsc::Receiver<Result<WithTxEnv<TxEnvFor<Evm>, I::Recovered>, I::Error>>,
+        CrossbeamReceiver<(usize, Result<WithTxEnv<TxEnvFor<Evm>, I::Recovered>, I::Error>)>,
     ) {
         let (prewarm_tx, prewarm_rx) = mpsc::sync_channel(transaction_count);
-        let (execute_tx, execute_rx) = mpsc::sync_channel(transaction_count);
+        let (execute_tx, execute_rx) = crossbeam_channel::bounded(transaction_count);
 
         if transaction_count == 0 {
             // Empty block — nothing to do.
@@ -458,7 +458,7 @@ where
                             let _ = prewarm_tx.send((idx, tx.clone()));
                             tx
                         });
-                        let _ = execute_tx.send(tx);
+                        let _ = execute_tx.send((idx, tx));
                         trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
                         });
                         });
@@ -737,7 +737,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
     iter: impl Iterator<Item = RawTx>,
     convert: &C,
     prewarm_tx: &mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>,
-    execute_tx: &mpsc::SyncSender<Result<WithTxEnv<TxEnv, Recovered>, Err>>,
+    execute_tx: &CrossbeamSender<(usize, Result<WithTxEnv<TxEnv, Recovered>, Err>)>,
 ) where
     Tx: ExecutableTxParts<TxEnv, InnerTx, Recovered = Recovered>,
     TxEnv: Clone,
@@ -752,7 +752,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
         if let Ok(tx) = &tx {
             let _ = prewarm_tx.send((idx, tx.clone()));
         }
-        let _ = execute_tx.send(tx);
+        let _ = execute_tx.send((idx, tx));
         trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
     }
 }
@@ -770,7 +770,7 @@ pub struct PayloadHandle<Tx, Err, R> {
     // must include the receiver of the state root wired to the sparse trie
     prewarm_handle: CacheTaskHandle<R>,
     /// Stream of block transactions
-    transactions: mpsc::Receiver<Result<Tx, Err>>,
+    transactions: CrossbeamReceiver<(usize, Result<Tx, Err>)>,
     /// Span for tracing
     _span: Span,
 }
@@ -860,7 +860,12 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
 
     /// Returns iterator yielding transactions from the stream.
     pub fn iter_transactions(&mut self) -> impl Iterator<Item = Result<Tx, Err>> + '_ {
-        self.transactions.iter()
+        self.transactions.iter().map(|(_, tx)| tx)
+    }
+
+    /// Returns a clone of the indexed transaction receiver.
+    pub fn clone_transaction_receiver(&self) -> CrossbeamReceiver<(usize, Result<Tx, Err>)> {
+        self.transactions.clone()
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1080,11 +1080,10 @@ where
     /// 2. Relies on BAL prewarm to stream sparse-trie updates and optional state prefetches.
     /// 3. Spawns the receipt-root task.
     /// 4. Calls [`crate::tree::payload_processor::bal::execute_block`].
-    /// 5. Adapts the BAL output to a [`BlockExecutionOutput`] and forwards receipts to the
-    ///    receipt-root channel.
+    /// 5. Adapts the BAL output to a [`BlockExecutionOutput`].
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     #[expect(clippy::type_complexity)]
-    fn execute_block_bal<S, Tx, InnerTx, Err, BalP>(
+    fn execute_block_bal<S, Tx, Err, BalP>(
         &self,
         _state_provider: S,
         env: ExecutionEnv<Evm>,
@@ -1102,8 +1101,7 @@ where
     >
     where
         S: StateProvider + Send,
-        Tx: ExecutableTxFor<Evm> + alloy_evm::RecoveredTx<InnerTx> + Send,
-        InnerTx: TxHashRef,
+        Tx: ExecutableTxFor<Evm> + Send,
         Err: core::error::Error + Send + Sync + 'static,
         BalP: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
         Evm: ConfigureEvm<Primitives = N>,
@@ -1131,18 +1129,6 @@ where
             .executor()
             .spawn_blocking_named("receipt-root", move || task_handle.run(receipts_len));
 
-        // Collect txs from the handle's iterator. The BAL executor needs a `Vec<Tx>` because it
-        // owns each tx for the (currently sequential) commit loop.
-        //
-        // TODO: this can be optimized so that transactions are streamed directly to the BAL
-        // executor.
-        let txs: Vec<Tx> = handle
-            .iter_transactions()
-            .collect::<Result<Vec<Tx>, Err>>()
-            .map_err(BlockExecutionError::other)?;
-        let senders: Vec<Address> =
-            txs.iter().map(|tx| *<Tx as alloy_evm::RecoveredTx<InnerTx>>::signer(tx)).collect();
-
         let make_db = move || {
             let provider = provider_builder
                 .build()
@@ -1154,23 +1140,18 @@ where
             )))
         };
         let execution_start = Instant::now();
-        let bal_output = crate::tree::payload_processor::bal::execute_block(
+        let (bal_output, senders) = crate::tree::payload_processor::bal::execute_block(
             &self.runtime,
             self.evm_config.clone(),
             make_db,
             decoded_bal,
             block,
-            txs,
+            env.transaction_count,
+            handle.clone_transaction_receiver(),
+            receipt_tx,
             header_bal_hash,
         )?;
         let execution_duration = execution_start.elapsed();
-
-        // Forward all receipts to the receipt-root task, in order. Drop the sender so the task
-        // knows the stream is closed.
-        for (i, receipt) in bal_output.receipts.iter().enumerate() {
-            let _ = receipt_tx.send(IndexedReceipt::new(i, receipt.clone()));
-        }
-        drop(receipt_tx);
 
         // Adapt BalExecutionOutput → BlockExecutionOutput.
         let result = alloy_evm::block::BlockExecutionResult {


### PR DESCRIPTION
Currently, in parallel BAL there are two serialisation points:

1. the recovered transactions are collected in a vec prior to kicking off the parallel execution
2. after the parallel execution the receipts are sent in bulk to the receipt root task.

This changeset restructures the execution loop in a way such that now the wait for a recovered transactions happens inside the workers themselves. Furthermore, the receipt streaming is also overlapping now with the canonical result application. Finally, before this we were recreating the db (`make_db`) for every transaction. Now, we are doing it once per worker.

Due to the restructuring I also took the liberty to express the loop more directly which should result, hopefully, in more readable code. Due to that I recommend reading this changeset as a whole diff.