### PR TITLE
feat(rpc): attach tx index to evm errors in multi-tx execution paths

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -121,6 +121,16 @@ pub trait FromEvmError<Evm: ConfigureEvm>:
         err.into()
     }
 
+    /// Converts from an EVM error to this type, tagging it with the failing transaction's
+    /// index in a multi-tx execution context (block replay, bundle simulation, trace).
+    ///
+    /// Preserves the inner error's JSON-RPC code and data; only prepends the index to the
+    /// message at the wire boundary.
+    fn from_evm_err_at_index(
+        err: EvmErrorFor<Evm, EvmDatabaseError<ProviderError>>,
+        tx_index: usize,
+    ) -> Self;
+
     /// Ensures the execution result is successful or returns an error,
     fn ensure_success(result: ExecutionResult<HaltReasonFor<Evm>>) -> Result<Bytes, Self> {
         match result {
@@ -137,9 +147,17 @@ impl<T, Evm> FromEvmError<Evm> for T
 where
     T: From<EvmErrorFor<Evm, EvmDatabaseError<ProviderError>>>
         + FromEvmHalt<HaltReasonFor<Evm>>
-        + FromRevert,
+        + FromRevert
+        + From<EthApiError>,
     Evm: ConfigureEvm,
+    EthApiError: From<EvmErrorFor<Evm, EvmDatabaseError<ProviderError>>>,
 {
+    fn from_evm_err_at_index(
+        err: EvmErrorFor<Evm, EvmDatabaseError<ProviderError>>,
+        tx_index: usize,
+    ) -> Self {
+        EthApiError::from(err).with_tx_index(tx_index).into()
+    }
 }
 
 /// Helper trait to convert from revm errors.

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -207,6 +207,19 @@ pub enum EthApiError {
         /// The underlying error object
         error: jsonrpsee_types::ErrorObject<'static>,
     },
+    /// Wraps an error with the index of the transaction that produced it in a multi-tx
+    /// execution context (block replay, bundle simulation, trace).
+    ///
+    /// Preserves the inner error's RPC code and data so JSON-RPC clients keep the original
+    /// typed information; only prepends index context to the message at the wire boundary.
+    #[error("transaction index {tx_index}: {source}")]
+    IndexedTxError {
+        /// Index of the failing transaction in the executed sequence.
+        tx_index: usize,
+        /// The underlying error produced by EVM execution.
+        #[source]
+        source: Box<Self>,
+    },
     /// Error thrown when trying to access block access list for blocks before Amsterdam
     #[error("Block access list not available for pre-Amsterdam blocks")]
     BlockAccessListNotAvailablePreAmsterdam,
@@ -228,6 +241,12 @@ impl EthApiError {
         error: jsonrpsee_types::ErrorObject<'static>,
     ) -> Self {
         Self::CallManyError { bundle_index, tx_index, error }
+    }
+
+    /// Wraps this error in a [`EthApiError::IndexedTxError`] variant tagged with the failing
+    /// transaction's index.
+    pub fn with_tx_index(self, tx_index: usize) -> Self {
+        Self::IndexedTxError { tx_index, source: Box::new(self) }
     }
 
     /// Returns `true` if error is [`RpcInvalidTransactionError::GasTooHigh`]
@@ -346,6 +365,14 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                         error.message()
                     ),
                     error.data(),
+                )
+            }
+            EthApiError::IndexedTxError { tx_index, source } => {
+                let inner: jsonrpsee_types::error::ErrorObject<'static> = (*source).into();
+                jsonrpsee_types::error::ErrorObject::owned(
+                    inner.code(),
+                    format!("transaction index {tx_index}: {}", inner.message()),
+                    inner.data().map(|d| d.to_owned()),
                 )
             }
             EthApiError::BlockAccessListNotAvailablePreAmsterdam => {
@@ -1235,5 +1262,39 @@ mod tests {
         let err = RevertError::new(revert.abi_encode().into());
         let msg = err.to_string();
         assert_eq!(msg, "execution reverted: test_revert_reason");
+    }
+
+    #[test]
+    fn indexed_tx_error_message() {
+        let err: jsonrpsee_types::error::ErrorObject<'static> =
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow {
+                tx: 5,
+                state: 10,
+            })
+            .with_tx_index(3)
+            .into();
+        assert_eq!(err.code(), EthRpcErrorCode::InvalidInput.code());
+        assert_eq!(err.message(), "transaction index 3: nonce too low: next nonce 10, tx nonce 5");
+    }
+
+    #[test]
+    fn indexed_tx_error_revert_data() {
+        let revert_bytes: Bytes = Revert::from("liquidity_too_low").abi_encode().into();
+
+        let unwrapped: jsonrpsee_types::error::ErrorObject<'static> =
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::Revert(RevertError::new(
+                revert_bytes.clone(),
+            )))
+            .into();
+        let wrapped: jsonrpsee_types::error::ErrorObject<'static> =
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::Revert(RevertError::new(
+                revert_bytes,
+            )))
+            .with_tx_index(7)
+            .into();
+
+        assert_eq!(wrapped.code(), unwrapped.code());
+        assert_eq!(wrapped.data().map(|d| d.to_string()), unwrapped.data().map(|d| d.to_string()));
+        assert_eq!(wrapped.message(), format!("transaction index 7: {}", unwrapped.message()));
     }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -723,11 +723,12 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
