### PR TITLE
ci: stop collector timers during reth benchmarks

### DIFF
--- a/.github/scripts/bench-reth-local.sh
+++ b/.github/scripts/bench-reth-local.sh
@@ -312,7 +312,14 @@ if [ "$TUNE" = "true" ]; then
   done
 
   # Stop noisy background services
-  sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+  sudo systemctl stop \
+    irqbalance cron atd unattended-upgrades snapd \
+    prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+    prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+    prometheus-node-exporter-ipmitool-sensor.timer prometheus-node-exporter-ipmitool-sensor.service \
+    sysstat-collect.timer sysstat-collect.service \
+    sysstat-summary.timer sysstat-summary.service \
+    2>/dev/null || true
 
   TUNING_APPLIED=true
 

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -457,7 +457,14 @@ jobs:
             echo 0 | sudo tee "$irq" 2>/dev/null || true
           done
           # Stop noisy background services
-          sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+          sudo systemctl stop \
+            irqbalance cron atd unattended-upgrades snapd \
+            prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+            prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+            prometheus-node-exporter-ipmitool-sensor.timer prometheus-node-exporter-ipmitool-sensor.service \
+            sysstat-collect.timer sysstat-collect.service \
+            sysstat-summary.timer sysstat-summary.service \
+            2>/dev/null || true
           echo "=== Benchmark environment ==="
           uname -r
           lscpu | grep -E 'Model name|CPU\(s\)|MHz|NUMA'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -963,7 +963,14 @@ jobs:
             echo 0 | sudo tee "$irq" 2>/dev/null || true
           done
           # Stop noisy background services
-          sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+          sudo systemctl stop \
+            irqbalance cron atd unattended-upgrades snapd \
+            prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+            prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+            prometheus-node-exporter-ipmitool-sensor.timer prometheus-node-exporter-ipmitool-sensor.service \
+            sysstat-collect.timer sysstat-collect.service \
+            sysstat-summary.timer sysstat-summary.service \
+            2>/dev/null || true
           # Log environment for reproducibility
           echo "=== Benchmark environment ==="
           uname -r


### PR DESCRIPTION
Stops the node-exporter apt, nvme, and ipmitool-sensor collector timers/services during benchmark setup so they cannot fire inside measured runs. Also stops sysstat collect/summary timers, which are active on the runner and were already observed as periodic benchmark-window noise.

Applies the same stop list to PR benchmarks, scheduled benchmarks, and the local benchmark helper.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: brian