### PR TITLE
fix(rpc): remove stale debug endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9827,7 +9827,6 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",
- "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -165,7 +165,7 @@ impl LogArgs {
     /// Initializes tracing with the configured options from cli args.
     ///
     /// When `enable_reload` is true, a global log handle is installed that allows changing
-    /// log levels at runtime via RPC methods like `debug_verbosity` and `debug_vmodule`.
+    /// log levels at runtime.
     ///
     /// # Arguments
     /// * `layers` - Pre-configured layers to include

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -162,12 +162,6 @@ pub trait DebugApi<TxReq: RpcObject> {
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness>;
 
-    /// Sets the logging backtrace location. When a backtrace location is set and a log message is
-    /// emitted at that location, the stack of the goroutine executing the log statement will
-    /// be printed to stderr.
-    #[method(name = "backtraceAt")]
-    async fn debug_backtrace_at(&self, location: &str) -> RpcResult<()>;
-
     /// Enumerates all accounts at a given block with paging capability. `maxResults` are returned
     /// in the page and the items have keys that come after the `start` key (hashed address).
     ///
@@ -183,12 +177,6 @@ pub trait DebugApi<TxReq: RpcObject> {
         nostorage: bool,
         incompletes: bool,
     ) -> RpcResult<()>;
-
-    /// Turns on block profiling for the given duration and writes profile data to disk. It uses a
-    /// profile rate of 1 for most accurate information. If a different rate is desired, set the
-    /// rate and write the profile manually using `debug_writeBlockProfile`.
-    #[method(name = "blockProfile")]
-    async fn debug_block_profile(&self, file: String, seconds: u64) -> RpcResult<()>;
 
     /// Flattens the entire key-value database into a single level, removing all unused slots and
     /// merging all keys.
@@ -212,10 +200,6 @@ pub trait DebugApi<TxReq: RpcObject> {
         block_id: Option<BlockId>,
     ) -> RpcResult<Option<Bytes>>;
 
-    /// Turns on CPU profiling for the given duration and writes profile data to disk.
-    #[method(name = "cpuProfile")]
-    async fn debug_cpu_profile(&self, file: String, seconds: u64) -> RpcResult<()>;
-
     /// Retrieves an ancient binary blob from the freezer. The freezer is a collection of
     /// append-only immutable files. The first argument `kind` specifies which table to look up data
     /// from. The list of all table kinds are as follows:
@@ -238,10 +222,6 @@ pub trait DebugApi<TxReq: RpcObject> {
     /// Forces garbage collection.
     #[method(name = "freeOSMemory")]
     async fn debug_free_os_memory(&self) -> RpcResult<()>;
-
-    /// Forces a temporary client freeze, normally when the server is overloaded.
-    #[method(name = "freezeClient")]
-    async fn debug_freeze_client(&self, node: String) -> RpcResult<()>;
 
     /// Returns garbage collection statistics.
     #[method(name = "gcStats")]
@@ -278,10 +258,6 @@ pub trait DebugApi<TxReq: RpcObject> {
         end_number: u64,
     ) -> RpcResult<()>;
 
-    /// Turns on Go runtime tracing for the given duration and writes trace data to disk.
-    #[method(name = "goTrace")]
-    async fn debug_go_trace(&self, file: String, seconds: u64) -> RpcResult<()>;
-
     /// Executes a block (bad- or canon- or side-), and returns a list of intermediate roots: the
     /// stateroot after each transaction.
     #[method(name = "intermediateRoots")]
@@ -295,12 +271,6 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "memStats")]
     async fn debug_mem_stats(&self) -> RpcResult<()>;
 
-    /// Turns on mutex profiling for `nsec` seconds and writes profile data to file. It uses a
-    /// profile rate of 1 for most accurate information. If a different rate is desired, set the
-    /// rate and write the profile manually.
-    #[method(name = "mutexProfile")]
-    async fn debug_mutex_profile(&self, file: String, nsec: u64) -> RpcResult<()>;
-
     /// Returns the preimage for a sha3 hash, if known.
     #[method(name = "preimage")]
     async fn debug_preimage(&self, hash: B256) -> RpcResult<()>;
