### PR TITLE
feat(reth-bb): enable otlp, otlp-logs, portable revm, and js-tracer by default

### DIFF
--- a/bin/reth-bb/Cargo.toml
+++ b/bin/reth-bb/Cargo.toml
@@ -71,6 +71,23 @@ default = [
     "asm-keccak",
     "keccak-cache-global",
     "min-trace-logs",
+    "otlp",
+    "otlp-logs",
+    "reth-revm/portable",
+    "js-tracer",
+]
+
+otlp = [
+    "reth-ethereum-cli/otlp",
+    "reth-node-core/otlp",
+]
+otlp-logs = [
+    "reth-ethereum-cli/otlp-logs",
+    "reth-node-core/otlp-logs",
+]
+js-tracer = [
+    "reth-node-builder/js-tracer",
+    "reth-node-ethereum/js-tracer",
 ]
 
 jemalloc = [


### PR DESCRIPTION
Aligns `reth-bb` default features with the `reth` binary.

### Features added to `reth-bb` defaults

| Feature | Description |
|---|---|
| `otlp` | OpenTelemetry OTLP exporter support |
| `otlp-logs` | OpenTelemetry OTLP log exporter support |
| `reth-revm/portable` | Portable EVM builds |
| `js-tracer` | JavaScript tracing support (scoped to `reth-node-builder` and `reth-node-ethereum` — `reth-bb` doesn't depend on `reth-rpc` / `reth-rpc-eth-types`) |

These were the only features present in `reth`'s `default` but absent from `reth-bb`'s.

`cargo check -p reth-bb` passes.