### PR TITLE
fix(engine): validate received BAL on serial path

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -33,12 +33,11 @@ impl From<RejectReason> for BalExecutionError {
 /// Reasons a block may be rejected on the BAL execution path.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RejectReason {
-    /// The rebuilt BAL's hash disagrees with `header.block_access_list_hash` at end-of-block.
-    /// Catches over-declared addresses and any divergence the per-tx fragment compares missed.
+    /// The rebuilt BAL disagrees with the received BAL at end-of-block.
     FinalHashMismatch {
         /// Hash of the rebuilt BAL.
         rebuilt: B256,
-        /// Hash committed in the block header.
+        /// Hash of the received BAL.
         expected: B256,
     },
 }

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -48,7 +48,7 @@ pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
     runtime: &Runtime,
     evm_config: &'a Evm,
     make_db: &'a MakeDb,
-    received_bal: Arc<DecodedBal>,
+    input_bal: Arc<DecodedBal>,
     evm_env: EvmEnvFor<Evm>,
     ctx: ExecutionCtxFor<'a, Evm>,
     transaction_count: usize,
@@ -71,7 +71,7 @@ where
             scope,
             evm_config,
             make_db,
-            received_bal,
+            input_bal,
             evm_env,
             ctx,
             transaction_count,
@@ -87,7 +87,7 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
     scope: &rayon::Scope<'scope>,
     evm_config: &'scope Evm,
     make_db: &'scope MakeDb,
-    received_bal: Arc<DecodedBal>,
+    input_bal: Arc<DecodedBal>,
     evm_env: EvmEnvFor<Evm>,
     ctx: ExecutionCtxFor<'scope, Evm>,
     transaction_count: usize,
@@ -103,8 +103,8 @@ where
     MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'scope,
     ReceiptTy<Evm::Primitives>: Clone,
 {
-    let bal = received_bal.as_bal();
-    let received_bal_revm: Arc<RevmBal> = Arc::new(
+    let bal = input_bal.as_bal();
+    let input_bal_revm: Arc<RevmBal> = Arc::new(
         RevmBal::try_from(Vec::<_>::from(bal.clone()))
             .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?,
     );
@@ -129,7 +129,7 @@ where
                 result_tx.clone(),
                 evm_config,
                 make_db,
-                Arc::clone(&received_bal_revm),
+                Arc::clone(&input_bal_revm),
                 evm_env.clone(),
                 ctx.clone(),
             );
@@ -144,6 +144,10 @@ where
         canonical_executor.apply_pre_execution_changes()?;
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
+        // `DecodedBal::hash` is lazy-cached. Compute the hash after workers are spawned and before
+        // waiting on ordered results, so the callsite can read the header commitment hash once
+        // execution finishes without adding serial work after the BAL equality check.
+        let _ = input_bal.hash();
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
             let output = output?;
 
@@ -170,7 +174,7 @@ where
         (block_result, senders)
     };
 
