### PR TITLE
refactor(tasks): use parking_lot mutex in lazy handle

### DIFF
--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -23,6 +23,7 @@ metrics.workspace = true
 
 # misc
 dashmap.workspace = true
+parking_lot.workspace = true
 thread-priority.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
@@ -30,7 +31,6 @@ thiserror.workspace = true
 # feature `rayon`
 rayon = { workspace = true, optional = true }
 crossbeam-utils = { workspace = true, optional = true }
-parking_lot = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -40,5 +40,5 @@ libc.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }
 
 [features]
-rayon = ["dep:rayon", "dep:crossbeam-utils", "dep:parking_lot", "pin-project"]
+rayon = ["dep:rayon", "dep:crossbeam-utils", "pin-project"]
 test-utils = []

--- a/crates/tasks/src/lazy.rs
+++ b/crates/tasks/src/lazy.rs
@@ -1,5 +1,6 @@
 //! A lazily-resolved handle to a value computed on a background thread.
 
+use parking_lot::Mutex;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::oneshot;
 
@@ -19,7 +20,7 @@ pub struct LazyHandle<T> {
 
 struct LazyHandleInner<T> {
     /// Pending receiver, taken on first access.
-    rx: std::sync::Mutex<Option<oneshot::Receiver<T>>>,
+    rx: Mutex<Option<oneshot::Receiver<T>>>,
     /// Cached result after the first successful receive.
     value: OnceLock<T>,
 }
@@ -28,17 +29,13 @@ impl<T: Send + 'static> LazyHandle<T> {
     /// Creates a new handle from a background task receiver.
     pub(crate) fn new(rx: oneshot::Receiver<T>) -> Self {
         Self {
-            inner: Arc::new(LazyHandleInner {
-                rx: std::sync::Mutex::new(Some(rx)),
-                value: OnceLock::new(),
-            }),
+            inner: Arc::new(LazyHandleInner { rx: Mutex::new(Some(rx)), value: OnceLock::new() }),
         }
     }
 
     /// Creates a handle that is already resolved with the given value.
     pub fn ready(value: T) -> Self {
-        let inner =
-            LazyHandleInner { rx: std::sync::Mutex::new(None), value: OnceLock::from(value) };
+        let inner = LazyHandleInner { rx: Mutex::new(None), value: OnceLock::from(value) };
         Self { inner: Arc::new(inner) }
     }
 
@@ -56,7 +53,6 @@ impl<T: Send + 'static> LazyHandle<T> {
                 .inner
                 .rx
                 .lock()
-                .expect("lock poisoned")
                 .take()
                 .expect("LazyHandle receiver already taken without value being set");
             rx.blocking_recv().expect("LazyHandle task dropped without producing a value")


### PR DESCRIPTION
Uses `parking_lot::Mutex` for the `LazyHandle` oneshot receiver instead of `std::sync::Mutex`.

This removes poisoning handling from the lazy result path and keeps the synchronization primitive aligned with the crate's existing `parking_lot` usage.