### PR TITLE
feat(rpc): support BAL with block RLP payloads

### DIFF
--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -225,10 +225,11 @@ pub(crate) fn block_to_new_payload(
     let wait_for_persistence = wait_for_persistence.rpc_value(block_number);
 
     if let Some(rlp) = rlp {
+        let bal = bal.map(|bal| alloy_rlp::encode(bal).into());
         return Ok((
             None,
             serde_json::to_value((
-                RethNewPayloadInput::<ExecutionData>::BlockRlp(rlp),
+                RethNewPayloadInput::<ExecutionData>::BlockRlp { block: rlp, bal },
                 wait_for_persistence,
                 no_wait_for_caches.then_some(false),
             ))?,

--- a/crates/rpc/rpc-api/src/reth_engine.rs
+++ b/crates/rpc/rpc-api/src/reth_engine.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::Bytes;
 use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Reth-specific payload status that includes server-measured execution latency.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,14 +30,48 @@ pub struct RethPayloadStatus {
 }
 
 /// Input for `reth_newPayload` that accepts either `ExecutionData` directly or an RLP-encoded
-/// block.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// block with optional side data.
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum RethNewPayloadInput<ExecutionData> {
     /// Standard execution data (payload + sidecar).
     ExecutionData(ExecutionData),
-    /// An RLP-encoded block.
-    BlockRlp(Bytes),
+    /// An RLP-encoded block and optional encoded block access list.
+    BlockRlp {
+        /// RLP-encoded block bytes.
+        block: Bytes,
+        /// RLP-encoded block access list bytes.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bal: Option<Bytes>,
+    },
+}
+
+impl<'de, ExecutionData> Deserialize<'de> for RethNewPayloadInput<ExecutionData>
+where
+    ExecutionData: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RethNewPayloadInputSerde<ExecutionData> {
+            ExecutionData(ExecutionData),
+            BlockRlp {
+                block: Bytes,
+                #[serde(default)]
+                bal: Option<Bytes>,
+            },
+            LegacyBlockRlp(Bytes),
+        }
+
+        Ok(match RethNewPayloadInputSerde::deserialize(deserializer)? {
+            RethNewPayloadInputSerde::ExecutionData(data) => Self::ExecutionData(data),
+            RethNewPayloadInputSerde::BlockRlp { block, bal } => Self::BlockRlp { block, bal },
+            RethNewPayloadInputSerde::LegacyBlockRlp(block) => Self::BlockRlp { block, bal: None },
+        })
+    }
 }
 
 /// Reth-specific engine API extensions.
@@ -74,4 +108,56 @@ pub trait RethEngineApi<ExecutionData> {
         &self,
         forkchoice_state: ForkchoiceState,
     ) -> RpcResult<ForkchoiceUpdated>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RethNewPayloadInput;
+    use alloy_primitives::Bytes;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestExecutionData {
+        payload: Bytes,
+        sidecar: Bytes,
+    }
+
+    #[test]
+    fn block_rlp_serializes_named_fields() {
+        let input = RethNewPayloadInput::<TestExecutionData>::BlockRlp {
+            block: Bytes::from_static(&[1]),
+            bal: Some(Bytes::from_static(&[2])),
+        };
+
+        assert_eq!(serde_json::to_value(input).unwrap(), json!({ "block": "0x01", "bal": "0x02" }));
+    }
+
+    #[test]
+    fn block_rlp_deserializes_without_bal() {
+        let input = serde_json::from_value::<RethNewPayloadInput<TestExecutionData>>(json!({
+            "block": "0x01"
+        }))
+        .unwrap();
+
+        let RethNewPayloadInput::BlockRlp { block, bal } = input else {
+            panic!("expected block rlp input")
+        };
+
+        assert_eq!(block, Bytes::from_static(&[1]));
+        assert_eq!(bal, None);
+    }
+
+    #[test]
+    fn block_rlp_deserializes_legacy_bytes() {
+        let input = serde_json::from_value::<RethNewPayloadInput<TestExecutionData>>(json!("0x01"))
+            .unwrap();
+
+        let RethNewPayloadInput::BlockRlp { block, bal } = input else {
+            panic!("expected block rlp input")
+        };
+
+        assert_eq!(block, Bytes::from_static(&[1]));
+        assert_eq!(bal, None);
+    }
 }

--- a/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/reth_engine_api.rs
@@ -40,10 +40,10 @@ impl<Payload: PayloadTypes> RethEngineApiServer<Payload::ExecutionData> for Reth
 
         let payload = match input {
             RethNewPayloadInput::ExecutionData(data) => data,
-            RethNewPayloadInput::BlockRlp(rlp) => {
-                let block = Decodable::decode(&mut rlp.as_ref())
+            RethNewPayloadInput::BlockRlp { block: block_rlp, bal } => {
+                let block = Decodable::decode(&mut block_rlp.as_ref())
                     .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
-                Payload::block_to_payload(SealedBlock::new_unhashed(block), None)
+                Payload::block_to_payload(SealedBlock::new_unhashed(block), bal)
             }
         };
 


### PR DESCRIPTION
Extends `RethNewPayloadInput::BlockRlp` to carry named `block` bytes and optional encoded BAL bytes while preserving legacy raw-bytes deserialization for block-only callers.

`reth_newPayload` now forwards optional BAL bytes into block-to-payload conversion, and `reth-bench` sends BAL side data with RLP block requests when available.