### PR TITLE
perf: flexible proof worker capacity

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -76,10 +76,6 @@ pub const SPARSE_TRIE_MAX_NODES_SHRINK_CAPACITY: usize = 1_000_000;
 /// 144MB.
 pub const SPARSE_TRIE_MAX_VALUES_SHRINK_CAPACITY: usize = 1_000_000;
 
-/// Blocks with fewer transactions than this skip prewarming, since the fixed overhead of spawning
-/// prewarm workers exceeds the execution time saved.
-pub const SMALL_BLOCK_TX_THRESHOLD: usize = 5;
-
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
 type IteratorTx<Evm, I> = RecoveredTx<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
 
@@ -506,9 +502,7 @@ where
             PrewarmMode::BlockAccessList(
                 env.decoded_bal.clone().expect("BAL dispatch implies decoded BAL"),
             )
-        } else if self.disable_transaction_prewarming ||
-            env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
-        {
+        } else if self.disable_transaction_prewarming {
             PrewarmMode::Skipped
         } else {
             PrewarmMode::Transactions(transactions)

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -57,7 +57,7 @@ pub(crate) struct MultiProofTaskMetrics {
 }
 
 /// Dispatches work items as a single unit or in chunks based on target size and worker
-/// availability.
+/// availability, returning the number of dispatched jobs.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn dispatch_with_chunking<T, I>(
     items: T,
@@ -68,7 +68,8 @@ pub(crate) fn dispatch_with_chunking<T, I>(
     has_multiple_idle_storage_workers: bool,
     chunker: impl FnOnce(T, usize) -> I,
     mut dispatch: impl FnMut(T),
-) where
+) -> usize
+where
     I: IntoIterator<Item = T>,
 {
     let enough_targets_for_idle_workers =
@@ -78,11 +79,14 @@ pub(crate) fn dispatch_with_chunking<T, I>(
             (has_multiple_idle_account_workers || has_multiple_idle_storage_workers));
 
     if should_chunk && chunk_size > 0 && chunking_len > chunk_size {
+        let mut chunks_dispatched = 0;
         for chunk in chunker(items, chunk_size) {
             dispatch(chunk);
+            chunks_dispatched += 1;
         }
-        return;
+        return chunks_dispatched;
     }
 
     dispatch(items);
+    1
 }

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -12,6 +12,9 @@ pub use reth_trie_parallel::state_root_task::{
 /// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.
 pub(crate) const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 
+/// Avoid splitting light proof batches into tiny chunks just because several workers are idle.
+const MIN_CHUNKS_FOR_IDLE_WORKER_CHUNKING: usize = 4;
+
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tree.root")]
 pub(crate) struct MultiProofTaskMetrics {
@@ -68,11 +71,13 @@ pub(crate) fn dispatch_with_chunking<T, I>(
 ) where
     I: IntoIterator<Item = T>,
 {
+    let enough_targets_for_idle_workers =
+        chunking_len >= chunk_size.saturating_mul(MIN_CHUNKS_FOR_IDLE_WORKER_CHUNKING);
     let should_chunk = chunking_len > max_targets_for_chunking ||
-        has_multiple_idle_account_workers ||
-        has_multiple_idle_storage_workers;
+        (enough_targets_for_idle_workers &&
+            (has_multiple_idle_account_workers || has_multiple_idle_storage_workers));
 
-    if should_chunk && chunking_len > chunk_size {
+    if should_chunk && chunk_size > 0 && chunking_len > chunk_size {
         for chunk in chunker(items, chunk_size) {
             dispatch(chunk);
         }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -410,7 +410,7 @@ where
             if self.updates.is_empty() && self.proof_result_rx.is_empty() {
                 // If we don't have any pending messages, we can spend some time on computing
                 // storage roots and promoting account updates.
-                self.dispatch_pending_targets();
+                let mut dispatched_proof_jobs = self.dispatch_pending_targets();
                 t = Instant::now();
                 let process_start = Instant::now();
                 self.process_new_updates()?;
@@ -436,11 +436,13 @@ where
                     break;
                 }
 
-                self.dispatch_pending_targets();
+                dispatched_proof_jobs += self.dispatch_pending_targets();
 
-                // If there's still no pending updates spend some time pre-computing the account
-                // trie upper hashes
-                if self.proof_result_rx.is_empty() {
+                // If there's still no pending work, spend some time pre-computing the account
+                // trie upper hashes. Avoid doing speculative work immediately after proof dispatch:
+                // proof results or new updates can arrive while `calculate_subtries` is running,
+                // and delaying those messages is worse than overlapping this pre-computation.
+                if dispatched_proof_jobs == 0 && self.proof_result_rx.is_empty() {
                     let calculate_start = Instant::now();
                     self.trie.calculate_subtries();
                     debug!(
@@ -1019,9 +1021,9 @@ where
         Ok(())
     }
 
-    fn dispatch_pending_targets(&mut self) {
+    fn dispatch_pending_targets(&mut self) -> usize {
         if self.pending_targets.is_empty() {
-            return;
+            return 0;
         }
 
         let _span = trace_span!("dispatch_pending_targets").entered();
@@ -1096,6 +1098,7 @@ where
             dispatch_elapsed_us = dispatch_start.elapsed().as_micros(),
             "Dispatched pending proof targets"
         );
+        chunks_dispatched
     }
 
     fn desired_worker_capacity(

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -1,6 +1,6 @@
 //! Sparse Trie task related functionality.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::tree::{
     multiproof::{
@@ -22,7 +22,8 @@ use reth_trie::{
 use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
 use reth_trie_parallel::{
     proof_task::{
-        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofResultStats,
+        ProofWorkerHandle,
     },
     root::ParallelStateRootError,
 };
@@ -301,26 +302,45 @@ where
                         .record(phase_end.duration_since(t));
                     t = phase_end;
 
-                    let Ok(result) = message else {
+                    let Ok(message) = message else {
                         unreachable!("we own the sender half")
                     };
 
-                    let mut result = result.result?;
+                    let mut proof_batch_stats = ProofResultBatchStats::default();
+                    proof_batch_stats.record(&message);
+                    let mut result = message.result?;
                     while let Ok(next) = self.proof_result_rx.try_recv() {
+                        proof_batch_stats.record(&next);
                         let res = next.result?;
                         result.extend(res);
                     }
 
                     let phase_end = Instant::now();
+                    let coalesce_elapsed = phase_end.duration_since(t);
                     self.metrics
                         .sparse_trie_proof_coalesce_duration_histogram
-                        .record(phase_end.duration_since(t));
+                        .record(coalesce_elapsed);
                     t = phase_end;
 
+                    let reveal_start = Instant::now();
                     self.on_proof_result(result)?;
+                    let reveal_elapsed = reveal_start.elapsed();
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        proof_results = proof_batch_stats.proof_results,
+                        account_targets = proof_batch_stats.account_targets,
+                        storage_targets = proof_batch_stats.storage_targets,
+                        storage_jobs = proof_batch_stats.storage_jobs,
+                        storage_wait_time_us = proof_batch_stats.storage_wait_time.as_micros(),
+                        worker_proof_time_us = proof_batch_stats.proof_elapsed.as_micros(),
+                        max_worker_elapsed_us = proof_batch_stats.max_elapsed.as_micros(),
+                        coalesce_elapsed_us = coalesce_elapsed.as_micros(),
+                        reveal_elapsed_us = reveal_elapsed.as_micros(),
+                        "Processed proof result batch"
+                    );
                     self.metrics
                         .sparse_trie_reveal_multiproof_duration_histogram
-                        .record(t.elapsed());
+                        .record(reveal_elapsed);
                 },
             }
 
@@ -804,17 +824,32 @@ where
         let _span = trace_span!("dispatch_pending_targets").entered();
         let (targets, target_counts) = self.pending_targets.take();
         let chunking_length = target_counts.total();
-        let (storage_worker_count, account_worker_count) =
-            self.desired_worker_capacity(target_counts);
-        self.proof_worker_handle.ensure_worker_capacity(storage_worker_count, account_worker_count);
+        let storage_jobs = targets.storage_targets.len();
+        let current_storage_worker_count = self.proof_worker_handle.total_storage_workers();
+        let current_account_worker_count = self.proof_worker_handle.total_account_workers();
+        let (desired_storage_worker_count, desired_account_worker_count) = self
+            .desired_worker_capacity(
+                target_counts,
+                current_storage_worker_count,
+                current_account_worker_count,
+            );
+        self.proof_worker_handle
+            .ensure_worker_capacity(desired_storage_worker_count, desired_account_worker_count);
+        let active_storage_worker_count = self.proof_worker_handle.total_storage_workers();
+        let active_account_worker_count = self.proof_worker_handle.total_account_workers();
+        let has_multiple_idle_account_workers =
+            self.proof_worker_handle.has_multiple_idle_account_workers();
+        let has_multiple_idle_storage_workers =
+            self.proof_worker_handle.has_multiple_idle_storage_workers();
 
-        dispatch_with_chunking(
+        let dispatch_start = Instant::now();
+        let chunks_dispatched = dispatch_with_chunking(
             targets,
             chunking_length,
             self.chunk_size,
             self.max_targets_for_chunking,
-            self.proof_worker_handle.has_multiple_idle_account_workers(),
-            self.proof_worker_handle.has_multiple_idle_storage_workers(),
+            has_multiple_idle_account_workers,
+            has_multiple_idle_storage_workers,
             MultiProofTargetsV2::chunks,
             |proof_targets| {
                 if let Err(e) =
@@ -831,12 +866,34 @@ where
                 }
             },
         );
+        debug!(
+            target: "engine::tree::payload_processor::sparse_trie",
+            account_targets = target_counts.account,
+            storage_targets = target_counts.storage,
+            storage_jobs,
+            total_targets = chunking_length,
+            chunk_size = self.chunk_size,
+            max_targets_for_chunking = self.max_targets_for_chunking,
+            has_multiple_idle_account_workers,
+            has_multiple_idle_storage_workers,
+            current_storage_workers = current_storage_worker_count,
+            current_account_workers = current_account_worker_count,
+            desired_storage_workers = desired_storage_worker_count,
+            desired_account_workers = desired_account_worker_count,
+            active_storage_workers = active_storage_worker_count,
+            active_account_workers = active_account_worker_count,
+            chunks_dispatched,
+            dispatch_elapsed_us = dispatch_start.elapsed().as_micros(),
+            "Dispatched pending proof targets"
+        );
     }
 
-    fn desired_worker_capacity(&self, target_counts: PendingTargetCounts) -> (usize, usize) {
-        let current_storage_workers = self.proof_worker_handle.total_storage_workers();
-        let current_account_workers = self.proof_worker_handle.total_account_workers();
-
+    fn desired_worker_capacity(
+        &self,
+        target_counts: PendingTargetCounts,
+        current_storage_workers: usize,
+        current_account_workers: usize,
+    ) -> (usize, usize) {
         if target_counts.total() <= self.max_targets_for_chunking {
             return (current_storage_workers, current_account_workers);
         }
@@ -891,6 +948,37 @@ struct PendingTargetCounts {
 impl PendingTargetCounts {
     const fn total(self) -> usize {
         self.account + self.storage
+    }
+}
+
+#[derive(Default)]
+struct ProofResultBatchStats {
+    proof_results: usize,
+    account_targets: usize,
+    storage_targets: usize,
+    storage_jobs: usize,
+    proof_elapsed: Duration,
+    storage_wait_time: Duration,
+    max_elapsed: Duration,
+}
+
+impl ProofResultBatchStats {
+    fn record(&mut self, message: &ProofResultMessage) {
+        let ProofResultStats {
+            account_targets,
+            storage_targets,
+            storage_jobs,
+            proof_elapsed,
+            storage_wait_time,
+        } = message.stats;
+
+        self.proof_results += 1;
+        self.account_targets += account_targets;
+        self.storage_targets += storage_targets;
+        self.storage_jobs += storage_jobs;
+        self.proof_elapsed += proof_elapsed;
+        self.storage_wait_time += storage_wait_time;
+        self.max_elapsed = self.max_elapsed.max(message.elapsed);
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -37,6 +37,9 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 /// Maximum number of pending/prewarm updates that we accumulate in memory before actually applying.
 const MAX_PENDING_UPDATES: usize = 100;
 
+/// Number of queued multiproof chunks that should be available per burst worker.
+const PROOF_TARGET_CHUNKS_PER_BURST_WORKER: usize = 4;
+
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = ConfigurableSparseTrie> {
     /// Sender for proof results.
@@ -799,7 +802,12 @@ where
         }
 
         let _span = trace_span!("dispatch_pending_targets").entered();
-        let (targets, chunking_length) = self.pending_targets.take();
+        let (targets, target_counts) = self.pending_targets.take();
+        let chunking_length = target_counts.total();
+        let (storage_worker_count, account_worker_count) =
+            self.desired_worker_capacity(target_counts);
+        self.proof_worker_handle.ensure_worker_capacity(storage_worker_count, account_worker_count);
+
         dispatch_with_chunking(
             targets,
             chunking_length,
@@ -824,6 +832,26 @@ where
             },
         );
     }
+
+    fn desired_worker_capacity(&self, target_counts: PendingTargetCounts) -> (usize, usize) {
+        let current_storage_workers = self.proof_worker_handle.total_storage_workers();
+        let current_account_workers = self.proof_worker_handle.total_account_workers();
+
+        if target_counts.total() <= self.max_targets_for_chunking {
+            return (current_storage_workers, current_account_workers);
+        }
+
+        let chunk_size = self.chunk_size.max(1);
+        let target_chunks = target_counts.total().div_ceil(chunk_size);
+        let storage_chunks = target_counts.storage.div_ceil(chunk_size);
+
+        let desired_account_workers = current_account_workers
+            .max(target_chunks.div_ceil(PROOF_TARGET_CHUNKS_PER_BURST_WORKER));
+        let desired_storage_workers = current_storage_workers
+            .max(storage_chunks.div_ceil(PROOF_TARGET_CHUNKS_PER_BURST_WORKER));
+
+        (desired_storage_workers, desired_account_workers)
+    }
 }
 
 /// RLP-encodes the account as a [`TrieAccount`] leaf value, or returns empty for deletions.
@@ -846,35 +874,54 @@ fn encode_account_leaf_value(
 struct PendingTargets {
     /// The proof targets.
     targets: MultiProofTargetsV2,
-    /// Number of account + storage proof targets currently queued.
-    len: usize,
+    /// Number of account proof targets currently queued.
+    account_len: usize,
+    /// Number of storage proof targets currently queued.
+    storage_len: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PendingTargetCounts {
+    /// Number of account proof targets currently queued.
+    account: usize,
+    /// Number of storage proof targets currently queued.
+    storage: usize,
+}
+
+impl PendingTargetCounts {
+    const fn total(self) -> usize {
+        self.account + self.storage
+    }
 }
 
 impl PendingTargets {
     /// Returns the number of pending targets.
     const fn len(&self) -> usize {
-        self.len
+        self.account_len + self.storage_len
     }
 
     /// Returns `true` if there are no pending targets.
     const fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len() == 0
     }
 
     /// Takes the pending targets, replacing with empty defaults.
-    fn take(&mut self) -> (MultiProofTargetsV2, usize) {
-        (std::mem::take(&mut self.targets), std::mem::take(&mut self.len))
+    fn take(&mut self) -> (MultiProofTargetsV2, PendingTargetCounts) {
+        let counts = PendingTargetCounts { account: self.account_len, storage: self.storage_len };
+        self.account_len = 0;
+        self.storage_len = 0;
+        (std::mem::take(&mut self.targets), counts)
     }
 
     /// Adds a target to the account targets.
     fn push_account_target(&mut self, target: ProofV2Target) {
         self.targets.account_targets.push(target);
-        self.len += 1;
+        self.account_len += 1;
     }
 
     /// Extends storage targets for the given address.
     fn extend_storage_targets(&mut self, address: &B256, targets: Vec<ProofV2Target>) {
-        self.len += targets.len();
+        self.storage_len += targets.len();
         self.targets.storage_targets.entry(*address).or_default().extend(targets);
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -183,27 +183,73 @@ where
 
             let msg = match message {
                 StateRootMessage::PrefetchProofs(targets) => {
+                    let account_targets = targets.account_targets.len();
+                    let storage_targets =
+                        targets.storage_targets.values().map(Vec::len).sum::<usize>();
+                    let storage_jobs = targets.storage_targets.len();
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        account_targets,
+                        storage_targets,
+                        storage_jobs,
+                        "Hashing task forwarded prefetch proof targets"
+                    );
                     SparseTrieTaskMessage::PrefetchProofs(targets)
                 }
                 StateRootMessage::StateUpdate(_, state) => {
                     let _span = trace_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
+                    let state_len = state.len();
+                    let hash_start = Instant::now();
                     let hashed = evm_state_to_hashed_post_state(state);
+                    let hash_elapsed = hash_start.elapsed();
+                    let hashed_stats = HashedStateStats::new(&hashed);
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        state_len,
+                        accounts = hashed_stats.accounts,
+                        storage_addresses = hashed_stats.storage_addresses,
+                        storage_slots = hashed_stats.storage_slots,
+                        hash_elapsed_us = hash_elapsed.as_micros(),
+                        "Hashing task converted state update"
+                    );
                     SparseTrieTaskMessage::HashedState(hashed)
                 }
                 StateRootMessage::FinishedStateUpdates => {
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        "Hashing task forwarded finished state updates"
+                    );
                     SparseTrieTaskMessage::FinishedStateUpdates
                 }
                 StateRootMessage::BlockAccessList(_) => {
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        "Hashing task ignored block access list message"
+                    );
                     idle_start = Instant::now();
                     continue;
                 }
                 StateRootMessage::HashedStateUpdate(state) => {
+                    let hashed_stats = HashedStateStats::new(&state);
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        accounts = hashed_stats.accounts,
+                        storage_addresses = hashed_stats.storage_addresses,
+                        storage_slots = hashed_stats.storage_slots,
+                        "Hashing task forwarded pre-hashed state update"
+                    );
                     SparseTrieTaskMessage::HashedState(state)
                 }
             };
+            let send_start = Instant::now();
             if hashed_state_tx.send(msg).is_err() {
                 break;
             }
+            debug!(
+                target: "engine::tree::payload_processor::sparse_trie",
+                send_elapsed_us = send_start.elapsed().as_micros(),
+                "Hashing task sent sparse trie message"
+            );
 
             idle_start = Instant::now();
         }
@@ -291,8 +337,25 @@ where
                         .sparse_trie_channel_wait_duration_histogram
                         .record(wake.duration_since(t));
 
+                    let message_stats = SparseTrieTaskMessageStats::new(&update);
+                    let on_message_start = Instant::now();
                     self.on_message(update);
                     self.pending_updates += 1;
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        message_kind = message_stats.kind,
+                        accounts = message_stats.accounts,
+                        storage_addresses = message_stats.storage_addresses,
+                        storage_slots = message_stats.storage_slots,
+                        prefetch_account_targets = message_stats.prefetch_account_targets,
+                        prefetch_storage_targets = message_stats.prefetch_storage_targets,
+                        prefetch_storage_jobs = message_stats.prefetch_storage_jobs,
+                        channel_wait_us = wake.duration_since(idle_start).as_micros(),
+                        on_message_elapsed_us = on_message_start.elapsed().as_micros(),
+                        pending_updates = self.pending_updates,
+                        finished_state_updates = self.finished_state_updates,
+                        "Sparse trie task processed input message"
+                    );
                 }
                 recv(self.proof_result_rx) -> message => {
                     let phase_end = Instant::now();
@@ -349,9 +412,22 @@ where
                 // storage roots and promoting account updates.
                 self.dispatch_pending_targets();
                 t = Instant::now();
+                let process_start = Instant::now();
                 self.process_new_updates()?;
+                let process_elapsed = process_start.elapsed();
+                let promote_start = Instant::now();
                 self.promote_pending_account_updates()?;
-                self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
+                let promote_elapsed = promote_start.elapsed();
+                let process_phase_elapsed = t.elapsed();
+                self.metrics
+                    .sparse_trie_process_updates_duration_histogram
+                    .record(process_phase_elapsed);
+                self.log_sparse_trie_phase(
+                    "Processed idle sparse trie update phase",
+                    process_elapsed,
+                    Some(promote_elapsed),
+                    process_phase_elapsed,
+                );
 
                 if self.finished_state_updates &&
                     self.account_updates.is_empty() &&
@@ -365,14 +441,31 @@ where
                 // If there's still no pending updates spend some time pre-computing the account
                 // trie upper hashes
                 if self.proof_result_rx.is_empty() {
+                    let calculate_start = Instant::now();
                     self.trie.calculate_subtries();
+                    debug!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        calculate_subtries_elapsed_us = calculate_start.elapsed().as_micros(),
+                        "Calculated account subtries"
+                    );
                 }
             } else if self.updates.is_empty() || self.pending_updates > MAX_PENDING_UPDATES {
                 // If we don't have any pending updates OR we've accumulated a lot already, apply
                 // them to the trie,
                 t = Instant::now();
+                let process_start = Instant::now();
                 self.process_new_updates()?;
-                self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
+                let process_elapsed = process_start.elapsed();
+                let process_phase_elapsed = t.elapsed();
+                self.metrics
+                    .sparse_trie_process_updates_duration_histogram
+                    .record(process_phase_elapsed);
+                self.log_sparse_trie_phase(
+                    "Processed sparse trie update phase",
+                    process_elapsed,
+                    None,
+                    process_phase_elapsed,
+                );
                 self.dispatch_pending_targets();
             } else if self.pending_targets.len() > self.chunk_size {
                 // Make sure to dispatch targets if we've accumulated a lot of them.
@@ -411,8 +504,21 @@ where
         let debug_recorders = self.trie.take_debug_recorders();
 
         let end = Instant::now();
-        self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
-        self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
+        let final_update_elapsed = end.duration_since(start);
+        let total_elapsed = end.duration_since(now);
+        self.metrics.sparse_trie_final_update_duration_histogram.record(final_update_elapsed);
+        self.metrics.sparse_trie_total_duration_histogram.record(total_elapsed);
+        debug!(
+            target: "engine::tree::payload_processor::sparse_trie",
+            final_update_elapsed_us = final_update_elapsed.as_micros(),
+            total_elapsed_us = total_elapsed.as_micros(),
+            sparse_trie_idle_time_us = total_idle_time.as_micros(),
+            account_cache_hits = self.account_cache_hits,
+            account_cache_misses = self.account_cache_misses,
+            storage_cache_hits = self.storage_cache_hits,
+            storage_cache_misses = self.storage_cache_misses,
+            "Computed sparse trie state root"
+        );
 
         self.metrics.sparse_trie_account_cache_hits.record(self.account_cache_hits as f64);
         self.metrics.sparse_trie_account_cache_misses.record(self.account_cache_misses as f64);
@@ -429,6 +535,25 @@ where
             #[cfg(feature = "trie-debug")]
             debug_recorders,
         })
+    }
+
+    fn log_sparse_trie_phase(
+        &self,
+        phase: &'static str,
+        process_elapsed: Duration,
+        promote_elapsed: Option<Duration>,
+        total_elapsed: Duration,
+    ) {
+        debug!(
+            target: "engine::tree::payload_processor::sparse_trie",
+            phase,
+            pending = ?SparseTriePendingStats::new(self),
+            process_new_updates_elapsed_us = process_elapsed.as_micros(),
+            promote_pending_account_updates_elapsed_us =
+                promote_elapsed.map_or(0, |elapsed| elapsed.as_micros()),
+            total_elapsed_us = total_elapsed.as_micros(),
+            "Sparse trie phase completed"
+        );
     }
 
     /// Processes a [`SparseTrieTaskMessage`] from the hashing task.
@@ -538,11 +663,16 @@ where
         }
 
         let _span = debug_span!("process_new_updates").entered();
+        let pending_updates = self.pending_updates;
+        let stats_before = SparseTriePendingStats::new(self);
         self.pending_updates = 0;
 
         // Firstly apply all new storage and account updates to the tries.
+        let leaf_start = Instant::now();
         self.process_leaf_updates(true)?;
+        let leaf_elapsed = leaf_start.elapsed();
 
+        let storage_merge_start = Instant::now();
         for (address, mut new) in self.new_storage_updates.drain() {
             match self.storage_updates.entry(address) {
                 Entry::Vacant(entry) => {
@@ -565,7 +695,9 @@ where
                 }
             }
         }
+        let storage_merge_elapsed = storage_merge_start.elapsed();
 
+        let account_merge_start = Instant::now();
         for (address, new) in self.new_account_updates.drain() {
             match self.account_updates.entry(address) {
                 Entry::Occupied(mut entry) => {
@@ -578,6 +710,18 @@ where
                 }
             }
         }
+        let account_merge_elapsed = account_merge_start.elapsed();
+        let stats_after = SparseTriePendingStats::new(self);
+        debug!(
+            target: "engine::tree::payload_processor::sparse_trie",
+            pending_updates,
+            before = ?stats_before,
+            after = ?stats_after,
+            leaf_update_elapsed_us = leaf_elapsed.as_micros(),
+            storage_merge_elapsed_us = storage_merge_elapsed.as_micros(),
+            account_merge_elapsed_us = account_merge_elapsed.as_micros(),
+            "Processed new sparse trie updates"
+        );
 
         Ok(())
     }