@@ -313,12 +283,6 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "seedHash")]
     async fn debug_seed_hash(&self, number: u64) -> RpcResult<B256>;
 
-    /// Sets the rate (in samples/sec) of goroutine block profile data collection. A non-zero rate
-    /// enables block profiling, setting it to zero stops the profile. Collected profile data can be
-    /// written using `debug_writeBlockProfile`.
-    #[method(name = "setBlockProfileRate")]
-    async fn debug_set_block_profile_rate(&self, rate: u64) -> RpcResult<()>;
-
     /// Sets the garbage collection target percentage. A negative value disables garbage collection.
     #[method(name = "setGCPercent")]
     async fn debug_set_gc_percent(&self, v: i32) -> RpcResult<()>;
@@ -328,19 +292,11 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "setHead")]
     async fn debug_set_head(&self, number: U64) -> RpcResult<()>;
 
-    /// Sets the rate of mutex profiling.
-    #[method(name = "setMutexProfileFraction")]
-    async fn debug_set_mutex_profile_fraction(&self, rate: i32) -> RpcResult<()>;
-
     /// Configures how often in-memory state tries are persisted to disk. The interval needs to be
     /// in a format parsable by a time.Duration. Note that the interval is not wall-clock time.
     /// Rather it is accumulated block processing time after which the state should be flushed.
     #[method(name = "setTrieFlushInterval")]
     async fn debug_set_trie_flush_interval(&self, interval: String) -> RpcResult<()>;
-
-    /// Returns a printed representation of the stacks of all goroutines.
-    #[method(name = "stacks")]
-    async fn debug_stacks(&self) -> RpcResult<()>;
 
     /// Used to obtain info about a block.
     #[method(name = "standardTraceBadBlockToFile")]
