### PR TITLE
feat(cli): add `download --force` snapshot overwrite support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7500,10 +7500,12 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde_json",
+ "tar",
  "tempfile",
  "tokio",
  "toml",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -75,9 +75,11 @@ alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 backon.workspace = true
 serde_json.workspace = true
+tar.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
+zstd.workspace = true
 
 [features]
 default = [

--- a/bin/reth/tests/it/main.rs
+++ b/bin/reth/tests/it/main.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use std::process::Command;
+use std::{fs, path::Path, process::Command};
 
 const RETH: &str = env!("CARGO_BIN_EXE_reth");
 
@@ -38,6 +38,23 @@ fn spawn_dev() -> (alloy_node_bindings::RethInstance, tempfile::TempDir) {
 
     // Return the TempDir alongside the instance so it lives as long as the node.
     (instance, datadir)
+}
+
+fn create_tar_zst_snapshot(path: &Path) {
+    let file = fs::File::create(path).expect("failed to create snapshot archive");
+    let encoder = zstd::Encoder::new(file, 0).expect("failed to create zstd encoder");
+    let mut archive = tar::Builder::new(encoder);
+
+    let contents = b"new snapshot data";
+    let mut header = tar::Header::new_gnu();
+    header.set_path("db/new.snapshot").expect("failed to set archive path");
+    header.set_size(contents.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    archive.append(&header, contents.as_slice()).expect("failed to append archive file");
+
+    let encoder = archive.into_inner().expect("failed to finish tar archive");
+    encoder.finish().expect("failed to finish zstd archive");
 }
 
 // ── Original tests (from PR #22069) ──────────────────────────────────────────
@@ -165,6 +182,43 @@ fn prune_help() {
 fn download_help() {
     let stdout = reth_ok(&["download", "--help"]);
     assert!(stdout.contains("--chain"), "stdout: {stdout}");
+    assert!(stdout.contains("--force"), "stdout: {stdout}");
+}
+
+#[test]
+fn download_force_overwrites_snapshot_data_but_preserves_identity_files() {
+    let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+    let datadir = tempdir.path().join("datadir");
+    let archive_path = tempdir.path().join("snapshot.tar.zst");
+
+    fs::create_dir_all(datadir.join("db")).expect("failed to create old db dir");
+    fs::create_dir_all(datadir.join("static_files")).expect("failed to create old static dir");
+    fs::write(datadir.join("db/old.mdbx"), b"old db").expect("failed to write old db file");
+    fs::write(datadir.join("static_files/old"), b"old static")
+        .expect("failed to write old static file");
+    fs::write(datadir.join("discovery-secret"), b"secret").expect("failed to write secret");
+    fs::write(datadir.join("known-peers.json"), br#"["peer"]"#)
+        .expect("failed to write known peers");
+    create_tar_zst_snapshot(&archive_path);
+
+    let datadir_arg = datadir.to_str().expect("datadir should be utf8");
+    let archive_url = format!("file://{}", archive_path.display());
+    reth_ok(&["download", "--datadir", datadir_arg, "--url", &archive_url, "--force"]);
+
+    assert_eq!(
+        fs::read(datadir.join("db/new.snapshot")).expect("missing extracted snapshot file"),
+        b"new snapshot data"
+    );
+    assert!(!datadir.join("db/old.mdbx").exists(), "old db file should be removed");
+    assert!(!datadir.join("static_files/old").exists(), "old static file should be removed");
+    assert_eq!(
+        fs::read(datadir.join("discovery-secret")).expect("missing preserved discovery secret"),
+        b"secret"
+    );
+    assert_eq!(
+        fs::read(datadir.join("known-peers.json")).expect("missing preserved known peers"),
+        br#"["peer"]"#
+    );
 }
 
 #[test]

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -470,25 +470,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         // Legacy single-URL mode: download one archive and extract it
         if let Some(ref url) = self.url {
             let target_dir = data_dir.data_dir();
-            if self.force && target_dir.try_exists()? {
-                info!(target: "reth::cli", dir = ?target_dir, "Clearing existing data directory");
-                for entry in fs::read_dir(target_dir)? {
-                    let entry = entry?;
-                    let file_name = entry.file_name();
-                    if FORCE_PRESERVED_DATADIR_FILES
-                        .iter()
-                        .any(|preserved| file_name == OsStr::new(preserved))
-                    {
-                        continue;
-                    }
-
-                    let path = entry.path();
-                    if entry.file_type()?.is_dir() {
-                        fs::remove_dir_all(&path)?;
-                    } else {
-                        fs::remove_file(&path)?;
-                    }
-                }
+            if self.force {
+                clear_existing_datadir(target_dir)?;
             }
             fs::create_dir_all(target_dir)?;
 
@@ -522,25 +505,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
 
         let target_dir = data_dir.data_dir();
         let planned_downloads = collect_planned_archives(&manifest, &selections)?;
-        if self.force && target_dir.try_exists()? {
-            info!(target: "reth::cli", dir = ?target_dir, "Clearing existing data directory");
-            for entry in fs::read_dir(target_dir)? {
-                let entry = entry?;
-                let file_name = entry.file_name();
-                if FORCE_PRESERVED_DATADIR_FILES
-                    .iter()
-                    .any(|preserved| file_name == OsStr::new(preserved))
-                {
-                    continue;
-                }
-
-                let path = entry.path();
-                if entry.file_type()?.is_dir() {
-                    fs::remove_dir_all(&path)?;
-                } else {
-                    fs::remove_file(&path)?;
-                }
-            }
+        if self.force {
+            clear_existing_datadir(target_dir)?;
         }
         fs::create_dir_all(target_dir)?;
         let startup_summary = summarize_download_startup(&planned_downloads.archives, target_dir)?;
@@ -895,6 +861,32 @@ fn selection_from_prune_mode(mode: Option<PruneMode>, snapshot_block: u64) -> Co
             }
         }
     }
+}
+
+/// Removes existing snapshot data while preserving node identity and known peers.
+fn clear_existing_datadir(target_dir: &Path) -> Result<()> {
+    if !target_dir.try_exists()? {
+        return Ok(());
+    }
+
+    info!(target: "reth::cli", dir = ?target_dir, "Clearing existing data directory");
+    for entry in fs::read_dir(target_dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        if FORCE_PRESERVED_DATADIR_FILES.iter().any(|preserved| file_name == OsStr::new(preserved))
+        {
+            continue;
+        }
+
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            fs::remove_dir_all(&path)?;
+        } else {
+            fs::remove_file(&path)?;
+        }
+    }
+
+    Ok(())
 }
 
 /// If all data components (txs, receipts, changesets) are `All`, automatically

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -863,7 +863,8 @@ fn selection_from_prune_mode(mode: Option<PruneMode>, snapshot_block: u64) -> Co
     }
 }
 
