### PR TITLE
feat(net): advertise eth/70 and eth/71 by default

### DIFF
--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -37,10 +37,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth71;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {


### PR DESCRIPTION
Bumps \`EthVersion::LATEST\` to \`Eth71\` and adds \`Eth70\`/\`Eth71\` to \`ALL_VERSIONS\`, so the default \`HelloMessage\` capability set negotiates them with peers.

The eth/70 (EIP-7975 partial receipts) and eth/71 (block access lists) message handling, request server, and session routing are already in tree — they were just gated behind a default capability set that capped at eth/69. This flips them on for the BAL devnet.