### PR TITLE
feat(bench): support txgen big-block benchmarks

### DIFF
--- a/.github/scripts/bench-txgen-build.sh
+++ b/.github/scripts/bench-txgen-build.sh
@@ -5,17 +5,25 @@
 # Usage: bench-txgen-build.sh <baseline|feature> <source-dir> <commit>
 #
 # This intentionally does not build or install reth-bench. Big-block benchmarks
-# still use the legacy reth-bench path because txgen does not yet replay the
-# reth-bb payload/env-switch/BAL format.
+# build reth-bb because txgen replays reth-bb's extended payload format.
 set -euxo pipefail
 
 MODE="$1"
 SOURCE_DIR="$2"
 COMMIT="$3"
 
-if [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
-  echo "::error::txgen path does not support big-block benchmarks yet; use the reth-bench driver"
+if [ -n "${BENCH_BAL:-}" ] && [ "${BENCH_BAL}" != "false" ]; then
+  echo "::error::txgen path does not support BAL replay yet; use big-blocks with the reth-bench driver"
   exit 1
+fi
+
+BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
+if [ "$BIG_BLOCKS" = "true" ]; then
+  NODE_BIN="reth-bb"
+  NODE_PKG="-p reth-bb"
+else
+  NODE_BIN="reth"
+  NODE_PKG="--bin reth"
 fi
 
 EXTRA_FEATURES=""
@@ -37,17 +45,17 @@ build_node_binary() {
 
   # shellcheck disable=SC2086
   RUSTFLAGS="-C target-cpu=native${EXTRA_RUSTFLAGS}" \
-    cargo build --locked --profile profiling --bin reth $workspace_arg $features_arg
+    cargo build --locked --profile profiling $NODE_PKG $workspace_arg $features_arg
 }
 
 case "$MODE" in
   baseline|main)
-    echo "Building baseline reth (${COMMIT}) from source for txgen benchmark..."
+    echo "Building baseline ${NODE_BIN} (${COMMIT}) from source for txgen benchmark..."
     build_node_binary
     ;;
 
   feature|branch)
-    echo "Building feature reth (${COMMIT}) from source for txgen benchmark..."
+    echo "Building feature ${NODE_BIN} (${COMMIT}) from source for txgen benchmark..."
     rustup show active-toolchain || rustup default stable
     build_node_binary
     ;;

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -7,7 +7,8 @@
 # Usage: bench-txgen-run.sh <label> <binary> <output-dir>
 #
 # Required env: SCHELK_MOUNT, BENCH_RPC_URL, BENCH_BLOCKS, BENCH_WARMUP_BLOCKS
-# Optional env: BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
+# Optional env: BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS, BENCH_BAL,
+#               BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
 #               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ
@@ -16,18 +17,19 @@ set -euxo pipefail
 LABEL="$1"
 BINARY="$2"
 OUTPUT_DIR="$3"
-DATADIR="$SCHELK_MOUNT/datadir"
+DATADIR_NAME="datadir"
+BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
+if [ "$BIG_BLOCKS" = "true" ]; then
+  DATADIR_NAME="datadir-big-blocks"
+fi
+DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
 mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
 
-# Unsupported txgen-path behavior is made explicit here. Keep these checks near
-# the top so new txgen support can be added one feature at a time.
-if [ "${BENCH_BIG_BLOCKS:-false}" = "true" ]; then
-  echo "::error::txgen driver does not support big-block benchmarks yet; use the reth-bench driver"
-  exit 1
-fi
+# Unsupported txgen-path behavior is made explicit here. Keep this check near
+# the top so BAL support can be added when txgen supports it.
 if [ -n "${BENCH_BAL:-}" ] && [ "${BENCH_BAL}" != "false" ]; then
   echo "::error::txgen driver does not support BAL replay yet; use big-blocks with the reth-bench driver"
   exit 1
