### PR TITLE
feat(storage): add BAL store flush hook

### DIFF
--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -132,6 +132,10 @@ impl BalStore for InMemoryBalStore {
         Ok(())
     }
 
+    fn flush(&self) -> ProviderResult<()> {
+        Ok(())
+    }
+
     fn prune(&self, tip: BlockNumber) -> ProviderResult<usize> {
         Ok(self.inner.write().prune(self.config.in_memory_retention, tip))
     }
@@ -209,6 +213,13 @@ mod tests {
         let store = InMemoryBalStore::default();
 
         assert!(store.get_by_range(1, 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn flush_is_noop() {
+        let store = InMemoryBalStore::default();
+
+        store.flush().unwrap();
     }
 
     #[test]

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -41,7 +41,17 @@ mod subscriptions {
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait BalStore: Send + Sync + 'static {
     /// Insert the BAL for the given block.
+    ///
+    /// Implementations may buffer inserts. Call [`Self::flush`] when pending BALs need to be made
+    /// durable.
     fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()>;
+
+    /// Flushes any pending BALs to the backing store.
+    ///
+    /// In-memory implementations may treat this as a no-op.
+    fn flush(&self) -> ProviderResult<()> {
+        Ok(())
+    }
 
     /// Prunes expired BALs according to the store's retention policy and the given chain tip.
     ///
@@ -158,6 +168,12 @@ impl BalStoreHandle {
     #[inline]
     pub fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
         self.inner.insert(num_hash, bal)
+    }
+
+    /// Flushes any pending BALs to the backing store.
+    #[inline]
+    pub fn flush(&self) -> ProviderResult<()> {
+        self.inner.flush()
     }
 
     /// Prunes expired BALs according to the store's retention policy and the given chain tip.
@@ -304,6 +320,13 @@ mod tests {
         assert!(store.get_by_hash(B256::random()).unwrap().is_none());
         assert!(by_range.is_empty());
         assert_eq!(store.prune(10).unwrap(), 0);
+    }
+
+    #[test]
+    fn noop_store_flush_is_noop() {
+        let store = BalStoreHandle::default();
+
+        store.flush().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Adds a `flush` hook to `BalStore` and exposes it through `BalStoreHandle` so implementations that buffer BALs can define their durability boundary.

The in-memory BAL store implements the hook as a no-op.
