### PR TITLE
bench: show per-phase status in PR comment during benchmark runs

### DIFF
--- a/.github/scripts/bench-update-status.sh
+++ b/.github/scripts/bench-update-status.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Updates the reth-bench PR comment with current status via the GitHub API.
+#
+# Usage: bench-update-status.sh "Running benchmark: feature (1/2)..."
+#
+# Reads from environment:
+#   BENCH_COMMENT_ID  – GitHub comment ID to update
+#   BENCH_GH_TOKEN    – GitHub token for API auth
+#   BENCH_ACTOR       – User who triggered the benchmark
+#   BENCH_JOB_URL     – URL to the Actions job page
+#   BENCH_CONFIG      – Config line (blocks, warmup, refs)
+#   GITHUB_REPOSITORY – owner/repo
+
+set -euo pipefail
+
+STATUS="$1"
+
+if [ -z "${BENCH_COMMENT_ID:-}" ] || [ -z "${BENCH_GH_TOKEN:-}" ]; then
+  exit 0
+fi
+
+BODY=$(printf 'cc @%s\n\n🚀 Benchmark started! [View job](%s)\n\n⏳ **Status:** %s\n\n%s' \
+  "${BENCH_ACTOR:-}" "${BENCH_JOB_URL:-}" "$STATUS" "${BENCH_CONFIG:-}")
+
+PAYLOAD=$(jq -n --arg body "$BODY" '{body: $body}')
+
+curl -sS -X PATCH \
+  "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${BENCH_COMMENT_ID}" \
+  -H "Authorization: token ${BENCH_GH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -d "$PAYLOAD" > /dev/null || echo "Warning: failed to update PR comment status"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1006,15 +1006,6 @@ jobs:
           echo "BENCH_METRICS_PROXY_PID=${PROXY_PID}" >> "$GITHUB_ENV"
           echo "Metrics proxy started (PID $PROXY_PID)"
 
-      - name: Update status (running benchmarks)
-        if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ secrets.DEREK_PAT }}
-          script: |
-            const s = require('./.github/scripts/bench-update-status.js');
-            await s({github, context, status: 'Running benchmarks...'});
-
       # Extract txgen payloads once so they are reused across all benchmark
       # runs instead of re-fetching from the remote RPC four times.
       - name: Extract txgen payloads
@@ -1033,7 +1024,9 @@ jobs:
         env:
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
           OTEL_RESOURCE_ATTRIBUTES: "benchmark_id=${{ env.BENCH_ID }},benchmark_run=feature-1,run_type=feature,git_ref=${{ steps.refs.outputs.feature-ref }}"
+          BENCH_GH_TOKEN: ${{ secrets.DEREK_PAT }}
         run: |
+          .github/scripts/bench-update-status.sh "Running benchmark: feature (1/2)..."
           LAST_RUN_START=$(date +%s)
           echo "BENCH_LAST_RUN_START=${LAST_RUN_START}" >> "$GITHUB_ENV"
           cat > "$BENCH_LABELS_FILE" <<LABELS
@@ -1050,7 +1043,9 @@ jobs:
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           OTEL_RESOURCE_ATTRIBUTES: "benchmark_id=${{ env.BENCH_ID }},benchmark_run=baseline-1,run_type=baseline,git_ref=${{ steps.refs.outputs.baseline-ref }}"
+          BENCH_GH_TOKEN: ${{ secrets.DEREK_PAT }}
         run: |
+          .github/scripts/bench-update-status.sh "Running benchmark: baseline (1/2)..."
           LAST_RUN_START=$(date +%s)
           echo "BENCH_LAST_RUN_START=${LAST_RUN_START}" >> "$GITHUB_ENV"
           cat > "$BENCH_LABELS_FILE" <<LABELS
@@ -1068,7 +1063,9 @@ jobs:
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           OTEL_RESOURCE_ATTRIBUTES: "benchmark_id=${{ env.BENCH_ID }},benchmark_run=baseline-2,run_type=baseline,git_ref=${{ steps.refs.outputs.baseline-ref }}"
+          BENCH_GH_TOKEN: ${{ secrets.DEREK_PAT }}
         run: |
+          .github/scripts/bench-update-status.sh "Running benchmark: baseline (2/2)..."
           LAST_RUN_START=$(date +%s)
           echo "BENCH_LAST_RUN_START=${LAST_RUN_START}" >> "$GITHUB_ENV"
           cat > "$BENCH_LABELS_FILE" <<LABELS
@@ -1086,7 +1083,9 @@ jobs:
         env:
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
           OTEL_RESOURCE_ATTRIBUTES: "benchmark_id=${{ env.BENCH_ID }},benchmark_run=feature-2,run_type=feature,git_ref=${{ steps.refs.outputs.feature-ref }}"
+          BENCH_GH_TOKEN: ${{ secrets.DEREK_PAT }}
         run: |
+          .github/scripts/bench-update-status.sh "Running benchmark: feature (2/2)..."
           LAST_RUN_START=$(date +%s)
           echo "BENCH_LAST_RUN_START=${LAST_RUN_START}" >> "$GITHUB_ENV"
           cat > "$BENCH_LABELS_FILE" <<LABELS


### PR DESCRIPTION
Replace the static **Running benchmarks…** status with per-phase updates before each run step (e.g. `Running benchmark: feature (1/2)…`).

Adds a status update step before each of the 4 benchmark runs (F-B-B-F order). The ABBA steps are gated on `BENCH_ABBA != 'false'` to match their run steps. Removes the now-redundant generic status update.