### PR TITLE
fix(net): model unavailable BALs explicitly

### DIFF
--- a/crates/net/eth-wire-types/src/block_access_lists.rs
+++ b/crates/net/eth-wire-types/src/block_access_lists.rs
@@ -2,7 +2,10 @@
 
 use alloc::vec::Vec;
 use alloy_primitives::{Bytes, B256};
-use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodableWrapper, RlpEncodableWrapper};
+use alloy_rlp::{
+    BufMut, Decodable, Encodable, Header, RlpDecodableWrapper, RlpEncodableWrapper,
+    EMPTY_STRING_CODE,
+};
 use reth_codecs_derive::add_arbitrary_tests;
 
 /// A request for block access lists from the given block hashes.
@@ -15,30 +18,35 @@ pub struct GetBlockAccessLists(
     pub Vec<B256>,
 );
 
-/// Response for [`GetBlockAccessLists`] containing one BAL per requested block hash.
+/// Response for [`GetBlockAccessLists`] containing one BAL entry per requested block hash.
 ///
-/// The inner `Bytes` values store raw BAL RLP payloads and are encoded as nested RLP items, not
-/// as RLP byte strings.
+/// Present `Bytes` values store raw BAL RLP payloads and are encoded as nested RLP items, not as
+/// RLP byte strings.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[add_arbitrary_tests(rlp)]
 pub struct BlockAccessLists(
     /// The requested block access lists as raw RLP blobs. Per EIP-8159, unavailable entries are
-    /// represented by an RLP-encoded empty list (`0xc0`).
-    pub Vec<Bytes>,
+    /// represented by `None` and encoded as the RLP empty string (`0x80`).
+    pub Vec<Option<Bytes>>,
 );
 
 impl Encodable for BlockAccessLists {
     fn encode(&self, out: &mut dyn BufMut) {
-        let payload_length = self.0.iter().map(|bytes| bytes.len()).sum();
+        let payload_length =
+            self.0.iter().map(|entry| entry.as_ref().map_or(1, |bytes| bytes.len())).sum();
         Header { list: true, payload_length }.encode(out);
-        for bal in &self.0 {
-            out.put_slice(bal);
+        for entry in &self.0 {
+            match entry {
+                Some(bal) => out.put_slice(bal),
+                None => out.put_u8(EMPTY_STRING_CODE),
+            }
         }
     }
 
     fn length(&self) -> usize {
-        let payload_length = self.0.iter().map(|bytes| bytes.len()).sum();
+        let payload_length =
+            self.0.iter().map(|entry| entry.as_ref().map_or(1, |bytes| bytes.len())).sum();
         Header { list: true, payload_length }.length_with_payload()
     }
 }
@@ -49,6 +57,9 @@ impl Decodable for BlockAccessLists {
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString)
         }
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort)
+        }
 
         let (mut payload, rest) = buf.split_at(header.payload_length);
         *buf = rest;
