### PR TITLE
feat: retain announced port

### DIFF
--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -309,7 +309,7 @@ pub enum PendingSessionEvent<N: NetworkPrimitives> {
         client_id: String,
         /// The TCP listening port the peer announced in its `Hello` message, if non-zero.
         ///
-        /// See [`ActiveSessionHandle::peer_listen_port`] for context.
+        /// See `ActiveSessionHandle::peer_listen_port` for context.
         peer_listen_port: Option<u16>,
     },
     /// Handshake unsuccessful, session was disconnected.

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -76,11 +76,8 @@ pub struct ActiveSessionHandle<N: NetworkPrimitives> {
     pub(crate) local_addr: Option<SocketAddr>,
     /// The TCP listening port the peer announced in its `Hello` message, if non-zero.
     ///
-    /// The devp2p `Hello` message's `listenPort` field is officially marked legacy in the
-    /// [RLPx spec](https://github.com/ethereum/devp2p/blob/master/rlpx.md), but most clients
-    /// (other than geth) still send their actual listening port. For inbound connections this
-    /// is the only in-band way to learn a peer's dialable port, since `remote_addr` only carries
-    /// the OS-assigned ephemeral source port of the TCP connection.
+    /// This is effectively deprecated, but we still keep it around if a peer announced it as it's
+    /// likely still more useful than the ephemeral source port.
     pub(crate) peer_listen_port: Option<u16>,
     /// The Status message the peer sent for the `eth` handshake
     pub(crate) status: Arc<UnifiedStatus>,

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -74,6 +74,14 @@ pub struct ActiveSessionHandle<N: NetworkPrimitives> {
     pub(crate) remote_addr: SocketAddr,
     /// The local address of the connection.
     pub(crate) local_addr: Option<SocketAddr>,
+    /// The TCP listening port the peer announced in its `Hello` message, if non-zero.
+    ///
+    /// The devp2p `Hello` message's `listenPort` field is officially marked legacy in the
+    /// [RLPx spec](https://github.com/ethereum/devp2p/blob/master/rlpx.md), but most clients
+    /// (other than geth) still send their actual listening port. For inbound connections this
+    /// is the only in-band way to learn a peer's dialable port, since `remote_addr` only carries
+    /// the OS-assigned ephemeral source port of the TCP connection.
+    pub(crate) peer_listen_port: Option<u16>,
     /// The Status message the peer sent for the `eth` handshake
     pub(crate) status: Arc<UnifiedStatus>,
 }
@@ -141,10 +149,24 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
 
     /// Extracts the [`PeerInfo`] from the session handle.
     pub(crate) fn peer_info(&self, record: &NodeRecord, kind: PeerKind) -> PeerInfo {
+        // For inbound connections, the `record` was built from the TCP socket address, which
+        // carries the peer's OS-assigned ephemeral source port (not dialable). If the peer
+        // announced a non-zero listening port in its `Hello` message, prefer that combined with
+        // the connection IP so the resulting enode is actually dialable.
+        let enode = match (self.direction, self.peer_listen_port) {
+            (Direction::Incoming, Some(port)) => NodeRecord::new_with_ports(
+                self.remote_addr.ip(),
+                port,
+                Some(record.udp_port),
+                record.id,
+            )
+            .to_string(),
+            _ => record.to_string(),
+        };
         PeerInfo {
             remote_id: self.remote_id,
             direction: self.direction,
-            enode: record.to_string(),
+            enode,
             enr: None,
             remote_addr: self.remote_addr,
             local_addr: self.local_addr,
@@ -288,6 +310,10 @@ pub enum PendingSessionEvent<N: NetworkPrimitives> {
         direction: Direction,
         /// The remote node's user agent, usually containing the client name and version
         client_id: String,
+        /// The TCP listening port the peer announced in its `Hello` message, if non-zero.
+        ///
+        /// See [`ActiveSessionHandle::peer_listen_port`] for context.
+        peer_listen_port: Option<u16>,
     },
     /// Handshake unsuccessful, session was disconnected.
     Disconnected {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -505,6 +505,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 status,
                 direction,
                 client_id,
+                peer_listen_port,
             } => {
                 // move from pending to established.
                 self.remove_pending_session(&session_id);
@@ -618,6 +619,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     client_version: Arc::clone(&client_version),
                     remote_addr,
                     local_addr,
+                    peer_listen_port,
                 };
 
                 self.active_sessions.insert(peer_id, handle);
@@ -1206,6 +1208,11 @@ async fn authenticate_stream<N: NetworkPrimitives>(
         (multiplex_stream.into(), their_status)
     };
 
+    // The devp2p `Hello.listenPort` field is officially marked legacy in the RLPx spec, but
+    // most clients still send their actual listening port. For inbound peers this is the only
+    // in-band way to learn a dialable port, so we retain it when non-zero.
+    let peer_listen_port = (their_hello.port != 0).then_some(their_hello.port);
+
     PendingSessionEvent::Established {
         session_id,
         remote_addr,
@@ -1216,5 +1223,6 @@ async fn authenticate_stream<N: NetworkPrimitives>(
         conn,
         direction,
         client_id: their_hello.client_version,
+        peer_listen_port,
     }
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1208,6 +1208,7 @@ async fn authenticate_stream<N: NetworkPrimitives>(
         (multiplex_stream.into(), their_status)
     };
 
+    // `port` field is effectively deprecated, so we treat 0 value as a missing port.
     let peer_listen_port = (their_hello.port != 0).then_some(their_hello.port);
 
     PendingSessionEvent::Established {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1208,9 +1208,6 @@ async fn authenticate_stream<N: NetworkPrimitives>(
         (multiplex_stream.into(), their_status)
     };
 
-    // The devp2p `Hello.listenPort` field is officially marked legacy in the RLPx spec, but
-    // most clients still send their actual listening port. For inbound peers this is the only
-    // in-band way to learn a dialable port, so we retain it when non-zero.
     let peer_listen_port = (their_hello.port != 0).then_some(their_hello.port);
 
     PendingSessionEvent::Established {


### PR DESCRIPTION
Changes networking code to retain deprecated `port` field if it's announced. Changes `admin_peers` entries to report this port instead of an ephemeral port if it's available.