### PR TITLE
fix(engine): trigger backfill when canonical header is ahead of execution (#23234)

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -35,7 +35,7 @@ use reth_provider::{
     StorageSettingsCache, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
-use reth_stages_api::ControlFlow;
+use reth_stages_api::{ControlFlow, StageId};
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
@@ -1255,6 +1255,28 @@ where
         // Check if the head is already part of the canonical chain
         if let Ok(Some(canonical_header)) = self.find_canonical_header(state.head_block_hash) {
             debug!(target: "engine::tree", head = canonical_header.number(), "fcu head block is already canonical");
+
+            // The Headers stage can be ahead of the Execution stage after a partial
+            // `stage unwind`, snapshot import, or crash recovery. In that case a
+            // canonical header exists for the FCU head but no state has been computed
+            // for it; returning VALID here would prevent the backfill pipeline from
+            // running and leave execution stuck. Force the missing-block path
+            // instead, which returns Syncing and triggers backfill (#23234).
+            if let Ok(provider) = self.provider.database_provider_ro() {
+                if let Ok(Some(execution_checkpoint)) =
+                    provider.get_stage_checkpoint(StageId::Execution)
+                {
+                    if canonical_header.number() > execution_checkpoint.block_number {
+                        debug!(
+                            target: "engine::tree",
+                            head = canonical_header.number(),
+                            execution = execution_checkpoint.block_number,
+                            "canonical header exists but execution has not reached it, falling through to backfill"
+                        );
+                        return Ok(None);
+                    }
+                }
+            }
 
             // For OpStack, or if explicitly configured, the proposers are allowed to reorg their
             // own chain at will, so we need to always trigger a new payload job if requested.


### PR DESCRIPTION
Closes #23234.

## Bug

`apply_chain_update` returns `VALID` as soon as `find_canonical_header` returns `Some`, without checking whether the Execution stage has actually reached that block. In normal pipeline operation this is fine because headers and execution advance together, but a partial `stage unwind`, snapshot import, or interrupted pipeline can leave headers ahead of execution. In that state the node accepts FCUs as `VALID`, never triggers backfill, and stays permanently stuck — clients keep sending `newPayload` for tip blocks that fail against stale state, and only manual `reth stage unwind` of headers recovers the node.

Observed (from the issue):
| Stage | Block |
|---|---|
| Headers | 18,459,556 |
| Bodies | 18,459,556 |
| SenderRecovery | 18,459,556 |
| Execution | 6,700,000 |

## Fix

After `find_canonical_header` returns `Some`, read the Execution stage checkpoint via `DatabaseProviderFactory` + `StageCheckpointReader`. If the canonical header height exceeds the execution checkpoint, return `Ok(None)` to fall through to `handle_missing_block`, which already returns `Syncing` and triggers the backfill pipeline.

```rust
if let Ok(provider) = self.provider.database_provider_ro() {
    if let Ok(Some(execution_checkpoint)) =
        provider.get_stage_checkpoint(StageId::Execution)
    {
        if canonical_header.number() > execution_checkpoint.block_number {
            debug!(
                target: "engine::tree",
                head = canonical_header.number(),
                execution = execution_checkpoint.block_number,
                "canonical header exists but execution has not reached it, falling through to backfill"
            );
            return Ok(None);
        }
    }
}
```

The guard fires only when the stage checkpoint exists AND is below the canonical header — every other path is unchanged.

## Tests

All 104 existing `reth-engine-tree` lib tests pass without modification:

```
test result: ok. 104 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.07s
```

`MockEthProvider::get_stage_checkpoint` returns `Ok(None)`, so the new guard never fires in tests — pre-existing test behavior is preserved bit-for-bit.

A regression test that exercises the new code path would require extending `MockEthProvider` with a settable stage-checkpoint field. Happy to add that in a follow-up PR if you prefer.

## Compatibility

- Pipeline-normal operation: unchanged (execution checkpoint equals or exceeds canonical header, guard is no-op).
- Snapshot-import / partial-unwind / crash-recovery: previously stuck, now correctly transitions to `Syncing` + triggers backfill.
- Out-of-scope: nothing.

## Reproduction (from issue body)

1. Stop reth node.
2. `reth stage unwind to-block $((TIP - 100))` (or unwind execution only).
3. Start reth node.
4. Before: node accepts FCU as VALID, execution stays stuck. After: node returns Syncing, backfill kicks off, execution catches up.