### PR TITLE
feat(bench): route BAL replays through txgen

### DIFF
--- a/.github/scripts/bench-txgen-build.sh
+++ b/.github/scripts/bench-txgen-build.sh
@@ -12,11 +12,6 @@ MODE="$1"
 SOURCE_DIR="$2"
 COMMIT="$3"
 
-if [ -n "${BENCH_BAL:-}" ] && [ "${BENCH_BAL}" != "false" ]; then
-  echo "::error::txgen path does not support BAL replay yet; use big-blocks with the reth-bench driver"
-  exit 1
-fi
-
 BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
 if [ "$BIG_BLOCKS" = "true" ]; then
   NODE_BIN="reth-bb"

--- a/.github/scripts/bench-txgen-extract.sh
+++ b/.github/scripts/bench-txgen-extract.sh
@@ -15,13 +15,19 @@
 #   <output-dir>/benchmark-blocks.ndjson
 #
 # Required env: SCHELK_MOUNT, BENCH_RPC_URL, BENCH_BLOCKS, BENCH_WARMUP_BLOCKS
-# Optional env: BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS
+# Optional env: BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS, BENCH_BAL
 set -euxo pipefail
 
 BINARY="$1"
 OUTPUT_DIR="$2"
 
 BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
+BAL_MODE="${BENCH_BAL:-false}"
+INCLUDE_BAL=false
+if [ "$BAL_MODE" != "false" ] && [ -n "$BAL_MODE" ]; then
+  INCLUDE_BAL=true
+fi
+
 DATADIR_NAME="datadir"
 if [ "$BIG_BLOCKS" = "true" ]; then
   DATADIR_NAME="datadir-big-blocks"
@@ -125,21 +131,27 @@ if [ "$BIG_BLOCKS" = "true" ]; then
 fi
 
 EXTRACT_FROM=$(( HEAD_DEC + 1 ))
+TXGEN_EXTRACT_ARGS=()
+if [ "$INCLUDE_BAL" = "true" ]; then
+  TXGEN_EXTRACT_ARGS+=(--bal)
+fi
 if [ "$BIG_BLOCKS" = "true" ]; then
-  echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+  echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured, bal=${INCLUDE_BAL})"
   "$TXGEN_ETHEREUM" extract-big-blocks \
     --rpc "$BENCH_RPC_URL" \
     --from "$EXTRACT_FROM" \
     --count "$TOTAL" \
     --target-gas "${BENCH_BIG_BLOCKS_TARGET_GAS:-1G}" \
+    "${TXGEN_EXTRACT_ARGS[@]}" \
     -o "$ALL_BLOCKS"
 else
   EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
-  echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+  echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured, bal=${INCLUDE_BAL})"
   "$TXGEN_ETHEREUM" extract \
     --rpc "$BENCH_RPC_URL" \
     --from "$EXTRACT_FROM" \
     --to "$EXTRACT_TO" \
+    "${TXGEN_EXTRACT_ARGS[@]}" \
     -o "$ALL_BLOCKS"
 fi
 
@@ -150,5 +162,12 @@ else
   : > "$WARMUP_FILE"
 fi
 awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_FILE"
+
+if [ "$INCLUDE_BAL" = "true" ] && [ "$BAL_MODE" != "true" ]; then
+  echo "Writing no-BAL payload variants for selective BAL mode (${BAL_MODE})"
+  for file in "$ALL_BLOCKS" "$WARMUP_FILE" "$BENCHMARK_FILE"; do
+    jq -c 'del(.bal, .merged_block_access_list)' "$file" > "${file%.ndjson}-no-bal.ndjson"
+  done
+fi
 
 echo "Extraction complete: $(wc -l < "$ALL_BLOCKS") payloads in ${OUTPUT_DIR}"

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -51,12 +51,29 @@ LOG="${OUTPUT_DIR}/node.log"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
 