@@ -57,12 +68,19 @@ impl Decodable for BlockAccessLists {
         while !payload.is_empty() {
             let item_start = payload;
             let item_header = Header::decode(&mut payload)?;
-            if !item_header.list {
+            let header_length = item_start.len() - payload.len();
+            let item_length = header_length + item_header.payload_length;
+            if item_length > item_start.len() {
+                return Err(alloy_rlp::Error::InputTooShort)
+            }
+            if item_header.list {
+                bals.push(Some(Bytes::copy_from_slice(&item_start[..item_length])));
+            } else if item_start[..item_length] == [EMPTY_STRING_CODE] {
+                bals.push(None);
+            } else {
                 return Err(alloy_rlp::Error::UnexpectedString)
             }
 
-            let item_length = item_header.length_with_payload();
-            bals.push(Bytes::copy_from_slice(&item_start[..item_length]));
             payload = &payload[item_header.payload_length..];
         }
 
@@ -73,12 +91,13 @@ impl Decodable for BlockAccessLists {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for BlockAccessLists {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let entries = Vec::<Vec<alloy_eip7928::AccountChanges>>::arbitrary(u)?
+        let entries = Vec::<Option<Vec<alloy_eip7928::AccountChanges>>>::arbitrary(u)?
             .into_iter()
             .map(|entry| {
+                let entry = entry?;
                 let mut out = Vec::new();
                 alloy_rlp::encode_list(&entry, &mut out);
-                Bytes::from(out)
+                Some(Bytes::from(out))
             })
             .collect();
         Ok(Self(entries))
@@ -92,7 +111,7 @@ mod tests {
         AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
     };
     use alloy_primitives::{Address, U256};
-    use alloy_rlp::EMPTY_LIST_CODE;
+    use alloy_rlp::{EMPTY_LIST_CODE, EMPTY_STRING_CODE};
 
     fn elaborate_account_changes(seed: u8) -> Vec<AccountChanges> {
         vec![
@@ -141,18 +160,25 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_bal_entry_encodes_as_empty_string() {
+        let encoded = alloy_rlp::encode(BlockAccessLists(vec![None]));
+        assert_eq!(encoded, vec![0xc1, EMPTY_STRING_CODE]);
+    }
+
+    #[test]
     fn empty_bal_entry_encodes_as_empty_list() {
         let encoded =
-            alloy_rlp::encode(BlockAccessLists(vec![Bytes::from_static(&[EMPTY_LIST_CODE])]));
+            alloy_rlp::encode(BlockAccessLists(vec![Some(Bytes::from_static(&[EMPTY_LIST_CODE]))]));
         assert_eq!(encoded, vec![0xc1, EMPTY_LIST_CODE]);
     }
 
     #[test]
     fn block_access_lists_roundtrip_preserves_raw_bal_items() {
         let original = BlockAccessLists(vec![
-            Bytes::from_static(&[EMPTY_LIST_CODE]),
-            Bytes::from_static(&[0xc1, EMPTY_LIST_CODE]),
-            Bytes::from_static(&[0xc2, EMPTY_LIST_CODE, EMPTY_LIST_CODE]),
+            None,
+            Some(Bytes::from_static(&[EMPTY_LIST_CODE])),
+            Some(Bytes::from_static(&[0xc1, EMPTY_LIST_CODE])),
+            Some(Bytes::from_static(&[0xc2, EMPTY_LIST_CODE, EMPTY_LIST_CODE])),
         ]);
 
         let encoded = alloy_rlp::encode(&original);
@@ -177,6 +203,19 @@ mod tests {
     }
 
     #[test]
+    fn rejects_non_empty_string_bal_entries() {
+        let err = alloy_rlp::decode_exact::<BlockAccessLists>(&[0xc2, 0x81, 0x80]).unwrap_err();
+        assert!(matches!(err, alloy_rlp::Error::UnexpectedString));
+    }
+
+    #[test]
+    fn rejects_truncated_response_payload() {
+        let err =
+            alloy_rlp::decode_exact::<BlockAccessLists>(&[0xc2, EMPTY_LIST_CODE]).unwrap_err();
+        assert!(matches!(err, alloy_rlp::Error::InputTooShort));
+    }
+
+    #[test]
     fn elaborate_bal_entry_roundtrips_into_account_changes() {
         let expected = elaborate_account_changes(0x11);
         let decoded =
@@ -188,9 +227,10 @@ mod tests {
     #[test]
     fn elaborate_block_access_lists_roundtrip_preserves_complex_bal_contents() {
         let original = BlockAccessLists(vec![
-            elaborate_bal_entry(0x11),
-            Bytes::from_static(&[EMPTY_LIST_CODE]),
-            elaborate_bal_entry(0x77),
+            Some(elaborate_bal_entry(0x11)),
+            None,
+            Some(Bytes::from_static(&[EMPTY_LIST_CODE])),
+            Some(elaborate_bal_entry(0x77)),
         ]);
 
         let encoded = alloy_rlp::encode(&original);
@@ -198,12 +238,16 @@ mod tests {
 
         assert_eq!(decoded, original);
         assert_eq!(
-            alloy_rlp::decode_exact::<Vec<AccountChanges>>(&decoded.0[0]).unwrap(),
+            alloy_rlp::decode_exact::<Vec<AccountChanges>>(decoded.0[0].as_ref().unwrap()).unwrap(),
             elaborate_account_changes(0x11)
         );
-        assert_eq!(alloy_rlp::decode_exact::<Vec<AccountChanges>>(&decoded.0[1]).unwrap(), vec![]);
+        assert!(decoded.0[1].is_none());
         assert_eq!(
-            alloy_rlp::decode_exact::<Vec<AccountChanges>>(&decoded.0[2]).unwrap(),
+            alloy_rlp::decode_exact::<Vec<AccountChanges>>(decoded.0[2].as_ref().unwrap()).unwrap(),
+            vec![]
+        );
+        assert_eq!(
+            alloy_rlp::decode_exact::<Vec<AccountChanges>>(decoded.0[3].as_ref().unwrap()).unwrap(),
             elaborate_account_changes(0x77)
         );
     }
@@ -212,7 +256,8 @@ mod tests {
     fn elaborate_block_access_lists_embed_raw_bal_payloads_without_reencoding() {
         let first = elaborate_bal_entry(0x21);
         let second = elaborate_bal_entry(0x42);
-        let encoded = alloy_rlp::encode(BlockAccessLists(vec![first.clone(), second.clone()]));
+        let encoded =
+            alloy_rlp::encode(BlockAccessLists(vec![Some(first.clone()), Some(second.clone())]));
 
         let header = alloy_rlp::Header::decode(&mut &encoded[..]).unwrap();
         let payload = &encoded[header.length()..];

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -511,8 +511,8 @@ mod tests {
         test_roundtrip(SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
             request_id: 42,
             block_access_lists: BlockAccessLists(vec![
-                Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]),
-                Bytes::from_static(&[0xc1, alloy_rlp::EMPTY_LIST_CODE]),
+                Some(Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE])),
+                Some(Bytes::from_static(&[0xc1, alloy_rlp::EMPTY_LIST_CODE])),
             ]),
         }));
     }

--- a/crates/net/eth-wire/src/eth_snap_stream.rs
+++ b/crates/net/eth-wire/src/eth_snap_stream.rs
@@ -575,9 +575,9 @@ mod tests {
         let inner = EthSnapStreamInner::<EthNetworkPrimitives>::new(EthVersion::Eth67);
         let snap2_msg = SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
             request_id: 1,
-            block_access_lists: BlockAccessLists(vec![alloy_primitives::Bytes::from_static(&[
-                alloy_rlp::EMPTY_LIST_CODE,
-            ])]),
+            block_access_lists: BlockAccessLists(vec![Some(alloy_primitives::Bytes::from_static(
+                &[alloy_rlp::EMPTY_LIST_CODE],
+            ))]),
         });
 
         let encoded = EthSnapStreamInner::<EthNetworkPrimitives>::new_with_snap_version(

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use alloy_consensus::{BlockHeader, ReceiptWithBloom};
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::Bytes;
 use alloy_rlp::Encodable;
 use futures::StreamExt;
 use reth_eth_wire::{
@@ -343,29 +342,10 @@ where
         request.0.truncate(MAX_BLOCK_ACCESS_LISTS_SERVE);
 
         let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(SOFT_RESPONSE_LIMIT);
-        let access_lists = self
-            .client
-            .bal_store()
-            .get_by_hashes_with_limit(&request.0, limit)
-            .unwrap_or_else(|_| empty_block_access_lists_with_limit(request.0.len(), limit));
+        let access_lists =
+            self.client.bal_store().get_by_hashes_with_limit(&request.0, limit).unwrap_or_default();
         let _ = response.send(Ok(BlockAccessLists(access_lists)));
     }
-}
-
-/// Builds the error fallback response while still enforcing the BAL response soft limit.
-fn empty_block_access_lists_with_limit(count: usize, limit: GetBlockAccessListLimit) -> Vec<Bytes> {
-    let mut out = Vec::with_capacity(count);
-    let mut size = 0;
-    for _ in 0..count {
-        let bal = Bytes::from_static(&[0xc0]);
-        size += bal.len();
-        out.push(bal);
-
-        if limit.exceeds(size) {
-            break
-        }
-    }
-    out
 }
 
 /// An endless future.

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -3,7 +3,7 @@
 
 use alloy_consensus::Header;
 use alloy_eips::NumHash;
-use alloy_primitives::{keccak256, Bytes, Sealed, B256};
+use alloy_primitives::{keccak256, BlockHash, BlockNumber, Bytes, Sealed, B256};
 use rand::Rng;
 use reth_eth_wire::{BlockAccessLists, EthVersion, GetBlockAccessLists, HeadersDirection};
 use reth_ethereum_primitives::Block;
@@ -19,7 +19,10 @@ use reth_network_p2p::{
     headers::client::{HeadersClient, HeadersRequest},
     BlockAccessListsClient,
 };
-use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore, SealedBal};
+use reth_provider::{
+    test_utils::MockEthProvider, BalNotificationStream, BalStore, BalStoreHandle, InMemoryBalStore,
+    ProviderError, ProviderResult, SealedBal,
+};
 use reth_transaction_pool::test_utils::{TestPool, TransactionGenerator};
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -549,10 +552,7 @@ async fn test_eth71_get_block_access_lists() {
     bal_store.insert(NumHash::new(3, hash2), sealed_bal(bal2.clone())).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1, hash2]).await;
-    assert_eq!(
-        response,
-        BlockAccessLists(vec![bal0, Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]), bal2,])
-    );
+    assert_eq!(response, BlockAccessLists(vec![Some(bal0), None, Some(bal2)]));
 }
 
 // Ensures BAL responses stop at the soft response limit while keeping the item that crosses it.
