### PR TITLE
ci(bench): add optional ClickHouse reporting to scheduled bench

### DIFF
--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -340,6 +340,11 @@ if [ "${BENCH_TRACY:-off}" != "off" ]; then
 fi
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.
+CLICKHOUSE_REPORT=()
+if [ -n "${CLICKHOUSE_URL:-}" ]; then
+  CLICKHOUSE_REPORT=(--report "clickhouse:$CLICKHOUSE_URL")
+fi
+
 echo "Running txgen measured benchmark (${BLOCKS} blocks)..."
 $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   --engine http://127.0.0.1:8551 \
@@ -348,6 +353,7 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   "${TXGEN_SEND_ARGS[@]}" \
   --wait-for-persistence never \
   --report json:"$OUTPUT_DIR/report.json" \
+  "${CLICKHOUSE_REPORT[@]}" \
   -m "git-sha=$GIT_SHA" \
   -m "git-ref=$GIT_REF" \
   -m "platform=ethereum" \

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -317,6 +317,9 @@ jobs:
       BENCH_OTLP_DISABLED: "true"
       BASELINE_REF: ${{ needs.resolve-refs.outputs.baseline-ref }}
       FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
+      CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
     steps:
       - name: Clean up previous bench-work
         run: sudo rm -rf "$BENCH_WORK_DIR" 2>/dev/null || true


### PR DESCRIPTION
Stacked on #24190.

Uses txgen's built-in ClickHouse reporter (`--report clickhouse:$CLICKHOUSE_URL`) to write scheduled bench results directly to `txgen_runs`/`txgen_blocks`/`txgen_metric_samples` tables.

**How it works:**
- When `CLICKHOUSE_URL` is set, adds `--report clickhouse:$CLICKHOUSE_URL` to `bench send-blocks`
- Reporter reads `CLICKHOUSE_USER`/`CLICKHOUSE_PASSWORD` from env
- Required metadata (`git-sha`, `git-ref`, `platform`, `scenario`) already set by #24190

**Enabled for:** `bench-scheduled.yml` only. `bench.yml` (PR benches) is unchanged — no secrets exposed.

**Requires:** `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` repo secrets.