### PR TITLE
fix: 🇵🇱 polish BAL error story

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -492,12 +492,15 @@ pub enum ConsensusError {
     /// EIP-7825: Transaction gas limit exceeds maximum allowed
     #[error(transparent)]
     TransactionGasLimitTooHigh(Box<TxGasLimitTooHighErr>),
-    /// Error when an unexpected block access list cost is encountered.
+    /// EIP-7928: Error when an unexpected block access list cost is encountered.
     #[error(transparent)]
     BlockAccessListCostMoreThanGasLimit(Box<BlockAccessListGasError>),
-    /// Error when the block access list hash doesn't match the expected value.
+    /// EIP-7928: Error when the block access list hash doesn't match the expected value.
     #[error("block access list hash mismatch: {0}")]
     BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
+    /// EIP-7928: Error when the block access list cannot be decoded or converted.
+    #[error("invalid block access list: {0}")]
+    BlockAccessListInvalid(String),
     /// Any additional consensus error, for example L2-specific errors.
     #[error(transparent)]
     Other(#[from] Arc<dyn Error + Send + Sync>),

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -117,10 +117,6 @@ pub enum InsertBlockErrorKind {
     /// Provider error.
     #[error(transparent)]
     Provider(#[from] ProviderError),
-    /// BAL-driven block execution rejected the block. Covers structural BAL errors and the
-    /// final-hash mismatch.
-    #[error(transparent)]
-    InvalidBlockAccessList(BalExecutionError),
     /// Other errors.
     #[error(transparent)]
     Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
@@ -129,11 +125,10 @@ pub enum InsertBlockErrorKind {
 impl From<BalExecutionError> for InsertBlockErrorKind {
     fn from(e: BalExecutionError) -> Self {
         match e {
-            // Worker EVM errors flow through the standard execution-error path so existing
-            // metrics and routing apply.
-            BalExecutionError::Evm(inner) => Self::Execution(inner),
+            BalExecutionError::Consensus(inner) => Self::Consensus(inner),
+            BalExecutionError::Execution(inner) => Self::Execution(inner),
             BalExecutionError::Provider(inner) => Self::Provider(inner),
-            other => Self::InvalidBlockAccessList(other),
+            BalExecutionError::Other(inner) => Self::Other(inner),
         }
     }
 }
@@ -164,9 +159,6 @@ impl InsertBlockErrorKind {
                 }
             }
             Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
-            Self::InvalidBlockAccessList(err) => {
-                Ok(InsertBlockValidationError::InvalidBlockAccessList(err))
-            }
             Self::Other(err) => Err(InternalBlockExecutionError::Other(err).into()),
         }
     }
@@ -192,10 +184,6 @@ pub enum InsertBlockValidationError {
     /// Validation error, transparently wrapping [`BlockValidationError`]
     #[error(transparent)]
     Validation(#[from] BlockValidationError),
-    /// BAL-driven block execution rejected the block. Covers structural BAL errors and the
-    /// final-hash mismatch.
-    #[error(transparent)]
-    InvalidBlockAccessList(BalExecutionError),
 }
 
 /// Errors that may occur when inserting a payload.

--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -1,43 +1,32 @@
 //! Errors for the BAL execution path.
 
 use alloy_evm::block::BlockExecutionError;
-use alloy_primitives::B256;
+use reth_consensus::ConsensusError;
 use reth_provider::ProviderError;
 
 /// Errors surfaced by `execute_block`.
 #[derive(Debug, thiserror::Error)]
 pub enum BalExecutionError {
-    /// BAL-specific rejection.
-    #[error("BAL rejection: {0:?}")]
-    Reject(RejectReason),
+    /// Block violated consensus rules while running the BAL path.
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
     /// Worker or canonical EVM failure.
-    ///
-    /// This includes revm `BalError` for undeclared accesses. Revm does not yet report the
-    /// offending address or storage slot here.
     #[error("evm execution failed: {0}")]
-    Evm(#[from] BlockExecutionError),
+    Execution(#[from] BlockExecutionError),
     /// Provider setup failed before EVM execution could start.
     #[error("provider setup failed: {0}")]
     Provider(#[from] ProviderError),
-    /// The received BAL could not be converted from alloy-format to revm-format.
-    #[error("alloy→revm BAL conversion failed: {0}")]
-    BalConversion(String),
+    /// BAL execution failed before it reached EVM execution.
+    #[error(transparent)]
+    Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
 }
 
-impl From<RejectReason> for BalExecutionError {
-    fn from(r: RejectReason) -> Self {
-        Self::Reject(r)
+impl BalExecutionError {
+    /// Create an [`Self::Other`] error from any boxed-error-compatible value.
+    pub(crate) fn other<E>(error: E) -> Self
+    where
+        E: Into<Box<dyn core::error::Error + Send + Sync + 'static>>,
+    {
+        Self::Other(error.into())
     }
-}
-
-/// Reasons a block may be rejected on the BAL execution path.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RejectReason {
-    /// The rebuilt BAL disagrees with the received BAL at end-of-block.
-    FinalHashMismatch {
-        /// Hash of the rebuilt BAL.
-        rebuilt: B256,
-        /// Hash of the received BAL.
-        expected: B256,
-    },
 }

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -10,14 +10,14 @@
 //! worker results in transaction order, tracks block gas admission, and builds the BAL that this
 //! execution actually produced.
 //!
-//! The final hash check compares that rebuilt BAL with the header commitment. The outer payload
-//! validator still handles consensus checks, receipt-root validation, state-root work, and block
-//! insertion.
+//! The rebuilt BAL is returned to the outer payload validator for consensus post-execution
+//! validation. This module only logs the first divergence between the received BAL and the BAL
+//! rebuilt from canonical execution.
 
-use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError, RejectReason};
+use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError};
 use alloy_eip7928::{
     bal::{Bal as AlloyBal, DecodedBal},
-    compute_block_access_list_hash,
+    compute_block_access_list_hash, BlockAccessList,
 };
 use alloy_evm::{
     block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
@@ -30,6 +30,7 @@ use reth_primitives_traits::ReceiptTy;
 use reth_provider::BlockExecutionOutput;
 use reth_tasks::Runtime;
 use revm::{
+    bytecode::BytecodeDecodeError,
     context::{result::ResultAndState, Block},
     database::{states::bundle_state::BundleRetention, State},
     primitives::{eip7825::TX_GAS_LIMIT_CAP, hardfork::SpecId},
@@ -51,7 +52,10 @@ pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
     transaction_count: usize,
     txs: Receiver<(usize, Result<Tx, Err>)>,
     receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
-) -> Result<(BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>), BalExecutionError>
+) -> Result<
+    (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, BlockAccessList),
+    BalExecutionError,
+>
 where
     Evm: ConfigureEvm + 'static,
     Tx: ExecutableTxFor<Evm> + Send + 'a,
@@ -91,7 +95,10 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
     txs: Receiver<(usize, Result<Tx, Err>)>,
     receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
     worker_count: usize,
-) -> Result<(BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>), BalExecutionError>
+) -> Result<
+    (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, BlockAccessList),
+    BalExecutionError,
+>
 where
     Evm: ConfigureEvm + 'scope,
     Tx: ExecutableTxFor<Evm> + Send + 'scope,
@@ -101,13 +108,8 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let bal = input_bal.as_bal();
-    let input_bal_revm: Arc<RevmBal> = Arc::new(
-        RevmBal::try_from(Vec::<_>::from(bal.clone()))
-            .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?,
-    );
+    let input_bal_revm = convert_alloy_to_revm_bal(bal)?;
 
-    // NOTE: technically Amsterdam implies BAL (the current path) we are on.
-    // TODO: should we do this
     let is_amsterdam = evm_env.cfg_env.spec.into().is_enabled_in(SpecId::AMSTERDAM);
     let block_gas_limit = evm_env.block_env.gas_limit();
     let mut canonical_state =
@@ -140,10 +142,6 @@ where
         canonical_executor.apply_pre_execution_changes()?;
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
-        // `DecodedBal::hash` is lazy-cached. Compute the hash after workers are spawned and before
-        // waiting on ordered results, so the callsite can read the header commitment hash once
-        // execution finishes without adding serial work after the BAL equality check.
-        let _ = input_bal.hash();
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
             let output = output?;
 
@@ -170,13 +168,37 @@ where
         (block_result, senders)
     };
 
-    validate_bal(&mut canonical_state, input_bal.as_ref())?;
+    let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, bal);
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
     Ok((
         BlockExecutionOutput { state: canonical_state.take_bundle(), result: block_result },
         senders,
+        built_bal,
     ))
+}
+
+fn convert_alloy_to_revm_bal(bal: &AlloyBal) -> Result<Arc<RevmBal>, BalExecutionError> {
+    // Convert the BAL from alloy to a BAL that can be consumed by revm, that is more amenable
+    // for state lookups.
+    //
+    // This is failable.
+    //
+    // This is due to bytecodes. A transaction can attempt to deploy illegal bytecodes, e.g. due to
+    // EIP-3541 or more specifically due to EIP-7702.
+    //
+    // During serial execution this check happens before the bytecode is deployed and if the check
+    // is triggered then the execution is reverted, and as such no actual code change event takes
+    // place. Therefore, if we do observe such a bytecode in a BAL then that means the BAL is
+    // invalid as no legal execution should've led to this bytecode deployment.
+    let alloy_bal: Vec<_> = Vec::<_>::from(bal.clone());
+    let received_bal_revm = RevmBal::try_from(alloy_bal).map_err(|e| {
+        let e: BytecodeDecodeError = e;
+        BalExecutionError::Consensus(reth_consensus::ConsensusError::BlockAccessListInvalid(
+            format!("{e:?}"),
+        ))
+    })?;
+    Ok(Arc::new(received_bal_revm))
 }
 
 fn load_bal_accounts<DB>(
@@ -196,49 +218,36 @@ where
     for account_changes in bal {
         canonical_state
             .load_cache_account(account_changes.address)
-            .map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+            .map_err(|e| BalExecutionError::Execution(BlockExecutionError::other(e)))?;
     }
 
     Ok(())
 }
 