@@ -575,7 +575,7 @@ async fn test_eth71_get_block_access_lists_respects_response_soft_limit() {
 
     let response = request_block_access_lists(&net, vec![hash0, hash1, hash2]).await;
 
-    assert_eq!(response, BlockAccessLists(vec![bal0, bal1]));
+    assert_eq!(response, BlockAccessLists(vec![Some(bal0), Some(bal1)]));
 }
 
 // Ensures a single BAL larger than the soft limit is still returned.
@@ -594,7 +594,7 @@ async fn test_eth71_get_block_access_lists_returns_single_oversized_bal() {
 
     let response = request_block_access_lists(&net, vec![hash0, hash1]).await;
 
-    assert_eq!(response, BlockAccessLists(vec![bal0]));
+    assert_eq!(response, BlockAccessLists(vec![Some(bal0)]));
 }
 
 // Ensures an empty BAL request roundtrips to an empty response.
@@ -643,10 +643,23 @@ async fn test_eth71_fetch_client_get_block_access_lists() {
     let fetch = net.peers()[0].network().fetch_client().await.unwrap();
     let response = fetch.get_block_access_lists(vec![hash0, hash1]).await.unwrap().into_data();
 
-    assert_eq!(
-        response,
-        BlockAccessLists(vec![bal0, Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE])])
-    );
+    assert_eq!(response, BlockAccessLists(vec![Some(bal0), None]));
+}
+
+// Ensures store errors produce a valid empty BAL response instead of synthesizing unavailable
+// entries.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth71_get_block_access_lists_returns_empty_on_store_error() {
+    reth_tracing::init_test_tracing();
+    let (net, _) = spawn_bal_testnet_with_store(
+        [EthVersion::Eth71, EthVersion::Eth71],
+        BalStoreHandle::new(FailingLookupBalStore),
+    )
+    .await;
+
+    let response = request_block_access_lists(&net, vec![B256::random(), B256::random()]).await;
+
+    assert_eq!(response, BlockAccessLists(Vec::new()));
 }
 
 // Ensures default fetch client BAL requests are rejected when no eth/71 peer is available.
