### PR TITLE
ci(bench): run reth benchmarks in dedicated slice

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -28,6 +28,10 @@ mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+RETH_SLICE_ARGS=()
+if [ -n "${RETH_SLICE:-}" ]; then
+  RETH_SLICE_ARGS+=(--slice="$RETH_SLICE")
+fi
 
 cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
@@ -188,7 +192,7 @@ echo "Memory limit: $(( MEM_LIMIT / 1024 / 1024 ))MB (95% of $(( TOTAL_MEM_KB / 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   RETH_ARGS+=(--log.samply)
   SAMPLY="$(which samply)"
-  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" "${RETH_SLICE_ARGS[@]}" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 \
     "$SAMPLY" record --save-only --presymbolicate --rate 10000 \
@@ -196,7 +200,7 @@ if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
     -- "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &
 else
-  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" "${RETH_SLICE_ARGS[@]}" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -111,7 +111,7 @@ grep Cached /proc/meminfo
 # Start reth
 # CPU layout: core 0 = OS/IRQs/reth-bench/aux, cores 1+ = reth node
 RETH_BENCH="$(which reth-bench)"
-ONLINE=$(nproc --all)
+ONLINE=$(nproc)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -95,7 +95,7 @@ echo "=== Cache state after drop ==="
 free -h
 grep Cached /proc/meminfo
 
-ONLINE=$(nproc --all)
+ONLINE=$(nproc)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -21,6 +21,10 @@ mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+RETH_SLICE_ARGS=()
+if [ -n "${RETH_SLICE:-}" ]; then
+  RETH_SLICE_ARGS+=(--slice="$RETH_SLICE")
+fi
 
 # Unsupported txgen-path behavior is made explicit here. Keep these checks near
 # the top so new txgen support can be added one feature at a time.
@@ -163,7 +167,7 @@ echo "Memory limit: $(( MEM_LIMIT / 1024 / 1024 ))MB (95% of $(( TOTAL_MEM_KB / 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   RETH_ARGS+=(--log.samply)
   SAMPLY="$(which samply)"
-  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" "${RETH_SLICE_ARGS[@]}" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 \
     "$SAMPLY" record --save-only --presymbolicate --rate 10000 \
@@ -171,7 +175,7 @@ if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
     -- "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &
 else
-  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" "${RETH_SLICE_ARGS[@]}" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -257,6 +257,7 @@ jobs:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc
       SCHELK_MOUNT: /reth-bench
       RETH_SCOPE: reth-bench.scope
