### PR TITLE
ci(bench): clear manual warmup default

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -55,7 +55,6 @@ on:
       warmup:
         description: "Number of warmup blocks (default: one-quarter of blocks)"
         required: false
-        default: ""
         type: string
 
 env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,7 +34,6 @@ on:
       warmup:
         description: "Number of warmup blocks (default: one-quarter of blocks)"
         required: false
-        default: ""
         type: string
       baseline:
         description: "Baseline git ref (default: merge-base)"


### PR DESCRIPTION
Removes the explicit empty default from manual warmup inputs so GitHub Actions renders the field without a preset value. The existing argument resolution still treats an omitted warmup as one-quarter of the requested block count.

Co-Authored-By: Brian Picciano <933154+mediocregopher@users.noreply.github.com>

Prompted by: mediocregopher