### PR TITLE
feat: generate big blocks in flight

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -251,28 +251,30 @@ if [ -n "${BENCH_WAIT_TIME:-}" ]; then
 fi
 
 if [ "$BIG_BLOCKS" = "true" ]; then
-  # Big blocks mode: replay pre-generated payloads
-  BIG_BLOCKS_DIR="${BENCH_BIG_BLOCKS_DIR:-${BENCH_WORK_DIR}/big-blocks}"
+  # Big blocks mode: generate synthetic payloads in flight with new-payload-fcu.
   BENCH_BAL_MODE="${BENCH_BAL:-false}"
 
   BB_BENCH_ARGS=(--reth-new-payload)
   if [ -n "${BENCH_WAIT_TIME:-}" ]; then
     BB_BENCH_ARGS+=(--wait-time "$BENCH_WAIT_TIME")
   fi
+  if [ -n "${BENCH_BIG_BLOCKS_TARGET_GAS:-}" ]; then
+    BB_BENCH_ARGS+=(--big-blocks-target-gas "$BENCH_BIG_BLOCKS_TARGET_GAS")
+  fi
   case "$BENCH_BAL_MODE" in
     false)
       ;;
     true)
-      BB_BENCH_ARGS+=(--bal)
+      BB_BENCH_ARGS+=(--enable-bal)
       ;;
     baseline)
       if [[ "$LABEL" == baseline* ]]; then
-        BB_BENCH_ARGS+=(--bal)
+        BB_BENCH_ARGS+=(--enable-bal)
       fi
       ;;
     feature)
       if [[ "$LABEL" == feature* ]]; then
-        BB_BENCH_ARGS+=(--bal)
+        BB_BENCH_ARGS+=(--enable-bal)
       fi
       ;;
     *)
@@ -285,12 +287,14 @@ if [ "$BIG_BLOCKS" = "true" ]; then
   WARMUP="${BENCH_WARMUP_BLOCKS:-50}"
   if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
     echo "Running big blocks warmup (${WARMUP} payloads)..."
-    $BENCH_NICE "$RETH_BENCH" replay-payloads \
+    $BENCH_NICE "$RETH_BENCH" new-payload-fcu \
+      --rpc-url "$BENCH_RPC_URL" \
       "${BB_BENCH_ARGS[@]}" \
-      --count "$WARMUP" \
-      --payload-dir "$BIG_BLOCKS_DIR/payloads" \
+      --big-blocks "$WARMUP" \
       --engine-rpc-url http://127.0.0.1:8551 \
       --jwt-secret "$DATADIR/jwt.hex" 2>&1 | sed -u "s/^/[bench] /"
+  else
+    echo "Skipping big blocks warmup (0 payloads)..."
   fi
 
   # Start tracy-capture after warmup so profile only covers the benchmark
@@ -301,20 +305,16 @@ if [ "$BIG_BLOCKS" = "true" ]; then
     sleep 0.5  # give tracy-capture time to connect
   fi
 
-  # Benchmark — skip warmup payloads so they aren't measured
-  BB_SKIP=0
-  if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
-    BB_SKIP="$WARMUP"
-  fi
-  if [ "${BENCH_BLOCKS:-0}" -gt 0 ] 2>/dev/null; then
-    BB_BENCH_ARGS+=(--count "$BENCH_BLOCKS")
+  if [ "${BENCH_BLOCKS:-0}" -le 0 ] 2>/dev/null; then
+    echo "::error::BENCH_BLOCKS must be greater than 0 for big-block benchmarks"
+    exit 1
   fi
 
-  echo "Running big blocks benchmark (replay-payloads, skip=${BB_SKIP})..."
-  $BENCH_NICE "$RETH_BENCH" replay-payloads \
+  echo "Running big blocks benchmark (new-payload-fcu, count=${BENCH_BLOCKS})..."
+  $BENCH_NICE "$RETH_BENCH" new-payload-fcu \
+    --rpc-url "$BENCH_RPC_URL" \
     "${BB_BENCH_ARGS[@]}" \