@@ -359,14 +315,6 @@ pub trait DebugApi<TxReq: RpcObject> {
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<()>;
 
-    /// Turns on CPU profiling indefinitely, writing to the given file.
-    #[method(name = "startCPUProfile")]
-    async fn debug_start_cpu_profile(&self, file: String) -> RpcResult<()>;
-
-    /// Starts writing a Go runtime trace to the given file.
-    #[method(name = "startGoTrace")]
-    async fn debug_start_go_trace(&self, file: String) -> RpcResult<()>;
-
     /// Returns the state root of the `HashedPostState` on top of the state for the given block with
     /// trie updates.
     #[method(name = "stateRootWithUpdates")]
@@ -375,14 +323,6 @@ pub trait DebugApi<TxReq: RpcObject> {
         hashed_state: HashedPostState,
         block_id: Option<BlockId>,
     ) -> RpcResult<(B256, TrieUpdates)>;
-
-    /// Stops an ongoing CPU profile.
-    #[method(name = "stopCPUProfile")]
-    async fn debug_stop_cpu_profile(&self) -> RpcResult<()>;
-
-    /// Stops writing the Go runtime trace.
-    #[method(name = "stopGoTrace")]
-    async fn debug_stop_go_trace(&self) -> RpcResult<()>;
 
     /// Returns the storage at the given block height and transaction index. The result can be
     /// paged by providing a `maxResult` to cap the number of storage slots returned as well as
@@ -406,48 +346,4 @@ pub trait DebugApi<TxReq: RpcObject> {
         block_hash: B256,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
-
-    /// Sets the logging verbosity ceiling. Log messages with level up to and including the given
-    /// level will be printed.
-    #[method(name = "verbosity")]
-    async fn debug_verbosity(&self, level: usize) -> RpcResult<()>;
-
-    /// Sets the logging verbosity pattern.
-    #[method(name = "vmodule")]
-    async fn debug_vmodule(&self, pattern: String) -> RpcResult<()>;
-
-    /// Writes a goroutine blocking profile to the given file.
-    #[method(name = "writeBlockProfile")]
-    async fn debug_write_block_profile(&self, file: String) -> RpcResult<()>;
-
-    /// Writes an allocation profile to the given file.
-    #[method(name = "writeMemProfile")]
-    async fn debug_write_mem_profile(&self, file: String) -> RpcResult<()>;
-
-    /// Writes a goroutine blocking profile to the given file.
-    #[method(name = "writeMutexProfile")]
-    async fn debug_write_mutex_profile(&self, file: String) -> RpcResult<()>;
-}
-
-/// An extension to the `debug_` namespace that provides additional methods for retrieving
-/// witnesses.
-///
-/// This is separate from the regular `debug_` api, because this depends on the network specific
-/// params. For optimism this will expect the optimism specific payload attributes
-#[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
-#[cfg_attr(feature = "client", rpc(server, client, namespace = "debug"))]
-pub trait DebugExecutionWitnessApi<Attributes> {
-    /// The `debug_executePayload` method allows for re-execution of a group of transactions with
-    /// the purpose of generating an execution witness. The witness comprises of a map of all
-    /// hashed trie nodes to their preimages that were required during the execution of the block,
-    /// including during state root recomputation.
-    ///
-    /// The first argument is the parent block hash. The second argument is the payload
-    /// attributes for the new block.
-    #[method(name = "executePayload")]
-    async fn execute_payload(
-        &self,
-        parent_block_hash: B256,
-        attributes: Attributes,
-    ) -> RpcResult<ExecutionWitness>;
 }

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -41,7 +41,7 @@ pub use servers::*;
 pub mod servers {
     pub use crate::{
         admin::AdminApiServer,
-        debug::{DebugApiServer, DebugExecutionWitnessApiServer},
+        debug::DebugApiServer,
         engine::{EngineApiServer, EngineEthApiServer, IntoEngineApiRpcModule},
         mev::{MevFullApiServer, MevSimApiServer},
         miner::MinerApiServer,
@@ -72,7 +72,7 @@ pub mod clients {
     pub use crate::{
         admin::AdminApiClient,
         anvil::AnvilApiClient,
-        debug::{DebugApiClient, DebugExecutionWitnessApiClient},
+        debug::DebugApiClient,
         engine::{EngineApiClient, EngineEthApiClient},
         hardhat::HardhatApiClient,
         mev::{MevFullApiClient, MevSimApiClient},

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -28,7 +28,6 @@ reth-network-api.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-revm = { workspace = true, features = ["witness"] }
 reth-tasks = { workspace = true, features = ["rayon"] }
-reth-tracing.workspace = true
 reth-rpc-convert.workspace = true
 revm-inspectors.workspace = true
 reth-network-peers = { workspace = true, features = ["secp256k1"] }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -831,10 +831,6 @@ where
         Self::debug_execution_witness_by_block_hash(self, hash, mode).await.map_err(Into::into)
     }
 
-    async fn debug_backtrace_at(&self, _location: &str) -> RpcResult<()> {
-        Ok(())
-    }
-
     async fn debug_account_range(
         &self,
         _block_number: BlockNumberOrTag,
@@ -844,10 +840,6 @@ where
         _nostorage: bool,
         _incompletes: bool,
     ) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_block_profile(&self, _file: String, _seconds: u64) -> RpcResult<()> {
         Ok(())
     }
 
@@ -869,10 +861,6 @@ where
         block_id: Option<BlockId>,
     ) -> RpcResult<Option<Bytes>> {
         Self::debug_code_by_hash(self, hash, block_id).await.map_err(Into::into)
-    }
-
-    async fn debug_cpu_profile(&self, _file: String, _seconds: u64) -> RpcResult<()> {
-        Ok(())
     }
 
     async fn debug_db_ancient(&self, _kind: String, _number: u64) -> RpcResult<()> {
@@ -925,10 +913,6 @@ where
         Ok(())
     }
 
-    async fn debug_freeze_client(&self, _node: String) -> RpcResult<()> {
-        Ok(())
-    }
-
     async fn debug_gc_stats(&self) -> RpcResult<()> {
         Ok(())
     }
@@ -957,10 +941,6 @@ where
         Ok(())
     }
 
-    async fn debug_go_trace(&self, _file: String, _seconds: u64) -> RpcResult<()> {
-        Ok(())
-    }
-
     async fn debug_intermediate_roots(
         &self,
         block_hash: B256,
@@ -971,10 +951,6 @@ where
     }
 
     async fn debug_mem_stats(&self) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_mutex_profile(&self, _file: String, _nsec: u64) -> RpcResult<()> {
         Ok(())
     }
 
@@ -990,10 +966,6 @@ where
         Ok(Default::default())
     }
 
-    async fn debug_set_block_profile_rate(&self, _rate: u64) -> RpcResult<()> {
-        Ok(())
-    }
-
     async fn debug_set_gc_percent(&self, _v: i32) -> RpcResult<()> {
         Ok(())
     }
@@ -1002,15 +974,7 @@ where
         Ok(())
     }
 
