### PR TITLE
ci(bench): add benchmarkoor replay workflow

### DIFF
--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -705,6 +705,10 @@ if [[ "$label" == baseline* ]]; then
   run_type="baseline"
 fi
 
+selected_count="$(grep -cve '^[[:space:]]*$' "$tests_jsonl" || true)"
+completed_count=0
+recorded_failure_count=0
+
 while IFS= read -r test_entry; do
   [ -n "$test_entry" ] || continue
   test_name="$(jq -r '.name' <<< "$test_entry")"
@@ -782,6 +786,7 @@ while IFS= read -r test_entry; do
       "$wall_elapsed_secs" \
       "$benchmarkoor_status" \
       "$results"
+    recorded_failure_count=$(( recorded_failure_count + 1 ))
   elif [ "$emitted_count" -le 0 ]; then
     echo "::warning::benchmarkoor-replay did not emit a run_many_result for ${test_name}; recording failure and continuing"
     append_benchmarkoor_failure_result \
@@ -795,8 +800,12 @@ while IFS= read -r test_entry; do
       "$wall_elapsed_secs" \
       0 \
       "$results"
+    recorded_failure_count=$(( recorded_failure_count + 1 ))
   fi
+
+  completed_count=$(( completed_count + 1 ))
 done < "$tests_jsonl"
 
+echo "Completed ${completed_count}/${selected_count} selected benchmarkoor test(s) for ${label}; recorded ${recorded_failure_count} replay failure(s)"
 finalize_run_state "$binary"
 echo "results=${results}"

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 #
-# Runs benchmarkoor-replay against a schelk-managed Reth datadir.
+# Runs benchmarkoor-replay against a Reth datadir mounted by schelk.
 #
 # Usage:
 #   bench-benchmarkoor-run.sh prepare <binary> <output-dir>
 #   bench-benchmarkoor-run.sh run <label> <binary> <output-dir> <tests-jsonl>
 #   bench-benchmarkoor-run.sh restart-node <binary> <label> <output-dir> <phase> <log>
 #
-# The prepare mode starts Reth on the imported snapshot, replays benchmarkoor's
-# gas-bump/funding prerun, and promotes that state as the schelk baseline.
+# The prepare mode starts Reth on the imported snapshot and replays benchmarkoor's
+# gas-bump/funding prerun. With BENCH_RESET_STRATEGY=schelk, it promotes that
+# state as the schelk baseline. With BENCH_RESET_STRATEGY=unwind, it leaves the
+# scratch volume mounted at the post-prerun head and later uses Reth unwind to
+# reset each test.
 #
-# The run mode recovers to that post-prerun baseline for each test, starts
-# Reth, then delegates the measured setup/testing split to benchmarkoor-replay's
-# native `run-many --mode setup-then-testing --json` mode. The restart-node mode
-# is invoked by benchmarkoor-replay between setup and measured testing.
+# The run mode resets to the post-prerun baseline for each test, starts Reth,
+# then delegates the measured setup/testing split to benchmarkoor-replay's native
+# `run-many --mode setup-then-testing --json` mode. The restart-node mode is
+# invoked by benchmarkoor-replay between setup and measured testing.
 set -euo pipefail
 
 MODE="${1:?mode is required}"
