### PR TITLE
feat(engine): return BAL in payload bodies by hash v2

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -7,7 +7,7 @@ use alloy_eips::{
     eip4895::Withdrawals,
     eip7685::RequestsOrHash,
 };
-use alloy_primitives::{BlockHash, BlockNumber, B128, B256, U64};
+use alloy_primitives::{BlockHash, BlockNumber, Bytes, B128, B256, U64};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ClientVersionV1, ExecutionData, ExecutionPayloadBodiesV1,
     ExecutionPayloadBodiesV2, ExecutionPayloadBodyV1, ExecutionPayloadBodyV2,
@@ -27,7 +27,7 @@ use reth_payload_primitives::{
 };
 use reth_primitives_traits::{Block, BlockBody};
 use reth_rpc_api::{EngineApiServer, IntoEngineApiRpcModule};
-use reth_storage_api::{BlockReader, HeaderProvider, StateProviderFactory};
+use reth_storage_api::{BalProvider, BlockReader, HeaderProvider, StateProviderFactory};
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
 use std::{
@@ -77,7 +77,7 @@ impl<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSpec>
 impl<Provider, PayloadT, Pool, Validator, ChainSpec>
     EngineApi<Provider, PayloadT, Pool, Validator, ChainSpec>
 where
-    Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
+    Provider: HeaderProvider + BlockReader + StateProviderFactory + BalProvider + 'static,
     PayloadT: PayloadTypes,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<PayloadT>,
@@ -294,7 +294,7 @@ where
 impl<Provider, EngineT, Pool, Validator, ChainSpec>
     EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
-    Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
+    Provider: HeaderProvider + BlockReader + StateProviderFactory + BalProvider + 'static,
     EngineT: EngineTypes,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<EngineT>,
@@ -759,6 +759,30 @@ where
         rx.await.map_err(|err| EngineApiError::Internal(Box::new(err)))?
     }
 
+    async fn get_block_access_lists_by_hashes(
+        &self,
+        hashes: Vec<BlockHash>,
+    ) -> EngineApiResult<Vec<Option<Bytes>>> {
+        let len = hashes.len() as u64;
+        if len > MAX_PAYLOAD_BODIES_LIMIT {
+            return Err(EngineApiError::PayloadRequestTooLarge { len });
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let bal_store = self.inner.provider.bal_store().clone();
+
+        self.inner.task_spawner.spawn_blocking_task(async move {
+            tx.send(
+                bal_store
+                    .get_by_hashes(&hashes)
+                    .map_err(|err| EngineApiError::Internal(Box::new(err))),
+            )
+            .ok();
+        });
+
+        rx.await.map_err(|err| EngineApiError::Internal(Box::new(err)))?
+    }
+
     /// Called to retrieve execution payload bodies by hashes.
     pub async fn get_payload_bodies_by_hash_v1(
         &self,
@@ -789,12 +813,23 @@ where
         &self,
         hashes: Vec<BlockHash>,
     ) -> EngineApiResult<ExecutionPayloadBodiesV2> {
-        self.get_payload_bodies_by_hash_with(hashes, |block| ExecutionPayloadBodyV2 {
-            transactions: block.body().encoded_2718_transactions(),
-            withdrawals: block.body().withdrawals().cloned().map(Withdrawals::into_inner),
-            block_access_list: None,
-        })
-        .await
+        let payload_bodies =
+            self.get_payload_bodies_by_hash_with(hashes.clone(), |block| ExecutionPayloadBodyV2 {
+                transactions: block.body().encoded_2718_transactions(),
+                withdrawals: block.body().withdrawals().cloned().map(Withdrawals::into_inner),
+                block_access_list: None,
+            });
+        let block_access_lists = self.get_block_access_lists_by_hashes(hashes);
+        let (mut payload_bodies, block_access_lists) =
+            tokio::try_join!(payload_bodies, block_access_lists)?;
+
+        for (payload_body, block_access_list) in payload_bodies.iter_mut().zip(block_access_lists) {
+            if let Some(payload_body) = payload_body {
+                payload_body.block_access_list = block_access_list;
+            }
+        }
+
+        Ok(payload_bodies)
     }
 
     /// Metrics version of `get_payload_bodies_by_hash_v2`
@@ -1067,7 +1102,7 @@ where
 impl<Provider, EngineT, Pool, Validator, ChainSpec> EngineApiServer<EngineT>
     for EngineApi<Provider, EngineT, Pool, Validator, ChainSpec>
 where
-    Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
+    Provider: HeaderProvider + BlockReader + StateProviderFactory + BalProvider + 'static,
     EngineT: EngineTypes<ExecutionData = ExecutionData>,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<EngineT>,
@@ -1498,8 +1533,8 @@ struct EngineApiInner<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eips::eip7685::Requests;
-    use alloy_primitives::{Address, Bytes, B256};
+    use alloy_eips::{eip7685::Requests, NumHash};
+    use alloy_primitives::{keccak256, Address, Bytes, Sealed, B256};
     use alloy_rpc_types_engine::{
         ClientCode, ClientVersionV1, ExecutionPayloadV2, PayloadAttributes, PayloadStatusEnum,
     };
@@ -1513,7 +1548,7 @@ mod tests {
     };
     use reth_node_ethereum::EthereumEngineValidator;
     use reth_payload_builder::test_utils::spawn_test_payload_service;
-    use reth_provider::test_utils::MockEthProvider;
+    use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore};
     use reth_tasks::Runtime;
     use reth_transaction_pool::noop::NoopTransactionPool;
     use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
