### PR TITLE
bench: reduce false positives with between-pairing CI and unified bootstrap

### DIFF
--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -25,6 +25,9 @@ import sys
 
 GIGAGAS = 1_000_000_000
 BOOTSTRAP_ITERATIONS = 10_000
+# t-critical for between-pairing CI (df=3, 4 cross-pairings).
+# Set conservatively to reduce false positives from run-level bias.
+T_BETWEEN_PAIRINGS = 4.5
 
 
 def _opt_int(row: dict, key: str) -> int | None:
@@ -230,6 +233,22 @@ def _bootstrap_percentile_ci(
     return (boot_diffs[hi] - boot_diffs[lo]) / 2
 
 
+def _between_pairing_ci(pairing_means: list[float]) -> float:
+    """Compute CI half-width from the variance between pairing means.
+
+    This captures run-level bias (thermal drift, background load) that
+    per-block pooling cannot detect. Uses T_BETWEEN_PAIRINGS as the
+    t-critical value (conservative for df=3).
+    """
+    n = len(pairing_means)
+    if n < 2:
+        return 0.0
+    mean = sum(pairing_means) / n
+    sd = math.sqrt(sum((x - mean) ** 2 for x in pairing_means) / (n - 1))
+    se = sd / math.sqrt(n)
+    return T_BETWEEN_PAIRINGS * se
+
+
 def _cross_pair_directions(
     baseline_runs: list[list[dict]],
     feature_runs: list[list[dict]],
@@ -276,9 +295,11 @@ def compute_paired_stats(
     """Compute paired statistics between baseline and feature runs.
 
     Uses all cross-pairings (B1-F1, B2-F2, B1-F2, B2-F1) for pooled
-    diffs and CIs. Also checks that the direction of change agrees
-    across all pairings — if any pairing disagrees, the metric is
-    flagged for downgrade to neutral.
+    diffs and CIs. The final CI for each metric is the max of:
+    - Within-block bootstrap CI (captures per-block variance)
+    - Between-pairing CI (captures run-level bias)
+
+    Also checks that the direction of change agrees across all pairings.
     """
     # Generate all cross-pairings for pooled stats
     all_pairs = []
@@ -287,6 +308,11 @@ def compute_paired_stats(
     all_total_lat_diffs = []
     all_persist_diffs = []
     blocks_per_pair = []
+    # Per-pairing means for between-pairing CI
+    per_pairing_lat_means = []
+    per_pairing_mgas_means = []
+    per_pairing_total_lat_means = []
+    per_pairing_persist_means = []
     for baseline in baseline_runs:
         for feature in feature_runs:
             pairs, lat_diffs, mgas_diffs, total_lat_diffs, persist_diffs = _paired_data(baseline, feature)
@@ -296,6 +322,14 @@ def compute_paired_stats(
             all_total_lat_diffs.extend(total_lat_diffs)
             all_persist_diffs.extend(persist_diffs)
             blocks_per_pair.append(len(pairs))
+            if lat_diffs:
+                per_pairing_lat_means.append(sum(lat_diffs) / len(lat_diffs))
+            if mgas_diffs:
+                per_pairing_mgas_means.append(sum(mgas_diffs) / len(mgas_diffs))
+            if total_lat_diffs:
+                per_pairing_total_lat_means.append(sum(total_lat_diffs) / len(total_lat_diffs))
+            if persist_diffs:
+                per_pairing_persist_means.append(sum(persist_diffs) / len(persist_diffs))
 
     if not all_lat_diffs:
         return {}
@@ -305,11 +339,23 @@ def compute_paired_stats(
 
     rng = random.Random(42)
 
-    # Bootstrap CI for all metrics (unified approach)
-    ci = _bootstrap_ci(rng, all_lat_diffs)
-    mgas_ci = _bootstrap_ci(rng, all_mgas_diffs) if all_mgas_diffs else 0.0
-    wall_clock_ci_ms = _bootstrap_ci(rng, all_total_lat_diffs) if all_total_lat_diffs else 0.0
-    persist_ci_ms = _bootstrap_ci(rng, all_persist_diffs) if all_persist_diffs else 0.0
+    # Within-block bootstrap CI
+    ci_within = _bootstrap_ci(rng, all_lat_diffs)
+    mgas_ci_within = _bootstrap_ci(rng, all_mgas_diffs) if all_mgas_diffs else 0.0
+    wall_ci_within = _bootstrap_ci(rng, all_total_lat_diffs) if all_total_lat_diffs else 0.0
+    persist_ci_within = _bootstrap_ci(rng, all_persist_diffs) if all_persist_diffs else 0.0
+
+    # Between-pairing CI (run-level variance floor)
+    ci_between = _between_pairing_ci(per_pairing_lat_means)
+    mgas_ci_between = _between_pairing_ci(per_pairing_mgas_means)
+    wall_ci_between = _between_pairing_ci(per_pairing_total_lat_means)
+    persist_ci_between = _between_pairing_ci(per_pairing_persist_means)
+
+    # Final CI = max(within, between)
+    ci = max(ci_within, ci_between)
+    mgas_ci = max(mgas_ci_within, mgas_ci_between)
+    wall_clock_ci_ms = max(wall_ci_within, wall_ci_between)
+    persist_ci_ms = max(persist_ci_within, persist_ci_between)
 
     # Bootstrap CI for percentile diffs
     base_lats = sorted([p[0] for p in all_pairs])
@@ -318,9 +364,27 @@ def compute_paired_stats(
     p90_diff = percentile(feature_lats, 90) - percentile(base_lats, 90)
     p99_diff = percentile(feature_lats, 99) - percentile(base_lats, 99)
 
-    p50_ci = _bootstrap_percentile_ci(rng, all_pairs, 50)
-    p90_ci = _bootstrap_percentile_ci(rng, all_pairs, 90)
-    p99_ci = _bootstrap_percentile_ci(rng, all_pairs, 99)
+    p50_ci_within = _bootstrap_percentile_ci(rng, all_pairs, 50)
+    p90_ci_within = _bootstrap_percentile_ci(rng, all_pairs, 90)
+    p99_ci_within = _bootstrap_percentile_ci(rng, all_pairs, 99)
+
+    # Between-pairing CI for percentile diffs
+    per_pairing_p50_diffs = []
+    per_pairing_p90_diffs = []
+    per_pairing_p99_diffs = []
+    for baseline in baseline_runs:
+        for feature in feature_runs:
+            pairs_i, _, _, _, _ = _paired_data(baseline, feature)
+            if pairs_i:
+                b_sorted = sorted(p[0] for p in pairs_i)
+                f_sorted = sorted(p[1] for p in pairs_i)
+                per_pairing_p50_diffs.append(percentile(f_sorted, 50) - percentile(b_sorted, 50))
+                per_pairing_p90_diffs.append(percentile(f_sorted, 90) - percentile(b_sorted, 90))
+                per_pairing_p99_diffs.append(percentile(f_sorted, 99) - percentile(b_sorted, 99))
+
+    p50_ci = max(p50_ci_within, _between_pairing_ci(per_pairing_p50_diffs))
+    p90_ci = max(p90_ci_within, _between_pairing_ci(per_pairing_p90_diffs))
+    p99_ci = max(p99_ci_within, _between_pairing_ci(per_pairing_p99_diffs))
 
     mean_mgas_diff = sum(all_mgas_diffs) / len(all_mgas_diffs) if all_mgas_diffs else 0.0
 
@@ -423,7 +487,6 @@ def compute_changes(
     dirs = paired_stats.get("directions_agree", {})
 
     metrics = [
-        ("mean", "mean_ms", "ci_ms", "mean_ms", True, dirs.get("lat", True)),
         ("p50", "p50_ms", "p50_ci_ms", "p50_ms", True, dirs.get("lat", True)),
         ("p90", "p90_ms", "p90_ci_ms", "p90_ms", True, dirs.get("lat", True)),
         ("p99", "p99_ms", "p99_ci_ms", "p99_ms", True, dirs.get("lat", True)),
@@ -466,7 +529,6 @@ def generate_comparison_table(
     def pct(base: float, feat: float) -> float:
         return (feat - base) / base * 100.0 if base > 0 else 0.0
 
-    mean_pct = pct(run1["mean_ms"], run2["mean_ms"])
     gas_pct = pct(run1["mean_mgas_s"], run2["mean_mgas_s"])
     wall_pct = pct(run1["wall_clock_s"], run2["wall_clock_s"])
 
@@ -481,8 +543,7 @@ def generate_comparison_table(
     p90_ci_pct = paired["p90_ci_ms"] / run1["p90_ms"] * 100.0 if run1["p90_ms"] > 0 else 0.0
     p99_ci_pct = paired["p99_ci_ms"] / run1["p99_ms"] * 100.0 if run1["p99_ms"] > 0 else 0.0
 
-    # CI as a percentage of baseline mean
-    lat_ci_pct = paired["ci_ms"] / run1["mean_ms"] * 100.0 if run1["mean_ms"] > 0 else 0.0
+    # CI as a percentage of baseline
     mgas_ci_pct = paired["mgas_ci"] / run1["mean_mgas_s"] * 100.0 if run1["mean_mgas_s"] > 0 else 0.0
     wall_ci_pct = paired["wall_clock_ci_ms"] / run1["mean_total_lat_ms"] * 100.0 if run1["mean_total_lat_ms"] > 0 else 0.0
     persist_ci_pct = paired["persist_ci_ms"] / run1["mean_persist_ms"] * 100.0 if run1["mean_persist_ms"] > 0 else 0.0
@@ -500,8 +561,6 @@ def generate_comparison_table(
     lines = [
         f"| Metric | {baseline_label} | {feature_label} | Change |",
         "|--------|------|--------|--------|",
-        f"| Mean | {fmt_ms(run1['mean_ms'])} | {fmt_ms(run2['mean_ms'])} | {change_str(mean_pct, lat_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
-        f"| StdDev | {fmt_ms(run1['stddev_ms'])} | {fmt_ms(run2['stddev_ms'])} | |",
         f"| P50 | {fmt_ms(run1['p50_ms'])} | {fmt_ms(run2['p50_ms'])} | {change_str(p50_pct, p50_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
         f"| P90 | {fmt_ms(run1['p90_ms'])} | {fmt_ms(run2['p90_ms'])} | {change_str(p90_pct, p90_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
         f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -230,29 +230,72 @@ def _bootstrap_percentile_ci(
     return (boot_diffs[hi] - boot_diffs[lo]) / 2
 
 
+def _cross_pair_directions(
+    baseline_runs: list[list[dict]],
+    feature_runs: list[list[dict]],
+) -> dict[str, bool]:
+    """Check if the direction of change agrees across all cross-pairings.
+
+    With ABBA runs [B1, B2] and [F1, F2], generates all 4 pairings:
+    (B1,F1), (B2,F2), (B1,F2), (B2,F1). For each metric, returns True
+    only if the mean diff has the same sign across all pairings.
+
+    With a single run pair, always returns True (no cross-check possible).
+    """
+    if len(baseline_runs) < 2 or len(feature_runs) < 2:
+        return {
+            "lat": True, "mgas": True, "total_lat": True, "persist": True,
+        }
+
+    cross_pairs = []
+    for b in baseline_runs:
+        for f in feature_runs:
+            cross_pairs.append(_paired_data(b, f))
+
+    def _signs_agree(diffs_per_pair: list[list[float]]) -> bool:
+        means = []
+        for diffs in diffs_per_pair:
+            if diffs:
+                means.append(sum(diffs) / len(diffs))
+        if len(means) < 2:
+            return True
+        return all(m > 0 for m in means) or all(m < 0 for m in means) or all(m == 0 for m in means)
+
+    return {
+        "lat": _signs_agree([cp[1] for cp in cross_pairs]),
+        "mgas": _signs_agree([cp[2] for cp in cross_pairs]),
+        "total_lat": _signs_agree([cp[3] for cp in cross_pairs]),
+        "persist": _signs_agree([cp[4] for cp in cross_pairs]),
+    }
+
+
 def compute_paired_stats(
     baseline_runs: list[list[dict]],
     feature_runs: list[list[dict]],
 ) -> dict:
     """Compute paired statistics between baseline and feature runs.
 
-    Each pair (baseline_runs[i], feature_runs[i]) produces per-block diffs.
-    All diffs are pooled and CIs are computed via bootstrap resampling.
+    Uses all cross-pairings (B1-F1, B2-F2, B1-F2, B2-F1) for pooled
+    diffs and CIs. Also checks that the direction of change agrees
+    across all pairings — if any pairing disagrees, the metric is
+    flagged for downgrade to neutral.
     """
+    # Generate all cross-pairings for pooled stats
     all_pairs = []
     all_lat_diffs = []
     all_mgas_diffs = []
     all_total_lat_diffs = []
     all_persist_diffs = []
     blocks_per_pair = []
-    for baseline, feature in zip(baseline_runs, feature_runs):
-        pairs, lat_diffs, mgas_diffs, total_lat_diffs, persist_diffs = _paired_data(baseline, feature)
-        all_pairs.extend(pairs)
-        all_lat_diffs.extend(lat_diffs)
-        all_mgas_diffs.extend(mgas_diffs)
-        all_total_lat_diffs.extend(total_lat_diffs)
-        all_persist_diffs.extend(persist_diffs)
-        blocks_per_pair.append(len(pairs))
+    for baseline in baseline_runs:
+        for feature in feature_runs:
+            pairs, lat_diffs, mgas_diffs, total_lat_diffs, persist_diffs = _paired_data(baseline, feature)
+            all_pairs.extend(pairs)
+            all_lat_diffs.extend(lat_diffs)
+            all_mgas_diffs.extend(mgas_diffs)
+            all_total_lat_diffs.extend(total_lat_diffs)
+            all_persist_diffs.extend(persist_diffs)
+            blocks_per_pair.append(len(pairs))
 
     if not all_lat_diffs:
         return {}
@@ -281,6 +324,9 @@ def compute_paired_stats(
 
     mean_mgas_diff = sum(all_mgas_diffs) / len(all_mgas_diffs) if all_mgas_diffs else 0.0
 
+    # Cross-pair direction agreement
+    directions = _cross_pair_directions(baseline_runs, feature_runs)
+
     return {
         "n": n,
         "mean_diff_ms": mean_diff,
@@ -296,6 +342,7 @@ def compute_paired_stats(
         "wall_clock_ci_ms": wall_clock_ci_ms,
         "persist_ci_ms": persist_ci_ms,
         "blocks": max(blocks_per_pair),
+        "directions_agree": directions,
     }
 
 
@@ -335,9 +382,14 @@ def display_bal_mode(bal_mode: str | None) -> str | None:
     return bal_mode
 
 
-def significance(pct: float, ci_pct: float, lower_is_better: bool) -> str:
-    """Return significance label: 'good', 'bad', or 'neutral'."""
-    significant = abs(pct) > ci_pct
+def significance(pct: float, ci_pct: float, lower_is_better: bool, directions_agree: bool = True) -> str:
+    """Return significance label: 'good', 'bad', or 'neutral'.
+
+    A result is only significant if:
+    1. The CI doesn't cross zero (|pct| > ci_pct), AND
+    2. All cross-pairings agree on direction (directions_agree=True).
+    """
+    significant = abs(pct) > ci_pct and directions_agree
     if not significant:
         return "neutral"
     elif (pct < 0) == lower_is_better:
@@ -346,14 +398,16 @@ def significance(pct: float, ci_pct: float, lower_is_better: bool) -> str:
         return "bad"
 
 
-def change_str(pct: float, ci_pct: float, lower_is_better: bool) -> str:
+def change_str(pct: float, ci_pct: float, lower_is_better: bool, directions_agree: bool = True) -> str:
     """Format change% with paired CI significance.
 
-    Significant if the CI doesn't cross zero (i.e. |pct| > ci_pct).
+    Significant if the CI doesn't cross zero (i.e. |pct| > ci_pct)
+    AND all cross-pairings agree on direction.
     """
-    sig = significance(pct, ci_pct, lower_is_better)
+    sig = significance(pct, ci_pct, lower_is_better, directions_agree)
     emoji = {"good": "✅", "bad": "❌", "neutral": "⚪"}[sig]
-    return f"{pct:+.2f}% {emoji} (±{ci_pct:.2f}%)"
+    qualifier = "" if directions_agree else " ↕"
+    return f"{pct:+.2f}% {emoji}{qualifier} (±{ci_pct:.2f}%)"
 
 
 def compute_changes(
@@ -366,23 +420,26 @@ def compute_changes(
     def ci_pct(ci_ms: float, base_ms: float) -> float:
         return ci_ms / base_ms * 100.0 if base_ms > 0 else 0.0
 
+    dirs = paired_stats.get("directions_agree", {})
+
     metrics = [
-        ("mean", "mean_ms", "ci_ms", "mean_ms", True),
-        ("p50", "p50_ms", "p50_ci_ms", "p50_ms", True),
-        ("p90", "p90_ms", "p90_ci_ms", "p90_ms", True),
-        ("p99", "p99_ms", "p99_ci_ms", "p99_ms", True),
-        ("mgas_s", "mean_mgas_s", "mgas_ci", "mean_mgas_s", False),
-        ("wall_clock", "wall_clock_s", "wall_clock_ci_ms", "mean_total_lat_ms", True),
-        ("persist_wait", "mean_persist_ms", "persist_ci_ms", "mean_persist_ms", True),
+        ("mean", "mean_ms", "ci_ms", "mean_ms", True, dirs.get("lat", True)),
+        ("p50", "p50_ms", "p50_ci_ms", "p50_ms", True, dirs.get("lat", True)),
+        ("p90", "p90_ms", "p90_ci_ms", "p90_ms", True, dirs.get("lat", True)),
+        ("p99", "p99_ms", "p99_ci_ms", "p99_ms", True, dirs.get("lat", True)),
+        ("mgas_s", "mean_mgas_s", "mgas_ci", "mean_mgas_s", False, dirs.get("mgas", True)),
+        ("wall_clock", "wall_clock_s", "wall_clock_ci_ms", "mean_total_lat_ms", True, dirs.get("total_lat", True)),
+        ("persist_wait", "mean_persist_ms", "persist_ci_ms", "mean_persist_ms", True, dirs.get("persist", True)),
     ]
     changes = {}
-    for name, stat_key, ci_key, base_key, lower_is_better in metrics:
+    for name, stat_key, ci_key, base_key, lower_is_better, dir_agree in metrics:
         p = pct(baseline_stats[stat_key], feature_stats[stat_key])
         c = ci_pct(paired_stats[ci_key], baseline_stats[base_key])
         changes[name] = {
             "pct": round(p, 4),
             "ci_pct": round(c, 4),
-            "sig": significance(p, c, lower_is_better),
+            "sig": significance(p, c, lower_is_better, dir_agree),
+            "directions_agree": dir_agree,
         }
     return changes
 
@@ -430,6 +487,12 @@ def generate_comparison_table(
     wall_ci_pct = paired["wall_clock_ci_ms"] / run1["mean_total_lat_ms"] * 100.0 if run1["mean_total_lat_ms"] > 0 else 0.0
     persist_ci_pct = paired["persist_ci_ms"] / run1["mean_persist_ms"] * 100.0 if run1["mean_persist_ms"] > 0 else 0.0
 
+    dirs = paired.get("directions_agree", {})
+    lat_agree = dirs.get("lat", True)
+    mgas_agree = dirs.get("mgas", True)
+    total_agree = dirs.get("total_lat", True)
+    persist_agree = dirs.get("persist", True)
+
     base_url = f"https://github.com/{repo}/commit"
     baseline_label = f"[`{baseline_name}`]({base_url}/{baseline_ref})"
     feature_label = f"[`{feature_name}`]({base_url}/{feature_sha})"
@@ -437,14 +500,14 @@ def generate_comparison_table(
     lines = [
         f"| Metric | {baseline_label} | {feature_label} | Change |",
         "|--------|------|--------|--------|",
-        f"| Mean | {fmt_ms(run1['mean_ms'])} | {fmt_ms(run2['mean_ms'])} | {change_str(mean_pct, lat_ci_pct, lower_is_better=True)} |",
+        f"| Mean | {fmt_ms(run1['mean_ms'])} | {fmt_ms(run2['mean_ms'])} | {change_str(mean_pct, lat_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
         f"| StdDev | {fmt_ms(run1['stddev_ms'])} | {fmt_ms(run2['stddev_ms'])} | |",
-        f"| P50 | {fmt_ms(run1['p50_ms'])} | {fmt_ms(run2['p50_ms'])} | {change_str(p50_pct, p50_ci_pct, lower_is_better=True)} |",
-        f"| P90 | {fmt_ms(run1['p90_ms'])} | {fmt_ms(run2['p90_ms'])} | {change_str(p90_pct, p90_ci_pct, lower_is_better=True)} |",
-        f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, lower_is_better=True)} |",
-        f"| Mgas/s | {fmt_mgas(run1['mean_mgas_s'])} | {fmt_mgas(run2['mean_mgas_s'])} | {change_str(gas_pct, mgas_ci_pct, lower_is_better=False)} |",
-        f"| Wall Clock | {fmt_s(run1['wall_clock_s'])} | {fmt_s(run2['wall_clock_s'])} | {change_str(wall_pct, wall_ci_pct, lower_is_better=True)} |",
-        f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, lower_is_better=True)} |",
+        f"| P50 | {fmt_ms(run1['p50_ms'])} | {fmt_ms(run2['p50_ms'])} | {change_str(p50_pct, p50_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
+        f"| P90 | {fmt_ms(run1['p90_ms'])} | {fmt_ms(run2['p90_ms'])} | {change_str(p90_pct, p90_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
+        f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, lower_is_better=True, directions_agree=lat_agree)} |",
+        f"| Mgas/s | {fmt_mgas(run1['mean_mgas_s'])} | {fmt_mgas(run2['mean_mgas_s'])} | {change_str(gas_pct, mgas_ci_pct, lower_is_better=False, directions_agree=mgas_agree)} |",
+        f"| Wall Clock | {fmt_s(run1['wall_clock_s'])} | {fmt_s(run2['wall_clock_s'])} | {change_str(wall_pct, wall_ci_pct, lower_is_better=True, directions_agree=total_agree)} |",
+        f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, lower_is_better=True, directions_agree=persist_agree)} |",
         "",
     ]
     meta_parts = [f"{n} {'big blocks' if big_blocks else 'blocks'}"]

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -195,66 +195,13 @@ def _paired_data(
     return pairs, lat_diffs_ms, mgas_diffs, total_lat_diffs_ms, persist_diffs_ms
 
 
-def _optimal_block_size(diffs: list[float]) -> int:
-    """Estimate optimal block size for block bootstrap using Newey-West
-    autocorrelation structure.
-
-    Uses the lag-1 autocorrelation to pick a block length that captures
-    serial dependence (e.g., from persistence phase offsets affecting
-    consecutive blocks). Falls back to 1 (iid bootstrap) when
-    autocorrelation is negligible.
-    """
-    n = len(diffs)
-    if n < 10:
-        return 1
-    mean = sum(diffs) / n
-    centered = [d - mean for d in diffs]
-
-    # Compute variance and lag-1 autocovariance
-    var = sum(c * c for c in centered) / n
-    if var < 1e-15:
-        return 1
-    cov1 = sum(centered[i] * centered[i + 1] for i in range(n - 1)) / n
-    rho = cov1 / var
-
-    # Politis & White (2004) rule-of-thumb: block_size ~ (2*rho/(1-rho^2))^(2/3) * n^(1/3)
-    # Clamp rho to avoid blowup near |rho| = 1
-    rho = max(-0.99, min(0.99, rho))
-    if abs(rho) < 0.02:
-        return 1
-    raw = abs(2.0 * rho / (1.0 - rho * rho)) ** (2.0 / 3.0) * n ** (1.0 / 3.0)
-    block_size = max(1, min(int(round(raw)), n // 4))
-    return block_size
-
-
-def _block_bootstrap_sample(rng: random.Random, data: list, block_size: int) -> list:
-    """Draw a block bootstrap sample of length len(data)."""
-    n = len(data)
-    if block_size <= 1:
-        return rng.choices(data, k=n)
-    result = []
-    while len(result) < n:
-        start = rng.randrange(n)
-        for j in range(block_size):
-            if len(result) >= n:
-                break
-            result.append(data[(start + j) % n])
-    return result
-
-
 def _bootstrap_ci(rng: random.Random, diffs: list[float], n_iter: int = BOOTSTRAP_ITERATIONS) -> float:
-    """Compute 95% bootstrap CI half-width for the mean of *diffs*.
-
-    Uses block bootstrap with Newey-West-derived block size to account
-    for autocorrelation in consecutive block diffs.
-    """
+    """Compute 95% bootstrap CI half-width for the mean of *diffs*."""
     if len(diffs) < 2:
         return 0.0
     n = len(diffs)
-    block_size = _optimal_block_size(diffs)
     boot_means = sorted(
-        sum(_block_bootstrap_sample(rng, diffs, block_size)) / n
-        for _ in range(n_iter)
+        sum(rng.choices(diffs, k=n)) / n for _ in range(n_iter)
     )
     lo = int(n_iter * 0.025)
     hi = int(n_iter * 0.975)
@@ -267,19 +214,13 @@ def _bootstrap_percentile_ci(
     pct: int,
     n_iter: int = BOOTSTRAP_ITERATIONS,
 ) -> float:
-    """Compute 95% bootstrap CI half-width for a difference-of-percentiles.
-
-    Uses block bootstrap to preserve autocorrelation structure.
-    """
+    """Compute 95% bootstrap CI half-width for a difference-of-percentiles."""
     if len(pairs) < 2:
         return 0.0
     n = len(pairs)
-    # Use latency diffs to determine block size (they carry the autocorrelation)
-    lat_diffs = [p[1] - p[0] for p in pairs]
-    block_size = _optimal_block_size(lat_diffs)
     boot_diffs = []
     for _ in range(n_iter):
-        sample = _block_bootstrap_sample(rng, pairs, block_size)
+        sample = rng.choices(pairs, k=n)
         b_sorted = sorted(p[0] for p in sample)
         f_sorted = sorted(p[1] for p in sample)
         boot_diffs.append(percentile(f_sorted, pct) - percentile(b_sorted, pct))

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -24,7 +24,6 @@ import random
 import sys
 
 GIGAGAS = 1_000_000_000
-T_CRITICAL = 1.96  # two-tailed 95% confidence
 BOOTSTRAP_ITERATIONS = 10_000
 
 
@@ -196,6 +195,41 @@ def _paired_data(
     return pairs, lat_diffs_ms, mgas_diffs, total_lat_diffs_ms, persist_diffs_ms
 
 
+def _bootstrap_ci(rng: random.Random, diffs: list[float], n_iter: int = BOOTSTRAP_ITERATIONS) -> float:
+    """Compute 95% bootstrap CI half-width for the mean of *diffs*."""
+    if len(diffs) < 2:
+        return 0.0
+    n = len(diffs)
+    boot_means = sorted(
+        sum(rng.choices(diffs, k=n)) / n for _ in range(n_iter)
+    )
+    lo = int(n_iter * 0.025)
+    hi = int(n_iter * 0.975)
+    return (boot_means[hi] - boot_means[lo]) / 2
+
+
+def _bootstrap_percentile_ci(
+    rng: random.Random,
+    pairs: list[tuple[float, float]],
+    pct: int,
+    n_iter: int = BOOTSTRAP_ITERATIONS,
+) -> float:
+    """Compute 95% bootstrap CI half-width for a difference-of-percentiles."""
+    if len(pairs) < 2:
+        return 0.0
+    n = len(pairs)
+    boot_diffs = []
+    for _ in range(n_iter):
+        sample = rng.choices(pairs, k=n)
+        b_sorted = sorted(p[0] for p in sample)
+        f_sorted = sorted(p[1] for p in sample)
+        boot_diffs.append(percentile(f_sorted, pct) - percentile(b_sorted, pct))
+    boot_diffs.sort()
+    lo = int(n_iter * 0.025)
+    hi = int(n_iter * 0.975)
+    return (boot_diffs[hi] - boot_diffs[lo]) / 2
+
+
 def compute_paired_stats(
     baseline_runs: list[list[dict]],
     feature_runs: list[list[dict]],
@@ -203,7 +237,7 @@ def compute_paired_stats(
     """Compute paired statistics between baseline and feature runs.
 
     Each pair (baseline_runs[i], feature_runs[i]) produces per-block diffs.
-    All diffs are pooled for the final CI.
+    All diffs are pooled and CIs are computed via bootstrap resampling.
     """
     all_pairs = []
     all_lat_diffs = []
@@ -225,57 +259,38 @@ def compute_paired_stats(
 
     n = len(all_lat_diffs)
     mean_diff = sum(all_lat_diffs) / n
-    std_diff = stddev(all_lat_diffs, mean_diff)
-    se = std_diff / math.sqrt(n) if n > 0 else 0.0
-    ci = T_CRITICAL * se
 
-    # Bootstrap CI on difference-of-percentiles (resample paired blocks)
+    rng = random.Random(42)
+
+    # Bootstrap CI for all metrics (unified approach)
+    ci = _bootstrap_ci(rng, all_lat_diffs)
+    mgas_ci = _bootstrap_ci(rng, all_mgas_diffs) if all_mgas_diffs else 0.0
+    wall_clock_ci_ms = _bootstrap_ci(rng, all_total_lat_diffs) if all_total_lat_diffs else 0.0
+    persist_ci_ms = _bootstrap_ci(rng, all_persist_diffs) if all_persist_diffs else 0.0
+
+    # Bootstrap CI for percentile diffs
     base_lats = sorted([p[0] for p in all_pairs])
     feature_lats = sorted([p[1] for p in all_pairs])
     p50_diff = percentile(feature_lats, 50) - percentile(base_lats, 50)
     p90_diff = percentile(feature_lats, 90) - percentile(base_lats, 90)
     p99_diff = percentile(feature_lats, 99) - percentile(base_lats, 99)
 
-    rng = random.Random(42)
-    p50_boot, p90_boot, p99_boot = [], [], []
-    for _ in range(BOOTSTRAP_ITERATIONS):
-        sample = rng.choices(all_pairs, k=n)
-        b_sorted = sorted(p[0] for p in sample)
-        f_sorted = sorted(p[1] for p in sample)
-        p50_boot.append(percentile(f_sorted, 50) - percentile(b_sorted, 50))
-        p90_boot.append(percentile(f_sorted, 90) - percentile(b_sorted, 90))
-        p99_boot.append(percentile(f_sorted, 99) - percentile(b_sorted, 99))
-    p50_boot.sort()
-    p90_boot.sort()
-    p99_boot.sort()
-    lo = int(BOOTSTRAP_ITERATIONS * 0.025)
-    hi = int(BOOTSTRAP_ITERATIONS * 0.975)
+    p50_ci = _bootstrap_percentile_ci(rng, all_pairs, 50)
+    p90_ci = _bootstrap_percentile_ci(rng, all_pairs, 90)
+    p99_ci = _bootstrap_percentile_ci(rng, all_pairs, 99)
 
     mean_mgas_diff = sum(all_mgas_diffs) / len(all_mgas_diffs) if all_mgas_diffs else 0.0
-    std_mgas_diff = stddev(all_mgas_diffs, mean_mgas_diff) if len(all_mgas_diffs) > 1 else 0.0
-    mgas_se = std_mgas_diff / math.sqrt(len(all_mgas_diffs)) if all_mgas_diffs else 0.0
-    mgas_ci = T_CRITICAL * mgas_se
-
-    mean_total_diff = sum(all_total_lat_diffs) / len(all_total_lat_diffs) if all_total_lat_diffs else 0.0
-    std_total_diff = stddev(all_total_lat_diffs, mean_total_diff) if len(all_total_lat_diffs) > 1 else 0.0
-    total_se = std_total_diff / math.sqrt(len(all_total_lat_diffs)) if all_total_lat_diffs else 0.0
-    wall_clock_ci_ms = T_CRITICAL * total_se
-
-    mean_persist_diff = sum(all_persist_diffs) / len(all_persist_diffs) if all_persist_diffs else 0.0
-    std_persist_diff = stddev(all_persist_diffs, mean_persist_diff) if len(all_persist_diffs) > 1 else 0.0
-    persist_se = std_persist_diff / math.sqrt(len(all_persist_diffs)) if all_persist_diffs else 0.0
-    persist_ci_ms = T_CRITICAL * persist_se
 
     return {
         "n": n,
         "mean_diff_ms": mean_diff,
         "ci_ms": ci,
         "p50_diff_ms": p50_diff,
-        "p50_ci_ms": (p50_boot[hi] - p50_boot[lo]) / 2,
+        "p50_ci_ms": p50_ci,
         "p90_diff_ms": p90_diff,
-        "p90_ci_ms": (p90_boot[hi] - p90_boot[lo]) / 2,
+        "p90_ci_ms": p90_ci,
         "p99_diff_ms": p99_diff,
-        "p99_ci_ms": (p99_boot[hi] - p99_boot[lo]) / 2,
+        "p99_ci_ms": p99_ci,
         "mean_mgas_diff": mean_mgas_diff,
         "mgas_ci": mgas_ci,
         "wall_clock_ci_ms": wall_clock_ci_ms,

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -195,13 +195,66 @@ def _paired_data(
     return pairs, lat_diffs_ms, mgas_diffs, total_lat_diffs_ms, persist_diffs_ms
 
 
+def _optimal_block_size(diffs: list[float]) -> int:
+    """Estimate optimal block size for block bootstrap using Newey-West
+    autocorrelation structure.
+
+    Uses the lag-1 autocorrelation to pick a block length that captures
+    serial dependence (e.g., from persistence phase offsets affecting
+    consecutive blocks). Falls back to 1 (iid bootstrap) when
+    autocorrelation is negligible.
+    """
+    n = len(diffs)
+    if n < 10:
+        return 1
+    mean = sum(diffs) / n
+    centered = [d - mean for d in diffs]
+
+    # Compute variance and lag-1 autocovariance
+    var = sum(c * c for c in centered) / n
+    if var < 1e-15:
+        return 1
+    cov1 = sum(centered[i] * centered[i + 1] for i in range(n - 1)) / n
+    rho = cov1 / var
+
+    # Politis & White (2004) rule-of-thumb: block_size ~ (2*rho/(1-rho^2))^(2/3) * n^(1/3)
+    # Clamp rho to avoid blowup near |rho| = 1
+    rho = max(-0.99, min(0.99, rho))
+    if abs(rho) < 0.02:
+        return 1
+    raw = abs(2.0 * rho / (1.0 - rho * rho)) ** (2.0 / 3.0) * n ** (1.0 / 3.0)
+    block_size = max(1, min(int(round(raw)), n // 4))
+    return block_size
+
+
+def _block_bootstrap_sample(rng: random.Random, data: list, block_size: int) -> list:
+    """Draw a block bootstrap sample of length len(data)."""
+    n = len(data)
+    if block_size <= 1:
+        return rng.choices(data, k=n)
+    result = []
+    while len(result) < n:
+        start = rng.randrange(n)
+        for j in range(block_size):
+            if len(result) >= n:
+                break
+            result.append(data[(start + j) % n])
+    return result
+
+
 def _bootstrap_ci(rng: random.Random, diffs: list[float], n_iter: int = BOOTSTRAP_ITERATIONS) -> float:
-    """Compute 95% bootstrap CI half-width for the mean of *diffs*."""
+    """Compute 95% bootstrap CI half-width for the mean of *diffs*.
+
+    Uses block bootstrap with Newey-West-derived block size to account
+    for autocorrelation in consecutive block diffs.
+    """
     if len(diffs) < 2:
         return 0.0
     n = len(diffs)
+    block_size = _optimal_block_size(diffs)
     boot_means = sorted(
-        sum(rng.choices(diffs, k=n)) / n for _ in range(n_iter)
+        sum(_block_bootstrap_sample(rng, diffs, block_size)) / n
+        for _ in range(n_iter)
     )
     lo = int(n_iter * 0.025)
     hi = int(n_iter * 0.975)
@@ -214,13 +267,19 @@ def _bootstrap_percentile_ci(
     pct: int,
     n_iter: int = BOOTSTRAP_ITERATIONS,
 ) -> float:
-    """Compute 95% bootstrap CI half-width for a difference-of-percentiles."""
+    """Compute 95% bootstrap CI half-width for a difference-of-percentiles.
+
+    Uses block bootstrap to preserve autocorrelation structure.
+    """
     if len(pairs) < 2:
         return 0.0
     n = len(pairs)
+    # Use latency diffs to determine block size (they carry the autocorrelation)
+    lat_diffs = [p[1] - p[0] for p in pairs]
+    block_size = _optimal_block_size(lat_diffs)
     boot_diffs = []
     for _ in range(n_iter):
-        sample = rng.choices(pairs, k=n)
+        sample = _block_bootstrap_sample(rng, pairs, block_size)
         b_sorted = sorted(p[0] for p in sample)
         f_sorted = sorted(p[1] for p in sample)
         boot_diffs.append(percentile(f_sorted, pct) - percentile(b_sorted, pct))

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -711,6 +711,9 @@ where
     ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
         trace!(target: "engine::tree", "invoked new payload");
 
+        // TEMPORARY: deliberate regression for bench CI validation (remove before merge)
+        std::thread::sleep(std::time::Duration::from_micros(500));
+
         // start timing for the new payload process
         let start = Instant::now();
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -711,9 +711,6 @@ where
     ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
         trace!(target: "engine::tree", "invoked new payload");
 
-        // TEMPORARY: deliberate regression for bench CI validation (remove before merge)
-        std::thread::sleep(std::time::Duration::from_micros(500));
-
         // start timing for the new payload process
         let start = Instant::now();
 


### PR DESCRIPTION
## Summary

Reduces false positives in bench comparisons by introducing a **between-pairing confidence interval** that captures run-level variance (thermal drift, background load) invisible to per-block pooling.

### Changes

1. **Unified bootstrap CI**: Replace mixed t-test / bootstrap CI computation with a single bootstrap approach for all metrics. Simplifies code, no behavioral change at large sample sizes.

2. **Cross-pair pooling**: Pool all 4 ABBA cross-pairings (B1-F1, B2-F2, B1-F2, B2-F1) instead of only the 2 adjacent pairs, doubling paired sample size. Also require all pairings to agree on direction — if any disagrees, the metric is marked ⚪ with ↕.

3. **Between-pairing CI floor**: Compute a second CI from the variance of the 4 cross-pairing means (t=4.5, df=3). The final CI for each metric is `max(within-block CI, between-pairing CI)`. This prevents the per-block CI from being artificially tight when run-level bias is the dominant noise source.

4. **Remove Mean row**: Mean latency is redundant with P50 (robust central tendency), Mgas/s (throughput), and Wall Clock (total cost), and is the most susceptible to run-level bias.

### Validation

**No-op PR data** (PR #24166, pipeline-only change — should show no engine effect):
- Before: 4 false ✅ (Mean, P50, Mgas/s, Wall Clock)
- After: 0 false ✅ (all ⚪)

**Deliberate regression** (500µs sleep in `on_new_payload`, ~2-3% slowdown):
- P50: +3.26% ❌ (±2.09%) — detected
- Mgas/s: -2.87% ❌ (±0.93%) — detected
- Wall Clock: +2.10% ❌ (±2.00%) — detected
- P90/P99/Persist: ⚪ — correctly neutral