### PR TITLE
fix(engine): gate BAL parallel execution on state cache

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -275,8 +275,9 @@ where
             config,
         );
         // BAL blocks only bypass the normal execution state hook when the parallel BAL executor
-        // consumes the BAL. If BAL execution is disabled, treat the BAL as absent here so the
-        // block follows today's sequential execution and transaction-prewarm path.
+        // consumes the BAL. If parallel BAL execution is disabled, or if state caching is
+        // disabled so the BAL executor cannot use a shared cache, treat the BAL as absent here so
+        // the block follows today's sequential execution and transaction-prewarm path.
         //
         // In the parallel BAL path, prewarm owns BAL-derived sparse-trie updates and optional
         // BAL state prefetching. `disable_bal_batch_io` controls the prefetch half inside

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -281,8 +281,9 @@ where
         // In the parallel BAL path, prewarm owns BAL-derived sparse-trie updates and optional
         // BAL state prefetching. `disable_bal_batch_io` controls the prefetch half inside
         // prewarm, not this dispatch decision.
-        let parallel_bal_execution =
-            !config.disable_bal_parallel_execution() && env.decoded_bal.is_some();
+        let parallel_bal_execution = !config.disable_state_cache() &&
+            !config.disable_bal_parallel_execution() &&
+            env.decoded_bal.is_some();
         let install_state_hook = !parallel_bal_execution;
         let prewarm_handle = self.spawn_caching_with(
             env,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1057,7 +1057,9 @@ where
     //     empirically once workers are parallel; meaningless while the commit loop is sequential.
     fn bal_path_eligible(&self, bal: Option<&DecodedBal>) -> Result<bool, InsertBlockErrorKind> {
         let has_bal = bal.is_some();
-        let parallel_execution = has_bal && !self.config.disable_bal_parallel_execution();
+        let parallel_execution = has_bal &&
+            !self.config.disable_state_cache() &&
+            !self.config.disable_bal_parallel_execution();
         if parallel_execution && self.config.disable_bal_parallel_state_root() {
             return Err(InsertBlockErrorKind::Other(
                 "disabling parallel state root is impossible when parallel execution is enabled"


### PR DESCRIPTION
Gates BAL parallel execution on the state cache in both the payload processor and validator.

The parallel BAL executor requires the shared execution cache from the payload handle, but `--engine.disable-state-cache` intentionally omits that cache. Treating state-cache-disabled blocks as ineligible for BAL parallel execution keeps those nodes on the existing sequential path, where BAL payloads can still execute and validate instead of failing before execution.