-    --skip "$BB_SKIP" \
-    --payload-dir "$BIG_BLOCKS_DIR/payloads" \
+    --big-blocks "$BENCH_BLOCKS" \
     --engine-rpc-url http://127.0.0.1:8551 \
     --jwt-secret "$DATADIR/jwt.hex" \
     --output "$OUTPUT_DIR" 2>&1 | sed -u "s/^/[bench] /"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ on:
         default: "500"
         type: string
       big_blocks:
-        description: "Use big blocks mode (pre-generated merged payloads with reth-bb)"
+        description: "Use big blocks mode (generated in flight with reth-bb)"
         required: false
         default: "false"
         type: boolean
@@ -805,7 +805,6 @@ jobs:
         run: |
           set -euo pipefail
           BIG_BLOCKS_DIR="$HOME/.reth-bench-big-blocks"
-          PAYLOAD_DIR="$BIG_BLOCKS_DIR/payloads"
           MANIFEST="$BIG_BLOCKS_DIR/manifest.json"
           echo "BENCH_BIG_BLOCKS_DIR=${BIG_BLOCKS_DIR}" >> "$GITHUB_ENV"
 
@@ -820,19 +819,7 @@ jobs:
             exit 1
           fi
 
-          if [ ! -d "$PAYLOAD_DIR" ]; then
-            echo "::error::Missing local big-block payload directory at $PAYLOAD_DIR"
-            exit 1
-          fi
-
-          PAYLOAD_COUNT=$(find "$PAYLOAD_DIR" -name '*.json' | wc -l)
-          if [ "$PAYLOAD_COUNT" -eq 0 ]; then
-            echo "::error::No payload files found in $PAYLOAD_DIR"
-            exit 1
-          fi
-
           echo "Big-blocks base snapshot: $BASE_SNAPSHOT"
-          echo "Payload files: $PAYLOAD_COUNT"
           echo "BENCH_SNAPSHOT_NAME=${BASE_SNAPSHOT}" >> "$GITHUB_ENV"
 
       - name: Prepare source dirs

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,10 +17,10 @@ on:
         default: "500"
         type: string
       big_blocks:
-        description: "Use big blocks mode (generated in flight with reth-bb)"
+        description: "Use big blocks mode: false, true, or target gas like 100M/2G"
         required: false
         default: "false"
-        type: boolean
+        type: string
       bal:
         description: "Replay block access lists during big-block benchmarks"
         required: false
@@ -124,6 +124,7 @@ jobs:
       slack: ${{ steps.args.outputs.slack }}
       cores: ${{ steps.args.outputs.cores }}
       big-blocks: ${{ steps.args.outputs.big-blocks }}
+      big-blocks-target-gas: ${{ steps.args.outputs.big-blocks-target-gas }}
       bal: ${{ steps.args.outputs.bal }}
       wait-time: ${{ steps.args.outputs.wait-time }}
       baseline-args: ${{ steps.args.outputs.baseline-args }}
@@ -162,9 +163,18 @@ jobs:
           script: |
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
-            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [slack=always|on-win|on-error|never] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
+            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false|100M|2G]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [slack=always|on-win|on-error|never] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
             let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks, bal;
+            let bigBlocksTargetGas = '';
             let explicitWarmup = false;
+
+            const parseBigBlocks = (value) => {
+              value = String(value || 'false');
+              if (value === 'true') return { enabled: 'true', targetGas: '' };
+              if (value === 'false') return { enabled: 'false', targetGas: '' };
+              if (/^\d+([kKmMgG])?$/.test(value)) return { enabled: 'true', targetGas: value };
+              return null;
+            };
 
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
@@ -176,7 +186,13 @@ jobs:
               samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
               var slack = '${{ github.event.inputs.slack }}' || 'never';
               cores = '${{ github.event.inputs.cores }}' || '0';
-              bigBlocks = '${{ github.event.inputs.big_blocks }}' === 'true' ? 'true' : 'false';
+              const parsedBigBlocks = parseBigBlocks('${{ github.event.inputs.big_blocks }}');
+              if (!parsedBigBlocks) {
+                core.setFailed(`Invalid big_blocks value: ${{ github.event.inputs.big_blocks }} (must be false, true, or a gas value like 100M or 2G)`);
+                return;
+              }
+              bigBlocks = parsedBigBlocks.enabled;
+              bigBlocksTargetGas = parsedBigBlocks.targetGas;
               bal = '${{ github.event.inputs.bal }}' || 'false';
               var abba = '${{ github.event.inputs.abba }}' !== 'false' ? 'true' : 'false';
               var otlp = '${{ github.event.inputs.otlp }}' === 'true' ? 'true' : 'false';