-                for tx in block.transactions_recovered() {
+                for (tx_index, tx) in block.transactions_recovered().enumerate() {
                     let tx_env = eth_api.evm_config().tx_env(tx);
                     {
                         let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
-                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+                        evm.transact_commit(tx_env)
+                            .map_err(|e| Eth::Error::from_evm_err_at_index(e, tx_index))?;
                     }
                     // Merge transitions into cumulative bundle_state
                     db.merge_transitions(BundleRetention::PlainState);

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -160,9 +160,9 @@ where
                 let mut evm = eth_api.evm_config().evm_with_env(db, evm_env);
 
                 let mut results = Vec::with_capacity(transactions.len());
-                let mut transactions = transactions.into_iter().peekable();
+                let mut transactions = transactions.into_iter().enumerate().peekable();
 
-                while let Some(tx) = transactions.next() {
+                while let Some((tx_index, tx)) = transactions.next() {
                     let signer = tx.signer();
                     let tx = {
                         let mut tx = <Eth::Pool as TransactionPool>::Transaction::from_pooled(tx);
@@ -183,7 +183,7 @@ where
                     hasher.update(*tx.tx_hash());
                     let ResultAndState { result, state } = evm
                         .transact(eth_api.evm_config().tx_env(&tx))
-                        .map_err(Eth::Error::from_evm_err)?;
+                        .map_err(|e| Eth::Error::from_evm_err_at_index(e, tx_index))?;
 
                     let gas_price = tx
                         .effective_tip_per_gas(basefee)

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -338,7 +338,7 @@ where
 
                     let ResultAndState { result, state } = evm
                         .transact(eth_api.evm_config().tx_env(&item.tx))
-                        .map_err(Eth::Error::from_evm_err)?;
+                        .map_err(|e| Eth::Error::from_evm_err_at_index(e, tx_index))?;
 
                     if !result.is_success() && !item.can_revert {
                         return Err(EthApiError::InvalidParams(


### PR DESCRIPTION
Closes #20301 

## Overview

This change enables rpc calls that contain sequenced transactions to accurately report errors indexed by the contained transaction that failed.

RPC Calls Affected:

- `debug_intermediateRoots` Replays a vector of transactions for a target block
- `eth_callBundle` Simulates a list of transactions against a block
- `mev_simBundle` Simulates a mev-share (nested) bundle

However, `eth_callMany` continues to use the existing `CallManyError`, which already carries both bundle and tx dimensions and preserves JSON-RPC codes correctly. 

> [!NOTE]
> Considered refactoring existing `CallManyError` to be used by the 3 RPC call sites above, however the CallManyError response is 2-dimensional by nature, whereas these 3 RPC call sites linearly sequence transactions to 1-dimension.

Before:
```
  nonce too low: next nonce 10, tx nonce 5
```

After:
```
  transaction index 3: nonce too low: next nonce 10, tx nonce 5
```

## What's Changed

Adds `EthApiError::IndexedTxError { tx_index, source }` variant that wraps any inner error with the failing transaction's position in a multi-tx execution context. The wrapping preserves the inner error's JSON-RPC code and data; only the message gets a `transaction index N:`.

  **New variant** ([context](https://github.com/shottah/reth/blob/68e8b684c1c09a35f0555729414cf69ccf37694b/crates/rpc/rpc-eth-types/src/error/mod.rs#L210-L222)):
  ```rust
  #[error("transaction index {tx_index}: {source}")]
  IndexedTxError {
      tx_index: usize,
      #[source]
      source: Box<Self>,
  },
  ```

  **Trait helper** ([context](https://github.com/shottah/reth/blob/68e8b684c1c09a35f0555729414cf69ccf37694b/crates/rpc/rpc-eth-types/src/error/api.rs#L154-L159)):
  ```rust
  fn from_evm_err_at_index(
      err: EvmErrorFor<Evm, EvmDatabaseError<ProviderError>>,
      tx_index: usize,
  ) -> Self {
      EthApiError::from(err).with_tx_index(tx_index).into()
  }
  ```

  **Example call site — `debug_intermediateRoots`** ([context](https://github.com/shottah/reth/blob/68e8b684c1c09a35f0555729414cf69ccf37694b/crates/rpc/rpc/src/debug.rs#L607-L614)):
  ```rust
  for (tx_index, tx) in block.transactions_recovered().enumerate() {
      let tx_env = eth_api.evm_config().tx_env(tx);
      {
          let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
          evm.transact_commit(tx_env)
              .map_err(|e| Eth::Error::from_evm_err_at_index(e, tx_index))?;
      }
  ```