### PR TITLE
bench: use workflow Slack notifier for bench results

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -838,7 +838,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const { verdict, fmtChange, fmtMs, metricRows, waitTimeRows, blocksLabel } = require('./.github/scripts/bench-utils');
+            const { verdict, fmtChange, fmtMs, metricRows, blocksLabel } = require('./.github/scripts/bench-utils');
 
             const token = process.env.SLACK_BENCH_BOT_TOKEN;
             const channel = process.env.SLACK_BENCH_CHANNEL;
@@ -955,33 +955,6 @@ jobs:
             if (!data.ok) {
               core.warning(`Slack API error: ${JSON.stringify(data)}`);
               return;
-            }
-
-            // Post wait time breakdown as threaded reply
-            const wtRows = waitTimeRows(summary);
-            if (data.ts && wtRows.length > 0) {
-              const waitTableRows = [
-                [cell('Wait Time'), cell('Baseline'), cell('Feature')],
-                ...wtRows.map(r => [cell(r.title), cell(r.baseline), cell(r.feature)]),
-              ];
-              await fetch('https://slack.com/api/chat.postMessage', {
-                method: 'POST',
-                headers: {
-                  'Authorization': `Bearer ${token}`,
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  channel,
-                  thread_ts: data.ts,
-                  blocks: [{
-                    type: 'table',
-                    column_settings: [{ align: 'left' }, { align: 'right' }, { align: 'right' }],
-                    rows: waitTableRows,
-                  }],
-                  text: 'Wait time breakdown',
-                  unfurl_links: false,
-                }),
-              });
             }
 
       - name: Send Slack notification (failure)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -646,6 +646,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.checkout-ref.outputs.ref }}
 
+      - name: Checkout workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+          path: .bench-workflow-scripts
+          sparse-checkout: .github/scripts
+
       - name: Resolve job URL and update status
         if: env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -1377,7 +1386,7 @@ jobs:
           SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
         with:
           script: |
-            const notify = require('./.github/scripts/bench-slack-notify.js');
+            const notify = require('./.bench-workflow-scripts/.github/scripts/bench-slack-notify.js');
             await notify.success({ core, context });
 
       - name: Update status (failed)
@@ -1433,7 +1442,7 @@ jobs:
             ];
             const failed = steps_status.find(([, o]) => o === 'failure');
             const failedStep = failed ? failed[0] : 'unknown step';
-            const notify = require('./.github/scripts/bench-slack-notify.js');
+            const notify = require('./.bench-workflow-scripts/.github/scripts/bench-slack-notify.js');
             await notify.failure({ core, context, failedStep });
 
       - name: Update status (cancelled)


### PR DESCRIPTION
## Summary
- load bench Slack notifier scripts from the workflow commit instead of the PR checkout being benchmarked
- prevents older PR branches from reintroducing removed Slack thread replies like the wait-time breakdown
- also removes the same wait-time thread reply from scheduled bench notifications

## Evidence
- linked Slack reply came from bench run 26030071357 for PR #24294 at 2026-05-18 11:27 UTC
- that run checked out PR head 23bf7eb before requiring .github/scripts/bench-slack-notify.js

## Testing
- rg checked for remaining bench workflow wait-time thread posts