### PR TITLE
fix(ci): configure bench chart git identity

### DIFF
--- a/.github/scripts/configure-git-token-user.sh
+++ b/.github/scripts/configure-git-token-user.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Configures a git repository to commit as the GitHub user associated with a token.
+#
+# Usage: configure-git-token-user.sh <repo-dir> <github-token>
+set -euo pipefail
+
+REPO_DIR="${1:?repo dir is required}"
+GITHUB_TOKEN="${2:?github token is required}"
+
+GITHUB_USER=$(curl -fsSL \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/user)
+GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
+GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
+
+git -C "${REPO_DIR}" config user.name "${GIT_USER_NAME}"
+git -C "${REPO_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"

--- a/.github/scripts/configure-git-token-user.sh
+++ b/.github/scripts/configure-git-token-user.sh
@@ -13,8 +13,8 @@ GITHUB_USER=$(curl -fsSL \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/user)
-GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
-GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
+GIT_USER_NAME=$(jq -r '.login' <<< "${GITHUB_USER}")
+GIT_USER_ID=$(jq -r '.id' <<< "${GITHUB_USER}")
 
 git -C "${REPO_DIR}" config user.name "${GIT_USER_NAME}"
 git -C "${REPO_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -671,16 +671,7 @@ jobs:
             git init "${TMP_DIR}"
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
-
-          GITHUB_USER=$(curl -fsSL \
-            -H "Authorization: Bearer ${DEREK_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/user)
-          GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
-          GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
-          git -C "${TMP_DIR}" config user.name "${GIT_USER_NAME}"
-          git -C "${TMP_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+          .github/scripts/configure-git-token-user.sh "${TMP_DIR}" "${DEREK_TOKEN}"
 
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
@@ -1021,16 +1012,7 @@ jobs:
             git init "${TMP_DIR}"
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
-
-          GITHUB_USER=$(curl -fsSL \
-            -H "Authorization: Bearer ${DEREK_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/user)
-          GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
-          GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
-          git -C "${TMP_DIR}" config user.name "${GIT_USER_NAME}"
-          git -C "${TMP_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+          .github/scripts/configure-git-token-user.sh "${TMP_DIR}" "${DEREK_TOKEN}"
 
           mkdir -p "${TMP_DIR}/state"
           echo "${FEATURE_REF}" > "${TMP_DIR}/state/${MODE}-last-feature-ref"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -672,11 +672,20 @@ jobs:
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
 
+          GITHUB_USER=$(curl -fsSL \
+            -H "Authorization: Bearer ${DEREK_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user)
+          GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
+          GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
+          git -C "${TMP_DIR}" config user.name "${GIT_USER_NAME}"
+          git -C "${TMP_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
           git -C "${TMP_DIR}" add "${CHART_DIR}"
-          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "nightly bench charts for run ${RUN_ID}"
+          git -C "${TMP_DIR}" commit -m "nightly bench charts for run ${RUN_ID}"
           git -C "${TMP_DIR}" push origin HEAD:main
           echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           rm -rf "${TMP_DIR}"
@@ -1013,11 +1022,20 @@ jobs:
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
 
+          GITHUB_USER=$(curl -fsSL \
+            -H "Authorization: Bearer ${DEREK_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user)
+          GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
+          GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
+          git -C "${TMP_DIR}" config user.name "${GIT_USER_NAME}"
+          git -C "${TMP_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+
           mkdir -p "${TMP_DIR}/state"
           echo "${FEATURE_REF}" > "${TMP_DIR}/state/${MODE}-last-feature-ref"
           git -C "${TMP_DIR}" add state/
           git -C "${TMP_DIR}" diff --cached --quiet && echo "No state change" && exit 0
-          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench: update ${MODE} state to ${FEATURE_REF}"
+          git -C "${TMP_DIR}" commit -m "bench: update ${MODE} state to ${FEATURE_REF}"
           git -C "${TMP_DIR}" push origin HEAD:state
           rm -rf "${TMP_DIR}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1280,16 +1280,7 @@ jobs:
             git init "${TMP_DIR}"
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
-
-          GITHUB_USER=$(curl -fsSL \
-            -H "Authorization: Bearer ${DEREK_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/user)
-          GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
-          GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
-          git -C "${TMP_DIR}" config user.name "${GIT_USER_NAME}"
-          git -C "${TMP_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+          .github/scripts/configure-git-token-user.sh "${TMP_DIR}" "${DEREK_TOKEN}"
 
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1281,6 +1281,16 @@ jobs:
             git -C "${TMP_DIR}" remote add origin "${CHARTS_REPO}"
           fi
 
+          GITHUB_USER=$(curl -fsSL \
+            -H "Authorization: Bearer ${DEREK_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user)
+          GIT_USER_NAME=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["login"])' <<< "${GITHUB_USER}")
+          GIT_USER_ID=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${GITHUB_USER}")
+          git -C "${TMP_DIR}" config user.name "${GIT_USER_NAME}"
+          git -C "${TMP_DIR}" config user.email "${GIT_USER_ID}+${GIT_USER_NAME}@users.noreply.github.com"
+
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
           git -C "${TMP_DIR}" add "${CHART_DIR}"
@@ -1290,8 +1300,7 @@ jobs:
             rm -rf "${TMP_DIR}"
             exit 0
           fi
-          git -C "${TMP_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "bench charts for PR #${PR_NUMBER} run ${RUN_ID}"
+          git -C "${TMP_DIR}" commit -m "bench charts for PR #${PR_NUMBER} run ${RUN_ID}"
 
           for attempt in 1 2 3 4 5; do
             if git -C "${TMP_DIR}" push origin HEAD:main; then


### PR DESCRIPTION
Adds `.github/scripts/configure-git-token-user.sh` to configure temporary git repositories as the GitHub account associated with `DEREK_TOKEN`, then reuses it from the benchmark chart and state push steps. This fixes retry rebases that need a committer identity after a push race, as seen in https://github.com/paradigmxyz/reth/actions/runs/25546883686/job/74985183114.
