### PR TITLE
refactor(storage): remove BAL range lookup

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -490,10 +490,6 @@ mod tests {
             Ok(vec![None; block_hashes.len()])
         }
 
-        fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
-            Ok(Vec::new())
-        }
-
         fn bal_stream(&self) -> BalNotificationStream {
             BalStoreHandle::noop().bal_stream()
         }

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -725,10 +725,6 @@ impl BalStore for FailingLookupBalStore {
         Err(ProviderError::other(std::io::Error::other("BAL lookup failed")))
     }
 
-    fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
-        Ok(Vec::new())
-    }
-
     fn bal_stream(&self) -> BalNotificationStream {
         BalStoreHandle::noop().bal_stream()
     }

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -1233,10 +1233,6 @@ mod tests {
             Ok(Some(test_decoded_revm_bal()))
         }
 
-        fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
-            Ok(Vec::new())
-        }
-
         fn bal_stream(&self) -> reth_storage_api::BalNotificationStream {
             reth_storage_api::NoopBalStore.bal_stream()
         }

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -202,24 +202,6 @@ impl BalStore for InMemoryBalStore {
         Ok(())
     }
 
-    fn get_by_range(&self, start: BlockNumber, count: u64) -> ProviderResult<Vec<Bytes>> {
-        let inner = self.inner.read();
-        let mut result = Vec::new();
-
-        for offset in 0..count {
-            let Some(block_number) = start.checked_add(offset) else { break };
-            let Some(block_hash) =
-                inner.hashes_by_number.get(&block_number).and_then(|hashes| hashes.first())
-            else {
-                break
-            };
-            let Some(entry) = inner.entries.get(block_hash) else { break };
-            result.push(entry.bal.clone());
-        }
-
-        Ok(result)
-    }
-
     fn bal_stream(&self) -> BalNotificationStream {
         self.notifications.new_listener()
     }
@@ -266,73 +248,6 @@ mod tests {
             store.get_by_hashes(&[hash0, hash1]).unwrap(),
             vec![Some(bal0.clone_inner()), Some(Bytes::from_static(b"bal1"))]
         );
-    }
-
-    #[test]
-    fn range_lookup_is_empty() {
-        let store = InMemoryBalStore::default();
-
-        assert!(store.get_by_range(1, 10).unwrap().is_empty());
-    }
-
-    #[test]
-    fn range_lookup_returns_ordered_bals() {
-        let store = InMemoryBalStore::default();
-        let bal1 = Bytes::from_static(b"bal1");
-        let bal2 = Bytes::from_static(b"bal2");
-        let bal3 = Bytes::from_static(b"bal3");
-
-        store.insert(NumHash::new(2, B256::random()), sealed_bal(bal2.clone())).unwrap();
-        store.insert(NumHash::new(1, B256::random()), sealed_bal(bal1.clone())).unwrap();
-        store.insert(NumHash::new(3, B256::random()), sealed_bal(bal3.clone())).unwrap();
-
-        assert_eq!(store.get_by_range(1, 3).unwrap(), vec![bal1, bal2, bal3]);
-    }
-
-    #[test]
-    fn range_lookup_stops_at_first_missing_block_number() {
-        let store = InMemoryBalStore::default();
-        let bal1 = Bytes::from_static(b"bal1");
-        let bal2 = Bytes::from_static(b"bal2");
-
-        store.insert(NumHash::new(1, B256::random()), sealed_bal(bal1.clone())).unwrap();
-        store.insert(NumHash::new(2, B256::random()), sealed_bal(bal2.clone())).unwrap();
-        store
-            .insert(NumHash::new(4, B256::random()), sealed_bal(Bytes::from_static(b"bal4")))
-            .unwrap();
-
-        assert_eq!(store.get_by_range(1, 4).unwrap(), vec![bal1, bal2]);
-    }
-
-    #[test]
-    fn range_lookup_handles_count_zero_and_start() {
-        let store = InMemoryBalStore::default();
-        let bal2 = Bytes::from_static(b"bal2");
-        let bal3 = Bytes::from_static(b"bal3");
-
-        store
-            .insert(NumHash::new(1, B256::random()), sealed_bal(Bytes::from_static(b"bal1")))
-            .unwrap();
-        store.insert(NumHash::new(2, B256::random()), sealed_bal(bal2.clone())).unwrap();
-        store.insert(NumHash::new(3, B256::random()), sealed_bal(bal3.clone())).unwrap();
-
-        assert!(store.get_by_range(2, 0).unwrap().is_empty());
-        assert_eq!(store.get_by_range(2, 2).unwrap(), vec![bal2, bal3]);
-    }
-
-    #[test]
-    fn range_lookup_uses_first_hash_for_same_number() {
-        let store = InMemoryBalStore::default();
-        let bal1a = Bytes::from_static(b"bal1a");
-        let bal2 = Bytes::from_static(b"bal2");
-
-        store.insert(NumHash::new(1, B256::random()), sealed_bal(bal1a.clone())).unwrap();
-        store
-            .insert(NumHash::new(1, B256::random()), sealed_bal(Bytes::from_static(b"bal1b")))
-            .unwrap();
-        store.insert(NumHash::new(2, B256::random()), sealed_bal(bal2.clone())).unwrap();
-
-        assert_eq!(store.get_by_range(1, 2).unwrap(), vec![bal1a, bal2]);
     }
 
     #[test]

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -139,11 +139,6 @@ pub trait BalStore: Send + Sync + 'static {
         Ok(())
     }
 
