### PR TITLE
fix(net): bind discovery to net-if address

### DIFF
--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -10,9 +10,86 @@ use reth_e2e_test_utils::{
     setup, setup_engine, setup_engine_with_connection, transaction::TransactionTestContext,
     wallet::Wallet,
 };
+use reth_network::{NetworkInfo, PeersInfo};
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::NetworkArgs, node_config::NodeConfig};
 use reth_node_ethereum::EthereumNode;
 use reth_rpc_api::EthApiServer;
-use std::{sync::Arc, time::Duration};
+use reth_tasks::Runtime;
+use std::{net::UdpSocket, sync::Arc, time::Duration};
+
+#[tokio::test]
+async fn can_launch_with_net_if_and_shared_discovery_port() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let runtime = Runtime::test();
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let discovery_port = unused_udp_port();
+    let mut network = NetworkArgs::default().with_unused_p2p_port();
+    network.bootnodes = Some(Vec::new());
+    network.net_if = Some(loopback_net_if().to_string());
+    network.discovery.disable_dns_discovery = true;
+    network.discovery.disable_nat = true;
+    network.discovery.port = discovery_port;
+    network.discovery.discv5_port = None;
+    network.discovery.discv5_port_ipv6 = None;
+
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_network(network);
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(runtime)
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    assert!(node.network.discv4().is_some());
+    assert!(node.network.discv5().is_some());
+    assert!(node.network.local_addr().ip().is_loopback());
+
+    let local_node_record = node.network.local_node_record();
+    let discv5_port = node.network.discv5().expect("discv5 should be enabled").local_port();
+    assert!(local_node_record.address.is_loopback());
+    assert_eq!(local_node_record.udp_port, discovery_port);
+    assert_eq!(discv5_port, discovery_port);
+
+    Ok(())
+}
+
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+const fn loopback_net_if() -> &'static str {
+    "lo0"
+}
+
+#[cfg(not(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd"
+)))]
+const fn loopback_net_if() -> &'static str {
+    "lo"
+}
+
+fn unused_udp_port() -> u16 {
+    UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .expect("failed to bind temporary UDP socket")
+        .local_addr()
+        .expect("failed to read temporary UDP socket address")
+        .port()
+}
 
 #[tokio::test]
 async fn can_sync() -> eyre::Result<()> {

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -375,6 +375,8 @@ pub struct NetworkArgs {
     /// Name of network interface used to communicate with peers.
     ///
     /// If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+    /// If `--discovery.addr` is left at its default, discv4 will also bind to the resolved
+    /// interface address.
     #[arg(long = "net-if.experimental", conflicts_with = "addr", value_name = "IF_NAME")]
     pub net_if: Option<String>,
 
@@ -441,7 +443,13 @@ pub struct NetworkArgs {
 }
 
 impl NetworkArgs {
-    /// Returns the resolved IP address.
+    /// Returns the IP address used for the `RLPx` TCP listener.
+    ///
+    /// If `--net-if.experimental` is set, this resolves the interface name to a concrete local IP
+    /// address. That concrete address is also passed to discv5 as the default address to advertise
+    /// in the local ENR.
+    ///
+    /// If no interface is configured, this returns the configured `--addr` value.
     pub fn resolved_addr(&self) -> IpAddr {
         if let Some(ref if_name) = self.net_if {
             let if_name = if if_name.is_empty() { DEFAULT_NET_IF_NAME } else { if_name };
@@ -460,6 +468,21 @@ impl NetworkArgs {
         }
 
         self.addr
+    }
+
+    /// Returns the IP address used for the discovery v4 UDP bind socket.
+    ///
+    /// By default this is `--discovery.addr`. When `--net-if.experimental` is set and
+    /// `--discovery.addr` is still the wildcard default, discovery v4 follows the resolved `RLPx`
+    /// listener address. That keeps discv4 and discv5 on the same concrete UDP address when they
+    /// share a port; otherwise discv4 would bind wildcard while discv5 binds the resolved
+    /// interface address, which prevents socket sharing.
+    fn resolved_discovery_addr(&self, listener_addr: IpAddr) -> IpAddr {
+        if self.net_if.is_some() && self.discovery.addr == DEFAULT_DISCOVERY_ADDR {
+            return listener_addr;
+        }
+
+        self.discovery.addr
     }
 
     /// Returns the resolved bootnodes if any are provided.
@@ -532,7 +555,13 @@ impl NetworkArgs {
         default_peers_file: PathBuf,
         executor: Runtime,
     ) -> NetworkConfigBuilder<N> {
-        let addr = self.resolved_addr();
+        // `listener_addr` is the concrete RLPx TCP bind address. With `--net-if.experimental`,
+        // this is the resolved interface IP and is also used as discv5's default address.
+        let listener_addr = self.resolved_addr();
+        // Discovery v4 has its own CLI bind address. If left at the wildcard default while
+        // `--net-if.experimental` is active, make it follow the listener address so discv4 and
+        // discv5 can share the same UDP socket.
+        let discovery_addr = self.resolved_discovery_addr(listener_addr);
         let chain_bootnodes = self
             .resolved_bootnodes()
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
@@ -569,11 +598,11 @@ impl NetworkArgs {
             })
             // apply discovery settings
             .apply(|builder| {
-                let rlpx_socket = (addr, self.port).into();
+                let rlpx_socket = (listener_addr, self.port).into();
                 self.discovery.apply_to_builder(builder, rlpx_socket, chain_bootnodes)
             })
-            .listener_addr(SocketAddr::new(addr, self.port))
-            .discovery_addr(SocketAddr::new(self.discovery.addr, self.discovery.port))
+            .listener_addr(SocketAddr::new(listener_addr, self.port))
+            .discovery_addr(SocketAddr::new(discovery_addr, self.discovery.port))
             .disable_tx_gossip(self.disable_tx_gossip)
             .required_block_hashes(self.required_block_hashes.clone())
             .eth_max_message_size_opt(self.eth_max_message_size.map(NonZeroUsize::get))
@@ -907,6 +936,9 @@ pub struct DiscoveryArgs {
     pub disable_nat: bool,
 
     /// The UDP address to use for devp2p peer discovery version 4.
+    ///
+    /// If unset and `--net-if.experimental` is used, discv4 binds to the resolved interface
+    /// address.
     #[arg(id = "discovery.addr", long = "discovery.addr", value_name = "DISCOVERY_ADDR", default_value_t = DefaultDiscoveryArgs::get_global().addr)]
     pub addr: IpAddr,
 
@@ -1311,6 +1343,39 @@ mod tests {
         let args = CommandParser::<NetworkArgs>::parse_from(["reth"]).args;
 
         assert_eq!(args, default_args);
+    }
+
+    #[test]
+    fn net_if_uses_resolved_addr_for_default_discovery_addr() {
+        let args =
+            CommandParser::<NetworkArgs>::parse_from(["reth", "--net-if.experimental", "en0"]).args;
+        let listener_addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+
+        assert_eq!(args.resolved_discovery_addr(listener_addr), listener_addr);
+    }
+
+    #[test]
+    fn net_if_preserves_custom_discovery_addr() {
+        let custom_discovery_addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+        let args = CommandParser::<NetworkArgs>::parse_from([
+            "reth",
+            "--net-if.experimental",
+            "en0",
+            "--discovery.addr",
+            "192.0.2.2",
+        ])
+        .args;
+        let listener_addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+
+        assert_eq!(args.resolved_discovery_addr(listener_addr), custom_discovery_addr);
+    }
+
+    #[test]
+    fn default_discovery_addr_is_preserved_without_net_if() {
+        let args = CommandParser::<NetworkArgs>::parse_from(["reth"]).args;
+        let listener_addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+
+        assert_eq!(args.resolved_discovery_addr(listener_addr), DEFAULT_DISCOVERY_ADDR);
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -94,7 +94,9 @@ Networking:
           Disable Nat discovery
 
       --discovery.addr <DISCOVERY_ADDR>
-          The UDP address to use for devp2p peer discovery version 4
+          The UDP address to use for devp2p peer discovery version 4.
+
+          If unset and `--net-if.experimental` is used, discv4 binds to the resolved interface address.
 
           [default: 0.0.0.0]
 
@@ -264,7 +266,7 @@ Networking:
       --net-if.experimental <IF_NAME>
           Name of network interface used to communicate with peers.
 
-          If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          If flag is set, but no value is passed, the default interface for docker `eth0` is tried. If `--discovery.addr` is left at its default, discv4 will also bind to the resolved interface address.
 
       --tx-propagation-policy <TX_PROPAGATION_POLICY>
           Transaction Propagation Policy

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -34,7 +34,9 @@ Networking:
           Disable Nat discovery
 
       --discovery.addr <DISCOVERY_ADDR>
-          The UDP address to use for devp2p peer discovery version 4
+          The UDP address to use for devp2p peer discovery version 4.
+
+          If unset and `--net-if.experimental` is used, discv4 binds to the resolved interface address.
 
           [default: 0.0.0.0]
 
@@ -204,7 +206,7 @@ Networking:
       --net-if.experimental <IF_NAME>
           Name of network interface used to communicate with peers.
 
-          If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          If flag is set, but no value is passed, the default interface for docker `eth0` is tried. If `--discovery.addr` is left at its default, discv4 will also bind to the resolved interface address.
 
       --tx-propagation-policy <TX_PROPAGATION_POLICY>
           Transaction Propagation Policy

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -34,7 +34,9 @@ Networking:
           Disable Nat discovery
 
       --discovery.addr <DISCOVERY_ADDR>
-          The UDP address to use for devp2p peer discovery version 4
+          The UDP address to use for devp2p peer discovery version 4.
+
+          If unset and `--net-if.experimental` is used, discv4 binds to the resolved interface address.
 
           [default: 0.0.0.0]
 
@@ -204,7 +206,7 @@ Networking:
       --net-if.experimental <IF_NAME>
           Name of network interface used to communicate with peers.
 
-          If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          If flag is set, but no value is passed, the default interface for docker `eth0` is tried. If `--discovery.addr` is left at its default, discv4 will also bind to the resolved interface address.
 
       --tx-propagation-policy <TX_PROPAGATION_POLICY>
           Transaction Propagation Policy

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -190,7 +190,9 @@ Networking:
           Disable Nat discovery
 
       --discovery.addr <DISCOVERY_ADDR>
-          The UDP address to use for devp2p peer discovery version 4
+          The UDP address to use for devp2p peer discovery version 4.
+
+          If unset and `--net-if.experimental` is used, discv4 binds to the resolved interface address.
 
           [default: 0.0.0.0]
 
@@ -360,7 +362,7 @@ Networking:
       --net-if.experimental <IF_NAME>
           Name of network interface used to communicate with peers.
 
-          If flag is set, but no value is passed, the default interface for docker `eth0` is tried.
+          If flag is set, but no value is passed, the default interface for docker `eth0` is tried. If `--discovery.addr` is left at its default, discv4 will also bind to the resolved interface address.
 
       --tx-propagation-policy <TX_PROPAGATION_POLICY>
           Transaction Propagation Policy


### PR DESCRIPTION
The crash came from the `NetworkArgs` settings flow resolving the RLPx/discv5 side to the selected `--net-if.experimental` interface while leaving default discv4 discovery on the wildcard bind address. With both discovery services using the same configured UDP port, startup could fail with `AddrInUse` from mismatched bind addresses.

This PR makes default discovery bind resolution follow the selected interface address in `NetworkArgs::network_config`, while preserving explicit `--discovery.addr` overrides. It adds settings tests, an Ethereum e2e launch test, and regenerated CLI docs for the updated flag help.
