### PR TITLE
fix(net): validate downloaded block access list hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9082,7 +9082,6 @@ name = "reth-network-p2p"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
  "alloy-eips 2.0.4",
  "alloy-primitives",
  "auto_impl",

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -23,7 +23,6 @@ reth-storage-errors.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true
-alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 
@@ -56,7 +55,6 @@ test-utils = [
 std = [
     "reth-consensus/std",
     "reth-ethereum-primitives/std",
-    "alloy-eip7928/std",
     "alloy-eips/std",
     "alloy-primitives/std",
     "reth-primitives-traits/std",

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -9,8 +9,7 @@ use crate::{
     BlockClient,
 };
 use alloy_consensus::BlockHeader;
-use alloy_eip7928::bal::Bal;
-use alloy_primitives::{Sealable, B256};
+use alloy_primitives::{keccak256, Bytes, Sealable, Sealed, B256};
 use core::marker::PhantomData;
 use futures::FutureExt;
 use reth_consensus::Consensus;
@@ -29,14 +28,23 @@ use std::{
     sync::Arc,
     task::{ready, Context, Poll},
 };
-use tracing::debug;
+use tracing::{debug, trace};
+
+/// RLP encoding for an empty list.
+const EMPTY_LIST_CODE: u8 = 0xc0;
 
 /// A sealed block with associated data.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SealedBlockWith<B: Block, T = Option<Bal>> {
+pub struct SealedBlockWith<B: Block, T = Option<Sealed<Bytes>>> {
     block: SealedBlock<B>,
     data: T,
 }
+
+/// Raw block access-list RLP bytes sealed by `header.block_access_list_hash`.
+pub type SealedBlockAccessList = Sealed<Bytes>;
+
+/// A sealed block with optional validated block access-list data.
+pub type SealedBlockWithAccessList<B> = SealedBlockWith<B, Option<SealedBlockAccessList>>;
 
 impl<B: Block, T> SealedBlockWith<B, T> {
     /// Creates a sealed block with associated data.
@@ -60,14 +68,19 @@ impl<B: Block, T> SealedBlockWith<B, T> {
     }
 }
 
-impl<B: Block> SealedBlockWith<B, Option<BlockAccessLists>> {
+impl<B: Block> SealedBlockWithAccessList<B> {
     /// Creates a full block response without block access-list data.
     pub const fn from_block(block: SealedBlock<B>) -> Self {
         Self::new(block, None)
     }
 
-    /// Returns the optional raw block access-list data.
-    pub const fn access_lists(&self) -> Option<&BlockAccessLists> {
+    /// Returns the optional raw block access-list data, sealed by its hash.
+    pub const fn access_list(&self) -> Option<&SealedBlockAccessList> {
+        self.data.as_ref()
+    }
+
+    /// Returns the optional raw block access-list data, sealed by its hash.
+    pub const fn access_lists(&self) -> Option<&SealedBlockAccessList> {
         self.data.as_ref()
     }
 }
@@ -153,7 +166,7 @@ impl<Client> FullBlockClient<Client>
 where
     Client: BlockClient + BlockAccessListsClient,
 {
-    /// Returns a future that fetches the [`SealedBlock`] and optionally its [`BlockAccessLists`]
+    /// Returns a future that fetches the [`SealedBlock`] and optionally its block access list
     /// for the given hash.
     ///
     /// Note: this future is cancel safe
@@ -167,7 +180,7 @@ where
         self.get_full_block_with_access_lists_with_requirement(hash, BalRequirement::default())
     }
 
-    /// Returns a future that fetches the [`SealedBlock`] and optionally its [`BlockAccessLists`]
+    /// Returns a future that fetches the [`SealedBlock`] and optionally its block access list
     /// for the given hash using the requested BAL availability policy.
     ///
     /// Note: this future is cancel safe
@@ -189,7 +202,7 @@ where
         }
     }
 
-    /// Returns a future that fetches [`SealedBlock`]s and optionally their [`BlockAccessLists`] for
+    /// Returns a future that fetches [`SealedBlock`]s and optionally their block access lists for
     /// the given hash and count.
     ///
     /// The block range is always the primary result. Access lists are requested after the block
@@ -207,7 +220,7 @@ where
         )
     }
 
