### PR TITLE
refactor(rpc): centralize transaction info builders

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -16,7 +16,7 @@ use reth_revm::{
     database::StateProviderDatabase,
     db::{bal::EvmDatabaseError, State},
 };
-use reth_rpc_eth_types::cache::db::StateCacheDb;
+use reth_rpc_eth_types::{cache::db::StateCacheDb, mined_transaction_info};
 use reth_storage_api::{ProviderBlock, ProviderTx};
 use revm::{context::Block, context_interface::result::ResultAndState};
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
@@ -305,14 +305,14 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                     .evm_factory()
                     .create_tracer(&mut db, evm_env, inspector_setup())
                     .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
-                        let tx_info = TransactionInfo {
-                            hash: Some(*ctx.tx.tx_hash()),
-                            index: Some(idx),
-                            block_hash: Some(block_hash),
-                            block_number: Some(block_number),
-                            block_timestamp: Some(block_timestamp),
-                            base_fee: Some(base_fee),
-                        };
+                        let tx_info = mined_transaction_info(
+                            *ctx.tx.tx_hash(),
+                            idx,
+                            block_hash,
+                            block_number,
+                            block_timestamp,
+                            Some(base_fee),
+                        );
                         idx += 1;
 
                         f(tx_info, ctx)

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -15,7 +15,7 @@ use alloy_dyn_abi::TypedData;
 use alloy_eips::{eip2718::Encodable2718, BlockId};
 use alloy_network::{TransactionBuilder, TransactionBuilder4844};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
-use alloy_rpc_types_eth::{state::EvmOverrides, TransactionInfo};
+use alloy_rpc_types_eth::state::EvmOverrides;
 use futures::{Future, StreamExt};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_primitives_traits::{
@@ -24,6 +24,7 @@ use reth_primitives_traits::{
 use reth_rpc_convert::{transaction::RpcConvert, RpcTxReq, TransactionConversionError};
 use reth_rpc_eth_types::{
     block::convert_transaction_receipt,
+    mined_transaction_info,
     utils::{binary_search, recover_raw_transaction},
     EthApiError::{self, TransactionConfirmationTimeout},
     FillTransaction, SignError, TransactionSource,
@@ -328,14 +329,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 let block_timestamp = block.timestamp();
                 let base_fee_per_gas = block.base_fee_per_gas();
                 if let Some((signer, tx)) = block.transactions_with_sender().nth(index) {
-                    let tx_info = TransactionInfo {
-                        hash: Some(*tx.tx_hash()),
-                        block_hash: Some(block_hash),
-                        block_number: Some(block_number),
-                        block_timestamp: Some(block_timestamp),
-                        base_fee: base_fee_per_gas,
-                        index: Some(index as u64),
-                    };
+                    let tx_info = mined_transaction_info(
+                        *tx.tx_hash(),
+                        index as u64,
+                        block_hash,
+                        block_number,
+                        block_timestamp,
+                        base_fee_per_gas,
+                    );
 
                     return Ok(Some(
                         self.converter().fill(tx.clone().with_signer(*signer), tx_info)?,
@@ -404,14 +405,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                         .enumerate()
                         .find(|(_, (signer, tx))| **signer == sender && (*tx).nonce() == nonce)
                         .map(|(index, (signer, tx))| {
-                            let tx_info = TransactionInfo {
-                                hash: Some(*tx.tx_hash()),
-                                block_hash: Some(block_hash),
-                                block_number: Some(block_number),
-                                block_timestamp: Some(block_timestamp),
-                                base_fee: base_fee_per_gas,
-                                index: Some(index as u64),
-                            };
+                            let tx_info = mined_transaction_info(
+                                *tx.tx_hash(),
+                                index as u64,
+                                block_hash,
+                                block_number,
+                                block_timestamp,
+                                base_fee_per_gas,
+                            );
                             Ok(self.converter().fill(tx.clone().with_signer(*signer), tx_info)?)
                         })
                 })

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -40,5 +40,5 @@ pub use gas_oracle::{
 };
 pub use id_provider::EthSubscriptionIdProvider;
 pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
-pub use transaction::TransactionSource;
+pub use transaction::{mined_transaction_info, pending_transaction_info, TransactionSource};
 pub use tx_forward::ForwardConfig;

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -58,15 +58,14 @@ impl<T: SignedTransaction> TransactionSource<T> {
                 block_timestamp,
                 base_fee,
             } => {
-                let tx_info = TransactionInfo {
-                    hash: Some(transaction.trie_hash()),
-                    index: Some(index),
-                    block_hash: Some(block_hash),
-                    block_number: Some(block_number),
-                    block_timestamp: Some(block_timestamp),
+                let tx_info = mined_transaction_info(
+                    transaction.trie_hash(),
+                    index,
+                    block_hash,
+                    block_number,
+                    block_timestamp,
                     base_fee,
-                };
-
+                );
                 resp_builder.fill(transaction, tx_info)
             }
         }
@@ -77,7 +76,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
         match self {
             Self::Pool(tx) => {
                 let hash = tx.trie_hash();
-                (tx, TransactionInfo { hash: Some(hash), ..Default::default() })
+                (tx, pending_transaction_info(hash))
             }
             Self::Block {
                 transaction,
@@ -90,17 +89,41 @@ impl<T: SignedTransaction> TransactionSource<T> {
                 let hash = transaction.trie_hash();
                 (
                     transaction,
-                    TransactionInfo {
-                        hash: Some(hash),
-                        index: Some(index),
-                        block_hash: Some(block_hash),
-                        block_number: Some(block_number),
-                        block_timestamp: Some(block_timestamp),
+                    mined_transaction_info(
+                        hash,
+                        index,
+                        block_hash,
+                        block_number,
+                        block_timestamp,
                         base_fee,
-                    },
+                    ),
                 )
             }
         }
+    }
+}
+
+/// Builds [`TransactionInfo`] for a pending transaction.
+pub fn pending_transaction_info(hash: B256) -> TransactionInfo {
+    TransactionInfo { hash: Some(hash), ..Default::default() }
+}
+
+/// Builds [`TransactionInfo`] for a mined transaction.
+pub fn mined_transaction_info(
+    hash: B256,
+    index: u64,
+    block_hash: B256,
+    block_number: u64,
+    block_timestamp: u64,
+    base_fee: Option<u64>,
+) -> TransactionInfo {
+    TransactionInfo {
+        hash: Some(hash),
+        index: Some(index),
+        block_hash: Some(block_hash),
+        block_number: Some(block_number),
+        block_timestamp: Some(block_timestamp),
+        base_fee,
     }
 }
 


### PR DESCRIPTION
Adds shared helpers for pending and mined `TransactionInfo` construction and routes RPC transaction lookup and trace paths through them. This removes repeated field/default assembly while preserving the existing response values.