@@ -682,11 +826,13 @@ where
     ///
     /// we trigger state root computation on a rayon pool.
     fn compute_drained_storage_roots(&mut self) {
+        let start = Instant::now();
         let addresses_to_compute_roots: Vec<_> = self
             .storage_updates
             .iter()
             .filter_map(|(address, updates)| updates.is_empty().then_some(*address))
             .collect();
+        let drained_storage_tries = addresses_to_compute_roots.len();
 
         struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);
         // SAFETY: this wrapper only forwards the pointer across rayon; deref invariants are
@@ -704,9 +850,17 @@ where
         }
 
         if tries_to_compute_roots.is_empty() {
+            debug!(
+                target: "engine::tree::payload_processor::sparse_trie",
+                drained_storage_tries,
+                storage_roots_computed = 0usize,
+                elapsed_us = start.elapsed().as_micros(),
+                "Computed drained storage roots"
+            );
             return;
         }
 
+        let storage_roots_computed = tries_to_compute_roots.len();
         let parent_span =
             debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
@@ -733,6 +887,13 @@ where
             // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
             unsafe { (*trie).root().expect("updates are drained, trie should be revealed by now") };
         });
+        debug!(
+            target: "engine::tree::payload_processor::sparse_trie",
+            drained_storage_tries,
+            storage_roots_computed,
+            elapsed_us = start.elapsed().as_micros(),
+            "Computed drained storage roots"
+        );
     }
 
     /// Iterates through all storage tries for which all updates were processed, computes their
