### PR TITLE
ci: reduce benchmark noise and add perf stat

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -312,7 +312,11 @@ if [ "$TUNE" = "true" ]; then
   done
 
   # Stop noisy background services
-  sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+  sudo systemctl stop \
+    irqbalance cron atd unattended-upgrades snapd \
+    prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+    prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+    2>/dev/null || true
 
   TUNING_APPLIED=true
 

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -11,6 +11,8 @@
 #               BENCH_WAIT_TIME (duration like 500ms, default empty)
 #               BENCH_BASELINE_ARGS (extra reth node args for baseline runs)
 #               BENCH_FEATURE_ARGS (extra reth node args for feature runs)
+#               BENCH_PERF_STAT (true to collect perf stat counters during measured run)
+#               BENCH_PERF_STAT_EVENTS (perf event list, default: task-clock,cycles,...)
 #               BENCH_OTLP_TRACES_ENDPOINT (OTLP HTTP endpoint for traces, e.g. https://host/insert/opentelemetry/v1/traces)
 #               BENCH_OTLP_LOGS_ENDPOINT (OTLP HTTP endpoint for logs, e.g. https://host/insert/opentelemetry/v1/logs)
 #               BENCH_OTLP_DISABLED (true to skip OTLP export even if endpoints are set)
@@ -28,9 +30,72 @@ mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+PERF_STAT_EVENTS="${BENCH_PERF_STAT_EVENTS:-task-clock,cycles,instructions,branches,branch-misses,cache-references,cache-misses,context-switches,cpu-migrations,page-faults,major-faults}"
+
+start_perf_stat() {
+  if [ "${BENCH_PERF_STAT:-false}" != "true" ]; then
+    return
+  fi
+
+  if ! command -v perf >/dev/null 2>&1; then
+    echo "::error::BENCH_PERF_STAT requested but perf is not installed"
+    exit 1
+  fi
+
+  local node_process_name
+  node_process_name="$(basename "$BINARY")"
+  local reth_pid=""
+  for _ in $(seq 1 10); do
+    reth_pid="$(sudo pgrep -n -x "$node_process_name" 2>/dev/null || true)"
+    if [ -n "$reth_pid" ]; then
+      break
+    fi
+    sleep 1
+  done
+  if [ -z "$reth_pid" ]; then
+    echo "::error::BENCH_PERF_STAT requested but no ${node_process_name} process was found"
+    exit 1
+  fi
+
+  echo "Starting perf stat for ${node_process_name} pid ${reth_pid}..."
+  sudo perf stat \
+    -x, \
+    -e "$PERF_STAT_EVENTS" \
+    -p "$reth_pid" \
+    -o "$OUTPUT_DIR/perf-stat.csv" \
+    -- sleep infinity &
+  PERF_PID=$!
+  sleep 0.5
+  if ! kill -0 "$PERF_PID" 2>/dev/null; then
+    wait "$PERF_PID" 2>/dev/null || true
+    echo "::error::perf stat exited before benchmark started"
+    exit 1
+  fi
+}
+
+stop_perf_stat() {
+  if [ -n "${PERF_PID:-}" ] && kill -0 "$PERF_PID" 2>/dev/null; then
+    echo "Stopping perf stat..."
+    sudo kill -INT "$PERF_PID" 2>/dev/null || kill -INT "$PERF_PID" 2>/dev/null || true
+    for i in $(seq 1 30); do
+      kill -0 "$PERF_PID" 2>/dev/null || break
+      if [ $((i % 10)) -eq 0 ]; then
+        echo "Waiting for perf stat to finish writing... (${i}s)"
+      fi
+      sleep 1
+    done
+    if kill -0 "$PERF_PID" 2>/dev/null; then
+      echo "perf stat still running after 30s, killing..."
+      sudo kill -TERM "$PERF_PID" 2>/dev/null || kill -TERM "$PERF_PID" 2>/dev/null || true
+    fi
+    wait "$PERF_PID" 2>/dev/null || true
+    PERF_PID=
+  fi
+}
 
 cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
+  stop_perf_stat
   # Stop tracy-capture first (SIGINT makes it disconnect and flush to disk)
   # Must happen before killing reth, otherwise reth keeps streaming data.
   if [ -n "${TRACY_PID:-}" ] && kill -0 "$TRACY_PID" 2>/dev/null; then
