### PR TITLE
docs(engine): update getPayloadV6 handler docs

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1343,7 +1343,7 @@ where
 
     /// Handler for `engine_getPayloadV6`
     ///
-    /// Post Amsterdam payload handler. Currently returns unsupported fork error.
+    /// Post-Amsterdam payload handler that includes Block Access Lists (BAL).
     ///
     /// See also <https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_getpayloadv6>
     async fn get_payload_v6(


### PR DESCRIPTION
Updates the `engine_getPayloadV6` handler doc to reflect that Amsterdam payload V6 is implemented and carries Block Access Lists, instead of saying it returns an unsupported fork error.

This removes stale documentation left after BAL payload support landed.