### PR TITLE
fix(rpc): return cached raw block access lists

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -5,7 +5,6 @@ use crate::{
     RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
 };
 use alloy_dyn_abi::TypedData;
-use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip2930::AccessListResult, BlockId, BlockNumberOrTag};
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, B64, U256, U64};
@@ -974,7 +973,6 @@ where
     async fn block_access_list_raw(&self, block: BlockId) -> RpcResult<Option<Bytes>> {
         trace!(target: "rpc::eth", ?block, "Serving eth_getBlockAccessListRaw");
 
-        let bal = self.get_block_access_list(block).await?;
-        Ok(bal.map(|b: BlockAccessList| alloy_rlp::encode(b).into()))
+        Ok(self.get_raw_block_access_list(block).await?)
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -1,6 +1,7 @@
 //! Helpers for `eth_blockAccessList` RPC method.
 use alloy_consensus::BlockHeader;
-use alloy_eips::eip7928::BlockAccessList;
+use alloy_eip7928::BlockAccessList;
+use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::BlockId;
 use reth_errors::RethError;
 use reth_evm::{block::BlockExecutor, ConfigureEvm, Evm};
@@ -68,6 +69,27 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
                 Ok(bal)
             })
             .await
+        }
+    }
+
+    /// Retrieves the raw RLP-encoded block access list for a block.
+    fn get_raw_block_access_list(
+        &self,
+        block_id: BlockId,
+    ) -> impl Future<Output = Result<Option<Bytes>, Self::Error>> + Send {
+        async move {
+            let block = self
+                .recovered_block(block_id)
+                .await?
+                .ok_or_else(|| EthApiError::HeaderNotFound(block_id))?;
+
+            if let Some(cached_bal) =
+                self.cache().get_bal(block.hash()).await.map_err(Self::Error::from_eth_err)?
+            {
+                return Ok(Some(cached_bal.as_raw().clone()))
+            }
+
+            Ok(self.get_block_access_list(block_id).await?.map(|bal| alloy_rlp::encode(bal).into()))
         }
     }
 }


### PR DESCRIPTION
Returns cached raw BAL bytes directly from the RPC BAL cache for `eth_getBlockAccessListRaw`.

Cache misses keep the existing `get_block_access_list` replay-and-encode path, while cache hits avoid cloning the decoded BAL and RLP-encoding it again.