### PR TITLE
bench: set OTLP service.version to baseline/feature label

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -157,7 +157,7 @@ fi
 # OTLP traces and logs export
 if [ "${BENCH_OTLP_DISABLED:-false}" != "true" ]; then
   if [ -n "${BENCH_OTLP_TRACES_ENDPOINT:-}" ]; then
-    RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench)
+    RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench --tracing-otlp.service-version="${LABEL}")
   fi
   if [ -n "${BENCH_OTLP_LOGS_ENDPOINT:-}" ]; then
     RETH_ARGS+=(--logs-otlp="${BENCH_OTLP_LOGS_ENDPOINT}" --logs-otlp.filter=debug)

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -137,7 +137,7 @@ fi
 
 if [ "${BENCH_OTLP_DISABLED:-false}" != "true" ]; then
   if [ -n "${BENCH_OTLP_TRACES_ENDPOINT:-}" ]; then
-    RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench)
+    RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench --tracing-otlp.service-version="${LABEL}")
   fi
   if [ -n "${BENCH_OTLP_LOGS_ENDPOINT:-}" ]; then
     RETH_ARGS+=(--logs-otlp="${BENCH_OTLP_LOGS_ENDPOINT}" --logs-otlp.filter=debug)


### PR DESCRIPTION
Pass `--tracing-otlp.service-version="${LABEL}"` in both `bench-reth-run.sh` and `bench-txgen-run.sh` so baseline and feature runs report distinct `service.version` values in OTLP telemetry.

Depends on #24142.

Prompted by: @alexey