### PR TITLE
fix(benches): extend samply shutdown wait

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -11,6 +11,7 @@
 #               BENCH_WAIT_TIME (duration like 500ms, default empty)
 #               BENCH_BASELINE_ARGS (extra reth node args for baseline runs)
 #               BENCH_FEATURE_ARGS (extra reth node args for feature runs)
+#               BENCH_SAMPLY_SHUTDOWN_TIMEOUT (seconds to wait for samply to flush, default 300)
 #               BENCH_OTLP_TRACES_ENDPOINT (OTLP HTTP endpoint for traces, e.g. https://host/insert/opentelemetry/v1/traces)
 #               BENCH_OTLP_LOGS_ENDPOINT (OTLP HTTP endpoint for logs, e.g. https://host/insert/opentelemetry/v1/logs)
 #               BENCH_OTLP_DISABLED (true to skip OTLP export even if endpoints are set)
@@ -28,6 +29,7 @@ mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+SAMPLY_SHUTDOWN_TIMEOUT="${BENCH_SAMPLY_SHUTDOWN_TIMEOUT:-300}"
 
 cleanup() {
   kill "$TAIL_PID" 2>/dev/null || true
@@ -56,7 +58,7 @@ cleanup() {
       # capture reth's exit and save the profile.
       sudo pkill -INT -x reth 2>/dev/null || true
       # Wait for samply to finish writing the profile and exit
-      for i in $(seq 1 120); do
+      for i in $(seq 1 "$SAMPLY_SHUTDOWN_TIMEOUT"); do
         sudo pgrep -x samply > /dev/null 2>&1 || break
         if [ $((i % 10)) -eq 0 ]; then
           echo "Waiting for samply to finish writing profile... (${i}s)"
@@ -64,7 +66,7 @@ cleanup() {
         sleep 1
       done
       if sudo pgrep -x samply > /dev/null 2>&1; then
-        echo "Samply still running after 120s, sending SIGTERM..."
+        echo "Samply still running after ${SAMPLY_SHUTDOWN_TIMEOUT}s, sending SIGTERM..."
         sudo pkill -x samply 2>/dev/null || true
       fi
     fi

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -10,7 +10,8 @@
 # Optional env: BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
-#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ
+#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ,
+#               BENCH_SAMPLY_SHUTDOWN_TIMEOUT
 set -euxo pipefail
 
 LABEL="$1"
@@ -21,6 +22,7 @@ mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+SAMPLY_SHUTDOWN_TIMEOUT="${BENCH_SAMPLY_SHUTDOWN_TIMEOUT:-300}"
 
 # Unsupported txgen-path behavior is made explicit here. Keep these checks near
 # the top so new txgen support can be added one feature at a time.
@@ -54,14 +56,17 @@ cleanup() {
   if sudo systemctl is-active "$RETH_SCOPE" >/dev/null 2>&1; then
     if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
       sudo pkill -INT -x reth 2>/dev/null || true
-      for i in $(seq 1 120); do
+      for i in $(seq 1 "$SAMPLY_SHUTDOWN_TIMEOUT"); do
         sudo pgrep -x samply > /dev/null 2>&1 || break
         if [ $((i % 10)) -eq 0 ]; then
           echo "Waiting for samply to finish writing profile... (${i}s)"
         fi
         sleep 1
       done
-      sudo pkill -x samply 2>/dev/null || true
+      if sudo pgrep -x samply > /dev/null 2>&1; then
+        echo "Samply still running after ${SAMPLY_SHUTDOWN_TIMEOUT}s, sending SIGTERM..."
+        sudo pkill -x samply 2>/dev/null || true
+      fi
     fi
     sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
     sleep 1


### PR DESCRIPTION
## Summary
- Raises the default samply shutdown wait in the benchmark runners from 120s to 300s so profile flushing has enough time to complete on slower runs.
- Adds `BENCH_SAMPLY_SHUTDOWN_TIMEOUT` to both bench scripts so the wait can be tuned without editing workflow code.
- Keeps the existing SIGTERM fallback, but only after the configured timeout expires.

## Testing
- Not run (not requested).
- Shell syntax and diff checks were used while validating the script changes locally.