### PR TITLE
ci(bench): add checkout step to save-state job

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -1035,6 +1035,12 @@ jobs:
     name: save-state
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: true
+
       - name: Push state to charts repo
         env:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}


### PR DESCRIPTION
## Summary

The `save-state` job in `bench-scheduled.yml` runs on a fresh `ubuntu-latest` runner without checking out the repo, so `.github/scripts/configure-git-token-user.sh` is missing — causing exit 127:

```
.github/scripts/configure-git-token-user.sh: No such file or directory
```

**Fix:** Add a sparse checkout of `.github/scripts`, matching the pattern already used by the `resolve-refs` job.

**Failing run:** https://github.com/paradigmxyz/reth/actions/runs/25666156313/job/75342043802

Prompted by: @shekhirin