### PR TITLE
fix(engine): validate BAL gas limit without redecoding

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -38,6 +38,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_consensus::Header;
+use alloy_eip7928::BlockAccessListGasError;
 use alloy_primitives::{BlockHash, BlockNumber, Bloom, B256};
 use core::{error::Error, fmt::Display};
 
@@ -476,8 +477,8 @@ pub enum ConsensusError {
     #[error(transparent)]
     TransactionGasLimitTooHigh(Box<TxGasLimitTooHighErr>),
     /// Error when an unexpected block access list cost is encountered.
-    #[error("block access list cost exceeds gas limit")]
-    BlockAccessListCostMoreThanGasLimit,
+    #[error(transparent)]
+    BlockAccessListCostMoreThanGasLimit(Box<BlockAccessListGasError>),
     /// Error when the block access list hash doesn't match the expected value.
     #[error("block access list hash mismatch: {0}")]
     BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
@@ -526,23 +527,6 @@ impl ConsensusError {
     }
 }
 
-/// Validates the block access list against the gas limit.
-///
-/// EIP-7925 specifies that the total cost of the block access list items must not exceed
-/// the gas limit. Each item costs `ITEM_COST` gas.
-pub fn validate_block_access_list_gas(
-    block_access_list: Option<&alloy_eip7928::BlockAccessList>,
-    gas_limit: u64,
-) -> Result<(), ConsensusError> {
-    if let Some(bal) = block_access_list {
-        let bal_items = alloy_eip7928::total_bal_items(bal);
-        if bal_items > gas_limit / alloy_eip7928::ITEM_COST as u64 {
-            return Err(ConsensusError::BlockAccessListCostMoreThanGasLimit)
-        }
-    }
-    Ok(())
-}
-
 impl From<InvalidTransactionError> for ConsensusError {
     fn from(value: InvalidTransactionError) -> Self {
         Self::InvalidTransaction(value)
@@ -552,6 +536,12 @@ impl From<InvalidTransactionError> for ConsensusError {
 impl From<TxGasLimitTooHighErr> for ConsensusError {
     fn from(value: TxGasLimitTooHighErr) -> Self {
         Self::TransactionGasLimitTooHigh(Box::new(value))
+    }
+}
+
+impl From<BlockAccessListGasError> for ConsensusError {
+    fn from(value: BlockAccessListGasError) -> Self {
+        Self::BlockAccessListCostMoreThanGasLimit(Box::new(value))
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -49,10 +49,7 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{
-    bal::{Bal, DecodedBal},
-    compute_block_access_list_hash, BlockAccessList,
-};
+use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -63,9 +60,7 @@ use crate::tree::payload_processor::receipt_root_task::{IndexedReceipt, ReceiptR
 use reth_chain_state::{
     CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, ExecutionTimingStats, LazyOverlay,
 };
-use reth_consensus::{
-    validate_block_access_list_gas, ConsensusError, FullConsensus, ReceiptRootBloom,
-};
+use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
     ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
 };
@@ -944,16 +939,17 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        if let Some(bal_opt) = input.block_access_list() {
-            let bal = bal_opt.map_err(BlockExecutionError::other)?;
-            validate_block_access_list_gas(Some(&bal), input.gas_limit())
+        if let Some(decoded_bal) = &env.decoded_bal {
+            decoded_bal
+                .as_bal()
+                .validate_gas_limit(input.gas_limit())
                 .map_err(|e| {
                     debug!(target: "engine::tree::payload_validator", "BAL is invalid since it contains more items than the gas limit allows");
-                    InsertBlockErrorKind::Consensus(e)
+                    InsertBlockErrorKind::Consensus(ConsensusError::from(e))
                 })?
         }
 
-        let has_bal = input.block_access_list().is_some();
+        let has_bal = env.decoded_bal.is_some();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
@@ -2288,16 +2284,6 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         match self {
             Self::Payload(_) => "payload",
             Self::Block(_) => "block",
-        }
-    }
-
-    /// Returns the block access list embedded in a payload, if present.
-    pub fn block_access_list(&self) -> Option<Result<BlockAccessList, alloy_rlp::Error>> {
-        match self {
-            Self::Payload(payload) => payload.block_access_list().map(|block_access_list| {
-                alloy_rlp::decode_exact::<Bal>(block_access_list.as_ref()).map(Bal::into_inner)
-            }),
-            Self::Block(_) => None,
         }
     }
 


### PR DESCRIPTION
Uses the decoded BAL already stored in the execution env to enforce the block gas limit via `Bal::validate_gas_limit`, avoiding a second payload-byte decode during block execution.

The consensus error now carries the native alloy gas-limit error, and the old standalone helper is removed.