@@ -82,6 +147,7 @@ cleanup() {
 }
 TAIL_PID=
 TRACY_PID=
+PERF_PID=
 trap cleanup EXIT
 
 # Clean up stale state from a previous cancelled run.
@@ -304,6 +370,7 @@ if [ "$BIG_BLOCKS" = "true" ]; then
     TRACY_PID=$!
     sleep 0.5  # give tracy-capture time to connect
   fi
+  start_perf_stat
 
   if [ "${BENCH_BLOCKS:-0}" -le 0 ] 2>/dev/null; then
     echo "::error::BENCH_BLOCKS must be greater than 0 for big-block benchmarks"
@@ -318,6 +385,7 @@ if [ "$BIG_BLOCKS" = "true" ]; then
     --engine-rpc-url http://127.0.0.1:8551 \
     --jwt-secret "$DATADIR/jwt.hex" \
     --output "$OUTPUT_DIR" 2>&1 | sed -u "s/^/[bench] /"
+  stop_perf_stat
 else
   # Standard mode: warmup + new-payload-fcu
   WARMUP="${BENCH_WARMUP_BLOCKS:-50}"
@@ -340,6 +408,7 @@ else
     TRACY_PID=$!
     sleep 0.5  # give tracy-capture time to connect
   fi
+  start_perf_stat
 
   # Benchmark
   $BENCH_NICE "$RETH_BENCH" new-payload-fcu \
@@ -349,6 +418,7 @@ else
     --advance "$BENCH_BLOCKS" \
     "${EXTRA_BENCH_ARGS[@]}" \
     --output "$OUTPUT_DIR" 2>&1 | sed -u "s/^/[bench] /"
