### PR TITLE
feat(rpc): add debug account state endpoints

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -3,7 +3,7 @@ use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, U64};
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{Bundle, StateContext};
+use alloy_rpc_types_eth::{Account, AccountInfo, Bundle, Index, StateContext};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -161,6 +161,26 @@ pub trait DebugApi<TxReq: RpcObject> {
         hash: B256,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness>;
+
+    /// Returns account information, including the storage root, at the state after executing the
+    /// transaction with the given index in the block.
+    #[method(name = "accountAt")]
+    async fn debug_account_at(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        address: Address,
+    ) -> RpcResult<Option<Account>>;
+
+    /// Returns account information at the state after executing the transaction with the given
+    /// index in the block.
+    #[method(name = "accountInfoAt")]
+    async fn debug_account_info_at(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        address: Address,
+    ) -> RpcResult<Option<AccountInfo>>;
 
     /// Enumerates all accounts at a given block with paging capability. `maxResults` are returned
     /// in the page and the items have keys that come after the `start` key (hashed address).

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -447,6 +447,22 @@ where
     DebugApiClient::<TransactionRequest>::raw_transaction(client, B256::default()).await.unwrap();
     DebugApiClient::<TransactionRequest>::raw_receipts(client, block_id).await.unwrap_err();
     DebugApiClient::<TransactionRequest>::bad_blocks(client).await.unwrap();
+    DebugApiClient::<TransactionRequest>::debug_account_at(
+        client,
+        block_id,
+        Index::default(),
+        Address::default(),
+    )
+    .await
+    .unwrap_err();
+    DebugApiClient::<TransactionRequest>::debug_account_info_at(
+        client,
+        block_id,
+        Index::default(),
+        Address::default(),
+    )
+    .await
+    .unwrap_err();
 }
 
 async fn test_basic_net_calls<C>(client: &C)

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::{transaction::TxHashRef, BlockHeader};
+use alloy_consensus::{constants::KECCAK_EMPTY, transaction::TxHashRef, BlockHeader};
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_evm::{env::BlockEnvironment, Evm};
 use alloy_genesis::ChainConfig;
@@ -6,7 +6,9 @@ use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
+use alloy_rpc_types_eth::{
+    state::EvmOverrides, Account, AccountInfo, BlockError, Bundle, Index, StateContext,
+};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
@@ -17,7 +19,7 @@ use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::ConsensusEngineEvent;
 use reth_errors::RethError;
-use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor};
+use reth_evm::{block::BlockExecutor, execute::Executor, ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{
     Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom, RecoveredBlock,
 };
@@ -28,15 +30,18 @@ use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
     FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
-    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, TransactionVariant,
+    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, StorageRootProvider,
+    TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
-use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
-use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
+use reth_trie_common::{
+    updates::TrieUpdates, ExecutionWitnessMode, HashedPostState, HashedStorage,
+};
+use revm::{database::states::bundle_state::BundleRetention, Database, DatabaseCommit};
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, sync::Arc};
@@ -553,6 +558,118 @@ where
             .await
     }
 
