### PR TITLE
fix(payload): avoid tx pool for empty payloads

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -131,7 +131,7 @@ where
             self.pool.clone(),
             self.builder_config.clone(),
             args,
-            |attributes| self.pool.best_transactions_with_attributes(attributes),
+            |_| -> BestTransactionsIter<Pool> { Box::new(std::iter::empty()) },
         )?
         .into_payload()
         .ok_or_else(|| PayloadBuilderError::MissingPayload)


### PR DESCRIPTION
Closes #24102

Changes Ethereum `build_empty_payload` to call the shared payload builder with an empty best-transaction iterator instead of the transaction pool. This keeps the missing-payload fallback cheap and avoids racing a second pool-backed payload build against the in-progress job.