### PR TITLE
fix(op): prioritize head over finalized as backfill target on OP Stack

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1848,33 +1848,22 @@ where
             self.canonical_in_memory_state.set_canonical_head(new_head);
         }
 
-        // check if we need to run backfill again by comparing the most recent finalized height to
-        // the backfill height
-        let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()
-        else {
-            return Ok(())
-        };
-        if sync_target_state.finalized_block_hash.is_zero() {
-            // no finalized block, can't check distance
-            return Ok(())
-        }
-        // get the block number of the finalized block, if we have it
-        let newest_finalized = self
-            .state
-            .buffer
-            .block(&sync_target_state.finalized_block_hash)
-            .map(|block| block.number());
+        // check if we need to run backfill again by comparing the most recent backfill target
+        // height to the backfill height
+        let Some(target_hash) = self.backfill_target_hash() else { return Ok(()) };
+        // get the block number of the backfill target block, if we have it buffered
+        let newest_target = self.state.buffer.block(&target_hash).map(|block| block.number());
 
-        // The block number that the backfill finished at - if the progress or newest
-        // finalized is None then we can't check the distance anyways.
+        // The block number that the backfill finished at - if the progress or newest target is
+        // None then we can't check the distance anyways.
         //
-        // If both are Some, we perform another distance check and return the desired
-        // backfill target
+        // If both are Some, we perform another distance check and return the desired backfill
+        // target
         if let Some(backfill_target) =
