### PR TITLE
refactor(engine): add validation output type

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -61,6 +61,7 @@ pub mod precompile_cache;
 #[cfg(test)]
 mod tests;
 mod trie_updates;
+pub mod types;
 
 use crate::{persistence::PersistenceResult, tree::error::AdvancePersistenceError};
 pub use block_buffer::BlockBuffer;
@@ -74,6 +75,7 @@ pub use reth_execution_cache::{
     CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider, ExecutionCache,
     PayloadExecutionCache, SavedCache,
 };
+pub use types::{ValidationOutcome, ValidationOutput};
 
 pub mod state;
 
@@ -2923,12 +2925,7 @@ where
         &mut self,
         block_id: BlockWithParent,
         input: Input,
-        execute: impl FnOnce(
-            &mut V,
-            Input,
-            TreeCtx<'_, N>,
-        )
-            -> Result<(ExecutedBlock<N>, Option<Box<ExecutionTimingStats>>), Err>,
+        execute: impl FnOnce(&mut V, Input, TreeCtx<'_, N>) -> Result<ValidationOutput<N>, Err>,
         convert_to_block: impl FnOnce(&mut Self, Input) -> Result<SealedBlock<N::Block>, Err>,
     ) -> Result<InsertPayloadOk, Err>
     where
@@ -2998,7 +2995,8 @@ where
 
         let start = Instant::now();
 
-        let (executed, timing_stats) = execute(&mut self.payload_validator, input, ctx)?;
+        let ValidationOutput { executed_block: executed, execution_timing_stats: timing_stats } =
+            execute(&mut self.payload_validator, input, ctx)?;
 
         // Emit slow block event immediately after execution so it appears even when
         // persistence hasn't completed yet (e.g. blocks arriving faster than persistence).

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -39,11 +39,12 @@
 //! [`SealedBlock`]: reth_primitives_traits::SealedBlock
 
 use crate::tree::{
-    error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
+    error::{InsertBlockError, InsertBlockErrorKind},
     instrumented_state::{InstrumentedStateProvider, StateProviderStats},
     multiproof::{StateRootComputeOutcome, StateRootHandle},
     payload_processor::PayloadProcessor,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
+    types::{InsertPayloadResult, ValidationOutput},
     CacheWaitDurations, CachedStateProvider, EngineApiMetrics, EngineApiTreeState, ExecutionEnv,
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
@@ -106,18 +107,10 @@ use std::{
 };
 use tracing::{debug, debug_span, error, info, instrument, trace, warn, Span};
 
-/// Output of block or payload validation.
-pub type ValidationOutcome<N, E = InsertPayloadError<BlockTy<N>>> =
-    Result<(ExecutedBlock<N>, Option<Box<ExecutionTimingStats>>), E>;
+pub use crate::tree::types::ValidationOutcome;
 
 /// Handle to a [`HashedPostState`] computed on a background thread.
 type LazyHashedPostState = reth_tasks::LazyHandle<Arc<HashedPostState>>;
-
-/// Result type for block validation with optional timing stats.
-type InsertPayloadResult<N> = Result<
-    (ExecutedBlock<N>, Option<Box<ExecutionTimingStats>>),
-    InsertPayloadError<<N as NodePrimitives>::Block>,
->;
 
 type ReceiptRootSender<N> =
     crossbeam_channel::Sender<IndexedReceipt<<N as NodePrimitives>::Receipt>>;
@@ -876,7 +869,7 @@ where
             trie_output,
             changeset_provider,
         );
-        Ok((executed_block, timing_stats))
+        Ok(ValidationOutput::new(executed_block, timing_stats))
     }
 
     /// Return sealed block header from database or in-memory state by hash.

--- a/crates/engine/tree/src/tree/types.rs
+++ b/crates/engine/tree/src/tree/types.rs
@@ -1,0 +1,31 @@
+//! Shared types for blockchain tree validation.
+
+use crate::tree::error::InsertPayloadError;
+use reth_chain_state::{ExecutedBlock, ExecutionTimingStats};
+use reth_primitives_traits::{BlockTy, NodePrimitives};
+
+/// Result of block or payload validation.
+pub type ValidationOutcome<N, E = InsertPayloadError<BlockTy<N>>> = Result<ValidationOutput<N>, E>;
+
+/// Result type for block validation with optional timing stats.
+pub(crate) type InsertPayloadResult<N> =
+    Result<ValidationOutput<N>, InsertPayloadError<<N as NodePrimitives>::Block>>;
+
+/// Output of block or payload validation.
+#[derive(Clone, Debug)]
+pub struct ValidationOutput<N: NodePrimitives> {
+    /// The executed block produced by validation.
+    pub executed_block: ExecutedBlock<N>,
+    /// Optional execution timing stats collected during validation.
+    pub execution_timing_stats: Option<Box<ExecutionTimingStats>>,
+}
+
+impl<N: NodePrimitives> ValidationOutput<N> {
+    /// Creates a new validation output.
+    pub const fn new(
+        executed_block: ExecutedBlock<N>,
+        execution_timing_stats: Option<Box<ExecutionTimingStats>>,
+    ) -> Self {
+        Self { executed_block, execution_timing_stats }
+    }
+}


### PR DESCRIPTION
Moves the block/payload validation output into `tree::types::ValidationOutput` with public fields for the executed block and optional timing stats. `ValidationOutcome` and the internal insert payload result now wrap that struct, leaving room for additional validation artifacts without extending tuple return values.