@@ -51,6 +54,27 @@ fi
 
 safe_name() {
   printf '%s' "$1" | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^-+//; s/-+$//' | cut -c1-180
+}
+
+now_ns() {
+  date +%s%N
+}
+
+elapsed_secs() {
+  local start_ns="$1"
+  local end_ns
+  end_ns="$(now_ns)"
+  awk -v ns="$(( end_ns - start_ns ))" 'BEGIN { printf "%.6f", ns / 1000000000 }'
+}
+
+reset_strategy() {
+  case "${BENCH_RESET_STRATEGY:-unwind}" in
+    unwind | schelk) printf '%s\n' "${BENCH_RESET_STRATEGY:-unwind}" ;;
+    *)
+      echo "::error::BENCH_RESET_STRATEGY must be 'unwind' or 'schelk', got '${BENCH_RESET_STRATEGY}'"
+      exit 1
+      ;;
+  esac
 }
 
 drop_caches() {
@@ -98,21 +122,28 @@ wait_for_prerun_head() {
   marker="$(prerun_head_file)"
   [ -f "$marker" ] || return 0
 
-  local expected_number_hex expected_hash actual_hash
+  local expected_number expected_number_hex expected_hash latest_hex latest_number actual_hash
+  expected_number="$(jq -er '.number' "$marker")"
   expected_number_hex="$(jq -er '.number_hex' "$marker")"
   expected_hash="$(jq -er '.hash' "$marker")"
 
   for i in $(seq 1 60); do
-    actual_hash="$(rpc_call eth_getBlockByNumber "[\"${expected_number_hex}\",false]" \
+    latest_hex="$(rpc_call eth_blockNumber | jq -r '.result // empty' 2>/dev/null || true)"
+    if [ -z "$latest_hex" ]; then
+      sleep 1
+      continue
+    fi
+    latest_number=$(( 16#${latest_hex#0x} ))
+    actual_hash="$(rpc_call eth_getBlockByNumber "[\"${latest_hex}\",false]" \
       | jq -r '.result.hash // empty' 2>/dev/null || true)"
-    if [ "$actual_hash" = "$expected_hash" ]; then
+    if [ "$latest_number" -eq "$expected_number" ] && [ "$actual_hash" = "$expected_hash" ]; then
       echo "Recovered post-prerun head ${expected_number_hex} (${expected_hash}) after ${i}s"
       return 0
     fi
     sleep 1
   done
 
-  echo "::error::Recovered datadir did not expose expected post-prerun head ${expected_number_hex} (${expected_hash})"
+  echo "::error::Recovered datadir did not expose expected post-prerun latest head ${expected_number_hex} (${expected_hash})"
   rpc_call eth_blockNumber || true
   exit 1
 }
@@ -127,7 +158,7 @@ reth_db_capture() {
   fi
   db_args+=(--datadir "$DATADIR" "$@")
 
-  "$binary" "${db_args[@]}" 2>&1
+  sudo "$binary" "${db_args[@]}" 2>&1
 }
 
 has_table_content() {
@@ -142,24 +173,60 @@ has_header_content() {
   }
 }
 
+parse_stage_checkpoint_block() {
+  sed -nE 's/.*block_number: ([0-9]+).*/\1/p' | head -n 1
+}
+
+output_has_expected_hash() {
+  local output="$1"
+  local expected_hash="$2"
+  has_table_content "$output" && grep -qi "${expected_hash#0x}" <<< "$output"
+}
+
+finish_stage_matches() {
+  local binary="$1"
+  local expected_number="$2"
+  local finish finish_number
+  finish="$(reth_db_capture "$binary" stage-checkpoints get --stage finish || true)"
+  finish_number="$(parse_stage_checkpoint_block <<< "$finish")"
+  [ -n "$finish_number" ] && [ "$finish_number" -eq "$expected_number" ]
+}
+
 persisted_prerun_head_present() {
   local binary="$1"
   local expected_number="$2"
   local expected_hash="$3"
   local canonical header
 
-  canonical="$(reth_db_capture "$binary" get mdbx CanonicalHeaders "$expected_number" || true)"
-  if ! has_table_content "$canonical" || ! grep -qi "${expected_hash#0x}" <<< "$canonical"; then
-    return 1
-  fi
-
   header="$(reth_db_capture "$binary" get static-file headers "$expected_number" || true)"
-  if has_header_content "$header"; then
-    return 0
+  if has_header_content "$header" && output_has_expected_hash "$header" "$expected_hash"; then
+    finish_stage_matches "$binary" "$expected_number"
+    return $?
   fi
 
-  header="$(reth_db_capture "$binary" get mdbx Headers "$expected_number" || true)"
-  has_header_content "$header"
+  canonical="$(reth_db_capture "$binary" get mdbx CanonicalHeaders "$expected_number" || true)"
+  if output_has_expected_hash "$canonical" "$expected_hash"; then
+    header="$(reth_db_capture "$binary" get mdbx Headers "$expected_number" || true)"
+    if has_header_content "$header"; then
+      finish_stage_matches "$binary" "$expected_number"
+      return $?
+    fi
+  fi
+
+  return 1
+}
+
+print_prerun_persistence_diagnostics() {
+  local binary="$1"
+  local expected_number="$2"
+  echo "Static-file header:"
+  reth_db_capture "$binary" get static-file headers "$expected_number" || true
+  echo "Finish stage checkpoint:"
+  reth_db_capture "$binary" stage-checkpoints get --stage finish || true
+  echo "CanonicalHeaders:"
+  reth_db_capture "$binary" get mdbx CanonicalHeaders "$expected_number" || true
+  echo "MDBX header:"
+  reth_db_capture "$binary" get mdbx Headers "$expected_number" || true
 }
 
 wait_for_persisted_prerun_head() {
@@ -175,25 +242,66 @@ wait_for_persisted_prerun_head() {
 
   for i in $(seq 1 120); do
     if persisted_prerun_head_present "$binary" "$expected_number" "$expected_hash"; then
-      echo "Post-prerun head ${expected_number} (${expected_hash}) is persisted after ${i}s"
+      echo "Post-prerun head ${expected_number} (${expected_hash}) is persisted and committed after ${i}s"
       return 0
     fi
     sleep 1
   done
 
   if [ "$required" != "true" ]; then
-    echo "Post-prerun head ${expected_number} (${expected_hash}) was not confirmed in on-disk Reth tables after 120s"
+    echo "Post-prerun head ${expected_number} (${expected_hash}) was not confirmed by static files and Finish checkpoint after 120s"
     return 1
   fi
 
-  echo "::error::Post-prerun head ${expected_number} (${expected_hash}) was not found in on-disk Reth tables"
-  echo "CanonicalHeaders:"
-  reth_db_capture "$binary" get mdbx CanonicalHeaders "$expected_number" || true
-  echo "Static-file header:"
-  reth_db_capture "$binary" get static-file headers "$expected_number" || true
-  echo "MDBX header:"
-  reth_db_capture "$binary" get mdbx Headers "$expected_number" || true
+  echo "::error::Post-prerun head ${expected_number} (${expected_hash}) was not confirmed by static files and Finish checkpoint"
+  print_prerun_persistence_diagnostics "$binary" "$expected_number"
   exit 1
+}
+
+reth_stage_unwind() {
+  local binary="$1"
+  local target="$2"
+
+  local -a unwind_args=(stage unwind)
+  if [ -f "$DATADIR/genesis.json" ]; then
+    unwind_args+=(--chain "$DATADIR/genesis.json")
+  fi
+  unwind_args+=(--datadir "$DATADIR" to-block "$target")
+
+  sudo "$binary" "${unwind_args[@]}"
+}
+
+unwind_to_prerun_head() {
+  local binary="$1"
+  local marker
+  marker="$(prerun_head_file)"
+  if [ ! -f "$marker" ]; then
+    echo "::error::Missing post-prerun head marker at ${marker}; cannot use unwind reset strategy"
+    exit 1
+  fi
+
+  local expected_number expected_hash start elapsed finish finish_number
+  expected_number="$(jq -er '.number' "$marker")"
+  expected_hash="$(jq -er '.hash' "$marker")"
+
+  start="$(now_ns)"
+  echo "Unwinding Reth datadir to post-prerun head ${expected_number} (${expected_hash})"
+  reth_stage_unwind "$binary" "$expected_number"
+  elapsed="$(elapsed_secs "$start")"
+
+  finish="$(reth_db_capture "$binary" stage-checkpoints get --stage finish || true)"
+  finish_number="$(parse_stage_checkpoint_block <<< "$finish")"
+  if [ "$finish_number" != "$expected_number" ]; then
+    echo "::error::Finish stage checkpoint is ${finish_number:-unknown}, expected ${expected_number} after unwind"
+    echo "$finish"
+    exit 1
+  fi
+  if ! persisted_prerun_head_present "$binary" "$expected_number" "$expected_hash"; then
+    echo "::error::Post-prerun head ${expected_number} (${expected_hash}) was not present after unwind"
+    print_prerun_persistence_diagnostics "$binary" "$expected_number"
+    exit 1
+  fi
+  echo "Unwind reset completed in ${elapsed}s"
 }
 
 stop_node() {
@@ -202,6 +310,22 @@ stop_node() {
     TAIL_PID=""
   fi
   sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+  sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+}
+
+stop_node_required() {
+  if [ -n "${TAIL_PID:-}" ]; then
+    kill "$TAIL_PID" 2>/dev/null || true
+    TAIL_PID=""
+  fi
+
+  if sudo systemctl list-units --all --full --no-legend "$RETH_SCOPE" | grep -q "$RETH_SCOPE"; then
+    if ! sudo systemctl stop "$RETH_SCOPE"; then
+      echo "::error::Failed to stop reth systemd scope ${RETH_SCOPE}"
+      sudo systemctl status "$RETH_SCOPE" --no-pager || true
+      exit 1
+    fi
+  fi
   sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
 }
 
@@ -216,6 +340,39 @@ recover_schelk() {
     exit 1
   fi
   drop_caches
+}
+
+reset_to_prerun_state() {
+  local binary="$1"
+  local strategy
+  strategy="$(reset_strategy)"
+
+  case "$strategy" in
+    schelk)
+      recover_schelk
+      ;;
+    unwind)
+      stop_node_required
+      unwind_to_prerun_head "$binary"
+      drop_caches
+      ;;
+  esac
+}
+
+finalize_run_state() {
+  local binary="$1"
+  local strategy
+  strategy="$(reset_strategy)"
+
+  case "$strategy" in
+    schelk)
+      sudo schelk recover -y --kill || true
+      ;;
+    unwind)
+      stop_node_required
+      unwind_to_prerun_head "$binary"
+      ;;
+  esac
 }
 
 start_node() {
@@ -388,6 +545,8 @@ run_benchmarkoor() {
     "BENCHMARKOOR_CACHE=$BENCHMARKOOR_CACHE" \
     "BENCH_CORES=${BENCH_CORES:-6}" \
     "BENCH_MEMORY_MAX=${BENCH_MEMORY_MAX:-32G}" \
+    "BENCH_RESET_STRATEGY=${BENCH_RESET_STRATEGY:-unwind}" \
+    "BENCH_PRERUN_HEAD_FILE=${BENCH_PRERUN_HEAD_FILE:-}" \
     "BENCH_BASELINE_ARGS=${BENCH_BASELINE_ARGS:-}" \
     "BENCH_FEATURE_ARGS=${BENCH_FEATURE_ARGS:-}" \
     "BENCH_METRICS_ADDR=${BENCH_METRICS_ADDR:-}" \
@@ -412,6 +571,7 @@ if [ "$MODE" = "prepare" ]; then
   binary="${1:?binary is required}"
   output_dir="${2:?output directory is required}"
   mkdir -p "$output_dir"
+  strategy="$(reset_strategy)"
 
   recover_schelk
   start_node "$binary" "prepare" "$output_dir" "prerun"
@@ -426,14 +586,16 @@ SH
   mapfile -d '' common < <(benchmarkoor_common_args "$binary" "$sudo_schelk")
   run_benchmarkoor "${common[@]}" baseline prepare --no-mount
   write_prerun_head_marker
-  wait_for_persisted_prerun_head "$binary" false ||
-    echo "Post-prerun head was not confirmed before shutdown; checking again after graceful stop"
 
-  stop_node
+  stop_node_required
   wait_for_persisted_prerun_head "$binary" true
-  sudo schelk promote -y
+  if [ "$strategy" = "schelk" ]; then
+    sudo schelk promote -y
+    echo "Promoted schelk baseline after benchmarkoor gas-bump/funding"
+  else
+    echo "Prepared unwind baseline after benchmarkoor gas-bump/funding"
+  fi
   sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
-  echo "Promoted schelk baseline after benchmarkoor gas-bump/funding"
   exit 0
 fi
 
@@ -450,6 +612,7 @@ results="${output_dir}/results.jsonl"
 mkdir -p "$output_dir/logs"
 : > "$results"
 
+strategy="$(reset_strategy)"
 mapfile -d '' common < <(benchmarkoor_common_args "$binary" "schelk")
 run_type="feature"
 if [[ "$label" == baseline* ]]; then
@@ -464,9 +627,12 @@ while IFS= read -r test_entry; do
   log_path="${output_dir}/logs/$(safe_name "${label}-${test_slug}").log"
   native_out="${output_dir}/native-$(safe_name "$test_slug").jsonl"
   before_count="$(wc -l < "$results" | tr -d ' ')"
+  test_start_ns="$(now_ns)"
+  reset_start_ns="$(now_ns)"
 
   echo "=== ${label}: ${test_name} ==="
-  recover_schelk
+  reset_to_prerun_state "$binary"
+  reset_elapsed_secs="$(elapsed_secs "$reset_start_ns")"
   start_node "$binary" "$label" "$output_dir" "${test_slug}-setup" "$log_path" false true
 
   restart_command="$(
@@ -483,12 +649,25 @@ while IFS= read -r test_entry; do
     --restart-node-command "$restart_command" \
     --json 2>&1 | tee "$native_out"
 
+  wall_elapsed_secs="$(elapsed_secs "$test_start_ns")"
+  echo "=== ${label}: ${test_name} completed in ${wall_elapsed_secs}s (reset=${reset_elapsed_secs}s, strategy=${strategy}) ==="
+
   jq -Rnc \
     --arg label "$label" \
     --arg run_type "$run_type" \
     --arg gas_bucket "$gas_bucket" \
+    --arg reset_strategy "$strategy" \
+    --argjson reset_elapsed_secs "$reset_elapsed_secs" \
+    --argjson wall_elapsed_secs "$wall_elapsed_secs" \
     'inputs | fromjson? | select(.kind == "run_many_result") |
-      . + {label: $label, run_type: $run_type, gas_bucket: $gas_bucket}' \
+      . + {
+        label: $label,
+        run_type: $run_type,
+        gas_bucket: $gas_bucket,
+        reset_strategy: $reset_strategy,
+        reset_elapsed_secs: $reset_elapsed_secs,
+        wall_elapsed_secs: $wall_elapsed_secs
+      }' \
     "$native_out" >> "$results"
 
   after_count="$(wc -l < "$results" | tr -d ' ')"
@@ -498,5 +677,5 @@ while IFS= read -r test_entry; do
   fi
 done < "$tests_jsonl"
 
-sudo schelk recover -y --kill || true
+finalize_run_state "$binary"
 echo "results=${results}"

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -154,6 +154,51 @@ wait_for_engine_port() {
   exit 1
 }
 
+snapshot_block_number() {
+  local block="${BENCHMARKOOR_SUITE#*/}"
+  if [[ "$block" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$block"
+  fi
+}
+
+wait_for_snapshot_pipeline() {
+  local expected_block timeout start_ns deadline
+  expected_block="$(snapshot_block_number)"
+  timeout="${BENCH_SNAPSHOT_PIPELINE_TIMEOUT_SECS:-300}"
+  start_ns="$(now_ns)"
+  deadline=$((SECONDS + timeout))
+
+  if [ -n "$expected_block" ]; then
+    echo "Waiting for Reth snapshot pipeline to finish at block ${expected_block}"
+  else
+    echo "Waiting for Reth snapshot pipeline to finish"
+  fi
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    local sync_response block_response block_hex block_dec
+    sync_response="$(rpc_call eth_syncing 2>/dev/null || true)"
+    if jq -e '.result == false' <<< "$sync_response" >/dev/null 2>&1; then
+      block_response="$(rpc_call eth_blockNumber 2>/dev/null || true)"
+      block_hex="$(jq -er '.result' <<< "$block_response" 2>/dev/null || true)"
+      if [[ "$block_hex" =~ ^0x[0-9a-fA-F]+$ ]]; then
+        block_dec=$(( 16#${block_hex#0x} ))
+        if [ -z "$expected_block" ] || [ "$block_dec" -ge "$expected_block" ]; then
+          echo "Reth snapshot pipeline finished after $(elapsed_secs "$start_ns")s at block ${block_dec}"
+          return 0
+        fi
+      elif [ -z "$expected_block" ]; then
+        echo "Reth snapshot pipeline finished after $(elapsed_secs "$start_ns")s"
+        return 0
+      fi
+    fi
+    sleep 0.05
+  done
+
+  echo "::error::reth snapshot pipeline did not finish within ${timeout}s before benchmarkoor prerun"
+  cat "$CURRENT_LOG"
+  exit 1
+}
+
 prerun_head_file() {
   if [ -n "${BENCH_PRERUN_HEAD_FILE:-}" ]; then
     printf '%s\n' "$BENCH_PRERUN_HEAD_FILE"
@@ -662,6 +707,7 @@ if [ "$MODE" = "prepare" ]; then
 
   recover_schelk
   start_node "$binary" "prepare" "$output_dir" "prerun"
+  wait_for_snapshot_pipeline
 
   sudo_schelk="${output_dir}/sudo-schelk"
   cat > "$sudo_schelk" <<'SH'

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -33,6 +33,7 @@ shift
 
 SCRIPT_PATH="$(readlink -f "$0")"
 DATADIR="${SCHELK_MOUNT}/datadir"
+JWT_SECRET="${DATADIR}/jwt.hex"
 RETH_SCOPE="${RETH_SCOPE:-reth-benchmarkoor.scope}"
 ENGINE_URL="${BENCHMARKOOR_ENGINE_URL:-http://127.0.0.1:8551}"
 HTTP_URL="http://127.0.0.1:8545"
@@ -68,13 +69,23 @@ elapsed_secs() {
 }
 
 reset_strategy() {
-  case "${BENCH_RESET_STRATEGY:-unwind}" in
-    unwind | schelk) printf '%s\n' "${BENCH_RESET_STRATEGY:-unwind}" ;;
+  case "${BENCH_RESET_STRATEGY:-schelk}" in
+    unwind | schelk) printf '%s\n' "${BENCH_RESET_STRATEGY:-schelk}" ;;
     *)
       echo "::error::BENCH_RESET_STRATEGY must be 'unwind' or 'schelk', got '${BENCH_RESET_STRATEGY}'"
       exit 1
       ;;
   esac
+}
+
+ensure_jwt_secret() {
+  sudo mkdir -p "$DATADIR"
+  if ! sudo test -s "$JWT_SECRET"; then
+    local secret
+    secret="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+    printf '%s\n' "$secret" | sudo tee "$JWT_SECRET" >/dev/null
+    sudo chmod 0600 "$JWT_SECRET"
+  fi
 }
 
 drop_caches() {
@@ -365,6 +376,7 @@ start_node() {
   fi
 
   stop_node
+  ensure_jwt_secret
 
   local online max_reth reth_cpus
   online="$(nproc --all)"
@@ -388,6 +400,7 @@ start_node() {
     --ws
     --ws.api all
     --authrpc.port 8551
+    --authrpc.jwtsecret "$JWT_SECRET"
     --disable-discovery
     --no-persist-peers
   )
@@ -455,7 +468,7 @@ benchmarkoor_common_args() {
     --metadata-root "$BENCHMARKOOR_METADATA_ROOT" \
     --cache-dir "$BENCHMARKOOR_CACHE" \
     --engine-url "$ENGINE_URL" \
-    --jwt-secret "$DATADIR/jwt.hex" \
+    --jwt-secret "$JWT_SECRET" \
     --reth-bin "$binary" \
     --schelk-bin "$schelk_bin"
 }
@@ -474,7 +487,7 @@ run_benchmarkoor() {
     "BENCHMARKOOR_CACHE=$BENCHMARKOOR_CACHE" \
     "BENCH_CORES=${BENCH_CORES:-6}" \
     "BENCH_MEMORY_MAX=${BENCH_MEMORY_MAX:-32G}" \
-    "BENCH_RESET_STRATEGY=${BENCH_RESET_STRATEGY:-unwind}" \
+    "BENCH_RESET_STRATEGY=${BENCH_RESET_STRATEGY:-schelk}" \
     "BENCH_PRERUN_HEAD_FILE=${BENCH_PRERUN_HEAD_FILE:-}" \
     "BENCH_BASELINE_ARGS=${BENCH_BASELINE_ARGS:-}" \
     "BENCH_FEATURE_ARGS=${BENCH_FEATURE_ARGS:-}" \

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -117,37 +117,6 @@ write_prerun_head_marker() {
   echo "Recorded post-prerun head ${head_dec} (${block_hash}) in ${marker}"
 }
 
-wait_for_prerun_head() {
-  local marker
-  marker="$(prerun_head_file)"
-  [ -f "$marker" ] || return 0
-
-  local expected_number expected_number_hex expected_hash latest_hex latest_number actual_hash
-  expected_number="$(jq -er '.number' "$marker")"
-  expected_number_hex="$(jq -er '.number_hex' "$marker")"
-  expected_hash="$(jq -er '.hash' "$marker")"
-
-  for i in $(seq 1 60); do
-    latest_hex="$(rpc_call eth_blockNumber | jq -r '.result // empty' 2>/dev/null || true)"
-    if [ -z "$latest_hex" ]; then
-      sleep 1
-      continue
-    fi
-    latest_number=$(( 16#${latest_hex#0x} ))
-    actual_hash="$(rpc_call eth_getBlockByNumber "[\"${latest_hex}\",false]" \
-      | jq -r '.result.hash // empty' 2>/dev/null || true)"
-    if [ "$latest_number" -eq "$expected_number" ] && [ "$actual_hash" = "$expected_hash" ]; then
-      echo "Recovered post-prerun head ${expected_number_hex} (${expected_hash}) after ${i}s"
-      return 0
-    fi
-    sleep 1
-  done
-
-  echo "::error::Recovered datadir did not expose expected post-prerun latest head ${expected_number_hex} (${expected_hash})"
-  rpc_call eth_blockNumber || true
-  exit 1
-}
-
 reth_db_capture() {
   local binary="$1"
   shift
@@ -430,10 +399,8 @@ start_node() {
   local node_help
   node_help="$("$binary" node --help 2>/dev/null || true)"
 
-  local sync_state_idle=false
   if grep -qF -- '--debug.startup-sync-state-idle' <<< "$node_help"; then
     reth_args+=(--debug.startup-sync-state-idle)
-    sync_state_idle=true
   fi
 
   if [[ "$phase" == "prerun" || "$phase" == *-setup ]] &&
@@ -474,44 +441,6 @@ start_node() {
   if [ "$follow_log" = "true" ]; then
     stdbuf -oL tail -f "$CURRENT_LOG" | sed -u "s/^/[reth] /" &
     TAIL_PID=$!
-  fi
-
-  for i in $(seq 1 60); do
-    if curl -sf "$HTTP_URL" -X POST \
-      -H 'Content-Type: application/json' \
-      -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-      > /dev/null 2>&1; then
-      echo "reth (${label}/${phase}) RPC is up after ${i}s"
-      break
-    fi
-    if [ "$i" -eq 60 ]; then
-      echo "::error::reth (${label}/${phase}) failed to start within 60s"
-      cat "$CURRENT_LOG"
-      exit 1
-    fi
-    sleep 1
-  done
-
-  if [ "$sync_state_idle" = true ]; then
-    for i in $(seq 1 300); do
-      sync_result="$(curl -sf "$HTTP_URL" -X POST \
-        -H 'Content-Type: application/json' \
-        -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)"
-      if [ -n "$sync_result" ] && jq -e '.result == false' <<< "$sync_result" > /dev/null 2>&1; then
-        echo "reth (${label}/${phase}) pipeline finished after ${i}s"
-        break
-      fi
-      if [ "$i" -eq 300 ]; then
-        echo "::error::reth (${label}/${phase}) pipeline did not finish within 300s"
-        cat "$CURRENT_LOG"
-        exit 1
-      fi
-      sleep 1
-    done
-  fi
-
-  if [[ "$phase" == *-setup ]]; then
-    wait_for_prerun_head
   fi
 }
 

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -557,6 +557,92 @@ shell_command() {
   printf '%q ' "$@"
 }
 
+benchmarkoor_failure_status() {
+  local native_out="$1"
+  if grep -q 'newPayload status is INVALID' "$native_out"; then
+    echo "invalid_newpayload"
+  else
+    echo "error"
+  fi
+}
+
+benchmarkoor_failure_phase() {
+  local native_out="$1"
+  if grep -q '/setup/' "$native_out"; then
+    echo "setup"
+  elif grep -q '/testing/' "$native_out"; then
+    echo "testing"
+  else
+    echo "unknown"
+  fi
+}
+
+benchmarkoor_error_summary() {
+  local native_out="$1"
+  { grep -E 'newPayload status is|JSON-RPC error|Error:|Caused by:' "$native_out" || true; } |
+    tail -n 12 |
+    sed -E 's/[[:space:]]+/ /g' |
+    paste -sd ' ' - |
+    cut -c1-1200
+}
+
+append_benchmarkoor_failure_result() {
+  local native_out="$1"
+  local test_name="$2"
+  local gas_bucket="$3"
+  local label="$4"
+  local run_type="$5"
+  local strategy="$6"
+  local reset_elapsed_secs="$7"
+  local wall_elapsed_secs="$8"
+  local benchmarkoor_status="$9"
+  local results="${10}"
+
+  local status phase error_summary
+  status="$(benchmarkoor_failure_status "$native_out")"
+  phase="$(benchmarkoor_failure_phase "$native_out")"
+  error_summary="$(benchmarkoor_error_summary "$native_out")"
+  if [ -z "$error_summary" ]; then
+    error_summary="benchmarkoor-replay exited with status ${benchmarkoor_status}"
+  fi
+
+  jq -nc \
+    --arg suite "$BENCHMARKOOR_SUITE" \
+    --arg test "$test_name" \
+    --arg label "$label" \
+    --arg run_type "$run_type" \
+    --arg gas_bucket "$gas_bucket" \
+    --arg reset_strategy "$strategy" \
+    --arg status "$status" \
+    --arg phase "$phase" \
+    --arg error_summary "$error_summary" \
+    --argjson reset_elapsed_secs "$reset_elapsed_secs" \
+    --argjson wall_elapsed_secs "$wall_elapsed_secs" \
+    --argjson benchmarkoor_exit_code "$benchmarkoor_status" \
+    '{
+      kind: "run_many_result",
+      status: $status,
+      suite: $suite,
+      test: $test,
+      label: $label,
+      run_type: $run_type,
+      gas_bucket: $gas_bucket,
+      reset_strategy: $reset_strategy,
+      reset_elapsed_secs: $reset_elapsed_secs,
+      wall_elapsed_secs: $wall_elapsed_secs,
+      benchmarkoor_exit_code: $benchmarkoor_exit_code,
+      invalid_newpayload: ($status == "invalid_newpayload"),
+      invalid_newpayload_phase: (if $status == "invalid_newpayload" then $phase else null end),
+      error_summary: $error_summary,
+      gas: 0,
+      elapsed_ms: 0,
+      gas_per_second: null,
+      testing_gas_per_sec: null,
+      testing_gas_used: 0,
+      testing_elapsed: null
+    }' >> "$results"
+}
+
 if [ "$MODE" = "restart-node" ]; then
   binary="${1:?binary is required}"
   label="${2:?label is required}"
@@ -639,6 +725,7 @@ while IFS= read -r test_entry; do
     shell_command "$SCRIPT_PATH" restart-node "$binary" "$label" "$output_dir" "${test_slug}-testing" "$log_path"
   )"
 
+  set +e
   run_benchmarkoor "${common[@]}" run-many \
     --exact "$test_name" \
     --limit 1 \
@@ -648,6 +735,14 @@ while IFS= read -r test_entry; do
     --drop-caches \
     --restart-node-command "$restart_command" \
     --json 2>&1 | tee "$native_out"
+  pipeline_status=("${PIPESTATUS[@]}")
+  set -e
+  benchmarkoor_status="${pipeline_status[0]}"
+  tee_status="${pipeline_status[1]}"
+  if [ "$tee_status" -ne 0 ]; then
+    echo "::error::tee failed while recording benchmarkoor output for ${test_name}"
+    exit 1
+  fi
 
   wall_elapsed_secs="$(elapsed_secs "$test_start_ns")"
   echo "=== ${label}: ${test_name} completed in ${wall_elapsed_secs}s (reset=${reset_elapsed_secs}s, strategy=${strategy}) ==="
@@ -661,6 +756,8 @@ while IFS= read -r test_entry; do
     --argjson wall_elapsed_secs "$wall_elapsed_secs" \
     'inputs | fromjson? | select(.kind == "run_many_result") |
       . + {
+        status: (.status // "ok"),
+        invalid_newpayload: (.invalid_newpayload // false),
         label: $label,
         run_type: $run_type,
         gas_bucket: $gas_bucket,
@@ -671,9 +768,33 @@ while IFS= read -r test_entry; do
     "$native_out" >> "$results"
 
   after_count="$(wc -l < "$results" | tr -d ' ')"
-  if [ "$after_count" -le "$before_count" ]; then
-    echo "::error::benchmarkoor-replay did not emit a run_many_result for ${test_name}"
-    exit 1
+  emitted_count=$(( after_count - before_count ))
+  if [ "$benchmarkoor_status" -ne 0 ]; then
+    echo "::warning::benchmarkoor-replay failed for ${test_name}; recording failure and continuing"
+    append_benchmarkoor_failure_result \
+      "$native_out" \
+      "$test_name" \
+      "$gas_bucket" \
+      "$label" \
+      "$run_type" \
+      "$strategy" \
+      "$reset_elapsed_secs" \
+      "$wall_elapsed_secs" \
+      "$benchmarkoor_status" \
+      "$results"
+  elif [ "$emitted_count" -le 0 ]; then
+    echo "::warning::benchmarkoor-replay did not emit a run_many_result for ${test_name}; recording failure and continuing"
+    append_benchmarkoor_failure_result \
+      "$native_out" \
+      "$test_name" \
+      "$gas_bucket" \
+      "$label" \
+      "$run_type" \
+      "$strategy" \
+      "$reset_elapsed_secs" \
+      "$wall_elapsed_secs" \
+      0 \
+      "$results"
   fi
 done < "$tests_jsonl"
 

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -60,6 +60,142 @@ drop_caches() {
   grep Cached /proc/meminfo
 }
 
+rpc_call() {
+  local method="$1"
+  local params="${2:-[]}"
+  curl -sf "$HTTP_URL" -X POST \
+    -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"method\":\"${method}\",\"params\":${params},\"id\":1}"
+}
+
+prerun_head_file() {
+  if [ -n "${BENCH_PRERUN_HEAD_FILE:-}" ]; then
+    printf '%s\n' "$BENCH_PRERUN_HEAD_FILE"
+  elif [ -n "${BENCH_WORK_DIR:-}" ]; then
+    printf '%s\n' "${BENCH_WORK_DIR}/prerun-head.json"
+  else
+    printf '%s\n' "${SCHELK_MOUNT}/prerun-head.json"
+  fi
+}
+
+write_prerun_head_marker() {
+  local marker head_hex head_dec block_hash
+  marker="$(prerun_head_file)"
+  head_hex="$(rpc_call eth_blockNumber | jq -er '.result')"
+  head_dec=$(( 16#${head_hex#0x} ))
+  block_hash="$(rpc_call eth_getBlockByNumber "[\"${head_hex}\",false]" | jq -er '.result.hash')"
+  mkdir -p "$(dirname "$marker")"
+  jq -n \
+    --argjson number "$head_dec" \
+    --arg number_hex "$head_hex" \
+    --arg hash "$block_hash" \
+    '{number: $number, number_hex: $number_hex, hash: $hash}' > "$marker"
+  echo "Recorded post-prerun head ${head_dec} (${block_hash}) in ${marker}"
+}
+
+wait_for_prerun_head() {
+  local marker
+  marker="$(prerun_head_file)"
+  [ -f "$marker" ] || return 0
+
+  local expected_number_hex expected_hash actual_hash
+  expected_number_hex="$(jq -er '.number_hex' "$marker")"
+  expected_hash="$(jq -er '.hash' "$marker")"
+
+  for i in $(seq 1 60); do
+    actual_hash="$(rpc_call eth_getBlockByNumber "[\"${expected_number_hex}\",false]" \
+      | jq -r '.result.hash // empty' 2>/dev/null || true)"
+    if [ "$actual_hash" = "$expected_hash" ]; then
+      echo "Recovered post-prerun head ${expected_number_hex} (${expected_hash}) after ${i}s"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "::error::Recovered datadir did not expose expected post-prerun head ${expected_number_hex} (${expected_hash})"
+  rpc_call eth_blockNumber || true
+  exit 1
+}
+
+reth_db_capture() {
+  local binary="$1"
+  shift
+
+  local -a db_args=(db)
+  if [ -f "$DATADIR/genesis.json" ]; then
+    db_args+=(--chain "$DATADIR/genesis.json")
+  fi
+  db_args+=(--datadir "$DATADIR" "$@")
+
+  "$binary" "${db_args[@]}" 2>&1
+}
+
+has_table_content() {
+  local output="$1"
+  [ -n "$output" ] && [[ "$output" != *"No content for the given table key"* ]]
+}
+
+has_header_content() {
+  local output="$1"
+  has_table_content "$output" && {
+    [[ "$output" == *"BlockHash"* ]] || [[ "$output" == *"parent_hash"* ]]
+  }
+}
+
+persisted_prerun_head_present() {
+  local binary="$1"
+  local expected_number="$2"
+  local expected_hash="$3"
+  local canonical header
+
+  canonical="$(reth_db_capture "$binary" get mdbx CanonicalHeaders "$expected_number" || true)"
+  if ! has_table_content "$canonical" || ! grep -qi "${expected_hash#0x}" <<< "$canonical"; then
+    return 1
+  fi
+
+  header="$(reth_db_capture "$binary" get static-file headers "$expected_number" || true)"
+  if has_header_content "$header"; then
+    return 0
+  fi
+
+  header="$(reth_db_capture "$binary" get mdbx Headers "$expected_number" || true)"
+  has_header_content "$header"
+}
+
+wait_for_persisted_prerun_head() {
+  local binary="$1"
+  local required="${2:-true}"
+  local marker
+  marker="$(prerun_head_file)"
+  [ -f "$marker" ] || return 0
+
+  local expected_number expected_hash
+  expected_number="$(jq -er '.number' "$marker")"
+  expected_hash="$(jq -er '.hash' "$marker")"
+
+  for i in $(seq 1 120); do
+    if persisted_prerun_head_present "$binary" "$expected_number" "$expected_hash"; then
+      echo "Post-prerun head ${expected_number} (${expected_hash}) is persisted after ${i}s"
+      return 0
+    fi
+    sleep 1
+  done
+
+  if [ "$required" != "true" ]; then
+    echo "Post-prerun head ${expected_number} (${expected_hash}) was not confirmed in on-disk Reth tables after 120s"
+    return 1
+  fi
+
+  echo "::error::Post-prerun head ${expected_number} (${expected_hash}) was not found in on-disk Reth tables"
+  echo "CanonicalHeaders:"
+  reth_db_capture "$binary" get mdbx CanonicalHeaders "$expected_number" || true
+  echo "Static-file header:"
+  reth_db_capture "$binary" get static-file headers "$expected_number" || true
+  echo "MDBX header:"
+  reth_db_capture "$binary" get mdbx Headers "$expected_number" || true
+  exit 1
+}
+
 stop_node() {
   if [ -n "${TAIL_PID:-}" ]; then
     kill "$TAIL_PID" 2>/dev/null || true
@@ -134,10 +270,19 @@ start_node() {
     reth_args+=(--chain "$DATADIR/genesis.json")
   fi
 
+  local node_help
+  node_help="$("$binary" node --help 2>/dev/null || true)"
+
   local sync_state_idle=false
-  if "$binary" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
+  if grep -qF -- '--debug.startup-sync-state-idle' <<< "$node_help"; then
     reth_args+=(--debug.startup-sync-state-idle)
     sync_state_idle=true
+  fi
+
+  if [[ "$phase" == "prerun" || "$phase" == *-setup ]] &&
+    grep -qF -- '--engine.persistence-threshold' <<< "$node_help" &&
+    grep -qF -- '--engine.persistence-backpressure-threshold' <<< "$node_help"; then
+    reth_args+=(--engine.persistence-threshold 0 --engine.persistence-backpressure-threshold 1)
   fi
 
   local extra_node_args=""
@@ -154,9 +299,15 @@ start_node() {
     reth_args+=(--metrics "$BENCH_METRICS_ADDR")
   fi
 
-  local total_mem_kb mem_limit
-  total_mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
-  mem_limit=$(( total_mem_kb * 95 / 100 * 1024 ))
+  local mem_limit
+  mem_limit="${BENCH_MEMORY_MAX:-32G}"
+  if [ -z "$mem_limit" ] || [ "$mem_limit" = "0" ]; then
+    local total_mem_kb
+    total_mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+    mem_limit=$(( total_mem_kb * 95 / 100 * 1024 ))
+  fi
+
+  echo "Starting reth (${label}/${phase}) with AllowedCPUs=${reth_cpus}, MemoryMax=${mem_limit}"
 
   sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
     -p MemoryMax="$mem_limit" -p AllowedCPUs="$reth_cpus" \
@@ -201,6 +352,10 @@ start_node() {
       sleep 1
     done
   fi
+
+  if [[ "$phase" == *-setup ]]; then
+    wait_for_prerun_head
+  fi
 }
 
 benchmarkoor_common_args() {
@@ -231,7 +386,8 @@ run_benchmarkoor() {
     "BENCHMARKOOR_TEST_TYPE=$BENCHMARKOOR_TEST_TYPE" \
     "BENCHMARKOOR_METADATA_ROOT=$BENCHMARKOOR_METADATA_ROOT" \
     "BENCHMARKOOR_CACHE=$BENCHMARKOOR_CACHE" \
-    "BENCH_CORES=${BENCH_CORES:-0}" \
+    "BENCH_CORES=${BENCH_CORES:-6}" \
+    "BENCH_MEMORY_MAX=${BENCH_MEMORY_MAX:-32G}" \
     "BENCH_BASELINE_ARGS=${BENCH_BASELINE_ARGS:-}" \
     "BENCH_FEATURE_ARGS=${BENCH_FEATURE_ARGS:-}" \
     "BENCH_METRICS_ADDR=${BENCH_METRICS_ADDR:-}" \
@@ -268,9 +424,14 @@ SH
   chmod +x "$sudo_schelk"
 
   mapfile -d '' common < <(benchmarkoor_common_args "$binary" "$sudo_schelk")
-  run_benchmarkoor "${common[@]}" baseline promote-prerun --kill
+  run_benchmarkoor "${common[@]}" baseline prepare --no-mount
+  write_prerun_head_marker
+  wait_for_persisted_prerun_head "$binary" false ||
+    echo "Post-prerun head was not confirmed before shutdown; checking again after graceful stop"
 
   stop_node
+  wait_for_persisted_prerun_head "$binary" true
+  sudo schelk promote -y
   sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
   echo "Promoted schelk baseline after benchmarkoor gas-bump/funding"
   exit 0

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -37,6 +37,8 @@ JWT_SECRET="${DATADIR}/jwt.hex"
 RETH_SCOPE="${RETH_SCOPE:-reth-benchmarkoor.scope}"
 ENGINE_URL="${BENCHMARKOOR_ENGINE_URL:-http://127.0.0.1:8551}"
 HTTP_URL="http://127.0.0.1:8545"
+ENGINE_HOST="127.0.0.1"
+ENGINE_PORT="8551"
 
 TAIL_PID=""
 CURRENT_LOG=""
@@ -101,6 +103,24 @@ rpc_call() {
   curl -sf "$HTTP_URL" -X POST \
     -H 'Content-Type: application/json' \
     -d "{\"jsonrpc\":\"2.0\",\"method\":\"${method}\",\"params\":${params},\"id\":1}"
+}
+
+wait_for_engine_port() {
+  local label="$1"
+  local phase="$2"
+  local deadline
+  deadline=$((SECONDS + 30))
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if timeout 0.1 bash -c "</dev/tcp/${ENGINE_HOST}/${ENGINE_PORT}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.05
+  done
+
+  echo "::error::reth (${label}/${phase}) engine port ${ENGINE_HOST}:${ENGINE_PORT} did not open within 30s"
+  cat "$CURRENT_LOG"
+  exit 1
 }
 
 prerun_head_file() {
@@ -455,6 +475,8 @@ start_node() {
     stdbuf -oL tail -f "$CURRENT_LOG" | sed -u "s/^/[reth] /" &
     TAIL_PID=$!
   fi
+
+  wait_for_engine_port "$label" "$phase"
 }
 
 benchmarkoor_common_args() {

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -42,6 +42,7 @@ ENGINE_PORT="8551"
 
 TAIL_PID=""
 CURRENT_LOG=""
+RESET_TIMINGS_FILE=""
 
 cleanup() {
   if [ -n "${TAIL_PID:-}" ]; then
@@ -70,6 +71,36 @@ elapsed_secs() {
   awk -v ns="$(( end_ns - start_ns ))" 'BEGIN { printf "%.6f", ns / 1000000000 }'
 }
 
+record_reset_timing() {
+  local step="$1"
+  local elapsed_secs="$2"
+  local status="${3:-0}"
+
+  if [ -n "${RESET_TIMINGS_FILE:-}" ]; then
+    echo "Reset timing: ${step}=${elapsed_secs}s status=${status}"
+    jq -nc \
+      --arg step "$step" \
+      --argjson elapsed_secs "$elapsed_secs" \
+      --argjson status "$status" \
+      '{step: $step, elapsed_secs: $elapsed_secs, status: $status}' >> "$RESET_TIMINGS_FILE"
+  fi
+}
+
+time_reset_step() {
+  local step="$1"
+  shift
+
+  local start_ns elapsed status
+  start_ns="$(now_ns)"
+  set +e
+  "$@"
+  status="$?"
+  set -e
+  elapsed="$(elapsed_secs "$start_ns")"
+  record_reset_timing "$step" "$elapsed" "$status"
+  return "$status"
+}
+
 reset_strategy() {
   case "${BENCH_RESET_STRATEGY:-schelk}" in
     unwind | schelk) printf '%s\n' "${BENCH_RESET_STRATEGY:-schelk}" ;;
@@ -91,10 +122,10 @@ ensure_jwt_secret() {
 }
 
 drop_caches() {
-  sync
-  sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
-  free -h
-  grep Cached /proc/meminfo
+  time_reset_step "drop_caches.sync" sync
+  time_reset_step "drop_caches.write" sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+  time_reset_step "drop_caches.free" free -h
+  time_reset_step "drop_caches.meminfo" grep Cached /proc/meminfo
 }
 
 rpc_call() {
@@ -330,9 +361,9 @@ stop_node_required() {
 }
 
 recover_schelk() {
-  stop_node
-  sudo schelk recover -y --kill || sudo schelk full-recover -y || true
-  sudo schelk mount -y
+  time_reset_step "stop_node" stop_node
+  time_reset_step "schelk.recover" sudo schelk recover -y --kill
+  time_reset_step "schelk.mount" sudo schelk mount -y
   if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
     echo "::error::Failed to mount benchmark datadir at ${DATADIR}"
     ls -la "$SCHELK_MOUNT" || true
@@ -352,8 +383,8 @@ reset_to_prerun_state() {
       recover_schelk
       ;;
     unwind)
-      stop_node_required
-      unwind_to_prerun_head "$binary"
+      time_reset_step "stop_node" stop_node_required
+      time_reset_step "reth.unwind" unwind_to_prerun_head "$binary"
       drop_caches
       ;;
   esac
@@ -558,9 +589,11 @@ append_benchmarkoor_failure_result() {
   local run_type="$5"
   local strategy="$6"
   local reset_elapsed_secs="$7"
-  local wall_elapsed_secs="$8"
-  local benchmarkoor_status="$9"
-  local results="${10}"
+  local reset_timings_json="$8"
+  local reset_timing_steps_json="$9"
+  local wall_elapsed_secs="${10}"
+  local benchmarkoor_status="${11}"
+  local results="${12}"
 
   local status phase error_summary
   status="$(benchmarkoor_failure_status "$native_out")"
@@ -581,6 +614,8 @@ append_benchmarkoor_failure_result() {
     --arg phase "$phase" \
     --arg error_summary "$error_summary" \
     --argjson reset_elapsed_secs "$reset_elapsed_secs" \
+    --argjson reset_timings "$reset_timings_json" \
+    --argjson reset_timing_steps "$reset_timing_steps_json" \
     --argjson wall_elapsed_secs "$wall_elapsed_secs" \
     --argjson benchmarkoor_exit_code "$benchmarkoor_status" \
     '{
@@ -603,7 +638,9 @@ append_benchmarkoor_failure_result() {
       gas_per_second: null,
       testing_gas_per_sec: null,
       testing_gas_used: 0,
-      testing_elapsed: null
+      testing_elapsed: null,
+      reset_timings: $reset_timings,
+      reset_timing_steps: $reset_timing_steps
     }' >> "$results"
 }
 
@@ -680,13 +717,19 @@ while IFS= read -r test_entry; do
   test_slug="$(safe_name "$test_name")"
   log_path="${output_dir}/logs/$(safe_name "${label}-${test_slug}").log"
   native_out="${output_dir}/native-$(safe_name "$test_slug").jsonl"
+  reset_timings_file="${output_dir}/reset-timings-$(safe_name "${label}-${test_slug}").jsonl"
+  : > "$reset_timings_file"
   before_count="$(wc -l < "$results" | tr -d ' ')"
   test_start_ns="$(now_ns)"
   reset_start_ns="$(now_ns)"
 
   echo "=== ${label}: ${test_name} ==="
+  RESET_TIMINGS_FILE="$reset_timings_file"
   reset_to_prerun_state "$binary"
   reset_elapsed_secs="$(elapsed_secs "$reset_start_ns")"
+  reset_timing_steps_json="$(jq -sc '.' "$reset_timings_file")"
+  reset_timings_json="$(jq -sc 'map({(.step): .elapsed_secs}) | add // {}' "$reset_timings_file")"
+  RESET_TIMINGS_FILE=""
   start_node "$binary" "$label" "$output_dir" "${test_slug}-setup" "$log_path" false true
 
   restart_command="$(
@@ -721,6 +764,8 @@ while IFS= read -r test_entry; do
     --arg gas_bucket "$gas_bucket" \
     --arg reset_strategy "$strategy" \
     --argjson reset_elapsed_secs "$reset_elapsed_secs" \
+    --argjson reset_timings "$reset_timings_json" \
+    --argjson reset_timing_steps "$reset_timing_steps_json" \
     --argjson wall_elapsed_secs "$wall_elapsed_secs" \
     'inputs | fromjson? | select(.kind == "run_many_result") |
       . + {
@@ -731,6 +776,8 @@ while IFS= read -r test_entry; do
         gas_bucket: $gas_bucket,
         reset_strategy: $reset_strategy,
         reset_elapsed_secs: $reset_elapsed_secs,
+        reset_timings: $reset_timings,
+        reset_timing_steps: $reset_timing_steps,
         wall_elapsed_secs: $wall_elapsed_secs
       }' \
     "$native_out" >> "$results"
@@ -747,6 +794,8 @@ while IFS= read -r test_entry; do
       "$run_type" \
       "$strategy" \
       "$reset_elapsed_secs" \
+      "$reset_timings_json" \
+      "$reset_timing_steps_json" \
       "$wall_elapsed_secs" \
       "$benchmarkoor_status" \
       "$results"
@@ -761,6 +810,8 @@ while IFS= read -r test_entry; do
       "$run_type" \
       "$strategy" \
       "$reset_elapsed_secs" \
+      "$reset_timings_json" \
+      "$reset_timing_steps_json" \
       "$wall_elapsed_secs" \
       0 \
       "$results"

--- a/.github/scripts/bench-benchmarkoor-run.sh
+++ b/.github/scripts/bench-benchmarkoor-run.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# Runs benchmarkoor-replay against a schelk-managed Reth datadir.
+#
+# Usage:
+#   bench-benchmarkoor-run.sh prepare <binary> <output-dir>
+#   bench-benchmarkoor-run.sh run <label> <binary> <output-dir> <tests-jsonl>
+#   bench-benchmarkoor-run.sh restart-node <binary> <label> <output-dir> <phase> <log>
+#
+# The prepare mode starts Reth on the imported snapshot, replays benchmarkoor's
+# gas-bump/funding prerun, and promotes that state as the schelk baseline.
+#
+# The run mode recovers to that post-prerun baseline for each test, starts
+# Reth, then delegates the measured setup/testing split to benchmarkoor-replay's
+# native `run-many --mode setup-then-testing --json` mode. The restart-node mode
+# is invoked by benchmarkoor-replay between setup and measured testing.
+set -euo pipefail
+
+MODE="${1:?mode is required}"
+shift
+
+: "${SCHELK_MOUNT:?SCHELK_MOUNT must be set}"
+: "${BENCHMARKOOR_BIN:?BENCHMARKOOR_BIN must be set}"
+: "${BENCHMARKOOR_SUITE:?BENCHMARKOOR_SUITE must be set}"
+: "${BENCHMARKOOR_CONTEXT:?BENCHMARKOOR_CONTEXT must be set}"
+: "${BENCHMARKOOR_FORK:?BENCHMARKOOR_FORK must be set}"
+: "${BENCHMARKOOR_TEST_TYPE:?BENCHMARKOOR_TEST_TYPE must be set}"
+: "${BENCHMARKOOR_METADATA_ROOT:?BENCHMARKOOR_METADATA_ROOT must be set}"
+: "${BENCHMARKOOR_CACHE:?BENCHMARKOOR_CACHE must be set}"
+
+SCRIPT_PATH="$(readlink -f "$0")"
+DATADIR="${SCHELK_MOUNT}/datadir"
+RETH_SCOPE="${RETH_SCOPE:-reth-benchmarkoor.scope}"
+ENGINE_URL="${BENCHMARKOOR_ENGINE_URL:-http://127.0.0.1:8551}"
+HTTP_URL="http://127.0.0.1:8545"
+
+TAIL_PID=""
+CURRENT_LOG=""
+
+cleanup() {
+  if [ -n "${TAIL_PID:-}" ]; then
+    kill "$TAIL_PID" 2>/dev/null || true
+  fi
+  sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+  sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+}
+
+if [ "$MODE" != "restart-node" ]; then
+  trap cleanup EXIT
+fi
+
+safe_name() {
+  printf '%s' "$1" | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^-+//; s/-+$//' | cut -c1-180
+}
+
+drop_caches() {
+  sync
+  sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+  free -h
+  grep Cached /proc/meminfo
+}
+
+stop_node() {
+  if [ -n "${TAIL_PID:-}" ]; then
+    kill "$TAIL_PID" 2>/dev/null || true
+    TAIL_PID=""
+  fi
+  sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+  sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+}
+
+recover_schelk() {
+  stop_node
+  sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+  sudo schelk mount -y
+  if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
+    echo "::error::Failed to mount benchmark datadir at ${DATADIR}"
+    ls -la "$SCHELK_MOUNT" || true
+    ls -la "$DATADIR" || true
+    exit 1
+  fi
+  drop_caches
+}
+
+start_node() {
+  local binary="$1"
+  local label="$2"
+  local output_dir="$3"
+  local phase="$4"
+  local log_path="${5:-}"
+  local append_log="${6:-false}"
+  local follow_log="${7:-true}"
+
+  mkdir -p "${output_dir}/logs"
+  if [ -z "$log_path" ]; then
+    log_path="${output_dir}/logs/$(safe_name "${label}-${phase}").log"
+  fi
+  CURRENT_LOG="$log_path"
+  if [ "$append_log" = "true" ]; then
+    : >> "$CURRENT_LOG"
+  else
+    : > "$CURRENT_LOG"
+  fi
+
+  stop_node
+
+  local online max_reth reth_cpus
+  online="$(nproc --all)"
+  max_reth=$(( online - 1 ))
+  if [ "${BENCH_CORES:-0}" -gt 0 ] && [ "$BENCH_CORES" -lt "$max_reth" ]; then
+    max_reth="$BENCH_CORES"
+  fi
+  if [ "$max_reth" -lt 1 ]; then
+    reth_cpus="0"
+  else
+    reth_cpus="1-${max_reth}"
+  fi
+
+  local -a reth_args=(
+    node
+    --datadir "$DATADIR"
+    --log.file.directory "$output_dir/reth-logs"
+    --engine.accept-execution-requests-hash
+    --http
+    --http.port 8545
+    --ws
+    --ws.api all
+    --authrpc.port 8551
+    --disable-discovery
+    --no-persist-peers
+  )
+
+  if [ -f "$DATADIR/genesis.json" ]; then
+    reth_args+=(--chain "$DATADIR/genesis.json")
+  fi
+
+  local sync_state_idle=false
+  if "$binary" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
+    reth_args+=(--debug.startup-sync-state-idle)
+    sync_state_idle=true
+  fi
+
+  local extra_node_args=""
+  case "$label" in
+    baseline*) extra_node_args="${BENCH_BASELINE_ARGS:-}" ;;
+    feature*) extra_node_args="${BENCH_FEATURE_ARGS:-}" ;;
+  esac
+  if [ -n "$extra_node_args" ]; then
+    # shellcheck disable=SC2206
+    reth_args+=($extra_node_args)
+  fi
+
+  if [ -n "${BENCH_METRICS_ADDR:-}" ]; then
+    reth_args+=(--metrics "$BENCH_METRICS_ADDR")
+  fi
+
+  local total_mem_kb mem_limit
+  total_mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+  mem_limit=$(( total_mem_kb * 95 / 100 * 1024 ))
+
+  sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
+    -p MemoryMax="$mem_limit" -p AllowedCPUs="$reth_cpus" \
+    nice -n -20 "$binary" "${reth_args[@]}" \
+    >> "$CURRENT_LOG" 2>&1 &
+
+  if [ "$follow_log" = "true" ]; then
+    stdbuf -oL tail -f "$CURRENT_LOG" | sed -u "s/^/[reth] /" &
+    TAIL_PID=$!
+  fi
+
+  for i in $(seq 1 60); do
+    if curl -sf "$HTTP_URL" -X POST \
+      -H 'Content-Type: application/json' \
+      -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+      > /dev/null 2>&1; then
+      echo "reth (${label}/${phase}) RPC is up after ${i}s"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "::error::reth (${label}/${phase}) failed to start within 60s"
+      cat "$CURRENT_LOG"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  if [ "$sync_state_idle" = true ]; then
+    for i in $(seq 1 300); do
+      sync_result="$(curl -sf "$HTTP_URL" -X POST \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}' 2>/dev/null || true)"
+      if [ -n "$sync_result" ] && jq -e '.result == false' <<< "$sync_result" > /dev/null 2>&1; then
+        echo "reth (${label}/${phase}) pipeline finished after ${i}s"
+        break
+      fi
+      if [ "$i" -eq 300 ]; then
+        echo "::error::reth (${label}/${phase}) pipeline did not finish within 300s"
+        cat "$CURRENT_LOG"
+        exit 1
+      fi
+      sleep 1
+    done
+  fi
+}
+
+benchmarkoor_common_args() {
+  local binary="$1"
+  local schelk_bin="$2"
+  printf '%s\0' \
+    --suite "$BENCHMARKOOR_SUITE" \
+    --context "$BENCHMARKOOR_CONTEXT" \
+    --fork "$BENCHMARKOOR_FORK" \
+    --test-type "$BENCHMARKOOR_TEST_TYPE" \
+    --metadata-root "$BENCHMARKOOR_METADATA_ROOT" \
+    --cache-dir "$BENCHMARKOOR_CACHE" \
+    --engine-url "$ENGINE_URL" \
+    --jwt-secret "$DATADIR/jwt.hex" \
+    --reth-bin "$binary" \
+    --schelk-bin "$schelk_bin"
+}
+
+run_benchmarkoor() {
+  sudo env \
+    "PATH=$PATH" \
+    "SCHELK_MOUNT=$SCHELK_MOUNT" \
+    "RETH_SCOPE=$RETH_SCOPE" \
+    "BENCHMARKOOR_BIN=$BENCHMARKOOR_BIN" \
+    "BENCHMARKOOR_SUITE=$BENCHMARKOOR_SUITE" \
+    "BENCHMARKOOR_CONTEXT=$BENCHMARKOOR_CONTEXT" \
+    "BENCHMARKOOR_FORK=$BENCHMARKOOR_FORK" \
+    "BENCHMARKOOR_TEST_TYPE=$BENCHMARKOOR_TEST_TYPE" \
+    "BENCHMARKOOR_METADATA_ROOT=$BENCHMARKOOR_METADATA_ROOT" \
+    "BENCHMARKOOR_CACHE=$BENCHMARKOOR_CACHE" \
+    "BENCH_CORES=${BENCH_CORES:-0}" \
+    "BENCH_BASELINE_ARGS=${BENCH_BASELINE_ARGS:-}" \
+    "BENCH_FEATURE_ARGS=${BENCH_FEATURE_ARGS:-}" \
+    "BENCH_METRICS_ADDR=${BENCH_METRICS_ADDR:-}" \
+    nice -n -20 "$BENCHMARKOOR_BIN" "$@"
+}
+
+shell_command() {
+  printf '%q ' "$@"
+}
+
+if [ "$MODE" = "restart-node" ]; then
+  binary="${1:?binary is required}"
+  label="${2:?label is required}"
+  output_dir="${3:?output directory is required}"
+  phase="${4:?phase is required}"
+  log_path="${5:?log path is required}"
+  start_node "$binary" "$label" "$output_dir" "$phase" "$log_path" true false
+  exit 0
+fi
+
+if [ "$MODE" = "prepare" ]; then
+  binary="${1:?binary is required}"
+  output_dir="${2:?output directory is required}"
+  mkdir -p "$output_dir"
+
+  recover_schelk
+  start_node "$binary" "prepare" "$output_dir" "prerun"
+
+  sudo_schelk="${output_dir}/sudo-schelk"
+  cat > "$sudo_schelk" <<'SH'
+#!/usr/bin/env bash
+exec sudo schelk "$@" -y
+SH
+  chmod +x "$sudo_schelk"
+
+  mapfile -d '' common < <(benchmarkoor_common_args "$binary" "$sudo_schelk")
+  run_benchmarkoor "${common[@]}" baseline promote-prerun --kill
+
+  stop_node
+  sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+  echo "Promoted schelk baseline after benchmarkoor gas-bump/funding"
+  exit 0
+fi
+
+if [ "$MODE" != "run" ]; then
+  echo "Usage: $0 prepare <binary> <output-dir> | run <label> <binary> <output-dir> <tests-jsonl> | restart-node <binary> <label> <output-dir> <phase> <log>"
+  exit 1
+fi
+
+label="${1:?label is required}"
+binary="${2:?binary is required}"
+output_dir="${3:?output directory is required}"
+tests_jsonl="${4:?tests jsonl is required}"
+results="${output_dir}/results.jsonl"
+mkdir -p "$output_dir/logs"
+: > "$results"
+
+mapfile -d '' common < <(benchmarkoor_common_args "$binary" "schelk")
+run_type="feature"
+if [[ "$label" == baseline* ]]; then
+  run_type="baseline"
+fi
+
+while IFS= read -r test_entry; do
+  [ -n "$test_entry" ] || continue
+  test_name="$(jq -r '.name' <<< "$test_entry")"
+  gas_bucket="$(jq -r '.gas_bucket // ""' <<< "$test_entry")"
+  test_slug="$(safe_name "$test_name")"
+  log_path="${output_dir}/logs/$(safe_name "${label}-${test_slug}").log"
+  native_out="${output_dir}/native-$(safe_name "$test_slug").jsonl"
+  before_count="$(wc -l < "$results" | tr -d ' ')"
+
+  echo "=== ${label}: ${test_name} ==="
+  recover_schelk
+  start_node "$binary" "$label" "$output_dir" "${test_slug}-setup" "$log_path" false true
+
+  restart_command="$(
+    shell_command "$SCRIPT_PATH" restart-node "$binary" "$label" "$output_dir" "${test_slug}-testing" "$log_path"
+  )"
+
+  run_benchmarkoor "${common[@]}" run-many \
+    --exact "$test_name" \
+    --limit 1 \
+    --repetitions 1 \
+    --mode setup-then-testing \
+    --no-schelk \
+    --drop-caches \
+    --restart-node-command "$restart_command" \
+    --json 2>&1 | tee "$native_out"
+
+  jq -Rnc \
+    --arg label "$label" \
+    --arg run_type "$run_type" \
+    --arg gas_bucket "$gas_bucket" \
+    'inputs | fromjson? | select(.kind == "run_many_result") |
+      . + {label: $label, run_type: $run_type, gas_bucket: $gas_bucket}' \
+    "$native_out" >> "$results"
+
+  after_count="$(wc -l < "$results" | tr -d ' ')"
+  if [ "$after_count" -le "$before_count" ]; then
+    echo "::error::benchmarkoor-replay did not emit a run_many_result for ${test_name}"
+    exit 1
+  fi
+done < "$tests_jsonl"
+
+sudo schelk recover -y --kill || true
+echo "results=${results}"

--- a/.github/scripts/bench-benchmarkoor-snapshot.sh
+++ b/.github/scripts/bench-benchmarkoor-snapshot.sh
@@ -19,7 +19,6 @@
 # Optional env:
 #   BENCHMARKOOR_SNAPSHOT_MC_ROOT  MinIO alias/root used when
 #                                  BENCHMARKOOR_SNAPSHOT is a bare prefix.
-#   BENCHMARKOOR_GENESIS           Genesis URL, mc path, or local path.
 #   BENCHMARKOOR_MIGRATE_V2        true to run reth db migrate-v2.
 set -euo pipefail
 
@@ -176,48 +175,6 @@ resolve_snapshot_object() {
   printf '%s\n' "$found"
 }
 
-download_optional_genesis() {
-  local manifest_source="$1"
-  local genesis_dest="${DATADIR}/genesis.json"
-  local sibling=""
-  local fallback_url=""
-
-  if [ -n "${BENCHMARKOOR_GENESIS:-}" ]; then
-    echo "Downloading explicit benchmarkoor genesis"
-    copy_source_to_file "$BENCHMARKOOR_GENESIS" "$genesis_dest"
-    return 0
-  fi
-
-  if [[ "$manifest_source" =~ ^https?:// ]]; then
-    sibling="$(dirname "$manifest_source")/genesis.json"
-  elif [[ "$manifest_source" == */* ]]; then
-    sibling="$(dirname "$manifest_source")/genesis.json"
-  fi
-
-  if [ -n "$sibling" ] && source_exists "$sibling"; then
-    echo "Downloading genesis from snapshot location"
-    copy_source_to_file "$sibling" "$genesis_dest"
-    return 0
-  fi
-
-  fallback_url="$(known_suite_genesis_url)"
-  if [ -n "$fallback_url" ]; then
-    echo "Downloading genesis from benchmarkoor suite fallback"
-    copy_source_to_file "$fallback_url" "$genesis_dest"
-  fi
-}
-
-known_suite_genesis_url() {
-  case "$BENCHMARKOOR_SUITE" in
-    perf-devnet-3/24358000)
-      printf '%s\n' "https://gist.githubusercontent.com/skylenet/83b19b06b91fb44e0131d275a1aa0495/raw/4fb5ed66370bc5dc7c6745a775d4972dd6c1a098/genesis-perf-devnet-3-24358000-amsterdam-genesis.json"
-      ;;
-    jochemnet/24402727)
-      printf '%s\n' "https://gist.githubusercontent.com/skylenet/8226878ba786efcf10b5fd74be97fe41/raw/ab888a0f90dcf214bd5d3c36b3dfa1827335ecf9/genesis-jochemnet-24402727-amsterdam-genesis.json"
-      ;;
-  esac
-}
-
 network="${BENCHMARKOOR_SUITE%%/*}"
 block="${BENCHMARKOOR_SUITE#*/}"
 suite_slug="$(
@@ -258,7 +215,15 @@ if manifest_object="$(resolve_manifest_object "$BENCHMARKOOR_SNAPSHOT")"; then
     --minimal \
     --datadir "$DATADIR"
 
-  download_optional_genesis "$manifest_object"
+  "$BENCHMARKOOR_BIN" \
+    --suite "$BENCHMARKOOR_SUITE" \
+    --context "$BENCHMARKOOR_CONTEXT" \
+    --fork "$BENCHMARKOOR_FORK" \
+    --test-type "$BENCHMARKOOR_TEST_TYPE" \
+    --metadata-root "$BENCHMARKOOR_METADATA_ROOT" \
+    --cache-dir "$BENCHMARKOOR_CACHE" \
+    genesis download \
+    --datadir "$DATADIR"
 
   if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
     echo "::error::Manifest download did not produce expected db/ and static_files/ directories"

--- a/.github/scripts/bench-benchmarkoor-snapshot.sh
+++ b/.github/scripts/bench-benchmarkoor-snapshot.sh
@@ -59,7 +59,8 @@ source_exists() {
     return 0
   fi
   if [[ "$source" =~ ^https?:// ]]; then
-    curl -fsI --retry 2 --retry-delay 2 "$source" >/dev/null 2>&1
+    curl -fsI --retry 2 --retry-delay 2 "$source" >/dev/null 2>&1 ||
+      curl -fsSL --retry 2 --retry-delay 2 --range 0-0 "$source" -o /dev/null >/dev/null 2>&1
     return $?
   fi
   mc stat "$source" >/dev/null 2>&1
@@ -70,13 +71,27 @@ mc_alias_url() {
   mc alias export "$alias" 2>/dev/null | jq -r '.url // empty'
 }
 
+mc_object_http_url() {
+  local object="$1"
+  local alias rest alias_url
+
+  alias="${object%%/*}"
+  rest="${object#*/}"
+  alias_url="$(mc_alias_url "$alias" || true)"
+  if [ -z "$alias_url" ] || [ "$rest" = "$object" ]; then
+    return 1
+  fi
+
+  printf '%s/%s\n' "$(trim_slashes "$alias_url")" "$rest"
+}
+
 mc_manifest_base_url() {
   local manifest_object="$1"
   local alias rest alias_url
 
   alias="${manifest_object%%/*}"
   rest="${manifest_object#*/}"
-  alias_url="$(mc_alias_url "$alias")"
+  alias_url="$(mc_alias_url "$alias" || true)"
   if [ -z "$alias_url" ] || [ "$rest" = "$manifest_object" ]; then
     return 1
   fi
@@ -87,7 +102,7 @@ mc_manifest_base_url() {
 resolve_manifest_object() {
   local source="$1"
   local root="${BENCHMARKOOR_SNAPSHOT_MC_ROOT:-minio}"
-  local candidate found
+  local candidate candidate_url found
 
   if [ -d "$source" ] && [ -f "$(trim_slashes "$source")/manifest.json" ]; then
     printf '%s\n' "$(trim_slashes "$source")/manifest.json"
@@ -111,10 +126,22 @@ resolve_manifest_object() {
     printf '%s\n' "$source"
     return 0
   fi
+  if [[ "$(basename "$source")" == "manifest.json" ]]; then
+    candidate_url="$(mc_object_http_url "$source" || true)"
+    if [ -n "$candidate_url" ] && source_exists "$candidate_url"; then
+      printf '%s\n' "$candidate_url"
+      return 0
+    fi
+  fi
 
   candidate="$(trim_slashes "$source")/manifest.json"
   if source_exists "$candidate"; then
     printf '%s\n' "$candidate"
+    return 0
+  fi
+  candidate_url="$(mc_object_http_url "$candidate" || true)"
+  if [ -n "$candidate_url" ] && source_exists "$candidate_url"; then
+    printf '%s\n' "$candidate_url"
     return 0
   fi
 
@@ -137,7 +164,7 @@ resolve_manifest_object() {
 log_manifest_lookup_diagnostics() {
   local source="$1"
   local root="${BENCHMARKOOR_SNAPSHOT_MC_ROOT:-minio}"
-  local trimmed candidate alias alias_url parent
+  local trimmed candidate candidate_url alias alias_url parent
 
   trimmed="$(trim_slashes "$source")"
   if [[ "$(basename "$trimmed")" == "manifest.json" ]]; then
@@ -150,12 +177,21 @@ log_manifest_lookup_diagnostics() {
   echo "BENCHMARKOOR_SNAPSHOT=${source}"
   echo "BENCHMARKOOR_SNAPSHOT_MC_ROOT=${root}"
   echo "Candidate manifest: ${candidate}"
+  candidate_url="$(mc_object_http_url "$candidate" || true)"
+  if [ -n "$candidate_url" ]; then
+    echo "Candidate manifest HTTP URL: ${candidate_url}"
+  fi
 
   if [[ "$source" =~ ^https?:// ]]; then
     echo "HTTP HEAD for candidate:"
     curl -fsI --retry 2 --retry-delay 2 "$candidate" || true
     echo "::endgroup::"
     return 0
+  fi
+
+  if [ -n "$candidate_url" ]; then
+    echo "HTTP HEAD for candidate manifest URL:"
+    curl -fsI --retry 2 --retry-delay 2 "$candidate_url" || true
   fi
 
   alias="${candidate%%/*}"

--- a/.github/scripts/bench-benchmarkoor-snapshot.sh
+++ b/.github/scripts/bench-benchmarkoor-snapshot.sh
@@ -227,7 +227,7 @@ suite_slug="$(
     sed -E 's/[^A-Za-z0-9_-]+/-/g; s/^-+//; s/-+$//'
 )"
 
-sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+sudo schelk recover -y --kill
 sudo schelk mount -y
 
 if ! manifest_object="$(resolve_manifest_object "$BENCHMARKOOR_SNAPSHOT")"; then

--- a/.github/scripts/bench-benchmarkoor-snapshot.sh
+++ b/.github/scripts/bench-benchmarkoor-snapshot.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+#
+# Imports a benchmarkoor replay snapshot into the schelk scratch volume and
+# promotes it as the schelk baseline. The later prerun step promotes again
+# after gas-bump/funding.
+#
+# Required env:
+#   SCHELK_MOUNT
+#   BENCHMARKOOR_BIN
+#   BENCHMARKOOR_SUITE
+#   BENCHMARKOOR_CONTEXT
+#   BENCHMARKOOR_FORK
+#   BENCHMARKOOR_TEST_TYPE
+#   BENCHMARKOOR_METADATA_ROOT
+#   BENCHMARKOOR_CACHE
+#   BENCHMARKOOR_SNAPSHOT
+#   BENCH_RETH_BINARY
+#
+# Optional env:
+#   BENCHMARKOOR_SNAPSHOT_MC_ROOT  MinIO alias/root used when
+#                                  BENCHMARKOOR_SNAPSHOT is a bare prefix.
+#   BENCHMARKOOR_GENESIS           Genesis URL, mc path, or local path.
+#   BENCHMARKOOR_MIGRATE_V2        true to run reth db migrate-v2.
+set -euo pipefail
+
+: "${SCHELK_MOUNT:?SCHELK_MOUNT must be set}"
+: "${BENCHMARKOOR_BIN:?BENCHMARKOOR_BIN must be set}"
+: "${BENCHMARKOOR_SUITE:?BENCHMARKOOR_SUITE must be set}"
+: "${BENCHMARKOOR_CONTEXT:?BENCHMARKOOR_CONTEXT must be set}"
+: "${BENCHMARKOOR_FORK:?BENCHMARKOOR_FORK must be set}"
+: "${BENCHMARKOOR_TEST_TYPE:?BENCHMARKOOR_TEST_TYPE must be set}"
+: "${BENCHMARKOOR_METADATA_ROOT:?BENCHMARKOOR_METADATA_ROOT must be set}"
+: "${BENCHMARKOOR_CACHE:?BENCHMARKOOR_CACHE must be set}"
+: "${BENCHMARKOOR_SNAPSHOT:?BENCHMARKOOR_SNAPSHOT must be set}"
+: "${BENCH_RETH_BINARY:?BENCH_RETH_BINARY must be set}"
+
+DATADIR="${SCHELK_MOUNT}/datadir"
+SNAPSHOT_DIR="${BENCHMARKOOR_CACHE}/snapshots"
+mkdir -p "$SNAPSHOT_DIR"
+
+trim_slashes() {
+  printf '%s' "$1" | sed -E 's:/*$::'
+}
+
+copy_source_to_file() {
+  local source="$1"
+  local dest="$2"
+
+  if [ -f "$source" ]; then
+    cp "$source" "$dest"
+  elif [[ "$source" =~ ^https?:// ]]; then
+    curl -fsSL --retry 3 --retry-delay 5 "$source" -o "$dest"
+  else
+    mc cp "$source" "$dest"
+  fi
+}
+
+source_exists() {
+  local source="$1"
+  if [ -f "$source" ]; then
+    return 0
+  fi
+  if [[ "$source" =~ ^https?:// ]]; then
+    curl -fsI --retry 2 --retry-delay 2 "$source" >/dev/null 2>&1
+    return $?
+  fi
+  mc stat "$source" >/dev/null 2>&1
+}
+
+mc_alias_url() {
+  local alias="$1"
+  mc alias export "$alias" 2>/dev/null | jq -r '.url // empty'
+}
+
+mc_manifest_base_url() {
+  local manifest_object="$1"
+  local alias rest alias_url
+
+  alias="${manifest_object%%/*}"
+  rest="${manifest_object#*/}"
+  alias_url="$(mc_alias_url "$alias")"
+  if [ -z "$alias_url" ] || [ "$rest" = "$manifest_object" ]; then
+    return 1
+  fi
+
+  printf '%s/%s\n' "$(trim_slashes "$alias_url")" "$(dirname "$rest")"
+}
+
+resolve_manifest_object() {
+  local source="$1"
+  local root="${BENCHMARKOOR_SNAPSHOT_MC_ROOT:-minio}"
+  local candidate found
+
+  if [ -d "$source" ] && [ -f "$(trim_slashes "$source")/manifest.json" ]; then
+    printf '%s\n' "$(trim_slashes "$source")/manifest.json"
+    return 0
+  fi
+
+  if [[ "$source" =~ ^https?:// ]]; then
+    if [[ "$(basename "$source")" == "manifest.json" ]]; then
+      candidate="$source"
+    else
+      candidate="$(trim_slashes "$source")/manifest.json"
+    fi
+    if source_exists "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    return 1
+  fi
+
+  if [[ "$(basename "$source")" == "manifest.json" ]] && source_exists "$source"; then
+    printf '%s\n' "$source"
+    return 0
+  fi
+
+  candidate="$(trim_slashes "$source")/manifest.json"
+  if source_exists "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  if [[ "$source" != */* ]]; then
+    found="$(
+      mc find "$root" --name manifest.json 2>/dev/null |
+        grep -F "$source" |
+        sort |
+        tail -n 1 || true
+    )"
+    if [ -n "$found" ]; then
+      printf '%s\n' "$found"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+resolve_snapshot_object() {
+  local source="$1"
+  local root="${BENCHMARKOOR_SNAPSHOT_MC_ROOT:-minio}"
+  local search_target prefix found
+
+  if [ -f "$source" ]; then
+    printf '%s\n' "$source"
+    return 0
+  fi
+
+  if mc stat "$source" >/dev/null 2>&1; then
+    printf '%s\n' "$source"
+    return 0
+  fi
+
+  if [[ "$source" == */* ]]; then
+    search_target="$source"
+    prefix=""
+  else
+    search_target="$root"
+    prefix="$source"
+  fi
+
+  echo "Searching ${search_target} for snapshot archive matching prefix '${prefix:-<none>}'"
+  found="$(
+    mc find "$search_target" --regex '(?i)\.(tar\.zst|tar\.gz|tgz)$' 2>/dev/null |
+      { if [ -n "$prefix" ]; then grep -F "$prefix" || true; else cat; fi; } |
+      sort |
+      tail -n 1
+  )"
+
+  if [ -z "$found" ]; then
+    echo "::error::Could not find a snapshot archive for BENCHMARKOOR_SNAPSHOT=${source}"
+    echo "Pass an exact mc path, a local archive path, or a prefix visible below ${root}."
+    exit 1
+  fi
+
+  printf '%s\n' "$found"
+}
+
+download_optional_genesis() {
+  local manifest_source="$1"
+  local genesis_dest="${DATADIR}/genesis.json"
+  local sibling=""
+  local fallback_url=""
+
+  if [ -n "${BENCHMARKOOR_GENESIS:-}" ]; then
+    echo "Downloading explicit benchmarkoor genesis"
+    copy_source_to_file "$BENCHMARKOOR_GENESIS" "$genesis_dest"
+    return 0
+  fi
+
+  if [[ "$manifest_source" =~ ^https?:// ]]; then
+    sibling="$(dirname "$manifest_source")/genesis.json"
+  elif [[ "$manifest_source" == */* ]]; then
+    sibling="$(dirname "$manifest_source")/genesis.json"
+  fi
+
+  if [ -n "$sibling" ] && source_exists "$sibling"; then
+    echo "Downloading genesis from snapshot location"
+    copy_source_to_file "$sibling" "$genesis_dest"
+    return 0
+  fi
+
+  fallback_url="$(known_suite_genesis_url)"
+  if [ -n "$fallback_url" ]; then
+    echo "Downloading genesis from benchmarkoor suite fallback"
+    copy_source_to_file "$fallback_url" "$genesis_dest"
+  fi
+}
+
+known_suite_genesis_url() {
+  case "$BENCHMARKOOR_SUITE" in
+    perf-devnet-3/24358000)
+      printf '%s\n' "https://gist.githubusercontent.com/skylenet/83b19b06b91fb44e0131d275a1aa0495/raw/4fb5ed66370bc5dc7c6745a775d4972dd6c1a098/genesis-perf-devnet-3-24358000-amsterdam-genesis.json"
+      ;;
+    jochemnet/24402727)
+      printf '%s\n' "https://gist.githubusercontent.com/skylenet/8226878ba786efcf10b5fd74be97fe41/raw/ab888a0f90dcf214bd5d3c36b3dfa1827335ecf9/genesis-jochemnet-24402727-amsterdam-genesis.json"
+      ;;
+  esac
+}
+
+network="${BENCHMARKOOR_SUITE%%/*}"
+block="${BENCHMARKOOR_SUITE#*/}"
+suite_slug="$(
+  printf '%s-%s-%s-%s-%s' \
+    "$network" "$block" "$BENCHMARKOOR_CONTEXT" "$BENCHMARKOOR_FORK" "$BENCHMARKOOR_TEST_TYPE" |
+    sed -E 's/[^A-Za-z0-9_-]+/-/g; s/^-+//; s/-+$//'
+)"
+
+sudo schelk recover -y --kill || sudo schelk full-recover -y || true
+sudo schelk mount -y
+sudo chown -R "$(id -u):$(id -g)" "$SCHELK_MOUNT"
+
+if manifest_object="$(resolve_manifest_object "$BENCHMARKOOR_SNAPSHOT")"; then
+  manifest_raw="${SNAPSHOT_DIR}/${suite_slug}-manifest.raw.json"
+  manifest_path="${SNAPSHOT_DIR}/${suite_slug}-manifest.json"
+  copy_source_to_file "$manifest_object" "$manifest_raw"
+
+  manifest_base_url=""
+  if [[ "$manifest_object" =~ ^https?:// ]]; then
+    manifest_base_url="$(dirname "$manifest_object")"
+  elif [[ "$manifest_object" == */* ]]; then
+    manifest_base_url="$(mc_manifest_base_url "$manifest_object" || true)"
+  fi
+
+  if [ -n "$manifest_base_url" ]; then
+    jq --arg base "$manifest_base_url" '.base_url = $base' "$manifest_raw" > "$manifest_path"
+  else
+    cp "$manifest_raw" "$manifest_path"
+  fi
+
+  sudo rm -rf "$DATADIR"
+  sudo mkdir -p "$DATADIR"
+  sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
+
+  "$BENCH_RETH_BINARY" download \
+    --manifest-path "$manifest_path" \
+    -y \
+    --minimal \
+    --datadir "$DATADIR"
+
+  download_optional_genesis "$manifest_object"
+
+  if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
+    echo "::error::Manifest download did not produce expected db/ and static_files/ directories"
+    ls -la "$DATADIR" || true
+    exit 1
+  fi
+
+  echo "Downloaded benchmarkoor snapshot from manifest: ${manifest_object}"
+else
+  snapshot_object="$(resolve_snapshot_object "$BENCHMARKOOR_SNAPSHOT")"
+  archive_name="$(basename "$snapshot_object")"
+  archive_path="${SNAPSHOT_DIR}/${archive_name}"
+
+  echo "Downloading snapshot archive: ${snapshot_object}"
+  copy_source_to_file "$snapshot_object" "$archive_path"
+
+  cached_archive="${SCHELK_MOUNT}/${suite_slug}-${archive_name}"
+  cp "$archive_path" "$cached_archive"
+
+  snapshot_args=(
+    --suite "$BENCHMARKOOR_SUITE"
+    --context "$BENCHMARKOOR_CONTEXT"
+    --fork "$BENCHMARKOOR_FORK"
+    --test-type "$BENCHMARKOOR_TEST_TYPE"
+    --metadata-root "$BENCHMARKOOR_METADATA_ROOT"
+    --cache-dir "$BENCHMARKOOR_CACHE"
+    --reth-bin "$BENCH_RETH_BINARY"
+    snapshot import
+    --datadir "$DATADIR"
+    --url "$archive_name"
+    --offline
+    --force
+  )
+
+  if [ "${BENCHMARKOOR_MIGRATE_V2:-false}" = "true" ]; then
+    snapshot_args+=(--migrate-v2)
+  fi
+
+  "$BENCHMARKOOR_BIN" "${snapshot_args[@]}"
+
+  # benchmarkoor-replay expects its offline archive beside the datadir, but that
+  # parent is the schelk mount in CI. Remove the temporary copy before promotion
+  # so the golden volume only contains the imported datadir.
+  rm -f "$cached_archive"
+
+  echo "Imported benchmarkoor snapshot archive: ${snapshot_object}"
+fi
+
+sync
+sudo schelk promote -y --kill
+sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+
+echo "Promoted benchmarkoor snapshot into schelk baseline"

--- a/.github/scripts/bench-benchmarkoor-snapshot.sh
+++ b/.github/scripts/bench-benchmarkoor-snapshot.sh
@@ -134,6 +134,55 @@ resolve_manifest_object() {
   return 1
 }
 
+log_manifest_lookup_diagnostics() {
+  local source="$1"
+  local root="${BENCHMARKOOR_SNAPSHOT_MC_ROOT:-minio}"
+  local trimmed candidate alias alias_url parent
+
+  trimmed="$(trim_slashes "$source")"
+  if [[ "$(basename "$trimmed")" == "manifest.json" ]]; then
+    candidate="$trimmed"
+  else
+    candidate="${trimmed}/manifest.json"
+  fi
+
+  echo "::group::Snapshot manifest lookup diagnostics"
+  echo "BENCHMARKOOR_SNAPSHOT=${source}"
+  echo "BENCHMARKOOR_SNAPSHOT_MC_ROOT=${root}"
+  echo "Candidate manifest: ${candidate}"
+
+  if [[ "$source" =~ ^https?:// ]]; then
+    echo "HTTP HEAD for candidate:"
+    curl -fsI --retry 2 --retry-delay 2 "$candidate" || true
+    echo "::endgroup::"
+    return 0
+  fi
+
+  alias="${candidate%%/*}"
+  alias_url="$(mc_alias_url "$alias" || true)"
+  if [ -n "$alias_url" ]; then
+    echo "MinIO alias '${alias}' URL: ${alias_url}"
+  else
+    echo "MinIO alias '${alias}' is not configured or has no exported URL"
+  fi
+
+  echo "mc stat candidate:"
+  mc stat "$candidate" || true
+
+  echo "mc ls snapshot prefix:"
+  mc ls "${trimmed}/" || true
+
+  parent="$(dirname "$trimmed")"
+  if [ "$parent" != "." ] && [ "$parent" != "$trimmed" ]; then
+    echo "mc ls parent prefix (${parent}/):"
+    mc ls "${parent}/" || true
+  fi
+
+  echo "Nearby manifest.json objects under ${root}:"
+  mc find "$root" --name manifest.json 2>/dev/null | grep -F "$(basename "$trimmed")" | head -20 || true
+  echo "::endgroup::"
+}
+
 network="${BENCHMARKOOR_SUITE%%/*}"
 block="${BENCHMARKOOR_SUITE#*/}"
 suite_slug="$(
@@ -146,6 +195,7 @@ sudo schelk recover -y --kill || sudo schelk full-recover -y || true
 sudo schelk mount -y
 
 if ! manifest_object="$(resolve_manifest_object "$BENCHMARKOOR_SNAPSHOT")"; then
+  log_manifest_lookup_diagnostics "$BENCHMARKOOR_SNAPSHOT"
   echo "::error::Could not find snapshot manifest for BENCHMARKOOR_SNAPSHOT=${BENCHMARKOOR_SNAPSHOT}"
   echo "Pass a MinIO manifest path, a MinIO prefix containing manifest.json, or an HTTP(S) manifest URL."
   exit 1

--- a/.github/scripts/bench-benchmarkoor-snapshot.sh
+++ b/.github/scripts/bench-benchmarkoor-snapshot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Imports a benchmarkoor replay snapshot into the schelk scratch volume and
-# promotes it as the schelk baseline. The later prerun step promotes again
+# Downloads a Reth snapshot from a MinIO manifest into the schelk scratch volume
+# and promotes it as the schelk baseline. The later prerun step promotes again
 # after gas-bump/funding.
 #
 # Required env:
@@ -19,7 +19,6 @@
 # Optional env:
 #   BENCHMARKOOR_SNAPSHOT_MC_ROOT  MinIO alias/root used when
 #                                  BENCHMARKOOR_SNAPSHOT is a bare prefix.
-#   BENCHMARKOOR_MIGRATE_V2        true to run reth db migrate-v2.
 set -euo pipefail
 
 : "${SCHELK_MOUNT:?SCHELK_MOUNT must be set}"
@@ -135,46 +134,6 @@ resolve_manifest_object() {
   return 1
 }
 
-resolve_snapshot_object() {
-  local source="$1"
-  local root="${BENCHMARKOOR_SNAPSHOT_MC_ROOT:-minio}"
-  local search_target prefix found
-
-  if [ -f "$source" ]; then
-    printf '%s\n' "$source"
-    return 0
-  fi
-
-  if mc stat "$source" >/dev/null 2>&1; then
-    printf '%s\n' "$source"
-    return 0
-  fi
-
-  if [[ "$source" == */* ]]; then
-    search_target="$source"
-    prefix=""
-  else
-    search_target="$root"
-    prefix="$source"
-  fi
-
-  echo "Searching ${search_target} for snapshot archive matching prefix '${prefix:-<none>}'"
-  found="$(
-    mc find "$search_target" --regex '(?i)\.(tar\.zst|tar\.gz|tgz)$' 2>/dev/null |
-      { if [ -n "$prefix" ]; then grep -F "$prefix" || true; else cat; fi; } |
-      sort |
-      tail -n 1
-  )"
-
-  if [ -z "$found" ]; then
-    echo "::error::Could not find a snapshot archive for BENCHMARKOOR_SNAPSHOT=${source}"
-    echo "Pass an exact mc path, a local archive path, or a prefix visible below ${root}."
-    exit 1
-  fi
-
-  printf '%s\n' "$found"
-}
-
 network="${BENCHMARKOOR_SUITE%%/*}"
 block="${BENCHMARKOOR_SUITE#*/}"
 suite_slug="$(
@@ -185,92 +144,57 @@ suite_slug="$(
 
 sudo schelk recover -y --kill || sudo schelk full-recover -y || true
 sudo schelk mount -y
-sudo chown -R "$(id -u):$(id -g)" "$SCHELK_MOUNT"
 
-if manifest_object="$(resolve_manifest_object "$BENCHMARKOOR_SNAPSHOT")"; then
-  manifest_raw="${SNAPSHOT_DIR}/${suite_slug}-manifest.raw.json"
-  manifest_path="${SNAPSHOT_DIR}/${suite_slug}-manifest.json"
-  copy_source_to_file "$manifest_object" "$manifest_raw"
-
-  manifest_base_url=""
-  if [[ "$manifest_object" =~ ^https?:// ]]; then
-    manifest_base_url="$(dirname "$manifest_object")"
-  elif [[ "$manifest_object" == */* ]]; then
-    manifest_base_url="$(mc_manifest_base_url "$manifest_object" || true)"
-  fi
-
-  if [ -n "$manifest_base_url" ]; then
-    jq --arg base "$manifest_base_url" '.base_url = $base' "$manifest_raw" > "$manifest_path"
-  else
-    cp "$manifest_raw" "$manifest_path"
-  fi
-
-  sudo rm -rf "$DATADIR"
-  sudo mkdir -p "$DATADIR"
-  sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
-
-  "$BENCH_RETH_BINARY" download \
-    --manifest-path "$manifest_path" \
-    -y \
-    --minimal \
-    --datadir "$DATADIR"
-
-  "$BENCHMARKOOR_BIN" \
-    --suite "$BENCHMARKOOR_SUITE" \
-    --context "$BENCHMARKOOR_CONTEXT" \
-    --fork "$BENCHMARKOOR_FORK" \
-    --test-type "$BENCHMARKOOR_TEST_TYPE" \
-    --metadata-root "$BENCHMARKOOR_METADATA_ROOT" \
-    --cache-dir "$BENCHMARKOOR_CACHE" \
-    genesis download \
-    --datadir "$DATADIR"
-
-  if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
-    echo "::error::Manifest download did not produce expected db/ and static_files/ directories"
-    ls -la "$DATADIR" || true
-    exit 1
-  fi
-
-  echo "Downloaded benchmarkoor snapshot from manifest: ${manifest_object}"
-else
-  snapshot_object="$(resolve_snapshot_object "$BENCHMARKOOR_SNAPSHOT")"
-  archive_name="$(basename "$snapshot_object")"
-  archive_path="${SNAPSHOT_DIR}/${archive_name}"
-
-  echo "Downloading snapshot archive: ${snapshot_object}"
-  copy_source_to_file "$snapshot_object" "$archive_path"
-
-  cached_archive="${SCHELK_MOUNT}/${suite_slug}-${archive_name}"
-  cp "$archive_path" "$cached_archive"
-
-  snapshot_args=(
-    --suite "$BENCHMARKOOR_SUITE"
-    --context "$BENCHMARKOOR_CONTEXT"
-    --fork "$BENCHMARKOOR_FORK"
-    --test-type "$BENCHMARKOOR_TEST_TYPE"
-    --metadata-root "$BENCHMARKOOR_METADATA_ROOT"
-    --cache-dir "$BENCHMARKOOR_CACHE"
-    --reth-bin "$BENCH_RETH_BINARY"
-    snapshot import
-    --datadir "$DATADIR"
-    --url "$archive_name"
-    --offline
-    --force
-  )
-
-  if [ "${BENCHMARKOOR_MIGRATE_V2:-false}" = "true" ]; then
-    snapshot_args+=(--migrate-v2)
-  fi
-
-  "$BENCHMARKOOR_BIN" "${snapshot_args[@]}"
-
-  # benchmarkoor-replay expects its offline archive beside the datadir, but that
-  # parent is the schelk mount in CI. Remove the temporary copy before promotion
-  # so the golden volume only contains the imported datadir.
-  rm -f "$cached_archive"
-
-  echo "Imported benchmarkoor snapshot archive: ${snapshot_object}"
+if ! manifest_object="$(resolve_manifest_object "$BENCHMARKOOR_SNAPSHOT")"; then
+  echo "::error::Could not find snapshot manifest for BENCHMARKOOR_SNAPSHOT=${BENCHMARKOOR_SNAPSHOT}"
+  echo "Pass a MinIO manifest path, a MinIO prefix containing manifest.json, or an HTTP(S) manifest URL."
+  exit 1
 fi
+
+manifest_raw="${SNAPSHOT_DIR}/${suite_slug}-manifest.raw.json"
+manifest_path="${SNAPSHOT_DIR}/${suite_slug}-manifest.json"
+copy_source_to_file "$manifest_object" "$manifest_raw"
+
+manifest_base_url=""
+if [[ "$manifest_object" =~ ^https?:// ]]; then
+  manifest_base_url="$(dirname "$manifest_object")"
+elif [[ "$manifest_object" == */* ]]; then
+  manifest_base_url="$(mc_manifest_base_url "$manifest_object" || true)"
+fi
+
+if [ -n "$manifest_base_url" ]; then
+  jq --arg base "$manifest_base_url" '.base_url = $base' "$manifest_raw" > "$manifest_path"
+else
+  cp "$manifest_raw" "$manifest_path"
+fi
+
+sudo rm -rf "$DATADIR"
+sudo mkdir -p "$DATADIR"
+sudo chown -R "$(id -u):$(id -g)" "$DATADIR"
+
+"$BENCH_RETH_BINARY" download \
+  --manifest-path "$manifest_path" \
+  -y \
+  --minimal \
+  --datadir "$DATADIR"
+
+"$BENCHMARKOOR_BIN" \
+  --suite "$BENCHMARKOOR_SUITE" \
+  --context "$BENCHMARKOOR_CONTEXT" \
+  --fork "$BENCHMARKOOR_FORK" \
+  --test-type "$BENCHMARKOOR_TEST_TYPE" \
+  --metadata-root "$BENCHMARKOOR_METADATA_ROOT" \
+  --cache-dir "$BENCHMARKOOR_CACHE" \
+  genesis download \
+  --datadir "$DATADIR"
+
+if [ ! -d "$DATADIR/db" ] || [ ! -d "$DATADIR/static_files" ]; then
+  echo "::error::Manifest download did not produce expected db/ and static_files/ directories"
+  ls -la "$DATADIR" || true
+  exit 1
+fi
+
+echo "Downloaded benchmarkoor snapshot from manifest: ${manifest_object}"
 
 sync
 sudo schelk promote -y --kill

--- a/.github/scripts/bench-benchmarkoor-summary.py
+++ b/.github/scripts/bench-benchmarkoor-summary.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Summarize benchmarkoor-replay gas/second results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+
+def fmt_rate(value: float) -> str:
+    if value >= 1_000_000_000:
+        return f"{value / 1_000_000_000:.2f} Ggas/s"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.2f} Mgas/s"
+    if value >= 1_000:
+        return f"{value / 1_000:.2f} Kgas/s"
+    return f"{value:.2f} gas/s"
+
+
+def fmt_change(value: float | None) -> str:
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value * 100:.2f}%"
+
+
+def median(values: list[float]) -> float:
+    return statistics.median(values) if values else 0.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", required=True, type=Path)
+    parser.add_argument("--output-json", required=True, type=Path)
+    parser.add_argument("--output-markdown", required=True, type=Path)
+    parser.add_argument("--baseline-name", required=True)
+    parser.add_argument("--baseline-ref", required=True)
+    parser.add_argument("--feature-name", required=True)
+    parser.add_argument("--feature-ref", required=True)
+    parser.add_argument("--repo", required=True)
+    args = parser.parse_args()
+
+    rows = [
+        json.loads(line)
+        for line in args.results.read_text().splitlines()
+        if line.strip()
+    ]
+    if not rows:
+        raise SystemExit("no benchmark results found")
+
+    normalized = []
+    for row in rows:
+        if "gas_per_second" not in row:
+            row["gas_per_second"] = row.get("gas_per_sec") or 0.0
+        if "gas" not in row:
+            row["gas"] = row.get("testing_gas_used") or 0
+        if "elapsed_ms" not in row:
+            row["elapsed_ms"] = (row.get("testing_elapsed") or 0.0) * 1000.0
+        normalized.append(row)
+
+    by_test: dict[str, dict[str, list[dict]]] = defaultdict(lambda: defaultdict(list))
+    for row in normalized:
+        by_test[row["test"]][row["run_type"]].append(row)
+
+    tests = []
+    ratios = []
+    for test, groups in sorted(by_test.items()):
+        baseline_rates = [float(row["gas_per_second"]) for row in groups.get("baseline", [])]
+        feature_rates = [float(row["gas_per_second"]) for row in groups.get("feature", [])]
+        baseline_rate = median(baseline_rates)
+        feature_rate = median(feature_rates)
+        change = None
+        if baseline_rate > 0 and feature_rate > 0:
+            change = feature_rate / baseline_rate - 1.0
+            ratios.append(feature_rate / baseline_rate)
+        tests.append(
+            {
+                "test": test,
+                "gas_bucket": (groups.get("feature") or groups.get("baseline") or [{}])[0].get(
+                    "gas_bucket", ""
+                ),
+                "baseline_gas_per_second": baseline_rate,
+                "feature_gas_per_second": feature_rate,
+                "change": change,
+                "baseline_runs": len(baseline_rates),
+                "feature_runs": len(feature_rates),
+            }
+        )
+
+    aggregate: dict[str, dict[str, float]] = {}
+    for run_type in ("baseline", "feature"):
+        type_rows = [row for row in normalized if row["run_type"] == run_type]
+        total_gas = sum(float(row["gas"]) for row in type_rows)
+        total_seconds = sum(float(row["elapsed_ms"]) / 1000.0 for row in type_rows)
+        aggregate[run_type] = {
+            "total_gas": total_gas,
+            "total_seconds": total_seconds,
+            "gas_per_second": total_gas / total_seconds if total_seconds > 0 else 0.0,
+        }
+
+    geomean_change = None
+    if ratios:
+        geomean = math.exp(sum(math.log(ratio) for ratio in ratios) / len(ratios))
+        geomean_change = geomean - 1.0
+
+    total_change = None
+    baseline_total = aggregate["baseline"]["gas_per_second"]
+    feature_total = aggregate["feature"]["gas_per_second"]
+    if baseline_total > 0 and feature_total > 0:
+        total_change = feature_total / baseline_total - 1.0
+
+    summary = {
+        "baseline": {"name": args.baseline_name, "ref": args.baseline_ref},
+        "feature": {"name": args.feature_name, "ref": args.feature_ref},
+        "aggregate": aggregate,
+        "changes": {
+            "geomean_gas_per_second": geomean_change,
+            "total_gas_per_second": total_change,
+        },
+        "tests": tests,
+        "raw_results": normalized,
+    }
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(summary, indent=2) + "\n")
+
+    commit_url = f"https://github.com/{args.repo}/commit"
+    diff_url = f"https://github.com/{args.repo}/compare/{args.baseline_ref}...{args.feature_ref}"
+    md = []
+    md.append("# Benchmarkoor Replay\n")
+    md.append(f"**Baseline:** [`{args.baseline_name}`]({commit_url}/{args.baseline_ref})\n")
+    md.append(
+        f"**Feature:** [`{args.feature_name}`]({commit_url}/{args.feature_ref}) ([diff]({diff_url}))\n"
+    )
+    md.append(f"**Tests:** {len(tests)}\n\n")
+    md.append("| Metric | Baseline | Feature | Change |\n")
+    md.append("|--------|----------|---------|--------|\n")
+    md.append(
+        "| Total measured gas/sec | "
+        f"{fmt_rate(baseline_total)} | {fmt_rate(feature_total)} | {fmt_change(total_change)} |\n"
+    )
+    md.append(
+        "| Per-test geomean gas/sec | "
+        f"n/a | n/a | {fmt_change(geomean_change)} |\n\n"
+    )
+    md.append("| Test | Gas | Baseline | Feature | Change |\n")
+    md.append("|------|-----|----------|---------|--------|\n")
+    for item in tests:
+        md.append(
+            f"| `{item['test']}` | {item['gas_bucket'] or 'n/a'} | "
+            f"{fmt_rate(item['baseline_gas_per_second'])} | "
+            f"{fmt_rate(item['feature_gas_per_second'])} | "
+            f"{fmt_change(item['change'])} |\n"
+        )
+
+    args.output_markdown.write_text("".join(md))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/bench-benchmarkoor-summary.py
+++ b/.github/scripts/bench-benchmarkoor-summary.py
@@ -67,6 +67,34 @@ def median(values: list[float]) -> float:
     return statistics.median(values) if values else 0.0
 
 
+def summarize_reset_timings(rows: list[dict]) -> dict[str, dict[str, dict[str, float]]]:
+    timing_values: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for row in rows:
+        run_type = row.get("run_type")
+        timings = row.get("reset_timings")
+        if run_type not in ("baseline", "feature") or not isinstance(timings, dict):
+            continue
+        for step, value in timings.items():
+            try:
+                seconds = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(seconds):
+                timing_values[run_type][step].append(seconds)
+
+    summary = {}
+    for run_type, steps in timing_values.items():
+        summary[run_type] = {}
+        for step, values in sorted(steps.items()):
+            summary[run_type][step] = {
+                "count": len(values),
+                "total_seconds": sum(values),
+                "median_seconds": median(values),
+                "mean_seconds": sum(values) / len(values),
+            }
+    return summary
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--results", required=True, type=Path)
@@ -142,6 +170,7 @@ def main() -> None:
 
     failures = [row for row in normalized if row.get("status") != "ok"]
     benchmark_rows = [row for row in normalized if row.get("status") == "ok"]
+    reset_timing_summary = summarize_reset_timings(normalized)
 
     aggregate: dict[str, dict[str, float]] = {}
     for run_type in ("baseline", "feature"):
@@ -184,6 +213,7 @@ def main() -> None:
             "total_gas_per_second": total_change,
             "total_wall_time": wall_time_change,
         },
+        "reset_timing_summary": reset_timing_summary,
         "tests": tests,
         "failures": failures,
         "raw_results": normalized,
@@ -219,6 +249,38 @@ def main() -> None:
         "| Per-test geomean gas/sec | "
         f"n/a | n/a | {fmt_change(geomean_change)} |\n\n"
     )
+    if reset_timing_summary:
+        steps = sorted(
+            {
+                step
+                for run_type in reset_timing_summary.values()
+                for step in run_type.keys()
+            }
+        )
+        md.append("## Reset Timing\n\n")
+        md.append("| Step | Baseline total | Baseline median | Feature total | Feature median |\n")
+        md.append("|------|----------------|-----------------|---------------|----------------|\n")
+        for step in steps:
+            baseline_timing = reset_timing_summary.get("baseline", {}).get(step)
+            feature_timing = reset_timing_summary.get("feature", {}).get(step)
+            baseline_total = (
+                fmt_duration(baseline_timing["total_seconds"]) if baseline_timing else "n/a"
+            )
+            baseline_median = (
+                fmt_duration(baseline_timing["median_seconds"]) if baseline_timing else "n/a"
+            )
+            feature_total = (
+                fmt_duration(feature_timing["total_seconds"]) if feature_timing else "n/a"
+            )
+            feature_median = (
+                fmt_duration(feature_timing["median_seconds"]) if feature_timing else "n/a"
+            )
+            md.append(
+                f"| `{md_escape(step)}` | {baseline_total} | {baseline_median} | "
+                f"{feature_total} | {feature_median} |\n"
+            )
+        md.append("\n")
+
     md.append("| Test | Gas | Baseline | Feature | Change | Status |\n")
     md.append("|------|-----|----------|---------|--------|--------|\n")
     for item in tests:

--- a/.github/scripts/bench-benchmarkoor-summary.py
+++ b/.github/scripts/bench-benchmarkoor-summary.py
@@ -21,6 +21,14 @@ def fmt_rate(value: float) -> str:
     return f"{value:.2f} gas/s"
 
 
+def fmt_duration(seconds: float) -> str:
+    if seconds >= 3600:
+        return f"{seconds / 3600:.2f} h"
+    if seconds >= 60:
+        return f"{seconds / 60:.2f} min"
+    return f"{seconds:.2f} s"
+
+
 def fmt_change(value: float | None) -> str:
     if value is None or not math.isfinite(value):
         return "n/a"
@@ -55,7 +63,9 @@ def main() -> None:
     normalized = []
     for row in rows:
         if "gas_per_second" not in row:
-            row["gas_per_second"] = row.get("gas_per_sec") or 0.0
+            row["gas_per_second"] = (
+                row.get("testing_gas_per_sec") or row.get("gas_per_sec") or 0.0
+            )
         if "gas" not in row:
             row["gas"] = row.get("testing_gas_used") or 0
         if "elapsed_ms" not in row:
@@ -96,9 +106,14 @@ def main() -> None:
         type_rows = [row for row in normalized if row["run_type"] == run_type]
         total_gas = sum(float(row["gas"]) for row in type_rows)
         total_seconds = sum(float(row["elapsed_ms"]) / 1000.0 for row in type_rows)
+        total_wall_seconds = sum(
+            float(row.get("wall_elapsed_secs") or row.get("total_elapsed_secs") or 0.0)
+            for row in type_rows
+        )
         aggregate[run_type] = {
             "total_gas": total_gas,
             "total_seconds": total_seconds,
+            "total_wall_seconds": total_wall_seconds,
             "gas_per_second": total_gas / total_seconds if total_seconds > 0 else 0.0,
         }
 
@@ -112,6 +127,11 @@ def main() -> None:
     feature_total = aggregate["feature"]["gas_per_second"]
     if baseline_total > 0 and feature_total > 0:
         total_change = feature_total / baseline_total - 1.0
+    baseline_wall_total = aggregate["baseline"]["total_wall_seconds"]
+    feature_wall_total = aggregate["feature"]["total_wall_seconds"]
+    wall_time_change = None
+    if baseline_wall_total > 0 and feature_wall_total > 0:
+        wall_time_change = feature_wall_total / baseline_wall_total - 1.0
 
     summary = {
         "baseline": {"name": args.baseline_name, "ref": args.baseline_ref},
@@ -120,6 +140,7 @@ def main() -> None:
         "changes": {
             "geomean_gas_per_second": geomean_change,
             "total_gas_per_second": total_change,
+            "total_wall_time": wall_time_change,
         },
         "tests": tests,
         "raw_results": normalized,
@@ -142,6 +163,12 @@ def main() -> None:
         "| Total measured gas/sec | "
         f"{fmt_rate(baseline_total)} | {fmt_rate(feature_total)} | {fmt_change(total_change)} |\n"
     )
+    if baseline_wall_total > 0 or feature_wall_total > 0:
+        md.append(
+            "| Cumulative wall time | "
+            f"{fmt_duration(baseline_wall_total)} | {fmt_duration(feature_wall_total)} | "
+            f"{fmt_change(wall_time_change)} |\n"
+        )
     md.append(
         "| Per-test geomean gas/sec | "
         f"n/a | n/a | {fmt_change(geomean_change)} |\n\n"

--- a/.github/scripts/bench-benchmarkoor-summary.py
+++ b/.github/scripts/bench-benchmarkoor-summary.py
@@ -36,6 +36,33 @@ def fmt_change(value: float | None) -> str:
     return f"{sign}{value * 100:.2f}%"
 
 
+def md_escape(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def status_label(rows: list[dict]) -> str:
+    if not rows:
+        return "missing"
+
+    labels = []
+    if any(row.get("status", "ok") == "ok" for row in rows):
+        labels.append("ok")
+
+    for row in rows:
+        status = row.get("status", "ok")
+        if status == "ok":
+            continue
+        if status == "invalid_newpayload":
+            phase = row.get("invalid_newpayload_phase") or "unknown"
+            label = f"INVALID newPayload ({phase})"
+        else:
+            label = status
+        if label not in labels:
+            labels.append(label)
+
+    return "; ".join(labels)
+
+
 def median(values: list[float]) -> float:
     return statistics.median(values) if values else 0.0
 
@@ -62,6 +89,8 @@ def main() -> None:
 
     normalized = []
     for row in rows:
+        row["status"] = row.get("status") or "ok"
+        row["invalid_newpayload"] = bool(row.get("invalid_newpayload", False))
         if "gas_per_second" not in row:
             row["gas_per_second"] = (
                 row.get("testing_gas_per_sec") or row.get("gas_per_sec") or 0.0
@@ -79,8 +108,16 @@ def main() -> None:
     tests = []
     ratios = []
     for test, groups in sorted(by_test.items()):
-        baseline_rates = [float(row["gas_per_second"]) for row in groups.get("baseline", [])]
-        feature_rates = [float(row["gas_per_second"]) for row in groups.get("feature", [])]
+        baseline_rates = [
+            float(row["gas_per_second"] or 0.0)
+            for row in groups.get("baseline", [])
+            if row.get("status") == "ok"
+        ]
+        feature_rates = [
+            float(row["gas_per_second"] or 0.0)
+            for row in groups.get("feature", [])
+            if row.get("status") == "ok"
+        ]
         baseline_rate = median(baseline_rates)
         feature_rate = median(feature_rates)
         change = None
@@ -98,14 +135,19 @@ def main() -> None:
                 "change": change,
                 "baseline_runs": len(baseline_rates),
                 "feature_runs": len(feature_rates),
+                "baseline_status": status_label(groups.get("baseline", [])),
+                "feature_status": status_label(groups.get("feature", [])),
             }
         )
 
+    failures = [row for row in normalized if row.get("status") != "ok"]
+    benchmark_rows = [row for row in normalized if row.get("status") == "ok"]
+
     aggregate: dict[str, dict[str, float]] = {}
     for run_type in ("baseline", "feature"):
-        type_rows = [row for row in normalized if row["run_type"] == run_type]
-        total_gas = sum(float(row["gas"]) for row in type_rows)
-        total_seconds = sum(float(row["elapsed_ms"]) / 1000.0 for row in type_rows)
+        type_rows = [row for row in benchmark_rows if row["run_type"] == run_type]
+        total_gas = sum(float(row["gas"] or 0.0) for row in type_rows)
+        total_seconds = sum(float(row["elapsed_ms"] or 0.0) / 1000.0 for row in type_rows)
         total_wall_seconds = sum(
             float(row.get("wall_elapsed_secs") or row.get("total_elapsed_secs") or 0.0)
             for row in type_rows
@@ -143,6 +185,7 @@ def main() -> None:
             "total_wall_time": wall_time_change,
         },
         "tests": tests,
+        "failures": failures,
         "raw_results": normalized,
     }
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
@@ -156,7 +199,10 @@ def main() -> None:
     md.append(
         f"**Feature:** [`{args.feature_name}`]({commit_url}/{args.feature_ref}) ([diff]({diff_url}))\n"
     )
-    md.append(f"**Tests:** {len(tests)}\n\n")
+    md.append(f"**Tests:** {len(tests)}\n")
+    if failures:
+        md.append(f"**Recorded failures:** {len(failures)}\n")
+    md.append("\n")
     md.append("| Metric | Baseline | Feature | Change |\n")
     md.append("|--------|----------|---------|--------|\n")
     md.append(
@@ -173,15 +219,30 @@ def main() -> None:
         "| Per-test geomean gas/sec | "
         f"n/a | n/a | {fmt_change(geomean_change)} |\n\n"
     )
-    md.append("| Test | Gas | Baseline | Feature | Change |\n")
-    md.append("|------|-----|----------|---------|--------|\n")
+    md.append("| Test | Gas | Baseline | Feature | Change | Status |\n")
+    md.append("|------|-----|----------|---------|--------|--------|\n")
     for item in tests:
         md.append(
             f"| `{item['test']}` | {item['gas_bucket'] or 'n/a'} | "
             f"{fmt_rate(item['baseline_gas_per_second'])} | "
             f"{fmt_rate(item['feature_gas_per_second'])} | "
-            f"{fmt_change(item['change'])} |\n"
+            f"{fmt_change(item['change'])} | "
+            f"B: {md_escape(item['baseline_status'])}<br>F: {md_escape(item['feature_status'])} |\n"
         )
+
+    if failures:
+        md.append("\n## Recorded Failures\n\n")
+        md.append("| Run | Test | Status | Phase | Error |\n")
+        md.append("|-----|------|--------|-------|-------|\n")
+        for row in failures:
+            phase = row.get("invalid_newpayload_phase") or "unknown"
+            md.append(
+                f"| {md_escape(str(row.get('label', '')))} | "
+                f"`{md_escape(str(row.get('test', '')))}` | "
+                f"{md_escape(str(row.get('status', 'error')))} | "
+                f"{md_escape(str(phase))} | "
+                f"{md_escape(str(row.get('error_summary', '')))} |\n"
+            )
 
     args.output_markdown.write_text("".join(md))
 

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -258,7 +258,7 @@ jobs:
               git -C "$replay_path" checkout --force origin/main
             fi
           else
-            replay_path="$BENCH_WORK_DIR/benchmarkoor-replay"
+            replay_path="${RUNNER_TEMP:-/tmp}/benchmarkoor-replay"
             rm -rf "$replay_path"
 
             if [ -n "${BENCHMARKOOR_REPLAY_DEPLOY_KEY:-}" ]; then

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -6,6 +6,11 @@
 # drops Linux page cache, and measures only the testing fixture replay.
 
 on:
+  # Temporary test trigger for branch-only workflow validation.
+  # Remove before merging this workflow.
+  push:
+    branches:
+      - dan/create-benchmarkoor-replay-workflow
   workflow_dispatch:
     inputs:
       pr:
@@ -46,17 +51,12 @@ on:
       snapshot:
         description: "Snapshot manifest/archive URL, MinIO path, or prefix"
         required: false
-        default: "perfnet"
+        default: "minio/reth-snapshots/perfnet-24358000-full/"
         type: string
       snapshot_mc_root:
         description: "MinIO root used when snapshot is only a prefix"
         required: false
         default: "minio"
-        type: string
-      genesis:
-        description: "Genesis URL/path override; empty tries snapshot sibling genesis.json"
-        required: false
-        default: ""
         type: string
       fixture_url:
         description: "Fixture archive URL/path override (empty uses suite default)"
@@ -161,20 +161,19 @@ jobs:
       SCHELK_MOUNT: /reth-bench
       RETH_SCOPE: reth-benchmarkoor.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
-      BENCH_CORES: ${{ inputs.cores }}
-      BENCH_BASELINE_ARGS: ${{ inputs.baseline_args }}
-      BENCH_FEATURE_ARGS: ${{ inputs.feature_args }}
+      BENCH_CORES: ${{ inputs.cores || '0' }}
+      BENCH_BASELINE_ARGS: ${{ inputs.baseline_args || '' }}
+      BENCH_FEATURE_ARGS: ${{ inputs.feature_args || '' }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      BENCHMARKOOR_SUITE: ${{ inputs.suite }}
-      BENCHMARKOOR_CONTEXT: ${{ inputs.context }}
-      BENCHMARKOOR_FORK: ${{ inputs.fork }}
-      BENCHMARKOOR_TEST_TYPE: ${{ inputs.test_type }}
-      BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root }}
-      BENCHMARKOOR_SNAPSHOT: ${{ inputs.snapshot }}
-      BENCHMARKOOR_SNAPSHOT_MC_ROOT: ${{ inputs.snapshot_mc_root }}
-      BENCHMARKOOR_GENESIS: ${{ inputs.genesis }}
+      BENCHMARKOOR_SUITE: ${{ inputs.suite || 'perf-devnet-3/24358000' }}
+      BENCHMARKOOR_CONTEXT: ${{ inputs.context || 'repricing' }}
+      BENCHMARKOOR_FORK: ${{ inputs.fork || 'amsterdam' }}
+      BENCHMARKOOR_TEST_TYPE: ${{ inputs.test_type || 'stateful' }}
+      BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root || '/home/ubuntu/projects/benchmarkoor-tests/configs' }}
+      BENCHMARKOOR_SNAPSHOT: ${{ inputs.snapshot || 'minio/reth-snapshots/perfnet-24358000-full/' }}
+      BENCHMARKOOR_SNAPSHOT_MC_ROOT: ${{ inputs.snapshot_mc_root || 'minio' }}
       BENCHMARKOOR_MIGRATE_V2: ${{ inputs.migrate_v2 && 'true' || 'false' }}
-      BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path }}
+      BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path || '/home/ubuntu/projects/benchmarkoor-replay' }}
       BENCHMARKOOR_CACHE: ${{ github.workspace }}/bench-work/benchmarkoor-cache
     steps:
       - name: Clean up previous bench-work
@@ -256,9 +255,9 @@ jobs:
       - name: Resolve refs
         id: refs
         env:
-          INPUT_PR: ${{ inputs.pr }}
-          INPUT_FEATURE: ${{ inputs.feature }}
-          INPUT_BASELINE: ${{ inputs.baseline }}
+          INPUT_PR: ${{ inputs.pr || '' }}
+          INPUT_FEATURE: ${{ inputs.feature || '' }}
+          INPUT_BASELINE: ${{ inputs.baseline || 'main' }}
         run: |
           set -euo pipefail
           git fetch origin main --quiet
@@ -340,6 +339,8 @@ jobs:
           fi
 
       - name: Download fixtures
+        env:
+          FIXTURE_URL: ${{ inputs.fixture_url || '' }}
         run: |
           set -euo pipefail
           args=(
@@ -351,22 +352,22 @@ jobs:
             --cache-dir "$BENCHMARKOOR_CACHE"
             fixtures download
           )
-          if [ -n "${{ inputs.fixture_url }}" ]; then
-            args+=(--url "${{ inputs.fixture_url }}")
+          if [ -n "$FIXTURE_URL" ]; then
+            args+=(--url "$FIXTURE_URL")
           fi
           "$BENCHMARKOOR_BIN" "${args[@]}"
 
       - name: Resolve test set
         id: tests
         env:
-          EXACT_TEST: ${{ inputs.exact_test }}
-          CONTAINS: ${{ inputs.contains }}
-          PATTERN: ${{ inputs.pattern }}
-          OPCODE: ${{ inputs.opcode }}
-          GAS_BUCKET: ${{ inputs.gas_bucket }}
-          CACHE_STRATEGY: ${{ inputs.cache_strategy }}
-          ACCOUNT_MODE: ${{ inputs.account_mode }}
-          LIMIT: ${{ inputs.limit }}
+          EXACT_TEST: ${{ inputs.exact_test || '' }}
+          CONTAINS: ${{ inputs.contains || 'test_account_access' }}
+          PATTERN: ${{ inputs.pattern || '' }}
+          OPCODE: ${{ inputs.opcode || '' }}
+          GAS_BUCKET: ${{ inputs.gas_bucket || '' }}
+          CACHE_STRATEGY: ${{ inputs.cache_strategy || '' }}
+          ACCOUNT_MODE: ${{ inputs.account_mode || '' }}
+          LIMIT: ${{ inputs.limit || '1' }}
         run: |
           set -euo pipefail
           if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [ "$LIMIT" -lt 1 ]; then
@@ -481,12 +482,14 @@ jobs:
             "$BENCH_WORK_DIR/prerun"
 
       - name: Run benchmarkoor comparison
+        env:
+          BENCHMARKOOR_REPETITIONS: ${{ inputs.repetitions || '1' }}
         run: |
           set -euo pipefail
           BASELINE_BIN="$(pwd)/../reth-baseline/target/profiling/reth"
           FEATURE_BIN="$(pwd)/../reth-feature/target/profiling/reth"
 
-          if [ "${{ inputs.repetitions }}" = "2" ]; then
+          if [ "$BENCHMARKOOR_REPETITIONS" = "2" ]; then
             RUNS=(
               "feature-1:$FEATURE_BIN"
               "baseline-1:$BASELINE_BIN"

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -119,7 +119,12 @@ on:
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
-        default: "0"
+        default: "6"
+        type: string
+      memory:
+        description: "Limit reth memory via systemd MemoryMax (0 = 95% RAM)"
+        required: false
+        default: "32G"
         type: string
       baseline_args:
         description: "Extra CLI args for the baseline reth node"
@@ -161,7 +166,8 @@ jobs:
       SCHELK_MOUNT: /reth-bench
       RETH_SCOPE: reth-benchmarkoor.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
-      BENCH_CORES: ${{ inputs.cores || '0' }}
+      BENCH_CORES: ${{ inputs.cores || '6' }}
+      BENCH_MEMORY_MAX: ${{ inputs.memory || '32G' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline_args || '' }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature_args || '' }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -49,7 +49,7 @@ on:
         default: "stateful"
         type: string
       snapshot:
-        description: "Snapshot manifest/archive URL, MinIO path, or prefix"
+        description: "Snapshot manifest URL, MinIO manifest path, or MinIO prefix"
         required: false
         default: "minio/reth-snapshots/perfnet-24358000-full/"
         type: string
@@ -136,11 +136,6 @@ on:
         required: false
         default: "~/projects/benchmarkoor-tests/configs"
         type: string
-      migrate_v2:
-        description: "Run reth db migrate-v2 after snapshot import"
-        required: false
-        default: false
-        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -172,7 +167,6 @@ jobs:
       BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root || '~/projects/benchmarkoor-tests/configs' }}
       BENCHMARKOOR_SNAPSHOT: ${{ inputs.snapshot || 'minio/reth-snapshots/perfnet-24358000-full/' }}
       BENCHMARKOOR_SNAPSHOT_MC_ROOT: ${{ inputs.snapshot_mc_root || 'minio' }}
-      BENCHMARKOOR_MIGRATE_V2: ${{ inputs.migrate_v2 && 'true' || 'false' }}
       BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path || '~/projects/benchmarkoor-replay' }}
       BENCHMARKOOR_CACHE: ${{ github.workspace }}/bench-work/benchmarkoor-cache
     steps:

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -121,11 +121,6 @@ on:
         required: false
         default: "6"
         type: string
-      memory:
-        description: "Limit reth memory via systemd MemoryMax (0 = 95% RAM)"
-        required: false
-        default: "32G"
-        type: string
       baseline_args:
         description: "Extra CLI args for the baseline reth node"
         required: false
@@ -167,7 +162,7 @@ jobs:
       RETH_SCOPE: reth-benchmarkoor.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_CORES: ${{ inputs.cores || '6' }}
-      BENCH_MEMORY_MAX: ${{ inputs.memory || '32G' }}
+      BENCH_MEMORY_MAX: "32G"
       BENCH_BASELINE_ARGS: ${{ inputs.baseline_args || '' }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature_args || '' }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: "main"
         type: string
+      download_ref:
+        description: "Reth git ref used only for snapshot download"
+        required: false
+        default: "pull/24027/head"
+        type: string
       suite:
         description: "benchmarkoor-replay suite"
         required: false
@@ -313,12 +318,18 @@ jobs:
           INPUT_PR: ${{ inputs.pr || '' }}
           INPUT_FEATURE: ${{ inputs.feature || '' }}
           INPUT_BASELINE: ${{ inputs.baseline || 'main' }}
+          INPUT_DOWNLOAD: ${{ inputs.download_ref || 'pull/24027/head' }}
         run: |
           set -euo pipefail
           git fetch origin main --quiet
 
           resolve_ref() {
             local ref="$1"
+            if [[ "$ref" =~ ^pull/[0-9]+/(head|merge)$ ]]; then
+              git fetch origin "$ref" --quiet
+              git rev-parse --verify "FETCH_HEAD^{commit}"
+              return 0
+            fi
             git fetch origin "$ref" --quiet 2>/dev/null || true
             if git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
               git rev-parse --verify "${ref}^{commit}"
@@ -341,12 +352,16 @@ jobs:
 
           BASELINE_NAME="${INPUT_BASELINE:-main}"
           BASELINE_REF="$(resolve_ref "$BASELINE_NAME")"
+          DOWNLOAD_NAME="${INPUT_DOWNLOAD:-pull/24027/head}"
+          DOWNLOAD_REF="$(resolve_ref "$DOWNLOAD_NAME")"
 
           {
             printf 'feature-ref=%s\n' "$FEATURE_REF"
             printf 'feature-name=%s\n' "$FEATURE_NAME"
             printf 'baseline-ref=%s\n' "$BASELINE_REF"
             printf 'baseline-name=%s\n' "$BASELINE_NAME"
+            printf 'download-ref=%s\n' "$DOWNLOAD_REF"
+            printf 'download-name=%s\n' "$DOWNLOAD_NAME"
           } >> "$GITHUB_OUTPUT"
 
       - name: Prepare source dirs
@@ -355,13 +370,18 @@ jobs:
           prepare_source_dir() {
             local dir="$1"
             local ref="$2"
+            local fetch_ref="${3:-}"
 
             if [ -d "$dir" ]; then
               git -C "$dir" reset --hard HEAD
               git -C "$dir" clean -fdx
-              git -C "$dir" fetch origin "$ref" || true
             else
               git clone . "$dir"
+            fi
+            if [ -n "$fetch_ref" ]; then
+              git -C "$dir" fetch origin "$fetch_ref" --quiet || true
+            else
+              git -C "$dir" fetch origin "$ref" --quiet || true
             fi
 
             git -C "$dir" checkout --force "$ref"
@@ -370,6 +390,7 @@ jobs:
 
           prepare_source_dir ../reth-baseline "${{ steps.refs.outputs.baseline-ref }}"
           prepare_source_dir ../reth-feature "${{ steps.refs.outputs.feature-ref }}"
+          prepare_source_dir ../reth-download "${{ steps.refs.outputs.download-ref }}" "${{ steps.refs.outputs.download-name }}"
 
       - name: Build binaries
         id: build
@@ -383,15 +404,19 @@ jobs:
           set -euo pipefail
           BASELINE_DIR="$(cd ../reth-baseline && pwd)"
           FEATURE_DIR="$(cd ../reth-feature && pwd)"
+          DOWNLOAD_DIR="$(cd ../reth-download && pwd)"
 
           .github/scripts/bench-reth-build.sh baseline "$BASELINE_DIR" "${{ steps.refs.outputs.baseline-ref }}" &
           PID_BASELINE=$!
           .github/scripts/bench-reth-build.sh feature "$FEATURE_DIR" "${{ steps.refs.outputs.feature-ref }}" &
           PID_FEATURE=$!
+          .github/scripts/bench-reth-build.sh baseline "$DOWNLOAD_DIR" "${{ steps.refs.outputs.download-ref }}" &
+          PID_DOWNLOAD=$!
 
           FAIL=0
           wait $PID_BASELINE || FAIL=1
           wait $PID_FEATURE || FAIL=1
+          wait $PID_DOWNLOAD || FAIL=1
           if [ $FAIL -ne 0 ]; then
             echo "::error::One or more build tasks failed"
             exit 1
@@ -494,7 +519,10 @@ jobs:
         id: snapshot
         run: |
           set -euo pipefail
-          BENCH_RETH_BINARY="$(pwd)/../reth-feature/target/profiling/reth" \
+          DOWNLOAD_RETH_BINARY="$(pwd)/../reth-download/target/profiling/reth"
+          echo "Using download reth from ${{ steps.refs.outputs.download-name }} (${{ steps.refs.outputs.download-ref }})"
+          "$DOWNLOAD_RETH_BINARY" --version
+          BENCH_RETH_BINARY="$DOWNLOAD_RETH_BINARY" \
             .github/scripts/bench-benchmarkoor-snapshot.sh
 
       - name: System setup

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -1,0 +1,572 @@
+# Runs benchmarkoor-replay fixtures against a PR/branch and compares them with main.
+#
+# Unlike the normal reth benchmark workflow, this promotes the schelk checkpoint
+# after benchmarkoor's gas-bump/funding prerun. Each selected test then recovers
+# to that checkpoint, runs setup outside the measured window, restarts Reth,
+# drops Linux page cache, and measures only the testing fixture replay.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to benchmark"
+        required: false
+        default: ""
+        type: string
+      feature:
+        description: "Feature git ref (default: dispatched ref, ignored when pr is set)"
+        required: false
+        default: ""
+        type: string
+      baseline:
+        description: "Baseline git ref"
+        required: false
+        default: "main"
+        type: string
+      suite:
+        description: "benchmarkoor-replay suite"
+        required: false
+        default: "perf-devnet-3/24358000"
+        type: string
+      context:
+        description: "benchmarkoor context"
+        required: false
+        default: "repricing"
+        type: string
+      fork:
+        description: "benchmarkoor fork"
+        required: false
+        default: "amsterdam"
+        type: string
+      test_type:
+        description: "benchmarkoor test type"
+        required: false
+        default: "stateful"
+        type: string
+      snapshot:
+        description: "Snapshot manifest/archive URL, MinIO path, or prefix"
+        required: false
+        default: "perfnet"
+        type: string
+      snapshot_mc_root:
+        description: "MinIO root used when snapshot is only a prefix"
+        required: false
+        default: "minio"
+        type: string
+      genesis:
+        description: "Genesis URL/path override; empty tries snapshot sibling genesis.json"
+        required: false
+        default: ""
+        type: string
+      fixture_url:
+        description: "Fixture archive URL/path override (empty uses suite default)"
+        required: false
+        default: ""
+        type: string
+      exact_test:
+        description: "Exact benchmarkoor test filename"
+        required: false
+        default: ""
+        type: string
+      contains:
+        description: "Substring test selector"
+        required: false
+        default: "test_account_access"
+        type: string
+      pattern:
+        description: "Regex test selector"
+        required: false
+        default: ""
+        type: string
+      opcode:
+        description: "Opcode selector"
+        required: false
+        default: ""
+        type: string
+      gas_bucket:
+        description: "Gas bucket selector, for example 210M"
+        required: false
+        default: ""
+        type: string
+      cache_strategy:
+        description: "Cache strategy selector, for example NO_CACHE"
+        required: false
+        default: ""
+        type: string
+      account_mode:
+        description: "Account mode selector, for example EXISTING_EOA"
+        required: false
+        default: ""
+        type: string
+      limit:
+        description: "Maximum matching tests to run"
+        required: false
+        default: "20"
+        type: string
+      repetitions:
+        description: "Runs per side: 1 or 2"
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "2"
+      cores:
+        description: "Limit reth to N CPU cores (0 = all available)"
+        required: false
+        default: "0"
+        type: string
+      baseline_args:
+        description: "Extra CLI args for the baseline reth node"
+        required: false
+        default: ""
+        type: string
+      feature_args:
+        description: "Extra CLI args for the feature reth node"
+        required: false
+        default: ""
+        type: string
+      benchmarkoor_replay_path:
+        description: "Local benchmarkoor-replay checkout on the runner"
+        required: false
+        default: "/home/ubuntu/projects/benchmarkoor-replay"
+        type: string
+      metadata_root:
+        description: "benchmarkoor-tests config root"
+        required: false
+        default: "/home/ubuntu/projects/benchmarkoor-tests/configs"
+        type: string
+      migrate_v2:
+        description: "Run reth db migrate-v2 after snapshot import"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
+
+name: bench-benchmarkoor
+
+permissions: {}
+
+jobs:
+  benchmarkoor:
+    name: bench-benchmarkoor
+    runs-on: [self-hosted, Linux, X64, available]
+    permissions:
+      contents: read
+    timeout-minutes: 180
+    env:
+      SCHELK_MOUNT: /reth-bench
+      RETH_SCOPE: reth-benchmarkoor.scope
+      BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
+      BENCH_CORES: ${{ inputs.cores }}
+      BENCH_BASELINE_ARGS: ${{ inputs.baseline_args }}
+      BENCH_FEATURE_ARGS: ${{ inputs.feature_args }}
+      BENCH_METRICS_ADDR: "127.0.0.1:9001"
+      BENCHMARKOOR_SUITE: ${{ inputs.suite }}
+      BENCHMARKOOR_CONTEXT: ${{ inputs.context }}
+      BENCHMARKOOR_FORK: ${{ inputs.fork }}
+      BENCHMARKOOR_TEST_TYPE: ${{ inputs.test_type }}
+      BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root }}
+      BENCHMARKOOR_SNAPSHOT: ${{ inputs.snapshot }}
+      BENCHMARKOOR_SNAPSHOT_MC_ROOT: ${{ inputs.snapshot_mc_root }}
+      BENCHMARKOOR_GENESIS: ${{ inputs.genesis }}
+      BENCHMARKOOR_MIGRATE_V2: ${{ inputs.migrate_v2 && 'true' || 'false' }}
+      BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path }}
+      BENCHMARKOOR_CACHE: ${{ github.workspace }}/bench-work/benchmarkoor-cache
+    steps:
+      - name: Clean up previous bench-work
+        run: sudo rm -rf "$BENCH_WORK_DIR" 2>/dev/null || true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: true
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        continue-on-error: true
+
+      - name: Install dependencies
+        env:
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            python3 make jq zstd curl dmsetup \
+            linux-tools-"$(uname -r)" || \
+            sudo apt-get install -y --no-install-recommends linux-tools-generic
+
+          if ! command -v mc &>/dev/null; then
+            curl -sSfL https://dl.min.io/client/mc/release/linux-amd64/mc -o "$HOME/.local/bin/mc"
+            chmod +x "$HOME/.local/bin/mc"
+          fi
+
+          git config --global url."https://x-access-token:${DEREK_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+          if ! command -v era_invalidate &>/dev/null; then
+            git clone --depth 1 https://github.com/jthornber/thin-provisioning-tools /tmp/tpt
+            sudo make -C /tmp/tpt install
+            rm -rf /tmp/tpt
+          fi
+
+          if ! sudo sh -c 'command -v schelk' &>/dev/null; then
+            cargo install --git https://github.com/tempoxyz/schelk --locked
+            sudo install "$HOME/.cargo/bin/schelk" /usr/local/bin/
+          fi
+
+      - name: Check dependencies
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          missing=()
+          for cmd in mc schelk cpupower taskset stdbuf python3 curl make jq cargo; do
+            command -v "$cmd" &>/dev/null || missing+=("$cmd")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required tools: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install benchmarkoor-replay
+        run: |
+          set -euo pipefail
+          if [ ! -d "$BENCHMARKOOR_REPLAY_PATH" ]; then
+            echo "::error::benchmarkoor-replay checkout not found at ${BENCHMARKOOR_REPLAY_PATH}"
+            exit 1
+          fi
+          if git -C "$BENCHMARKOOR_REPLAY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git -C "$BENCHMARKOOR_REPLAY_PATH" fetch origin main --quiet
+            git -C "$BENCHMARKOOR_REPLAY_PATH" checkout --force origin/main
+          fi
+          cargo install --path "$BENCHMARKOOR_REPLAY_PATH" --locked --force
+          BENCHMARKOOR_BIN="$(command -v benchmarkoor-replay)"
+          "$BENCHMARKOOR_BIN" run-many --help | grep -q -- 'setup-then-testing'
+          echo "BENCHMARKOOR_BIN=${BENCHMARKOOR_BIN}" >> "$GITHUB_ENV"
+
+      - name: Resolve refs
+        id: refs
+        env:
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_FEATURE: ${{ inputs.feature }}
+          INPUT_BASELINE: ${{ inputs.baseline }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --quiet
+
+          resolve_ref() {
+            local ref="$1"
+            git fetch origin "$ref" --quiet 2>/dev/null || true
+            git rev-parse "$ref" 2>/dev/null || git rev-parse "origin/$ref"
+          }
+
+          if [ -n "$INPUT_PR" ]; then
+            git fetch origin "pull/${INPUT_PR}/head:refs/remotes/pr/${INPUT_PR}" --quiet
+            FEATURE_REF="$(git rev-parse "refs/remotes/pr/${INPUT_PR}")"
+            FEATURE_NAME="pr-${INPUT_PR}"
+          elif [ -n "$INPUT_FEATURE" ]; then
+            FEATURE_REF="$(resolve_ref "$INPUT_FEATURE")"
+            FEATURE_NAME="$INPUT_FEATURE"
+          else
+            FEATURE_REF="$(git rev-parse HEAD)"
+            FEATURE_NAME="${GITHUB_REF_NAME}"
+          fi
+
+          BASELINE_NAME="${INPUT_BASELINE:-main}"
+          BASELINE_REF="$(resolve_ref "$BASELINE_NAME")"
+
+          {
+            echo "feature-ref=$FEATURE_REF"
+            echo "feature-name=$FEATURE_NAME"
+            echo "baseline-ref=$BASELINE_REF"
+            echo "baseline-name=$BASELINE_NAME"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare source dirs
+        run: |
+          set -euo pipefail
+          prepare_source_dir() {
+            local dir="$1"
+            local ref="$2"
+
+            if [ -d "$dir" ]; then
+              git -C "$dir" reset --hard HEAD
+              git -C "$dir" clean -fdx
+              git -C "$dir" fetch origin "$ref" || true
+            else
+              git clone . "$dir"
+            fi
+
+            git -C "$dir" checkout --force "$ref"
+            git -C "$dir" submodule update --init --recursive
+          }
+
+          prepare_source_dir ../reth-baseline "${{ steps.refs.outputs.baseline-ref }}"
+          prepare_source_dir ../reth-feature "${{ steps.refs.outputs.feature-ref }}"
+
+      - name: Build binaries
+        id: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEREK_PAT: ${{ secrets.DEREK_PAT }}
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
+          BENCH_REPO: ${{ github.repository }}
+          BENCH_BIG_BLOCKS: "false"
+        run: |
+          set -euo pipefail
+          BASELINE_DIR="$(cd ../reth-baseline && pwd)"
+          FEATURE_DIR="$(cd ../reth-feature && pwd)"
+
+          .github/scripts/bench-reth-build.sh baseline "$BASELINE_DIR" "${{ steps.refs.outputs.baseline-ref }}" &
+          PID_BASELINE=$!
+          .github/scripts/bench-reth-build.sh feature "$FEATURE_DIR" "${{ steps.refs.outputs.feature-ref }}" &
+          PID_FEATURE=$!
+
+          FAIL=0
+          wait $PID_BASELINE || FAIL=1
+          wait $PID_FEATURE || FAIL=1
+          if [ $FAIL -ne 0 ]; then
+            echo "::error::One or more build tasks failed"
+            exit 1
+          fi
+
+      - name: Download fixtures
+        run: |
+          set -euo pipefail
+          args=(
+            --suite "$BENCHMARKOOR_SUITE"
+            --context "$BENCHMARKOOR_CONTEXT"
+            --fork "$BENCHMARKOOR_FORK"
+            --test-type "$BENCHMARKOOR_TEST_TYPE"
+            --metadata-root "$BENCHMARKOOR_METADATA_ROOT"
+            --cache-dir "$BENCHMARKOOR_CACHE"
+            fixtures download
+          )
+          if [ -n "${{ inputs.fixture_url }}" ]; then
+            args+=(--url "${{ inputs.fixture_url }}")
+          fi
+          "$BENCHMARKOOR_BIN" "${args[@]}"
+
+      - name: Resolve test set
+        id: tests
+        env:
+          EXACT_TEST: ${{ inputs.exact_test }}
+          CONTAINS: ${{ inputs.contains }}
+          PATTERN: ${{ inputs.pattern }}
+          OPCODE: ${{ inputs.opcode }}
+          GAS_BUCKET: ${{ inputs.gas_bucket }}
+          CACHE_STRATEGY: ${{ inputs.cache_strategy }}
+          ACCOUNT_MODE: ${{ inputs.account_mode }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [ "$LIMIT" -lt 1 ]; then
+            echo "::error::limit must be a positive integer"
+            exit 1
+          fi
+
+          INDEX="$(find "$BENCHMARKOOR_CACHE/fixtures" -name index.json -print -quit)"
+          if [ -z "$INDEX" ]; then
+            echo "::error::benchmarkoor fixture index not found"
+            exit 1
+          fi
+          TESTS_FILE="$BENCH_WORK_DIR/tests.jsonl"
+          mkdir -p "$BENCH_WORK_DIR"
+
+          jq -c \
+            --arg exact "$EXACT_TEST" \
+            --arg contains "$CONTAINS" \
+            --arg pattern "$PATTERN" \
+            --arg opcode "$OPCODE" \
+            --arg gas_bucket "$GAS_BUCKET" \
+            --arg cache_strategy "$CACHE_STRATEGY" \
+            --arg account_mode "$ACCOUNT_MODE" \
+            --argjson limit "$LIMIT" '
+            def searchable:
+              [.name, (.setup.rel_path // ""), (.testing.rel_path // ""), (.cleanup.rel_path // "")]
+              | join(" ");
+            def matches_exact($v):
+              .name == $v or (.setup.name // "") == $v or (.setup.rel_path // "") == $v or
+              (.testing.name // "") == $v or (.testing.rel_path // "") == $v or
+              (.cleanup.name // "") == $v or (.cleanup.rel_path // "") == $v;
+            def norm: ascii_downcase;
+            [
+              .tests[]
+              | select(.setup != null and .testing != null)
+              | select($exact == "" or matches_exact($exact))
+              | select($contains == "" or (searchable | contains($contains)))
+              | select($pattern == "" or (searchable | test($pattern)))
+              | select($opcode == "" or ((.metadata.opcode // "" | norm) == ($opcode | norm)))
+              | select($gas_bucket == "" or ((.metadata.gas_bucket // "" | norm) == ($gas_bucket | norm)))
+              | select($cache_strategy == "" or ((.metadata.cache_strategy // "" | norm) == ($cache_strategy | norm)))
+              | select($account_mode == "" or ((.metadata.account_mode // "" | norm) == ($account_mode | norm)))
+            ][: $limit]
+            | .[]
+            | {name, gas_bucket: .metadata.gas_bucket, opcode: .metadata.opcode, cache_strategy: .metadata.cache_strategy, account_mode: .metadata.account_mode}
+            ' "$INDEX" > "$TESTS_FILE"
+
+          COUNT="$(wc -l < "$TESTS_FILE" | tr -d ' ')"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::No benchmarkoor tests matched the requested selectors"
+            exit 1
+          fi
+          echo "Selected ${COUNT} test(s):"
+          jq -r '.name' "$TESTS_FILE"
+
+          {
+            echo "index=$INDEX"
+            echo "tests-file=$TESTS_FILE"
+            echo "count=$COUNT"
+          } >> "$GITHUB_OUTPUT"
+          echo "BENCHMARKOOR_INDEX=$INDEX" >> "$GITHUB_ENV"
+          echo "BENCHMARKOOR_TESTS_FILE=$TESTS_FILE" >> "$GITHUB_ENV"
+
+      - name: Import snapshot into schelk
+        id: snapshot
+        run: |
+          set -euo pipefail
+          BENCH_RETH_BINARY="$(pwd)/../reth-feature/target/profiling/reth" \
+            .github/scripts/bench-benchmarkoor-snapshot.sh
+
+      - name: System setup
+        run: |
+          set -euo pipefail
+          echo passive | sudo tee /sys/devices/system/cpu/amd_pstate/status 2>/dev/null || true
+          sudo cpupower frequency-set -g performance || true
+          sudo swapoff -a || true
+          echo 0 | sudo tee /proc/sys/kernel/randomize_va_space || true
+          for cpu in /sys/devices/system/cpu/cpu*/topology/thread_siblings_list; do
+            first=$(cut -d, -f1 < "$cpu" | cut -d- -f1)
+            current=$(echo "$cpu" | grep -o 'cpu[0-9]*' | grep -o '[0-9]*')
+            if [ "$current" != "$first" ]; then
+              echo 0 | sudo tee "/sys/devices/system/cpu/cpu${current}/online" || true
+            fi
+          done
+          for p in /sys/kernel/mm/transparent_hugepage /sys/kernel/mm/transparent_hugepages; do
+            [ -d "$p" ] && echo never | sudo tee "$p/enabled" && echo never | sudo tee "$p/defrag" && break
+          done || true
+          sudo pkill -f '^bench-cpu-dma-latency' 2>/dev/null || true
+          sudo bash -c 'exec 3<>/dev/cpu_dma_latency; printf "\0\0\0\0" >&3; exec -a bench-cpu-dma-latency sleep infinity' &
+          echo "BENCH_CPU_DMA_LATENCY_PID=$!" >> "$GITHUB_ENV"
+          for irq in /proc/irq/*/smp_affinity_list; do
+            echo 0 | sudo tee "$irq" 2>/dev/null || true
+          done
+          sudo systemctl stop \
+            irqbalance cron atd unattended-upgrades snapd \
+            prometheus-node-exporter-apt.timer prometheus-node-exporter-apt.service \
+            prometheus-node-exporter-nvme.timer prometheus-node-exporter-nvme.service \
+            prometheus-node-exporter-ipmitool-sensor.timer prometheus-node-exporter-ipmitool-sensor.service \
+            sysstat-collect.timer sysstat-collect.service \
+            sysstat-summary.timer sysstat-summary.service \
+            2>/dev/null || true
+          uname -r
+          lscpu | grep -E 'Model name|CPU\(s\)|MHz|NUMA'
+          free -h
+
+      - name: Checkpoint after gas bump and funding
+        run: |
+          set -euo pipefail
+          taskset -c 0 .github/scripts/bench-benchmarkoor-run.sh \
+            prepare \
+            "$(pwd)/../reth-feature/target/profiling/reth" \
+            "$BENCH_WORK_DIR/prerun"
+
+      - name: Run benchmarkoor comparison
+        run: |
+          set -euo pipefail
+          BASELINE_BIN="$(pwd)/../reth-baseline/target/profiling/reth"
+          FEATURE_BIN="$(pwd)/../reth-feature/target/profiling/reth"
+
+          if [ "${{ inputs.repetitions }}" = "2" ]; then
+            RUNS=(
+              "feature-1:$FEATURE_BIN"
+              "baseline-1:$BASELINE_BIN"
+              "baseline-2:$BASELINE_BIN"
+              "feature-2:$FEATURE_BIN"
+            )
+          else
+            RUNS=(
+              "baseline-1:$BASELINE_BIN"
+              "feature-1:$FEATURE_BIN"
+            )
+          fi
+
+          for item in "${RUNS[@]}"; do
+            label="${item%%:*}"
+            binary="${item#*:}"
+            taskset -c 0 .github/scripts/bench-benchmarkoor-run.sh \
+              run "$label" "$binary" "$BENCH_WORK_DIR/$label" "$BENCHMARKOOR_TESTS_FILE"
+          done
+
+      - name: Parse results
+        id: results
+        if: success()
+        run: |
+          set -euo pipefail
+          RESULTS="$BENCH_WORK_DIR/results.jsonl"
+          find "$BENCH_WORK_DIR" -path '*/results.jsonl' -print0 | xargs -0 cat > "$RESULTS"
+          python3 .github/scripts/bench-benchmarkoor-summary.py \
+            --results "$RESULTS" \
+            --output-json "$BENCH_WORK_DIR/summary.json" \
+            --output-markdown "$BENCH_WORK_DIR/summary.md" \
+            --repo "${{ github.repository }}" \
+            --baseline-name "${{ steps.refs.outputs.baseline-name }}" \
+            --baseline-ref "${{ steps.refs.outputs.baseline-ref }}" \
+            --feature-name "${{ steps.refs.outputs.feature-name }}" \
+            --feature-ref "${{ steps.refs.outputs.feature-ref }}"
+
+      - name: Write job summary
+        if: success()
+        run: cat "$BENCH_WORK_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Scan logs for errors
+        if: "!cancelled()"
+        run: |
+          set -euo pipefail
+          ERRORS_FILE="$BENCH_WORK_DIR/errors.md"
+          found=false
+          while IFS= read -r -d '' log; do
+            panics=$(grep -c -E 'panicked at' "$log" || true)
+            errors=$(grep -c ' ERROR ' "$log" || true)
+            if [ "$panics" -gt 0 ] || [ "$errors" -gt 0 ]; then
+              if [ "$found" = false ]; then
+                printf '### Node Errors\n\n' >> "$ERRORS_FILE"
+                found=true
+              fi
+              printf '<details><summary><b>%s</b>: %d panic(s), %d error(s)</summary>\n\n' "$log" "$panics" "$errors" >> "$ERRORS_FILE"
+              grep -E 'panicked at| ERROR ' "$log" | head -30 >> "$ERRORS_FILE" || true
+              printf '\n</details>\n\n' >> "$ERRORS_FILE"
+            fi
+          done < <(find "$BENCH_WORK_DIR" -name '*.log' -print0)
+
+      - name: Upload results
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: benchmarkoor-results
+          path: ${{ env.BENCH_WORK_DIR }}
+
+      - name: Clean build outputs
+        if: always()
+        run: sudo rm -rf ../reth-baseline/target ../reth-feature/target "$BENCH_WORK_DIR" 2>/dev/null || true
+
+      - name: Restore system settings
+        if: always()
+        run: |
+          if [ -n "${BENCH_CPU_DMA_LATENCY_PID:-}" ]; then
+            sudo kill "$BENCH_CPU_DMA_LATENCY_PID" 2>/dev/null || true
+          fi
+          sudo pkill -f '^bench-cpu-dma-latency' 2>/dev/null || true
+          sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
+          sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true
+          sudo schelk recover -y --kill || true
+          sudo systemctl start irqbalance cron atd 2>/dev/null || true

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -183,6 +183,18 @@ jobs:
       - name: Clean up previous bench-work
         run: sudo rm -rf "$BENCH_WORK_DIR" 2>/dev/null || true
 
+      - name: Print runner OS and kernel
+        run: |
+          set -euo pipefail
+          echo "::group::Runner OS"
+          uname -a
+          echo "kernel=$(uname -r)"
+          if [ -f /etc/os-release ]; then
+            cat /etc/os-release
+          fi
+          lsb_release -a 2>/dev/null || true
+          echo "::endgroup::"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -119,11 +119,11 @@ on:
       reset_strategy:
         description: "Reset state between tests"
         required: false
-        default: "unwind"
+        default: "schelk"
         type: choice
         options:
-          - "unwind"
           - "schelk"
+          - "unwind"
       baseline_args:
         description: "Extra CLI args for the baseline reth node"
         required: false
@@ -166,7 +166,7 @@ jobs:
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_CORES: ${{ inputs.cores || '6' }}
       BENCH_MEMORY_MAX: "32G"
-      BENCH_RESET_STRATEGY: ${{ inputs.reset_strategy || 'unwind' }}
+      BENCH_RESET_STRATEGY: ${{ inputs.reset_strategy || 'schelk' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline_args || '' }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature_args || '' }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -101,7 +101,7 @@ on:
       limit:
         description: "Maximum matching tests to run (0 = all)"
         required: false
-        default: "0"
+        default: "20"
         type: string
       repetitions:
         description: "Runs per side: 1 or 2"
@@ -456,7 +456,7 @@ jobs:
           GAS_BUCKET: ${{ inputs.gas_bucket || '' }}
           CACHE_STRATEGY: ${{ inputs.cache_strategy || '' }}
           ACCOUNT_MODE: ${{ inputs.account_mode || '' }}
-          LIMIT: ${{ inputs.limit || '0' }}
+          LIMIT: ${{ inputs.limit || '20' }}
         run: |
           set -euo pipefail
           if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
@@ -519,6 +519,43 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "BENCHMARKOOR_INDEX=$INDEX" >> "$GITHUB_ENV"
           echo "BENCHMARKOOR_TESTS_FILE=$TESTS_FILE" >> "$GITHUB_ENV"
+
+      - name: Check block discard support
+        run: |
+          set -euo pipefail
+          echo "::group::Block discard capabilities"
+          lsblk -D -o NAME,TYPE,SIZE,DISC-GRAN,DISC-MAX,DISC-ZERO,MOUNTPOINTS || true
+          echo
+
+          if sudo test -f /var/lib/schelk/state.json; then
+            echo "schelk state:"
+            sudo jq . /var/lib/schelk/state.json || true
+            echo
+          fi
+
+          found=0
+          for queue in /sys/block/{ram*,brd*,loop*,nvme*,dm-*}/queue; do
+            [ -d "$queue" ] || continue
+            found=1
+            dev="$(basename "$(dirname "$queue")")"
+            max="$(cat "$queue/discard_max_bytes" 2>/dev/null || printf 'missing')"
+            gran="$(cat "$queue/discard_granularity" 2>/dev/null || printf 'missing')"
+            zeroes="$(cat "$queue/discard_zeroes_data" 2>/dev/null || printf 'missing')"
+            printf '%s: discard_max_bytes=%s discard_granularity=%s discard_zeroes_data=%s\n' \
+              "$dev" "$max" "$gran" "$zeroes"
+            if [[ "$dev" == ram* || "$dev" == brd* ]]; then
+              if [[ "$max" =~ ^[0-9]+$ ]] && [ "$max" -gt 0 ]; then
+                echo "::notice::/dev/${dev} advertises discard support with discard_max_bytes=${max}"
+              else
+                echo "::notice::/dev/${dev} does not advertise discard support; discard_max_bytes=${max}"
+              fi
+            fi
+          done
+
+          if [ "$found" -eq 0 ]; then
+            echo "::notice::No matching sysfs block queues found for discard diagnostics"
+          fi
+          echo "::endgroup::"
 
       - name: Import snapshot into schelk
         id: snapshot

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -127,12 +127,12 @@ on:
         default: ""
         type: string
       benchmarkoor_replay_path:
-        description: "Local benchmarkoor-replay checkout on the runner"
+        description: "Optional local benchmarkoor-replay checkout on the runner"
         required: false
         default: "/home/ubuntu/projects/benchmarkoor-replay"
         type: string
       metadata_root:
-        description: "benchmarkoor-tests config root"
+        description: "Optional local benchmarkoor-tests config root"
         required: false
         default: "/home/ubuntu/projects/benchmarkoor-tests/configs"
         type: string
@@ -239,18 +239,42 @@ jobs:
       - name: Install benchmarkoor-replay
         run: |
           set -euo pipefail
-          if [ ! -d "$BENCHMARKOOR_REPLAY_PATH" ]; then
-            echo "::error::benchmarkoor-replay checkout not found at ${BENCHMARKOOR_REPLAY_PATH}"
-            exit 1
+
+          replay_path="$BENCHMARKOOR_REPLAY_PATH"
+          if [ -d "$replay_path" ]; then
+            if git -C "$replay_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+              git -C "$replay_path" fetch origin main --quiet
+              git -C "$replay_path" checkout --force origin/main
+            fi
+          else
+            replay_path="$BENCH_WORK_DIR/benchmarkoor-replay"
+            rm -rf "$replay_path"
+            git clone --depth 1 https://github.com/tempoxyz/benchmarkoor-replay "$replay_path"
           fi
-          if git -C "$BENCHMARKOOR_REPLAY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            git -C "$BENCHMARKOOR_REPLAY_PATH" fetch origin main --quiet
-            git -C "$BENCHMARKOOR_REPLAY_PATH" checkout --force origin/main
-          fi
-          cargo install --path "$BENCHMARKOOR_REPLAY_PATH" --locked --force
+
+          cargo install --path "$replay_path" --locked --force
           BENCHMARKOOR_BIN="$(command -v benchmarkoor-replay)"
           "$BENCHMARKOOR_BIN" run-many --help | grep -q -- 'setup-then-testing'
           echo "BENCHMARKOOR_BIN=${BENCHMARKOOR_BIN}" >> "$GITHUB_ENV"
+
+      - name: Prepare benchmarkoor metadata
+        run: |
+          set -euo pipefail
+
+          metadata_root="$BENCHMARKOOR_METADATA_ROOT"
+          if [ ! -d "$metadata_root" ]; then
+            tests_path="$BENCH_WORK_DIR/benchmarkoor-tests"
+            rm -rf "$tests_path"
+            git clone --depth 1 https://github.com/ethpandaops/benchmarkoor-tests "$tests_path"
+            metadata_root="$tests_path/configs"
+          fi
+
+          if [ ! -d "$metadata_root" ]; then
+            echo "::error::benchmarkoor metadata root not found at ${metadata_root}"
+            exit 1
+          fi
+
+          echo "BENCHMARKOOR_METADATA_ROOT=${metadata_root}" >> "$GITHUB_ENV"
 
       - name: Resolve refs
         id: refs

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -129,12 +129,12 @@ on:
       benchmarkoor_replay_path:
         description: "Optional local benchmarkoor-replay checkout on the runner"
         required: false
-        default: "/home/ubuntu/projects/benchmarkoor-replay"
+        default: "~/projects/benchmarkoor-replay"
         type: string
       metadata_root:
         description: "Optional local benchmarkoor-tests config root"
         required: false
-        default: "/home/ubuntu/projects/benchmarkoor-tests/configs"
+        default: "~/projects/benchmarkoor-tests/configs"
         type: string
       migrate_v2:
         description: "Run reth db migrate-v2 after snapshot import"
@@ -169,11 +169,11 @@ jobs:
       BENCHMARKOOR_CONTEXT: ${{ inputs.context || 'repricing' }}
       BENCHMARKOOR_FORK: ${{ inputs.fork || 'amsterdam' }}
       BENCHMARKOOR_TEST_TYPE: ${{ inputs.test_type || 'stateful' }}
-      BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root || '/home/ubuntu/projects/benchmarkoor-tests/configs' }}
+      BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root || '~/projects/benchmarkoor-tests/configs' }}
       BENCHMARKOOR_SNAPSHOT: ${{ inputs.snapshot || 'minio/reth-snapshots/perfnet-24358000-full/' }}
       BENCHMARKOOR_SNAPSHOT_MC_ROOT: ${{ inputs.snapshot_mc_root || 'minio' }}
       BENCHMARKOOR_MIGRATE_V2: ${{ inputs.migrate_v2 && 'true' || 'false' }}
-      BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path || '/home/ubuntu/projects/benchmarkoor-replay' }}
+      BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path || '~/projects/benchmarkoor-replay' }}
       BENCHMARKOOR_CACHE: ${{ github.workspace }}/bench-work/benchmarkoor-cache
     steps:
       - name: Clean up previous bench-work
@@ -208,7 +208,9 @@ jobs:
             chmod +x "$HOME/.local/bin/mc"
           fi
 
-          git config --global url."https://x-access-token:${DEREK_TOKEN}@github.com/".insteadOf "https://github.com/"
+          if [ -n "${DEREK_TOKEN:-}" ]; then
+            git config --global url."https://x-access-token:${DEREK_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
 
           if ! command -v era_invalidate &>/dev/null; then
             git clone --depth 1 https://github.com/jthornber/thin-provisioning-tools /tmp/tpt
@@ -237,10 +239,16 @@ jobs:
           fi
 
       - name: Install benchmarkoor-replay
+        env:
+          DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
         run: |
           set -euo pipefail
 
           replay_path="$BENCHMARKOOR_REPLAY_PATH"
+          case "$replay_path" in
+            "~") replay_path="$HOME" ;;
+            "~/"*) replay_path="$HOME/${replay_path#"~/"}" ;;
+          esac
           if [ -d "$replay_path" ]; then
             if git -C "$replay_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
               git -C "$replay_path" fetch origin main --quiet
@@ -249,7 +257,15 @@ jobs:
           else
             replay_path="$BENCH_WORK_DIR/benchmarkoor-replay"
             rm -rf "$replay_path"
-            git clone --depth 1 https://github.com/tempoxyz/benchmarkoor-replay "$replay_path"
+            clone_url="https://github.com/tempoxyz/benchmarkoor-replay"
+            if [ -n "${DEREK_TOKEN:-}" ]; then
+              clone_url="https://x-access-token:${DEREK_TOKEN}@github.com/tempoxyz/benchmarkoor-replay"
+            fi
+            if ! git clone --depth 1 "$clone_url" "$replay_path"; then
+              rm -rf "$replay_path"
+              GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new" \
+                git clone --depth 1 git@github.com:tempoxyz/benchmarkoor-replay.git "$replay_path"
+            fi
           fi
 
           cargo install --path "$replay_path" --locked --force
@@ -262,6 +278,10 @@ jobs:
           set -euo pipefail
 
           metadata_root="$BENCHMARKOOR_METADATA_ROOT"
+          case "$metadata_root" in
+            "~") metadata_root="$HOME" ;;
+            "~/"*) metadata_root="$HOME/${metadata_root#"~/"}" ;;
+          esac
           if [ ! -d "$metadata_root" ]; then
             tests_path="$BENCH_WORK_DIR/benchmarkoor-tests"
             rm -rf "$tests_path"

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -1,9 +1,9 @@
 # Runs benchmarkoor-replay fixtures against a PR/branch and compares them with main.
 #
-# Unlike the normal reth benchmark workflow, this promotes the schelk checkpoint
-# after benchmarkoor's gas-bump/funding prerun. Each selected test then recovers
-# to that checkpoint, runs setup outside the measured window, restarts Reth,
-# drops Linux page cache, and measures only the testing fixture replay.
+# Unlike the normal reth benchmark workflow, this prepares a post gas-bump/funding
+# baseline with benchmarkoor-replay. Each selected test then resets to that
+# baseline, runs setup outside the measured window, restarts Reth, drops Linux
+# page cache, and measures only the testing fixture replay.
 
 on:
   # Temporary test trigger for branch-only workflow validation.
@@ -57,11 +57,6 @@ on:
         description: "Snapshot manifest URL, MinIO manifest path, or MinIO prefix"
         required: false
         default: "minio/reth-snapshots/perfnet-24358000-full/"
-        type: string
-      snapshot_mc_root:
-        description: "MinIO root used when snapshot is only a prefix"
-        required: false
-        default: "minio"
         type: string
       fixture_url:
         description: "Fixture archive URL/path override (empty uses suite default)"
@@ -121,6 +116,14 @@ on:
         required: false
         default: "6"
         type: string
+      reset_strategy:
+        description: "Reset state between tests"
+        required: false
+        default: "unwind"
+        type: choice
+        options:
+          - "unwind"
+          - "schelk"
       baseline_args:
         description: "Extra CLI args for the baseline reth node"
         required: false
@@ -163,6 +166,7 @@ jobs:
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work
       BENCH_CORES: ${{ inputs.cores || '6' }}
       BENCH_MEMORY_MAX: "32G"
+      BENCH_RESET_STRATEGY: ${{ inputs.reset_strategy || 'unwind' }}
       BENCH_BASELINE_ARGS: ${{ inputs.baseline_args || '' }}
       BENCH_FEATURE_ARGS: ${{ inputs.feature_args || '' }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
@@ -172,7 +176,7 @@ jobs:
       BENCHMARKOOR_TEST_TYPE: ${{ inputs.test_type || 'stateful' }}
       BENCHMARKOOR_METADATA_ROOT: ${{ inputs.metadata_root || '~/projects/benchmarkoor-tests/configs' }}
       BENCHMARKOOR_SNAPSHOT: ${{ inputs.snapshot || 'minio/reth-snapshots/perfnet-24358000-full/' }}
-      BENCHMARKOOR_SNAPSHOT_MC_ROOT: ${{ inputs.snapshot_mc_root || 'minio' }}
+      BENCHMARKOOR_SNAPSHOT_MC_ROOT: "minio"
       BENCHMARKOOR_REPLAY_PATH: ${{ inputs.benchmarkoor_replay_path || '~/projects/benchmarkoor-replay' }}
       BENCHMARKOOR_CACHE: ${{ github.workspace }}/bench-work/benchmarkoor-cache
     steps:

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -603,7 +603,15 @@ jobs:
         run: |
           set -euo pipefail
           RESULTS="$BENCH_WORK_DIR/results.jsonl"
-          find "$BENCH_WORK_DIR" -path '*/results.jsonl' -print0 | xargs -0 cat > "$RESULTS"
+          TMP_RESULTS="$BENCH_WORK_DIR/results.merged.jsonl"
+          rm -f "$RESULTS" "$TMP_RESULTS"
+          mapfile -d '' RESULT_FILES < <(find "$BENCH_WORK_DIR" -path '*/results.jsonl' -print0)
+          if [ "${#RESULT_FILES[@]}" -eq 0 ]; then
+            echo "::error::No per-run benchmarkoor results found"
+            exit 1
+          fi
+          cat "${RESULT_FILES[@]}" > "$TMP_RESULTS"
+          mv "$TMP_RESULTS" "$RESULTS"
           python3 .github/scripts/bench-benchmarkoor-summary.py \
             --results "$RESULTS" \
             --output-json "$BENCH_WORK_DIR/summary.json" \

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -240,6 +240,9 @@ jobs:
 
       - name: Install benchmarkoor-replay
         env:
+          BENCHMARKOOR_REPLAY_DEPLOY_KEY: ${{ secrets.BENCHMARKOOR_REPLAY_DEPLOY_KEY }}
+          BENCHMARKOOR_REPLAY_TOKEN: ${{ secrets.BENCHMARKOOR_REPLAY_TOKEN }}
+          GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
         run: |
           set -euo pipefail
@@ -257,14 +260,28 @@ jobs:
           else
             replay_path="$BENCH_WORK_DIR/benchmarkoor-replay"
             rm -rf "$replay_path"
-            clone_url="https://github.com/tempoxyz/benchmarkoor-replay"
-            if [ -n "${DEREK_TOKEN:-}" ]; then
-              clone_url="https://x-access-token:${DEREK_TOKEN}@github.com/tempoxyz/benchmarkoor-replay"
+
+            if [ -n "${BENCHMARKOOR_REPLAY_DEPLOY_KEY:-}" ]; then
+              mkdir -p "$HOME/.ssh"
+              printf '%s\n' "$BENCHMARKOOR_REPLAY_DEPLOY_KEY" > "$HOME/.ssh/benchmarkoor_replay_deploy_key"
+              chmod 600 "$HOME/.ssh/benchmarkoor_replay_deploy_key"
+              ssh-keyscan github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
+              GIT_SSH_COMMAND="ssh -i $HOME/.ssh/benchmarkoor_replay_deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new" \
+                git clone --depth 1 git@github.com:tempoxyz/benchmarkoor-replay.git "$replay_path" || rm -rf "$replay_path"
             fi
-            if ! git clone --depth 1 "$clone_url" "$replay_path"; then
+
+            auth_token="${BENCHMARKOOR_REPLAY_TOKEN:-${GH_PROJECT_TOKEN:-${DEREK_TOKEN:-}}}"
+            if [ ! -d "$replay_path" ] && [ -n "$auth_token" ]; then
+              git clone --depth 1 "https://x-access-token:${auth_token}@github.com/tempoxyz/benchmarkoor-replay" "$replay_path" || rm -rf "$replay_path"
+            fi
+
+            if [ ! -d "$replay_path" ]; then
               rm -rf "$replay_path"
               GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new" \
-                git clone --depth 1 git@github.com:tempoxyz/benchmarkoor-replay.git "$replay_path"
+                git clone --depth 1 git@github.com:tempoxyz/benchmarkoor-replay.git "$replay_path" || {
+                  echo "::error::benchmarkoor-replay was not found at ${BENCHMARKOOR_REPLAY_PATH} and could not be cloned. Install it under ~/projects/benchmarkoor-replay on the runner, grant GH_PROJECT_TOKEN/DEREK_TOKEN read access to tempoxyz/benchmarkoor-replay, or add BENCHMARKOOR_REPLAY_DEPLOY_KEY/BENCHMARKOOR_REPLAY_TOKEN."
+                  exit 1
+                }
             fi
           fi
 

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -104,9 +104,9 @@ on:
         default: ""
         type: string
       limit:
-        description: "Maximum matching tests to run"
+        description: "Maximum matching tests to run (0 = all)"
         required: false
-        default: "20"
+        default: "0"
         type: string
       repetitions:
         description: "Runs per side: 1 or 2"
@@ -451,11 +451,11 @@ jobs:
           GAS_BUCKET: ${{ inputs.gas_bucket || '' }}
           CACHE_STRATEGY: ${{ inputs.cache_strategy || '' }}
           ACCOUNT_MODE: ${{ inputs.account_mode || '' }}
-          LIMIT: ${{ inputs.limit || '1' }}
+          LIMIT: ${{ inputs.limit || '0' }}
         run: |
           set -euo pipefail
-          if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [ "$LIMIT" -lt 1 ]; then
-            echo "::error::limit must be a positive integer"
+          if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+            echo "::error::limit must be a non-negative integer"
             exit 1
           fi
 
@@ -494,7 +494,7 @@ jobs:
               | select($gas_bucket == "" or ((.metadata.gas_bucket // "" | norm) == ($gas_bucket | norm)))
               | select($cache_strategy == "" or ((.metadata.cache_strategy // "" | norm) == ($cache_strategy | norm)))
               | select($account_mode == "" or ((.metadata.account_mode // "" | norm) == ($account_mode | norm)))
-            ][: $limit]
+            ] | if $limit > 0 then .[: $limit] else . end
             | .[]
             | {name, gas_bucket: .metadata.gas_bucket, opcode: .metadata.opcode, cache_strategy: .metadata.cache_strategy, account_mode: .metadata.account_mode}
             ' "$INDEX" > "$TESTS_FILE"

--- a/.github/workflows/bench-benchmarkoor.yml
+++ b/.github/workflows/bench-benchmarkoor.yml
@@ -326,7 +326,11 @@ jobs:
           resolve_ref() {
             local ref="$1"
             git fetch origin "$ref" --quiet 2>/dev/null || true
-            git rev-parse "$ref" 2>/dev/null || git rev-parse "origin/$ref"
+            if git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+              git rev-parse --verify "${ref}^{commit}"
+            else
+              git rev-parse --verify "origin/${ref}^{commit}"
+            fi
           }
 
           if [ -n "$INPUT_PR" ]; then
@@ -345,10 +349,10 @@ jobs:
           BASELINE_REF="$(resolve_ref "$BASELINE_NAME")"
 
           {
-            echo "feature-ref=$FEATURE_REF"
-            echo "feature-name=$FEATURE_NAME"
-            echo "baseline-ref=$BASELINE_REF"
-            echo "baseline-name=$BASELINE_NAME"
+            printf 'feature-ref=%s\n' "$FEATURE_REF"
+            printf 'feature-name=%s\n' "$FEATURE_NAME"
+            printf 'baseline-ref=%s\n' "$BASELINE_REF"
+            printf 'baseline-name=%s\n' "$BASELINE_NAME"
           } >> "$GITHUB_OUTPUT"
 
       - name: Prepare source dirs


### PR DESCRIPTION
## Summary
Adds a new `bench-benchmarkoor` workflow that replays a selected benchmarkoor test set against a feature branch or PR and compares it with `main`.

The workflow imports the perfnet MinIO snapshot, checkpoints with schelk after gas bump and funding, and then runs the measured replay through `benchmarkoor-replay`.