@@ -669,8 +682,15 @@ async fn spawn_eth71_bal_testnet() -> (BalTestnetHandle, BalStoreHandle) {
 async fn spawn_bal_testnet(
     versions: impl IntoIterator<Item = EthVersion>,
 ) -> (BalTestnetHandle, BalStoreHandle) {
+    spawn_bal_testnet_with_store(versions, BalStoreHandle::new(InMemoryBalStore::default())).await
+}
+
+// Spawns a BAL testnet with one peer per requested eth protocol version and the given BAL store.
+async fn spawn_bal_testnet_with_store(
+    versions: impl IntoIterator<Item = EthVersion>,
+    bal_store: BalStoreHandle,
+) -> (BalTestnetHandle, BalStoreHandle) {
     let mut mock_provider = MockEthProvider::default();
-    let bal_store = BalStoreHandle::new(InMemoryBalStore::default());
     mock_provider.bal_store = bal_store.clone();
     let mock_provider = Arc::new(mock_provider);
 
@@ -687,6 +707,31 @@ async fn spawn_bal_testnet(
     net.connect_peers().await;
 
     (net, bal_store)
+}
+
+#[derive(Debug)]
+struct FailingLookupBalStore;
+
+impl BalStore for FailingLookupBalStore {
+    fn insert(&self, _num_hash: NumHash, _bal: SealedBal) -> ProviderResult<()> {
+        Ok(())
+    }
+
+    fn prune(&self, _tip: BlockNumber) -> ProviderResult<usize> {
+        Ok(0)
+    }
+
+    fn get_by_hashes(&self, _block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
+        Err(ProviderError::other(std::io::Error::other("BAL lookup failed")))
+    }
+
+    fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
+        Ok(Vec::new())
+    }
+
+    fn bal_stream(&self) -> BalNotificationStream {
+        BalStoreHandle::noop().bal_stream()
+    }
 }
 
 // Sends a GetBlockAccessLists request from peer 0 to peer 1.

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -30,9 +30,6 @@ use std::{
 };
 use tracing::{debug, trace};
 
-/// RLP encoding for an empty list.
-const EMPTY_LIST_CODE: u8 = 0xc0;
-
 /// A sealed block with associated data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SealedBlockWith<B: Block, T = Option<Sealed<Bytes>>> {
@@ -541,7 +538,7 @@ where
 /// Tracks the BAL request and its completed result.
 enum BalRequestState<Req> {
     Pending(Req),
-    Ready(Option<WithPeerId<Bytes>>),
+    Ready(Option<WithPeerId<Option<Bytes>>>),
 }
 
 impl<Req> BalRequestState<Req> {
@@ -1165,23 +1162,19 @@ impl<Net> Default for NoopFullBlockClient<Net> {
 /// Validates one raw block access-list entry against the block's access-list hash.
 ///
 /// Returns `Ok(Some(_))` for a matching entry, `Ok(None)` when the block has no access-list hash
-/// or the peer returned the RLP empty-list unavailable marker, and `Err(peer)` for a non-empty hash
-/// mismatch that should be reported as a bad message.
+/// or the peer returned an unavailable entry, and `Err(peer)` for a hash mismatch that should be
+/// reported as a bad message.
 fn seal_block_access_list_for_block<B: Block>(
     block: &SealedBlock<B>,
-    access_list: WithPeerId<Bytes>,
+    access_list: WithPeerId<Option<Bytes>>,
 ) -> Result<Option<Sealed<Bytes>>, PeerId> {
     let Some(expected) = block.header().block_access_list_hash() else { return Ok(None) };
 
     let (peer, access_list) = access_list.split();
+    let Some(access_list) = access_list else { return Ok(None) };
     let computed = keccak256(access_list.as_ref());
     if computed == expected {
         return Ok(Some(Sealed::new_unchecked(access_list, expected)))
-    }
-
-    // A mismatched RLP empty list means the peer returned the "unavailable" BAL entry.
-    if access_list.as_ref() == [EMPTY_LIST_CODE] {
-        return Ok(None)
     }
 
     debug!(
@@ -1271,6 +1264,8 @@ mod tests {
             Arc,
         },
     };
+
+    const EMPTY_LIST_CODE: u8 = 0xc0;
     use tokio::time::{timeout, Duration};
 
     fn sealed_access_list(access_list: Bytes) -> Sealed<Bytes> {
@@ -1407,13 +1402,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_single_full_block_with_access_lists_treats_empty_entry_as_unavailable() {
+    async fn download_single_full_block_with_access_lists_treats_none_as_unavailable() {
         let client = FullBlockWithAccessListsClient::default();
         let body = BlockBody::default();
         let expected_access_list = Bytes::from_static(&[0xc1, 0x01]);
-        let unavailable_access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
         let header = sealed_header_with_access_list_hash(&expected_access_list);
-        client.insert(header.clone(), body.clone(), unavailable_access_list);
+        client.inner.insert(header.clone(), body.clone());
 
         let bad_messages = Arc::clone(&client.bad_messages);
         let client = FullBlockClient::test_client(client);
@@ -1426,6 +1420,28 @@ mod tests {
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert!(received.access_list().is_none());
         assert_eq!(bad_messages.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn download_single_full_block_with_access_lists_rejects_wrong_empty_list() {
+        let client = FullBlockWithAccessListsClient::default();
+        let body = BlockBody::default();
+        let expected_access_list = Bytes::from_static(&[0xc1, 0x01]);
+        let wrong_empty_access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&expected_access_list);
+        client.insert(header.clone(), body.clone(), wrong_empty_access_list);
+
+        let bad_messages = Arc::clone(&client.bad_messages);
+        let client = FullBlockClient::test_client(client);
+
+        let received =
+            timeout(Duration::from_secs(1), client.get_full_block_with_access_lists(header.hash()))
+                .await
+                .expect("block request should complete without access lists");
+
+        assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
+        assert!(received.access_list().is_none());
+        assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -1672,16 +1688,10 @@ mod tests {
             let mut access_lists: Vec<_> = hashes
                 .into_iter()
                 .take(self.access_list_soft_limit.load(Ordering::SeqCst))
-                .map(|hash| {
-                    self.access_lists
-                        .lock()
-                        .get(&hash)
-                        .cloned()
-                        .unwrap_or_else(|| Bytes::from_static(&[EMPTY_LIST_CODE]))
-                })
+                .map(|hash| self.access_lists.lock().get(&hash).cloned())
                 .collect();
             for _ in 0..self.extra_access_list_entries.load(Ordering::SeqCst) {
-                access_lists.push(Bytes::from_static(&[EMPTY_LIST_CODE]));
+                access_lists.push(None);
             }
 
             MaybePendingAccessLists::new(
@@ -1936,7 +1946,7 @@ mod tests {
     async fn download_full_block_range_with_access_lists_preserves_unavailable_entries() {
         let client = FullBlockWithAccessListsClient::default();
         let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
-        client.access_lists.lock().insert(header.hash(), Bytes::from_static(&[EMPTY_LIST_CODE]));
+        client.access_lists.lock().remove(&header.hash());
 
         let access_lists = Arc::clone(&client.access_lists);
         let bad_messages = Arc::clone(&client.bad_messages);

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -184,18 +184,14 @@ impl BalStore for InMemoryBalStore {
         &self,
         block_hashes: &[BlockHash],
         limit: GetBlockAccessListLimit,
-        out: &mut Vec<Bytes>,
+        out: &mut Vec<Option<Bytes>>,
     ) -> ProviderResult<()> {
         let inner = self.inner.read();
         let mut size = 0;
 
         for hash in block_hashes {
-            let bal = inner
-                .entries
-                .get(hash)
-                .map(|entry| entry.bal.clone())
-                .unwrap_or_else(|| Bytes::from_static(&[0xc0]));
-            size += bal.len();
+            let bal = inner.entries.get(hash).map(|entry| entry.bal.clone());
+            size += bal.as_ref().map_or(1, |bytes| bytes.len());
             out.push(bal);
 
             if limit.exceeds(size) {
@@ -293,7 +289,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(limited, vec![bal0, bal1]);
+        assert_eq!(limited, vec![Some(bal0), Some(bal1)]);
     }
 
     #[test]

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -105,13 +105,13 @@ pub trait BalStore: Send + Sync + 'static {
     /// Fetch BAL response entries for the given block hashes, stopping after the soft limit is
     /// exceeded.
     ///
-    /// Entries are returned in request order. Unavailable BALs are represented as an RLP-encoded
-    /// empty list (`0xc0`). The limit is soft: the entry that exceeds the limit is included.
+    /// Entries are returned in request order. Unavailable BALs are represented as `None`. The
+    /// limit is soft: the entry that exceeds the limit is included.
     fn get_by_hashes_with_limit(
         &self,
         block_hashes: &[BlockHash],
         limit: GetBlockAccessListLimit,
-    ) -> ProviderResult<Vec<Bytes>> {
+    ) -> ProviderResult<Vec<Option<Bytes>>> {
         let mut out = Vec::new();
         self.append_by_hashes_with_limit(block_hashes, limit, &mut out)?;
         out.shrink_to_fit();
@@ -125,12 +125,11 @@ pub trait BalStore: Send + Sync + 'static {
         &self,
         block_hashes: &[BlockHash],
         limit: GetBlockAccessListLimit,
-        out: &mut Vec<Bytes>,
+        out: &mut Vec<Option<Bytes>>,
     ) -> ProviderResult<()> {
         let mut size = 0;
         for bal in self.get_by_hashes(block_hashes)? {
-            let bal = bal.unwrap_or_else(|| Bytes::from_static(&[0xc0]));
-            size += bal.len();
+            size += bal.as_ref().map_or(1, |bytes| bytes.len());
             out.push(bal);
 
             if limit.exceeds(size) {
@@ -248,7 +247,7 @@ impl BalStoreHandle {
         &self,
         block_hashes: &[BlockHash],
         limit: GetBlockAccessListLimit,
-    ) -> ProviderResult<Vec<Bytes>> {
+    ) -> ProviderResult<Vec<Option<Bytes>>> {
         self.inner.get_by_hashes_with_limit(block_hashes, limit)
     }
 
@@ -258,7 +257,7 @@ impl BalStoreHandle {
         &self,
         block_hashes: &[BlockHash],
         limit: GetBlockAccessListLimit,
-        out: &mut Vec<Bytes>,
+        out: &mut Vec<Option<Bytes>>,
     ) -> ProviderResult<()> {
         self.inner.append_by_hashes_with_limit(block_hashes, limit, out)
     }
@@ -321,13 +320,12 @@ impl BalStore for NoopBalStore {
         &self,
         block_hashes: &[BlockHash],
         limit: GetBlockAccessListLimit,
-        out: &mut Vec<Bytes>,
+        out: &mut Vec<Option<Bytes>>,
     ) -> ProviderResult<()> {
         let mut size = 0;
         for _ in block_hashes {
-            let bal = Bytes::from_static(&[0xc0]);
-            size += bal.len();
-            out.push(bal);
+            size += 1;
+            out.push(None);
 
             if limit.exceeds(size) {
                 break
@@ -352,6 +350,8 @@ mod tests {
     use alloy_primitives::B256;
     #[cfg(feature = "std")]
     use tokio_stream::StreamExt;
+
+    const EMPTY_LIST_CODE: u8 = 0xc0;
 
     #[test]
     fn noop_store_returns_empty_results() {
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn decoded_lookup_decodes_raw_bal() {
         let hash = B256::random();
-        let raw_bal = Bytes::from_static(&[0xc0]);
+        let raw_bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
         let store = BalStoreHandle::new(TestBalStore { hash, raw_bal: raw_bal.clone() });
 
         assert_eq!(store.get_by_hash(hash).unwrap(), Some(raw_bal.clone()));
@@ -408,7 +408,7 @@ mod tests {
             .get_by_hashes_with_limit(&hashes, GetBlockAccessListLimit::ResponseSizeSoftLimit(1))
             .unwrap();
 
-        assert_eq!(limited, vec![Bytes::from_static(&[0xc0]), Bytes::from_static(&[0xc0])]);
+        assert_eq!(limited, vec![None, None]);
     }
 
     #[test]


### PR DESCRIPTION
EIP-8159 specifies unavailable `BlockAccessLists` entries as the RLP empty string (`0x80`), while a valid empty BAL is the RLP empty list (`0xc0`).

This models unavailable entries as `None` in `BlockAccessLists` and BAL store response helpers. Encoding maps `None` to `0x80`; present BALs are still emitted as raw RLP items, so a real empty BAL remains `Some(0xc0)`.

Store lookup errors now return an empty `BlockAccessLists` response instead of synthesizing unavailable entries. This removes sentinel-byte ambiguity before hashing and validation.