### PR TITLE
ci(bench): use online CPUs for reth affinity

### DIFF
--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -107,7 +107,7 @@ grep Cached /proc/meminfo
 # Start reth
 # CPU layout: core 0 = OS/IRQs/reth-bench/aux, cores 1+ = reth node
 RETH_BENCH="$(which reth-bench)"
-ONLINE=$(nproc)
+ONLINE=$(getconf _NPROCESSORS_ONLN)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-reth-run.sh
+++ b/.github/scripts/bench-reth-run.sh
@@ -107,7 +107,7 @@ grep Cached /proc/meminfo
 # Start reth
 # CPU layout: core 0 = OS/IRQs/reth-bench/aux, cores 1+ = reth node
 RETH_BENCH="$(which reth-bench)"
-ONLINE=$(nproc --all)
+ONLINE=$(nproc)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -94,7 +94,7 @@ echo "=== Cache state after drop ==="
 free -h
 grep Cached /proc/meminfo
 
-ONLINE=$(nproc)
+ONLINE=$(getconf _NPROCESSORS_ONLN)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -94,7 +94,7 @@ echo "=== Cache state after drop ==="
 free -h
 grep Cached /proc/meminfo
 
-ONLINE=$(nproc --all)
+ONLINE=$(nproc)
 MAX_RETH=$(( ONLINE - 1 ))
 if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$MAX_RETH" ]; then
   MAX_RETH=$BENCH_CORES


### PR DESCRIPTION
Use `getconf _NPROCESSORS_ONLN` rather than `nproc --all` when computing the CPU range assigned to the benchmarked reth process. This keeps `AllowedCPUs` aligned with online CPUs after SMT siblings are offlined, while avoiding `nproc`'s task-affinity behavior because the benchmark script itself runs under `taskset -c 0`.

Verified with `bash -n .github/scripts/bench-reth-run.sh .github/scripts/bench-txgen-run.sh` and `git diff --check`.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: Brian