### PR TITLE
fix(discv5): advertise configured NAT IP in ENR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9310,6 +9310,7 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-signer",
  "alloy-sol-types",
+ "enr",
  "eyre",
  "futures",
  "jsonrpsee-core",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -78,6 +78,7 @@ tokio.workspace = true
 serde_json.workspace = true
 rand.workspace = true
 serde.workspace = true
+enr = { workspace = true, features = ["rust-secp256k1"] }
 alloy-rpc-types-trace.workspace = true
 similar-asserts.workspace = true
 

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -23,6 +23,7 @@ use reth_payload_primitives::BuiltPayload;
 use reth_rpc_api::servers::AdminApiServer;
 use reth_tasks::Runtime;
 use std::{
+    net::{IpAddr, Ipv4Addr},
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -416,6 +417,52 @@ async fn test_admin_node_info_uses_discv5_port_when_discv4_is_disabled() -> eyre
     assert_eq!(info.ports.listener, local_record.tcp_port);
     assert_eq!(info.enode, local_record.to_string());
     assert!(info.enode.contains(&format!("?discport={discv5_port}")));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_admin_node_info_discv5_enr_uses_nat_extip_when_discv4_is_disabled() -> eyre::Result<()>
+{
+    reth_tracing::init_test_tracing();
+
+    let runtime = Runtime::test();
+
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
+    let chain_spec =
+        Arc::new(ChainSpecBuilder::default().chain(MAINNET.chain).genesis(genesis).build());
+
+    let mut network = NetworkArgs::default().with_unused_ports();
+    network.bootnodes = Some(Vec::new());
+    network.discovery.disable_dns_discovery = true;
+    network.discovery.disable_discv4_discovery = true;
+    let external_ip = Ipv4Addr::new(203, 0, 113, 7);
+    network = network.with_nat_resolver(NatResolver::ExternalIp(IpAddr::V4(external_ip)));
+
+    let node_config = NodeConfig::test()
+        .with_chain(chain_spec)
+        .with_network(network)
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime)
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    assert!(node.network.discv4().is_none());
+    let discv5 = node.network.discv5().expect("discv5 should be enabled");
+    let discv5_port = discv5.local_port();
+    let info = node.add_ons_handle.admin_api().node_info().await.unwrap();
+    let admin_enr: enr::Enr<enr::secp256k1::SecretKey> =
+        info.enr.parse().map_err(|err| eyre::eyre!("failed to parse admin ENR: {err}"))?;
+
+    assert_eq!(discv5.local_enr().ip4(), Some(external_ip));
+    assert_eq!(discv5.local_enr().udp4(), Some(discv5_port));
+    assert_eq!(admin_enr.ip4(), Some(external_ip));
+    assert_eq!(admin_enr.udp4(), Some(discv5_port));
+    assert_eq!(info.ip, IpAddr::V4(external_ip));
+    assert_eq!(info.ports.discovery, discv5_port);
 
     Ok(())
 }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -72,6 +72,12 @@ pub struct ConfigBuilder {
     /// NOTE: IP address of `RLPx` socket overwrites IP address of same IP version in
     /// [`discv5::ListenConfig`].
     tcp_socket: SocketAddr,
+    /// IP address to advertise in the local ENR instead of the listen socket address.
+    ///
+    /// This is separate from [`discv5::ListenConfig`] because the listen address describes where
+    /// discv5 binds its UDP socket. Nodes commonly bind to an unspecified address like `0.0.0.0`
+    /// while advertising an externally reachable address from NAT configuration.
+    advertised_ip: Option<IpAddr>,
     /// List of `(key, rlp-encoded-value)` tuples that should be advertised in local node record
     /// (in addition to tcp port, udp port and fork).
     other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -95,6 +101,7 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
+            advertised_ip,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -107,6 +114,7 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork: fork.map(|(key, fork_id)| (key, fork_id.fork_id)),
             tcp_socket,
+            advertised_ip,
             other_enr_kv_pairs,
             lookup_interval: Some(lookup_interval),
             bootstrap_lookup_interval: Some(bootstrap_lookup_interval),
@@ -177,6 +185,13 @@ impl ConfigBuilder {
         self
     }
 
+    /// Sets the IP address to advertise in the local [`Enr`](discv5::enr::Enr), without changing
+    /// the discv5 listen socket.
+    pub const fn advertised_ip(mut self, ip: IpAddr) -> Self {
+        self.advertised_ip = Some(ip);
+        self
+    }
+
     /// Adds an additional kv-pair to include in the local [`Enr`](discv5::enr::Enr). Takes the key
     /// to use for the kv-pair and the rlp encoded value.
     pub fn add_enr_kv_pair(mut self, key: &'static [u8], value: Bytes) -> Self {
@@ -221,6 +236,7 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
+            advertised_ip,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -234,6 +250,12 @@ impl ConfigBuilder {
 
         discv5_config.listen_config =
             amend_listen_config_wrt_rlpx(&discv5_config.listen_config, tcp_socket.ip());
+        if advertised_ip.is_some() {
+            // The upstream discv5 service can update local ENR IP fields from peer-observed
+            // socket addresses. When the operator configured a NAT address, that address is
+            // intentional advertisement state and must not be replaced by peer observations.
+            discv5_config.enr_update = false;
+        }
 
         let fork = fork.map(|(key, fork_id)| (key, fork_id.into()));
 
@@ -251,6 +273,7 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
+            advertised_ip,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -276,6 +299,8 @@ pub struct Config {
     /// NOTE: IP address of `RLPx` socket overwrites IP address of same IP version in
     /// [`discv5::ListenConfig`].
     pub(super) tcp_socket: SocketAddr,
+    /// IP address to advertise in the local ENR instead of the listen socket address.
+    pub(super) advertised_ip: Option<IpAddr>,
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to
     /// peers by including in local node record.
     pub(super) other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -300,6 +325,7 @@ impl Config {
             bootstrap_nodes: HashSet::default(),
             fork: None,
             tcp_socket: rlpx_tcp_socket,
+            advertised_ip: None,
             other_enr_kv_pairs: Vec::new(),
             lookup_interval: None,
             bootstrap_lookup_interval: None,

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -471,20 +471,26 @@ pub fn build_local_enr(
 ) -> (Enr<SecretKey>, NodeRecord, Option<&'static [u8]>, IpMode) {
     let mut builder = discv5::enr::Enr::builder();
 
-    let Config { discv5_config, fork, tcp_socket, other_enr_kv_pairs, .. } = config;
+    let Config { discv5_config, fork, tcp_socket, advertised_ip, other_enr_kv_pairs, .. } = config;
 
     let socket = {
         let v4 = crate::config::ipv4(&discv5_config.listen_config);
         let v6 = crate::config::ipv6(&discv5_config.listen_config);
 
+        // Prefer an explicit advertised IP for ENR IP fields. Listen sockets still supply UDP
+        // ports and determine which address-family fields are emitted.
         if let Some(addr) = v4 {
-            if *addr.ip() != Ipv4Addr::UNSPECIFIED {
+            if let Some(IpAddr::V4(ip)) = advertised_ip {
+                builder.ip4(*ip);
+            } else if *addr.ip() != Ipv4Addr::UNSPECIFIED {
                 builder.ip4(*addr.ip());
             }
             builder.udp4(addr.port());
         }
         if let Some(addr) = v6 {
-            if *addr.ip() != Ipv6Addr::UNSPECIFIED {
+            if let Some(IpAddr::V6(ip)) = advertised_ip {
+                builder.ip6(*ip);
+            } else if *addr.ip() != Ipv6Addr::UNSPECIFIED {
                 builder.ip6(*addr.ip());
             }
             builder.udp6(addr.port());

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -657,16 +657,24 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             total_difficulty: chain_spec.genesis().difficulty,
         });
 
+        let listener_addr = listener_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS);
+        // Static NAT addresses (`extip`/`extaddr`) tell peers which IP to dial, but that IP may
+        // not exist on a local interface. Keep binding to `listener_addr` and use the NAT IP only
+        // as the ENR address.
+        let advertised_ip = nat.clone().and_then(|nat| nat.as_external_ip(listener_addr.port()));
+
         discovery_v5_builder = discovery_v5_builder.map(|mut builder| {
             if let Some(network_stack_id) = NetworkStackId::id(&chain_spec) {
                 let fork_id = chain_spec.fork_id(&head);
                 builder = builder.fork(network_stack_id, fork_id)
             }
 
+            if let Some(ip) = advertised_ip {
+                builder = builder.advertised_ip(ip);
+            }
+
             builder
         });
-
-        let listener_addr = listener_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS);
 
         let mut hello_message =
             hello_message.unwrap_or_else(|| HelloMessage::builder(peer_id).build());


### PR DESCRIPTION
Supersedes #23639, #23755, #23863.

Passes the existing network NAT resolver into the discv5 config before building the local ENR. This keeps the listen socket unchanged while ensuring `--nat extip:<IP>` is advertised by discv5 and visible through `admin_nodeInfo.enr` when discv4 is disabled.

The discv5 ENR previously came from the listen config address only, so a `0.0.0.0` bind did not pick up the configured external address.