+  stop_perf_stat
 fi
 
 # cleanup runs via trap

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -57,14 +57,25 @@ start_perf_stat() {
     exit 1
   fi
 
+  local perf_bin
+  perf_bin="$(command -v perf)"
+  PERF_STAT_PID_FILE="$OUTPUT_DIR/perf-stat.pid"
+
   echo "Starting perf stat for ${node_process_name} pid ${reth_pid}..."
-  sudo perf stat \
-    -x, \
-    -e "$PERF_STAT_EVENTS" \
-    -p "$reth_pid" \
-    -o "$OUTPUT_DIR/perf-stat.csv" \
-    -- sleep infinity &
+  sudo bash -c 'echo $$ > "$1"; exec "$2" stat -x, -e "$3" -p "$4" -o "$5"' \
+    _ \
+    "$PERF_STAT_PID_FILE" \
+    "$perf_bin" \
+    "$PERF_STAT_EVENTS" \
+    "$reth_pid" \
+    "$OUTPUT_DIR/perf-stat.csv" &
   PERF_PID=$!
+  for _ in $(seq 1 10); do
+    if [ -s "$PERF_STAT_PID_FILE" ]; then
+      break
+    fi
+    sleep 0.1
+  done
   sleep 0.5
   if ! kill -0 "$PERF_PID" 2>/dev/null; then
     wait "$PERF_PID" 2>/dev/null || true
@@ -76,7 +87,15 @@ start_perf_stat() {
 stop_perf_stat() {
   if [ -n "${PERF_PID:-}" ] && kill -0 "$PERF_PID" 2>/dev/null; then
     echo "Stopping perf stat..."
-    sudo kill -INT "$PERF_PID" 2>/dev/null || kill -INT "$PERF_PID" 2>/dev/null || true
+    local perf_stat_pid=""
+    if [ -n "${PERF_STAT_PID_FILE:-}" ] && [ -f "$PERF_STAT_PID_FILE" ]; then
+      perf_stat_pid="$(cat "$PERF_STAT_PID_FILE" 2>/dev/null || true)"
+    fi
+    if [ -z "$perf_stat_pid" ]; then
+      perf_stat_pid="$PERF_PID"
+    fi
+
+    sudo kill -INT "$perf_stat_pid" 2>/dev/null || kill -INT "$perf_stat_pid" 2>/dev/null || true
     for i in $(seq 1 30); do
       kill -0 "$PERF_PID" 2>/dev/null || break
       if [ $((i % 10)) -eq 0 ]; then
@@ -86,10 +105,12 @@ stop_perf_stat() {
     done
     if kill -0 "$PERF_PID" 2>/dev/null; then
       echo "perf stat still running after 30s, killing..."
+      sudo kill -TERM "$perf_stat_pid" 2>/dev/null || kill -TERM "$perf_stat_pid" 2>/dev/null || true
       sudo kill -TERM "$PERF_PID" 2>/dev/null || kill -TERM "$PERF_PID" 2>/dev/null || true
     fi
     wait "$PERF_PID" 2>/dev/null || true
     PERF_PID=
+    PERF_STAT_PID_FILE=
   fi
 }
 
@@ -148,6 +169,7 @@ cleanup() {
 TAIL_PID=
 TRACY_PID=
 PERF_PID=
+PERF_STAT_PID_FILE=
 trap cleanup EXIT
 
 # Clean up stale state from a previous cancelled run.

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -49,14 +49,25 @@ start_perf_stat() {
     exit 1
   fi
 
+  local perf_bin
+  perf_bin="$(command -v perf)"
+  PERF_STAT_PID_FILE="$OUTPUT_DIR/perf-stat.pid"
+
   echo "Starting perf stat for ${node_process_name} pid ${reth_pid}..."
-  sudo perf stat \
-    -x, \
-    -e "$PERF_STAT_EVENTS" \
-    -p "$reth_pid" \
-    -o "$OUTPUT_DIR/perf-stat.csv" \
-    -- sleep infinity &
+  sudo bash -c 'echo $$ > "$1"; exec "$2" stat -x, -e "$3" -p "$4" -o "$5"' \
+    _ \
+    "$PERF_STAT_PID_FILE" \
+    "$perf_bin" \
+    "$PERF_STAT_EVENTS" \
+    "$reth_pid" \
+    "$OUTPUT_DIR/perf-stat.csv" &
   PERF_PID=$!
+  for _ in $(seq 1 10); do
+    if [ -s "$PERF_STAT_PID_FILE" ]; then
+      break
+    fi
+    sleep 0.1
+  done
   sleep 0.5
   if ! kill -0 "$PERF_PID" 2>/dev/null; then
     wait "$PERF_PID" 2>/dev/null || true
@@ -68,7 +79,15 @@ start_perf_stat() {
 stop_perf_stat() {
   if [ -n "${PERF_PID:-}" ] && kill -0 "$PERF_PID" 2>/dev/null; then
     echo "Stopping perf stat..."
-    sudo kill -INT "$PERF_PID" 2>/dev/null || kill -INT "$PERF_PID" 2>/dev/null || true
+    local perf_stat_pid=""
+    if [ -n "${PERF_STAT_PID_FILE:-}" ] && [ -f "$PERF_STAT_PID_FILE" ]; then
+      perf_stat_pid="$(cat "$PERF_STAT_PID_FILE" 2>/dev/null || true)"
+    fi
+    if [ -z "$perf_stat_pid" ]; then
+      perf_stat_pid="$PERF_PID"
+    fi
+
+    sudo kill -INT "$perf_stat_pid" 2>/dev/null || kill -INT "$perf_stat_pid" 2>/dev/null || true
     for i in $(seq 1 30); do
       kill -0 "$PERF_PID" 2>/dev/null || break
       if [ $((i % 10)) -eq 0 ]; then
@@ -78,10 +97,12 @@ stop_perf_stat() {
     done
     if kill -0 "$PERF_PID" 2>/dev/null; then
       echo "perf stat still running after 30s, killing..."
+      sudo kill -TERM "$perf_stat_pid" 2>/dev/null || kill -TERM "$perf_stat_pid" 2>/dev/null || true
       sudo kill -TERM "$PERF_PID" 2>/dev/null || kill -TERM "$PERF_PID" 2>/dev/null || true
     fi
     wait "$PERF_PID" 2>/dev/null || true
     PERF_PID=
+    PERF_STAT_PID_FILE=
   fi
 }
 
@@ -137,6 +158,7 @@ cleanup() {
 TAIL_PID=
 TRACY_PID=
 PERF_PID=
+PERF_STAT_PID_FILE=
 trap cleanup EXIT
 
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -10,7 +10,8 @@
 # Optional env: BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
-#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ
+#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ,
+#               BENCH_PERF_STAT, BENCH_PERF_STAT_EVENTS
 set -euxo pipefail
 
 LABEL="$1"
@@ -21,6 +22,68 @@ mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+PERF_STAT_EVENTS="${BENCH_PERF_STAT_EVENTS:-task-clock,cycles,instructions,branches,branch-misses,cache-references,cache-misses,context-switches,cpu-migrations,page-faults,major-faults}"
+
+start_perf_stat() {
+  if [ "${BENCH_PERF_STAT:-false}" != "true" ]; then
+    return
+  fi
+
+  if ! command -v perf >/dev/null 2>&1; then
+    echo "::error::BENCH_PERF_STAT requested but perf is not installed"
+    exit 1
+  fi
+
+  local node_process_name
+  node_process_name="$(basename "$BINARY")"
+  local reth_pid=""
+  for _ in $(seq 1 10); do
+    reth_pid="$(sudo pgrep -n -x "$node_process_name" 2>/dev/null || true)"
+    if [ -n "$reth_pid" ]; then
+      break
+    fi
+    sleep 1
+  done
+  if [ -z "$reth_pid" ]; then
+    echo "::error::BENCH_PERF_STAT requested but no ${node_process_name} process was found"
+    exit 1
+  fi
+
+  echo "Starting perf stat for ${node_process_name} pid ${reth_pid}..."
+  sudo perf stat \
+    -x, \
+    -e "$PERF_STAT_EVENTS" \
+    -p "$reth_pid" \
+    -o "$OUTPUT_DIR/perf-stat.csv" \
+    -- sleep infinity &
+  PERF_PID=$!
+  sleep 0.5
+  if ! kill -0 "$PERF_PID" 2>/dev/null; then
+    wait "$PERF_PID" 2>/dev/null || true
+    echo "::error::perf stat exited before benchmark started"
+    exit 1
+  fi
+}
+
+stop_perf_stat() {
+  if [ -n "${PERF_PID:-}" ] && kill -0 "$PERF_PID" 2>/dev/null; then
+    echo "Stopping perf stat..."
+    sudo kill -INT "$PERF_PID" 2>/dev/null || kill -INT "$PERF_PID" 2>/dev/null || true
+    for i in $(seq 1 30); do
+      kill -0 "$PERF_PID" 2>/dev/null || break
+      if [ $((i % 10)) -eq 0 ]; then
+        echo "Waiting for perf stat to finish writing... (${i}s)"
+      fi
+      sleep 1
+    done
+    if kill -0 "$PERF_PID" 2>/dev/null; then
+      echo "perf stat still running after 30s, killing..."
+      sudo kill -TERM "$PERF_PID" 2>/dev/null || kill -TERM "$PERF_PID" 2>/dev/null || true
+    fi
+    wait "$PERF_PID" 2>/dev/null || true
+    PERF_PID=
+  fi
+}
 
 # Unsupported txgen-path behavior is made explicit here. Keep these checks near
 # the top so new txgen support can be added one feature at a time.
@@ -35,6 +98,7 @@ fi
 
 cleanup() {
   kill "${TAIL_PID:-}" 2>/dev/null || true
+  stop_perf_stat
   if [ -n "${TRACY_PID:-}" ] && kill -0 "$TRACY_PID" 2>/dev/null; then
     echo "Stopping tracy-capture..."
     kill -INT "$TRACY_PID" 2>/dev/null || true
@@ -72,6 +136,7 @@ cleanup() {
 }
 TAIL_PID=
 TRACY_PID=
+PERF_PID=
 trap cleanup EXIT
 
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
@@ -278,6 +343,7 @@ if [ "${BENCH_TRACY:-off}" != "off" ]; then
   TRACY_PID=$!
   sleep 0.5
 fi
+start_perf_stat
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.
 # TODO(txgen): support reth-bb payload/env-switch/BAL replay so big-blocks can move here.
@@ -289,5 +355,6 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   "${TXGEN_SEND_ARGS[@]}" \
   --wait-for-persistence never \
   --report json:"$OUTPUT_DIR/report.json" 2>&1 | sed -u "s/^/[bench] /"
+stop_perf_stat
 
 python3 .github/scripts/bench-txgen-report-to-reth-csv.py "$OUTPUT_DIR/report.json" "$OUTPUT_DIR"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -457,7 +457,11 @@ jobs:
             echo 0 | sudo tee "$irq" 2>/dev/null || true
           done
           # Stop noisy background services
-          sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+          sudo systemctl stop \
+            irqbalance cron atd unattended-upgrades snapd \
+            prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+            prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+            2>/dev/null || true
           echo "=== Benchmark environment ==="
           uname -r
           lscpu | grep -E 'Model name|CPU\(s\)|MHz|NUMA'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,6 +66,11 @@ on:
         required: false
         default: "false"
         type: boolean
+      perf_stat:
+        description: "Collect perf stat counters during measured runs"
+        required: false
+        default: "false"
+        type: boolean
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
@@ -121,6 +126,7 @@ jobs:
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
+      perf-stat: ${{ steps.args.outputs.perf-stat }}
       slack: ${{ steps.args.outputs.slack }}
       cores: ${{ steps.args.outputs.cores }}
       big-blocks: ${{ steps.args.outputs.big-blocks }}
@@ -163,8 +169,8 @@ jobs:
           script: |
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
-            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false|100M|2G]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [slack=always|on-win|on-error|never] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
-            let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks, bal;
+            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false|100M|2G]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [perf-stat] [slack=always|on-win|on-error|never] [cores=N] [abba=true|false] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
+            let pr, actor, blocks, warmup, baseline, feature, samply, perfStat, cores, bigBlocks, bal;
             let bigBlocksTargetGas = '';
             let explicitWarmup = false;
 
@@ -184,6 +190,7 @@ jobs:
               baseline = '${{ github.event.inputs.baseline }}';
               feature = '${{ github.event.inputs.feature }}';
               samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
+              perfStat = '${{ github.event.inputs.perf_stat }}' === 'true' ? 'true' : 'false';
               var slack = '${{ github.event.inputs.slack }}' || 'never';
               cores = '${{ github.event.inputs.cores }}' || '0';
               const parsedBigBlocks = parseBigBlocks('${{ github.event.inputs.big_blocks }}');
@@ -220,12 +227,12 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['warmup', 'cores', 'blocks']);
               const refArgs = new Set(['baseline', 'feature']);
-              const boolArgs = new Set(['samply']);
+              const boolArgs = new Set(['samply', 'perf-stat']);
               const boolDefaultTrue = new Set(['abba']);
               const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes]]);
               const durationArgs = new Set(['wait-time']);
               const stringArgs = new Set(['baseline-args', 'feature-args']);
-              const defaults = { blocks: '500', warmup: '200', baseline: '', feature: '', samply: 'false', slack: 'always', 'big-blocks': 'false', bal: 'false', cores: '0', abba: 'true', otlp: 'false', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
+              const defaults = { blocks: '500', warmup: '200', baseline: '', feature: '', samply: 'false', 'perf-stat': 'false', slack: 'always', 'big-blocks': 'false', bal: 'false', cores: '0', abba: 'true', otlp: 'false', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -317,6 +324,7 @@ jobs:
               baseline = defaults.baseline;
               feature = defaults.feature;
               samply = defaults.samply;
+              perfStat = defaults['perf-stat'];
               var slack = defaults.slack;
               cores = defaults.cores;
               const parsedBigBlocks = parseBigBlocks(defaults['big-blocks']);
@@ -385,6 +393,7 @@ jobs:
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
+            core.setOutput('perf-stat', perfStat);
             core.setOutput('slack', slack);
             core.setOutput('cores', cores);
             core.setOutput('big-blocks', bigBlocks);
@@ -459,6 +468,8 @@ jobs:
             const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
             const bal = '${{ steps.args.outputs.bal }}' || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const perfStatEnabled = '${{ steps.args.outputs.perf-stat }}' === 'true';
+            const perfStatNote = perfStatEnabled ? ', perf-stat: `enabled`' : '';
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const balNote = bigBlocks && bal !== 'false' ? `, BAL: \`${bal}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
@@ -477,7 +488,7 @@ jobs:
             const driverReason = '${{ steps.args.outputs.driver-reason }}';
             const driverNote = driverReason ? `, driver: \`${driver}\` (fallback: \`${driverReason}\`)` : `, driver: \`${driver}\``;
             const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${driverNote}${samplyNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${driverNote}${samplyNote}${perfStatNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -506,6 +517,8 @@ jobs:
             const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
             const bal = '${{ steps.args.outputs.bal }}' || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const perfStatEnabled = '${{ steps.args.outputs.perf-stat }}' === 'true';
+            const perfStatNote = perfStatEnabled ? ', perf-stat: `enabled`' : '';
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const balNote = bigBlocks && bal !== 'false' ? `, BAL: \`${bal}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
@@ -524,7 +537,7 @@ jobs:
             const driverReason = '${{ steps.args.outputs.driver-reason }}';
             const driverNote = driverReason ? `, driver: \`${driver}\` (fallback: \`${driverReason}\`)` : `, driver: \`${driver}\``;
             const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${driverNote}${samplyNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${driverNote}${samplyNote}${perfStatNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -591,6 +604,7 @@ jobs:
       BENCH_BLOCKS: ${{ needs.reth-bench-ack.outputs.blocks }}
       BENCH_WARMUP_BLOCKS: ${{ needs.reth-bench-ack.outputs.warmup }}
       BENCH_SAMPLY: ${{ needs.reth-bench-ack.outputs.samply }}
+      BENCH_PERF_STAT: ${{ needs.reth-bench-ack.outputs.perf-stat }}
       BENCH_CORES: ${{ needs.reth-bench-ack.outputs.cores }}
       BENCH_BIG_BLOCKS: ${{ needs.reth-bench-ack.outputs.big-blocks }}
       BENCH_BIG_BLOCKS_TARGET_GAS: ${{ needs.reth-bench-ack.outputs.big-blocks-target-gas }}
@@ -666,6 +680,8 @@ jobs:
             const bigBlocks = process.env.BENCH_BIG_BLOCKS === 'true';
             const bal = process.env.BENCH_BAL || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const perfStatEnabled = process.env.BENCH_PERF_STAT === 'true';
+            const perfStatNote = perfStatEnabled ? ', perf-stat: `enabled`' : '';
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const balNote = bigBlocks && bal !== 'false' ? `, BAL: \`${bal}\`` : '';
             const cores = process.env.BENCH_CORES || '0';
@@ -684,7 +700,7 @@ jobs:
             const driverReason = process.env.BENCH_DRIVER_REASON || '';
             const driverNote = driverReason ? `, driver: \`${driver}\` (fallback: \`${driverReason}\`)` : `, driver: \`${driver}\``;
             const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${driverNote}${samplyNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${driverNote}${samplyNote}${perfStatNote}${slackNote}${balNote}${coresNote}${abbaNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -745,6 +761,11 @@ jobs:
             sudo install "$HOME/.cargo/bin/samply" /usr/local/bin/
           fi
 
+          if [ "${BENCH_PERF_STAT:-false}" = "true" ] && ! command -v perf &>/dev/null; then
+            echo "::error::perf stat requested but perf is unavailable after installing linux-tools"
+            exit 1
+          fi
+
       # Verify all required tools are available
       - name: Check dependencies
         run: |
@@ -755,6 +776,9 @@ jobs:
           for cmd in mc schelk cpupower taskset stdbuf python3 curl make uv jq; do
             command -v "$cmd" &>/dev/null || missing+=("$cmd")
           done
+          if [ "${BENCH_PERF_STAT:-false}" = "true" ]; then
+            command -v perf &>/dev/null || missing+=("perf")
+          fi
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Missing required tools: ${missing[*]}"
             exit 1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -987,7 +987,11 @@ jobs:
             echo 0 | sudo tee "$irq" 2>/dev/null || true
           done
           # Stop noisy background services
-          sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+          sudo systemctl stop \
+            irqbalance cron atd unattended-upgrades snapd \
+            prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+            prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+            2>/dev/null || true
           # Log environment for reproducibility
           echo "=== Benchmark environment ==="
           uname -r


### PR DESCRIPTION
Adds an optional `perf-stat` bench flag that records `perf stat` counters for the measured window of each run and uploads them with the existing bench artifact. The collection is wired into both the txgen and reth-bench drivers so normal and big-block runs can capture cycles, instructions, IPC inputs, cache misses, branch misses, context switches, migrations, and faults.

Also stops the node-exporter apt/nvme timer units during benchmark setup so scheduled host collectors do not fire inside benchmark windows.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: brian