### PR TITLE
perf: add and use `Cursor::replace_current`

### DIFF
--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -122,7 +122,10 @@ pub trait DbCursorRW<T: Table> {
     fn append(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
     /// Replace the value at the cursor's current position with `value`.
-    fn put_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
+    ///
+    /// For `DUPSORT` tables the new `value` must sort to the same dup position as the entry
+    /// currently under the cursor (only the trailing payload may differ).
+    fn replace_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
     /// Delete current value that cursor points to
     fn delete_current(&mut self) -> Result<(), DatabaseError>;

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -121,6 +121,9 @@ pub trait DbCursorRW<T: Table> {
     /// [`DbCursorRW::insert`].
     fn append(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
 
+    /// Replace the value at the cursor's current position with `value`.
+    fn put_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError>;
+
     /// Delete current value that cursor points to
     fn delete_current(&mut self) -> Result<(), DatabaseError>;
 }

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -389,6 +389,16 @@ impl<T: Table> DbCursorRW<T> for CursorMock {
     fn delete_current(&mut self) -> Result<(), DatabaseError> {
         Ok(())
     }
+
+    /// Replaces the entry at the current cursor position.
+    /// **Mock behavior**: Always succeeds without modifying any data.
+    fn put_current(
+        &mut self,
+        _key: <T as Table>::Key,
+        _value: &<T as Table>::Value,
+    ) -> Result<(), DatabaseError> {
+        Ok(())
+    }
 }
 
 impl<T: DupSort> DbDupCursorRW<T> for CursorMock {

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -392,7 +392,7 @@ impl<T: Table> DbCursorRW<T> for CursorMock {
 
     /// Replaces the entry at the current cursor position.
     /// **Mock behavior**: Always succeeds without modifying any data.
-    fn put_current(
+    fn replace_current(
         &mut self,
         _key: <T as Table>::Key,
         _value: &<T as Table>::Value,

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -327,6 +327,28 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
             this.inner.del(WriteFlags::CURRENT).map_err(|e| DatabaseError::Delete(e.into()))
         })
     }
+
+    fn put_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
+        let key = key.encode();
+        let value = compress_to_buf_or_ref!(self, value);
+        self.execute_with_operation_metric(
+            Operation::CursorUpsert,
+            Some(value.unwrap_or(&self.buf).len()),
+            |this| {
+                this.inner
+                    .put(key.as_ref(), value.unwrap_or(&this.buf), WriteFlags::CURRENT)
+                    .map_err(|e| {
+                        DatabaseWriteError {
+                            info: e.into(),
+                            operation: DatabaseWriteOperation::CursorUpsert,
+                            table_name: T::NAME,
+                            key: key.into_vec(),
+                        }
+                        .into()
+                    })
+            },
+        )
+    }
 }
 
 impl<T: DupSort> DbDupCursorRW<T> for Cursor<RW, T> {

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -328,7 +328,7 @@ impl<T: Table> DbCursorRW<T> for Cursor<RW, T> {
         })
     }
 
-    fn put_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
+    fn replace_current(&mut self, key: T::Key, value: &T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = compress_to_buf_or_ref!(self, value);
         self.execute_with_operation_metric(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2702,15 +2702,18 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             for (hashed_slot, value) in storage.storage_slots_ref() {
                 let entry = StorageEntry { key: *hashed_slot, value: *value };
 
-                if let Some(db_entry) =
-                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&
-                    db_entry.key == entry.key
-                {
-                    hashed_storage_cursor.delete_current()?;
-                }
+                let existing = hashed_storage_cursor
+                    .seek_by_key_subkey(*hashed_address, entry.key)?
+                    .is_some_and(|db_entry| db_entry.key == entry.key);
 
                 if !entry.value.is_zero() {
-                    hashed_storage_cursor.upsert(*hashed_address, &entry)?;
+                    if existing {
+                        hashed_storage_cursor.replace_current(*hashed_address, &entry)?;
+                    } else {
+                        hashed_storage_cursor.upsert(*hashed_address, &entry)?;
+                    }
+                } else if existing {
+                    hashed_storage_cursor.delete_current()?;
                 }
             }
         }

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -304,10 +304,9 @@ where
                     &A::StorageValue::new(nibbles, node.clone()),
                 )?,
                 (true, None) => self.cursor.delete_current()?,
-                (false, Some(node)) => self.cursor.upsert(
-                    self.hashed_address,
-                    &A::StorageValue::new(nibbles, node.clone()),
-                )?,
+                (false, Some(node)) => self
+                    .cursor
+                    .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?,
                 (false, None) => {}
             }
         }

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -291,20 +291,29 @@ where
         {
             num_entries += 1;
             let nibbles = A::StorageSubKey::from(*nibbles);
-            // Delete the old entry if it exists.
-            if self
+
+            let existing = self
                 .cursor
                 .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
                 .as_ref()
-                .is_some_and(|e| *e.nibbles() == nibbles)
-            {
-                self.cursor.delete_current()?;
-            }
+                .is_some_and(|e| *e.nibbles() == nibbles);
 
-            // There is an updated version of this node, insert new entry.
-            if let Some(node) = maybe_updated {
-                self.cursor
-                    .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
+            match (existing, maybe_updated) {
+                // Update in place: same nibbles (subkey), only payload changes. `put_current`
+                // avoids the dup-sub-tree rebalance that delete + upsert would cause.
+                (true, Some(node)) => self.cursor.put_current(
+                    self.hashed_address,
+                    &A::StorageValue::new(nibbles, node.clone()),
+                )?,
+                // Pure delete (node removed from trie).
+                (true, None) => self.cursor.delete_current()?,
+                // Pure insert (new node).
+                (false, Some(node)) => self.cursor.upsert(
+                    self.hashed_address,
+                    &A::StorageValue::new(nibbles, node.clone()),
+                )?,
+                // Nothing to do: wanted to delete an entry that doesn't exist.
+                (false, None) => {}
             }
         }
 

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -299,20 +299,15 @@ where
                 .is_some_and(|e| *e.nibbles() == nibbles);
 
             match (existing, maybe_updated) {
-                // Update in place: same nibbles (subkey), only payload changes. `put_current`
-                // avoids the dup-sub-tree rebalance that delete + upsert would cause.
-                (true, Some(node)) => self.cursor.put_current(
+                (true, Some(node)) => self.cursor.replace_current(
                     self.hashed_address,
                     &A::StorageValue::new(nibbles, node.clone()),
                 )?,
-                // Pure delete (node removed from trie).
                 (true, None) => self.cursor.delete_current()?,
-                // Pure insert (new node).
                 (false, Some(node)) => self.cursor.upsert(
                     self.hashed_address,
                     &A::StorageValue::new(nibbles, node.clone()),
                 )?,
-                // Nothing to do: wanted to delete an entry that doesn't exist.
                 (false, None) => {}
             }
         }


### PR DESCRIPTION
Right now when writing hashed storages and storage trie updates we are doing delete+upsert pattern because we need to make sure that older dupsort entry is removed. mdbx cursors support upserts with `MDBX_CURRENT` write flag which effectively does the same thing with one optimization — if the new value is of the same size, the old value is rewritten in place, allowing to save an expensive delete step

This PR propagates this API and uses it for hashed storage and storage trie updates writing