+      RETH_SLICE: reth-bench.slice
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_PR: ""
       BENCH_MODE: ${{ needs.resolve-refs.outputs.mode }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -976,6 +976,11 @@ jobs:
           done
           # Stop noisy background services
           sudo systemctl stop irqbalance cron atd unattended-upgrades snapd 2>/dev/null || true
+          # Keep host background work on the housekeeping core. The reth process
+          # is placed in reth-bench.slice and constrained by the run scripts.
+          sudo systemctl set-property --runtime system.slice AllowedCPUs=0
+          sudo systemctl set-property --runtime user.slice AllowedCPUs=0
+          sudo systemctl set-property --runtime machine.slice AllowedCPUs=0
           # Log environment for reproducibility
           echo "=== Benchmark environment ==="
           uname -r
@@ -1508,6 +1513,9 @@ jobs:
       - name: Restore system settings
         if: always()
         run: |
+          sudo systemctl set-property --runtime system.slice AllowedCPUs= 2>/dev/null || true
+          sudo systemctl set-property --runtime user.slice AllowedCPUs= 2>/dev/null || true
+          sudo systemctl set-property --runtime machine.slice AllowedCPUs= 2>/dev/null || true
           # Restore frequency scaling to full range
           for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_min_freq; do
             cat "$(dirname "$f")/cpuinfo_min_freq" | sudo tee "$f" > /dev/null 2>&1 || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -886,6 +886,32 @@ jobs:
           FEATURE_REF="${{ steps.refs.outputs.feature-ref }}"
           prepare_source_dir ../reth-feature "$FEATURE_REF"
 
+      - name: Reset runner CPU affinity
+        run: |
+          FULL_CPUS=$(cat /sys/fs/cgroup/cpuset.cpus.effective 2>/dev/null || true)
+          if [ -z "$FULL_CPUS" ]; then
+            FULL_CPUS="0-$(( $(nproc --all) - 1 ))"
+          fi
+
+          sudo systemctl set-property --runtime system.slice AllowedCPUs= 2>/dev/null || true
+          sudo systemctl set-property --runtime user.slice AllowedCPUs= 2>/dev/null || true
+          sudo systemctl set-property --runtime machine.slice AllowedCPUs= 2>/dev/null || true
+
+          for slice in system.slice user.slice machine.slice; do
+            if [ -d "/sys/fs/cgroup/${slice}" ]; then
+              cpuset="/sys/fs/cgroup/${slice}/cpuset.cpus"
+              current_cpuset=$(cat "$cpuset" 2>/dev/null || true)
+              if [ -n "$current_cpuset" ] && [ "$current_cpuset" != "$FULL_CPUS" ]; then
+                echo "$FULL_CPUS" | sudo tee "$cpuset" >/dev/null 2>&1 || true
+              fi
+              find "/sys/fs/cgroup/${slice}" -name cgroup.procs -print0 2>/dev/null | while IFS= read -r -d '' procs; do
+                while IFS= read -r pid; do
+                  [ -n "$pid" ] && sudo taskset -pc "$FULL_CPUS" "$pid" >/dev/null 2>&1 || true
+                done < "$procs"
+              done
+            fi
+          done
+
       - name: Build binaries
         id: build
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -900,10 +900,7 @@ jobs:
           for slice in system.slice user.slice machine.slice; do
             if [ -d "/sys/fs/cgroup/${slice}" ]; then
               cpuset="/sys/fs/cgroup/${slice}/cpuset.cpus"
-              current_cpuset=$(cat "$cpuset" 2>/dev/null || true)
-              if [ -n "$current_cpuset" ] && [ "$current_cpuset" != "$FULL_CPUS" ]; then
-                echo "$FULL_CPUS" | sudo tee "$cpuset" >/dev/null 2>&1 || true
-              fi
+              echo "$FULL_CPUS" | sudo tee "$cpuset" >/dev/null 2>&1 || true
               find "/sys/fs/cgroup/${slice}" -name cgroup.procs -print0 2>/dev/null | while IFS= read -r -d '' procs; do
                 while IFS= read -r pid; do
                   [ -n "$pid" ] && sudo taskset -pc "$FULL_CPUS" "$pid" >/dev/null 2>&1 || true
@@ -1562,10 +1559,7 @@ jobs:
           for slice in system.slice user.slice machine.slice; do
             if [ -d "/sys/fs/cgroup/${slice}" ]; then
               cpuset="/sys/fs/cgroup/${slice}/cpuset.cpus"
-              current_cpuset=$(cat "$cpuset" 2>/dev/null || true)
-              if [ -n "$current_cpuset" ] && [ "$current_cpuset" != "$FULL_CPUS" ]; then
-                echo "$FULL_CPUS" | sudo tee "$cpuset" >/dev/null 2>&1 || true
-              fi
+              echo "$FULL_CPUS" | sudo tee "$cpuset" >/dev/null 2>&1 || true
               find "/sys/fs/cgroup/${slice}" -name cgroup.procs -print0 2>/dev/null | while IFS= read -r -d '' procs; do
                 while IFS= read -r pid; do
                   [ -n "$pid" ] && sudo taskset -pc "$FULL_CPUS" "$pid" >/dev/null 2>&1 || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1520,9 +1520,33 @@ jobs:
       - name: Restore system settings
         if: always()
         run: |
+          FULL_CPUS=$(cat /sys/fs/cgroup/cpuset.cpus.effective 2>/dev/null || true)
+          if [ -z "$FULL_CPUS" ]; then
+            FULL_CPUS="0-$(( $(nproc --all) - 1 ))"
+          fi
           sudo systemctl set-property --runtime system.slice AllowedCPUs= 2>/dev/null || true
           sudo systemctl set-property --runtime user.slice AllowedCPUs= 2>/dev/null || true
           sudo systemctl set-property --runtime machine.slice AllowedCPUs= 2>/dev/null || true
+
+          # Clearing AllowedCPUs removes the cgroup restriction, but tasks that
+          # were running while the slice was CPU0-only can retain a narrowed
+          # sched affinity mask. Reset tasks in the affected slices so the
+          # persistent runner service does not pass CPU0-only affinity to the
+          # next job's build step.
+          for slice in system.slice user.slice machine.slice; do
+            if [ -d "/sys/fs/cgroup/${slice}" ]; then
+              cpuset="/sys/fs/cgroup/${slice}/cpuset.cpus"
+              current_cpuset=$(cat "$cpuset" 2>/dev/null || true)
+              if [ -n "$current_cpuset" ] && [ "$current_cpuset" != "$FULL_CPUS" ]; then
+                echo "$FULL_CPUS" | sudo tee "$cpuset" >/dev/null 2>&1 || true
+              fi
+              find "/sys/fs/cgroup/${slice}" -name cgroup.procs -print0 2>/dev/null | while IFS= read -r -d '' procs; do
+                while IFS= read -r pid; do
+                  [ -n "$pid" ] && sudo taskset -pc "$FULL_CPUS" "$pid" >/dev/null 2>&1 || true
+                done < "$procs"
+              done
+            fi
+          done
           # Restore frequency scaling to full range
           for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_min_freq; do
             cat "$(dirname "$f")/cpuinfo_min_freq" | sudo tee "$f" > /dev/null 2>&1 || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -600,6 +600,7 @@ jobs:
       BENCH_RPC_URL: https://ethereum.reth.rs/rpc
       SCHELK_MOUNT: /reth-bench
       RETH_SCOPE: reth-bench.scope
+      RETH_SLICE: reth-bench.slice
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_PR: ${{ needs.reth-bench-ack.outputs.pr }}
       BENCH_PR_HEAD_SHA: ${{ needs.reth-bench-ack.outputs.pr-head-sha }}


### PR DESCRIPTION
Runs reth benchmark scopes under a dedicated `reth-bench.slice` by passing `--slice` to the shared benchmark launch scripts. This keeps the existing `reth-bench.scope` unit name while making the bench cgroup a top-level slice that can later be isolated independently from `system.slice`.

Verified with YAML parsing, bash syntax checks, and `git diff --check`.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: brian