@@ -1568,6 +1603,62 @@ mod tests {
         let (_, api) = setup_engine_api();
         let res = api.get_client_version_v1(client.clone());
         assert_eq!(res.unwrap(), vec![client]);
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_hash_v2_returns_block_access_list_from_store() {
+        let bal_store = BalStoreHandle::new(InMemoryBalStore::default());
+        let mut provider = MockEthProvider::default();
+        provider.bal_store = bal_store.clone();
+        let provider = Arc::new(provider);
+
+        let client = ClientVersionV1 {
+            code: ClientCode::RH,
+            name: "Reth".to_string(),
+            version: "v0.2.0-beta.5".to_string(),
+            commit: "defa64b2".to_string(),
+        };
+        let chain_spec: Arc<ChainSpec> = MAINNET.clone();
+        let payload_store = spawn_test_payload_service::<EthEngineTypes>();
+        let (to_engine, _engine_rx) = unbounded_channel();
+        let api = EngineApi::new(
+            provider.clone(),
+            chain_spec.clone(),
+            ConsensusEngineHandle::new(to_engine),
+            payload_store.into(),
+            NoopTransactionPool::default(),
+            Runtime::test(),
+            client,
+            EngineCapabilities::default(),
+            EthereumEngineValidator::new(chain_spec),
+            false,
+            NoopNetwork::default(),
+        );
+
+        let mut block = Block::default();
+        block.header.number = 1;
+        let block_hash = block.header.hash_slow();
+        provider.add_block(block_hash, block);
+
+        let mut block_without_bal = Block::default();
+        block_without_bal.header.number = 2;
+        let block_without_bal_hash = block_without_bal.header.hash_slow();
+        provider.add_block(block_without_bal_hash, block_without_bal);
+
+        let raw_bal = Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]);
+        let sealed_bal = Sealed::new_unchecked(raw_bal.clone(), keccak256(&raw_bal));
+        bal_store.insert(NumHash::new(1, block_hash), sealed_bal).unwrap();
+
+        let missing_hash = B256::with_last_byte(3);
+        let response = api
+            .get_payload_bodies_by_hash_v2(vec![block_hash, block_without_bal_hash, missing_hash])
+            .await
+            .unwrap();
+
+        assert_eq!(response.len(), 3);
+        assert_eq!(response[0].as_ref().unwrap().block_access_list, Some(raw_bal));
+        assert_eq!(response[1].as_ref().unwrap().block_access_list, None);
+        assert!(response[2].is_none());
     }
 
     struct EngineApiTestHandle {


### PR DESCRIPTION
 Returns stored block access lists in `engine_getPayloadBodiesByHashV2` instead of always setting `block_access_list` to `null`.

The Engine API now receives a `BalStoreHandle` directly and uses it to batch-load BALs for the requested hashes. This keeps BAL lookup out of the `EngineApiServer` provider bounds while preserving the existing payload body request limit and shared block lookup path.

cc @mattsse 