### PR TITLE
feat(otlp): make service.version configurable

### DIFF
--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -115,6 +115,20 @@ pub struct TraceArgs {
     )]
     pub service_name: String,
 
+    /// Service version to use for OTLP tracing export.
+    ///
+    /// Overrides the default version reported in the `service.version` OTLP resource attribute.
+    /// Falls back to the crate's `CARGO_PKG_VERSION` if not specified.
+    #[arg(
+        long = "tracing-otlp.service-version",
+        env = "OTEL_SERVICE_VERSION",
+        global = true,
+        value_name = "VERSION",
+        hide = true,
+        help_heading = "Tracing"
+    )]
+    pub service_version: Option<String>,
+
     /// Trace sampling ratio to control the percentage of traces to export.
     ///
     /// Valid range: 0.0 to 1.0
@@ -143,6 +157,7 @@ impl Default for TraceArgs {
             logs_otlp_filter: EnvFilter::try_new("info").expect("valid filter"),
             sample_ratio: None,
             service_name: "reth".to_string(),
+            service_version: None,
         }
     }
 }
@@ -168,12 +183,15 @@ impl TraceArgs {
             #[cfg(feature = "otlp")]
             {
                 {
-                    let config = reth_tracing_otlp::OtlpConfig::new(
+                    let mut config = reth_tracing_otlp::OtlpConfig::new(
                         self.service_name.clone(),
                         endpoint.clone(),
                         self.protocol,
                         self.sample_ratio,
                     )?;
+                    if let Some(version) = &self.service_version {
+                        config = config.with_service_version(version.clone());
+                    }
 
                     _layers.with_span_layer(config.clone(), self.otlp_filter.clone())?;
 
@@ -201,11 +219,14 @@ impl TraceArgs {
 
             #[cfg(feature = "otlp-logs")]
             {
-                let config = reth_tracing_otlp::OtlpLogsConfig::new(
+                let mut config = reth_tracing_otlp::OtlpLogsConfig::new(
                     self.service_name.clone(),
                     endpoint.clone(),
                     self.protocol,
                 )?;
+                if let Some(version) = &self.service_version {
+                    config = config.with_service_version(version.clone());
+                }
 
                 _layers.with_log_layer(config.clone(), self.logs_otlp_filter.clone())?;
 

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -38,7 +38,8 @@ where
 {
     global::set_text_map_propagator(TraceContextPropagator::new());
 
-    let resource = build_resource(otlp_config.service_name.clone());
+    let resource =
+        build_resource(otlp_config.service_name.clone(), otlp_config.service_version.as_deref());
 
     let span_builder = SpanExporter::builder();
 
@@ -85,7 +86,8 @@ pub fn log_layer(
     use opentelemetry_otlp::LogExporter;
     use opentelemetry_sdk::logs::SdkLoggerProvider;
 
-    let resource = build_resource(otlp_config.service_name.clone());
+    let resource =
+        build_resource(otlp_config.service_name.clone(), otlp_config.service_version.as_deref());
 
     let log_builder = LogExporter::builder();
 
@@ -111,6 +113,8 @@ pub fn log_layer(
 pub struct OtlpConfig {
     /// Service name for trace identification
     service_name: String,
+    /// Optional service version override. Falls back to `CARGO_PKG_VERSION` if `None`.
+    service_version: Option<String>,
     /// Otlp endpoint URL
     endpoint: Url,
     /// Transport protocol, HTTP or gRPC
@@ -135,7 +139,19 @@ impl OtlpConfig {
             );
         }
 
-        Ok(Self { service_name: service_name.into(), endpoint, protocol, sample_ratio })
+        Ok(Self {
+            service_name: service_name.into(),
+            service_version: None,
+            endpoint,
+            protocol,
+            sample_ratio,
+        })
+    }
+
+    /// Sets the service version for OTLP resource identification.
+    pub fn with_service_version(mut self, version: impl Into<String>) -> Self {
+        self.service_version = Some(version.into());
+        self
     }
 
     /// Returns the service name.
@@ -164,6 +180,8 @@ impl OtlpConfig {
 pub struct OtlpLogsConfig {
     /// Service name for log identification
     service_name: String,
+    /// Optional service version override. Falls back to `CARGO_PKG_VERSION` if `None`.
+    service_version: Option<String>,
     /// Otlp endpoint URL
     endpoint: Url,
     /// Transport protocol, HTTP or gRPC
@@ -177,7 +195,13 @@ impl OtlpLogsConfig {
         endpoint: Url,
         protocol: OtlpProtocol,
     ) -> eyre::Result<Self> {
-        Ok(Self { service_name: service_name.into(), endpoint, protocol })
+        Ok(Self { service_name: service_name.into(), service_version: None, endpoint, protocol })
+    }
+
+    /// Sets the service version for OTLP resource identification.
+    pub fn with_service_version(mut self, version: impl Into<String>) -> Self {
+        self.service_version = Some(version.into());
+        self
     }
 
     /// Returns the service name.
@@ -197,10 +221,14 @@ impl OtlpLogsConfig {
 }
 
 // Builds OTLP resource with service information.
-fn build_resource(service_name: impl Into<Value>) -> Resource {
+fn build_resource(
+    service_name: impl Into<Value>,
+    service_version: Option<&str>,
+) -> Resource {
+    let version = service_version.unwrap_or(env!("CARGO_PKG_VERSION"));
     Resource::builder()
         .with_service_name(service_name)
-        .with_schema_url([KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION"))], SCHEMA_URL)
+        .with_schema_url([KeyValue::new(SERVICE_VERSION, version.to_string())], SCHEMA_URL)
         .build()
 }
 

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -221,10 +221,7 @@ impl OtlpLogsConfig {
 }
 
 // Builds OTLP resource with service information.
-fn build_resource(
-    service_name: impl Into<Value>,
-    service_version: Option<&str>,
-) -> Resource {
+fn build_resource(service_name: impl Into<Value>, service_version: Option<&str>) -> Resource {
     let version = service_version.unwrap_or(env!("CARGO_PKG_VERSION"));
     Resource::builder()
         .with_service_name(service_name)


### PR DESCRIPTION
## Summary

Adds a `service_version` field to `OtlpConfig` and `OtlpLogsConfig` with a builder method `with_service_version()`. When set, the provided version is used for the OTLP `service.version` resource attribute instead of the crate's `CARGO_PKG_VERSION`.

Adds a corresponding `--tracing-otlp.service-version` CLI arg (and `OTEL_SERVICE_VERSION` env var) to `TraceArgs`.

## Motivation

Downstream binaries that embed reth (e.g. Tempo) currently report reth's crate version as `service.version` in OTLP telemetry, which makes it impossible to distinguish the downstream binary's version in observability backends. This change lets embedders override the version while keeping reth's version as the default.

## Changes

- `reth-tracing-otlp`: `OtlpConfig` and `OtlpLogsConfig` gain an optional `service_version` field and `with_service_version()` builder method. `build_resource()` uses the override when present, falls back to `CARGO_PKG_VERSION`.
- `reth-node-core`: `TraceArgs` gains a hidden `--tracing-otlp.service-version` arg backed by the `OTEL_SERVICE_VERSION` env var. Wired into both `init_otlp_tracing` and `init_otlp_logs`.

Prompted by: @alexey