@@ -54,6 +56,7 @@ cleanup() {
   if sudo systemctl is-active "$RETH_SCOPE" >/dev/null 2>&1; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
       sudo pkill -INT -x reth 2>/dev/null || true
+      sudo pkill -INT -x reth-bb 2>/dev/null || true
       for i in $(seq 1 120); do
         sudo pgrep -x samply > /dev/null 2>&1 || break
         if [ $((i % 10)) -eq 0 ]; then
@@ -157,12 +160,13 @@ if [ -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]; then
 fi
 
 TOTAL_MEM_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
-MEM_LIMIT=$(( TOTAL_MEM_KB * 95 / 100 * 1024 ))
+MEM_LIMIT=$(( TOTAL_MEM_KB * 95 * 1024 / 100 ))
 echo "Memory limit: $(( MEM_LIMIT / 1024 / 1024 ))MB (95% of $(( TOTAL_MEM_KB / 1024 ))MB)"
 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   RETH_ARGS+=(--log.samply)
   SAMPLY="$(which samply)"
+  # shellcheck disable=SC2024
   sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 \
@@ -171,6 +175,7 @@ if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
     -- "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &
 else
+  # shellcheck disable=SC2024
   sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
@@ -242,15 +247,33 @@ mkdir -p "$TXGEN_DIR"
 ALL_BLOCKS="$TXGEN_DIR/all-blocks.ndjson"
 WARMUP_BLOCKS="$TXGEN_DIR/warmup-blocks.ndjson"
 BENCHMARK_BLOCKS="$TXGEN_DIR/benchmark-blocks.ndjson"
+if [ "$BIG_BLOCKS" = "true" ]; then
+  ALL_BIG_BLOCKS="$TXGEN_DIR/all-big-blocks.ndjson"
+  WARMUP_BIG_BLOCKS="$TXGEN_DIR/warmup-big-blocks.ndjson"
+  MEASURED_BIG_BLOCKS="$TXGEN_DIR/measured-big-blocks.ndjson"
+  ALL_BLOCKS="$ALL_BIG_BLOCKS"
+  WARMUP_BLOCKS="$WARMUP_BIG_BLOCKS"
+  BENCHMARK_BLOCKS="$MEASURED_BIG_BLOCKS"
+fi
 
 EXTRACT_FROM=$(( HEAD_DEC + 1 ))
-EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
-echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
-"$TXGEN_ETHEREUM" extract \
-  --rpc "$BENCH_RPC_URL" \
-  --from "$EXTRACT_FROM" \
-  --to "$EXTRACT_TO" \
-  -o "$ALL_BLOCKS"
+if [ "$BIG_BLOCKS" = "true" ]; then
+  echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+  "$TXGEN_ETHEREUM" extract-big-blocks \
+    --rpc "$BENCH_RPC_URL" \
+    --from "$EXTRACT_FROM" \
+    --count "$TOTAL" \
+    --target-gas "${BENCH_BIG_BLOCKS_TARGET_GAS:-1G}" \
+    -o "$ALL_BIG_BLOCKS"
+else
+  EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
+  echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+  "$TXGEN_ETHEREUM" extract \
+    --rpc "$BENCH_RPC_URL" \
+    --from "$EXTRACT_FROM" \
+    --to "$EXTRACT_TO" \
+    -o "$ALL_BLOCKS"
+fi
 
 if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
   head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_BLOCKS"
@@ -280,7 +303,6 @@ if [ "${BENCH_TRACY:-off}" != "off" ]; then
 fi
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.
-# TODO(txgen): support reth-bb payload/env-switch/BAL replay so big-blocks can move here.
 echo "Running txgen measured benchmark (${BLOCKS} blocks)..."
 $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   --engine http://127.0.0.1:8551 \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -631,7 +631,7 @@ jobs:
       BENCH_DRIVER_REASON: ${{ needs.reth-bench-ack.outputs.driver-reason }}
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      TXGEN_REV: 5b04a80d557cc6658573db6ccf49ce04cbf07ea3
+      TXGEN_REV: 15c7070e645cc66c7f88b492ac73fe683c73fdd4
       BENCH_OTLP_TRACES_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_TRACES_ENDPOINT || '' }}
       BENCH_OTLP_LOGS_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_LOGS_ENDPOINT || '' }}
     steps:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -631,7 +631,7 @@ jobs:
       BENCH_DRIVER_REASON: ${{ needs.reth-bench-ack.outputs.driver-reason }}
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      TXGEN_REV: 15c7070e645cc66c7f88b492ac73fe683c73fdd4
+      TXGEN_REV: 64826ac816380586e4856e2d1d2d20f4d4e66198
       BENCH_OTLP_TRACES_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_TRACES_ENDPOINT || '' }}
       BENCH_OTLP_LOGS_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_LOGS_ENDPOINT || '' }}
     steps:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -393,7 +393,6 @@ jobs:
             }
 
             const fallbackReasons = [];
-            if (bigBlocks === 'true') fallbackReasons.push('big-blocks');
             if (bal !== 'false') fallbackReasons.push('BAL');
             const driver = fallbackReasons.length ? 'reth-bench' : 'txgen';
             const nodeBin = bigBlocks === 'true' ? 'reth-bb' : 'reth';
@@ -496,7 +495,7 @@ jobs:
             const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
-            const driver = '${{ steps.args.outputs.driver }}' || (bigBlocks ? 'reth-bench' : 'txgen');
+            const driver = '${{ steps.args.outputs.driver }}' || (bal !== 'false' ? 'reth-bench' : 'txgen');
             const driverReason = '${{ steps.args.outputs.driver-reason }}';
             const driverNote = driverReason ? `, driver: \`${driver}\` (fallback: \`${driverReason}\`)` : `, driver: \`${driver}\``;
             const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;
@@ -543,7 +542,7 @@ jobs:
             const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
-            const driver = '${{ steps.args.outputs.driver }}' || (bigBlocks ? 'reth-bench' : 'txgen');
+            const driver = '${{ steps.args.outputs.driver }}' || (bal !== 'false' ? 'reth-bench' : 'txgen');
             const driverReason = '${{ steps.args.outputs.driver-reason }}';
             const driverNote = driverReason ? `, driver: \`${driver}\` (fallback: \`${driverReason}\`)` : `, driver: \`${driver}\``;
             const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;
@@ -702,7 +701,7 @@ jobs:
             const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
             const featureArgsVal = process.env.BENCH_FEATURE_ARGS || '';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
-            const driver = process.env.BENCH_DRIVER || (bigBlocks ? 'reth-bench' : 'txgen');
+            const driver = process.env.BENCH_DRIVER || (bal !== 'false' ? 'reth-bench' : 'txgen');
             const driverReason = process.env.BENCH_DRIVER_REASON || '';
             const driverNote = driverReason ? `, driver: \`${driver}\` (fallback: \`${driverReason}\`)` : `, driver: \`${driver}\``;
             const blocksDesc = bigBlocks ? 'blocks: `big`' : `${blocks} blocks, ${warmup} warmup blocks`;


### PR DESCRIPTION
Allows the txgen benchmark driver to run non-BAL big-block benchmarks by building reth-bb, using datadir-big-blocks, and extracting/replaying txgen big-block NDJSON. BAL modes continue to fall back to reth-bench.

Validated with shellcheck and dry routing/build-command checks.