### PR TITLE
fix(rpc): Support hostname resolution for peers added via admin_addTrustedPeer

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -151,6 +151,13 @@ pub trait Peers: PeersInfo {
         self.add_peer_kind(peer, Some(PeerKind::Trusted), tcp_addr, Some(udp_addr));
     }
 
+    /// Registers a trusted peer that may use a hostname instead of an IP address.
+    ///
+    /// Resolution is performed asynchronously by the periodic DNS resolver; the peer is
+    /// added to the peer set on first successful resolution and re-resolved periodically
+    /// so address changes are picked up automatically.
+    fn add_trusted_peer_node(&self, _peer: reth_network_peers::TrustedPeer) {}
+
     /// Adds a peer to the known peer set, with the given kind.
     ///
     /// If the peer already exists, then this will update its tracked info.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -714,6 +714,11 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             NetworkHandleMessage::AddTrustedPeerId(peer_id) => {
                 self.swarm.state_mut().add_trusted_peer_id(peer_id);
             }
+            NetworkHandleMessage::AddTrustedPeerNode(trusted_peer) => {
+                if !self.swarm.is_shutting_down() {
+                    self.swarm.state_mut().add_trusted_peer_node(trusted_peer);
+                }
+            }
             NetworkHandleMessage::AddPeerAddress(peer, kind, addr) => {
                 // only add peer if we are not shutting down
                 if !self.swarm.is_shutting_down() {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -21,7 +21,7 @@ use reth_network_api::{
     PeersInfo,
 };
 use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState, SyncStateProvider};
-use reth_network_peers::{NodeRecord, PeerId};
+use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
 use reth_network_types::{PeerAddr, PeerKind, Reputation, ReputationChangeKind};
 use reth_tokio_util::{EventSender, EventStream};
 use secp256k1::SecretKey;
@@ -321,6 +321,10 @@ impl<N: NetworkPrimitives> Peers for NetworkHandle<N> {
         self.send_message(NetworkHandleMessage::AddTrustedPeerId(peer));
     }
 
+    fn add_trusted_peer_node(&self, peer: TrustedPeer) {
+        self.send_message(NetworkHandleMessage::AddTrustedPeerNode(peer));
+    }
+
     /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to add a peer to the known
     /// set, with the given kind.
     fn add_peer_kind(
@@ -532,6 +536,8 @@ pub trait NetworkProtocols: Send + Sync {
 pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Marks a peer as trusted.
     AddTrustedPeerId(PeerId),
+    /// Adds a trusted peer that may use a hostname, registering it for periodic DNS re-resolution.
+    AddTrustedPeerNode(TrustedPeer),
     /// Adds an address for a peer, including its ID, kind, and socket address.
     AddPeerAddress(PeerId, Option<PeerKind>, PeerAddr),
     /// Removes a peer from the peerset corresponding to the given kind.

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -12,7 +12,7 @@ use reth_eth_wire::{errors::EthStreamError, DisconnectReason};
 use reth_ethereum_forks::ForkId;
 use reth_net_banlist::BanList;
 use reth_network_api::test_utils::{PeerCommand, PeersHandle};
-use reth_network_peers::{NodeRecord, PeerId};
+use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
 use reth_network_types::{
     is_connection_failed_reputation,
     peers::{
@@ -819,6 +819,23 @@ impl PeersManager {
         self.add_peer_kind(peer_id, Some(PeerKind::Trusted), addr, None)
     }
 
+    /// Adds a trusted peer that may use a hostname instead of an IP address.
+    ///
+    /// Registers the peer with the [`TrustedPeersResolver`] and triggers an immediate
+    /// resolution cycle. The peer is added to [`Self::peers`] in [`Self::on_resolved_peer`]
+    /// once DNS resolution succeeds. Calling this repeatedly for the same peer id replaces
+    /// the prior entry rather than accumulating duplicates.
+    pub(crate) fn add_trusted_peer_node(&mut self, trusted: TrustedPeer) {
+        let peer_id = trusted.id;
+        self.trusted_peer_ids.insert(peer_id);
+        // Drop any prior entry for this peer id so repeat RPC calls don't accumulate.
+        self.trusted_peers_resolver.remove(peer_id);
+        self.trusted_peers_resolver.trusted_peers.push(trusted);
+        // Bring the next resolution forward instead of waiting for the periodic tick. Resolution
+        // itself runs on the async path, so the network loop is never blocked on getaddrinfo.
+        self.trusted_peers_resolver.interval.reset_immediately();
+    }
+
     /// Called for a newly discovered peer.
     ///
     /// If the peer already exists, then the address, kind and `fork_id` will be updated.
@@ -971,7 +988,12 @@ impl PeersManager {
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         self.trusted_peers_resolver.remove(peer_id);
 
-        let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
+        let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else {
+            // No connected/known entry to demote, but still clear the trusted id set in case the
+            // peer was registered for hostname resolution before being resolved.
+            self.trusted_peer_ids.remove(&peer_id);
+            return
+        };
         if !entry.get().is_trusted() {
             return
         }
@@ -1063,17 +1085,22 @@ impl PeersManager {
     }
 
     fn on_resolved_peer(&mut self, peer_id: PeerId, new_record: NodeRecord) {
-        if let Some(peer) = self.peers.get_mut(&peer_id) {
-            let new_addr = PeerAddr::new_with_ports(
-                new_record.address,
-                new_record.tcp_port,
-                Some(new_record.udp_port),
-            );
+        let new_addr = PeerAddr::new_with_ports(
+            new_record.address,
+            new_record.tcp_port,
+            Some(new_record.udp_port),
+        );
 
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
             if peer.addr != new_addr {
                 peer.addr = new_addr;
                 trace!(target: "net::peers", ?peer_id, addr=?peer.addr, "Updated resolved trusted peer address");
             }
+        } else {
+            // Peer was registered for resolution (e.g. via admin_addTrustedPeer with a hostname)
+            // before its IP was known. Now that resolution succeeded, add it as trusted.
+            trace!(target: "net::peers", ?peer_id, ?new_addr, "Adding trusted peer after first successful resolution");
+            self.add_peer_kind(peer_id, Some(PeerKind::Trusted), new_addr, None);
         }
     }
 
@@ -3309,5 +3336,92 @@ mod tests {
 
         let (best_id, _) = peers.best_unconnected().unwrap();
         assert_eq!(best_id, with_fork, "fork_id should break tie when reputation is equal");
+    }
+
+    #[tokio::test]
+    async fn test_add_trusted_peer_node_registers_for_resolution() {
+        let peer_id = PeerId::random();
+        let trusted = TrustedPeer {
+            host: url::Host::Domain("example.invalid".to_string()),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+
+        let mut manager = PeersManager::default();
+        manager.add_trusted_peer_node(trusted.clone());
+
+        // Peer is marked trusted synchronously so any connection during the resolution window
+        // is treated as a trusted peer.
+        assert!(manager.trusted_peer_ids.contains(&peer_id));
+
+        // The resolver holds the peer keyed by id, ready for the next (immediate) tick.
+        assert_eq!(manager.trusted_peers_resolver.trusted_peers.len(), 1);
+        assert!(manager.trusted_peers_resolver.trusted_peers.iter().any(|p| p.id == peer_id));
+
+        // No `peers` entry exists yet — that happens in `on_resolved_peer` after DNS succeeds.
+        assert!(manager.peers.get(&peer_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_add_trusted_peer_node_dedups_repeat_calls() {
+        let peer_id = PeerId::random();
+        let trusted = TrustedPeer {
+            host: url::Host::Domain("example.invalid".to_string()),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+
+        let mut manager = PeersManager::default();
+        manager.add_trusted_peer_node(trusted.clone());
+        manager.add_trusted_peer_node(trusted.clone());
+        manager.add_trusted_peer_node(trusted);
+
+        assert_eq!(manager.trusted_peers_resolver.trusted_peers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_on_resolved_peer_adds_when_absent() {
+        let peer_id = PeerId::random();
+        let mut manager = PeersManager::default();
+
+        // Simulate a hostname-trusted peer that has been registered but not yet resolved.
+        manager.trusted_peer_ids.insert(peer_id);
+
+        let resolved = NodeRecord {
+            address: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+        manager.on_resolved_peer(peer_id, resolved);
+
+        let peer = manager.peers.get(&peer_id).expect("peer should be added after resolution");
+        assert!(peer.kind.is_trusted());
+        assert_eq!(peer.addr.tcp().ip(), "10.0.0.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_remove_trusted_peer_clears_resolver_entry() {
+        let peer_id = PeerId::random();
+        let trusted = TrustedPeer {
+            host: url::Host::Domain("example.invalid".to_string()),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+
+        let mut manager = PeersManager::default();
+        manager.add_trusted_peer_node(trusted);
+        assert!(manager.trusted_peers_resolver.trusted_peers.iter().any(|p| p.id == peer_id));
+        assert!(manager.trusted_peer_ids.contains(&peer_id));
+
+        manager.remove_peer_from_trusted_set(peer_id);
+
+        // Resolver and trusted-id set are both cleared even though the peer was never resolved
+        // into `self.peers`.
+        assert!(!manager.trusted_peers_resolver.trusted_peers.iter().any(|p| p.id == peer_id));
+        assert!(!manager.trusted_peer_ids.contains(&peer_id));
     }
 }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -307,6 +307,11 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         self.peers_manager.add_trusted_peer_id(peer_id)
     }
 
+    /// Adds a trusted peer that may use a hostname, with periodic DNS re-resolution.
+    pub(crate) fn add_trusted_peer_node(&mut self, trusted: reth_network_peers::TrustedPeer) {
+        self.peers_manager.add_trusted_peer_node(trusted)
+    }
+
     /// Adds a peer and its address with the given kind to the peerset.
     pub(crate) fn add_peer_kind(
         &mut self,

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -121,42 +121,32 @@ pub enum AnyNode {
     Enr(Enr<secp256k1::SecretKey>),
     /// An incomplete "enode" with only a peer id
     PeerId(PeerId),
+    /// An "enode:" peer whose host may be a domain name instead of an IP address
+    TrustedPeer(TrustedPeer),
 }
 
 impl AnyNode {
     /// Returns the peer id of the node.
-    #[cfg(not(feature = "secp256k1"))]
-    pub const fn peer_id(&self) -> PeerId {
-        match self {
-            Self::NodeRecord(record) => record.id,
-            Self::PeerId(peer_id) => *peer_id,
-        }
-    }
-
-    /// Returns the peer id of the node.
-    #[cfg(feature = "secp256k1")]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn peer_id(&self) -> PeerId {
         match self {
             Self::NodeRecord(record) => record.id,
+            #[cfg(feature = "secp256k1")]
             Self::Enr(enr) => pk2id(&enr.public_key()),
             Self::PeerId(peer_id) => *peer_id,
+            Self::TrustedPeer(peer) => peer.id,
         }
     }
 
     /// Returns the full node record if available.
-    #[cfg(not(feature = "secp256k1"))]
-    pub const fn node_record(&self) -> Option<NodeRecord> {
-        match self {
-            Self::NodeRecord(record) => Some(*record),
-            Self::PeerId(_) => None,
-        }
-    }
-
-    /// Returns the full node record if available.
-    #[cfg(feature = "secp256k1")]
+    ///
+    /// For [`AnyNode::TrustedPeer`] variants with a domain host, this returns `None` because
+    /// DNS resolution is required first.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
+            #[cfg(feature = "secp256k1")]
             Self::Enr(enr) => {
                 let node_record = NodeRecord {
                     address: enr
@@ -170,7 +160,17 @@ impl AnyNode {
                 .into_ipv4_mapped();
                 Some(node_record)
             }
-            Self::PeerId(_) => None,
+            #[cfg(any(test, feature = "std"))]
+            Self::TrustedPeer(peer) => peer.try_node_record().ok(),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TrustedPeer`] if this is a `TrustedPeer` variant.
+    pub const fn trusted_peer(&self) -> Option<&TrustedPeer> {
+        match self {
+            Self::TrustedPeer(peer) => Some(peer),
+            _ => None,
         }
     }
 }
@@ -196,7 +196,11 @@ impl FromStr for AnyNode {
             if let Ok(record) = NodeRecord::from_str(s) {
                 return Ok(Self::NodeRecord(record))
             }
-            // incomplete enode
+            // Try as TrustedPeer (supports hostnames in addition to IPs)
+            if let Ok(trusted) = TrustedPeer::from_str(s) {
+                return Ok(Self::TrustedPeer(trusted))
+            }
+            // incomplete enode with only a peer id
             if let Ok(peer_id) = PeerId::from_str(rem) {
                 return Ok(Self::PeerId(peer_id))
             }
@@ -210,6 +214,12 @@ impl FromStr for AnyNode {
     }
 }
 
+impl From<TrustedPeer> for AnyNode {
+    fn from(value: TrustedPeer) -> Self {
+        Self::TrustedPeer(value)
+    }
+}
+
 impl core::fmt::Display for AnyNode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -219,6 +229,7 @@ impl core::fmt::Display for AnyNode {
             Self::PeerId(peer_id) => {
                 write!(f, "enode://{}", alloy_primitives::hex::encode(peer_id.as_slice()))
             }
+            Self::TrustedPeer(peer) => write!(f, "{peer}"),
         }
     }
 }
@@ -340,6 +351,29 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(node.to_string(), url);
+    }
+
+    #[test]
+    fn test_trusted_peer_parse_hostname() {
+        let url = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@my-node.example.com:30303";
+        let node: AnyNode = url.parse().unwrap();
+        assert!(matches!(node, AnyNode::TrustedPeer(_)));
+        assert_eq!(
+            node.peer_id(),
+            "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0".parse::<PeerId>().unwrap()
+        );
+        // node_record() returns None for hostname-based peers (requires DNS resolution)
+        assert!(node.node_record().is_none());
+        assert!(node.trusted_peer().is_some());
+        assert_eq!(node.to_string(), url);
+    }
+
+    #[test]
+    fn test_trusted_peer_parse_ip_still_returns_node_record() {
+        let url = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301";
+        let node: AnyNode = url.parse().unwrap();
+        // IP-based enodes should still parse as NodeRecord (not TrustedPeer)
+        assert!(matches!(node, AnyNode::NodeRecord(_)));
     }
 
     #[test]

--- a/crates/net/peers/src/trusted_peer.rs
+++ b/crates/net/peers/src/trusted_peer.rs
@@ -50,8 +50,9 @@ impl TrustedPeer {
     }
 
     /// Tries to resolve directly to a [`NodeRecord`] if the host is an IP address.
+    /// Returns `Err` with the domain name if the host is a domain that requires DNS resolution.
     #[cfg(any(test, feature = "std"))]
-    fn try_node_record(&self) -> Result<NodeRecord, &str> {
+    pub fn try_node_record(&self) -> Result<NodeRecord, &str> {
         match &self.host {
             Host::Ipv4(ip) => Ok(self.to_node_record((*ip).into())),
             Host::Ipv6(ip) => Ok(self.to_node_record((*ip).into())),

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -56,10 +56,18 @@ where
 
     /// Handler for `admin_addTrustedPeer`
     fn add_trusted_peer(&self, record: AnyNode) -> RpcResult<bool> {
-        if let Some(record) = record.node_record() {
-            self.network.add_trusted_peer_with_udp(record.id, record.tcp_addr(), record.udp_addr())
+        if let Some(trusted) = record.trusted_peer().cloned() {
+            self.network.add_trusted_peer_node(trusted);
+        } else {
+            if let Some(record) = record.node_record() {
+                self.network.add_trusted_peer_with_udp(
+                    record.id,
+                    record.tcp_addr(),
+                    record.udp_addr(),
+                )
+            }
+            self.network.add_trusted_peer_id(record.peer_id());
         }
-        self.network.add_trusted_peer_id(record.peer_id());
         Ok(true)
     }
 


### PR DESCRIPTION
Adds `TrustedPeer` as a trait to `AnyNode` so that we can re-use the trusted peer resolver that exists for `--trusted-peers` to continually resolve DNS for any peers added via hostname rather than IP address. Refactors the internals of the resolver to use a HashMap to help both deduplication of peers being repeatedly added (by any sort of reconciler), as well as make it so we can remove peer hostnames from the resolvers if a peer is untrusted.