### PR TITLE
refactor(engine): move BlockOrPayload to tree types

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -49,11 +49,7 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{
-    bal::{Bal, DecodedBal},
-    compute_block_access_list_hash, BlockAccessList,
-};
-use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
+use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
 #[cfg(feature = "trie-debug")]
@@ -67,7 +63,7 @@ use reth_consensus::{
     validate_block_access_list_gas, ConsensusError, FullConsensus, ReceiptRootBloom,
 };
 use reth_engine_primitives::{
-    ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
+    ConfigureEngineEvm, ExecutableTxIterator, InvalidBlockHook, PayloadValidator,
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
@@ -80,7 +76,7 @@ use reth_payload_primitives::{
     PayloadTypes,
 };
 use reth_primitives_traits::{
-    AlloyBlockHeader, BlockBody, BlockTy, FastInstant as Instant, GotExpected, NodePrimitives,
+    AlloyBlockHeader, BlockBody, FastInstant as Instant, GotExpected, NodePrimitives,
     RecoveredBlock, SealedBlock, SealedHeader, SignerRecoverable,
 };
 use reth_provider::{
@@ -107,7 +103,7 @@ use std::{
 };
 use tracing::{debug, debug_span, error, info, instrument, trace, warn, Span};
 
-pub use crate::tree::types::ValidationOutcome;
+pub use crate::tree::types::{BlockOrPayload, ValidationOutcome};
 
 /// Handle to a [`HashedPostState`] computed on a background thread.
 type LazyHashedPostState = reth_tasks::LazyHandle<Arc<HashedPostState>>;
@@ -2238,121 +2234,5 @@ where
 {
     fn wait_for_caches(&self) -> CacheWaitDurations {
         self.payload_processor.wait_for_caches()
-    }
-}
-
-/// Enum representing either block or payload being validated.
-#[derive(Debug, Clone)]
-pub enum BlockOrPayload<T: PayloadTypes> {
-    /// Payload.
-    Payload(T::ExecutionData),
-    /// Block.
-    Block(SealedBlock<BlockTy<<T::BuiltPayload as BuiltPayload>::Primitives>>),
-}
-
-impl<T: PayloadTypes> BlockOrPayload<T> {
-    /// Returns the hash of the block.
-    pub fn hash(&self) -> B256 {
-        match self {
-            Self::Payload(payload) => payload.block_hash(),
-            Self::Block(block) => block.hash(),
-        }
-    }
-
-    /// Returns the number and hash of the block.
-    pub fn num_hash(&self) -> NumHash {
-        match self {
-            Self::Payload(payload) => payload.num_hash(),
-            Self::Block(block) => block.num_hash(),
-        }
-    }
-
-    /// Returns the parent hash of the block.
-    pub fn parent_hash(&self) -> B256 {
-        match self {
-            Self::Payload(payload) => payload.parent_hash(),
-            Self::Block(block) => block.parent_hash(),
-        }
-    }
-
-    /// Returns [`BlockWithParent`] for the block.
-    pub fn block_with_parent(&self) -> BlockWithParent {
-        match self {
-            Self::Payload(payload) => payload.block_with_parent(),
-            Self::Block(block) => block.block_with_parent(),
-        }
-    }
-
-    /// Returns a string showing whether or not this is a block or payload.
-    pub const fn type_name(&self) -> &'static str {
-        match self {
-            Self::Payload(_) => "payload",
-            Self::Block(_) => "block",
-        }
-    }
-
-    /// Returns the block access list embedded in a payload, if present.
-    pub fn block_access_list(&self) -> Option<Result<BlockAccessList, alloy_rlp::Error>> {
-        match self {
-            Self::Payload(payload) => payload.block_access_list().map(|block_access_list| {
-                alloy_rlp::decode_exact::<Bal>(block_access_list.as_ref()).map(Bal::into_inner)
-            }),
-            Self::Block(_) => None,
-        }
-    }
-
-    /// Returns the decoded block access list, if present and successfully decoded.
-    pub fn try_decoded_access_list(&self) -> Result<Option<DecodedBal>, alloy_rlp::Error> {
-        match self {
-            Self::Payload(payload) => payload
-                .block_access_list()
-                .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
-                .transpose(),
-            Self::Block(_) => Ok(None),
-        }
-    }
-
-    /// Returns the number of transactions in the payload or block.
-    pub fn transaction_count(&self) -> usize
-    where
-        T::ExecutionData: ExecutionPayload,
-    {
-        match self {
-            Self::Payload(payload) => payload.transaction_count(),
-            Self::Block(block) => block.transaction_count(),
-        }
-    }
-
-    /// Returns the withdrawals from the payload or block.
-    pub fn withdrawals(&self) -> Option<&[Withdrawal]>
-    where
-        T::ExecutionData: ExecutionPayload,
-    {
-        match self {
-            Self::Payload(payload) => payload.withdrawals().map(|w| w.as_slice()),
-            Self::Block(block) => block.body().withdrawals().map(|w| w.as_slice()),
-        }
-    }
-
-    /// Returns the total gas used by the block.
-    pub fn gas_used(&self) -> u64
-    where
-        T::ExecutionData: ExecutionPayload,
-    {
-        match self {
-            Self::Payload(payload) => payload.gas_used(),
-            Self::Block(block) => block.gas_used(),
-        }
-    }
-
-    /// Returns the gas limit used by the block.
-    pub fn gas_limit(&self) -> u64
-    where
-        T::ExecutionData: ExecutionPayload,
-    {
-        match self {
-            Self::Payload(payload) => payload.gas_limit(),
-            Self::Block(block) => block.gas_limit(),
-        }
     }
 }

--- a/crates/engine/tree/src/tree/types.rs
+++ b/crates/engine/tree/src/tree/types.rs
@@ -1,8 +1,17 @@
 //! Shared types for blockchain tree validation.
 
 use crate::tree::error::InsertPayloadError;
+use alloy_consensus::BlockHeader;
+use alloy_eip7928::{
+    bal::{Bal, DecodedBal},
+    BlockAccessList,
+};
+use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
+use alloy_primitives::B256;
 use reth_chain_state::{ExecutedBlock, ExecutionTimingStats};
-use reth_primitives_traits::{BlockTy, NodePrimitives};
+use reth_engine_primitives::ExecutionPayload;
+use reth_payload_primitives::{BuiltPayload, PayloadTypes};
+use reth_primitives_traits::{BlockBody, BlockTy, NodePrimitives, SealedBlock};
 
 /// Result of block or payload validation.
 pub type ValidationOutcome<N, E = InsertPayloadError<BlockTy<N>>> = Result<ValidationOutput<N>, E>;
@@ -27,5 +36,121 @@ impl<N: NodePrimitives> ValidationOutput<N> {
         execution_timing_stats: Option<Box<ExecutionTimingStats>>,
     ) -> Self {
         Self { executed_block, execution_timing_stats }
+    }
+}
+
+/// Enum representing either block or payload being validated.
+#[derive(Debug, Clone)]
+pub enum BlockOrPayload<T: PayloadTypes> {
+    /// Payload.
+    Payload(T::ExecutionData),
+    /// Block.
+    Block(SealedBlock<BlockTy<<T::BuiltPayload as BuiltPayload>::Primitives>>),
+}
+
+impl<T: PayloadTypes> BlockOrPayload<T> {
+    /// Returns the hash of the block.
+    pub fn hash(&self) -> B256 {
+        match self {
+            Self::Payload(payload) => payload.block_hash(),
+            Self::Block(block) => block.hash(),
+        }
+    }
+
+    /// Returns the number and hash of the block.
+    pub fn num_hash(&self) -> NumHash {
+        match self {
+            Self::Payload(payload) => payload.num_hash(),
+            Self::Block(block) => block.num_hash(),
+        }
+    }
+
+    /// Returns the parent hash of the block.
+    pub fn parent_hash(&self) -> B256 {
+        match self {
+            Self::Payload(payload) => payload.parent_hash(),
+            Self::Block(block) => block.parent_hash(),
+        }
+    }
+
+    /// Returns [`BlockWithParent`] for the block.
+    pub fn block_with_parent(&self) -> BlockWithParent {
+        match self {
+            Self::Payload(payload) => payload.block_with_parent(),
+            Self::Block(block) => block.block_with_parent(),
+        }
+    }
+
+    /// Returns a string showing whether or not this is a block or payload.
+    pub const fn type_name(&self) -> &'static str {
+        match self {
+            Self::Payload(_) => "payload",
+            Self::Block(_) => "block",
+        }
+    }
+
+    /// Returns the block access list embedded in a payload, if present.
+    pub fn block_access_list(&self) -> Option<Result<BlockAccessList, alloy_rlp::Error>> {
+        match self {
+            Self::Payload(payload) => payload.block_access_list().map(|block_access_list| {
+                alloy_rlp::decode_exact::<Bal>(block_access_list.as_ref()).map(Bal::into_inner)
+            }),
+            Self::Block(_) => None,
+        }
+    }
+
+    /// Returns the decoded block access list, if present and successfully decoded.
+    pub fn try_decoded_access_list(&self) -> Result<Option<DecodedBal>, alloy_rlp::Error> {
+        match self {
+            Self::Payload(payload) => payload
+                .block_access_list()
+                .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
+                .transpose(),
+            Self::Block(_) => Ok(None),
+        }
+    }
+
+    /// Returns the number of transactions in the payload or block.
+    pub fn transaction_count(&self) -> usize
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.transaction_count(),
+            Self::Block(block) => block.transaction_count(),
+        }
+    }
+
+    /// Returns the withdrawals from the payload or block.
+    pub fn withdrawals(&self) -> Option<&[Withdrawal]>
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.withdrawals().map(|w| w.as_slice()),
+            Self::Block(block) => block.body().withdrawals().map(|w| w.as_slice()),
+        }
+    }
+
+    /// Returns the total gas used by the block.
+    pub fn gas_used(&self) -> u64
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.gas_used(),
+            Self::Block(block) => block.gas_used(),
+        }
+    }
+
+    /// Returns the gas limit used by the block.
+    pub fn gas_limit(&self) -> u64
+    where
+        T::ExecutionData: ExecutionPayload,
+    {
+        match self {
+            Self::Payload(payload) => payload.gas_limit(),
+            Self::Block(block) => block.gas_limit(),
+        }
     }
 }


### PR DESCRIPTION
Moves `BlockOrPayload` out of `payload_validator.rs` and into the engine tree shared types module.

Re-exports it from `payload_validator` so existing imports continue to work.