-            ctrl.block_number().zip(newest_finalized).and_then(|(progress, finalized_number)| {
+            ctrl.block_number().zip(newest_target).and_then(|(progress, target_number)| {
                 // Determines whether or not we should run backfill again, in case
                 // the new gap is still large enough and requires running backfill again
-                self.backfill_sync_target(progress, finalized_number, None)
+                self.backfill_sync_target(progress, target_number, None)
             })
         {
             // request another backfill run
@@ -1885,6 +1874,10 @@ where
         };
 
         // Check if there are more blocks to sync between current head and FCU target
+        let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()
+        else {
+            return Ok(())
+        };
         if let Some(lowest_buffered) =
             self.state.buffer.lowest_ancestor(&sync_target_state.head_block_hash)
         {
@@ -2532,85 +2525,73 @@ where
         }
     }
 
-    /// Returns the target hash to sync to if the distance from the local tip to the block is
-    /// greater than the threshold and we're not synced to the finalized block yet (if we've seen
-    /// that block already).
+    /// Returns the block hash that backfill should target.
     ///
-    /// If this is invoked after a new block has been downloaded, the downloaded block could be the
-    /// (missing) finalized block.
+    /// Defaults to the finalized block hash. The head block hash is used instead when:
+    /// * The chain is OP Stack — the CL finalizes in large batches and the finalized hash can lag
+    ///   the canonical tip by a wide margin; reorgs are rare in practice, so syncing to head is
+    ///   preferable to syncing to a stale finalized block. In addition, EL syncing is used to fill
+    ///   unsafe chain gaps on OP Stack.
+    /// * The finalized hash is zero — the CL has no finalized block yet (optimistic sync); fall
+    ///   back to head as the backfill target.
+    ///
+    /// Returns `None` if no forkchoice state has been received or the resolved target hash is
+    /// zero.
+    fn backfill_target_hash(&self) -> Option<B256> {
+        let state = self.state.forkchoice_state_tracker.sync_target_state()?;
+        let hash = if self.engine_kind.is_opstack() || state.finalized_block_hash.is_zero() {
+            state.head_block_hash
+        } else {
+            state.finalized_block_hash
+        };
+        (!hash.is_zero()).then_some(hash)
+    }
+
+    /// Returns the target hash to sync to if the distance from the local tip is greater than the
+    /// threshold and we're not yet synced to the backfill target (see
+    /// [`Self::backfill_target_hash`]).
+    ///
+    /// If this is invoked after a new block has been downloaded, the downloaded block could be
+    /// the (missing) target block.
     fn backfill_sync_target(
         &self,
         canonical_tip_num: u64,
         target_block_number: u64,
         downloaded_block: Option<BlockNumHash>,
     ) -> Option<B256> {
-        let sync_target_state = self.state.forkchoice_state_tracker.sync_target_state();
+        let target_hash = self.backfill_target_hash()?;
 
-        // check if the downloaded block is the tracked finalized block
-        let exceeds_backfill_threshold =
-            match (downloaded_block.as_ref(), sync_target_state.as_ref()) {
-                // if we downloaded the finalized block we can now check how far we're off
-                (Some(downloaded_block), Some(state))
-                    if downloaded_block.hash == state.finalized_block_hash =>
-                {
-                    self.exceeds_backfill_run_threshold(canonical_tip_num, downloaded_block.number)
-                }
-                _ => match sync_target_state
-                    .as_ref()
-                    .and_then(|state| self.state.buffer.block(&state.finalized_block_hash))
-                {
-                    Some(buffered_finalized) => {
-                        // if we have buffered the finalized block, we should check how far we're
-                        // off
-                        self.exceeds_backfill_run_threshold(
-                            canonical_tip_num,
-                            buffered_finalized.number(),
-                        )
-                    }
-                    None => {
-                        // check if the distance exceeds the threshold for backfill sync
-                        self.exceeds_backfill_run_threshold(canonical_tip_num, target_block_number)
-                    }
-                },
-            };
-
-        // if the number of missing blocks is greater than the max, trigger backfill
-        if exceeds_backfill_threshold && let Some(state) = sync_target_state {
-            // if we have already canonicalized the finalized block, we should skip backfill
-            match self.provider.header_by_hash_or_number(state.finalized_block_hash.into()) {
-                Err(err) => {
-                    warn!(target: "engine::tree", %err, "Failed to get finalized block header");
-                }
-                Ok(None) => {
-                    // ensure the finalized block is known (not the zero hash)
-                    if !state.finalized_block_hash.is_zero() {
-                        // we don't have the block yet and the distance exceeds the allowed
-                        // threshold
-                        return Some(state.finalized_block_hash)
-                    }
-
-                    // OPTIMISTIC SYNCING
-                    //
-                    // It can happen when the node is doing an
-                    // optimistic sync, where the CL has no knowledge of the finalized hash,
-                    // but is expecting the EL to sync as high
-                    // as possible before finalizing.
-                    //
-                    // This usually doesn't happen on ETH mainnet since CLs use the more
-                    // secure checkpoint syncing.
-                    //
-                    // However, optimism chains will do this. The risk of a reorg is however
-                    // low.
-                    debug!(target: "engine::tree", hash=?state.head_block_hash, "Setting head hash as an optimistic backfill target.");
-                    return Some(state.head_block_hash)
-                }
-                Ok(Some(_)) => {
-                    // we're fully synced to the finalized block
-                }
+        // check if the downloaded block is the tracked backfill target
+        let exceeds_backfill_threshold = match downloaded_block.as_ref() {
+            // if we downloaded the target block we can now check how far we're off
+            Some(downloaded_block) if downloaded_block.hash == target_hash => {
+                self.exceeds_backfill_run_threshold(canonical_tip_num, downloaded_block.number)
             }
+            _ => match self.state.buffer.block(&target_hash) {
+                // if we have buffered the target block, we should check how far we're off
+                Some(buffered_target) => {
+                    self.exceeds_backfill_run_threshold(canonical_tip_num, buffered_target.number())
+                }
+                // check if the distance exceeds the threshold for backfill sync
+                None => self.exceeds_backfill_run_threshold(canonical_tip_num, target_block_number),
+            },
+        };
+
+        if !exceeds_backfill_threshold {
+            return None
         }
 
-        None
+        // if we have already canonicalized the target block, we should skip backfill
+        match self.provider.header_by_hash_or_number(target_hash.into()) {
+            Err(err) => {
+                warn!(target: "engine::tree", %err, "Failed to get backfill target block header");
+                None
+            }
+            // we don't have the block yet and the distance exceeds the allowed threshold
+            Ok(None) => Some(target_hash),
+            // we're fully synced to the target block
+            Ok(Some(_)) => None,
+        }
     }
 
     /// This method tries to detect whether on-disk and in-memory states have diverged. It might

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1850,7 +1850,18 @@ where
 
         // check if we need to run backfill again by comparing the most recent backfill target
         // height to the backfill height
-        let Some(target_hash) = self.backfill_target_hash() else { return Ok(()) };
+        let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()
+        else {
+            return Ok(())
+        };
+        if !self.engine_kind.is_opstack() && sync_target_state.finalized_block_hash.is_zero() {
+            // no finalized block, can't check distance on non-OP Stack chains
+            return Ok(())
+        }
+        let target_hash = self.backfill_target_hash(sync_target_state);
+        if target_hash.is_zero() {
+            return Ok(())
+        }
         // get the block number of the backfill target block, if we have it buffered
         let newest_target = self.state.buffer.block(&target_hash).map(|block| block.number());
 
@@ -1874,10 +1885,6 @@ where
         };
 
         // Check if there are more blocks to sync between current head and FCU target
-        let Some(sync_target_state) = self.state.forkchoice_state_tracker.sync_target_state()
-        else {
-            return Ok(())
-        };
         if let Some(lowest_buffered) =
             self.state.buffer.lowest_ancestor(&sync_target_state.head_block_hash)
         {
@@ -2527,24 +2534,17 @@ where
 
     /// Returns the block hash that backfill should target.
     ///
-    /// Defaults to the finalized block hash. The head block hash is used instead when:
-    /// * The chain is OP Stack — the CL finalizes in large batches and the finalized hash can lag
-    ///   the canonical tip by a wide margin; reorgs are rare in practice, so syncing to head is
-    ///   preferable to syncing to a stale finalized block. In addition, EL syncing is used to fill
-    ///   unsafe chain gaps on OP Stack.
-    /// * The finalized hash is zero — the CL has no finalized block yet (optimistic sync); fall
-    ///   back to head as the backfill target.
+    /// Defaults to the finalized block hash. On OP Stack, the CL finalizes in large batches and the
+    /// finalized hash can lag the canonical tip by a wide margin, so backfill targets the head.
     ///
-    /// Returns `None` if no forkchoice state has been received or the resolved target hash is
-    /// zero.
-    fn backfill_target_hash(&self) -> Option<B256> {
-        let state = self.state.forkchoice_state_tracker.sync_target_state()?;
-        let hash = if self.engine_kind.is_opstack() || state.finalized_block_hash.is_zero() {
+    /// The zero-finalized optimistic-sync fallback for non-OP Stack chains is handled by
+    /// [`Self::backfill_sync_target`].
+    const fn backfill_target_hash(&self, state: ForkchoiceState) -> B256 {
+        if self.engine_kind.is_opstack() {
             state.head_block_hash
         } else {
             state.finalized_block_hash
-        };
-        (!hash.is_zero()).then_some(hash)
+        }
     }
 
     /// Returns the target hash to sync to if the distance from the local tip is greater than the
@@ -2559,7 +2559,8 @@ where
         target_block_number: u64,
         downloaded_block: Option<BlockNumHash>,
     ) -> Option<B256> {
-        let target_hash = self.backfill_target_hash()?;
+        let state = self.state.forkchoice_state_tracker.sync_target_state()?;
+        let target_hash = self.backfill_target_hash(state);
 
         // check if the downloaded block is the tracked backfill target
         let exceeds_backfill_threshold = match downloaded_block.as_ref() {
@@ -2588,7 +2589,23 @@ where
                 None
             }
             // we don't have the block yet and the distance exceeds the allowed threshold
-            Ok(None) => Some(target_hash),
+            Ok(None) if !target_hash.is_zero() => Some(target_hash),
+            Ok(None) => {
+                // OPTIMISTIC SYNCING
+                //
+                // It can happen when the node is doing an
+                // optimistic sync, where the CL has no knowledge of the finalized hash,
+                // but is expecting the EL to sync as high
+                // as possible before finalizing.
+                //
+                // This usually doesn't happen on ETH mainnet since CLs use the more
+                // secure checkpoint syncing.
+                //
+                // However, optimism chains will do this. The risk of a reorg is however
+                // low.
+                debug!(target: "engine::tree", hash=?state.head_block_hash, "Setting head hash as an optimistic backfill target.");
+                Some(state.head_block_hash)
+            }
             // we're fully synced to the target block
             Ok(Some(_)) => None,
         }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -2316,3 +2316,258 @@ fn test_canonicalizing_downloaded_sync_target_head_updates_finalized() {
     );
     assert!(test_harness.tree.state.forkchoice_state_tracker.sync_target_state().is_none());
 }
+
+// --- Backfill target selection tests ---
+//
+// Cover `backfill_target_hash` and its consumer `backfill_sync_target`, exercised end-to-end
+// via `on_disconnected_downloaded_block`. The OP Stack branch targets head; the Ethereum
+// branch targets finalized. When the CL has no finalized hash yet, the optimistic fallback to
+// head is handled by `backfill_sync_target`.
+
+#[test]
+fn test_backfill_target_hash_eth_returns_finalized() {
+    let test_harness = TestHarness::new(MAINNET.clone());
+    let head = B256::from([0xAA; 32]);
+    let finalized = B256::from([0xBB; 32]);
+    let state = ForkchoiceState {
+        head_block_hash: head,
+        safe_block_hash: B256::ZERO,
+        finalized_block_hash: finalized,
+    };
+
+    assert_eq!(test_harness.tree.backfill_target_hash(state), finalized);
+}
+
+#[test]
+fn test_backfill_target_hash_eth_returns_zero_finalized() {
+    let test_harness = TestHarness::new(MAINNET.clone());
+    let head = B256::from([0xAA; 32]);
+    let state = ForkchoiceState {
+        head_block_hash: head,
+        safe_block_hash: B256::ZERO,
+        finalized_block_hash: B256::ZERO,
+    };
+
+    assert_eq!(test_harness.tree.backfill_target_hash(state), B256::ZERO);
+}
+
+#[test]
+fn test_backfill_target_hash_opstack_returns_head() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    test_harness.tree.engine_kind = EngineApiKind::OpStack;
+    let head = B256::from([0xAA; 32]);
+    let finalized = B256::from([0xBB; 32]);
+    let state = ForkchoiceState {
+        head_block_hash: head,
+        safe_block_hash: B256::ZERO,
+        finalized_block_hash: finalized,
+    };
+
+    // OP Stack: finalized can lag far behind the canonical tip; target head regardless.
+    assert_eq!(test_harness.tree.backfill_target_hash(state), head);
+}
+
+#[test]
+fn test_backfill_sync_target_without_sync_state_returns_none() {
+    let test_harness = TestHarness::new(MAINNET.clone());
+    assert_eq!(
+        test_harness.tree.backfill_sync_target(0, MIN_BLOCKS_FOR_PIPELINE_RUN + 100, None),
+        None
+    );
+}
+
+/// On OP Stack, a disconnected downloaded block whose missing parent is far ahead of the
+/// canonical tip should trigger a backfill targeting `head_block_hash`, not finalized.
+#[test]
+fn test_on_disconnected_downloaded_block_opstack_targets_head() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    test_harness.tree.engine_kind = EngineApiKind::OpStack;
+
+    let head_hash = B256::from([0xAA; 32]);
+    let finalized_hash = B256::from([0xBB; 32]);
+    test_harness.tree.state.forkchoice_state_tracker.set_latest(
+        ForkchoiceState {
+            head_block_hash: head_hash,
+            safe_block_hash: B256::ZERO,
+            finalized_block_hash: finalized_hash,
+        },
+        ForkchoiceStatus::Syncing,
+    );
+
+    let canonical_head = BlockNumHash::new(0, B256::ZERO);
+    let downloaded_block =
+        BlockNumHash::new(MIN_BLOCKS_FOR_PIPELINE_RUN + 100, B256::from([0xCC; 32]));
+    let missing_parent =
+        BlockNumHash::new(MIN_BLOCKS_FOR_PIPELINE_RUN + 99, B256::from([0xDD; 32]));
+
+    let event = test_harness.tree.on_disconnected_downloaded_block(
+        downloaded_block,
+        missing_parent,
+        canonical_head,
+    );
+
+    match event {
+        Some(TreeEvent::BackfillAction(BackfillAction::Start(target))) => {
+            assert_eq!(
+                target.sync_target(),
+                Some(head_hash),
+                "OP Stack backfill should target head, not finalized"
+            );
+        }
+        other => panic!("Expected BackfillAction(Start), got: {other:?}"),
+    }
+}
+
+/// On Ethereum, a disconnected downloaded block whose missing parent is far ahead of the
+/// canonical tip should trigger a backfill targeting `finalized_block_hash`.
+#[test]
+fn test_on_disconnected_downloaded_block_eth_targets_finalized() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+
+    let head_hash = B256::from([0xAA; 32]);
+    let finalized_hash = B256::from([0xBB; 32]);
+    test_harness.tree.state.forkchoice_state_tracker.set_latest(
+        ForkchoiceState {
+            head_block_hash: head_hash,
+            safe_block_hash: B256::ZERO,
+            finalized_block_hash: finalized_hash,
+        },
+        ForkchoiceStatus::Syncing,
+    );
+
+    let canonical_head = BlockNumHash::new(0, B256::ZERO);
+    let downloaded_block =
+        BlockNumHash::new(MIN_BLOCKS_FOR_PIPELINE_RUN + 100, B256::from([0xCC; 32]));
+    let missing_parent =
+        BlockNumHash::new(MIN_BLOCKS_FOR_PIPELINE_RUN + 99, B256::from([0xDD; 32]));
+
+    let event = test_harness.tree.on_disconnected_downloaded_block(
+        downloaded_block,
+        missing_parent,
+        canonical_head,
+    );
+
+    match event {
+        Some(TreeEvent::BackfillAction(BackfillAction::Start(target))) => {
+            assert_eq!(
+                target.sync_target(),
+                Some(finalized_hash),
+                "Ethereum backfill should target finalized"
+            );
+        }
+        other => panic!("Expected BackfillAction(Start), got: {other:?}"),
+    }
+}
+
+/// On Ethereum, a zero finalized hash means optimistic sync. The helper still selects finalized,
+/// but the sync-target builder falls back to `head_block_hash`.
+#[test]
+fn test_on_disconnected_downloaded_block_eth_zero_finalized_targets_head() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+
+    let head_hash = B256::from([0xAA; 32]);
+    test_harness.tree.state.forkchoice_state_tracker.set_latest(
+        ForkchoiceState {
+            head_block_hash: head_hash,
+            safe_block_hash: B256::ZERO,
+            finalized_block_hash: B256::ZERO,
+        },
+        ForkchoiceStatus::Syncing,
+    );
+
+    let canonical_head = BlockNumHash::new(0, B256::ZERO);
+    let downloaded_block =
+        BlockNumHash::new(MIN_BLOCKS_FOR_PIPELINE_RUN + 100, B256::from([0xCC; 32]));
+    let missing_parent =
+        BlockNumHash::new(MIN_BLOCKS_FOR_PIPELINE_RUN + 99, B256::from([0xDD; 32]));
+
+    let event = test_harness.tree.on_disconnected_downloaded_block(
+        downloaded_block,
+        missing_parent,
+        canonical_head,
+    );
+
+    match event {
+        Some(TreeEvent::BackfillAction(BackfillAction::Start(target))) => {
+            assert_eq!(
+                target.sync_target(),
+                Some(head_hash),
+                "Ethereum optimistic backfill should target head when finalized is zero"
+            );
+        }
+        other => panic!("Expected BackfillAction(Start), got: {other:?}"),
+    }
+}
+
+/// Verifies that the post-backfill recheck path in `on_backfill_sync_finished` retriggers a
+/// new backfill targeting whichever block `backfill_target_hash` resolves to — head on OP
+/// Stack, finalized on Ethereum — when that block is buffered far ahead of where the
+/// just-finished pipeline landed.
+async fn assert_post_backfill_recheck_retriggers_to_buffered_target(engine_kind: EngineApiKind) {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    test_harness.tree.engine_kind = engine_kind;
+
+    let base_chain: Vec<_> = test_harness.block_builder.get_executed_blocks(0..1).collect();
+    test_harness = test_harness.with_blocks(base_chain.clone());
+    test_harness
+        .fcu_to(base_chain.last().unwrap().recovered_block().hash(), ForkchoiceStatus::Valid)
+        .await;
+
+    // Long unsynced chain. The last block is what the helper should resolve to.
+    let main_chain = test_harness
+        .block_builder
+        .create_fork(base_chain[0].recovered_block(), MIN_BLOCKS_FOR_PIPELINE_RUN + 50);
+    let target_block = main_chain.last().unwrap().clone();
+    let target_hash = target_block.hash();
+
+    // Buffer the target block — the recheck looks up the helper's resolved hash in the buffer
+    // to decide whether to retrigger.
+    test_harness.tree.state.buffer.insert_block(target_block.clone_sealed_block());
+
+    // Place the buffered hash in the FCU slot the helper picks for this chain type, and put
+    // an unrelated hash (not in buffer) in the other slot to keep the two slots distinct.
+    let other_hash = B256::from([0xFF; 32]);
+    let (head_block_hash, finalized_block_hash) = if engine_kind.is_opstack() {
+        (target_hash, other_hash)
+    } else {
+        (other_hash, target_hash)
+    };
+    test_harness.tree.state.forkchoice_state_tracker.set_latest(
+        ForkchoiceState { head_block_hash, safe_block_hash: head_block_hash, finalized_block_hash },
+        ForkchoiceStatus::Syncing,
+    );
+
+    // Simulate backfill finishing far below the buffered target (gap > threshold).
+    let backfill_finished_block_number = MIN_BLOCKS_FOR_PIPELINE_RUN + 1;
+    let backfill_tip_block = main_chain[(backfill_finished_block_number - 1) as usize].clone();
+    test_harness.provider.add_block(backfill_tip_block.hash(), backfill_tip_block.into_block());
+    let backfill_finished = FromOrchestrator::BackfillSyncFinished(ControlFlow::Continue {
+        block_number: backfill_finished_block_number,
+    });
+    let _ = test_harness.tree.on_engine_message(FromEngine::Event(backfill_finished)).unwrap();
+
+    let event = test_harness.from_tree_rx.recv().await.unwrap();
+    match event {
+        EngineApiEvent::BackfillAction(BackfillAction::Start(emitted_target)) => {
+            assert_eq!(
+                emitted_target.sync_target(),
+                Some(target_hash),
+                "post-backfill recheck should retrigger backfill to the buffered target"
+            );
+        }
+        _ => panic!("Expected BackfillAction(Start), got: {event:#?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_on_backfill_sync_finished_opstack_retriggers_backfill_to_buffered_head() {
+    assert_post_backfill_recheck_retriggers_to_buffered_target(EngineApiKind::OpStack).await;
+}
+
+#[tokio::test]
+async fn test_on_backfill_sync_finished_eth_retriggers_backfill_to_buffered_finalized() {
+    assert_post_backfill_recheck_retriggers_to_buffered_target(EngineApiKind::Ethereum).await;
+}


### PR DESCRIPTION
On OP Stack, the CL finalizes in large batches and the finalized hash can lag the canonical tip by a wide margin. Backfill now targets head only for OP Stack; non-OP chains continue targeting finalized, with the existing zero-finalized optimistic fallback left in `backfill_sync_target`.

Adds coverage for OP Stack head targeting, Ethereum finalized targeting, the optimistic fallback, and post-backfill rechecks.

Alternative approach to #24140 that also covers post-initial-sync gap filling.