### PR TITLE
feat(storage): add BAL store pruning

### DIFF
--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -72,7 +72,6 @@ impl Default for BalConfig {
 struct InMemoryBalStoreInner {
     entries: HashMap<BlockHash, BalEntry>,
     hashes_by_number: BTreeMap<BlockNumber, Vec<BlockHash>>,
-    highest_block_number: Option<BlockNumber>,
 }
 
 impl InMemoryBalStoreInner {
@@ -90,16 +89,13 @@ impl InMemoryBalStoreInner {
         }
 
         self.hashes_by_number.entry(block_number).or_default().push(block_hash);
-        self.highest_block_number = Some(
-            self.highest_block_number.map_or(block_number, |highest| highest.max(block_number)),
-        );
     }
 
-    // Removes BALs outside the configured retention window.
-    fn prune(&mut self, prune_mode: Option<PruneMode>) {
-        let Some(prune_mode) = prune_mode else { return };
-        let Some(tip) = self.highest_block_number else { return };
+    // Removes BALs outside the configured retention window for the given chain tip.
+    fn prune(&mut self, prune_mode: Option<PruneMode>, tip: BlockNumber) -> usize {
+        let Some(prune_mode) = prune_mode else { return 0 };
 
+        let mut pruned = 0;
         while let Some((&block_number, _)) = self.hashes_by_number.first_key_value() {
             if !prune_mode.should_prune(block_number, tip) {
                 break
@@ -107,9 +103,10 @@ impl InMemoryBalStoreInner {
 
             let Some((_, hashes)) = self.hashes_by_number.pop_first() else { break };
             for hash in hashes {
-                self.entries.remove(&hash);
+                pruned += usize::from(self.entries.remove(&hash).is_some());
             }
         }
+        pruned
     }
 }
 
@@ -123,9 +120,13 @@ impl BalStore for InMemoryBalStore {
     fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
         let mut inner = self.inner.write();
         inner.insert(num_hash.hash, num_hash.number, bal.clone_inner());
-        inner.prune(self.config.in_memory_retention);
+        inner.prune(self.config.in_memory_retention, num_hash.number);
         self.notifications.notify(BalNotification::new(num_hash, bal));
         Ok(())
+    }
+
+    fn prune(&self, tip: BlockNumber) -> ProviderResult<usize> {
+        Ok(self.inner.write().prune(self.config.in_memory_retention, tip))
     }
 
     fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
@@ -258,6 +259,25 @@ mod tests {
     }
 
     #[test]
+    fn prune_uses_chain_tip() {
+        let store =
+            InMemoryBalStore::new(BalConfig::with_in_memory_retention(PruneMode::Distance(2)));
+        let old_hash = B256::random();
+        let retained_hash = B256::random();
+        let old_bal = Bytes::from_static(b"old");
+        let retained_bal = Bytes::from_static(b"retained");
+
+        store.insert(NumHash::new(7, old_hash), sealed_bal(old_bal)).unwrap();
+        store.insert(NumHash::new(8, retained_hash), sealed_bal(retained_bal.clone())).unwrap();
+
+        assert_eq!(store.prune(10).unwrap(), 1);
+        assert_eq!(
+            store.get_by_hashes(&[old_hash, retained_hash]).unwrap(),
+            vec![None, Some(retained_bal)]
+        );
+    }
+
+    #[test]
     fn unbounded_retention_keeps_old_bals() {
         let store = InMemoryBalStore::new(BalConfig::unbounded());
         let old_hash = B256::random();
@@ -277,6 +297,7 @@ mod tests {
             store.get_by_hashes(&[old_hash, tip_hash]).unwrap(),
             vec![Some(old_bal), Some(tip_bal)]
         );
+        assert_eq!(store.prune(BAL_RETENTION_PERIOD_SLOTS + 2).unwrap(), 0);
     }
 
     #[test]

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -95,11 +95,6 @@ impl InMemoryBalStoreInner {
         );
     }
 
-    // Removes BALs outside the configured retention window using the highest inserted block.
-    fn prune_from_highest_block(&mut self, prune_mode: Option<PruneMode>) -> usize {
-        self.highest_block_number.map_or(0, |tip| self.prune(prune_mode, tip))
-    }
-
     // Removes BALs outside the configured retention window for the given chain tip.
     fn prune(&mut self, prune_mode: Option<PruneMode>, tip: BlockNumber) -> usize {
         let Some(prune_mode) = prune_mode else { return 0 };
@@ -129,7 +124,9 @@ impl BalStore for InMemoryBalStore {
     fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
         let mut inner = self.inner.write();
         inner.insert(num_hash.hash, num_hash.number, bal.clone_inner());
-        inner.prune_from_highest_block(self.config.in_memory_retention);
+        if let Some(tip) = inner.highest_block_number {
+            inner.prune(self.config.in_memory_retention, tip);
+        }
         self.notifications.notify(BalNotification::new(num_hash, bal));
         Ok(())
     }

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -124,8 +124,9 @@ impl BalStore for InMemoryBalStore {
     fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
         let mut inner = self.inner.write();
         inner.insert(num_hash.hash, num_hash.number, bal.clone_inner());
-        if let Some(tip) = inner.highest_block_number {
-            inner.prune(self.config.in_memory_retention, tip);
+        if let Some(highest_block_number) = inner.highest_block_number {
+            // This preserves insert-time cleanup based on the highest inserted BAL block.
+            inner.prune(self.config.in_memory_retention, highest_block_number);
         }
         self.notifications.notify(BalNotification::new(num_hash, bal));
         Ok(())

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -72,6 +72,7 @@ impl Default for BalConfig {
 struct InMemoryBalStoreInner {
     entries: HashMap<BlockHash, BalEntry>,
     hashes_by_number: BTreeMap<BlockNumber, Vec<BlockHash>>,
+    highest_block_number: Option<BlockNumber>,
 }
 
 impl InMemoryBalStoreInner {
@@ -89,6 +90,14 @@ impl InMemoryBalStoreInner {
         }
 
         self.hashes_by_number.entry(block_number).or_default().push(block_hash);
+        self.highest_block_number = Some(
+            self.highest_block_number.map_or(block_number, |highest| highest.max(block_number)),
+        );
+    }
+
+    // Removes BALs outside the configured retention window using the highest inserted block.
+    fn prune_from_highest_block(&mut self, prune_mode: Option<PruneMode>) -> usize {
+        self.highest_block_number.map_or(0, |tip| self.prune(prune_mode, tip))
     }
 
     // Removes BALs outside the configured retention window for the given chain tip.
@@ -120,7 +129,7 @@ impl BalStore for InMemoryBalStore {
     fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
         let mut inner = self.inner.write();
         inner.insert(num_hash.hash, num_hash.number, bal.clone_inner());
-        inner.prune(self.config.in_memory_retention, num_hash.number);
+        inner.prune_from_highest_block(self.config.in_memory_retention);
         self.notifications.notify(BalNotification::new(num_hash, bal));
         Ok(())
     }
@@ -274,6 +283,26 @@ mod tests {
         assert_eq!(
             store.get_by_hashes(&[old_hash, retained_hash]).unwrap(),
             vec![None, Some(retained_bal)]
+        );
+    }
+
+    #[test]
+    fn insert_prunes_from_highest_inserted_block() {
+        let store =
+            InMemoryBalStore::new(BalConfig::with_in_memory_retention(PruneMode::Distance(2)));
+        let old_hash = B256::random();
+        let high_hash = B256::random();
+        let late_hash = B256::random();
+        let high_bal = Bytes::from_static(b"high");
+        let late_bal = Bytes::from_static(b"late");
+
+        store.insert(NumHash::new(7, old_hash), sealed_bal(Bytes::from_static(b"old"))).unwrap();
+        store.insert(NumHash::new(10, high_hash), sealed_bal(high_bal.clone())).unwrap();
+        store.insert(NumHash::new(8, late_hash), sealed_bal(late_bal.clone())).unwrap();
+
+        assert_eq!(
+            store.get_by_hashes(&[old_hash, high_hash, late_hash]).unwrap(),
+            vec![None, Some(high_bal), Some(late_bal)]
         );
     }
 

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -43,6 +43,13 @@ pub trait BalStore: Send + Sync + 'static {
     /// Insert the BAL for the given block.
     fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()>;
 
+    /// Prunes expired BALs according to the store's retention policy and the given chain tip.
+    ///
+    /// Returns the number of BALs pruned.
+    fn prune(&self, _tip: BlockNumber) -> ProviderResult<usize> {
+        Ok(0)
+    }
+
     /// Fetch BALs for the given block hashes.
     ///
     /// The returned vector must align with `block_hashes`.
@@ -153,6 +160,12 @@ impl BalStoreHandle {
     #[inline]
     pub fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
         self.inner.insert(num_hash, bal)
+    }
+
+    /// Prunes expired BALs according to the store's retention policy and the given chain tip.
+    #[inline]
+    pub fn prune(&self, tip: BlockNumber) -> ProviderResult<usize> {
+        self.inner.prune(tip)
     }
 
     /// Fetch BALs for the given block hashes.
@@ -288,6 +301,7 @@ mod tests {
         assert_eq!(by_hash, vec![None, None]);
         assert!(store.get_by_hash(B256::random()).unwrap().is_none());
         assert!(by_range.is_empty());
+        assert_eq!(store.prune(10).unwrap(), 0);
     }
 
     #[test]

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -46,9 +46,7 @@ pub trait BalStore: Send + Sync + 'static {
     /// Prunes expired BALs according to the store's retention policy and the given chain tip.
     ///
     /// Returns the number of BALs pruned.
-    fn prune(&self, _tip: BlockNumber) -> ProviderResult<usize> {
-        Ok(0)
-    }
+    fn prune(&self, tip: BlockNumber) -> ProviderResult<usize>;
 
     /// Fetch BALs for the given block hashes.
     ///
@@ -250,6 +248,10 @@ impl BalStore for NoopBalStore {
         Ok(())
     }
 
+    fn prune(&self, _tip: BlockNumber) -> ProviderResult<usize> {
+        Ok(0)
+    }
+
     fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
         Ok(block_hashes.iter().map(|_| None).collect())
     }
@@ -365,6 +367,10 @@ mod tests {
     impl BalStore for TestBalStore {
         fn insert(&self, _num_hash: NumHash, _bal: SealedBal) -> ProviderResult<()> {
             Ok(())
+        }
+
+        fn prune(&self, _tip: BlockNumber) -> ProviderResult<usize> {
+            Ok(0)
         }
 
         fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {


### PR DESCRIPTION
Adds a tip-based `BalStore::prune` API so BAL stores can expire old entries according to their configured retention policy.

`InMemoryBalStore` now prunes against an explicit chain tip while preserving its existing insert-time cleanup behavior based on the highest inserted BAL block.

cc @mattsse 