@@ -744,15 +905,37 @@ where
         skip_all
     )]
     fn promote_pending_account_updates(&mut self) -> SparseTrieResult<()> {
+        let start = Instant::now();
+        let stats_before = SparseTriePendingStats::new(self);
+        let leaf_start = Instant::now();
         self.process_leaf_updates(false)?;
+        let leaf_elapsed = leaf_start.elapsed();
 
         if self.pending_account_updates.is_empty() {
+            debug!(
+                target: "engine::tree::payload_processor::sparse_trie",
+                before = ?stats_before,
+                after = ?SparseTriePendingStats::new(self),
+                leaf_update_elapsed_us = leaf_elapsed.as_micros(),
+                storage_root_elapsed_us = 0u128,
+                account_leaf_update_elapsed_us = 0u128,
+                promotion_iterations = 0usize,
+                promoted_accounts = 0usize,
+                total_elapsed_us = start.elapsed().as_micros(),
+                "Promoted pending account updates"
+            );
             return Ok(());
         }
 
+        let storage_root_start = Instant::now();
         self.compute_drained_storage_roots();
+        let storage_root_elapsed = storage_root_start.elapsed();
 
+        let mut promotion_iterations = 0usize;
+        let mut promoted_accounts = 0usize;
+        let mut account_leaf_update_elapsed = Duration::ZERO;
         loop {
+            promotion_iterations += 1;
             let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
             // Now handle pending account updates that can be upgraded to a proper update.
             let account_rlp_buf = &mut self.account_rlp_buf;
@@ -803,15 +986,35 @@ where
             });
             span.record("promoted", num_promoted);
             drop(span);
