### PR TITLE
fix(storage): respect prune checkpoints in consistency check

### DIFF
--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -136,8 +136,8 @@ where
     V::Transaction:
         PoolTransaction<Consensus = TxTy<Node::Types>> + reth_transaction_pool::EthPoolTransaction,
 {
-    /// Consume the ype and build the [`reth_transaction_pool::Pool`] with the given config and blob
-    /// store.
+    /// Consume the type and build the [`reth_transaction_pool::Pool`] with the given config and
+    /// blob store.
     pub fn build<BS>(
         self,
         blob_store: BS,

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -67,10 +67,10 @@ mod tests {
         providers::{StaticFileProvider, StaticFileWriter},
         test_utils::MockNodeTypesWithDB,
         AccountExtReader, BlockBodyIndicesProvider, BlockWriter, DatabaseProviderFactory,
-        ProviderFactory, ProviderResult, ReceiptProvider, StageCheckpointWriter,
-        StaticFileProviderFactory, StorageReader,
+        ProviderFactory, ProviderResult, PruneCheckpointWriter, ReceiptProvider,
+        StageCheckpointWriter, StaticFileProviderFactory, StorageReader,
     };
-    use reth_prune_types::{PruneMode, PruneModes};
+    use reth_prune_types::{PruneCheckpoint, PruneMode, PruneModes, PruneSegment};
     use reth_stages_api::{
         ExecInput, ExecutionStageThresholds, PipelineTarget, Stage, StageCheckpoint, StageId,
     };
@@ -533,5 +533,76 @@ mod tests {
 
         // Fill the gap, and ensure no unwind is necessary.
         update_db_and_check::<tables::Receipts>(&db, current + 1, None);
+    }
+
+    #[test]
+    fn test_consistency_respects_distance_prune_checkpoint() {
+        use reth_db_api::models::StorageSettings;
+        use reth_storage_api::StorageSettingsCache;
+
+        let db = seed_data(90).unwrap();
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let tip = 89;
+        let static_file_provider = db.factory.static_file_provider();
+        {
+            let db_provider = db.factory.database_provider_ro().unwrap();
+            let mut writer =
+                static_file_provider.latest_writer(StaticFileSegment::TransactionSenders).unwrap();
+
+            for block_number in 0..=tip {
+                let indices = db_provider.block_body_indices(block_number).unwrap().unwrap();
+                writer.ensure_at_block(block_number).unwrap();
+                writer
+                    .append_transaction_senders(indices.tx_num_range().map(|tx_num| {
+                        (tx_num, address!("0x1000000000000000000000000000000000000000"))
+                    }))
+                    .unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        assert_eq!(
+            static_file_provider
+                .get_highest_static_file_block(StaticFileSegment::TransactionSenders),
+            Some(tip)
+        );
+
+        while let Some(highest_block) = static_file_provider
+            .get_highest_static_file_block(StaticFileSegment::TransactionSenders)
+        {
+            static_file_provider
+                .delete_jar(StaticFileSegment::TransactionSenders, highest_block)
+                .unwrap();
+        }
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(Some(PipelineTarget::Unwind(_)))
+        ));
+
+        let provider_rw = db.factory.provider_rw().unwrap();
+        for segment in [
+            PruneSegment::SenderRecovery,
+            PruneSegment::AccountHistory,
+            PruneSegment::StorageHistory,
+        ] {
+            provider_rw
+                .save_prune_checkpoint(
+                    segment,
+                    PruneCheckpoint {
+                        block_number: Some(tip),
+                        tx_number: None,
+                        prune_mode: PruneMode::Distance(2_000_000),
+                    },
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(None)
+        ));
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1568,7 +1568,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         highest_block: Option<BlockNumber>,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
         N: NodePrimitives<Receipt: Value, BlockHeader: Value, SignedTx: Value>,
     {
         match segment {
@@ -1640,7 +1640,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         highest_static_file_block: Option<BlockNumber>,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
     {
         debug!(target: "reth::providers::static_file", "Ensuring invariants");
         let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
@@ -1685,16 +1685,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let checkpoint_block_number =
             provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
         debug!(target: "reth::providers::static_file", ?stage_id, checkpoint_block_number, "Retrieved stage checkpoint");
+        let effective_available_block =
+            Self::effective_available_block(provider, segment, highest_static_file_block)?;
 
         // If the checkpoint is ahead, then we lost static file data. May be data corruption.
-        if checkpoint_block_number > highest_static_file_block {
+        if checkpoint_block_number > effective_available_block {
             info!(
                 target: "reth::providers::static_file",
                 checkpoint_block_number,
-                unwind_target = highest_static_file_block,
+                unwind_target = effective_available_block,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block));
+            return Ok(Some(effective_available_block));
         }
 
         // If the checkpoint is ahead, or matches, then nothing to do.
@@ -1774,7 +1776,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         block_from_key: F,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
         T: Table,
         F: Fn(&T::Key) -> BlockNumber,
     {
@@ -1822,16 +1824,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let stage_id = segment.to_stage_id();
         let checkpoint_block_number =
             provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
+        let effective_available_block =
+            Self::effective_available_block(provider, segment, highest_static_file_block)?;
 
-        if checkpoint_block_number > highest_static_file_block {
+        if checkpoint_block_number > effective_available_block {
             info!(
                 target: "reth::providers::static_file",
                 checkpoint_block_number,
-                unwind_target = highest_static_file_block,
+                unwind_target = effective_available_block,
                 ?segment,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block))
+            return Ok(Some(effective_available_block))
         }
 
         if checkpoint_block_number < highest_static_file_block {
@@ -1856,6 +1860,36 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         }
 
         Ok(None)
+    }
+
+    fn effective_available_block<Provider>(
+        provider: &Provider,
+        segment: StaticFileSegment,
+        highest_static_file_block: BlockNumber,
+    ) -> ProviderResult<BlockNumber>
+    where
+        Provider: PruneCheckpointReader,
+    {
+        let Some(prune_segment) = Self::prune_segment_for_static_file(segment) else {
+            return Ok(highest_static_file_block)
+        };
+
+        let prune_checkpoint_block = provider
+            .get_prune_checkpoint(prune_segment)?
+            .and_then(|checkpoint| checkpoint.block_number)
+            .unwrap_or_default();
+
+        Ok(highest_static_file_block.max(prune_checkpoint_block))
+    }
+
+    const fn prune_segment_for_static_file(segment: StaticFileSegment) -> Option<PruneSegment> {
+        match segment {
+            StaticFileSegment::Receipts => Some(PruneSegment::Receipts),
+            StaticFileSegment::TransactionSenders => Some(PruneSegment::SenderRecovery),
+            StaticFileSegment::AccountChangeSets => Some(PruneSegment::AccountHistory),
+            StaticFileSegment::StorageChangeSets => Some(PruneSegment::StorageHistory),
+            StaticFileSegment::Headers | StaticFileSegment::Transactions => None,
+        }
     }
 
     /// Returns the earliest available block number that has not been expired and is still


### PR DESCRIPTION
Closes #23463

Respects prune checkpoints when static-file consistency checks compare stage checkpoints against the latest available static-file block. This prevents distance-pruned static-file segments from triggering an unwind when their data was intentionally pruned.

Also fixes an existing transaction pool doc typo found by `make pr`.

Credits #21636 for the original approach.