-    async fn debug_set_mutex_profile_fraction(&self, _rate: i32) -> RpcResult<()> {
-        Ok(())
-    }
-
     async fn debug_set_trie_flush_interval(&self, _interval: String) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_stacks(&self) -> RpcResult<()> {
         Ok(())
     }
 
@@ -1030,28 +994,12 @@ where
         Ok(())
     }
 
-    async fn debug_start_cpu_profile(&self, _file: String) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_start_go_trace(&self, _file: String) -> RpcResult<()> {
-        Ok(())
-    }
-
     async fn debug_state_root_with_updates(
         &self,
         hashed_state: HashedPostState,
         block_id: Option<BlockId>,
     ) -> RpcResult<(B256, TrieUpdates)> {
         Self::debug_state_root_with_updates(self, hashed_state, block_id).await.map_err(Into::into)
-    }
-
-    async fn debug_stop_cpu_profile(&self) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_stop_go_trace(&self) -> RpcResult<()> {
-        Ok(())
     }
 
     async fn debug_storage_range_at(
@@ -1086,26 +1034,6 @@ where
 
         let opts = opts.map(|o| o.tracing_options).unwrap_or_default();
         self.trace_block(entry.block.clone(), evm_env, opts).await.map_err(Into::into)
-    }
-
-    async fn debug_verbosity(&self, level: usize) -> RpcResult<()> {
-        reth_tracing::set_log_verbosity(level).map_err(internal_rpc_err)
-    }
-
-    async fn debug_vmodule(&self, pattern: String) -> RpcResult<()> {
-        reth_tracing::set_log_vmodule(&pattern).map_err(internal_rpc_err)
-    }
-
-    async fn debug_write_block_profile(&self, _file: String) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_write_mem_profile(&self, _file: String) -> RpcResult<()> {
-        Ok(())
-    }
-
-    async fn debug_write_mutex_profile(&self, _file: String) -> RpcResult<()> {
-        Ok(())
     }
 }
 

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -87,7 +87,7 @@ pub struct RethTracer {
     #[cfg(feature = "tracy")]
     tracy: Option<LayerInfo>,
     /// When true, the stdout filter is wrapped in a reload layer so log levels
-    /// can be changed at runtime via RPC (`debug_verbosity`, `debug_vmodule`).
+    /// can be changed at runtime.
     enable_reload: bool,
 }
 
@@ -149,7 +149,7 @@ impl RethTracer {
         self
     }
 
-    /// Enables runtime log filter reloading via RPC (`debug_verbosity`, `debug_vmodule`).
+    /// Enables runtime log filter reloading.
     pub const fn with_reload(mut self, enable: bool) -> Self {
         self.enable_reload = enable;
         self


### PR DESCRIPTION
References https://hackmd.io/@bomanaps/rJXLPhYRWl.

Removes Reth-only `debug_` RPC endpoints that were inherited from older geth-style profiling/runtime APIs but only returned no-op responses, plus the unimplemented `debug_executePayload` trait surface. This keeps the advertised debug API closer to actual behavior while leaving implemented Reth-specific methods such as `debug_codeByHash`, `debug_stateRootWithUpdates`, and `debug_getRawTransactions` intact.