+            promoted_accounts += num_promoted;
 
             // Only exit when no new updates are processed.
             //
             // We need to keep iterating if any updates are being drained because that might
             // indicate that more pending account updates can be promoted.
-            if num_promoted == 0 || !self.process_account_leaf_updates(false)? {
+            if num_promoted == 0 {
                 break
             }
+
+            let account_leaf_start = Instant::now();
+            if !self.process_account_leaf_updates(false)? {
+                account_leaf_update_elapsed += account_leaf_start.elapsed();
+                break
+            }
+            account_leaf_update_elapsed += account_leaf_start.elapsed();
         }
+        debug!(
+            target: "engine::tree::payload_processor::sparse_trie",
+            before = ?stats_before,
+            after = ?SparseTriePendingStats::new(self),
+            leaf_update_elapsed_us = leaf_elapsed.as_micros(),
+            storage_root_elapsed_us = storage_root_elapsed.as_micros(),
+            account_leaf_update_elapsed_us = account_leaf_update_elapsed.as_micros(),
+            promotion_iterations,
+            promoted_accounts,
+            total_elapsed_us = start.elapsed().as_micros(),
+            "Promoted pending account updates"
+        );
 
         Ok(())
     }
@@ -833,8 +1036,10 @@ where
                 current_storage_worker_count,
                 current_account_worker_count,
             );
+        let ensure_capacity_start = Instant::now();
         self.proof_worker_handle
             .ensure_worker_capacity(desired_storage_worker_count, desired_account_worker_count);
+        let ensure_capacity_elapsed = ensure_capacity_start.elapsed();
         let active_storage_worker_count = self.proof_worker_handle.total_storage_workers();
         let active_account_worker_count = self.proof_worker_handle.total_account_workers();
         let has_multiple_idle_account_workers =
@@ -882,7 +1087,12 @@ where
             desired_account_workers = desired_account_worker_count,
             active_storage_workers = active_storage_worker_count,
             active_account_workers = active_account_worker_count,
+            spawned_storage_workers =
+                active_storage_worker_count.saturating_sub(current_storage_worker_count),
+            spawned_account_workers =
+                active_account_worker_count.saturating_sub(current_account_worker_count),
             chunks_dispatched,
+            ensure_capacity_elapsed_us = ensure_capacity_elapsed.as_micros(),
             dispatch_elapsed_us = dispatch_start.elapsed().as_micros(),
             "Dispatched pending proof targets"
         );
