### PR TITLE
ci(bench): add git-sha, git-ref, platform, scenario metadata to txgen bench

### DIFF
--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -340,6 +340,11 @@ if [ "${BENCH_TRACY:-off}" != "off" ]; then
 fi
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.
+CLICKHOUSE_REPORT=()
+if [ -n "${CLICKHOUSE_URL:-}" ]; then
+  CLICKHOUSE_REPORT=(--report "clickhouse:$CLICKHOUSE_URL")
+fi
+
 echo "Running txgen measured benchmark (${BLOCKS} blocks)..."
 $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   --engine http://127.0.0.1:8551 \
@@ -348,6 +353,7 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   "${TXGEN_SEND_ARGS[@]}" \
   --wait-for-persistence never \
   --report json:"$OUTPUT_DIR/report.json" \
+  "${CLICKHOUSE_REPORT[@]}" \
   -m "git-sha=$GIT_SHA" \
   -m "git-ref=$GIT_REF" \
   -m "platform=ethereum" \

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -351,6 +351,6 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   -m "git-sha=$GIT_SHA" \
   -m "git-ref=$GIT_REF" \
   -m "platform=ethereum" \
-  -m "mode=replay" 2>&1 | sed -u "s/^/[bench] /"
+  -m "scenario=replay" 2>&1 | sed -u "s/^/[bench] /"
 
 python3 .github/scripts/bench-txgen-report-to-reth-csv.py "$OUTPUT_DIR/report.json" "$OUTPUT_DIR"

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -351,6 +351,6 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   -m "git-sha=$GIT_SHA" \
   -m "git-ref=$GIT_REF" \
   -m "platform=ethereum" \
-  -m "scenario=replay" 2>&1 | sed -u "s/^/[bench] /"
+  -m "mode=replay" 2>&1 | sed -u "s/^/[bench] /"
 
 python3 .github/scripts/bench-txgen-report-to-reth-csv.py "$OUTPUT_DIR/report.json" "$OUTPUT_DIR"

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -18,6 +18,28 @@ set -euxo pipefail
 LABEL="$1"
 BINARY="$2"
 OUTPUT_DIR="$3"
+
+# Resolve git SHA for this run label
+GIT_SHA=""
+case "$LABEL" in
+  baseline*) GIT_SHA="${BASELINE_REF:-}" ;;
+  feature*)  GIT_SHA="${FEATURE_REF:-}" ;;
+esac
+
+# Resolve git-ref: tag if tagged, otherwise branch name, otherwise raw SHA
+GIT_REF="$GIT_SHA"
+if [ -n "$GIT_SHA" ]; then
+  TAG_NAME=$(git tag --points-at "$GIT_SHA" 2>/dev/null | head -1)
+  if [ -n "$TAG_NAME" ]; then
+    GIT_REF="$TAG_NAME"
+  else
+    BRANCH_NAME=$(git branch -r --points-at "$GIT_SHA" 2>/dev/null | sed 's|^ *origin/||' | head -1)
+    if [ -n "$BRANCH_NAME" ]; then
+      GIT_REF="$BRANCH_NAME"
+    fi
+  fi
+fi
+
 DATADIR_NAME="datadir"
 BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
 if [ "$BIG_BLOCKS" = "true" ]; then
@@ -325,6 +347,10 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   --input "$BENCHMARK_BLOCKS" \
   "${TXGEN_SEND_ARGS[@]}" \
   --wait-for-persistence never \
-  --report json:"$OUTPUT_DIR/report.json" 2>&1 | sed -u "s/^/[bench] /"
+  --report json:"$OUTPUT_DIR/report.json" \
+  -m "git-sha=$GIT_SHA" \
+  -m "git-ref=$GIT_REF" \
+  -m "platform=ethereum" \
+  -m "scenario=replay" 2>&1 | sed -u "s/^/[bench] /"
 
 python3 .github/scripts/bench-txgen-report-to-reth-csv.py "$OUTPUT_DIR/report.json" "$OUTPUT_DIR"

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -317,6 +317,9 @@ jobs:
       BENCH_OTLP_DISABLED: "true"
       BASELINE_REF: ${{ needs.resolve-refs.outputs.baseline-ref }}
       FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
+      CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
     steps:
       - name: Clean up previous bench-work
         run: sudo rm -rf "$BENCH_WORK_DIR" 2>/dev/null || true


### PR DESCRIPTION
Adds four metadata fields to the txgen `bench send-blocks` call in `bench-txgen-run.sh`:

- `git-sha` — raw commit SHA
- `git-ref` — resolved as tag > branch name > SHA (e.g. `v1.0.0` or `main`)
- `platform=ethereum`
- `scenario=replay`

These are passed via `-m` flags that `bench send-blocks` already supports. Enables ClickHouse consumers to identify and filter benchmark results.