### PR TITLE
ci(bench): bump txgen to latest commit

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -615,7 +615,7 @@ jobs:
       BENCH_NODE_BIN: ${{ needs.bench-ack.outputs.node-bin }}
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      TXGEN_REV: 51e7dd935728b5d77c10ddac59ba327418271aab
+      TXGEN_REV: f439eec4e0f6dbe0675dd3bac8192d9f0299d409
       BENCH_OTLP_TRACES_ENDPOINT: ${{ needs.bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_TRACES_ENDPOINT || '' }}
       BENCH_OTLP_LOGS_ENDPOINT: ${{ needs.bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_LOGS_ENDPOINT || '' }}
     steps:


### PR DESCRIPTION
Updates `TXGEN_REV` to [`f439eec`](https://github.com/tempoxyz/txgen/commit/f439eec4e0f6dbe0675dd3bac8192d9f0299d409) (HEAD of `tempoxyz/txgen` main).

**New commits since `51e7dd9`:**
- [`f439eec`](https://github.com/tempoxyz/txgen/commit/f439eec) feat(extract): buffered prefetch for block fetching (#97)
- [`a53457f`](https://github.com/tempoxyz/txgen/commit/a53457f) feat(reporter): split JSON report and samples into separate files (#96)
- [`775b8f7`](https://github.com/tempoxyz/txgen/commit/775b8f7) perf(bench): drain metrics in background (#95)