### PR TITLE
feat(engine): add optional BAL field to RethNewPayloadInput::BlockRlp

### DIFF
--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -225,10 +225,11 @@ pub(crate) fn block_to_new_payload(
     let wait_for_persistence = wait_for_persistence.rpc_value(block_number);
 
     if let Some(rlp) = rlp {
+        let bal = bal.map(|b| alloy_rlp::encode(b).into());
         return Ok((
             None,
             serde_json::to_value((
-                RethNewPayloadInput::<ExecutionData>::BlockRlp(rlp),
+                RethNewPayloadInput::<ExecutionData>::BlockRlp { rlp, bal },
                 wait_for_persistence,
                 no_wait_for_caches.then_some(false),
             ))?,

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -30,14 +30,20 @@ pub struct RethPayloadStatus {
 }
 
 /// Input for `reth_newPayload` that accepts either `ExecutionData` directly or an RLP-encoded
-/// block.
+/// block with an optional block access list.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RethNewPayloadInput<ExecutionData> {
     /// Standard execution data (payload + sidecar).
     ExecutionData(ExecutionData),
-    /// An RLP-encoded block.
-    BlockRlp(Bytes),
+    /// An RLP-encoded block with an optional RLP-encoded block access list.
+    BlockRlp {
+        /// The RLP-encoded block.
+        rlp: Bytes,
+        /// Optional RLP-encoded block access list.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bal: Option<Bytes>,
+    },
 }
 
 /// Reth-specific engine API extensions.

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -40,10 +40,10 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
 
         let payload = match input {
             RethNewPayloadInput::ExecutionData(data) => data,
-            RethNewPayloadInput::BlockRlp(rlp) => {
+            RethNewPayloadInput::BlockRlp { rlp, bal } => {
                 let block = Decodable::decode(&mut rlp.as_ref())
                     .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
-                Payload::block_to_payload(SealedBlock::new_unhashed(block), None)
+                Payload::block_to_payload(SealedBlock::new_unhashed(block), bal)
             }
         };
 


### PR DESCRIPTION
## Summary

Extends `RethNewPayloadInput::BlockRlp` from a bare `Bytes` tuple variant to a struct variant carrying both the RLP-encoded block and an optional RLP-encoded block access list:

```rust
BlockRlp {
    rlp: Bytes,
    bal: Option<Bytes>,
}
```

### Changes

- **`reth-rpc-api`**: Change `BlockRlp(Bytes)` → `BlockRlp { rlp, bal }` struct variant with `#[serde(default, skip_serializing_if)]` on the BAL field for backward-compatible JSON serialization (clients not sending `bal` get `None`).
- **`reth-rpc-engine-api`**: Forward the `bal` field to `PayloadTypes::block_to_payload()` instead of hardcoding `None`. The trait method already accepts `Option<Bytes>` since #23989.
- **`reth-bench`**: The `block_to_new_payload` RLP path now RLP-encodes and passes the BAL when available.

### Context

Follow-up to #23989 which added `bal: Option<Bytes>` to `PayloadTypes::block_to_payload` but left the `BlockRlp` RPC variant without a way to supply it. This lets bench tooling (including txgen) forward BALs when replaying raw blocks via `reth_newPayload`.