### PR TITLE
docs(rpc): mark admin_peerEvents as unimplemented

### DIFF
--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -166,55 +166,21 @@ Clears all transactions from the transaction pool. Returns the number of removed
 
 ## `admin_peerEvents`, `admin_peerEvents_unsubscribe`
 
-Subscribe to events received by peers over the network. This creates a subscription that emits notifications about peer connections and disconnections.
+`admin_peerEvents` is currently not implemented in reth.
 
-The events provide information about peer activities such as when peers connect, disconnect, or experience errors. Each event contains details about the affected peer, including its enode URL, IP address, and the reason for the event.
-
-Like other subscription methods, this returns the ID of the subscription, which is then used in all events subsequently.
-
-To unsubscribe from peer events, call `admin_peerEvents_unsubscribe` with the subscription ID.
+Calling `admin_peerEvents` returns an RPC error with message `admin_peerEvents is not implemented yet`, so `admin_peerEvents_unsubscribe` is not usable at this time.
 
 | Client | Method invocation                                            |
 | ------ | ------------------------------------------------------------ |
 | RPC    | `{"method": "admin_peerEvents", "params": []}`               |
 | RPC    | `{"method": "admin_peerEvents_unsubscribe", "params": [id]}` |
 
-### Event Types
-
-The subscription emits events with the following structure:
-
-```json
-{
-    "jsonrpc": "2.0",
-    "method": "admin_subscription",
-    "params": {
-        "subscription": "0xcd0c3e8af590364c09d0fa6a1210faf5",
-        "result": {
-            "type": "add", // or "drop", "error"
-            "peer": {
-                "id": "8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a",
-                "enode": "enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303",
-                "addr": "192.168.1.1:30303"
-            },
-            "error": "reason for disconnect or error" // only present for "drop" and "error" events
-        }
-    }
-}
-```
-
 ### Example
 
 ```js
 // > {"jsonrpc":"2.0","id":1,"method":"admin_peerEvents","params":[]}
-// responds with subscription ID
-{"jsonrpc": "2.0", "id": 1, "result": "0xcd0c3e8af590364c09d0fa6a1210faf5"}
-
-// Example event when a peer connects
-{"jsonrpc":"2.0","method":"admin_subscription","params":{"subscription":"0xcd0c3e8af590364c09d0fa6a1210faf5","result":{"type":"add","peer":{"id":"8915d6ec2f53ede650d5b9bea77d7756f177092171648ee1d8cbc550d334fa7a","enode":"enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@192.168.1.1:30303","addr":"192.168.1.1:30303"}}}}
-
-// Unsubscribe
-// > {"jsonrpc":"2.0","id":2,"method":"admin_peerEvents_unsubscribe","params":["0xcd0c3e8af590364c09d0fa6a1210faf5"]}
-{"jsonrpc":"2.0","id":2,"result":true}
+// returns an RPC error with message:
+// "admin_peerEvents is not implemented yet"
 ```
 
 [enode]: https://ethereum.org/en/developers/docs/networking-layer/network-addresses/#enode


### PR DESCRIPTION
The docs currently describe `admin_peerEvents` as a working subscription, but the implementation returns `admin_peerEvents is not implemented yet` and this change aligns the API page with actual runtime behavior. 