### PR TITLE
feat(net): make full block BAL lookup optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9079,6 +9079,7 @@ name = "reth-network-p2p"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips 2.0.4",
  "alloy-primitives",
  "auto_impl",

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -23,6 +23,7 @@ reth-storage-errors.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true
+alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 
@@ -55,6 +56,7 @@ test-utils = [
 std = [
     "reth-consensus/std",
     "reth-ethereum-primitives/std",
+    "alloy-eip7928/std",
     "alloy-eips/std",
     "alloy-primitives/std",
     "reth-primitives-traits/std",

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -394,15 +394,14 @@ where
     /// Exactly one returned BAL entry is preserved. Empty responses, malformed responses, and
     /// request errors resolve to `None` instead of being retried, so a BAL failure cannot block
     /// returning the downloaded block.
-    fn poll_bal_request(&mut self, cx: &mut Context<'_>) {
-        let poll = match &mut self.bal_request_state {
-            BalRequestState::Pending(fut) => fut.poll_unpin(cx),
-            BalRequestState::Ready(_) => return,
+    fn poll_bal_request(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        let res = match &mut self.bal_request_state {
+            BalRequestState::Pending(fut) => ready!(fut.poll_unpin(cx)),
+            BalRequestState::Ready(_) => return Poll::Ready(()),
         };
 
-        match poll {
-            Poll::Pending => {}
-            Poll::Ready(Ok(bal)) => {
+        match res {
+            Ok(bal) => {
                 let (peer, access_lists) = bal.split();
                 match access_lists.0.len() {
                     0 => self.bal_request_state = BalRequestState::Ready(None),
@@ -420,7 +419,7 @@ where
                     }
                 }
             }
-            Poll::Ready(Err(err)) => {
+            Err(err) => {
                 debug!(
                     target: "downloaders",
                     %err,
@@ -430,6 +429,8 @@ where
                 self.bal_request_state = BalRequestState::Ready(None);
             }
         }
+
+        Poll::Ready(())
     }
 
     /// Returns the block once the block download and optional BAL lookup have both completed.
@@ -461,7 +462,7 @@ where
             this.block_result = Some(block);
         }
 
-        this.poll_bal_request(cx);
+        ready!(this.poll_bal_request(cx));
 
         if let Some(res) = this.take_block_and_access_lists() {
             return Poll::Ready(res)

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -396,6 +396,11 @@ where
         self.block_result.as_ref().map(|block| block.number()).or_else(|| self.block.block_number())
     }
 
+    /// Polls the optional BAL request once and records its final best-effort result.
+    ///
+    /// Exactly one returned BAL entry is preserved. Empty responses, malformed responses, and
+    /// request errors resolve to `None` instead of being retried, so a BAL failure cannot block
+    /// returning the downloaded block.
     fn poll_bal_request(&mut self, cx: &mut Context<'_>) {
         let poll = match &mut self.bal_request_state {
             BalRequestState::Pending(fut) => fut.poll_unpin(cx),
@@ -434,6 +439,11 @@ where
         }
     }
 
+    /// Returns the block once the block download and optional BAL lookup have both completed.
+    ///
+    /// The BAL lookup must be ready even when it resolved to `None`, which prevents a fast block
+    /// response from racing a still-pending BAL response and incorrectly dropping available BAL
+    /// data.
     fn take_block_and_access_lists(
         &mut self,
     ) -> Option<SealedBlockWith<Client::Block, Option<BlockAccessLists>>> {

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -64,13 +64,6 @@ impl<B: Block, T> SealedBlockWith<B, T> {
     }
 }
 
-impl<B: Block> SealedBlockWith<B> {
-    /// Creates a sealed block without associated BAL data.
-    pub const fn without_data(block: SealedBlock<B>) -> Self {
-        Self::new(block, None)
-    }
-}
-
 impl<B: Block> SealedBlockWith<B, Option<BlockAccessLists>> {
     /// Creates a full block response without block access-list data.
     pub const fn from_block(block: SealedBlock<B>) -> Self {
@@ -85,7 +78,7 @@ impl<B: Block> SealedBlockWith<B, Option<BlockAccessLists>> {
 
 impl<B: Block> From<SealedBlock<B>> for SealedBlockWith<B> {
     fn from(block: SealedBlock<B>) -> Self {
-        Self::without_data(block)
+        Self::new(block, None)
     }
 }
 

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -9,6 +9,7 @@ use crate::{
     BlockClient,
 };
 use alloy_consensus::BlockHeader;
+use alloy_eip7928::bal::Bal;
 use alloy_primitives::{Sealable, B256};
 use core::marker::PhantomData;
 use futures::FutureExt;
@@ -34,43 +35,57 @@ use tracing::debug;
 pub type FullBlockRangeWithOptionalAccessListsResponse<B> =
     (Vec<SealedBlock<B>>, Option<BlockAccessLists>);
 
-/// A full block with optional raw block access-list data.
+/// A sealed block with associated data.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlockWithOptionalAccessLists<B: Block> {
+pub struct SealedBlockWith<B: Block, T = Option<Bal>> {
     block: SealedBlock<B>,
-    access_lists: Option<BlockAccessLists>,
+    data: T,
 }
 
-impl<B: Block> BlockWithOptionalAccessLists<B> {
-    /// Creates a full block response with optional block access-list data.
-    pub const fn new(block: SealedBlock<B>, access_lists: Option<BlockAccessLists>) -> Self {
-        Self { block, access_lists }
+impl<B: Block, T> SealedBlockWith<B, T> {
+    /// Creates a sealed block with associated data.
+    pub const fn new(block: SealedBlock<B>, data: T) -> Self {
+        Self { block, data }
     }
 
+    /// Returns the sealed block.
+    pub const fn block(&self) -> &SealedBlock<B> {
+        &self.block
+    }
+
+    /// Returns the associated data.
+    pub const fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// Consumes the wrapper and returns its parts.
+    pub fn into_parts(self) -> (SealedBlock<B>, T) {
+        (self.block, self.data)
+    }
+}
+
+impl<B: Block> SealedBlockWith<B> {
+    /// Creates a sealed block without associated BAL data.
+    pub const fn without_data(block: SealedBlock<B>) -> Self {
+        Self::new(block, None)
+    }
+}
+
+impl<B: Block> SealedBlockWith<B, Option<BlockAccessLists>> {
     /// Creates a full block response without block access-list data.
     pub const fn without_access_lists(block: SealedBlock<B>) -> Self {
         Self::new(block, None)
     }
 
-    /// Returns the downloaded block.
-    pub const fn block(&self) -> &SealedBlock<B> {
-        &self.block
-    }
-
     /// Returns the optional raw block access-list data.
     pub const fn access_lists(&self) -> Option<&BlockAccessLists> {
-        self.access_lists.as_ref()
-    }
-
-    /// Consumes the wrapper and returns its parts.
-    pub fn into_parts(self) -> (SealedBlock<B>, Option<BlockAccessLists>) {
-        (self.block, self.access_lists)
+        self.data.as_ref()
     }
 }
 
-impl<B: Block> From<SealedBlock<B>> for BlockWithOptionalAccessLists<B> {
+impl<B: Block> From<SealedBlock<B>> for SealedBlockWith<B> {
     fn from(block: SealedBlock<B>) -> Self {
-        Self::without_access_lists(block)
+        Self::without_data(block)
     }
 }
 
@@ -421,14 +436,10 @@ where
 
     fn take_block_and_access_lists(
         &mut self,
-    ) -> Option<BlockWithOptionalAccessLists<Client::Block>> {
+    ) -> Option<SealedBlockWith<Client::Block, Option<BlockAccessLists>>> {
+        let BalRequestState::Ready(access_lists) = &mut self.bal_request_state else { return None };
         let block = self.block_result.take()?;
-        let access_lists = match &mut self.bal_request_state {
-            BalRequestState::Ready(access_lists) => access_lists.take(),
-            // BAL lookup is best-effort, so a ready block is returned without waiting.
-            BalRequestState::Pending(_) => None,
-        };
-        Some(BlockWithOptionalAccessLists::new(block, access_lists))
+        Some(SealedBlockWith::new(block, access_lists.take()))
     }
 }
 
@@ -436,7 +447,7 @@ impl<Client> Future for FetchFullBlockWithAccessListsFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader + Sealable> + BlockAccessListsClient + 'static,
 {
-    type Output = BlockWithOptionalAccessLists<Client::Block>;
+    type Output = SealedBlockWith<Client::Block, Option<BlockAccessLists>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -1176,6 +1187,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn download_single_full_block_with_access_lists_waits_for_pending_access_lists() {
+        let client = FullBlockWithAccessListsClient::default();
+        client.set_access_list_pending_polls(1);
+
+        let header: SealedHeader = SealedHeader::default();
+        let body = BlockBody::default();
+        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        client.insert(header.clone(), body.clone(), access_list.clone());
+
+        let request_count = Arc::clone(&client.access_list_requests);
+        let client = FullBlockClient::test_client(client);
+
+        let received =
+            timeout(Duration::from_secs(1), client.get_full_block_with_access_lists(header.hash()))
+                .await
+                .expect("access list request should complete");
+
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert_eq!(received.access_lists(), Some(&BlockAccessLists(vec![access_list])));
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn download_single_full_block_with_access_lists_returns_none_after_empty_response() {
         let client = FullBlockWithAccessListsClient::default();
         client.empty_first_response.store(true, Ordering::SeqCst);
@@ -1256,6 +1290,7 @@ mod tests {
         access_lists: Arc<Mutex<HashMap<B256, Bytes>>>,
         access_list_requests: Arc<AtomicUsize>,
         access_list_soft_limit: Arc<AtomicUsize>,
+        access_list_pending_polls: Arc<AtomicUsize>,
         extra_access_list_entries: Arc<AtomicUsize>,
         unsupported_access_lists: Arc<AtomicBool>,
         last_access_list_requirement: Arc<Mutex<Option<BalRequirement>>>,
@@ -1270,6 +1305,7 @@ mod tests {
                 access_lists: Arc::new(Mutex::new(HashMap::default())),
                 access_list_requests: Arc::new(AtomicUsize::new(0)),
                 access_list_soft_limit: Arc::new(AtomicUsize::new(usize::MAX)),
+                access_list_pending_polls: Arc::new(AtomicUsize::new(0)),
                 extra_access_list_entries: Arc::new(AtomicUsize::new(0)),
                 unsupported_access_lists: Arc::new(AtomicBool::new(false)),
                 last_access_list_requirement: Arc::new(Mutex::new(None)),
@@ -1287,6 +1323,10 @@ mod tests {
 
         fn set_access_list_soft_limit(&self, limit: usize) {
             self.access_list_soft_limit.store(limit, Ordering::SeqCst);
+        }
+
+        fn set_access_list_pending_polls(&self, polls: usize) {
+            self.access_list_pending_polls.store(polls, Ordering::SeqCst);
         }
 
         fn set_extra_access_list_entries(&self, count: usize) {
@@ -1357,8 +1397,33 @@ mod tests {
         }
     }
 
+    struct MaybePendingAccessLists {
+        response: Option<PeerRequestResult<BlockAccessLists>>,
+        pending_polls: usize,
+    }
+
+    impl MaybePendingAccessLists {
+        const fn new(response: PeerRequestResult<BlockAccessLists>, pending_polls: usize) -> Self {
+            Self { response: Some(response), pending_polls }
+        }
+    }
+
+    impl std::future::Future for MaybePendingAccessLists {
+        type Output = PeerRequestResult<BlockAccessLists>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.pending_polls > 0 {
+                self.pending_polls -= 1;
+                cx.waker().wake_by_ref();
+                return Poll::Pending
+            }
+
+            Poll::Ready(self.response.take().expect("future polled after completion"))
+        }
+    }
+
     impl BlockAccessListsClient for FullBlockWithAccessListsClient {
-        type Output = futures::future::Ready<PeerRequestResult<BlockAccessLists>>;
+        type Output = MaybePendingAccessLists;
 
         fn get_block_access_lists_with_priority_and_requirement(
             &self,
@@ -1368,16 +1433,20 @@ mod tests {
         ) -> Self::Output {
             self.access_list_requests.fetch_add(1, Ordering::SeqCst);
             *self.last_access_list_requirement.lock() = Some(requirement);
+            let pending_polls = self.access_list_pending_polls.swap(0, Ordering::SeqCst);
 
             if self.unsupported_access_lists.load(Ordering::SeqCst) {
-                return futures::future::ready(Err(RequestError::UnsupportedCapability))
+                return MaybePendingAccessLists::new(
+                    Err(RequestError::UnsupportedCapability),
+                    pending_polls,
+                )
             }
 
             if self.empty_first_response.swap(false, Ordering::SeqCst) {
-                return futures::future::ready(Ok(WithPeerId::new(
-                    PeerId::random(),
-                    BlockAccessLists(Vec::new()),
-                )))
+                return MaybePendingAccessLists::new(
+                    Ok(WithPeerId::new(PeerId::random(), BlockAccessLists(Vec::new()))),
+                    pending_polls,
+                )
             }
 
             let mut access_lists: Vec<_> = hashes
@@ -1395,10 +1464,10 @@ mod tests {
                 access_lists.push(Bytes::from_static(&[EMPTY_LIST_CODE]));
             }
 
-            futures::future::ready(Ok(WithPeerId::new(
-                PeerId::random(),
-                BlockAccessLists(access_lists),
-            )))
+            MaybePendingAccessLists::new(
+                Ok(WithPeerId::new(PeerId::random(), BlockAccessLists(access_lists))),
+                pending_polls,
+            )
         }
     }
 

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -73,7 +73,7 @@ impl<B: Block> SealedBlockWith<B> {
 
 impl<B: Block> SealedBlockWith<B, Option<BlockAccessLists>> {
     /// Creates a full block response without block access-list data.
-    pub const fn without_access_lists(block: SealedBlock<B>) -> Self {
+    pub const fn from_block(block: SealedBlock<B>) -> Self {
         Self::new(block, None)
     }
 

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -174,9 +174,9 @@ where
     pub fn get_full_block_with_access_lists(
         &self,
         hash: B256,
-    ) -> FetchFullBlockWithAccessListsFuture<Client> {
+    ) -> FetchFullBlockWithBalFuture<Client> {
         let client = self.client.clone();
-        FetchFullBlockWithAccessListsFuture {
+        FetchFullBlockWithBalFuture {
             block: FetchFullBlockFuture::new(client.clone(), self.consensus.clone(), hash),
             block_result: None,
             bal_request_state: BalRequestState::Pending(
@@ -368,7 +368,7 @@ where
 /// This composes the existing full block downloader with a block access list request so the
 /// header/body logic stays centralized. Missing access lists do not block returning the full block.
 #[must_use = "futures do nothing unless polled"]
-pub struct FetchFullBlockWithAccessListsFuture<Client>
+pub struct FetchFullBlockWithBalFuture<Client>
 where
     Client: BlockClient + BlockAccessListsClient,
 {
@@ -377,7 +377,7 @@ where
     bal_request_state: BalRequestState<<Client as BlockAccessListsClient>::Output>,
 }
 
-impl<Client> FetchFullBlockWithAccessListsFuture<Client>
+impl<Client> FetchFullBlockWithBalFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader> + BlockAccessListsClient,
 {
@@ -387,7 +387,7 @@ where
     }
 }
 
-impl<Client> FetchFullBlockWithAccessListsFuture<Client>
+impl<Client> FetchFullBlockWithBalFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader + Sealable> + BlockAccessListsClient + 'static,
 {
@@ -453,7 +453,7 @@ where
     }
 }
 
-impl<Client> Future for FetchFullBlockWithAccessListsFuture<Client>
+impl<Client> Future for FetchFullBlockWithBalFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader + Sealable> + BlockAccessListsClient + 'static,
 {
@@ -478,12 +478,12 @@ where
     }
 }
 
-impl<Client> Debug for FetchFullBlockWithAccessListsFuture<Client>
+impl<Client> Debug for FetchFullBlockWithBalFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader> + BlockAccessListsClient,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FetchFullBlockWithAccessListsFuture")
+        f.debug_struct("FetchFullBlockWithBalFuture")
             .field("hash", &self.block.hash())
             .field("block_ready", &self.block_result.is_some())
             .field("bal_request_ready", &self.bal_request_state.is_ready())

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -17,7 +17,7 @@ use reth_eth_wire_types::{
     BlockAccessLists, EthNetworkPrimitives, HeadersDirection, NetworkPrimitives,
 };
 use reth_network_peers::{PeerId, WithPeerId};
-use reth_primitives_traits::{SealedBlock, SealedHeader};
+use reth_primitives_traits::{Block, SealedBlock, SealedHeader};
 use std::{
     cmp::Reverse,
     collections::{HashMap, VecDeque},
@@ -33,6 +33,46 @@ use tracing::debug;
 /// Response returned by [`FetchFullBlockRangeWithOptionalAccessListsFuture`].
 pub type FullBlockRangeWithOptionalAccessListsResponse<B> =
     (Vec<SealedBlock<B>>, Option<BlockAccessLists>);
+
+/// A full block with optional raw block access-list data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockWithOptionalAccessLists<B: Block> {
+    block: SealedBlock<B>,
+    access_lists: Option<BlockAccessLists>,
+}
+
+impl<B: Block> BlockWithOptionalAccessLists<B> {
+    /// Creates a full block response with optional block access-list data.
+    pub const fn new(block: SealedBlock<B>, access_lists: Option<BlockAccessLists>) -> Self {
+        Self { block, access_lists }
+    }
+
+    /// Creates a full block response without block access-list data.
+    pub const fn without_access_lists(block: SealedBlock<B>) -> Self {
+        Self::new(block, None)
+    }
+
+    /// Returns the downloaded block.
+    pub const fn block(&self) -> &SealedBlock<B> {
+        &self.block
+    }
+
+    /// Returns the optional raw block access-list data.
+    pub const fn access_lists(&self) -> Option<&BlockAccessLists> {
+        self.access_lists.as_ref()
+    }
+
+    /// Consumes the wrapper and returns its parts.
+    pub fn into_parts(self) -> (SealedBlock<B>, Option<BlockAccessLists>) {
+        (self.block, self.access_lists)
+    }
+}
+
+impl<B: Block> From<SealedBlock<B>> for BlockWithOptionalAccessLists<B> {
+    fn from(block: SealedBlock<B>) -> Self {
+        Self::without_access_lists(block)
+    }
+}
 
 /// A Client that can fetch full blocks from the network.
 #[derive(Debug, Clone)]
@@ -109,8 +149,8 @@ impl<Client> FullBlockClient<Client>
 where
     Client: BlockClient + BlockAccessListsClient,
 {
-    /// Returns a future that fetches the [`SealedBlock`] and its [`BlockAccessLists`] for the
-    /// given hash.
+    /// Returns a future that fetches the [`SealedBlock`] and optionally its [`BlockAccessLists`]
+    /// for the given hash.
     ///
     /// Note: this future is cancel safe
     ///
@@ -124,7 +164,10 @@ where
         FetchFullBlockWithAccessListsFuture {
             block: FetchFullBlockFuture::new(client.clone(), self.consensus.clone(), hash),
             block_result: None,
-            bal_request_state: BalRequestState::Pending(client.get_block_access_lists(vec![hash])),
+            bal_request_state: BalRequestState::Pending(
+                client
+                    .get_block_access_lists_with_requirement(vec![hash], BalRequirement::Optional),
+            ),
         }
     }
 
@@ -305,10 +348,10 @@ where
     }
 }
 
-/// A future that downloads a full block and its block access lists from the network.
+/// A future that downloads a full block and optionally its block access lists from the network.
 ///
 /// This composes the existing full block downloader with a block access list request so the
-/// header/body logic stays centralized.
+/// header/body logic stays centralized. Missing access lists do not block returning the full block.
 #[must_use = "futures do nothing unless polled"]
 pub struct FetchFullBlockWithAccessListsFuture<Client>
 where
@@ -338,69 +381,54 @@ where
         self.block_result.as_ref().map(|block| block.number()).or_else(|| self.block.block_number())
     }
 
-    fn send_bal_request(&mut self) {
-        let hash = *self.block.hash();
-        self.bal_request_state =
-            BalRequestState::Pending(self.block.client.get_block_access_lists(vec![hash]));
-    }
-
-    // This retries BAL failures inline instead of surfacing them to the outer future, so
-    // `FetchFullBlockWithAccessListsFuture` only makes progress once the BAL request either
-    // becomes pending again or resolves with a single access-list entry.
     fn poll_bal_request(&mut self, cx: &mut Context<'_>) {
-        loop {
-            let poll = match &mut self.bal_request_state {
-                BalRequestState::Pending(fut) => fut.poll_unpin(cx),
-                BalRequestState::Ready(_) => return,
-            };
+        let poll = match &mut self.bal_request_state {
+            BalRequestState::Pending(fut) => fut.poll_unpin(cx),
+            BalRequestState::Ready(_) => return,
+        };
 
-            match poll {
-                Poll::Pending => return,
-                Poll::Ready(res) => match res {
-                    Ok(bal) => {
-                        let (peer, access_lists) = bal.split();
-                        if access_lists.0.len() == 1 {
-                            self.bal_request_state = BalRequestState::Ready(access_lists);
-                            return;
-                        }
-
+        match poll {
+            Poll::Pending => {}
+            Poll::Ready(Ok(bal)) => {
+                let (peer, access_lists) = bal.split();
+                match access_lists.0.len() {
+                    0 => self.bal_request_state = BalRequestState::Ready(None),
+                    1 => self.bal_request_state = BalRequestState::Ready(Some(access_lists)),
+                    received => {
                         debug!(
                             target: "downloaders",
                             hash = ?self.block.hash(),
                             expected = 1,
-                            received = access_lists.0.len(),
+                            received,
                             "Received wrong access list response",
                         );
                         self.block.client.report_bad_message(peer);
-                        self.send_bal_request();
+                        self.bal_request_state = BalRequestState::Ready(None);
                     }
-                    Err(err) => {
-                        debug!(
-                            target: "downloaders",
-                            %err,
-                            hash = ?self.block.hash(),
-                            "Access list download failed",
-                        );
-                        self.send_bal_request();
-                    }
-                },
+                }
+            }
+            Poll::Ready(Err(err)) => {
+                debug!(
+                    target: "downloaders",
+                    %err,
+                    hash = ?self.block.hash(),
+                    "Access list download failed",
+                );
+                self.bal_request_state = BalRequestState::Ready(None);
             }
         }
     }
 
     fn take_block_and_access_lists(
         &mut self,
-    ) -> Option<(SealedBlock<Client::Block>, BlockAccessLists)> {
-        if self.block_result.is_some() && self.bal_request_state.is_ready() {
-            let block = self.block_result.take().expect("block result should exist");
-            let access_lists = match &mut self.bal_request_state {
-                BalRequestState::Ready(access_lists) => std::mem::take(access_lists),
-                BalRequestState::Pending(_) => unreachable!("access lists should be ready"),
-            };
-            return Some((block, access_lists))
-        }
-
-        None
+    ) -> Option<BlockWithOptionalAccessLists<Client::Block>> {
+        let block = self.block_result.take()?;
+        let access_lists = match &mut self.bal_request_state {
+            BalRequestState::Ready(access_lists) => access_lists.take(),
+            // BAL lookup is best-effort, so a ready block is returned without waiting.
+            BalRequestState::Pending(_) => None,
+        };
+        Some(BlockWithOptionalAccessLists::new(block, access_lists))
     }
 }
 
@@ -408,7 +436,7 @@ impl<Client> Future for FetchFullBlockWithAccessListsFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader + Sealable> + BlockAccessListsClient + 'static,
 {
-    type Output = (SealedBlock<Client::Block>, BlockAccessLists);
+    type Output = BlockWithOptionalAccessLists<Client::Block>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -445,7 +473,7 @@ where
 /// Tracks the BAL request and its completed result.
 enum BalRequestState<Req> {
     Pending(Req),
-    Ready(BlockAccessLists),
+    Ready(Option<BlockAccessLists>),
 }
 
 impl<Req> BalRequestState<Req> {
@@ -1140,16 +1168,15 @@ mod tests {
         let request_count = Arc::clone(&client.access_list_requests);
         let client = FullBlockClient::test_client(client);
 
-        let (received_block, received_access_lists) =
-            client.get_full_block_with_access_lists(header.hash()).await;
+        let received = client.get_full_block_with_access_lists(header.hash()).await;
 
-        assert_eq!(received_block, SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received_access_lists, BlockAccessLists(vec![access_list]));
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert_eq!(received.access_lists(), Some(&BlockAccessLists(vec![access_list])));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
-    async fn download_single_full_block_with_access_lists_retries_after_invalid_response() {
+    async fn download_single_full_block_with_access_lists_returns_none_after_empty_response() {
         let client = FullBlockWithAccessListsClient::default();
         client.empty_first_response.store(true, Ordering::SeqCst);
 
@@ -1162,15 +1189,44 @@ mod tests {
         let bad_messages = Arc::clone(&client.bad_messages);
         let client = FullBlockClient::test_client(client);
 
-        let (received_block, received_access_lists) =
+        let received =
             timeout(Duration::from_secs(1), client.get_full_block_with_access_lists(header.hash()))
                 .await
-                .expect("access list request retry should complete");
+                .expect("block request should complete without access lists");
 
-        assert_eq!(received_block, SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received_access_lists, BlockAccessLists(vec![access_list]));
-        assert_eq!(request_count.load(Ordering::SeqCst), 2);
-        assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert!(received.access_lists().is_none());
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn download_single_full_block_with_access_lists_returns_block_when_unavailable() {
+        let client = FullBlockWithAccessListsClient::default();
+        client.set_access_lists_unsupported(true);
+
+        let header: SealedHeader = SealedHeader::default();
+        let body = BlockBody::default();
+        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        client.insert(header.clone(), body.clone(), access_list);
+
+        let request_count = Arc::clone(&client.access_list_requests);
+        let requirement = Arc::clone(&client.last_access_list_requirement);
+        let client = FullBlockClient::test_client(client);
+
+        let received =
+            timeout(Duration::from_secs(1), client.get_full_block_with_access_lists(header.hash()))
+                .await
+                .expect("block request should complete without access lists");
+
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert!(received.access_lists().is_none());
+        assert_eq!(request_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *requirement.lock(),
+            Some(BalRequirement::Optional),
+            "single block BAL lookup should be best-effort"
+        );
     }
 
     /// Inserts headers and returns the last header and block body.
@@ -1202,6 +1258,7 @@ mod tests {
         access_list_soft_limit: Arc<AtomicUsize>,
         extra_access_list_entries: Arc<AtomicUsize>,
         unsupported_access_lists: Arc<AtomicBool>,
+        last_access_list_requirement: Arc<Mutex<Option<BalRequirement>>>,
         bad_messages: Arc<AtomicUsize>,
         empty_first_response: Arc<AtomicBool>,
     }
@@ -1215,6 +1272,7 @@ mod tests {
                 access_list_soft_limit: Arc::new(AtomicUsize::new(usize::MAX)),
                 extra_access_list_entries: Arc::new(AtomicUsize::new(0)),
                 unsupported_access_lists: Arc::new(AtomicBool::new(false)),
+                last_access_list_requirement: Arc::new(Mutex::new(None)),
                 bad_messages: Arc::new(AtomicUsize::new(0)),
                 empty_first_response: Arc::new(AtomicBool::new(false)),
             }
@@ -1306,9 +1364,10 @@ mod tests {
             &self,
             hashes: Vec<B256>,
             _priority: Priority,
-            _requirement: crate::block_access_lists::client::BalRequirement,
+            requirement: BalRequirement,
         ) -> Self::Output {
             self.access_list_requests.fetch_add(1, Ordering::SeqCst);
+            *self.last_access_list_requirement.lock() = Some(requirement);
 
             if self.unsupported_access_lists.load(Ordering::SeqCst) {
                 return futures::future::ready(Err(RequestError::UnsupportedCapability))


### PR DESCRIPTION
 - Extracts the net/p2p BAL download changes from #23911, building on the BAL store helpers from #23998.
 - Full block downloads now return the block with optional raw BAL data. Missing or unsupported BALs no longer block returning the downloaded block .
 
 cc @mattsse 
