### PR TITLE
fix(db): warn on ZFS after creating database path

### DIFF
--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -79,8 +79,6 @@ pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Resu
     use crate::version::{check_db_version_file, create_db_version_file, DatabaseVersionError};
 
     let rpath = path.as_ref();
-    warn_if_zfs(rpath);
-
     if is_database_empty(rpath) {
         reth_fs_util::create_dir_all(rpath)
             .wrap_err_with(|| format!("Could not create database directory {}", rpath.display()))?;
@@ -92,6 +90,8 @@ pub fn create_db<P: AsRef<Path>>(path: P, args: DatabaseArguments) -> eyre::Resu
             Err(err) => return Err(err.into()),
         }
     }
+
+    warn_if_zfs(rpath);
 
     Ok(DatabaseEnv::open(rpath, DatabaseEnvKind::RW, args)?)
 }


### PR DESCRIPTION
Follow-up to #23685.

Runs the ZFS filesystem warning after the database directory/version file setup, so new database paths can be checked with `statfs` before MDBX opens them.