@@ -204,7 +220,7 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['warmup', 'cores', 'blocks']);
               const refArgs = new Set(['baseline', 'feature']);
-              const boolArgs = new Set(['samply', 'big-blocks']);
+              const boolArgs = new Set(['samply']);
               const boolDefaultTrue = new Set(['abba']);
               const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes]]);
               const durationArgs = new Set(['wait-time']);
@@ -221,7 +237,9 @@ jobs:
               for (const part of parts) {
                 const eq = part.indexOf('=');
                 if (eq === -1) {
-                  if (boolArgs.has(part)) {
+                  if (part === 'big-blocks') {
+                    defaults[part] = 'true';
+                  } else if (boolArgs.has(part)) {
                     defaults[part] = 'true';
                   } else if (boolDefaultTrue.has(part)) {
                     defaults[part] = 'true';
@@ -236,7 +254,14 @@ jobs:
                 if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
                   value = value.slice(1, -1);
                 }
-                if (boolArgs.has(key) || boolDefaultTrue.has(key)) {
+                if (key === 'big-blocks') {
+                  const parsed = parseBigBlocks(value);
+                  if (parsed) {
+                    defaults[key] = value;
+                  } else {
+                    invalid.push(`\`${key}=${value}\` (must be false, true, or a gas value like 100M or 2G)`);
+                  }
+                } else if (boolArgs.has(key) || boolDefaultTrue.has(key)) {
                   if (value === 'true' || value === 'false') {
                     defaults[key] = value;
                   } else {
@@ -294,7 +319,9 @@ jobs:
               samply = defaults.samply;
               var slack = defaults.slack;
               cores = defaults.cores;
-              bigBlocks = defaults['big-blocks'];
+              const parsedBigBlocks = parseBigBlocks(defaults['big-blocks']);
+              bigBlocks = parsedBigBlocks.enabled;
+              bigBlocksTargetGas = parsedBigBlocks.targetGas;
               bal = defaults.bal;
               var abba = defaults.abba;
               var otlp = defaults.otlp;
@@ -361,6 +388,7 @@ jobs:
             core.setOutput('slack', slack);
             core.setOutput('cores', cores);
             core.setOutput('big-blocks', bigBlocks);
+            core.setOutput('big-blocks-target-gas', bigBlocksTargetGas);
             core.setOutput('bal', bal);
             core.setOutput('wait-time', waitTime);
             core.setOutput('baseline-args', baselineNodeArgs);
@@ -565,6 +593,7 @@ jobs:
       BENCH_SAMPLY: ${{ needs.reth-bench-ack.outputs.samply }}
       BENCH_CORES: ${{ needs.reth-bench-ack.outputs.cores }}
       BENCH_BIG_BLOCKS: ${{ needs.reth-bench-ack.outputs.big-blocks }}
+      BENCH_BIG_BLOCKS_TARGET_GAS: ${{ needs.reth-bench-ack.outputs.big-blocks-target-gas }}
       BENCH_BAL: ${{ needs.reth-bench-ack.outputs.bal }}
       BENCH_WAIT_TIME: ${{ needs.reth-bench-ack.outputs.wait-time }}
       BENCH_BASELINE_ARGS: ${{ needs.reth-bench-ack.outputs.baseline-args }}

--- a/bin/reth-bench/src/bench/context.rs
+++ b/bin/reth-bench/src/bench/context.rs
@@ -1,8 +1,12 @@
 //! This contains the [`BenchContext`], which is information that all replay-based benchmarks need.
 //! The initialization code is also the same, so this can be shared across benchmark commands.
 
-use crate::{authenticated_transport::AuthenticatedTransportConnect, bench_mode::BenchMode};
+use crate::{
+    authenticated_transport::AuthenticatedTransportConnect,
+    bench::generate_big_block::BigBlocksInitialState, bench_mode::BenchMode,
+};
 use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
 use alloy_rpc_client::ClientBuilder;
 use alloy_rpc_types_engine::JwtSecret;
@@ -36,6 +40,8 @@ pub(crate) struct BenchContext {
     pub(crate) wait_for_persistence: WaitForPersistence,
     /// Whether to skip waiting for caches (pass `wait_for_caches: false`).
     pub(crate) no_wait_for_caches: bool,
+    /// Initial state for generated big blocks.
+    pub(crate) big_blocks_initial_state: Option<BigBlocksInitialState>,
 }
 
 impl BenchContext {
@@ -98,6 +104,7 @@ impl BenchContext {
         // - If only `--to` is provided, fetches the latest block from the engine and sets:
         //     - `from = head`
         // - Otherwise, uses the values from `--from` and `--to`.
+        let mut big_blocks_initial_state = None;
         let (from, to) = if let Some(advance) = bench_args.advance {
             if advance == 0 {
                 return Err(eyre::eyre!("--advance must be greater than 0"));
@@ -109,6 +116,12 @@ impl BenchContext {
                 .ok_or_else(|| eyre::eyre!("Failed to fetch latest block for --advance"))?;
             let head_number = head_block.header.number;
             (Some(head_number), Some(head_number + advance))
+        } else if bench_args.big_blocks.is_some() && bench_args.from.is_none() {
+            let (from, initial_state) =
+                derive_big_blocks_initial_state(&auth_provider, &block_provider).await?;
+            big_blocks_initial_state = initial_state;
+
+            (Some(from), bench_args.to)
         } else if bench_args.from.is_none() && bench_args.to.is_some() {
             let head_block = auth_provider
                 .get_block_by_number(BlockNumberOrTag::Latest)
@@ -116,13 +129,6 @@ impl BenchContext {
                 .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from engine"))?;
             let head_number = head_block.header.number;
             info!(target: "reth-bench", "No --from provided, derived from engine head: {}", head_number);
-            (Some(head_number), bench_args.to)
-        } else if bench_args.big_blocks.is_some() && bench_args.from.is_none() {
-            let head_block = auth_provider
-                .get_block_by_number(BlockNumberOrTag::Latest)
-                .await?
-                .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from engine"))?;
-            let head_number = head_block.header.number;
             (Some(head_number), bench_args.to)
         } else {
             (bench_args.from, bench_args.to)
@@ -180,6 +186,74 @@ impl BenchContext {
             rlp_blocks,
             wait_for_persistence,
             no_wait_for_caches,
+            big_blocks_initial_state,
         })
     }
+}
+
+/// Derives the initial state for big blocks benchmark from RPC of the local node.
+async fn derive_big_blocks_initial_state(
+    local_provider: &RootProvider<AnyNetwork>,
+    source_provider: &RootProvider<AnyNetwork>,
+) -> eyre::Result<(u64, Option<BigBlocksInitialState>)> {
+    let local_head = local_provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .full()
+        .await?
+        .ok_or_else(|| eyre::eyre!("Failed to fetch latest block from engine"))?;
+
+    let local_head_number = local_head.header.number;
+    let local_head_hash = local_head.header.hash;
+
+    let source_block_at_local_head = source_provider
+        .get_block_by_number(local_head_number.into())
+        .await?
+        .ok_or_else(|| eyre::eyre!("Failed to fetch block {local_head_number} from RPC"))?;
+
+    // Node's tip is not synthetic, no initial state needed
+    if source_block_at_local_head.header.number == local_head_number &&
+        source_block_at_local_head.header.hash == local_head_hash
+    {
+        return Ok((local_head_number, None));
+    }
+
+    // If the tip is synthetic, derive last regular block from the last transaction the node has.
+    let last_regular_block = if let Some(tx_hash) = local_head.transactions.hashes().last() {
+        let tx = source_provider
+            .get_transaction_by_hash(tx_hash)
+            .await?
+            .ok_or_else(|| eyre::eyre!("Failed to fetch transaction {tx_hash} from RPC"))?;
+        tx.block_number
+            .ok_or_else(|| eyre::eyre!("Transaction {tx_hash} from local head is pending on RPC"))?
+    } else {
+        return Err(eyre::eyre!(
+            "Synthetic local tip has no transactions, can't derive last regular block"
+        ));
+    };
+
+    let initial_state = BigBlocksInitialState {
+        prior_block_hashes: fetch_recent_block_hashes(source_provider, last_regular_block).await?,
+        parent_hash: local_head_hash,
+        next_synthetic_block_number: local_head_number + 1,
+    };
+
+    Ok((last_regular_block, Some(initial_state)))
+}
+
+async fn fetch_recent_block_hashes(
+    provider: &RootProvider<AnyNetwork>,
+    latest_regular_block: u64,
+) -> eyre::Result<Vec<(u64, B256)>> {
+    const BLOCKHASH_HISTORY: u64 = 256;
+
+    let start = latest_regular_block.saturating_sub(BLOCKHASH_HISTORY - 1);
+    let mut hashes = Vec::with_capacity((latest_regular_block - start + 1) as usize);
+    for block_number in start..=latest_regular_block {
+        let Some(block) = provider.get_block_by_number(block_number.into()).await? else {
+            continue;
+        };
+        hashes.push((block_number, block.header.hash));
+    }
+
+    Ok(hashes)
 }

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -228,6 +228,17 @@ pub struct BigBlockPayload {
     pub block_access_list: Option<BlockAccessList>,
 }
 
+/// State used to continue generated big block replay from the benchmark node's current tip.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct BigBlocksInitialState {
+    /// Real block hashes from previous big blocks, used for BLOCKHASH lookups.
+    pub prior_block_hashes: Vec<(u64, B256)>,
+    /// Hash of the previous synthetic big block.
+    pub parent_hash: B256,
+    /// Block number to assign to the first generated synthetic block.
+    pub next_synthetic_block_number: u64,
+}
+
 /// `reth bench generate-big-block` command
 ///
 /// Generates a large block by fetching consecutive blocks from an RPC, merging their
@@ -328,7 +339,7 @@ impl Command {
             .buffered(prefetch_buffer);
 
         let mut big_blocks_stream =
-            Box::pin(big_blocks_stream(self.num_big_blocks, self.target_gas, block_stream));
+            Box::pin(big_blocks_stream(self.num_big_blocks, self.target_gas, block_stream, None));
 
         while let Some(big_block) = big_blocks_stream.next().await {
             let big_block = big_block?;
@@ -365,14 +376,24 @@ pub(crate) fn big_blocks_stream(
     target_gas: u64,
     block_stream: impl Stream<Item = eyre::Result<Option<(AnyRpcBlock, Option<BlockAccessList>)>>>
         + Unpin,
+    initial_state: Option<BigBlocksInitialState>,
 ) -> impl Stream<Item = eyre::Result<BigBlockPayload>> {
     futures::stream::try_unfold(
-        (block_stream, Vec::new(), 0, None, false, 0),
+        (
+            block_stream,
+            initial_state.as_ref().map(|s| s.prior_block_hashes.clone()).unwrap_or_default(),
+            0,
+            initial_state.as_ref().map(|s| s.parent_hash),
+            initial_state.as_ref().map(|s| s.next_synthetic_block_number),
+            false,
+            0,
+        ),
         move |(
             mut block_stream,
             mut accumulated_block_hashes,
             mut big_block_idx,
             mut prev_big_block_hash,
+            next_synthetic_block_number,
             mut reached_chain_tip,
             mut first_block,
         )| async move {
@@ -520,7 +541,9 @@ pub(crate) fn big_blocks_stream(
                 base.payload.as_v1_mut().parent_hash = prev_hash;
                 // First big block keeps its original block number (from_block).
                 // Subsequent big blocks increment from there.
-                base.payload.as_v1_mut().block_number = first_block + big_block_idx;
+                let synthetic_block_number =
+                    next_synthetic_block_number.unwrap_or(first_block) + big_block_idx;
+                base.payload.as_v1_mut().block_number = synthetic_block_number;
             }
 
             // Merge blob data from all constituent blocks:  concatenate versioned
@@ -588,6 +611,7 @@ pub(crate) fn big_blocks_stream(
                     accumulated_block_hashes,
                     big_block_idx,
                     prev_big_block_hash,
+                    next_synthetic_block_number,
                     reached_chain_tip,
                     first_block,
                 ),

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -357,11 +357,6 @@ impl Command {
                 target: "reth-bench",
                 path = %filepath.display(),
                 block_hash = %block_hash,
-                total_txs = big_block.execution_data.payload.transactions().len(),
-                total_gas_used = big_block.execution_data.payload.as_v1().gas_used,
-                env_switches = big_block.big_block_data.env_switches.len(),
-                prior_block_hashes = big_block.big_block_data.prior_block_hashes.len(),
-                bal_accounts = big_block.block_access_list.as_ref().map_or(0, Vec::len),
                 "Big block payload saved"
             );
         }
@@ -413,8 +408,6 @@ pub(crate) fn big_blocks_stream(
             let mut accumulated_block_gas: u64 = 0;
 
             while accumulated_block_gas < target_gas {
-                info!(target: "reth-bench", big_block = big_block_idx, "Awaiting prefetched block");
-
                 let (block, block_access_list) = match block_stream.next().await {
                     Some(Ok(Some(fetched))) => fetched,
                     Some(Ok(None)) => {
@@ -450,14 +443,6 @@ pub(crate) fn big_blocks_stream(
                 let execution_data = ExecutionData { payload, sidecar };
 
                 let block_gas = execution_data.payload.as_v1().gas_used;
-
-                info!(
-                    target: "reth-bench",
-                    block_number = block.header.number,
-                    gas_used = block_gas,
-                    tx_count = execution_data.payload.transactions().len(),
-                    "Fetched block"
-                );
 
                 accumulated_block_gas += block_gas;
                 blocks.push(execution_data);
@@ -602,6 +587,16 @@ pub(crate) fn big_blocks_stream(
                 let excess = accumulated_block_hashes.len() - 256;
                 accumulated_block_hashes.drain(..excess);
             }
+
+            info!(
+                target: "reth-bench",
+                block_hash = %big_block.execution_data.payload.as_v1().block_hash,
+                total_txs = %big_block.execution_data.payload.transactions().len(),
+                total_gas_used = %big_block.execution_data.payload.as_v1().gas_used,
+                env_switches = %big_block.big_block_data.env_switches.len(),
+                prior_block_hashes = %big_block.big_block_data.prior_block_hashes.len(),
+                bal_accounts = %big_block.block_access_list.as_ref().map_or(0, Vec::len),
+            );
 
             big_block_idx += 1;
             Ok(Some((

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -596,6 +596,7 @@ pub(crate) fn big_blocks_stream(
                 env_switches = %big_block.big_block_data.env_switches.len(),
                 prior_block_hashes = %big_block.big_block_data.prior_block_hashes.len(),
                 bal_accounts = %big_block.block_access_list.as_ref().map_or(0, Vec::len),
+                "Generated big block"
             );
 
             big_block_idx += 1;

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -200,6 +200,7 @@ impl Command {
             rlp_blocks,
             wait_for_persistence,
             no_wait_for_caches,
+            big_blocks_initial_state,
         } = BenchContext::new(&self.benchmark, self.rpc_url).await?;
 
         let total_blocks = benchmark_mode.total_blocks();
@@ -308,6 +309,7 @@ impl Command {
                 num_big_blocks as u64,
                 self.big_blocks_target_gas,
                 block_stream,
+                big_blocks_initial_state,
             ));
             let (tx, rx) = mpsc::channel(buffer_size);
             tokio::task::spawn_blocking(|| {


### PR DESCRIPTION
Changes `new-payload-fcu` to support running in big blocks mode against a node which tip is already a synthetic big block. This is useful in cases when you want to run big blocks bench against a node while stopping it temporarily and without waiting for unwind back to canonical chain. For bench workflow specifically this is useful to support warmup+bench patter,

Migrates bench workflow to generate big blocks in flight, thus no longer requiring the pre-generated big blocks to be provided.

This allowed to support `derek bench big-blocks=100M|1G|2G` pattern where the target gas usage of the big blocks is specified directly when invoking a benchmark. Additionally this now allows us to make changes to reth-bb APIs like https://github.com/paradigmxyz/reth/pull/23912 without distrupting the bench workflows