### PR TITLE
feat(rpc): add builder submission v6 validation

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,11 +1,12 @@
-use crate::utils::eth_payload_attributes;
+use crate::utils::{eth_payload_attributes, eth_payload_attributes_amsterdam};
 use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig};
 use alloy_genesis::Genesis;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder, SendableTx};
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequestV3, BuilderBlockValidationRequestV4,
-    SignedBidSubmissionV3, SignedBidSubmissionV4,
+    BuilderBlockValidationRequestV6, SignedBidSubmissionV3, SignedBidSubmissionV4,
+    SignedBidSubmissionV6,
 };
 use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 use alloy_rpc_types_eth::TransactionRequest;
@@ -293,6 +294,92 @@ async fn test_flashbots_validate_v4() -> eyre::Result<()> {
         .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV4".into(), (&request,))
         .await
         .is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_flashbots_validate_v6() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .amsterdam_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec.clone(),
+        false,
+        Default::default(),
+        eth_payload_attributes_amsterdam,
+    )
+    .await?;
+    let mut node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    for nonce in 0..3 {
+        let _ = provider
+            .send_transaction(TransactionRequest::default().to(Address::ZERO).nonce(nonce))
+            .await?;
+    }
+
+    let payload = node.new_payload().await?;
+    assert!(payload.block_access_list().is_some());
+    assert!(payload.block().body().transactions().count() >= 3);
+
+    let envelope = payload.clone().try_into_v6()?;
+    let mut request = BuilderBlockValidationRequestV6 {
+        request: SignedBidSubmissionV6 {
+            message: BidTrace {
+                parent_hash: payload.block().parent_hash,
+                block_hash: payload.block().hash(),
+                gas_used: payload.block().gas_used,
+                gas_limit: payload.block().gas_limit,
+                ..Default::default()
+            },
+            execution_payload: envelope.execution_payload,
+            blobs_bundle: envelope.blobs_bundle,
+            execution_requests: envelope.execution_requests.try_into().unwrap(),
+            signature: Default::default(),
+        },
+        parent_beacon_block_root: payload.block().parent_beacon_block_root.unwrap(),
+        registered_gas_limit: payload.block().gas_limit,
+    };
+
+    provider
+        .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV6".into(), (&request,))
+        .await
+        .expect("request should validate");
+
+    request.registered_gas_limit -= 1;
+    assert!(provider
+        .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV6".into(), (&request,))
+        .await
+        .is_err());
+    request.registered_gas_limit += 1;
+
+    let mut invalid_bal_request = request.clone();
+    invalid_bal_request.request.execution_payload.block_access_list = Bytes::from_static(&[0xc0]);
+    assert!(provider
+        .raw_request::<_, ()>(
+            "flashbots_validateBuilderSubmissionV6".into(),
+            (&invalid_bal_request,)
+        )
+        .await
+        .is_err());
+
+    request.request.execution_payload.payload_inner.payload_inner.payload_inner.state_root =
+        B256::ZERO;
+    assert!(provider
+        .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV6".into(), (&request,))
+        .await
+        .is_err());
+
     Ok(())
 }
 

--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -41,6 +41,23 @@ pub(crate) const fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAt
     }
 }
 
+/// Helper function to create Amsterdam payload attributes.
+///
+/// Amsterdam payloads include block access lists, and the payload builder expects a
+/// `slot_number` in the attributes once Amsterdam is active. Tests use the timestamp as a
+/// deterministic dummy slot because the exact beacon slot is irrelevant for these local e2e
+/// payloads.
+pub(crate) const fn eth_payload_attributes_amsterdam(timestamp: u64) -> PayloadAttributes {
+    PayloadAttributes {
+        timestamp,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(B256::ZERO),
+        slot_number: Some(timestamp),
+    }
+}
+
 /// Advances node by producing blocks with random transactions.
 pub(crate) async fn advance_with_random_transactions<Provider>(
     node: &mut NodeHelperType<EthereumNode, Provider>,

--- a/crates/rpc/rpc-api/src/validation.rs
+++ b/crates/rpc/rpc-api/src/validation.rs
@@ -3,7 +3,7 @@
 use alloy_rpc_types_beacon::relay::{
     BuilderBlockValidationRequest, BuilderBlockValidationRequestV2,
     BuilderBlockValidationRequestV3, BuilderBlockValidationRequestV4,
-    BuilderBlockValidationRequestV5,
+    BuilderBlockValidationRequestV5, BuilderBlockValidationRequestV6,
 };
 use jsonrpsee::proc_macros::rpc;
 
@@ -44,5 +44,12 @@ pub trait BlockSubmissionValidationApi {
     async fn validate_builder_submission_v5(
         &self,
         request: BuilderBlockValidationRequestV5,
+    ) -> jsonrpsee::core::RpcResult<()>;
+
+    /// A Request to validate a block submission.
+    #[method(name = "validateBuilderSubmissionV6")]
+    async fn validate_builder_submission_v6(
+        &self,
+        request: BuilderBlockValidationRequestV6,
     ) -> jsonrpsee::core::RpcResult<()>;
 }

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -1,12 +1,12 @@
 use alloy_consensus::{
     BlobTransactionValidationError, BlockHeader, EnvKzgSettings, Transaction, TxReceipt,
 };
-use alloy_eips::eip7685::RequestsOrHash;
+use alloy_eips::{eip7685::RequestsOrHash, eip7928::bal::DecodedBal};
 use alloy_primitives::map::AddressSet;
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequest, BuilderBlockValidationRequestV2,
     BuilderBlockValidationRequestV3, BuilderBlockValidationRequestV4,
-    BuilderBlockValidationRequestV5,
+    BuilderBlockValidationRequestV5, BuilderBlockValidationRequestV6,
 };
 use alloy_rpc_types_engine::{
     BlobsBundleV1, BlobsBundleV2, CancunPayloadFields, ExecutionData, ExecutionPayload,
@@ -127,6 +127,7 @@ where
         block: RecoveredBlock<<E::Primitives as NodePrimitives>::Block>,
         message: BidTrace,
         registered_gas_limit: u64,
+        _decoded_bal: Option<DecodedBal>,
     ) -> Result<(), ValidationApiError> {
         self.validate_message_against_header(block.sealed_header(), &message)?;
 
@@ -387,6 +388,7 @@ where
             block,
             request.request.message,
             request.registered_gas_limit,
+            None,
         )
         .await
     }
