### PR TITLE
feat(rpc): add eth_pendingTransactions

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -186,6 +186,10 @@ pub trait EthApi<
         nonce: U64,
     ) -> RpcResult<Option<T>>;
 
+    /// Returns all transactions in the local pending pool.
+    #[method(name = "pendingTransactions")]
+    fn pending_transactions(&self) -> RpcResult<Vec<T>>;
+
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]
     async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<R>>;
@@ -646,6 +650,12 @@ where
         trace!(target: "rpc::eth", ?sender, ?nonce, "Serving eth_getTransactionBySenderAndNonce");
         Ok(EthTransactions::get_transaction_by_sender_and_nonce(self, sender, nonce.to(), true)
             .await?)
+    }
+
+    /// Handler for: `eth_pendingTransactions`
+    fn pending_transactions(&self) -> RpcResult<Vec<RpcTransaction<T::NetworkTypes>>> {
+        trace!(target: "rpc::eth", "Serving eth_pendingTransactions");
+        Ok(EthTransactions::pending_transactions(self)?)
     }
 
     /// Handler for: `eth_getTransactionReceipt`

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -157,6 +157,16 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         LoadTransaction::transaction_by_hash(self, hash)
     }
 
+    /// Returns all transactions from the local pending pool.
+    fn pending_transactions(&self) -> Result<Vec<RpcTransaction<Self::NetworkTypes>>, Self::Error> {
+        self.pool()
+            .pending_transactions()
+            .into_iter()
+            .map(|tx| self.converter().fill_pending(tx.transaction.clone_into_consensus()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Self::Error::from)
+    }
+
     /// Get all transactions in the block with the given hash.
     ///
     /// Returns `None` if block does not exist.


### PR DESCRIPTION
Adds `eth_pendingTransactions` to the `eth_` RPC namespace for compatibility with clients and tooling that call this method.

The endpoint returns the local transaction pool pending transactions and reuses the existing pending transaction RPC conversion path, so block-related fields remain unset. It does not include queued/future transactions.

ref https://hackmd.io/@bomanaps/rJXLPhYRWl