### PR TITLE
fix(engine): handle closed persistence wait channels

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1682,6 +1682,7 @@ where
                                 );
 
                                 let backpressure_wait = enqueued_at.elapsed();
+                                let num_hash = payload.num_hash();
 
                                 let explicit_persistence_wait = if wait_for_persistence {
                                     let pending_persistence = self.persistence_state.rx.take();
@@ -1692,26 +1693,68 @@ where
                                             "wait-persist",
                                             move || {
                                                 let start = Instant::now();
-                                                let result = rx
-                                                    .recv()
-                                                    .expect("persistence state channel closed");
-                                                let _ = persistence_tx.send((
-                                                    result,
-                                                    start_time,
-                                                    start.elapsed(),
-                                                ));
+                                                let result = rx.recv().map(|result| {
+                                                    (result, start_time, start.elapsed())
+                                                });
+                                                let _ = persistence_tx.send(result);
                                             },
                                         );
-                                        let (result, start_time, wait_duration) = persistence_rx
-                                            .recv()
-                                            .expect("persistence result channel closed");
-                                        let _ = self.on_persistence_complete(result, start_time);
-                                        wait_duration
+                                        match persistence_rx.recv() {
+                                            Ok(Ok((result, start_time, wait_duration))) => {
+                                                let _ = self
+                                                    .on_persistence_complete(result, start_time);
+                                                Ok(wait_duration)
+                                            }
+                                            Ok(Err(_)) => Err(BeaconOnNewPayloadError::internal(
+                                                std::io::Error::other(
+                                                    "persistence state channel closed",
+                                                ),
+                                            )),
+                                            Err(_) => Err(BeaconOnNewPayloadError::internal(
+                                                std::io::Error::other(
+                                                    "persistence result channel closed",
+                                                ),
+                                            )),
+                                        }
                                     } else {
-                                        Duration::ZERO
+                                        Ok(Duration::ZERO)
                                     }
                                 } else {
-                                    Duration::ZERO
+                                    Ok(Duration::ZERO)
+                                };
+
+                                let explicit_persistence_wait = match explicit_persistence_wait {
+                                    Ok(wait) => wait,
+                                    Err(err) => {
+                                        error!(
+                                            target: "engine::tree",
+                                            payload = ?num_hash,
+                                            ?err,
+                                            "Failed to wait for in-flight persistence"
+                                        );
+                                        self.metrics
+                                            .engine
+                                            .new_payload
+                                            .new_payload_messages
+                                            .increment(1);
+                                        self.metrics
+                                            .engine
+                                            .new_payload
+                                            .new_payload_error
+                                            .increment(1);
+                                        if let Err(send_err) = tx.send(Err(err)) {
+                                            warn!(
+                                                target: "engine::tree",
+                                                payload = ?num_hash,
+                                                "Failed to deliver reth_newPayload error response, receiver dropped (request cancelled): {send_err:?}"
+                                            );
+                                            self.metrics
+                                                .engine
+                                                .failed_new_payload_response_deliveries
+                                                .increment(1);
+                                        }
+                                        return Ok(ops::ControlFlow::Continue(()))
+                                    }
                                 };
 
                                 let cache_wait = wait_for_caches
@@ -1719,7 +1762,6 @@ where
 
                                 let start = Instant::now();
                                 let gas_used = payload.gas_used();
-                                let num_hash = payload.num_hash();
                                 let mut output = self.on_new_payload(payload);
                                 let latency = start.elapsed();
                                 self.metrics.engine.new_payload.update_response_metrics(

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -36,7 +36,7 @@ use std::{
         mpsc::{Receiver, Sender},
         Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio::sync::oneshot;
 
@@ -695,6 +695,47 @@ async fn test_holesky_payload() {
 
     let resp = rx.await.unwrap().unwrap();
     assert!(resp.is_syncing());
+}
+
+fn holesky_execution_data() -> ExecutionData {
+    let s = include_str!("../../test-data/holesky/1.rlp");
+    let data = Bytes::from_str(s).unwrap();
+    let block: Block = Block::decode(&mut data.as_ref()).unwrap();
+    let sealed = block.seal_slow();
+    let hash = sealed.hash();
+    let block = sealed.into_block();
+    let payload = ExecutionPayloadV1::from_block_unchecked(hash, &block);
+
+    ExecutionData { payload: payload.into(), sidecar: ExecutionPayloadSidecar::none() }
+}
+
+#[tokio::test]
+async fn test_reth_new_payload_returns_error_when_persistence_channel_closes() {
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
+    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
+
+    let (persist_tx, persist_rx) = crossbeam_channel::bounded(1);
+    let persisted = blocks.last().unwrap().recovered_block().num_hash();
+    test_harness.tree.persistence_state.start_save(persisted, persist_rx);
+    drop(persist_tx);
+
+    let (tx, rx) = oneshot::channel();
+    let _ = test_harness
+        .tree
+        .on_engine_message(FromEngine::Request(
+            BeaconEngineMessage::RethNewPayload {
+                payload: holesky_execution_data(),
+                wait_for_persistence: true,
+                wait_for_caches: true,
+                tx,
+                enqueued_at: Instant::now(),
+            }
+            .into(),
+        ))
+        .unwrap();
+
+    let err = rx.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("persistence state channel closed"));
 }
 
 #[test]


### PR DESCRIPTION
Converts closed persistence wait channels in the `reth_newPayload` path into returned engine errors. The branch now records the error counters and attempts to deliver a response instead of panicking from the wait helper.