### PR TITLE
fix(provider): add default rocksdb write buffer manager

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -28,7 +28,7 @@ use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
     DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
     OptimisticTransactionOptions, Options, SnapshotWithThreadMode, Transaction,
-    WriteBatchWithTransaction, WriteOptions, DB,
+    WriteBatchWithTransaction, WriteBufferManager, WriteOptions, DB,
 };
 use std::{
     collections::BTreeMap,
@@ -133,6 +133,12 @@ const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
 /// to 64 MB default, with negligible impact on mean throughput.
 const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 << 20;
 
+/// Default total `RocksDB` memtable memory budget across column families (4 GiB).
+///
+/// This is a soft limit; with write stalls enabled, `RocksDB` waits for flushes once
+/// memtable arena usage exceeds the budget.
+const DEFAULT_WRITE_BUFFER_MANAGER_SIZE: usize = 4 * 1024 * 1024 * 1024;
+
 /// Default buffer capacity for compression in batches.
 /// 4 KiB matches common block/page sizes and comfortably holds typical history values,
 /// reducing the first few reallocations without over-allocating.
@@ -207,6 +213,9 @@ impl RocksDBBuilder {
         options.create_missing_column_families(true);
         options.set_max_background_jobs(DEFAULT_MAX_BACKGROUND_JOBS);
         options.set_bytes_per_sync(DEFAULT_BYTES_PER_SYNC);
+        let write_buffer_manager =
+            WriteBufferManager::new_write_buffer_manager(DEFAULT_WRITE_BUFFER_MANAGER_SIZE, true);
+        options.set_write_buffer_manager(&write_buffer_manager);
 
         options.set_bottommost_compression_type(DBCompressionType::Zstd);
         options.set_bottommost_zstd_max_train_bytes(0, true);

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -144,12 +144,13 @@ const DEFAULT_WRITE_BUFFER_MANAGER_SIZE: usize = 4 * 1024 * 1024 * 1024;
 /// reducing the first few reallocations without over-allocating.
 const DEFAULT_COMPRESS_BUF_CAPACITY: usize = 4096;
 
-/// Default auto-commit threshold for batch writes (4 GiB).
+/// Default auto-commit threshold for batch writes (512 MiB).
 ///
 /// When a batch exceeds this size, it is automatically committed to prevent OOM
-/// during large bulk writes. The consistency check on startup heals any crash
-/// that occurs between auto-commits.
-const DEFAULT_AUTO_COMMIT_THRESHOLD: usize = 4 * 1024 * 1024 * 1024;
+/// during large bulk writes. Keep this below the `RocksDB` write buffer manager
+/// budget so stalls can recover without waiting on a single large flush.
+/// The consistency check on startup heals any crash that occurs between auto-commits.
+const DEFAULT_AUTO_COMMIT_THRESHOLD: usize = 512 * 1024 * 1024;
 
 /// Builder for [`RocksDBProvider`].
 pub struct RocksDBBuilder {


### PR DESCRIPTION
Adds a default RocksDB `WriteBufferManager` to cap total memtable memory across column families and enable write stalls when that budget is exceeded.

This also lowers the auto-commit threshold to 512 MiB of serialized `WriteBatch` data. The auto-commit threshold only controls how much data Reth buffers before calling into RocksDB. It does not bound RocksDB’s internal memory after the batch is committed.

When a `WriteBatch` is committed, RocksDB applies the entries to its WAL and in-memory memtables. Those memtables are later flushed to SST files, and compaction may later merge those SSTs through the LSM tree. If ingestion is faster than RocksDB can flush memtables, immutable memtables can accumulate in memory and drive memory usage well beyond the `WriteBatch` threshold.

The `WriteBufferManager` adds backpressure to RocksDB writes. It tracks memtable arena allocations across column families. When memtable usage grows past RocksDB’s internal flush threshold, RocksDB schedules memtable flushes. If total tracked memtable usage reaches the configured `WriteBufferManager` budget and `allow_stall=true`, RocksDB blocks and stops accepting further writes until background flushes finish and the memtables are freed.

The `WriteBufferManager` with a 4GB limit.

Previously, the `TransactionLookup` stage would OOM because rocksdb could not flush memtables as fast as the stage could create them. Linked below is a profile before OOM. Note that this is with an auto commit threshold of 4GB, the memory usage is >20GB.
https://pprof.me/9b038261e89bf38bf0af34ad9ee690a1/

Previous memory usage during txlookup insertion (OOM included):
<img width="1359" height="852" alt="Screenshot 2026-05-05 at 5 50 03 PM" src="https://github.com/user-attachments/assets/a37cc7fc-3d5e-446d-afce-0004d42e93ac" />

New memory usage:
<img width="1359" height="852" alt="Screenshot 2026-05-05 at 5 51 43 PM" src="https://github.com/user-attachments/assets/e7078caa-5662-40f0-911d-729911073b45" />