-/// Validates that execution rebuilt the same BAL that was provided with the payload.
-///
-/// This consumes the BAL built by `canonical_state` and compares it against the decoded input
-/// BAL before post-execution validation relies on `DecodedBal::hash()` as the header commitment.
-pub(crate) fn validate_bal<DB>(
+fn take_built_bal_and_log_divergence<DB>(
     canonical_state: &mut State<DB>,
-    input_bal: &DecodedBal,
-) -> Result<(), BalExecutionError>
+    received_bal: &AlloyBal,
+) -> BlockAccessList
 where
     DB: Database,
 {
-    let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
-    let input_bal_entries = input_bal.as_bal();
-    if composed_alloy == input_bal_entries.as_slice() {
-        return Ok(());
-    }
-    let rebuilt = compute_block_access_list_hash(&composed_alloy);
-    let expected_bal_hash = input_bal.hash();
-
-    if tracing::enabled!(
-        target: "engine::tree::payload_processor::bal",
-        tracing::Level::DEBUG
-    ) {
-        let div = input_bal_entries.diff(&composed_alloy);
+    let built_bal = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+    if tracing::enabled!(target: "engine::tree::payload_processor::bal", tracing::Level::DEBUG) &&
+        built_bal.as_slice() != received_bal.as_slice()
+    {
+        let rebuilt = compute_block_access_list_hash(built_bal.as_slice());
+        let expected = compute_block_access_list_hash(received_bal.as_slice());
+        let div = received_bal.diff(built_bal.as_slice());
         tracing::debug!(
             target: "engine::tree::payload_processor::bal",
             %rebuilt,
-            expected = %expected_bal_hash,
+            %expected,
             %div,
             "first BAL divergence",
         );
     }
 
-    Err(BalExecutionError::Reject(RejectReason::FinalHashMismatch {
-        rebuilt,
-        expected: expected_bal_hash,
-    }))
+    built_bal
 }
 
 /// Closes the abort channel on drop, waking scoped workers before the scope exits.
@@ -298,7 +307,7 @@ impl BlockGasTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::{BlockHeader, EthereumReceipt, Header};
+    use alloy_consensus::{BlockHeader, Header};
     use alloy_eip7928::{bal::Bal as AlloyBal, BlockAccessList};
     use alloy_eips::{
         eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE},
@@ -306,7 +315,7 @@ mod tests {
         eip7002::{WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_PREDEPLOY_CODE},
     };
     use alloy_primitives::{keccak256, B256, U256};
-    use reth_ethereum_primitives::{Block, BlockBody, TransactionSigned};
+    use reth_ethereum_primitives::{Block, BlockBody, Receipt, TransactionSigned};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_primitives_traits::{Block as _, Recovered, SealedBlock};
     use reth_revm::db::BundleState;
@@ -473,7 +482,24 @@ mod tests {
         input_bal: Arc<DecodedBal>,
         block: &SealedBlock<Block>,
         txs: Vec<Tx>,
-    ) -> Result<BlockExecutionOutput<EthereumReceipt>, BalExecutionError>
+    ) -> Result<BlockExecutionOutput<Receipt>, BalExecutionError>
+    where
+        Tx: ExecutableTxFor<EthEvmConfig> + Send,
+        DB: Database + Send,
+        MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
+    {
+        run_execute_block_full(runtime, evm_config, make_db, input_bal, block, txs)
+            .map(|(output, _)| output)
+    }
+
+    fn run_execute_block_full<Tx, DB, MakeDb>(
+        runtime: &Runtime,
+        evm_config: EthEvmConfig,
+        make_db: MakeDb,
+        input_bal: Arc<DecodedBal>,
+        block: &SealedBlock<Block>,
+        txs: Vec<Tx>,
+    ) -> Result<(BlockExecutionOutput<Receipt>, BlockAccessList), BalExecutionError>
     where
         Tx: ExecutableTxFor<EthEvmConfig> + Send,
         DB: Database + Send,