-/// Removes existing snapshot data while preserving node identity and known peers.
+/// Removes existing snapshot data while preserving files listed in
+/// [`FORCE_PRESERVED_DATADIR_FILES`].
 fn clear_existing_datadir(target_dir: &Path) -> Result<()> {
     if !target_dir.try_exists()? {
         return Ok(());

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -114,6 +114,7 @@ use source::{
 use std::{
     borrow::Cow,
     collections::BTreeMap,
+    ffi::OsStr,
     path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
@@ -124,6 +125,7 @@ const RETH_SNAPSHOTS_BASE_URL: &str = "https://snapshots-r2.reth.rs";
 const RETH_SNAPSHOTS_API_URL: &str = "https://snapshots.reth.rs/api/snapshots";
 const RETH_SNAPSHOTS_SOURCE: &str = "https://snapshots.reth.rs (default)";
 const SNAPSHOT_API_PATH: &str = "/api/snapshots";
+const FORCE_PRESERVED_DATADIR_FILES: &[&str] = &["discovery-secret", "known-peers.json"];
 
 /// Maximum number of simultaneous HTTP downloads across the entire snapshot job.
 const MAX_CONCURRENT_DOWNLOADS: usize = 8;
@@ -419,6 +421,10 @@ pub struct DownloadCommand<C: ChainSpecParser> {
     #[arg(long, short = 'y')]
     non_interactive: bool,
 
+    /// Overwrite existing snapshot data while preserving discovery-secret and known-peers.json.
+    #[arg(long, conflicts_with = "list")]
+    force: bool,
+
     /// Enable resumable two-phase downloads (download to disk first, then extract).
     ///
     /// Archives are downloaded to a `.part` file with HTTP Range resume support
@@ -448,11 +454,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
     pub async fn execute<N>(self) -> Result<()> {
         let chain = self.env.chain.chain();
         let chain_id = chain.id();
-        let data_dir = self.env.datadir.clone().resolve_datadir(chain);
-        fs::create_dir_all(&data_dir)?;
-
-        let cancel_token = CancellationToken::new();
-        let _cancel_guard = cancel_token.drop_guard();
 
         // --list: print available snapshots and exit
         if self.list {
@@ -461,8 +462,36 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             return Ok(());
         }
 
+        let data_dir = self.env.datadir.clone().resolve_datadir(chain);
+
+        let cancel_token = CancellationToken::new();
+        let _cancel_guard = cancel_token.drop_guard();
+
         // Legacy single-URL mode: download one archive and extract it
         if let Some(ref url) = self.url {
+            let target_dir = data_dir.data_dir();
+            if self.force && target_dir.try_exists()? {
+                info!(target: "reth::cli", dir = ?target_dir, "Clearing existing data directory");
+                for entry in fs::read_dir(target_dir)? {
+                    let entry = entry?;
+                    let file_name = entry.file_name();
+                    if FORCE_PRESERVED_DATADIR_FILES
+                        .iter()
+                        .any(|preserved| file_name == OsStr::new(preserved))
+                    {
+                        continue;
+                    }
+
+                    let path = entry.path();
+                    if entry.file_type()?.is_dir() {
+                        fs::remove_dir_all(&path)?;
+                    } else {
+                        fs::remove_file(&path)?;
+                    }
+                }
+            }
+            fs::create_dir_all(target_dir)?;
+
             let request_limiter = DownloadRequestLimiter::new(self.download_concurrency.max(1));
             info!(target: "reth::cli",
                 dir = ?data_dir.data_dir(),
@@ -493,6 +522,27 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
 
         let target_dir = data_dir.data_dir();
         let planned_downloads = collect_planned_archives(&manifest, &selections)?;
+        if self.force && target_dir.try_exists()? {
+            info!(target: "reth::cli", dir = ?target_dir, "Clearing existing data directory");
+            for entry in fs::read_dir(target_dir)? {
+                let entry = entry?;
+                let file_name = entry.file_name();
+                if FORCE_PRESERVED_DATADIR_FILES
+                    .iter()
+                    .any(|preserved| file_name == OsStr::new(preserved))
+                {
+                    continue;
+                }
+
+                let path = entry.path();
+                if entry.file_type()?.is_dir() {
+                    fs::remove_dir_all(&path)?;
+                } else {
+                    fs::remove_file(&path)?;
+                }
+            }
+        }
+        fs::create_dir_all(target_dir)?;
         let startup_summary = summarize_download_startup(&planned_downloads.archives, target_dir)?;
         info!(target: "reth::cli",
             reusable = startup_summary.reusable,

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -202,6 +202,9 @@ Storage:
   -y, --non-interactive
           Skip interactive component selection. Downloads the minimal set (state + headers + transactions + changesets) unless explicit --with-* flags narrow it
 
+      --force
+          Overwrite existing snapshot data while preserving discovery-secret and known-peers.json
+
       --resumable [<RESUMABLE>]
           Enable resumable two-phase downloads (download to disk first, then extract).
 


### PR DESCRIPTION
- Adds `reth download --force` to clear existing snapshot data before extraction.
- Preserves `discovery-secret` and `known-peers.json` so node identity and peer state survive overwrites.
- Covers the behavior with a binary integration test that runs the real `reth download` path against a local `file://` snapshot archive.