### PR TITLE
perf: fast-path cached parent overlays

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1569,6 +1569,16 @@ where
         parent_hash: B256,
         state: &EngineApiTreeState<N>,
     ) -> (Option<LazyOverlay<N>>, B256) {
+        if let Some(cached) = state.tree_state.get_cached_overlay_for_parent(parent_hash) {
+            debug!(
+                target: "engine::tree::payload_validator",
+                %parent_hash,
+                anchor_hash = %cached.anchor_hash,
+                "Using cached canonical overlay"
+            );
+            return (Some(cached.overlay.clone()), cached.anchor_hash)
+        }
+
         // Get blocks leading to the parent to determine the anchor
         let (anchor_hash, blocks) =
             state.tree_state.blocks_by_hash(parent_hash).unwrap_or_else(|| (parent_hash, vec![]));

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -152,6 +152,14 @@ impl<N: NodePrimitives> TreeState<N> {
         })
     }
 
+    /// Returns the cached overlay if it matches the requested parent hash.
+    pub fn get_cached_overlay_for_parent(
+        &self,
+        parent_hash: B256,
+    ) -> Option<&PreparedCanonicalOverlay<N>> {
+        self.cached_canonical_overlay.as_ref().filter(|cached| cached.parent_hash == parent_hash)
+    }
+
     /// Invalidates the cached overlay.
     ///
     /// Should be called when the anchor changes (e.g., after persistence).


### PR DESCRIPTION
Check the prepared canonical overlay before rebuilding the in-memory parent chain in get_parent_lazy_overlay.\n\nThis lets canonical-head payload validation and build setup reuse the cached lazy overlay without cloning the same block chain just to rediscover the cached entry and anchor.