+    /// Returns account information, including the storage root, after replaying the block through
+    /// the transaction at the given index.
+    pub async fn debug_account_at(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        address: Address,
+    ) -> Result<Option<Account>, Eth::Error> {
+        self.replay_block_until(block_id, tx_index, move |db| Self::account(db, address))
+            .await
+            .map(Option::flatten)
+    }
+
+    /// Returns account information after replaying the block through the transaction at the given
+    /// index.
+    pub async fn debug_account_info_at(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        address: Address,
+    ) -> Result<Option<AccountInfo>, Eth::Error> {
+        self.replay_block_until(block_id, tx_index, move |db| Self::account_info(db, address)).await
+    }
+
+    /// Replays a block through the transaction at the given index and calls `f` with the resulting
+    /// state.
+    async fn replay_block_until<F, R>(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        f: F,
+    ) -> Result<Option<R>, Eth::Error>
+    where
+        F: FnOnce(&mut StateCacheDb) -> Result<R, Eth::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        let block = self
+            .eth_api()
+            .recovered_block(block_id)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+        let tx_index = usize::from(tx_index);
+        let transaction_count = block.transaction_count();
+        if tx_index >= transaction_count {
+            return Err(EthApiError::InvalidParams(format!(
+                "tx_index {tx_index} out of bounds for block with {transaction_count} transactions"
+            ))
+            .into())
+        }
+
+        self.eth_api()
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
+                let mut executor = eth_api
+                    .evm_config()
+                    .executor_for_block(&mut db, block.sealed_block())
+                    .map_err(RethError::other)
+                    .map_err(Eth::Error::from_eth_err)?;
+                executor.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
+
+                for tx in block.transactions_recovered().take(tx_index + 1) {
+                    executor.execute_transaction(tx).map_err(Eth::Error::from_eth_err)?;
+                }
+                drop(executor);
+
+                f(&mut db)
+            })
+            .await
+            .map(Some)
+    }
+
+    /// Retrieves the account's balance, nonce, code hash, and storage root from the given state.
+    fn account(db: &mut StateCacheDb, address: Address) -> Result<Option<Account>, Eth::Error> {
+        let account = db.basic(address).map_err(Eth::Error::from_eth_err)?;
+        let Some(account) = account else { return Ok(None) };
+
+        let balance = account.balance;
+        let nonce = account.nonce;
+        let code_hash = account.code_hash;
+        let hashed_storage = db
+            .cache
+            .accounts
+            .get(&address)
+            .and_then(|account| {
+                account.account.as_ref().map(|plain_account| {
+                    HashedStorage::from_plain_storage(account.status, plain_account.storage.iter())
+                })
+            })
+            .unwrap_or_default();
+        let storage_root =
+            db.database.storage_root(address, hashed_storage).map_err(Eth::Error::from_eth_err)?;
+
+        Ok(Some(Account { balance, nonce, code_hash, storage_root }))
+    }
+
+    /// Retrieves the account's balance, nonce, and code from the given state.
+    fn account_info<DB>(db: &mut DB, address: Address) -> Result<AccountInfo, Eth::Error>
+    where
+        DB: Database,
+        EthApiError: From<DB::Error>,
+    {
+        let account = db.basic(address).map_err(Eth::Error::from_eth_err)?.unwrap_or_default();
+        let code = if account.code_hash == KECCAK_EMPTY {
+            Default::default()
+        } else if let Some(code) = account.code {
+            code.original_bytes()
+        } else {
+            db.code_by_hash(account.code_hash).map_err(Eth::Error::from_eth_err)?.original_bytes()
+        };
+
+        Ok(AccountInfo { balance: account.balance, nonce: account.nonce, code })
+    }
+
     /// Returns the code associated with a given hash at the specified block ID. If no code is
     /// found, it returns None. If no block ID is provided, it defaults to the latest block.
     pub async fn debug_code_by_hash(
@@ -829,6 +946,28 @@ where
     ) -> RpcResult<ExecutionWitness> {
         let _permit = self.acquire_trace_permit().await;
         Self::debug_execution_witness_by_block_hash(self, hash, mode).await.map_err(Into::into)
+    }
+
+    /// Handler for `debug_accountAt`
+    async fn debug_account_at(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        address: Address,
+    ) -> RpcResult<Option<Account>> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_account_at(self, block_id, tx_index, address).await.map_err(Into::into)
+    }
+
+    /// Handler for `debug_accountInfoAt`
+    async fn debug_account_info_at(
+        &self,
+        block_id: BlockId,
+        tx_index: Index,
+        address: Address,
+    ) -> RpcResult<Option<AccountInfo>> {
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_account_info_at(self, block_id, tx_index, address).await.map_err(Into::into)
     }
 
     async fn debug_account_range(

--- a/docs/vocs/docs/pages/jsonrpc/debug.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/debug.mdx
@@ -139,6 +139,22 @@ Similar to [`debug_executionWitness`](#debug_executionwitness), but accepts a bl
 | ------ | ---------------------------------------------------------------------- |
 | RPC    | `{"method": "debug_executionWitnessByBlockHash", "params": [hash]}` |
 
+## `debug_accountAt`
+
+Returns account information, including the storage root, after replaying a block through the transaction at the given index.
+
+| Client | Method invocation                                                   |
+| ------ | ------------------------------------------------------------------- |
+| RPC    | `{"method": "debug_accountAt", "params": [block_id, tx_index, address]}` |
+
+## `debug_accountInfoAt`
+
+Returns account information, without the storage root, after replaying a block through the transaction at the given index.
+
+| Client | Method invocation                                                       |
+| ------ | ----------------------------------------------------------------------- |
+| RPC    | `{"method": "debug_accountInfoAt", "params": [block_id, tx_index, address]}` |
+
 ## `debug_dbGet`
 
 Retrieves a raw value from the database.

--- a/docs/vocs/docs/pages/run/faq/pruning.mdx
+++ b/docs/vocs/docs/pages/run/faq/pruning.mdx
@@ -146,6 +146,8 @@ The following tables describe RPC methods available in the full node.
 
 | RPC                                 | Note                                                       |
 | ----------------------------------- | ---------------------------------------------------------- |
+| `debug_accountAt`                   | Only for the last 10064 blocks                             |
+| `debug_accountInfoAt`               | Only for the last 10064 blocks                             |
 | `debug_chainConfig`                 |                                                            |
 | `debug_codeByHash`                  | Only for the last 10064 blocks                             |
 | `debug_dbGet`                       |                                                            |
@@ -257,6 +259,8 @@ The following tables describe the requirements for prune segments, per RPC metho
 
 | RPC / Segment                       | Sender Recovery | Transaction Lookup | Receipts | Account History | Storage History |
 | ----------------------------------- | --------------- | ------------------ | -------- | --------------- | --------------- |
+| `debug_accountAt`                   | ✅              | ✅                 | ✅       | ❌              | ❌              |
+| `debug_accountInfoAt`               | ✅              | ✅                 | ✅       | ❌              | ❌              |
 | `debug_chainConfig`                 | ✅              | ✅                 | ✅       | ✅              | ✅              |
 | `debug_codeByHash`                  | ✅              | ✅                 | ✅       | ❌              | ✅              |
 | `debug_dbGet`                       | ✅              | ✅                 | ✅       | ✅              | ✅              |


### PR DESCRIPTION
Adds `debug_accountAt` and `debug_accountInfoAt` for inspecting account state after replaying a block through a transaction index. `debug_accountAt` mirrors `eth_getAccount` by including the storage root, while `debug_accountInfoAt` mirrors `eth_getAccountInfo` without the root.

This fills debug endpoints from the client support comparison doc: https://hackmd.io/@bomanaps/rJXLPhYRWl