-    /// Fetch BALs for the requested range.
-    ///
-    /// Implementations may stop at the first gap and return the contiguous prefix.
-    fn get_by_range(&self, start: BlockNumber, count: u64) -> ProviderResult<Vec<Bytes>>;
-
     /// Returns a stream of BAL insert notifications.
     ///
     /// Notifications are emitted only after a BAL has been successfully inserted into the store.
@@ -262,12 +257,6 @@ impl BalStoreHandle {
         self.inner.append_by_hashes_with_limit(block_hashes, limit, out)
     }
 
-    /// Fetch BALs for the requested range.
-    #[inline]
-    pub fn get_by_range(&self, start: BlockNumber, count: u64) -> ProviderResult<Vec<Bytes>> {
-        self.inner.get_by_range(start, count)
-    }
-
     /// Returns a stream of BAL insert notifications.
     #[cfg(feature = "std")]
     #[inline]
@@ -334,10 +323,6 @@ impl BalStore for NoopBalStore {
         Ok(())
     }
 
-    fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
-        Ok(Vec::new())
-    }
-
     #[cfg(feature = "std")]
     fn bal_stream(&self) -> BalNotificationStream {
         reth_tokio_util::EventSender::new(1).new_listener()
@@ -359,11 +344,9 @@ mod tests {
         let hashes = [B256::random(), B256::random()];
 
         let by_hash = store.get_by_hashes(&hashes).unwrap();
-        let by_range = store.get_by_range(1, 10).unwrap();
 
         assert_eq!(by_hash, vec![None, None]);
         assert!(store.get_by_hash(B256::random()).unwrap().is_none());
-        assert!(by_range.is_empty());
         assert_eq!(store.prune(10).unwrap(), 0);
     }
 
@@ -451,10 +434,6 @@ mod tests {
                 .iter()
                 .map(|hash| (*hash == self.hash).then(|| self.raw_bal.clone()))
                 .collect())
-        }
-
-        fn get_by_range(&self, _start: BlockNumber, _count: u64) -> ProviderResult<Vec<Bytes>> {
-            Ok(Vec::new())
         }
 
         #[cfg(feature = "std")]


### PR DESCRIPTION
Removes `BalStore::get_by_range` and the in-memory range lookup implementation.

BAL consumers fetch by block hash, and a range API is hard to define cleanly for disk-backed stores without reintroducing canonical hash lookup assumptions.