### PR TITLE
refactor(tx-pool): simplify blob cell lookup

### DIFF
--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -392,28 +392,10 @@ impl BlobStore for DiskFileBlobStore {
             return Ok(None);
         };
 
-        let versioned_hashes = sidecar.versioned_hashes().collect::<Vec<_>>();
-
-        let matches =
-            self.get_by_versioned_hashes_cells_eip7594(&versioned_hashes, indices_bitarray)?;
-
-        let mut cells = Vec::new();
-
-        for matched in matches {
-            let Some(matched) = matched else {
-                return Ok(None);
-            };
-
-            for cell in matched.blob_cells {
-                let Some(cell) = cell else {
-                    return Ok(None);
-                };
-
-                cells.push(cell);
-            }
-        }
-
-        Ok(Some(cells))
+        sidecar
+            .compute_matching_cells(BlobCellMask::new(indices_bitarray))
+            .map(Some)
+            .map_err(|err| BlobStoreError::Other(Box::new(err)))
     }
 
     fn data_size_hint(&self) -> Option<usize> {
@@ -1083,6 +1065,31 @@ mod tests {
         let cells_and_proofs = v4[0].as_ref().unwrap();
         assert_eq!(cells_and_proofs.blob_cells.len(), 1);
         assert_eq!(cells_and_proofs.proofs, vec![Some(Bytes48::default())]);
+    }
+
+    #[test]
+    fn disk_get_cells_can_fallback_to_disk() {
+        let (store, _dir) = tmp_store();
+
+        let tx_hash = TxHash::random();
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(tx_hash, sidecar).unwrap();
+
+        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let expected = store
+            .get_by_versioned_hashes_v4(&[versioned_hash], indices_bitarray)
+            .unwrap()
+            .pop()
+            .unwrap()
+            .unwrap()
+            .blob_cells
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .unwrap();
+
+        store.clear_cache();
+
+        assert_eq!(store.get_cells(tx_hash, indices_bitarray).unwrap(), Some(expected));
     }
 
     #[test]

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -238,28 +238,10 @@ impl BlobStore for InMemoryBlobStore {
             return Ok(None);
         };
 
-        let versioned_hashes = sidecar.versioned_hashes().collect::<Vec<_>>();
-
-        let matches =
-            self.get_by_versioned_hashes_cells_eip7594(&versioned_hashes, indices_bitarray)?;
-
-        let mut cells = Vec::new();
-
-        for matched in matches {
-            let Some(matched) = matched else {
-                return Ok(None);
-            };
-
-            for cell in matched.blob_cells {
-                let Some(cell) = cell else {
-                    return Ok(None);
-                };
-
-                cells.push(cell);
-            }
-        }
-
-        Ok(Some(cells))
+        sidecar
+            .compute_matching_cells(BlobCellMask::new(indices_bitarray))
+            .map(Some)
+            .map_err(|err| BlobStoreError::Other(Box::new(err)))
     }
 
     fn data_size_hint(&self) -> Option<usize> {
@@ -351,5 +333,28 @@ mod tests {
         assert_eq!(cells_and_proofs.proofs.len(), 2);
         assert!(cells_and_proofs.blob_cells.iter().all(Option::is_some));
         assert_eq!(cells_and_proofs.proofs, vec![Some(Bytes48::default()); 2]);
+    }
+
+    #[test]
+    fn mem_get_cells_returns_requested_cells() {
+        let store = InMemoryBlobStore::default();
+
+        let tx_hash = B256::random();
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(tx_hash, sidecar).unwrap();
+
+        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let expected = store
+            .get_by_versioned_hashes_v4(&[versioned_hash], indices_bitarray)
+            .unwrap()
+            .pop()
+            .unwrap()
+            .unwrap()
+            .blob_cells
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(store.get_cells(tx_hash, indices_bitarray).unwrap(), Some(expected));
     }
 }


### PR DESCRIPTION
Uses Alloy's EIP-7594 `compute_matching_cells` helper for tx-hash cell lookups instead of rebuilding the request through versioned hashes and unwrapping per-cell options.

Adds direct `get_cells` coverage for memory and disk blob stores, including disk reads after cache eviction.