@@ -948,6 +1158,105 @@ struct PendingTargetCounts {
 impl PendingTargetCounts {
     const fn total(self) -> usize {
         self.account + self.storage
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct HashedStateStats {
+    accounts: usize,
+    storage_addresses: usize,
+    storage_slots: usize,
+}
+
+impl HashedStateStats {
+    fn new(state: &HashedPostState) -> Self {
+        Self {
+            accounts: state.accounts.len(),
+            storage_addresses: state.storages.len(),
+            storage_slots: state.storages.values().map(|storage| storage.storage.len()).sum(),
+        }
+    }
+}
+
+struct SparseTrieTaskMessageStats {
+    kind: &'static str,
+    accounts: usize,
+    storage_addresses: usize,
+    storage_slots: usize,
+    prefetch_account_targets: usize,
+    prefetch_storage_targets: usize,
+    prefetch_storage_jobs: usize,
+}
+
+impl SparseTrieTaskMessageStats {
+    fn new(message: &SparseTrieTaskMessage) -> Self {
+        match message {
+            SparseTrieTaskMessage::PrefetchProofs(targets) => Self {
+                kind: "prefetch_proofs",
+                accounts: 0,
+                storage_addresses: 0,
+                storage_slots: 0,
+                prefetch_account_targets: targets.account_targets.len(),
+                prefetch_storage_targets: targets.storage_targets.values().map(Vec::len).sum(),
+                prefetch_storage_jobs: targets.storage_targets.len(),
+            },
+            SparseTrieTaskMessage::HashedState(state) => {
+                let HashedStateStats { accounts, storage_addresses, storage_slots } =
+                    HashedStateStats::new(state);
+                Self {
+                    kind: "hashed_state",
+                    accounts,
+                    storage_addresses,
+                    storage_slots,
+                    prefetch_account_targets: 0,
+                    prefetch_storage_targets: 0,
+                    prefetch_storage_jobs: 0,
+                }
+            }
+            SparseTrieTaskMessage::FinishedStateUpdates => Self {
+                kind: "finished_state_updates",
+                accounts: 0,
+                storage_addresses: 0,
+                storage_slots: 0,
+                prefetch_account_targets: 0,
+                prefetch_storage_targets: 0,
+                prefetch_storage_jobs: 0,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct SparseTriePendingStats {
+    pending_updates: usize,
+    new_account_updates: usize,
+    account_updates: usize,
+    pending_account_updates: usize,
+    new_storage_tries: usize,
+    new_storage_updates: usize,
+    storage_tries: usize,
+    storage_updates: usize,
+    pending_targets: usize,
+}
+
+impl SparseTriePendingStats {
+    fn new<A, S>(task: &SparseTrieCacheTask<A, S>) -> Self {
+        Self {
+            pending_updates: task.pending_updates,
+            new_account_updates: task.new_account_updates.len(),
+            account_updates: task.account_updates.len(),
+            pending_account_updates: task.pending_account_updates.len(),
+            new_storage_tries: task.new_storage_updates.len(),
+            new_storage_updates: task
+                .new_storage_updates
+                .values()
+                .map(|updates| updates.len())
+                .sum(),
+            storage_tries: task.storage_updates.len(),
+            storage_updates: task.storage_updates.values().map(|updates| updates.len()).sum(),
+            pending_targets: task.pending_targets.len(),
+        }
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -38,8 +38,11 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 /// Maximum number of pending/prewarm updates that we accumulate in memory before actually applying.
 const MAX_PENDING_UPDATES: usize = 100;
 
-/// Number of queued multiproof chunks that should be available per burst worker.
-const PROOF_TARGET_CHUNKS_PER_BURST_WORKER: usize = 4;
+/// Account proofs can block on database/page-cache latency, so large account-only batches benefit
+/// from keeping as many proof requests in flight as the configured worker cap allows.
+const ACCOUNT_PROOF_TARGET_CHUNKS_PER_BURST_WORKER: usize = 1;
+/// Storage proof jobs are spawned by account proof workers, so keep a smaller storage burst.
+const STORAGE_PROOF_TARGET_CHUNKS_PER_BURST_WORKER: usize = 4;
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = ConfigurableSparseTrie> {
@@ -1116,9 +1119,9 @@ where
         let storage_chunks = target_counts.storage.div_ceil(chunk_size);
 
         let desired_account_workers = current_account_workers
-            .max(target_chunks.div_ceil(PROOF_TARGET_CHUNKS_PER_BURST_WORKER));
+            .max(target_chunks.div_ceil(ACCOUNT_PROOF_TARGET_CHUNKS_PER_BURST_WORKER));
         let desired_storage_workers = current_storage_workers
-            .max(storage_chunks.div_ceil(PROOF_TARGET_CHUNKS_PER_BURST_WORKER));
+            .max(storage_chunks.div_ceil(STORAGE_PROOF_TARGET_CHUNKS_PER_BURST_WORKER));
 
         (desired_storage_workers, desired_account_workers)
     }

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -103,7 +103,13 @@ where
                         reth_tasks::RuntimeConfig::default().with_rayon(RayonConfig {
                             reserved_cpu_cores: command.engine.reserved_cpu_cores,
                             proof_storage_worker_threads: command.engine.storage_worker_count,
+                            proof_storage_worker_max_threads: command
+                                .engine
+                                .storage_worker_max_count,
                             proof_account_worker_threads: command.engine.account_worker_count,
+                            proof_account_worker_max_threads: command
+                                .engine
+                                .account_worker_max_count,
                             prewarming_threads: command.engine.prewarming_threads,
                             ..Default::default()
                         })

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -41,7 +41,9 @@ pub struct DefaultEngineValues {
     always_process_payload_attributes_on_canonical_head: bool,
     allow_unwind_canonical_header: bool,
     storage_worker_count: Option<usize>,
+    storage_worker_max_count: Option<usize>,
     account_worker_count: Option<usize>,
+    account_worker_max_count: Option<usize>,
     prewarming_threads: Option<usize>,
     cache_metrics_disabled: bool,
     sparse_trie_max_hot_slots: usize,
@@ -178,9 +180,21 @@ impl DefaultEngineValues {
         self
     }
 
+    /// Set the default storage worker burst cap
+    pub const fn with_storage_worker_max_count(mut self, v: Option<usize>) -> Self {
+        self.storage_worker_max_count = v;
+        self
+    }
+
     /// Set the default account worker count
     pub const fn with_account_worker_count(mut self, v: Option<usize>) -> Self {
         self.account_worker_count = v;
+        self
+    }
+
+    /// Set the default account worker burst cap
+    pub const fn with_account_worker_max_count(mut self, v: Option<usize>) -> Self {
+        self.account_worker_max_count = v;
         self
     }
 
@@ -278,7 +292,9 @@ impl Default for DefaultEngineValues {
             always_process_payload_attributes_on_canonical_head: false,
             allow_unwind_canonical_header: false,
             storage_worker_count: None,
+            storage_worker_max_count: None,
             account_worker_count: None,
+            account_worker_max_count: None,
             prewarming_threads: None,
             cache_metrics_disabled: false,
             sparse_trie_max_hot_slots: DEFAULT_SPARSE_TRIE_MAX_HOT_SLOTS,
@@ -411,15 +427,25 @@ pub struct EngineArgs {
     #[arg(long = "engine.allow-unwind-canonical-header", default_value_t = DefaultEngineValues::get_global().allow_unwind_canonical_header)]
     pub allow_unwind_canonical_header: bool,
 
-    /// Configure the number of storage proof workers in the Tokio blocking pool.
+    /// Configure the base number of storage proof workers.
     /// If not specified, defaults to 2x available parallelism.
     #[arg(long = "engine.storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_count.map(|v| v.to_string().into())))]
     pub storage_worker_count: Option<usize>,
 
-    /// Configure the number of account proof workers in the Tokio blocking pool.
+    /// Configure the maximum number of storage proof workers for proof-heavy blocks.
+    /// If not specified, defaults to the larger of storage-worker-count and the runtime burst cap.
+    #[arg(long = "engine.max-storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_max_count.map(|v| v.to_string().into())))]
+    pub storage_worker_max_count: Option<usize>,
+
+    /// Configure the base number of account proof workers.
     /// If not specified, defaults to the same count as storage workers.
     #[arg(long = "engine.account-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().account_worker_count.map(|v| v.to_string().into())))]
     pub account_worker_count: Option<usize>,
+
+    /// Configure the maximum number of account proof workers for proof-heavy blocks.
+    /// If not specified, defaults to the larger of account-worker-count and the runtime burst cap.
+    #[arg(long = "engine.max-account-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().account_worker_max_count.map(|v| v.to_string().into())))]
+    pub account_worker_max_count: Option<usize>,
 
     /// Configure the number of prewarming threads.
     /// If not specified, defaults to available parallelism.
@@ -561,7 +587,9 @@ impl Default for EngineArgs {
             always_process_payload_attributes_on_canonical_head,
             allow_unwind_canonical_header,
             storage_worker_count,
+            storage_worker_max_count,
             account_worker_count,
+            account_worker_max_count,
             prewarming_threads,
             cache_metrics_disabled,
             sparse_trie_max_hot_slots,
@@ -598,7 +626,9 @@ impl Default for EngineArgs {
             always_process_payload_attributes_on_canonical_head,
             allow_unwind_canonical_header,
             storage_worker_count,
+            storage_worker_max_count,
             account_worker_count,
+            account_worker_max_count,
             prewarming_threads,
             cache_metrics_disabled,
             sparse_trie_max_hot_slots,
@@ -724,7 +754,9 @@ mod tests {
             always_process_payload_attributes_on_canonical_head: true,
             allow_unwind_canonical_header: true,
             storage_worker_count: Some(16),
+            storage_worker_max_count: Some(64),
             account_worker_count: Some(8),
+            account_worker_max_count: Some(32),
             prewarming_threads: Some(4),
             cache_metrics_disabled: true,
             sparse_trie_max_hot_slots: 100,
@@ -770,8 +802,12 @@ mod tests {
             "--engine.allow-unwind-canonical-header",
             "--engine.storage-worker-count",
             "16",
+            "--engine.max-storage-worker-count",
+            "64",
             "--engine.account-worker-count",
             "8",
+            "--engine.max-account-worker-count",
+            "32",
             "--engine.prewarming-threads",
             "4",
             "--engine.disable-cache-metrics",

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -50,7 +50,7 @@ pub use for_each_ordered::ForEachOrdered;
 
 pub use lazy::LazyHandle;
 #[cfg(feature = "rayon")]
-pub use runtime::RayonConfig;
+pub use runtime::{RayonConfig, DEFAULT_PROOF_WORKER_MAX_THREADS};
 pub use runtime::{Runtime, RuntimeBuildError, RuntimeBuilder, RuntimeConfig, TokioConfig};
 
 /// A [`TaskExecutor`] is now an alias for [`Runtime`].

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -44,6 +44,9 @@ pub const DEFAULT_STORAGE_POOL_THREADS: usize = 16;
 /// Default maximum number of concurrent blocking tasks (for RPC tracing guard).
 pub const DEFAULT_MAX_BLOCKING_TASKS: usize = 512;
 
+/// Default upper bound for proof workers that can be activated for proof-heavy blocks.
+pub const DEFAULT_PROOF_WORKER_MAX_THREADS: usize = 128;
+
 /// Configuration for the tokio runtime.
 #[derive(Debug, Clone)]
 pub enum TokioConfig {
@@ -106,9 +109,15 @@ pub struct RayonConfig {
     /// Number of threads for the proof storage worker pool (trie storage proof workers).
     /// If `None`, derived from available parallelism.
     pub proof_storage_worker_threads: Option<usize>,
+    /// Maximum number of proof storage workers that can be activated for proof-heavy blocks.
+    /// If `None`, uses [`DEFAULT_PROOF_WORKER_MAX_THREADS`].
+    pub proof_storage_worker_max_threads: Option<usize>,
     /// Number of threads for the proof account worker pool (trie account proof workers).
     /// If `None`, derived from available parallelism.
     pub proof_account_worker_threads: Option<usize>,
+    /// Maximum number of proof account workers that can be activated for proof-heavy blocks.
+    /// If `None`, uses [`DEFAULT_PROOF_WORKER_MAX_THREADS`].
+    pub proof_account_worker_max_threads: Option<usize>,
     /// Number of threads for the prewarming pool (execution prewarming workers).
     /// If `None`, derived from available parallelism.
     pub prewarming_threads: Option<usize>,
@@ -127,7 +136,9 @@ impl Default for RayonConfig {
             storage_threads: None,
             max_blocking_tasks: DEFAULT_MAX_BLOCKING_TASKS,
             proof_storage_worker_threads: None,
+            proof_storage_worker_max_threads: None,
             proof_account_worker_threads: None,
+            proof_account_worker_max_threads: None,
             prewarming_threads: None,
             bal_streaming_threads: None,
         }
@@ -169,12 +180,30 @@ impl RayonConfig {
         self
     }
 
+    /// Set the maximum number of proof storage workers.
+    pub const fn with_proof_storage_worker_max_threads(
+        mut self,
+        proof_storage_worker_max_threads: usize,
+    ) -> Self {
+        self.proof_storage_worker_max_threads = Some(proof_storage_worker_max_threads);
+        self
+    }
+
     /// Set the number of threads for the proof account worker pool.
     pub const fn with_proof_account_worker_threads(
         mut self,
         proof_account_worker_threads: usize,
     ) -> Self {
         self.proof_account_worker_threads = Some(proof_account_worker_threads);
+        self
+    }
+
+    /// Set the maximum number of proof account workers.
+    pub const fn with_proof_account_worker_max_threads(
+        mut self,
+        proof_account_worker_max_threads: usize,
+    ) -> Self {
+        self.proof_account_worker_max_threads = Some(proof_account_worker_max_threads);
         self
     }
 
@@ -266,9 +295,15 @@ struct RuntimeInner {
     /// Proof storage worker pool (trie storage proof computation).
     #[cfg(feature = "rayon")]
     proof_storage_worker_pool: WorkerPool,
+    /// Maximum storage proof workers that can be activated for proof-heavy blocks.
+    #[cfg(feature = "rayon")]
+    proof_storage_worker_max_threads: usize,
     /// Proof account worker pool (trie account proof computation).
     #[cfg(feature = "rayon")]
     proof_account_worker_pool: WorkerPool,
+    /// Maximum account proof workers that can be activated for proof-heavy blocks.
+    #[cfg(feature = "rayon")]
+    proof_account_worker_max_threads: usize,
     /// Prewarming pool (execution prewarming workers).
     #[cfg(feature = "rayon")]
     prewarming_pool: WorkerPool,
@@ -348,10 +383,22 @@ impl Runtime {
         &self.0.proof_storage_worker_pool
     }
 
+    /// Get the maximum storage proof worker count.
+    #[cfg(feature = "rayon")]
+    pub fn proof_storage_worker_max_threads(&self) -> usize {
+        self.0.proof_storage_worker_max_threads
+    }
+
     /// Get the proof account worker pool.
     #[cfg(feature = "rayon")]
     pub fn proof_account_worker_pool(&self) -> &WorkerPool {
         &self.0.proof_account_worker_pool
+    }
+
+    /// Get the maximum account proof worker count.
+    #[cfg(feature = "rayon")]
+    pub fn proof_account_worker_max_threads(&self) -> usize {
+        self.0.proof_account_worker_max_threads
     }
 
     /// Get the prewarming pool.
@@ -397,7 +444,9 @@ impl Runtime {
                 storage_threads: Some(2),
                 max_blocking_tasks: 16,
                 proof_storage_worker_threads: Some(2),
+                proof_storage_worker_max_threads: Some(2),
                 proof_account_worker_threads: Some(2),
+                proof_account_worker_max_threads: Some(2),
                 prewarming_threads: Some(2),
                 bal_streaming_threads: Some(2),
             },
@@ -820,7 +869,9 @@ impl RuntimeBuilder {
             storage_pool,
             blocking_guard,
             proof_storage_worker_pool,
+            proof_storage_worker_max_threads,
             proof_account_worker_pool,
+            proof_account_worker_max_threads,
             prewarming_pool,
             bal_streaming_pool,
         ) = {
@@ -854,11 +905,21 @@ impl RuntimeBuilder {
                 config.rayon.proof_storage_worker_threads.unwrap_or(default_threads * 2);
             let proof_storage_worker_pool =
                 WorkerPool::new(proof_storage_worker_threads, "proof-strg");
+            let proof_storage_worker_max_threads = config
+                .rayon
+                .proof_storage_worker_max_threads
+                .unwrap_or(DEFAULT_PROOF_WORKER_MAX_THREADS)
+                .max(proof_storage_worker_threads);
 
             let proof_account_worker_threads =
                 config.rayon.proof_account_worker_threads.unwrap_or(default_threads * 2);
             let proof_account_worker_pool =
                 WorkerPool::new(proof_account_worker_threads, "proof-acct");
+            let proof_account_worker_max_threads = config
+                .rayon
+                .proof_account_worker_max_threads
+                .unwrap_or(DEFAULT_PROOF_WORKER_MAX_THREADS)
+                .max(proof_account_worker_threads);
 
             let prewarming_threads = config.rayon.prewarming_threads.unwrap_or(default_threads);
             let prewarming_pool = WorkerPool::new(prewarming_threads, "prewarm");
@@ -872,7 +933,9 @@ impl RuntimeBuilder {
                 rpc_threads,
                 storage_threads,
                 proof_storage_worker_threads,
+                proof_storage_worker_max_threads,
                 proof_account_worker_threads,
+                proof_account_worker_max_threads,
                 prewarming_threads,
                 bal_streaming_threads,
                 max_blocking_tasks = config.rayon.max_blocking_tasks,
@@ -885,7 +948,9 @@ impl RuntimeBuilder {
                 storage_pool,
                 blocking_guard,
                 proof_storage_worker_pool,
+                proof_storage_worker_max_threads,
                 proof_account_worker_pool,
+                proof_account_worker_max_threads,
                 prewarming_pool,
                 bal_streaming_pool,
             )
@@ -917,7 +982,11 @@ impl RuntimeBuilder {
             #[cfg(feature = "rayon")]
             proof_storage_worker_pool,
             #[cfg(feature = "rayon")]
+            proof_storage_worker_max_threads,
+            #[cfg(feature = "rayon")]
             proof_account_worker_pool,
+            #[cfg(feature = "rayon")]
+            proof_account_worker_max_threads,
             #[cfg(feature = "rayon")]
             prewarming_pool,
             #[cfg(feature = "rayon")]

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -45,7 +45,7 @@ pub const DEFAULT_STORAGE_POOL_THREADS: usize = 16;
 pub const DEFAULT_MAX_BLOCKING_TASKS: usize = 512;
 
 /// Default upper bound for proof workers that can be activated for proof-heavy blocks.
-pub const DEFAULT_PROOF_WORKER_MAX_THREADS: usize = 128;
+pub const DEFAULT_PROOF_WORKER_MAX_THREADS: usize = 256;
 
 /// Configuration for the tokio runtime.
 #[derive(Debug, Clone)]

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -590,6 +590,7 @@ impl ProofWorkerHandle {
                 let _ = result_tx.send(ProofResultMessage {
                     result: Err(ParallelStateRootError::Provider(error.clone())),
                     elapsed: start.elapsed(),
+                    stats: ProofResultStats::default(),
                     state,
                 });
 
@@ -707,8 +708,25 @@ pub struct ProofResultMessage {
     pub result: Result<DecodedMultiProofV2, ParallelStateRootError>,
     /// Time taken for the entire proof calculation (from dispatch to completion)
     pub elapsed: Duration,
+    /// Proof target and timing stats for observability.
+    pub stats: ProofResultStats,
     /// Original state update that triggered this proof
     pub state: HashedPostState,
+}
+
+/// Summary stats for a completed account multiproof job.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProofResultStats {
+    /// Number of account proof targets in the job.
+    pub account_targets: usize,
+    /// Number of storage proof targets in the job.
+    pub storage_targets: usize,
+    /// Number of storage proof jobs dispatched by the account worker.
+    pub storage_jobs: usize,
+    /// Time spent computing the account multiproof on the worker.
+    pub proof_elapsed: Duration,
+    /// Time the account worker spent waiting for storage proofs.
+    pub storage_wait_time: Duration,
 }
 
 /// Context for sending proof calculation results back to `SparseTrieCacheTask`.
@@ -1240,6 +1258,9 @@ where
         let proof_start = Instant::now();
 
         let AccountMultiproofInput { targets, proof_result_sender } = input;
+        let account_targets = targets.account_targets.len();
+        let storage_jobs = targets.storage_targets.len();
+        let storage_targets = targets.storage_targets.values().map(Vec::len).sum();
         let (result, value_encoder_stats) = match self.compute_v2_account_multiproof::<Provider>(
             v2_account_calculator,
             v2_storage_calculator,
@@ -1255,9 +1276,19 @@ where
         let proof_elapsed = proof_start.elapsed();
         let total_elapsed = start.elapsed();
         *account_proofs_processed += 1;
+        let stats = ProofResultStats {
+            account_targets,
+            storage_targets,
+            storage_jobs,
+            proof_elapsed,
+            storage_wait_time: value_encoder_stats.storage_wait_time,
+        };
 
         // Send result to SparseTrieCacheTask
-        if result_tx.send(ProofResultMessage { result, elapsed: total_elapsed, state }).is_err() {
+        if result_tx
+            .send(ProofResultMessage { result, elapsed: total_elapsed, stats, state })
+            .is_err()
+        {
             trace!(
                 target: "trie::proof_task",
                 worker_id=self.worker_id,
@@ -1270,6 +1301,10 @@ where
             target: "trie::proof_task",
             proof_time_us = proof_elapsed.as_micros(),
             total_elapsed_us = total_elapsed.as_micros(),
+            storage_wait_time_us = stats.storage_wait_time.as_micros(),
+            account_targets = stats.account_targets,
+            storage_targets = stats.storage_targets,
+            storage_jobs = stats.storage_jobs,
             total_processed = account_proofs_processed,
             "Account multiproof completed"
         );

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -51,11 +51,13 @@ use reth_trie::{
 };
 use std::{
     cell::RefCell,
+    fmt,
     rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
+    thread,
     time::Duration,
 };
 use tracing::{debug, debug_span, error, instrument, trace};
@@ -127,12 +129,14 @@ impl AvailabilitySheet {
     }
 }
 
+type WorkerSpawner = Arc<dyn Fn(usize) -> bool + Send + Sync>;
+
 /// A handle that provides type-safe access to proof worker pools.
 ///
 /// The handle stores direct senders to both storage and account worker pools,
 /// eliminating the need for a routing thread. All handles share reference-counted
 /// channels, and workers shut down gracefully when all handles are dropped.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ProofWorkerHandle {
     /// Direct sender to storage worker pool
     storage_work_tx: CrossbeamSender<StorageWorkerJob>,
@@ -144,10 +148,29 @@ pub struct ProofWorkerHandle {
     /// Per-worker availability flags for account workers. Used to determine whether to chunk
     /// multiproofs.
     account_availability: Arc<AvailabilitySheet>,
-    /// Total number of storage workers spawned
-    storage_worker_count: usize,
-    /// Total number of account workers spawned
-    account_worker_count: usize,
+    /// Active storage workers.
+    storage_worker_count: Arc<AtomicUsize>,
+    /// Maximum storage workers that can be activated for this block.
+    max_storage_worker_count: usize,
+    /// Active account workers.
+    account_worker_count: Arc<AtomicUsize>,
+    /// Maximum account workers that can be activated for this block.
+    max_account_worker_count: usize,
+    /// Spawns additional storage workers when proof target pressure warrants it.
+    spawn_storage_worker: WorkerSpawner,
+    /// Spawns additional account workers when proof target pressure warrants it.
+    spawn_account_worker: WorkerSpawner,
+}
+
+impl fmt::Debug for ProofWorkerHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProofWorkerHandle")
+            .field("storage_worker_count", &self.total_storage_workers())
+            .field("max_storage_worker_count", &self.max_storage_worker_count)
+            .field("account_worker_count", &self.total_account_workers())
+            .field("max_account_worker_count", &self.max_account_worker_count)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ProofWorkerHandle {
@@ -184,20 +207,42 @@ impl ProofWorkerHandle {
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
         let divisor = if halve_workers { 2 } else { 1 };
-        let storage_worker_count =
-            runtime.proof_storage_worker_pool().current_num_threads() / divisor;
-        let account_worker_count =
-            runtime.proof_account_worker_pool().current_num_threads() / divisor;
+        let initial_storage_worker_count =
+            (runtime.proof_storage_worker_pool().current_num_threads() / divisor).max(1);
+        let initial_account_worker_count =
+            (runtime.proof_account_worker_pool().current_num_threads() / divisor).max(1);
+        let max_storage_worker_count =
+            runtime.proof_storage_worker_max_threads().max(initial_storage_worker_count).max(1);
+        let max_account_worker_count =
+            runtime.proof_account_worker_max_threads().max(initial_account_worker_count).max(1);
 
-        let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
-        let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
+        let storage_availability = Arc::new(AvailabilitySheet::new(max_storage_worker_count));
+        let account_availability = Arc::new(AvailabilitySheet::new(max_account_worker_count));
+        let storage_worker_count = Arc::new(AtomicUsize::new(initial_storage_worker_count));
+        let account_worker_count = Arc::new(AtomicUsize::new(initial_account_worker_count));
 
         debug!(
             target: "trie::proof_task",
-            storage_worker_count,
-            account_worker_count,
+            storage_worker_count = initial_storage_worker_count,
+            account_worker_count = initial_account_worker_count,
+            max_storage_worker_count,
+            max_account_worker_count,
             halve_workers,
             "Spawning proof worker pools"
+        );
+
+        let spawn_storage_worker = Self::storage_worker_spawner(
+            task_ctx.clone(),
+            storage_work_rx.clone(),
+            storage_availability.clone(),
+            cached_storage_roots.clone(),
+        );
+        let spawn_account_worker = Self::account_worker_spawner(
+            task_ctx.clone(),
+            account_work_rx.clone(),
+            storage_work_tx.clone(),
+            account_availability.clone(),
+            cached_storage_roots.clone(),
         );
 
         // broadcast blocks until all workers exit (channel close), so run on
@@ -209,7 +254,7 @@ impl ProofWorkerHandle {
         let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
-            storage_rt.proof_storage_worker_pool().broadcast(storage_worker_count, |_| {
+            storage_rt.proof_storage_worker_pool().broadcast(initial_storage_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
                 let span = debug_span!(target: "trie::proof_task", parent: storage_parent_span.clone(), "storage_worker", ?worker_id);
                 let _guard = span.enter();
@@ -247,7 +292,7 @@ impl ProofWorkerHandle {
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
             let worker_id = AtomicUsize::new(0);
-            account_rt.proof_account_worker_pool().broadcast(account_worker_count, |_| {
+            account_rt.proof_account_worker_pool().broadcast(initial_account_worker_count, |_| {
                 let worker_id = worker_id.fetch_add(1, Ordering::Relaxed);
                 let span = debug_span!(target: "trie::proof_task", parent: account_parent_span.clone(), "account_worker", ?worker_id);
                 let _guard = span.enter();
@@ -286,7 +331,188 @@ impl ProofWorkerHandle {
             storage_availability,
             account_availability,
             storage_worker_count,
+            max_storage_worker_count,
             account_worker_count,
+            max_account_worker_count,
+            spawn_storage_worker,
+            spawn_account_worker,
+        }
+    }
+
+    fn storage_worker_spawner<Factory>(
+        task_ctx: ProofTaskCtx<Factory>,
+        work_rx: CrossbeamReceiver<StorageWorkerJob>,
+        availability: Arc<AvailabilitySheet>,
+        cached_storage_roots: Arc<DashMap<B256, B256>>,
+    ) -> WorkerSpawner
+    where
+        Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+    {
+        Arc::new(move |worker_id| {
+            let task_ctx = task_ctx.clone();
+            let work_rx = work_rx.clone();
+            let availability = availability.clone();
+            let cached_storage_roots = cached_storage_roots.clone();
+            thread::Builder::new()
+                .name(format!("proof-strg-{worker_id:02}"))
+                .spawn(move || {
+                    let span =
+                        debug_span!(target: "trie::proof_task", "storage_worker", ?worker_id);
+                    let _guard = span.enter();
+
+                    #[cfg(feature = "metrics")]
+                    let metrics = ProofTaskTrieMetrics::default();
+                    #[cfg(feature = "metrics")]
+                    let cursor_metrics = ProofTaskCursorMetrics::new();
+
+                    let worker = StorageProofWorker::new(
+                        task_ctx,
+                        work_rx,
+                        worker_id,
+                        availability,
+                        cached_storage_roots,
+                        #[cfg(feature = "metrics")]
+                        metrics,
+                        #[cfg(feature = "metrics")]
+                        cursor_metrics,
+                    );
+                    if let Err(error) = worker.run() {
+                        error!(
+                            target: "trie::proof_task",
+                            worker_id,
+                            ?error,
+                            "Storage worker failed"
+                        );
+                    }
+                })
+                .inspect_err(|error| {
+                    error!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        %error,
+                        "Failed to spawn storage proof worker"
+                    );
+                })
+                .is_ok()
+        })
+    }
+
+    fn account_worker_spawner<Factory>(
+        task_ctx: ProofTaskCtx<Factory>,
+        work_rx: CrossbeamReceiver<AccountWorkerJob>,
+        storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+        availability: Arc<AvailabilitySheet>,
+        cached_storage_roots: Arc<DashMap<B256, B256>>,
+    ) -> WorkerSpawner
+    where
+        Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+    {
+        Arc::new(move |worker_id| {
+            let task_ctx = task_ctx.clone();
+            let work_rx = work_rx.clone();
+            let storage_work_tx = storage_work_tx.clone();
+            let availability = availability.clone();
+            let cached_storage_roots = cached_storage_roots.clone();
+            thread::Builder::new()
+                .name(format!("proof-acct-{worker_id:02}"))
+                .spawn(move || {
+                    let span =
+                        debug_span!(target: "trie::proof_task", "account_worker", ?worker_id);
+                    let _guard = span.enter();
+
+                    #[cfg(feature = "metrics")]
+                    let metrics = ProofTaskTrieMetrics::default();
+                    #[cfg(feature = "metrics")]
+                    let cursor_metrics = ProofTaskCursorMetrics::new();
+
+                    let worker = AccountProofWorker::new(
+                        task_ctx,
+                        work_rx,
+                        worker_id,
+                        storage_work_tx,
+                        availability,
+                        cached_storage_roots,
+                        #[cfg(feature = "metrics")]
+                        metrics,
+                        #[cfg(feature = "metrics")]
+                        cursor_metrics,
+                    );
+                    if let Err(error) = worker.run() {
+                        error!(
+                            target: "trie::proof_task",
+                            worker_id,
+                            ?error,
+                            "Account worker failed"
+                        );
+                    }
+                })
+                .inspect_err(|error| {
+                    error!(
+                        target: "trie::proof_task",
+                        worker_id,
+                        %error,
+                        "Failed to spawn account proof worker"
+                    );
+                })
+                .is_ok()
+        })
+    }
+
+    /// Ensures at least the requested number of proof workers are active, capped by the configured
+    /// per-block maximums.
+    pub fn ensure_worker_capacity(&self, storage_worker_count: usize, account_worker_count: usize) {
+        self.ensure_storage_worker_capacity(storage_worker_count);
+        self.ensure_account_worker_capacity(account_worker_count);
+    }
+
+    fn ensure_storage_worker_capacity(&self, desired_workers: usize) {
+        Self::ensure_capacity(
+            &self.storage_worker_count,
+            self.max_storage_worker_count,
+            desired_workers,
+            self.spawn_storage_worker.as_ref(),
+        );
+    }
+
+    fn ensure_account_worker_capacity(&self, desired_workers: usize) {
+        Self::ensure_capacity(
+            &self.account_worker_count,
+            self.max_account_worker_count,
+            desired_workers,
+            self.spawn_account_worker.as_ref(),
+        );
+    }
+
+    fn ensure_capacity(
+        active_workers: &AtomicUsize,
+        max_workers: usize,
+        desired_workers: usize,
+        spawn_worker: &(dyn Fn(usize) -> bool + Send + Sync),
+    ) {
+        let desired_workers = desired_workers.max(1).min(max_workers);
+
+        loop {
+            let current = active_workers.load(Ordering::Acquire);
+            if current >= desired_workers {
+                return;
+            }
+
+            if active_workers
+                .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok() &&
+                !spawn_worker(current)
+            {
+                active_workers.fetch_sub(1, Ordering::AcqRel);
+                return;
+            }
         }
     }
 
@@ -311,13 +537,13 @@ impl ProofWorkerHandle {
     }
 
     /// Returns the total number of storage workers in the pool.
-    pub const fn total_storage_workers(&self) -> usize {
-        self.storage_worker_count
+    pub fn total_storage_workers(&self) -> usize {
+        self.storage_worker_count.load(Ordering::Acquire)
     }
 
     /// Returns the total number of account workers in the pool.
-    pub const fn total_account_workers(&self) -> usize {
-        self.account_worker_count
+    pub fn total_account_workers(&self) -> usize {
+        self.account_worker_count.load(Ordering::Acquire)
     }
 
     /// Dispatch a storage proof computation to storage worker pool

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1033,10 +1033,16 @@ Engine:
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
-          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
+          Configure the base number of storage proof workers. If not specified, defaults to 2x available parallelism
+
+      --engine.max-storage-worker-count <STORAGE_WORKER_MAX_COUNT>
+          Configure the maximum number of storage proof workers for proof-heavy blocks. If not specified, defaults to the larger of storage-worker-count and the runtime burst cap
 
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
-          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers
+          Configure the base number of account proof workers. If not specified, defaults to the same count as storage workers
+
+      --engine.max-account-worker-count <ACCOUNT_WORKER_MAX_COUNT>
+          Configure the maximum number of account proof workers for proof-heavy blocks. If not specified, defaults to the larger of account-worker-count and the runtime burst cap
 
       --engine.prewarming-threads <PREWARMING_THREADS>
           Configure the number of prewarming threads. If not specified, defaults to available parallelism


### PR DESCRIPTION
Adds a burst strategy for proof workers so the default pool stays CPU-derived for normal blocks, but proof-heavy blocks can activate additional storage and account workers up to a configurable cap