### PR TITLE
ci(bench): bump BENCH_RUNNERS from 2 to 4

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,7 +95,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
-  BENCH_RUNNERS: 2
+  BENCH_RUNNERS: 4
 
 name: bench
 


### PR DESCRIPTION
The `BENCH_RUNNERS` env var in `bench.yml` was hardcoded to `2`, but there are 4 active self-hosted bench runners. This caused the queue position message in PR comments to show `(2 runner(s))` and miscalculate queue depth.

This bumps the constant to `4` to match the actual runner count.