### PR TITLE
feat(rpc): implement eth_baseFee

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -314,6 +314,10 @@ pub trait EthApi<
     #[method(name = "maxPriorityFeePerGas")]
     async fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
 
+    /// Returns the base fee for the next block, or `null` before London activation.
+    #[method(name = "baseFee")]
+    async fn base_fee(&self) -> RpcResult<Option<U256>>;
+
     /// Introduced in EIP-4844, returns the current blob base fee in wei.
     #[method(name = "blobBaseFee")]
     async fn blob_base_fee(&self) -> RpcResult<U256>;
@@ -812,6 +816,12 @@ where
     async fn blob_base_fee(&self) -> RpcResult<U256> {
         trace!(target: "rpc::eth", "Serving eth_blobBaseFee");
         Ok(EthFees::blob_base_fee(self).await?)
+    }
+
+    /// Handler for: `eth_baseFee`
+    async fn base_fee(&self) -> RpcResult<Option<U256>> {
+        trace!(target: "rpc::eth", "Serving eth_baseFee");
+        Ok(EthFees::base_fee(self).await?)
     }
 
     // FeeHistory is calculated based on lazy evaluation of fees for historical blocks, and further

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -43,6 +43,14 @@ pub trait EthFees:
         LoadFee::blob_base_fee(self)
     }
 
+    /// Returns the base fee for the next block, or `None` before London activation.
+    fn base_fee(&self) -> impl Future<Output = Result<Option<U256>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+    {
+        LoadFee::base_fee(self)
+    }
+
     /// Returns a suggestion for the priority fee (the tip)
     fn suggested_priority_fee(&self) -> impl Future<Output = Result<U256, Self::Error>> + Send
     where
@@ -397,6 +405,22 @@ where
                 })
                 .ok_or(EthApiError::ExcessBlobGasNotSet.into())
                 .map(U256::from)
+        }
+    }
+
+    /// Returns the base fee for the next block, or `None` before London activation.
+    fn base_fee(&self) -> impl Future<Output = Result<Option<U256>, Self::Error>> + Send {
+        async move {
+            let header = self
+                .provider()
+                .latest_header()
+                .map_err(Self::Error::from_eth_err)?
+                .ok_or(EthApiError::HeaderNotFound(BlockNumberOrTag::Latest.into()))?;
+            Ok(self
+                .provider()
+                .chain_spec()
+                .next_block_base_fee(&header, header.timestamp())
+                .map(U256::from))
         }
     }
 


### PR DESCRIPTION
Implements the nonstandard `eth_baseFee` rpc call, which returns the base fee of the next block, similar to `eth_blobBaseFee`.