-    validate_bal(&mut canonical_state, bal)?;
+    validate_bal(&mut canonical_state, input_bal.as_ref())?;
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
     Ok((
@@ -202,29 +206,34 @@ where
     Ok(())
 }
 
-fn validate_bal<DB>(
+/// Validates that execution rebuilt the same BAL that was provided with the payload.
+///
+/// This consumes the BAL built by `canonical_state` and compares it against the decoded input
+/// BAL before post-execution validation relies on `DecodedBal::hash()` as the header commitment.
+pub(crate) fn validate_bal<DB>(
     canonical_state: &mut State<DB>,
-    received_bal: &AlloyBal,
+    input_bal: &DecodedBal,
 ) -> Result<(), BalExecutionError>
 where
     DB: Database,
 {
     let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
-    if composed_alloy == received_bal.as_ref() {
+    let input_bal_entries = input_bal.as_bal();
+    if composed_alloy == input_bal_entries.as_slice() {
         return Ok(());
     }
     let rebuilt = compute_block_access_list_hash(&composed_alloy);
-    let header_bal_hash = compute_block_access_list_hash(received_bal);
+    let expected_bal_hash = input_bal.hash();
 
     if tracing::enabled!(
         target: "engine::tree::payload_processor::bal",
         tracing::Level::DEBUG
     ) {
-        let div = received_bal.diff(&composed_alloy);
+        let div = input_bal_entries.diff(&composed_alloy);
         tracing::debug!(
             target: "engine::tree::payload_processor::bal",
             %rebuilt,
-            expected = %header_bal_hash,
+            expected = %expected_bal_hash,
             %div,
             "first BAL divergence",
         );
@@ -232,7 +241,7 @@ where
 
     Err(BalExecutionError::Reject(RejectReason::FinalHashMismatch {
         rebuilt,
-        expected: header_bal_hash,
+        expected: expected_bal_hash,
     }))
 }
 
@@ -423,10 +432,10 @@ mod tests {
         //      pass (A, B, D, F).
         let evm_config = EthEvmConfig::mainnet();
 
-        let received_bal = reference_bal_for_empty_block(&evm_config);
-        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&received_bal);
+        let input_bal = reference_bal_for_empty_block(&evm_config);
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&input_bal);
         // Sanity: reference BAL is non-empty (system calls populated it).
-        assert!(!received_bal.is_empty(), "empty BAL means system calls didn't record state");
+        assert!(!input_bal.is_empty(), "empty BAL means system calls didn't record state");
 
         let block = empty_amsterdam_block(bal_hash);
 
@@ -434,7 +443,7 @@ mod tests {
             &Runtime::test(),
             evm_config,
             db_factory(system_contracts_db()),
-            to_arc_decoded(received_bal),
+            to_arc_decoded(input_bal),
             &block,
             Vec::<Recovered<TransactionSigned>>::new(),
         );
@@ -465,7 +474,7 @@ mod tests {
         runtime: &Runtime,
         evm_config: EthEvmConfig,
         make_db: MakeDb,
-        received_bal: Arc<DecodedBal>,
+        input_bal: Arc<DecodedBal>,
         block: &SealedBlock<Block>,
         txs: Vec<Tx>,
     ) -> Result<BlockExecutionOutput<EthereumReceipt>, BalExecutionError>
@@ -482,7 +491,7 @@ mod tests {
             runtime,
             &evm_config,
             &make_db,
-            received_bal,
+            input_bal,
             evm_env,
             execution_ctx,
             transaction_count,

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -16,3 +16,4 @@ pub mod execute;
 
 pub use error::{BalExecutionError, RejectReason};
 pub use execute::execute_block;
+pub(crate) use execute::validate_bal;

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -49,7 +49,7 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
+use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -568,21 +568,12 @@ where
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
-        let (output, senders, receipt_root_rx, built_bal) = if bal_eligible {
-            let built_bal = Some(
-                env.decoded_bal
-                    .as_ref()
-                    .expect("eligibility implies BAL is present")
-                    .as_bal()
-                    .clone()
-                    .into(),
-            );
+        let decoded_bal = env.decoded_bal.clone();
+        let (output, senders, receipt_root_rx) = if bal_eligible {
             let provider_builder =
                 bal_provider_builder.expect("eligibility implies builder was cloned");
             match self.execute_block_bal(state_provider, env, &input, &handle, provider_builder) {
-                Ok((output, senders, receipt_root_rx)) => {
-                    (output, senders, receipt_root_rx, built_bal)
-                }
+                Ok(output) => output,
                 Err(err) => return self.handle_execution_error(input, err, &parent_block),
             }
         } else {
@@ -591,6 +582,7 @@ where
                 Err(err) => return self.handle_execution_error(input, err, &parent_block),
             }
         };
+        let block_access_list_hash = decoded_bal.as_ref().map(|decoded_bal| decoded_bal.hash());
         let execution_duration = execute_block_start.elapsed();
 
         // After executing the block we can stop prewarming transactions
@@ -668,7 +660,7 @@ where
                 transaction_root,
                 receipt_root_bloom,
                 hashed_state,
-                built_bal
+                block_access_list_hash
             ),
             block
         );
@@ -921,12 +913,7 @@ where
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
     ) -> Result<
-        (
-            BlockExecutionOutput<N::Receipt>,
-            Vec<Address>,
-            ReceiptRootReceiver,
-            Option<BlockAccessList>,
-        ),
+        (BlockExecutionOutput<N::Receipt>, Vec<Address>, ReceiptRootReceiver),
         InsertBlockErrorKind,
     >
     where
@@ -1014,12 +1001,16 @@ where
             .map(|(evm, result)| (evm.into_db(), result))?;
         self.metrics.record_post_execution(post_exec_start.elapsed());
 
+        if let Some(decoded_bal) = &env.decoded_bal {
+            // Regular execution still handles BAL payloads when the parallel BAL path is
+            // disabled. Prove that execution rebuilt the payload-provided BAL before
+            // post-execution validation uses `decoded_bal.hash()` as the header commitment.
+            crate::tree::payload_processor::bal::validate_bal(&mut db, decoded_bal)?;
+        }
+
         // Merge transitions into bundle state
         debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
-
-        // Extract the built bal if payload has bal
-        let built_bal = if has_bal { db.take_built_alloy_bal() } else { None };
 
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
@@ -1028,7 +1019,7 @@ where
         self.metrics.record_block_execution_gas_bucket(output.result.gas_used, execution_duration);
         debug!(target: "engine::tree::payload_validator", elapsed = ?execution_duration, "Executed block");
 
-        Ok((output, senders, result_rx, built_bal))
+        Ok((output, senders, result_rx))
     }
 
     /// Returns true when the BAL execute path should be used for this block.
@@ -1094,7 +1085,7 @@ where
         let saved_cache = SavedCache::new(env.parent_hash, cache);
 
         let (receipt_tx, result_rx) = self.spawn_receipt_root_task(env.transaction_count);
-        let decoded_bal = env.decoded_bal.ok_or_else(|| {
+        let input_bal = env.decoded_bal.ok_or_else(|| {
             InsertBlockErrorKind::Other("BAL execute path: no decoded BAL available".into())
         })?;
 
@@ -1115,7 +1106,7 @@ where
             &self.runtime,
             &self.evm_config,
             &make_db,
-            decoded_bal,
+            input_bal,
             env.evm_env,
             ctx,
             env.transaction_count,
@@ -1520,7 +1511,7 @@ where
         transaction_root: Option<B256>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
         hashed_state: LazyHashedPostState,
-        built_bal: Option<BlockAccessList>,
+        block_access_list_hash: Option<B256>,
     ) -> Result<LazyHashedPostState, InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1547,9 +1538,6 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
-        let block_access_list_hash =
-            built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal));
-
         if let Err(err) = self.consensus.validate_block_post_execution(
             block,
             output,


### PR DESCRIPTION
The regular execution path built a BAL and validated that rebuilt hash against the header, but did not validate that the rebuilt BAL matched the received payload BAL. The parallel BAL path already performed that rebuilt-vs-received check.

This shares the rebuilt-vs-received BAL validation with regular execution so both paths enforce the same invariant.

Once that invariant holds, post-execution validation can use the cached hash from `DecodedBal` instead of re-encoding the rebuilt BAL.
