### PR TITLE
fix(mdbx): disable posix_fallocate to fix ENOSPC on ZFS

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -20,7 +20,13 @@ fn main() {
     }
 
     let flags = format!("{:?}", cc.get_compiler().cflags_env());
-    cc.define("MDBX_BUILD_FLAGS", flags.as_str()).define("MDBX_TXN_CHECKOWNER", "0");
+    cc.define("MDBX_BUILD_FLAGS", flags.as_str())
+        .define("MDBX_TXN_CHECKOWNER", "0")
+        // Disable posix_fallocate() usage. On filesystems that do not support fallocate (e.g. ZFS),
+        // glibc's posix_fallocate() emulates it by writing zeros, which can spuriously fail with
+        // ENOSPC even when sufficient disk space is available. The fallback path uses ftruncate()
+        // which works correctly on all filesystems.
+        .define("MDBX_USE_FALLOCATE", "0");
 
     // Enable debugging on debug builds
     #[cfg(debug_assertions)]


### PR DESCRIPTION
## Problem

The v0.13.7 → v0.13.12 libmdbx bump (#24007) introduced a new `MDBX_USE_FALLOCATE` feature that calls `posix_fallocate()` before `ftruncate()` when extending the database file (`osal_ftruncate` was renamed to `osal_fsetsize` and gained a fallocate pre-pass).

On filesystems that do not natively support `fallocate` (notably **ZFS**), glibc's `posix_fallocate()` falls back to writing zeros across the entire requested range. This can fail with `ENOSPC` (errno 28) even when there is plenty of free disk space — for example, a node with 950+ GB free at 72% disk usage was failing with:

```
Error: failed to open the database: No space left on device (28)
```

## Root Cause

In v0.13.7, `osal_ftruncate()` was a single call:
```c
return ftruncate(fd, length) == 0 ? MDBX_SUCCESS : errno;
```

In v0.13.12, it was rewritten as `osal_fsetsize()` which first tries `posix_fallocate(fd, 0, length)` when `MDBX_USE_FALLOCATE=1` (the new default on Linux with glibc ≥ 2.10). On ZFS:

1. Kernel `fallocate` syscall returns `EOPNOTSUPP`
2. glibc `posix_fallocate()` masks this and falls back to writing zeros
3. The zero-fill tries to physically allocate blocks on the COW filesystem
4. This fails with `ENOSPC` because the requested allocation exceeds available space

The `MDBX_USE_FALLOCATE` feature **did not exist at all** in v0.13.7 — it was added entirely in the v0.13.12 bump.

## Fix

Set `MDBX_USE_FALLOCATE=0` at compile time to restore the `ftruncate()`-only behavior, which works correctly on all filesystems.