@@ -415,6 +417,7 @@ where
             block,
             request.request.message,
             request.registered_gas_limit,
+            None,
         )
         .await
     }
@@ -455,6 +458,51 @@ where
             block,
             request.request.message,
             request.registered_gas_limit,
+            None,
+        )
+        .await
+    }
+
+    /// Core logic for validating the builder submission v6
+    async fn validate_builder_submission_v6(
+        &self,
+        request: BuilderBlockValidationRequestV6,
+    ) -> Result<(), ValidationApiError> {
+        let decoded_bal =
+            DecodedBal::from_rlp_bytes(request.request.execution_payload.block_access_list.clone())
+                .map_err(ValidationApiError::InvalidBlockAccessList)?;
+
+        let block = self.payload_validator.ensure_well_formed_payload(ExecutionData {
+            payload: ExecutionPayload::V4(request.request.execution_payload),
+            sidecar: ExecutionPayloadSidecar::v4(
+                CancunPayloadFields {
+                    parent_beacon_block_root: request.parent_beacon_block_root,
+                    versioned_hashes: self
+                        .validate_blobs_bundle_v2(request.request.blobs_bundle)?,
+                },
+                PraguePayloadFields {
+                    requests: RequestsOrHash::Requests(
+                        request.request.execution_requests.to_requests(),
+                    ),
+                },
+            ),
+        })?;
+
+        let chain_spec = self.provider.chain_spec();
+        if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) &&
+            block.rlp_length() > MAX_RLP_BLOCK_SIZE
+        {
+            return Err(ValidationApiError::Consensus(ConsensusError::BlockTooLarge {
+                rlp_length: block.rlp_length(),
+                max_rlp_length: MAX_RLP_BLOCK_SIZE,
+            }));
+        }
+
+        self.validate_message_against_block(
+            block,
+            request.request.message,
+            request.registered_gas_limit,
+            Some(decoded_bal),
         )
         .await
     }
@@ -533,6 +581,24 @@ where
 
         self.task_spawner.spawn_blocking_task(async move {
             let result = Self::validate_builder_submission_v5(&this, request)
+                .await
+                .map_err(ErrorObject::from);
+            let _ = tx.send(result);
+        });
+
+        rx.await.map_err(|_| internal_rpc_err("Internal blocking task error"))?
+    }
+
+    /// Validates a block submitted to the relay
+    async fn validate_builder_submission_v6(
+        &self,
+        request: BuilderBlockValidationRequestV6,
+    ) -> RpcResult<()> {
+        let this = self.clone();
+        let (tx, rx) = oneshot::channel();
+
+        self.task_spawner.spawn_blocking_task(async move {
+            let result = Self::validate_builder_submission_v6(&this, request)
                 .await
                 .map_err(ErrorObject::from);
             let _ = tx.send(result);
@@ -630,6 +696,8 @@ pub enum ValidationApiError {
     ProposerPayment,
     #[error("invalid blobs bundle")]
     InvalidBlobsBundle,
+    #[error("invalid block access list: {_0}")]
+    InvalidBlockAccessList(alloy_rlp::Error),
     #[error("block accesses blacklisted address: {_0}")]
     Blacklist(Address),
     #[error(transparent)]
@@ -654,6 +722,7 @@ impl From<ValidationApiError> for ErrorObject<'static> {
             ValidationApiError::Blacklist(_) |
             ValidationApiError::ProposerPayment |
             ValidationApiError::InvalidBlobsBundle |
+            ValidationApiError::InvalidBlockAccessList(_) |
             ValidationApiError::Blob(_) => invalid_params_rpc_err(error.to_string()),
 
             ValidationApiError::MissingLatestBlock |


### PR DESCRIPTION
Adds `flashbots_validateBuilderSubmissionV6` support for Amsterdam execution payloads using Alloy's V6 relay request types. The V6 path decodes the submitted block access list and plumbs it through `validate_message_against_block` for follow-up validation work.