### PR TITLE
bench: extract txgen payloads once and reuse across runs

### DIFF
--- a/.github/scripts/bench-txgen-extract.sh
+++ b/.github/scripts/bench-txgen-extract.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Pre-extracts txgen payloads (normal or big blocks) so they can be reused
+# across multiple benchmark runs instead of re-fetching from the remote RPC
+# every time.
+#
+# Starts a throwaway reth node to discover the snapshot's chain tip, extracts
+# payloads from BENCH_RPC_URL, then stops the node and recovers the snapshot.
+#
+# Usage: bench-txgen-extract.sh <binary> <output-dir>
+#
+# On success, writes:
+#   <output-dir>/all-blocks.ndjson   (or all-big-blocks.ndjson)
+#   <output-dir>/warmup-blocks.ndjson
+#   <output-dir>/benchmark-blocks.ndjson
+#
+# Required env: SCHELK_MOUNT, BENCH_RPC_URL, BENCH_BLOCKS, BENCH_WARMUP_BLOCKS
+# Optional env: BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS
+set -euxo pipefail
+
+BINARY="$1"
+OUTPUT_DIR="$2"
+
+BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
+DATADIR_NAME="datadir"
+if [ "$BIG_BLOCKS" = "true" ]; then
+  DATADIR_NAME="datadir-big-blocks"
+fi
+DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
+
+RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
+
+mkdir -p "$OUTPUT_DIR"
+
+cleanup() {
+  sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+  sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+  kill "${TAIL_PID:-}" 2>/dev/null || true
+  sudo schelk recover -y --kill || true
+}
+TAIL_PID=
+trap cleanup EXIT
+
+# Mount snapshot
+sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+sudo schelk mount -y || true
+if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
+  echo "::error::Failed to mount benchmark datadir at ${DATADIR}"
+  exit 1
+fi
+
+# Start a lightweight reth node just to query the chain tip.
+RETH_ARGS=(
+  node
+  --datadir "$DATADIR"
+  --http
+  --http.port 8545
+  --disable-discovery
+  --no-persist-peers
+)
+
+if "$BINARY" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
+  RETH_ARGS+=(--debug.startup-sync-state-idle)
+fi
+
+LOG="$OUTPUT_DIR/extract-node.log"
+sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+  nice -n -20 "$BINARY" "${RETH_ARGS[@]}" \
+  > "$LOG" 2>&1 &
+stdbuf -oL tail -f "$LOG" | sed -u "s/^/[reth-extract] /" &
+TAIL_PID=$!
+
+# Wait for RPC
+for i in $(seq 1 60); do
+  if curl -sf http://127.0.0.1:8545 -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    > /dev/null 2>&1; then
+    echo "reth (extract) RPC is up after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "::error::reth (extract) failed to start within 60s"
+    cat "$LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+HEAD_JSON=$(curl -sf http://127.0.0.1:8545 -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}')
+HEAD_HEX=$(jq -r '.result' <<< "$HEAD_JSON")
+HEAD_DEC=$((16#${HEAD_HEX#0x}))
+echo "Snapshot chain tip: ${HEAD_DEC}"
+
+# Stop the throwaway node and recover snapshot before extraction.
+sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+kill "${TAIL_PID:-}" 2>/dev/null || true
+TAIL_PID=
+sudo schelk recover -y --kill || true
+
+# --- Extract payloads from the remote RPC ---
+
+TXGEN_ETHEREUM="$(which txgen-ethereum)"
+WARMUP="${BENCH_WARMUP_BLOCKS:-0}"
+BLOCKS="${BENCH_BLOCKS:?BENCH_BLOCKS must be set}"
+TOTAL=$(( WARMUP + BLOCKS ))
+if [ "$BLOCKS" -le 0 ] || [ "$TOTAL" -le 0 ]; then
+  echo "::error::BENCH_BLOCKS must be greater than 0"
+  exit 1
+fi
+
+ALL_BLOCKS="$OUTPUT_DIR/all-blocks.ndjson"
+WARMUP_FILE="$OUTPUT_DIR/warmup-blocks.ndjson"
+BENCHMARK_FILE="$OUTPUT_DIR/benchmark-blocks.ndjson"
+
+if [ "$BIG_BLOCKS" = "true" ]; then
+  ALL_BLOCKS="$OUTPUT_DIR/all-big-blocks.ndjson"
+  WARMUP_FILE="$OUTPUT_DIR/warmup-big-blocks.ndjson"
+  BENCHMARK_FILE="$OUTPUT_DIR/measured-big-blocks.ndjson"
+fi
+
+EXTRACT_FROM=$(( HEAD_DEC + 1 ))
+if [ "$BIG_BLOCKS" = "true" ]; then
+  echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+  "$TXGEN_ETHEREUM" extract-big-blocks \
+    --rpc "$BENCH_RPC_URL" \
+    --from "$EXTRACT_FROM" \
+    --count "$TOTAL" \
+    --target-gas "${BENCH_BIG_BLOCKS_TARGET_GAS:-1G}" \
+    -o "$ALL_BLOCKS"
+else
+  EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
+  echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+  "$TXGEN_ETHEREUM" extract \
+    --rpc "$BENCH_RPC_URL" \
+    --from "$EXTRACT_FROM" \
+    --to "$EXTRACT_TO" \
+    -o "$ALL_BLOCKS"
+fi
+
+# Split into warmup and measured files
+if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
+  head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_FILE"
+else
+  : > "$WARMUP_FILE"
+fi
+awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_FILE"
+
+echo "Extraction complete: $(wc -l < "$ALL_BLOCKS") payloads in ${OUTPUT_DIR}"

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -11,7 +11,8 @@
 #               BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
-#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ
+#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ,
+#               TXGEN_PAYLOADS_DIR (pre-extracted payloads; skips extraction)
 set -euxo pipefail
 
 LABEL="$1"
@@ -220,19 +221,12 @@ else
   echo "reth (${LABEL}) binary does not support --debug.startup-sync-state-idle, skipping sync wait"
 fi
 
-TXGEN_ETHEREUM="$(which txgen-ethereum)"
 TXGEN_BENCH="$(which bench)"
 BENCH_NICE="sudo nice -n -20 sudo -u $(id -un)"
 TXGEN_SEND_ARGS=()
 if [ -n "${BENCH_WAIT_TIME:-}" ]; then
   TXGEN_SEND_ARGS+=(--wait-time "$BENCH_WAIT_TIME")
 fi
-
-HEAD_JSON=$(curl -sf http://127.0.0.1:8545 -X POST \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}')
-HEAD_HEX=$(jq -r '.result' <<< "$HEAD_JSON")
-HEAD_DEC=$((16#${HEAD_HEX#0x}))
 
 WARMUP="${BENCH_WARMUP_BLOCKS:-0}"
 BLOCKS="${BENCH_BLOCKS:?BENCH_BLOCKS must be set}"
@@ -244,43 +238,64 @@ fi
 
 TXGEN_DIR="$OUTPUT_DIR/txgen"
 mkdir -p "$TXGEN_DIR"
-ALL_BLOCKS="$TXGEN_DIR/all-blocks.ndjson"
-WARMUP_BLOCKS="$TXGEN_DIR/warmup-blocks.ndjson"
-BENCHMARK_BLOCKS="$TXGEN_DIR/benchmark-blocks.ndjson"
-if [ "$BIG_BLOCKS" = "true" ]; then
-  ALL_BIG_BLOCKS="$TXGEN_DIR/all-big-blocks.ndjson"
-  WARMUP_BIG_BLOCKS="$TXGEN_DIR/warmup-big-blocks.ndjson"
-  MEASURED_BIG_BLOCKS="$TXGEN_DIR/measured-big-blocks.ndjson"
-  ALL_BLOCKS="$ALL_BIG_BLOCKS"
-  WARMUP_BLOCKS="$WARMUP_BIG_BLOCKS"
-  BENCHMARK_BLOCKS="$MEASURED_BIG_BLOCKS"
-fi
 
-EXTRACT_FROM=$(( HEAD_DEC + 1 ))
-if [ "$BIG_BLOCKS" = "true" ]; then
-  echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
-  "$TXGEN_ETHEREUM" extract-big-blocks \
-    --rpc "$BENCH_RPC_URL" \
-    --from "$EXTRACT_FROM" \
-    --count "$TOTAL" \
-    --target-gas "${BENCH_BIG_BLOCKS_TARGET_GAS:-1G}" \
-    -o "$ALL_BIG_BLOCKS"
+# Use pre-extracted payloads if available, otherwise extract inline.
+if [ -n "${TXGEN_PAYLOADS_DIR:-}" ] && [ -d "$TXGEN_PAYLOADS_DIR" ]; then
+  echo "Using pre-extracted payloads from ${TXGEN_PAYLOADS_DIR}"
+  if [ "$BIG_BLOCKS" = "true" ]; then
+    WARMUP_BLOCKS="$TXGEN_PAYLOADS_DIR/warmup-big-blocks.ndjson"
+    BENCHMARK_BLOCKS="$TXGEN_PAYLOADS_DIR/measured-big-blocks.ndjson"
+  else
+    WARMUP_BLOCKS="$TXGEN_PAYLOADS_DIR/warmup-blocks.ndjson"
+    BENCHMARK_BLOCKS="$TXGEN_PAYLOADS_DIR/benchmark-blocks.ndjson"
+  fi
+  if [ ! -f "$BENCHMARK_BLOCKS" ]; then
+    echo "::error::Pre-extracted payloads missing: ${BENCHMARK_BLOCKS}"
+    exit 1
+  fi
 else
-  EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
-  echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
-  "$TXGEN_ETHEREUM" extract \
-    --rpc "$BENCH_RPC_URL" \
-    --from "$EXTRACT_FROM" \
-    --to "$EXTRACT_TO" \
-    -o "$ALL_BLOCKS"
-fi
+  TXGEN_ETHEREUM="$(which txgen-ethereum)"
+  HEAD_JSON=$(curl -sf http://127.0.0.1:8545 -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}')
+  HEAD_HEX=$(jq -r '.result' <<< "$HEAD_JSON")
+  HEAD_DEC=$((16#${HEAD_HEX#0x}))
 
-if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
-  head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_BLOCKS"
-else
-  : > "$WARMUP_BLOCKS"
+  ALL_BLOCKS="$TXGEN_DIR/all-blocks.ndjson"
+  WARMUP_BLOCKS="$TXGEN_DIR/warmup-blocks.ndjson"
+  BENCHMARK_BLOCKS="$TXGEN_DIR/benchmark-blocks.ndjson"
+  if [ "$BIG_BLOCKS" = "true" ]; then
+    ALL_BLOCKS="$TXGEN_DIR/all-big-blocks.ndjson"
+    WARMUP_BLOCKS="$TXGEN_DIR/warmup-big-blocks.ndjson"
+    BENCHMARK_BLOCKS="$TXGEN_DIR/measured-big-blocks.ndjson"
+  fi
+
+  EXTRACT_FROM=$(( HEAD_DEC + 1 ))
+  if [ "$BIG_BLOCKS" = "true" ]; then
+    echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+    "$TXGEN_ETHEREUM" extract-big-blocks \
+      --rpc "$BENCH_RPC_URL" \
+      --from "$EXTRACT_FROM" \
+      --count "$TOTAL" \
+      --target-gas "${BENCH_BIG_BLOCKS_TARGET_GAS:-1G}" \
+      -o "$ALL_BLOCKS"
+  else
+    EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
+    echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+    "$TXGEN_ETHEREUM" extract \
+      --rpc "$BENCH_RPC_URL" \
+      --from "$EXTRACT_FROM" \
+      --to "$EXTRACT_TO" \
+      -o "$ALL_BLOCKS"
+  fi
+
+  if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
+    head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_BLOCKS"
+  else
+    : > "$WARMUP_BLOCKS"
+  fi
+  awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_BLOCKS"
 fi
-awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_BLOCKS"
 
 if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
   echo "Running txgen warmup (${WARMUP} blocks)..."

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -556,6 +556,17 @@ jobs:
           echo "BENCH_METRICS_PROXY_PID=${PROXY_PID}" >> "$GITHUB_ENV"
           echo "Metrics proxy started (PID $PROXY_PID)"
 
+      # Extract txgen payloads once so they are reused across all benchmark
+      # runs instead of re-fetching from the remote RPC four times.
+      - name: Extract txgen payloads
+        if: env.BENCH_DRIVER == 'txgen'
+        run: |
+          PAYLOADS_DIR="$BENCH_WORK_DIR/txgen-payloads"
+          .github/scripts/bench-txgen-extract.sh \
+            "../reth-feature/target/profiling/${BENCH_NODE_BIN}" \
+            "$PAYLOADS_DIR"
+          echo "TXGEN_PAYLOADS_DIR=${PAYLOADS_DIR}" >> "$GITHUB_ENV"
+
       # Interleaved run order (B-F-F-B) to reduce systematic bias
       - name: "Run benchmark: baseline (1/2)"
         id: run-baseline-1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1015,6 +1015,17 @@ jobs:
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmarks...'});
 
+      # Extract txgen payloads once so they are reused across all benchmark
+      # runs instead of re-fetching from the remote RPC four times.
+      - name: Extract txgen payloads
+        if: env.BENCH_DRIVER == 'txgen'
+        run: |
+          PAYLOADS_DIR="$BENCH_WORK_DIR/txgen-payloads"
+          .github/scripts/bench-txgen-extract.sh \
+            "../reth-feature/target/profiling/${BENCH_NODE_BIN}" \
+            "$PAYLOADS_DIR"
+          echo "TXGEN_PAYLOADS_DIR=${PAYLOADS_DIR}" >> "$GITHUB_ENV"
+
       # Interleaved run order (F-B-B-F) to reduce systematic bias from
       # thermal drift and cache warming.
       - name: "Run benchmark: feature (1/2)"


### PR DESCRIPTION
## Summary

Extracts txgen payloads (normal and big blocks) once before the ABBA benchmark runs instead of re-fetching from the remote RPC on every run (4x for ABBA).

Fixes the issue seen in e.g. [this run](https://github.com/paradigmxyz/reth/actions/runs/25726568118/job/75546656569) where big blocks are regenerated for each of the 4 benchmark passes.

## Changes

- **New `bench-txgen-extract.sh`** — starts a throwaway reth node to query the snapshot tip, runs `txgen-ethereum extract` / `extract-big-blocks` once against the remote RPC, splits into warmup + measured files, then tears down the node and recovers the snapshot.
- **`bench-txgen-run.sh`** — when `TXGEN_PAYLOADS_DIR` is set and points to an existing directory, skips extraction entirely and reads the pre-built ndjson files. Falls back to inline extraction if unset (backward-compatible).
- **`bench.yml` and `bench-scheduled.yml`** — new "Extract txgen payloads" step (guarded by `BENCH_DRIVER == 'txgen'`) runs once before the benchmark runs, exports `TXGEN_PAYLOADS_DIR` into `GITHUB_ENV`.