### PR TITLE
feat: support big blocks in `reth-bench new-payload-fcu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7621,6 +7621,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tower",
  "tracing",
  "url",

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -65,6 +65,7 @@ url.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "time", "rt-multi-thread"] }
+tokio-stream.workspace = true
 
 # misc
 clap = { workspace = true, features = ["derive", "env"] }

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -117,6 +117,13 @@ impl BenchContext {
             let head_number = head_block.header.number;
             info!(target: "reth-bench", "No --from provided, derived from engine head: {}", head_number);
             (Some(head_number), bench_args.to)
+        } else if bench_args.big_blocks.is_some() && bench_args.from.is_none() {
+            let head_block = auth_provider
+                .get_block_by_number(BlockNumberOrTag::Latest)
+                .await?
+                .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from engine"))?;
+            let head_number = head_block.header.number;
+            (Some(head_number), bench_args.to)
         } else {
             (bench_args.from, bench_args.to)
         };

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -11,7 +11,10 @@ use alloy_eips::{
     Typed2718,
 };
 use alloy_primitives::{Bytes, B256};
-use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
+use alloy_provider::{
+    network::{AnyNetwork, AnyRpcBlock},
+    Provider, RootProvider,
+};
 use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionData, ExecutionPayload, ExecutionPayloadSidecar,
@@ -19,7 +22,7 @@ use alloy_rpc_types_engine::{
 };
 use clap::Parser;
 use eyre::Context;
-use futures::{stream, StreamExt};
+use futures::{stream, Stream, StreamExt};
 use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_runner::CliContext;
@@ -312,9 +315,6 @@ impl Command {
             .http(self.rpc_url.parse()?);
         let provider = RootProvider::<AnyNetwork>::new(client);
 
-        let mut prev_big_block_hash: Option<B256> = None;
-        let mut accumulated_block_hashes: Vec<(u64, B256)> = Vec::new();
-
         // Persistent prefetch stream: keeps `prefetch_buffer` per-block fetches in flight
         // ahead of the merger across all big blocks. Each item is a fully materialized
         // `FetchedBlock` (or `None` once the chain tip is reached on this fetch).
@@ -326,31 +326,79 @@ impl Command {
                 async move { fetch_one_block(provider, block_number, bal_enabled).await }
             })
             .buffered(prefetch_buffer);
-        let mut block_stream = Box::pin(block_stream);
 
-        // Track the next block number we expect from the stream (purely for logging /
-        // big-block range bookkeeping; the stream produces blocks in `from_block..` order).
-        let mut next_block = self.from_block;
+        let mut big_blocks_stream =
+            Box::pin(big_blocks_stream(self.num_big_blocks, self.target_gas, block_stream));
 
-        for big_block_idx in 0..self.num_big_blocks {
-            let range_start = next_block;
+        while let Some(big_block) = big_blocks_stream.next().await {
+            let big_block = big_block?;
+            // Save to disk
+            let range_start = big_block.big_block_data.env_switches[0].1.block_number();
+            let range_end = big_block.big_block_data.env_switches.last().unwrap().1.block_number();
+            let block_hash = big_block.execution_data.payload.as_v1().block_hash;
+            let filename = format!("big_block_{range_start}_to_{range_end}.json");
+            let filepath = self.output_dir.join(&filename);
+            let json = serde_json::to_string_pretty(&big_block)?;
+            std::fs::write(&filepath, &json)
+                .wrap_err_with(|| format!("Failed to write payload to {:?}", filepath))?;
+
+            info!(
+                target: "reth-bench",
+                path = %filepath.display(),
+                block_hash = %block_hash,
+                total_txs = big_block.execution_data.payload.transactions().len(),
+                total_gas_used = big_block.execution_data.payload.as_v1().gas_used,
+                env_switches = big_block.big_block_data.env_switches.len(),
+                prior_block_hashes = big_block.big_block_data.prior_block_hashes.len(),
+                bal_accounts = big_block.block_access_list.as_ref().map_or(0, Vec::len),
+                "Big block payload saved"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Produces a stream of big block payloads given a stream of regular blocks.
+pub(crate) fn big_blocks_stream(
+    num_big_blocks: u64,
+    target_gas: u64,
+    block_stream: impl Stream<Item = eyre::Result<Option<(AnyRpcBlock, Option<BlockAccessList>)>>>
+        + Unpin,
+) -> impl Stream<Item = eyre::Result<BigBlockPayload>> {
+    futures::stream::try_unfold(
+        (block_stream, Vec::new(), 0, None, false, 0),
+        move |(
+            mut block_stream,
+            mut accumulated_block_hashes,
+            mut big_block_idx,
+            mut prev_big_block_hash,
+            mut reached_chain_tip,
+            mut first_block,
+        )| async move {
+            if reached_chain_tip || num_big_blocks == big_block_idx {
+                warn!(
+                    target: "reth-bench",
+                    generated = big_block_idx + 1,
+                    requested = num_big_blocks,
+                    "Reached chain tip, stopping generation early"
+                );
+                return Ok(None);
+            }
 
             // Drain the prefetch stream until the gas target is reached for this big block.
             let mut blocks = Vec::new();
             let mut block_access_lists: Vec<Option<BlockAccessList>> = Vec::new();
             let mut accumulated_block_gas: u64 = 0;
 
-            let mut reached_chain_tip = false;
-            while accumulated_block_gas < self.target_gas {
-                let block_number = next_block;
-                info!(target: "reth-bench", block_number, big_block = big_block_idx, "Awaiting prefetched block");
+            while accumulated_block_gas < target_gas {
+                info!(target: "reth-bench", big_block = big_block_idx, "Awaiting prefetched block");
 
-                let fetched = match block_stream.next().await {
+                let (block, block_access_list) = match block_stream.next().await {
                     Some(Ok(Some(fetched))) => fetched,
                     Some(Ok(None)) => {
                         warn!(
                             target: "reth-bench",
-                            block_number,
                             "Block not found — reached chain tip"
                         );
                         reached_chain_tip = true;
@@ -364,13 +412,27 @@ impl Command {
                         break;
                     }
                 };
-                let FetchedBlock { execution_data, block_access_list } = fetched;
+
+                if first_block == 0 {
+                    first_block = block.header.number;
+                }
+
+                let block = block
+                    .into_inner()
+                    .map_header(|header| header.map(|h| h.into_header_with_defaults()))
+                    .try_map_transactions(|tx| -> eyre::Result<TxEnvelope> {
+                        tx.try_into().map_err(|_| eyre::eyre!("unsupported tx type"))
+                    })?
+                    .into_consensus();
+
+                let (payload, sidecar) = ExecutionPayload::from_block_slow(&block);
+                let execution_data = ExecutionData { payload, sidecar };
 
                 let block_gas = execution_data.payload.as_v1().gas_used;
 
                 info!(
                     target: "reth-bench",
-                    block_number,
+                    block_number = block.header.number,
                     gas_used = block_gas,
                     tx_count = execution_data.payload.transactions().len(),
                     "Fetched block"
@@ -379,7 +441,6 @@ impl Command {
                 accumulated_block_gas += block_gas;
                 blocks.push(execution_data);
                 block_access_lists.push(block_access_list);
-                next_block += 1;
             }
 
             // If we hit the chain tip without fetching any blocks, stop generating.
@@ -387,10 +448,10 @@ impl Command {
                 warn!(
                     target: "reth-bench",
                     big_block = big_block_idx,
-                    requested = self.num_big_blocks,
+                    requested = num_big_blocks,
                     "No blocks available, stopping generation early"
                 );
-                break;
+                return Ok(None);
             }
 
             // Block 0 is the base
@@ -459,7 +520,7 @@ impl Command {
                 base.payload.as_v1_mut().parent_hash = prev_hash;
                 // First big block keeps its original block number (from_block).
                 // Subsequent big blocks increment from there.
-                base.payload.as_v1_mut().block_number = self.from_block + big_block_idx;
+                base.payload.as_v1_mut().block_number = first_block + big_block_idx;
             }
 
             // Merge blob data from all constituent blocks:  concatenate versioned
@@ -519,47 +580,20 @@ impl Command {
                 accumulated_block_hashes.drain(..excess);
             }
 
-            // Save to disk
-            let range_end = next_block - 1;
-            let filename = format!("big_block_{range_start}_to_{range_end}.json");
-            let filepath = self.output_dir.join(&filename);
-            let json = serde_json::to_string_pretty(&big_block)?;
-            std::fs::write(&filepath, &json)
-                .wrap_err_with(|| format!("Failed to write payload to {:?}", filepath))?;
-
-            info!(
-                target: "reth-bench",
-                path = %filepath.display(),
-                block_hash = %block_hash,
-                total_txs = big_block.execution_data.payload.transactions().len(),
-                total_gas_used = big_block.execution_data.payload.as_v1().gas_used,
-                env_switches = big_block.big_block_data.env_switches.len(),
-                prior_block_hashes = big_block.big_block_data.prior_block_hashes.len(),
-                bal_accounts = big_block.block_access_list.as_ref().map_or(0, Vec::len),
-                "Big block payload saved"
-            );
-
-            if reached_chain_tip {
-                warn!(
-                    target: "reth-bench",
-                    generated = big_block_idx + 1,
-                    requested = self.num_big_blocks,
-                    "Reached chain tip, stopping generation early"
-                );
-                break;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// One fully-materialized block fetched by the prefetcher.
-struct FetchedBlock {
-    /// Execution payload with sidecar derived from the RPC block.
-    execution_data: ExecutionData,
-    /// `eth_getBlockAccessListByBlockNumber` result when `--bal` is enabled.
-    block_access_list: Option<BlockAccessList>,
+            big_block_idx += 1;
+            Ok(Some((
+                big_block,
+                (
+                    block_stream,
+                    accumulated_block_hashes,
+                    big_block_idx,
+                    prev_big_block_hash,
+                    reached_chain_tip,
+                    first_block,
+                ),
+            )))
+        },
+    )
 }
 
 /// Fetches one block + receipts (and optionally its BAL) from the RPC. Returns `Ok(None)`
@@ -568,7 +602,7 @@ async fn fetch_one_block(
     provider: RootProvider<AnyNetwork>,
     block_number: u64,
     bal_enabled: bool,
-) -> eyre::Result<Option<FetchedBlock>> {
+) -> eyre::Result<Option<(AnyRpcBlock, Option<BlockAccessList>)>> {
     let (rpc_block, block_access_list) =
         tokio::try_join!(provider.get_block_by_number(block_number.into()).full(), async {
             if bal_enabled {
@@ -581,18 +615,7 @@ async fn fetch_one_block(
         return Ok(None);
     };
 
-    let block = rpc_block
-        .into_inner()
-        .map_header(|header| header.map(|h| h.into_header_with_defaults()))
-        .try_map_transactions(|tx| -> eyre::Result<TxEnvelope> {
-            tx.try_into().map_err(|_| eyre::eyre!("unsupported tx type"))
-        })?
-        .into_consensus();
-
-    let (payload, sidecar) = ExecutionPayload::from_block_slow(&block);
-    let execution_data = ExecutionData { payload, sidecar };
-
-    Ok(Some(FetchedBlock { execution_data, block_access_list }))
+    Ok(Some((rpc_block, block_access_list)))
 }
 
 fn merge_block_access_list(

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -4,19 +4,22 @@
 use crate::{
     bench::{
         context::BenchContext,
+        generate_big_block::big_blocks_stream,
         helpers::{fetch_block_access_list, parse_duration},
         metrics_scraper::MetricsScraper,
         output::{
             write_benchmark_results, CombinedResult, NewPayloadResult, TotalGasOutput, TotalGasRow,
         },
+        BigBlockPayload,
     },
     valid_payload::{
         block_to_new_payload, call_forkchoice_updated_with_reth, call_new_payload_with_reth,
     },
 };
 use alloy_consensus::TxEnvelope;
+use alloy_eip7928::BlockAccessList;
 use alloy_eips::Encodable2718;
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_provider::{
     ext::DebugApi,
     network::{AnyNetwork, AnyRpcBlock},
@@ -27,12 +30,18 @@ use alloy_rpc_types_engine::{
 };
 use clap::Parser;
 use eyre::{bail, ensure, Context, OptionExt};
-use futures::{stream, StreamExt, TryStreamExt};
+use futures::{stream, Stream, StreamExt, TryStreamExt};
 use reth_cli_runner::CliContext;
 use reth_engine_primitives::config::DEFAULT_PERSISTENCE_THRESHOLD;
-use reth_node_core::args::BenchmarkArgs;
+use reth_node_api::{EngineApiMessageVersion, ExecutionPayload};
+use reth_node_core::args::{BenchmarkArgs, WaitForPersistence};
 use reth_rpc_api::{RethNewPayloadInput, TestingBuildBlockRequestV1};
-use std::time::{Duration, Instant};
+use std::{
+    pin::Pin,
+    time::{Duration, Instant},
+};
+use tokio::{runtime::Handle, sync::mpsc};
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info, warn};
 
 /// `reth benchmark new-payload-fcu` command
@@ -104,6 +113,10 @@ pub struct Command {
     /// Weather to enable bal by default or not.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     enable_bal: bool,
+
+    /// The target gas for the big blocks.
+    #[arg(long, value_name = "TARGET_GAS", default_value = "1G", value_parser = super::helpers::parse_gas_limit)]
+    pub big_blocks_target_gas: u64,
 
     #[command(flatten)]
     benchmark: BenchmarkArgs,
@@ -198,14 +211,15 @@ impl Command {
         }
 
         let buffer_size = self.rpc_block_buffer_size;
-
-        let mut blocks = Box::pin(
+        let provider = block_provider.clone();
+        let bench_mode = benchmark_mode.clone();
+        let mut blocks: Pin<Box<dyn Stream<Item = eyre::Result<Payload>> + Send>> = Box::pin(
             stream::iter((next_block..)
-                .take_while(|next_block| {
-                    benchmark_mode.contains(*next_block)
+                .take_while(move |next_block| {
+                    bench_mode.contains(*next_block)
                 }))
-                .map(|next_block| {
-                    let block_provider = block_provider.clone();
+                .map(move |next_block| {
+                    let block_provider = provider.clone();
                     async move {
                         let block_res = block_provider
                             .get_block_by_number(next_block.into())
@@ -222,6 +236,15 @@ impl Command {
                                     return Err(e)
                                 }
                             };
+
+
+                        let bal = if !rlp_blocks &&
+                            (block.header.block_access_list_hash.is_some() || self.enable_bal)
+                        {
+                            Some(fetch_block_access_list(&block_provider, block.header.number).await?)
+                        } else {
+                            None
+                        };
 
                         let rlp = if rlp_blocks {
                             let rlp = match block_provider
@@ -259,11 +282,44 @@ impl Command {
                             Ok(None) | Err(_) => head_block_hash,
                         };
 
-                        Ok((block, head_block_hash, safe_block_hash, finalized_block_hash, rlp))
+                        let forkchoice = ForkchoiceState {
+                            head_block_hash,
+                            safe_block_hash,
+                            finalized_block_hash,
+                        };
+
+                        Ok(Payload::Block(block, rlp, bal, forkchoice))
                     }
                 })
                 .buffered(buffer_size),
         );
+
+        // Big blocks: convert the stream of regular blocks into a stream of big blocks.
+        if let Some(num_big_blocks) = self.benchmark.big_blocks {
+            let block_stream = blocks.map(|res| {
+                res.map(|payload| {
+                    let Payload::Block(block, _, bal, _) = payload else {
+                        unreachable!();
+                    };
+                    Some((block, bal))
+                })
+            });
+            let mut big_blocks = Box::pin(big_blocks_stream(
+                num_big_blocks as u64,
+                self.big_blocks_target_gas,
+                block_stream,
+            ));
+            let (tx, rx) = mpsc::channel(buffer_size);
+            tokio::task::spawn_blocking(|| {
+                Handle::current().block_on(async move {
+                    while let Some(big_block) = big_blocks.next().await {
+                        tx.send(big_block.map(Payload::BigBlock)).await.unwrap();
+                    }
+                });
+            });
+
+            blocks = Box::pin(ReceiverStream::new(rx));
+        }
 
         let mut results = Vec::new();
         let mut blocks_processed = 0u64;
@@ -271,46 +327,30 @@ impl Command {
         let mut total_wait_time = Duration::ZERO;
         let mut reorg_state = self.reorg.map(ReorgState::new);
         let mut queued_fork_block = None;
-        while let Some((block, head, safe, finalized, rlp)) = {
+        while let Some(payload) = {
             let wait_start = Instant::now();
             let result = blocks.try_next().await?;
             total_wait_time += wait_start.elapsed();
             result
         } {
-            let gas_used = block.header.gas_used;
-            let gas_limit = block.header.gas_limit;
-            let block_number = block.header.number;
-            let canonical_parent_hash = block.header.parent_hash;
-            let transaction_count = block.transactions.len() as u64;
+            let gas_used = payload.gas_used();
+            let gas_limit = payload.gas_limit();
+            let block_number = payload.block_number();
+            let canonical_parent_hash = payload.parent_hash();
+            let transaction_count = payload.transaction_count() as u64;
             let deferred_branch_start_block = reorg_state
                 .as_ref()
                 .filter(|state| state.fork_length == 0 && queued_fork_block.is_none())
-                .map(|_| block.clone());
-            let canonical_forkchoice_state = ForkchoiceState {
-                head_block_hash: head,
-                safe_block_hash: safe,
-                finalized_block_hash: finalized,
-            };
-
-            let bal = if rlp.is_none() &&
-                (block.header.block_access_list_hash.is_some() || self.enable_bal)
-            {
-                Some(fetch_block_access_list(&block_provider, block.header.number).await?)
-            } else {
-                None
-            };
-
-            let (version, params) = block_to_new_payload(
-                block,
-                rlp,
-                use_reth_namespace,
-                wait_for_persistence,
-                no_wait_for_caches,
-                bal,
-            )?;
+                .map(|_| payload.block().cloned());
 
             debug!(target: "reth-bench", ?block_number, "Sending payload");
             let start = Instant::now();
+            let canonical_forkchoice_state = payload.forkchoice_state();
+            let (version, params) = payload.into_new_payload_params(
+                use_reth_namespace,
+                wait_for_persistence,
+                no_wait_for_caches,
+            )?;
             let server_timings =
                 call_new_payload_with_reth(&auth_provider, version, params).await?;
             let np_latency =
@@ -359,7 +399,9 @@ impl Command {
                         block_number,
                         prepared: prepare_built_block(
                             &local_rpc_provider,
-                            block,
+                            block
+                                .as_ref()
+                                .ok_or_eyre("missing deferred fork block for reorg branch start")?,
                             canonical_parent_hash,
                             no_wait_for_caches,
                         )
@@ -637,4 +679,99 @@ fn parse_reorg_depth(value: &str) -> Result<usize, String> {
     }
 
     Ok(depth)
+}
+
+/// Payload types used during benchmarking.
+#[expect(clippy::large_enum_variant)]
+enum Payload {
+    /// A regular block payload.
+    Block(AnyRpcBlock, Option<Bytes>, Option<BlockAccessList>, ForkchoiceState),
+    /// A big block payload.
+    BigBlock(BigBlockPayload),
+}
+
+impl Payload {
+    fn into_new_payload_params(
+        self,
+        use_reth_namespace: bool,
+        wait_for_persistence: WaitForPersistence,
+        no_wait_for_caches: bool,
+    ) -> eyre::Result<(Option<EngineApiMessageVersion>, serde_json::Value)> {
+        match self {
+            Self::Block(block, rlp, bal, _) => block_to_new_payload(
+                block,
+                rlp,
+                use_reth_namespace,
+                wait_for_persistence,
+                no_wait_for_caches,
+                bal,
+            ),
+            Self::BigBlock(big_block) => {
+                let wait_for_persistence =
+                    wait_for_persistence.rpc_value(big_block.execution_data.block_number());
+                Ok((
+                    None,
+                    serde_json::to_value((
+                        RethNewPayloadInput::ExecutionData(big_block.execution_data),
+                        wait_for_persistence,
+                        no_wait_for_caches.then_some(false),
+                        Some(big_block.big_block_data),
+                    ))?,
+                ))
+            }
+        }
+    }
+
+    fn gas_used(&self) -> u64 {
+        match self {
+            Self::Block(block, _, _, _) => block.header.gas_used,
+            Self::BigBlock(big_block) => big_block.execution_data.gas_used(),
+        }
+    }
+
+    fn gas_limit(&self) -> u64 {
+        match self {
+            Self::Block(block, _, _, _) => block.header.gas_limit,
+            Self::BigBlock(big_block) => big_block.execution_data.gas_limit(),
+        }
+    }
+
+    fn block_number(&self) -> u64 {
+        match self {
+            Self::Block(block, _, _, _) => block.header.number,
+            Self::BigBlock(big_block) => big_block.execution_data.block_number(),
+        }
+    }
+
+    fn parent_hash(&self) -> B256 {
+        match self {
+            Self::Block(block, _, _, _) => block.header.parent_hash,
+            Self::BigBlock(big_block) => big_block.execution_data.parent_hash(),
+        }
+    }
+
+    fn transaction_count(&self) -> usize {
+        match self {
+            Self::Block(block, _, _, _) => block.transactions.len(),
+            Self::BigBlock(big_block) => big_block.execution_data.transaction_count(),
+        }
+    }
+
+    const fn block(&self) -> Option<&AnyRpcBlock> {
+        match self {
+            Self::Block(block, _, _, _) => Some(block),
+            Self::BigBlock(_) => None,
+        }
+    }
+
+    const fn forkchoice_state(&self) -> ForkchoiceState {
+        match self {
+            Self::Block(_, _, _, forkchoice) => *forkchoice,
+            Self::BigBlock(big_block) => ForkchoiceState {
+                head_block_hash: big_block.execution_data.block_hash(),
+                safe_block_hash: big_block.execution_data.block_hash(),
+                finalized_block_hash: big_block.execution_data.block_hash(),
+            },
+        }
+    }
 }

--- a/bin/reth-bench/src/bench_mode.rs
+++ b/bin/reth-bench/src/bench_mode.rs
@@ -3,7 +3,7 @@
 use std::ops::RangeInclusive;
 
 /// Whether or not the benchmark should run as a continuous stream of payloads.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BenchMode {
     /// Run the benchmark as a continuous stream of payloads, until the benchmark is interrupted.
     Continuous(u64),

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -133,7 +133,7 @@ pub struct BenchmarkArgs {
 
     /// If provided, the benchmark will generate the specified number of big blocks and use them
     /// instead of regular blocks.
-    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    #[arg(long, verbatim_doc_comment)]
     pub big_blocks: Option<usize>,
 }
 

--- a/crates/node/core/src/args/benchmark_args.rs
+++ b/crates/node/core/src/args/benchmark_args.rs
@@ -130,6 +130,11 @@ pub struct BenchmarkArgs {
     /// Fetch and replay RLP-encoded blocks. Implies `reth_new_payload`.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub rlp_blocks: bool,
+
+    /// If provided, the benchmark will generate the specified number of big blocks and use them
+    /// instead of regular blocks.
+    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    pub big_blocks: Option<usize>,
 }
 
 /// Retry strategy for fetching blocks from the benchmark RPC provider.


### PR DESCRIPTION
Based on https://github.com/paradigmxyz/reth/pull/24025

Extends `reth-bench new-payload-fcu` to support generating big blocks in flight and using them to drive the node. The logic for generating big blocks is shared between `generate-big-block` and `new-payload-fcu`