-    /// Returns a future that fetches [`SealedBlock`]s and optionally their [`BlockAccessLists`] for
+    /// Returns a future that fetches [`SealedBlock`]s and optionally their block access lists for
     /// the given hash and count using the requested BAL availability policy.
     ///
     /// The block range is always the primary result. Access lists are requested after the block
@@ -434,7 +447,11 @@ where
                 let (peer, access_lists) = bal.split();
                 match access_lists.0.len() {
                     0 => self.bal_request_state = BalRequestState::Ready(None),
-                    1 => self.bal_request_state = BalRequestState::Ready(Some(access_lists)),
+                    1 => {
+                        let access_list = access_lists.0.into_iter().next().expect("len checked");
+                        self.bal_request_state =
+                            BalRequestState::Ready(Some(WithPeerId::new(peer, access_list)));
+                    }
                     received => {
                         debug!(
                             target: "downloaders",
@@ -467,12 +484,19 @@ where
     /// The BAL lookup must be ready even when it resolved to `None`, which prevents a fast block
     /// response from racing a still-pending BAL response and incorrectly dropping available BAL
     /// data.
-    fn take_block_and_access_lists(
-        &mut self,
-    ) -> Option<SealedBlockWith<Client::Block, Option<BlockAccessLists>>> {
-        let BalRequestState::Ready(access_lists) = &mut self.bal_request_state else { return None };
+    fn take_block_and_access_lists(&mut self) -> Option<SealedBlockWithAccessList<Client::Block>> {
+        let BalRequestState::Ready(access_list) = &mut self.bal_request_state else { return None };
         let block = self.block_result.take()?;
-        Some(SealedBlockWith::new(block, access_lists.take()))
+        let access_list = access_list.take().and_then(|access_list| {
+            match seal_block_access_list_for_block(&block, access_list) {
+                Ok(access_list) => access_list,
+                Err(peer) => {
+                    self.block.client.report_bad_message(peer);
+                    None
+                }
+            }
+        });
+        Some(SealedBlockWith::new(block, access_list))
     }
 }
 
@@ -480,7 +504,7 @@ impl<Client> Future for FetchFullBlockWithBalFuture<Client>
 where
     Client: BlockClient<Header: BlockHeader + Sealable> + BlockAccessListsClient + 'static,
 {
-    type Output = SealedBlockWith<Client::Block, Option<BlockAccessLists>>;
+    type Output = SealedBlockWithAccessList<Client::Block>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -517,7 +541,7 @@ where
 /// Tracks the BAL request and its completed result.
 enum BalRequestState<Req> {
     Pending(Req),
-    Ready(Option<BlockAccessLists>),
+    Ready(Option<WithPeerId<Bytes>>),
 }
 
 impl<Req> BalRequestState<Req> {
@@ -565,30 +589,6 @@ where
         );
     }
 
-    fn on_access_lists_response(&mut self, response: WithPeerId<BlockAccessLists>) {
-        let (peer, access_lists) = response.split();
-        let expected =
-            self.block_result.as_ref().expect("blocks should be ready before BAL response").len();
-        let received = access_lists.0.len();
-
-        if received > expected {
-            debug!(
-                target: "downloaders",
-                start_hash = ?self.blocks.start_hash(),
-                expected,
-                received,
-                "Received wrong access list range response",
-            );
-            self.client.report_bad_message(peer);
-            self.access_lists = OptionalBlockAccessListsState::Ready(None);
-            return
-        }
-
-        // Short BAL responses are allowed by the wire protocol. Preserve the returned prefix and
-        // let callers decide whether they need to fetch the remaining entries.
-        self.access_lists = OptionalBlockAccessListsState::Ready(Some(access_lists));
-    }
-
     /// Starts and polls the optional BAL request once, if it is ready to make progress.
     fn poll_access_lists(&mut self, cx: &mut Context<'_>) {
         self.start_access_lists_request_if_possible();
@@ -601,7 +601,9 @@ where
 
         match poll {
             Poll::Pending => {}
-            Poll::Ready(Ok(access_lists)) => self.on_access_lists_response(access_lists),
+            Poll::Ready(Ok(access_lists)) => {
+                self.access_lists = OptionalBlockAccessListsState::Ready(Some(access_lists));
+            }
             Poll::Ready(Err(err)) => {
                 debug!(
                     target: "downloaders",
@@ -618,29 +620,14 @@ where
     }
 
     /// Returns the block range once blocks and the optional BAL lookup are both complete.
-    fn take_response(
-        &mut self,
-    ) -> Option<Vec<SealedBlockWith<Client::Block, Option<BlockAccessLists>>>> {
+    fn take_response(&mut self) -> Option<Vec<SealedBlockWithAccessList<Client::Block>>> {
         let OptionalBlockAccessListsState::Ready(access_lists) = &mut self.access_lists else {
             return None
         };
 
         let blocks = self.block_result.take()?;
-        let mut access_lists = access_lists.take().map(|access_lists| access_lists.0.into_iter());
 
-        Some(
-            blocks
-                .into_iter()
-                .map(|block| {
-                    let access_lists = access_lists
-                        .as_mut()
-                        .and_then(|access_lists| access_lists.next())
-                        .map(|access_list| BlockAccessLists(vec![access_list]));
-
-                    SealedBlockWith::new(block, access_lists)
-                })
-                .collect(),
-        )
+        Some(seal_blocks_with_access_lists(&self.client, blocks, access_lists.take()))
     }
 }
 
@@ -650,7 +637,7 @@ where
         + BlockAccessListsClient
         + 'static,
 {
-    type Output = Vec<SealedBlockWith<Client::Block, Option<BlockAccessLists>>>;
+    type Output = Vec<SealedBlockWithAccessList<Client::Block>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -682,7 +669,7 @@ enum OptionalBlockAccessListsState<Req> {
     /// A `GetBlockAccessLists` request is in flight.
     Pending(Req),
     /// `None` means the block range is available but optional BAL data is not.
-    Ready(Option<BlockAccessLists>),
+    Ready(Option<WithPeerId<BlockAccessLists>>),
 }
 
 impl<Client> Debug for FetchFullBlockFuture<Client>
@@ -1175,13 +1162,106 @@ impl<Net> Default for NoopFullBlockClient<Net> {
     }
 }
 
+/// Validates one raw block access-list entry against the block's access-list hash.
+///
+/// Returns `Ok(Some(_))` for a matching entry, `Ok(None)` when the block has no access-list hash
+/// or the peer returned the RLP empty-list unavailable marker, and `Err(peer)` for a non-empty hash
+/// mismatch that should be reported as a bad message.
+fn seal_block_access_list_for_block<B: Block>(
+    block: &SealedBlock<B>,
+    access_list: WithPeerId<Bytes>,
+) -> Result<Option<Sealed<Bytes>>, PeerId> {
+    let Some(expected) = block.header().block_access_list_hash() else { return Ok(None) };
+
+    let (peer, access_list) = access_list.split();
+    let computed = keccak256(access_list.as_ref());
+    if computed == expected {
+        return Ok(Some(Sealed::new_unchecked(access_list, expected)))
+    }
+
+    // A mismatched RLP empty list means the peer returned the "unavailable" BAL entry.
+    if access_list.as_ref() == [EMPTY_LIST_CODE] {
+        return Ok(None)
+    }
+
+    debug!(
+        target: "downloaders",
+        block_hash = ?block.hash(),
+        ?computed,
+        ?expected,
+        "Received block access list with wrong hash",
+    );
+    Err(peer)
+}
+
+/// Wraps a block range with validated block access-list entries.
+///
+/// Short responses are treated as a valid prefix and the remaining blocks receive `None`.
+/// Responses longer than the requested block range return the full block range without access-list
+/// data. Non-empty hash mismatches stop accepting access-list data after reporting the peer, so any
+/// already validated prefix is preserved.
+fn seal_blocks_with_access_lists<Client>(
+    client: &Client,
+    blocks: Vec<SealedBlock<Client::Block>>,
+    access_lists: Option<WithPeerId<BlockAccessLists>>,
+) -> Vec<SealedBlockWithAccessList<Client::Block>>
+where
+    Client: BlockClient,
+{
+    let Some(access_lists) = access_lists else {
+        return blocks.into_iter().map(SealedBlockWith::from_block).collect()
+    };
+
+    let (peer, access_lists) = access_lists.split();
+    let expected = blocks.len();
+    let received = access_lists.0.len();
+
+    if received > expected {
+        trace!(
+            target: "downloaders",
+            expected,
+            received,
+            "Ignoring overlong access list range response",
+        );
+        return blocks.into_iter().map(SealedBlockWith::from_block).collect()
+    }
+
+    let mut access_lists = access_lists.0.into_iter();
+    let mut blocks = blocks.into_iter();
+    let mut response = Vec::with_capacity(expected);
+
+    for block in blocks.by_ref() {
+        let Some(access_list) = access_lists.next() else {
+            // Short BAL responses are valid; the current block and all remaining blocks are
+            // returned without access-list data below.
+            response.push(SealedBlockWith::from_block(block));
+            break
+        };
+
+        match seal_block_access_list_for_block(&block, WithPeerId::new(peer, access_list)) {
+            Ok(access_list) => response.push(SealedBlockWith::new(block, access_list)),
+            Err(peer) => {
+                // A hash mismatch means this BAL entry is not for the current block. Stop matching
+                // later positional entries and return the rest of the range without BAL data.
+                client.report_bad_message(peer);
+                response.push(SealedBlockWith::from_block(block));
+                break
+            }
+        }
+    }
+
+    response.extend(blocks.map(SealedBlockWith::from_block));
+    response
+}
+
 #[cfg(test)]
 mod tests {
     use reth_ethereum_primitives::BlockBody;
 
     use super::*;
     use crate::{error::RequestError, test_utils::TestFullBlockClient};
-    use alloy_primitives::Bytes;
+    use alloy_consensus::Header;
+    use alloy_primitives::{keccak256, Bytes};
     use parking_lot::Mutex;
     use std::{
         collections::HashMap,
@@ -1193,13 +1273,23 @@ mod tests {
     };
     use tokio::time::{timeout, Duration};
 
-    // RLP encoding for an empty list.
-    const EMPTY_LIST_CODE: u8 = 0xc0;
+    fn sealed_access_list(access_list: Bytes) -> Sealed<Bytes> {
+        let hash = keccak256(access_list.as_ref());
+        Sealed::new_unchecked(access_list, hash)
+    }
+
+    fn sealed_header_with_access_list_hash(access_list: &Bytes) -> SealedHeader {
+        let header = Header {
+            block_access_list_hash: Some(keccak256(access_list.as_ref())),
+            ..Default::default()
+        };
+        SealedHeader::seal_slow(header)
+    }
 
     fn range_access_lists<B: Block>(
-        blocks: &[SealedBlockWith<B, Option<BlockAccessLists>>],
-    ) -> Vec<Option<BlockAccessLists>> {
-        blocks.iter().map(|block| block.access_lists().cloned()).collect()
+        blocks: &[SealedBlockWithAccessList<B>],
+    ) -> Vec<Option<Sealed<Bytes>>> {
+        blocks.iter().map(|block| block.access_list().cloned()).collect()
     }
 
     #[tokio::test]
@@ -1230,27 +1320,28 @@ mod tests {
     #[tokio::test]
     async fn download_single_full_block_with_access_lists() {
         let client = FullBlockWithAccessListsClient::default();
-        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&access_list);
         client.insert(header.clone(), body.clone(), access_list.clone());
 
         let request_count = Arc::clone(&client.access_list_requests);
         let client = FullBlockClient::test_client(client);
 
         let received = client.get_full_block_with_access_lists(header.hash()).await;
+        let expected_access_list = sealed_access_list(access_list);
 
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received.access_lists(), Some(&BlockAccessLists(vec![access_list])));
+        assert_eq!(received.access_list(), Some(&expected_access_list));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
     async fn download_single_full_block_with_access_lists_uses_requested_requirement() {
         let client = FullBlockWithAccessListsClient::default();
-        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&access_list);
         client.insert(header.clone(), body.clone(), access_list.clone());
 
         let requirement = Arc::clone(&client.last_access_list_requirement);
@@ -1263,8 +1354,9 @@ mod tests {
             )
             .await;
 
+        let expected_access_list = sealed_access_list(access_list);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received.access_lists(), Some(&BlockAccessLists(vec![access_list])));
+        assert_eq!(received.access_list(), Some(&expected_access_list));
         assert_eq!(*requirement.lock(), Some(BalRequirement::Mandatory));
     }
 
@@ -1273,9 +1365,9 @@ mod tests {
         let client = FullBlockWithAccessListsClient::default();
         client.set_access_list_pending_polls(1);
 
-        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&access_list);
         client.insert(header.clone(), body.clone(), access_list.clone());
 
         let request_count = Arc::clone(&client.access_list_requests);
@@ -1286,9 +1378,54 @@ mod tests {
                 .await
                 .expect("access list request should complete");
 
+        let expected_access_list = sealed_access_list(access_list);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received.access_lists(), Some(&BlockAccessLists(vec![access_list])));
+        assert_eq!(received.access_list(), Some(&expected_access_list));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_single_full_block_with_access_lists_rejects_wrong_hash() {
+        let client = FullBlockWithAccessListsClient::default();
+        let body = BlockBody::default();
+        let expected_access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let wrong_access_list = Bytes::from_static(&[0xc1, 0x01]);
+        let header = sealed_header_with_access_list_hash(&expected_access_list);
+        client.insert(header.clone(), body.clone(), wrong_access_list);
+
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let received =
+            timeout(Duration::from_secs(1), client.get_full_block_with_access_lists(header.hash()))
+                .await
+                .expect("block request should complete without access lists");
+
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert!(received.access_list().is_none());
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_single_full_block_with_access_lists_treats_empty_entry_as_unavailable() {
+        let client = FullBlockWithAccessListsClient::default();
+        let body = BlockBody::default();
+        let expected_access_list = Bytes::from_static(&[0xc1, 0x01]);
+        let unavailable_access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&expected_access_list);
+        client.insert(header.clone(), body.clone(), unavailable_access_list);
+
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let received =
+            timeout(Duration::from_secs(1), client.get_full_block_with_access_lists(header.hash()))
+                .await
+                .expect("block request should complete without access lists");
+
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert!(received.access_list().is_none());
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -1296,9 +1433,9 @@ mod tests {
         let client = FullBlockWithAccessListsClient::default();
         client.empty_first_response.store(true, Ordering::SeqCst);
 
-        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&access_list);
         client.insert(header.clone(), body.clone(), access_list.clone());
 
         let request_count = Arc::clone(&client.access_list_requests);
@@ -1311,7 +1448,7 @@ mod tests {
                 .expect("block request should complete without access lists");
 
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert!(received.access_lists().is_none());
+        assert!(received.access_list().is_none());
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
         assert_eq!(bad_messages.load(Ordering::SeqCst), 0);
     }
@@ -1321,9 +1458,9 @@ mod tests {
         let client = FullBlockWithAccessListsClient::default();
         client.set_access_lists_unsupported(true);
 
-        let header: SealedHeader = SealedHeader::default();
         let body = BlockBody::default();
         let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&access_list);
         client.insert(header.clone(), body.clone(), access_list);
 
         let request_count = Arc::clone(&client.access_list_requests);
@@ -1336,7 +1473,7 @@ mod tests {
                 .expect("block request should complete without access lists");
 
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert!(received.access_lists().is_none());
+        assert!(received.access_list().is_none());
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
         assert_eq!(
             *requirement.lock(),
@@ -1431,9 +1568,10 @@ mod tests {
             let (mut header, hash) = sealed_header.split();
             header.parent_hash = hash;
             header.number += 1;
+            let access_list = Bytes::from(vec![0xc1, block_idx as u8]);
+            header.block_access_list_hash = Some(keccak256(access_list.as_ref()));
 
             sealed_header = SealedHeader::seal_slow(header);
-            let access_list = Bytes::from(vec![EMPTY_LIST_CODE, block_idx as u8]);
 
             client.insert(sealed_header.clone(), body.clone(), access_list);
         }
@@ -1700,7 +1838,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(BlockAccessLists(vec![access_list]))
+                    Some(sealed_access_list(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1786,12 +1924,51 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(BlockAccessLists(vec![access_list]))
+                    Some(sealed_access_list(access_list))
                 })
                 .collect::<Vec<_>>()
         };
         assert_eq!(range_access_lists(&blocks), expected);
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_preserves_unavailable_entries() {
+        let client = FullBlockWithAccessListsClient::default();
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+        client.access_lists.lock().insert(header.hash(), Bytes::from_static(&[EMPTY_LIST_CODE]));
+
+        let access_lists = Arc::clone(&client.access_lists);
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let blocks = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete");
+
+        assert_eq!(blocks.len(), 3);
+        let expected = {
+            let access_lists = access_lists.lock();
+            blocks
+                .iter()
+                .map(|block| {
+                    if block.block().hash() == header.hash() {
+                        return None
+                    }
+
+                    let access_list = access_lists
+                        .get(&block.block().hash())
+                        .cloned()
+                        .expect("access list exists");
+                    Some(sealed_access_list(access_list))
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(range_access_lists(&blocks), expected);
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -1816,7 +1993,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_full_block_range_with_access_lists_rejects_long_response() {
+    async fn download_full_block_range_with_access_lists_ignores_long_response() {
         let client = FullBlockWithAccessListsClient::default();
         client.set_extra_access_list_entries(1);
         let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
@@ -1835,6 +2012,55 @@ mod tests {
         assert_eq!(blocks.len(), 3);
         assert_eq!(range_access_lists(&blocks), vec![None; blocks.len()]);
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_rejects_wrong_hash() {
+        let client = FullBlockWithAccessListsClient::default();
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+        client.access_lists.lock().insert(header.hash(), Bytes::from_static(&[0xc1, 0x7f]));
+
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let blocks = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete without access lists");
+
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(range_access_lists(&blocks), vec![None; blocks.len()]);
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn download_full_block_range_with_access_lists_preserves_valid_prefix_until_wrong_hash() {
+        let client = FullBlockWithAccessListsClient::default();
+        let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
+        let first_access_list =
+            client.access_lists.lock().get(&header.hash()).cloned().expect("access list exists");
+        let second_hash = header.parent_hash;
+        client.access_lists.lock().insert(second_hash, Bytes::from_static(&[0xc1, 0x7f]));
+
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let blocks = timeout(
+            Duration::from_secs(1),
+            client.get_full_block_range_with_optional_access_lists(header.hash(), 3),
+        )
+        .await
+        .expect("range request should complete without unvalidated access lists");
+
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(blocks[1].block().hash(), second_hash);
+        assert_eq!(
+            range_access_lists(&blocks),
+            vec![Some(sealed_access_list(first_access_list)), None, None]
+        );
         assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
     }
 


### PR DESCRIPTION
Validates downloaded block access list bytes against the block header hash before surfacing them from the full-block downloader APIs.

The downloader now returns validated `Sealed<Bytes>` payloads and treats `0xc0` unavailable entries as missing data, while reporting peers that provide non-empty mismatched BALs.