-# Unsupported txgen-path behavior is made explicit here. Keep this check near
-# the top so BAL support can be added when txgen supports it.
-if [ -n "${BENCH_BAL:-}" ] && [ "${BENCH_BAL}" != "false" ]; then
-  echo "::error::txgen driver does not support BAL replay yet; use big-blocks with the reth-bench driver"
-  exit 1
-fi
+bal_enabled_for_label() {
+  case "${BENCH_BAL:-false}" in
+    false|"")
+      echo false
+      ;;
+    true)
+      echo true
+      ;;
+    feature)
+      if [[ "$LABEL" == feature* ]]; then echo true; else echo false; fi
+      ;;
+    baseline)
+      if [[ "$LABEL" == baseline* ]]; then echo true; else echo false; fi
+      ;;
+    *)
+      echo "::error::Unknown BENCH_BAL value: ${BENCH_BAL}" >&2
+      return 1
+      ;;
+  esac
+}
+
+USE_BAL="$(bal_enabled_for_label)"
+echo "BAL replay for ${LABEL}: ${USE_BAL} (mode=${BENCH_BAL:-false})"
 
 cleanup() {
   kill "${TAIL_PID:-}" 2>/dev/null || true
@@ -271,6 +288,15 @@ if [ -n "${TXGEN_PAYLOADS_DIR:-}" ] && [ -d "$TXGEN_PAYLOADS_DIR" ]; then
     WARMUP_BLOCKS="$TXGEN_PAYLOADS_DIR/warmup-blocks.ndjson"
     BENCHMARK_BLOCKS="$TXGEN_PAYLOADS_DIR/benchmark-blocks.ndjson"
   fi
+  if [ "$USE_BAL" != "true" ]; then
+    WARMUP_NO_BAL="${WARMUP_BLOCKS%.ndjson}-no-bal.ndjson"
+    BENCHMARK_NO_BAL="${BENCHMARK_BLOCKS%.ndjson}-no-bal.ndjson"
+    if [ -f "$BENCHMARK_NO_BAL" ]; then
+      WARMUP_BLOCKS="$WARMUP_NO_BAL"
+      BENCHMARK_BLOCKS="$BENCHMARK_NO_BAL"
+    fi
+  fi
+  echo "Selected txgen payloads: warmup=${WARMUP_BLOCKS}, benchmark=${BENCHMARK_BLOCKS}"
   if [ ! -f "$BENCHMARK_BLOCKS" ]; then
     echo "::error::Pre-extracted payloads missing: ${BENCHMARK_BLOCKS}"
     exit 1
@@ -293,21 +319,27 @@ else
   fi
 
   EXTRACT_FROM=$(( HEAD_DEC + 1 ))
+  TXGEN_EXTRACT_ARGS=()
+  if [ "$USE_BAL" = "true" ]; then
+    TXGEN_EXTRACT_ARGS+=(--bal)
+  fi
   if [ "$BIG_BLOCKS" = "true" ]; then
-    echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+    echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured, bal=${USE_BAL})"
     "$TXGEN_ETHEREUM" extract-big-blocks \
       --rpc "$BENCH_RPC_URL" \
       --from "$EXTRACT_FROM" \
       --count "$TOTAL" \
       --target-gas "${BENCH_BIG_BLOCKS_TARGET_GAS:-1G}" \
+      "${TXGEN_EXTRACT_ARGS[@]}" \
       -o "$ALL_BLOCKS"
   else
     EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
-    echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured)"
+    echo "Extracting blocks ${EXTRACT_FROM}..${EXTRACT_TO} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured, bal=${USE_BAL})"
     "$TXGEN_ETHEREUM" extract \
       --rpc "$BENCH_RPC_URL" \
       --from "$EXTRACT_FROM" \
       --to "$EXTRACT_TO" \
+      "${TXGEN_EXTRACT_ARGS[@]}" \
       -o "$ALL_BLOCKS"
   fi
 
@@ -357,6 +389,8 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   -m "git-sha=$GIT_SHA" \
   -m "git-ref=$GIT_REF" \
   -m "platform=ethereum" \
-  -m "scenario=replay" 2>&1 | sed -u "s/^/[bench] /"
+  -m "scenario=replay" \
+  -m "bal-mode=${BENCH_BAL:-false}" \
+  -m "bal-enabled=$USE_BAL" 2>&1 | sed -u "s/^/[bench] /"
 
 python3 .github/scripts/bench-txgen-report-to-reth-csv.py "$OUTPUT_DIR/report.json" "$OUTPUT_DIR"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -392,11 +392,9 @@ jobs:
               if (!featureName) featureName = '${{ github.ref_name }}';
             }
 
-            const fallbackReasons = [];
-            if (bal !== 'false') fallbackReasons.push('BAL');
-            const driver = fallbackReasons.length ? 'reth-bench' : 'txgen';
+            const driver = 'txgen';
             const nodeBin = bigBlocks === 'true' ? 'reth-bb' : 'reth';
-            const driverReason = fallbackReasons.join(',');
+            const driverReason = '';
 
             core.setOutput('pr', pr || '');
             core.setOutput('actor', actor);
@@ -631,7 +629,7 @@ jobs:
       BENCH_DRIVER_REASON: ${{ needs.reth-bench-ack.outputs.driver-reason }}
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      TXGEN_REV: 64826ac816380586e4856e2d1d2d20f4d4e66198
+      TXGEN_REV: 51e7dd935728b5d77c10ddac59ba327418271aab
       BENCH_OTLP_TRACES_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_TRACES_ENDPOINT || '' }}
       BENCH_OTLP_LOGS_ENDPOINT: ${{ needs.reth-bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_LOGS_ENDPOINT || '' }}
     steps:


### PR DESCRIPTION
Routes PR BAL benchmark replay through txgen now that txgen can extract and submit block access lists. Keeps the existing txgen revision for non-BAL runs and uses the BAL-capable revision only when BAL is requested.