### PR TITLE
fix: reth-bench: use per-run bench metrics labels file

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -399,7 +399,7 @@ BASELINE_BIN="${BASELINE_SRC}/target/profiling/reth"
 FEATURE_BIN="${FEATURE_SRC}/target/profiling/reth"
 
 # Start metrics proxy (reth → label injection → Prometheus)
-LABELS_FILE="/tmp/bench-metrics-labels.json"
+LABELS_FILE="$(mktemp "${TMPDIR:-/tmp}/bench-metrics-labels.XXXXXX")"
 echo '{}' > "$LABELS_FILE"
 METRICS_SUBNET="${METRICS_SUBNET:-10.10.0.0/24}"
 METRICS_PORT="${METRICS_PORT:-9090}"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -475,7 +475,7 @@ jobs:
           echo "BENCH_ID=${BENCH_ID}" >> "$GITHUB_ENV"
           echo "BENCH_REFERENCE_EPOCH=${BENCH_REFERENCE_EPOCH}" >> "$GITHUB_ENV"
 
-          LABELS_FILE="/tmp/bench-metrics-labels.json"
+          LABELS_FILE="$(mktemp "${RUNNER_TEMP:-/tmp}/bench-metrics-labels.XXXXXX")"
           echo '{}' > "$LABELS_FILE"
           echo "BENCH_LABELS_FILE=${LABELS_FILE}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -931,7 +931,7 @@ jobs:
           echo "BENCH_ID=${BENCH_ID}" >> "$GITHUB_ENV"
           echo "BENCH_REFERENCE_EPOCH=${BENCH_REFERENCE_EPOCH}" >> "$GITHUB_ENV"
 
-          LABELS_FILE="/tmp/bench-metrics-labels.json"
+          LABELS_FILE="$(mktemp "${RUNNER_TEMP:-/tmp}/bench-metrics-labels.XXXXXX")"
           echo '{}' > "$LABELS_FILE"
           echo "BENCH_LABELS_FILE=${LABELS_FILE}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
The bench workflows now create the metrics labels file with mktemp under the runner temp directory instead of reusing `/tmp/bench-metrics-labels.json`. This avoids permission failures when stale files are left behind by previous
  runner users. Local bench runs use the same pattern under `${TMPDIR:-/tmp}`.