@@ -494,7 +520,7 @@ mod tests {
             tx_stream(txs),
             receipt_tx,
         )
-        .map(|(output, _)| output)
+        .map(|(output, _, built_bal)| (output, built_bal))
     }
 
     /// Inserts `AccountInfo { nonce: 0, balance }` for `addr` into the canonical DB.
@@ -890,7 +916,7 @@ mod tests {
         );
 
         match result {
-            Err(BalExecutionError::Evm(err)) => assert!(matches!(
+            Err(BalExecutionError::Execution(err)) => assert!(matches!(
                 err.as_validation(),
                 Some(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. })
             )),
@@ -1018,10 +1044,10 @@ mod tests {
     }
 
     #[test]
-    fn rejects_final_hash_mismatch() {
+    fn returns_built_bal_for_final_hash_mismatch() {
         // Build the BAL an empty block actually produces, then append a phantom address
-        // that execution never touches. The rebuilt BAL omits it, so the final hash check
-        // must fail.
+        // that execution never touches. The rebuilt BAL omits it, and the outer consensus
+        // validator is responsible for comparing that rebuilt hash to the header commitment.
         use alloy_eip7928::AccountChanges;
 
         let evm_config = EthEvmConfig::mainnet();
@@ -1047,7 +1073,7 @@ mod tests {
             Arc::new(DecodedBal::new(tampered_bal, raw))
         };
 
-        let result = run_execute_block(
+        let result = run_execute_block_full(
             &Runtime::test(),
             evm_config,
             db_factory(system_contracts_db()),
@@ -1057,14 +1083,11 @@ mod tests {
         );
 
         match result {
-            Err(BalExecutionError::Reject(RejectReason::FinalHashMismatch {
-                rebuilt,
-                expected,
-            })) => {
-                assert_ne!(rebuilt, expected, "rebuilt and expected hashes must differ");
+            Ok((_, built_bal)) => {
+                let rebuilt = alloy_eip7928::compute_block_access_list_hash(&built_bal);
+                assert_ne!(rebuilt, tampered_hash, "rebuilt and header hashes must differ");
             }
-            Err(e) => panic!("expected FinalHashMismatch, got {e:?}"),
-            Ok(_) => panic!("expected FinalHashMismatch, got Ok"),
+            Err(e) => panic!("expected success with rebuilt BAL, got {e:?}"),
         }
     }
 
@@ -1095,9 +1118,9 @@ mod tests {
     }
 
     #[test]
-    fn worker_tx_recovery_error_becomes_evm_error() {
+    fn worker_tx_recovery_error_becomes_other_error() {
         // A tx recovery failure fed into the worker channel must surface as
-        // BalExecutionError::Evm. Uses execute_block directly since tx_stream hardcodes
+        // BalExecutionError::Other. Uses execute_block directly since tx_stream hardcodes
         // Infallible and cannot inject errors.
         let evm_config = EthEvmConfig::mainnet();
         let block = empty_amsterdam_block(B256::ZERO);
@@ -1126,8 +1149,8 @@ mod tests {
         );
 
         assert!(
-            matches!(result, Err(BalExecutionError::Evm(_))),
-            "expected Evm error from tx recovery failure, got {result:?}",
+            matches!(result, Err(BalExecutionError::Other(_))),
+            "expected Other error from tx recovery failure, got {result:?}",
         );
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -14,6 +14,5 @@ mod worker;
 pub mod error;
 pub mod execute;
 
-pub use error::{BalExecutionError, RejectReason};
+pub use error::BalExecutionError;
 pub use execute::execute_block;
-pub(crate) use execute::validate_bal;

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -1,8 +1,29 @@
 //! Ordering adapter for speculative BAL worker results.
 
-use super::{worker::BalWorkerOutput, BalExecutionError};
-use alloy_evm::block::BlockExecutionError;
+use super::{
+    worker::{BalWorkerError, BalWorkerOutput},
+    BalExecutionError,
+};
 use crossbeam_channel::Receiver;
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum OrderedWorkerOutputError {
+    /// A worker returned an error.
+    #[error(transparent)]
+    Worker(#[from] BalWorkerError),
+    /// The result channel closed before every transaction had an output.
+    #[error("BAL worker result channel closed while waiting for ordered outputs")]
+    ResultChannelClosed,
+}
+
+impl From<OrderedWorkerOutputError> for BalExecutionError {
+    fn from(err: OrderedWorkerOutputError) -> Self {
+        match err {
+            OrderedWorkerOutputError::Worker(err) => err.into(),
+            other => Self::other(other),
+        }
+    }
+}
 
 /// Returns a blocking iterator over worker outputs in transaction order.
 ///
@@ -10,24 +31,22 @@ use crossbeam_channel::Receiver;
 /// yields each output only when every earlier transaction has been yielded. It owns no execution
 /// state and performs no canonical commit work.
 ///
-/// Contract for callers:
+/// Behavior:
 /// - each yielded `Ok` output has the next transaction index
 /// - worker errors are forwarded unchanged
-/// - closed channels before `total` outputs, out-of-bounds indices, and duplicate indices yield
-///   `Err`
+/// - closed channels before `total` outputs yield `Err`
+/// - out-of-bounds and duplicate indices panic because they violate the internal worker/dispatcher
+///   index invariant
 /// - after the first error, the iterator is exhausted
-///
-/// Callers that intentionally abort workers must stop polling this iterator after initiating
-/// abort. Before `total` outputs are yielded, channel closure is treated as an execution error.
 pub(super) fn ordered_worker_outputs<R>(
-    result_rx: &Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+    result_rx: &Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
     total: usize,
-) -> impl Iterator<Item = Result<BalWorkerOutput<R>, BalExecutionError>> + '_ {
+) -> impl Iterator<Item = Result<BalWorkerOutput<R>, OrderedWorkerOutputError>> + '_ {
     OrderedWorkerOutputs::new(result_rx, total)
 }
 
 struct OrderedWorkerOutputs<'a, R> {
-    result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+    result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
     pending: Vec<Option<BalWorkerOutput<R>>>,
     next: usize,
     total: usize,
@@ -36,7 +55,7 @@ struct OrderedWorkerOutputs<'a, R> {
 
 impl<'a, R> OrderedWorkerOutputs<'a, R> {
     fn new(
-        result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalExecutionError>>,
+        result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
         total: usize,
     ) -> Self {
         Self {
@@ -50,7 +69,7 @@ impl<'a, R> OrderedWorkerOutputs<'a, R> {
 }
 
 impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
-    type Item = Result<BalWorkerOutput<R>, BalExecutionError>;
+    type Item = Result<BalWorkerOutput<R>, OrderedWorkerOutputError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.failed || self.next >= self.total {
@@ -67,30 +86,24 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
                 Ok(Ok(output)) => output,
                 Ok(Err(err)) => {
                     self.failed = true;
-                    return Some(Err(err));
+                    return Some(Err(err.into()));
                 }
                 Err(_) => {
                     self.failed = true;
-                    return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                        "BAL worker result channel closed while waiting for ordered outputs",
-                    ))));
+                    return Some(Err(OrderedWorkerOutputError::ResultChannelClosed));
                 }
             };
 
             let index = output.index;
-            if index >= self.total {
-                self.failed = true;
-                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                    "BAL worker returned out-of-bounds transaction index",
-                ))));
-            }
-
-            if index < self.next || self.pending[index].is_some() {
-                self.failed = true;
-                return Some(Err(BalExecutionError::Evm(BlockExecutionError::msg(
-                    "BAL worker returned duplicate transaction index",
-                ))));
-            }
+            assert!(
+                index < self.total,
+                "BAL worker returned out-of-bounds transaction index {index}; total={}",
+                self.total
+            );
+            assert!(
+                index >= self.next && self.pending[index].is_none(),
+                "BAL worker returned duplicate transaction index {index}",
+            );
 
             self.pending[index] = Some(output);
         }
@@ -100,13 +113,17 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tree::payload_processor::bal::BalExecutionError;
     use alloy_primitives::Address;
 
     fn output(index: usize, result: u64) -> BalWorkerOutput<u64> {
         BalWorkerOutput { index, signer: Address::ZERO, tx_gas_limit: 0, result }
     }
 
-    fn expect_err_contains<R>(result: Result<BalWorkerOutput<R>, BalExecutionError>, text: &str) {
+    fn expect_err_contains<R>(
+        result: Result<BalWorkerOutput<R>, OrderedWorkerOutputError>,
+        text: &str,
+    ) {
         let Err(err) = result else {
             panic!("expected ordered worker output error");
         };
@@ -131,7 +148,10 @@ mod tests {
     #[test]
     fn forwards_worker_errors_and_then_stops() {
         let (tx, rx) = crossbeam_channel::unbounded();
-        tx.send(Err(BalExecutionError::Evm(BlockExecutionError::msg("worker failed")))).unwrap();
+        tx.send(Err(BalWorkerError::Setup(BalExecutionError::Execution(
+            alloy_evm::block::BlockExecutionError::msg("worker failed"),
+        ))))
+        .unwrap();
         drop(tx);
 
         let mut outputs = ordered_worker_outputs::<u64>(&rx, 1);
@@ -152,32 +172,31 @@ mod tests {
     }
 
     #[test]
-    fn rejects_out_of_bounds_index() {
+    #[should_panic(expected = "out-of-bounds transaction index")]
+    fn panics_on_out_of_bounds_index() {
         let (tx, rx) = crossbeam_channel::unbounded();
         tx.send(Ok(output(1, 10))).unwrap();
         drop(tx);
 
         let mut outputs = ordered_worker_outputs(&rx, 1);
-
-        expect_err_contains(outputs.next().expect("first item"), "out-of-bounds");
-        assert!(outputs.next().is_none());
+        let _ = outputs.next();
     }
 
     #[test]
-    fn rejects_duplicate_pending_index() {
+    #[should_panic(expected = "duplicate transaction index")]
+    fn panics_on_duplicate_pending_index() {
         let (tx, rx) = crossbeam_channel::unbounded();
         tx.send(Ok(output(1, 10))).unwrap();
         tx.send(Ok(output(1, 11))).unwrap();
         drop(tx);
 
         let mut outputs = ordered_worker_outputs(&rx, 2);
-
-        expect_err_contains(outputs.next().expect("first item"), "duplicate");
-        assert!(outputs.next().is_none());
+        let _ = outputs.next();
     }
 
     #[test]
-    fn rejects_duplicate_already_yielded_index() {
+    #[should_panic(expected = "duplicate transaction index")]
+    fn panics_on_duplicate_already_yielded_index() {
         let (tx, rx) = crossbeam_channel::unbounded();
         tx.send(Ok(output(0, 0))).unwrap();
         tx.send(Ok(output(0, 1))).unwrap();
@@ -186,7 +205,6 @@ mod tests {
         let mut outputs = ordered_worker_outputs(&rx, 2);
 
         assert_eq!(outputs.next().expect("first item").expect("first output").result, 0);
-        expect_err_contains(outputs.next().expect("second item"), "duplicate");
-        assert!(outputs.next().is_none());
+        let _ = outputs.next();
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -12,6 +12,29 @@ use revm::database::State;
 use revm_state::bal::Bal as RevmBal;
 use std::sync::Arc;
 
+#[derive(Debug, thiserror::Error)]
+pub(super) enum BalWorkerError {
+    /// Worker state or provider setup failed.
+    #[error("BAL worker setup failed: {0}")]
+    Setup(#[source] BalExecutionError),
+    /// Transaction recovery or conversion failed before EVM execution.
+    #[error("BAL worker transaction conversion failed: {0}")]
+    Transaction(Box<dyn core::error::Error + Send + Sync + 'static>),
+    /// EVM transaction execution failed.
+    #[error("BAL worker EVM execution failed: {0}")]
+    Execution(BlockExecutionError),
+}
+
+impl From<BalWorkerError> for BalExecutionError {
+    fn from(err: BalWorkerError) -> Self {
+        match err {
+            BalWorkerError::Setup(err) => err,
+            BalWorkerError::Transaction(err) => Self::Other(err),
+            BalWorkerError::Execution(err) => Self::Execution(err),
+        }
+    }
+}
+
 pub(super) struct BalWorkerOutput<R> {
     pub(super) index: usize,
     pub(super) signer: Address,
@@ -23,7 +46,7 @@ type WorkerExecutorResult<Cfg> =
     <<Cfg as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::TxExecutionResult;
 
 type WorkerResultSender<Cfg> =
-    Sender<Result<BalWorkerOutput<WorkerExecutorResult<Cfg>>, BalExecutionError>>;
+    Sender<Result<BalWorkerOutput<WorkerExecutorResult<Cfg>>, BalWorkerError>>;
 
 #[expect(clippy::too_many_arguments)]
 pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
@@ -44,9 +67,9 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
     MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'scope,
 {
     scope.spawn(move |_| {
-        let worker_result = (|| -> Result<(), BalExecutionError> {
+        let worker_result = (|| -> Result<(), BalWorkerError> {
             let mut worker_state = State::builder()
-                .with_database(make_db()?)
+                .with_database(make_db().map_err(BalWorkerError::Setup)?)
                 .with_bal(received_bal_revm)
                 .with_bundle_update()
                 .build();
@@ -61,14 +84,14 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                         Err(_) => break,
                     },
                 };
-                let tx = tx.map_err(|e| BalExecutionError::Evm(BlockExecutionError::other(e)))?;
+                let tx = tx.map_err(|e| BalWorkerError::Transaction(Box::new(e)))?;
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
                 executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
                 let result = executor
                     .execute_transaction_without_commit(tx)
-                    .map_err(BalExecutionError::Evm)?;
+                    .map_err(BalWorkerError::Execution)?;
 
                 if result_tx
                     .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }))

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -49,7 +49,7 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::bal::DecodedBal;
+use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -452,8 +452,12 @@ where
         // Extract the decoded BAL, if valid and available.
         let decoded_bal = ensure_ok!(input
             .try_decoded_access_list()
-            .map_err(|err| { Box::<dyn std::error::Error + Send + Sync>::from(err) }))
+            .map_err(|err| ConsensusError::BlockAccessListInvalid(err.to_string())))
         .map(Arc::new);
+
+        if let Some(decoded_bal) = decoded_bal.as_deref() {
+            ensure_ok!(Self::validate_received_bal_gas(decoded_bal, input.gas_limit()));
+        }
 
         let env = ExecutionEnv {
             evm_env,
@@ -531,8 +535,7 @@ where
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
-        let decoded_bal = env.decoded_bal.clone();
-        let (output, senders, receipt_root_rx) = if bal_eligible {
+        let (output, senders, receipt_root_rx, built_bal) = if bal_eligible {
             let provider_builder =
                 bal_provider_builder.expect("eligibility implies builder was cloned");
             ensure_ok!(self.execute_block_bal(
@@ -545,7 +548,6 @@ where
         } else {
             ensure_ok!(self.execute_block(state_provider, env, &input, &mut handle))
         };
-        let block_access_list_hash = decoded_bal.as_ref().map(|decoded_bal| decoded_bal.hash());
         let execution_duration = execute_block_start.elapsed();
 
         // After executing the block we can stop prewarming transactions
@@ -610,7 +612,7 @@ where
                 &output,
                 &mut ctx,
                 receipt_root_bloom,
-                block_access_list_hash
+                built_bal
             ),
             block
         );
@@ -952,6 +954,13 @@ where
         }
     }
 
+    fn validate_received_bal_gas(
+        decoded_bal: &DecodedBal,
+        gas_limit: u64,
+    ) -> Result<(), ConsensusError> {
+        decoded_bal.as_bal().validate_gas_limit(gas_limit).map_err(ConsensusError::from)
+    }
+
     /// Executes a block with the given state provider.
     ///
     /// This method orchestrates block execution:
@@ -968,7 +977,12 @@ where
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
     ) -> Result<
-        (BlockExecutionOutput<N::Receipt>, Vec<Address>, ReceiptRootReceiver),
+        (
+            BlockExecutionOutput<N::Receipt>,
+            Vec<Address>,
+            ReceiptRootReceiver,
+            Option<BlockAccessList>,
+        ),
         InsertBlockErrorKind,
     >
     where
@@ -979,16 +993,6 @@ where
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
-
-        if let Some(decoded_bal) = &env.decoded_bal {
-            decoded_bal
-                .as_bal()
-                .validate_gas_limit(input.gas_limit())
-                .map_err(|e| {
-                    debug!(target: "engine::tree::payload_validator", "BAL is invalid since it contains more items than the gas limit allows");
-                    InsertBlockErrorKind::Consensus(ConsensusError::from(e))
-                })?
-        }
 
         let has_bal = env.decoded_bal.is_some();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
@@ -1056,17 +1060,11 @@ where
             .map(|(evm, result)| (evm.into_db(), result))?;
         self.metrics.record_post_execution(post_exec_start.elapsed());
 
-        if let Some(decoded_bal) = &env.decoded_bal {
-            // Regular execution still handles BAL payloads when the parallel BAL path is
-            // disabled. Prove that execution rebuilt the payload-provided BAL before
-            // post-execution validation uses `decoded_bal.hash()` as the header commitment.
-            crate::tree::payload_processor::bal::validate_bal(&mut db, decoded_bal)?;
-        }
-
         // Merge transitions into bundle state
         debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
+        let built_bal = if has_bal { db.take_built_alloy_bal() } else { None };
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
         let execution_duration = execution_start.elapsed();
@@ -1074,7 +1072,7 @@ where
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
 
-        Ok((output, senders, result_rx))
+        Ok((output, senders, result_rx, built_bal))
     }
 
     /// Returns true when the BAL execute path should be used for this block.
@@ -1108,7 +1106,7 @@ where
     /// 2. Relies on BAL prewarm to stream sparse-trie updates and optional state prefetches.
     /// 3. Spawns the receipt-root task.
     /// 4. Calls [`crate::tree::payload_processor::bal::execute_block`].
-    /// 5. Adapts the BAL output to a [`BlockExecutionOutput`].
+    /// 5. Returns the rebuilt BAL for post-execution consensus validation.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     #[expect(clippy::type_complexity)]
     fn execute_block_bal<S, Tx, Err, BalP, T>(
@@ -1119,7 +1117,12 @@ where
         handle: &PayloadHandle<Tx, Err, N::Receipt>,
         provider_builder: StateProviderBuilder<N, BalP>,
     ) -> Result<
-        (BlockExecutionOutput<N::Receipt>, Vec<Address>, ReceiptRootReceiver),
+        (
+            BlockExecutionOutput<N::Receipt>,
+            Vec<Address>,
+            ReceiptRootReceiver,
+            Option<BlockAccessList>,
+        ),
         InsertBlockErrorKind,
     >
     where
@@ -1157,7 +1160,7 @@ where
         let execution_start = Instant::now();
         let ctx =
             self.execution_ctx_for(input).map_err(|e| InsertBlockErrorKind::Other(Box::new(e)))?;
-        let (output, senders) = crate::tree::payload_processor::bal::execute_block(
+        let (output, senders, built_bal) = crate::tree::payload_processor::bal::execute_block(
             &self.runtime,
             &self.evm_config,
             &make_db,
@@ -1178,7 +1181,7 @@ where
             "Executed block via BAL path",
         );
 
-        Ok((output, senders, result_rx))
+        Ok((output, senders, result_rx, Some(built_bal)))
     }
 
     fn spawn_receipt_root_task(
@@ -1577,7 +1580,7 @@ where
         output: &BlockExecutionOutput<N::Receipt>,
         ctx: &mut TreeCtx<'_, N>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
-        block_access_list_hash: Option<B256>,
+        built_bal: Option<BlockAccessList>,
     ) -> Result<(), InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1590,6 +1593,9 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
+        let block_access_list_hash =
+            built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal));
+
         if let Err(err) = self.consensus.validate_block_post_execution(
             block,
             output,


### PR DESCRIPTION
In this changeset we go over different error paths with the goal of properly classifying them. This is important for not aborting the whole node in case an invalid block was received.