### PR TITLE
feat(rpc): add eth_getLogsWithCursor for paginated log queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10090,6 +10090,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
+ "data-encoding",
  "derive_more",
  "futures",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10072,6 +10072,7 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -58,6 +58,7 @@ tokio.workspace = true
 # misc
 auto_impl.workspace = true
 dyn-clone.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true
 

--- a/crates/rpc/rpc-eth-api/src/filter.rs
+++ b/crates/rpc/rpc-eth-api/src/filter.rs
@@ -3,6 +3,7 @@
 use alloy_json_rpc::RpcObject;
 use alloy_rpc_types_eth::{Filter, FilterChanges, FilterId, Log, PendingTransactionFilterKind};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use serde::{Deserialize, Serialize};
 use std::future::Future;
 
 /// Rpc Interface for poll-based ethereum filter API.
@@ -39,6 +40,38 @@ pub trait EthFilterApi<T: RpcObject> {
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
     async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+
+    /// Returns logs matching given filter object with cursor-based pagination.
+    ///
+    /// On the first call, pass `cursor = None`. The response contains a page of matching
+    /// logs and, if more pages are available, a `next_cursor` token. Pass that token
+    /// back on the next call (with the same `filter`) to fetch the next page. When the
+    /// response's `next_cursor` is `None`, all matching logs have been returned.
+    ///
+    /// Pagination is at block boundaries: a single response always contains complete
+    /// blocks (mirroring the atomicity guarantee of `eth_getLogs`). The cursor is bound
+    /// to the filter it was issued for; reusing a cursor with a different filter returns
+    /// a `cursor was issued for a different filter` error.
+    #[method(name = "getLogsWithCursor")]
+    async fn logs_with_cursor(
+        &self,
+        filter: Filter,
+        cursor: Option<String>,
+    ) -> RpcResult<LogsResponseWithCursor>;
+}
+
+/// Response returned by `eth_getLogsWithCursor`.
+///
+/// `next_cursor` is `None` when there are no more pages.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogsResponseWithCursor {
+    /// Matching logs for this page (in block, transaction, log order).
+    pub logs: Vec<Log>,
+    /// Opaque token to pass back on the next call to continue pagination. `None`
+    /// when all matching logs have been returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 /// Limits for logs queries

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -24,7 +24,7 @@ pub mod types;
 pub use bundle::{EthBundleApiServer, EthCallBundleApiServer};
 pub use core::{EthApiServer, FullEthApiServer};
 pub use ext::L2EthApiExtServer;
-pub use filter::{EngineEthFilter, EthFilterApiServer, QueryLimits};
+pub use filter::{EngineEthFilter, EthFilterApiServer, LogsResponseWithCursor, QueryLimits};
 pub use helpers::config::EthConfigApiServer;
 pub use node::{RpcNodeCore, RpcNodeCoreExt};
 pub use pubsub::EthPubSubApiServer;

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -63,6 +63,7 @@ schnellru.workspace = true
 rand.workspace = true
 tracing.workspace = true
 itertools.workspace = true
+data-encoding.workspace = true
 
 [dev-dependencies]
 reth-db-models.workspace = true

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -3,9 +3,10 @@
 //! Log parsing for building filter.
 
 use alloy_consensus::TxReceipt;
-use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
-use alloy_primitives::TxHash;
-use alloy_rpc_types_eth::{Filter, Log};
+use alloy_eips::{eip2718::Encodable2718, BlockNumHash, BlockNumberOrTag};
+use alloy_primitives::{keccak256, TxHash};
+use alloy_rpc_types_eth::{Filter, FilterBlockOption, Log};
+use data_encoding::BASE64URL_NOPAD;
 use reth_chainspec::ChainInfo;
 use reth_errors::ProviderError;
 use reth_primitives_traits::{BlockBody, RecoveredBlock, SignedTransaction};
@@ -178,6 +179,132 @@ pub fn get_filter_block_range(
     Ok((from_block_number, to_block_number))
 }
 
+/// Opaque cursor returned by `eth_getLogsWithCursor` to resume paginated log queries.
+///
+/// Encodes (version, filter hash, next block to resume from) into a base64url-no-pad
+/// string. Opaque to clients — they should treat it as a string token to pass back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogsCursor {
+    version: u8,
+    filter_hash: [u8; 16],
+    next_block: u64,
+}
+
+/// Current cursor format version. Incremented on wire-format changes.
+const LOGS_CURSOR_VERSION: u8 = 1;
+
+/// Decoded cursor length in bytes: 1 (version) + 16 (filter hash) + 8 (next block BE).
+const LOGS_CURSOR_BYTES: usize = 25;
+
+impl LogsCursor {
+    /// Build a cursor for the current format version.
+    pub const fn new(filter_hash: [u8; 16], next_block: u64) -> Self {
+        Self { version: LOGS_CURSOR_VERSION, filter_hash, next_block }
+    }
+
+    /// Block number the next paginated call should resume from.
+    pub const fn next_block(&self) -> u64 {
+        self.next_block
+    }
+
+    /// Hash of the filter this cursor was issued for; used by the server to detect
+    /// callers reusing a cursor against a different filter.
+    pub const fn filter_hash(&self) -> &[u8; 16] {
+        &self.filter_hash
+    }
+
+    /// Encode to the wire-format base64url-no-pad string.
+    pub fn encode(&self) -> String {
+        let mut bytes = [0u8; LOGS_CURSOR_BYTES];
+        bytes[0] = self.version;
+        bytes[1..17].copy_from_slice(&self.filter_hash);
+        bytes[17..25].copy_from_slice(&self.next_block.to_be_bytes());
+        BASE64URL_NOPAD.encode(&bytes)
+    }
+
+    /// Decode from the wire-format base64url-no-pad string.
+    pub fn decode(s: &str) -> Result<Self, LogsCursorError> {
+        let bytes = BASE64URL_NOPAD.decode(s.as_bytes()).map_err(|_| LogsCursorError::Invalid)?;
+        if bytes.len() != LOGS_CURSOR_BYTES {
+            return Err(LogsCursorError::Invalid);
+        }
+        let version = bytes[0];
+        if version != LOGS_CURSOR_VERSION {
+            return Err(LogsCursorError::UnsupportedVersion(version));
+        }
+        let mut filter_hash = [0u8; 16];
+        filter_hash.copy_from_slice(&bytes[1..17]);
+        let next_block = u64::from_be_bytes(bytes[17..25].try_into().expect("checked length"));
+        Ok(Self { version, filter_hash, next_block })
+    }
+}
+
+/// Hashes a [`Filter`] into a deterministic 16-byte fingerprint used for cursor binding.
+///
+/// Filters that differ only in the order of addresses or topics produce the same fingerprint.
+/// Cursors carry this fingerprint so the server can detect callers reusing a cursor against
+/// a different filter and reject early instead of returning silently wrong results.
+pub fn canonical_filter_hash(filter: &Filter) -> [u8; 16] {
+    let mut buf = Vec::with_capacity(128);
+
+    match &filter.block_option {
+        FilterBlockOption::Range { from_block, to_block } => {
+            buf.push(0);
+            serialize_block_number_or_tag(&mut buf, from_block.as_ref());
+            serialize_block_number_or_tag(&mut buf, to_block.as_ref());
+        }
+        FilterBlockOption::AtBlockHash(hash) => {
+            buf.push(1);
+            buf.extend_from_slice(hash.as_slice());
+        }
+    }
+
+    let mut addrs: Vec<_> = filter.address.iter().collect();
+    addrs.sort();
+    buf.extend_from_slice(&(addrs.len() as u32).to_be_bytes());
+    for addr in addrs {
+        buf.extend_from_slice(addr.as_slice());
+    }
+
+    for topic in &filter.topics {
+        let mut topics: Vec<_> = topic.iter().collect();
+        topics.sort();
+        buf.extend_from_slice(&(topics.len() as u32).to_be_bytes());
+        for t in topics {
+            buf.extend_from_slice(t.as_slice());
+        }
+    }
+
+    let hash = keccak256(&buf);
+    hash[..16].try_into().expect("keccak256 returns 32 bytes")
+}
+
+fn serialize_block_number_or_tag(buf: &mut Vec<u8>, opt: Option<&BlockNumberOrTag>) {
+    match opt {
+        Some(BlockNumberOrTag::Number(n)) => {
+            buf.push(0);
+            buf.extend_from_slice(&n.to_be_bytes());
+        }
+        Some(BlockNumberOrTag::Latest) => buf.push(1),
+        Some(BlockNumberOrTag::Earliest) => buf.push(2),
+        Some(BlockNumberOrTag::Pending) => buf.push(3),
+        Some(BlockNumberOrTag::Safe) => buf.push(4),
+        Some(BlockNumberOrTag::Finalized) => buf.push(5),
+        None => buf.push(0xff),
+    }
+}
+
+/// Errors decoding a [`LogsCursor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum LogsCursorError {
+    /// Cursor string was not valid base64url or had the wrong length.
+    #[error("invalid cursor")]
+    Invalid,
+    /// Cursor was encoded with a version this server does not support.
+    #[error("unsupported cursor version: {0}")]
+    UnsupportedVersion(u8),
+}
+
 /// Errors for filter block range validation.
 ///
 /// See also <https://github.com/ethereum/go-ethereum/blob/master/eth/filters/filter.go#L224-L230>.
@@ -278,6 +405,65 @@ mod tests {
             err,
             FilterBlockRangeError::BlockRangeExceedsHead { requested: to, head: info.best_number }
         );
+    }
+
+    #[test]
+    fn logs_cursor_roundtrip() {
+        let filter_hash = [0xab; 16];
+        let cursor = LogsCursor::new(filter_hash, 12345);
+        let encoded = cursor.encode();
+        let decoded = LogsCursor::decode(&encoded).unwrap();
+        assert_eq!(decoded.next_block(), 12345);
+        assert_eq!(decoded.filter_hash(), &filter_hash);
+    }
+
+    #[test]
+    fn logs_cursor_rejects_unsupported_version() {
+        let mut bytes = [0u8; LOGS_CURSOR_BYTES];
+        bytes[0] = 99;
+        let encoded = BASE64URL_NOPAD.encode(&bytes);
+        let err = LogsCursor::decode(&encoded).unwrap_err();
+        assert_eq!(err, LogsCursorError::UnsupportedVersion(99));
+    }
+
+    #[test]
+    fn logs_cursor_rejects_wrong_length() {
+        let too_short = BASE64URL_NOPAD.encode(&[1u8; 10]);
+        assert_eq!(LogsCursor::decode(&too_short).unwrap_err(), LogsCursorError::Invalid);
+        let too_long = BASE64URL_NOPAD.encode(&[1u8; 100]);
+        assert_eq!(LogsCursor::decode(&too_long).unwrap_err(), LogsCursorError::Invalid);
+    }
+
+    #[test]
+    fn logs_cursor_rejects_invalid_base64() {
+        assert_eq!(LogsCursor::decode("not!valid!base64!").unwrap_err(), LogsCursorError::Invalid);
+    }
+
+    #[test]
+    fn canonical_filter_hash_deterministic() {
+        let filter = Filter::new()
+            .address(alloy_primitives::address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"))
+            .from_block(100u64)
+            .to_block(200u64);
+        let h1 = canonical_filter_hash(&filter);
+        let h2 = canonical_filter_hash(&filter);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn canonical_filter_hash_differs_per_filter() {
+        let a = Filter::new().from_block(100u64).to_block(200u64);
+        let b = Filter::new().from_block(100u64).to_block(300u64);
+        assert_ne!(canonical_filter_hash(&a), canonical_filter_hash(&b));
+    }
+
+    #[test]
+    fn canonical_filter_hash_address_order_independent() {
+        let addr1 = alloy_primitives::address!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let addr2 = alloy_primitives::address!("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        let a = Filter::new().address(vec![addr1, addr2]);
+        let b = Filter::new().address(vec![addr2, addr1]);
+        assert_eq!(canonical_filter_hash(&a), canonical_filter_hash(&b));
     }
 
     #[test]

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -820,6 +820,7 @@ where
             range_mode.next().await?
         {
             let num_hash = header.num_hash();
+            let prev_len = all_logs.len();
             append_matching_block_logs(
                 &mut all_logs,
                 recovered_block
@@ -839,10 +840,22 @@ where
                 is_multi_block_range &&
                 all_logs.len() > max_logs_per_response
             {
-                // In paginated mode, return a cursor pointing to the next unprocessed block
-                // instead of erroring. The current block is fully processed and included.
-                if paginated && num_hash.number < to_block {
-                    return Ok((all_logs, Some(num_hash.number + 1)));
+                // In paginated mode, keep the response within the per-response cap by
+                // excluding the block that would push us over and pointing the cursor at
+                // it for the next call. Single-block atomicity is preserved: if this block
+                // alone exceeds the cap (no prior blocks in the page), it is returned in
+                // full and the cursor advances past it.
+                if paginated {
+                    if prev_len > 0 {
+                        all_logs.truncate(prev_len);
+                        return Ok((all_logs, Some(num_hash.number)));
+                    }
+                    // Sole block in this page exceeds the cap. Return it in full; advance
+                    // the cursor past it (or terminate if it was the final block).
+                    if num_hash.number < to_block {
+                        return Ok((all_logs, Some(num_hash.number + 1)));
+                    }
+                    return Ok((all_logs, None));
                 }
 
                 let retry_to_block =
@@ -2028,6 +2041,83 @@ mod tests {
         assert_eq!(max_logs, 2);
         assert_eq!(from_block, 100);
         assert_eq!(to_block, 101);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_range_caps_response_at_max_logs() {
+        // Same fixture shape as the overflow-error test above: blocks 100, 101, 102 each
+        // with one matching log; max_logs_per_response = 2. In paginated mode, the response
+        // should be capped at 2 logs (blocks 100 + 101) with a cursor pointing at block 102.
+        use reth_db_api::models::StoredBlockBodyIndices;
+        let provider = MockEthProvider::default();
+        let tx_inner = alloy_consensus::TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 21_000,
+            gas_limit: 21_000,
+            to: alloy_primitives::TxKind::Call(alloy_primitives::Address::ZERO),
+            value: alloy_primitives::U256::ZERO,
+            input: alloy_primitives::Bytes::new(),
+        };
+        let signature = alloy_primitives::Signature::test_signature();
+        let tx =
+            reth_ethereum_primitives::TransactionSigned::new_unhashed(tx_inner.into(), signature);
+
+        let mock_log = alloy_primitives::Log {
+            address: alloy_primitives::Address::ZERO,
+            data: alloy_primitives::LogData::new_unchecked(vec![], alloy_primitives::Bytes::new()),
+        };
+        let receipt = reth_ethereum_primitives::Receipt {
+            tx_type: TxType::Legacy,
+            cumulative_gas_used: 21_000,
+            logs: vec![mock_log],
+            success: true,
+        };
+
+        let mut prev_hash = alloy_primitives::B256::default();
+        for (idx, block_number) in (100u64..=102).enumerate() {
+            let header = alloy_consensus::Header {
+                number: block_number,
+                parent_hash: prev_hash,
+                logs_bloom: alloy_primitives::Bloom::from([1u8; 256]),
+                ..Default::default()
+            };
+            let hash = header.hash_slow();
+            prev_hash = hash;
+            let block = reth_ethereum_primitives::Block {
+                header,
+                body: reth_ethereum_primitives::BlockBody {
+                    transactions: vec![tx.clone()],
+                    ..Default::default()
+                },
+            };
+            provider.add_block(hash, block);
+            provider.add_receipts(block_number, vec![receipt.clone()]);
+            provider.add_block_body_indices(
+                block_number,
+                StoredBlockBodyIndices { first_tx_num: idx as u64, tx_count: 1 },
+            );
+        }
+
+        let eth_api = build_test_eth_api(provider);
+        let eth_filter = EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+        let (logs, next_block) = eth_filter
+            .inner
+            .clone()
+            .get_logs_in_block_range(
+                Filter::default(),
+                100,
+                102,
+                QueryLimits { max_blocks_per_filter: None, max_logs_per_response: Some(2) },
+                true, // paginated
+            )
+            .await
+            .expect("paginated range should succeed");
+
+        // Strict cap: response holds at most max_logs_per_response (=2), and the cursor
+        // points at the block we excluded so the caller can resume there.
+        assert_eq!(logs.len(), 2);
+        assert_eq!(next_block, Some(102));
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -2134,4 +2134,38 @@ mod tests {
         assert_eq!(logs[0].block_hash, Some(expected_hashes[0])); // block 100
         assert_eq!(logs[1].block_hash, Some(expected_hashes[2])); // block 102
     }
+
+    #[tokio::test]
+    async fn logs_with_cursor_rejects_invalid_cursor() {
+        let provider = MockEthProvider::default();
+        let eth_api = build_test_eth_api(provider);
+        let eth_filter = EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+
+        let err = eth_filter
+            .logs_with_cursor(Filter::default(), Some("not-a-valid-cursor".to_string()))
+            .await
+            .expect_err("invalid cursor should be rejected");
+        assert_eq!(err.code(), jsonrpsee::types::error::INVALID_PARAMS_CODE);
+        assert!(err.message().contains("invalid cursor"));
+    }
+
+    #[tokio::test]
+    async fn logs_with_cursor_rejects_filter_mismatch() {
+        let provider = MockEthProvider::default();
+        let eth_api = build_test_eth_api(provider);
+        let eth_filter = EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+
+        // Issue a cursor under filter A, then submit it with filter B.
+        let filter_a = Filter::new().from_block(100u64).to_block(200u64);
+        let filter_b = Filter::new().from_block(100u64).to_block(300u64);
+        let hash_a = canonical_filter_hash(&filter_a);
+        let cursor_for_a = LogsCursor::new(hash_a, 150).encode();
+
+        let err = eth_filter
+            .logs_with_cursor(filter_b, Some(cursor_for_a))
+            .await
+            .expect_err("cursor reuse against different filter should be rejected");
+        assert_eq!(err.code(), jsonrpsee::types::error::INVALID_PARAMS_CODE);
+        assert!(err.message().contains("cursor was issued for a different filter"));
+    }
 }

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -19,11 +19,13 @@ use reth_errors::ProviderError;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadReceipt},
-    EngineEthFilter, EthApiTypes, EthFilterApiServer, FullEthApiTypes, QueryLimits, RpcConvert,
-    RpcNodeCoreExt, RpcTransaction,
+    EngineEthFilter, EthApiTypes, EthFilterApiServer, FullEthApiTypes, LogsResponseWithCursor,
+    QueryLimits, RpcConvert, RpcNodeCoreExt, RpcTransaction,
 };
 use reth_rpc_eth_types::{
-    logs_utils::{self, append_matching_block_logs, ProviderOrBlock},
+    logs_utils::{
+        self, append_matching_block_logs, canonical_filter_hash, LogsCursor, ProviderOrBlock,
+    },
     EthApiError, EthFilterConfig, EthStateCache, EthSubscriptionIdProvider,
 };
 use reth_rpc_server_types::{result::rpc_error_with_code, ToRpcResult};
@@ -282,7 +284,7 @@ where
                         (block_number, block_number)
                     }
                 };
-                let logs = self
+                let (logs, _) = self
                     .inner
                     .clone()
                     .get_logs_in_block_range(
@@ -290,6 +292,7 @@ where
                         from_block_number,
                         to_block_number,
                         self.inner.query_limits,
+                        false,
                     )
                     .await?;
                 Ok(FilterChanges::Logs(logs))
@@ -414,6 +417,94 @@ where
     async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
         trace!(target: "rpc::eth", "Serving eth_getLogs");
         Ok(self.logs_for_filter(filter, self.inner.query_limits).await?)
+    }
+
+    /// Returns logs matching given filter object with cursor-based pagination.
+    ///
+    /// Handler for `eth_getLogsWithCursor`.
+    async fn logs_with_cursor(
+        &self,
+        filter: Filter,
+        cursor: Option<String>,
+    ) -> RpcResult<LogsResponseWithCursor> {
+        trace!(target: "rpc::eth", "Serving eth_getLogsWithCursor");
+
+        let filter_hash = canonical_filter_hash(&filter);
+
+        // Decode the cursor (if any) and verify it was issued for this filter.
+        let cursor_start_block = match cursor.as_deref() {
+            Some(s) => {
+                let decoded = LogsCursor::decode(s).map_err(EthFilterError::from)?;
+                if decoded.filter_hash() != &filter_hash {
+                    return Err(EthFilterError::CursorFilterMismatch.into());
+                }
+                Some(decoded.next_block())
+            }
+            None => None,
+        };
+
+        let limits = self.inner.query_limits;
+
+        // Resolve the block range from the filter, matching `logs_for_filter`'s semantics.
+        let (resolved_from, to_block_number) = match filter.block_option {
+            FilterBlockOption::AtBlockHash(block_hash) => {
+                let block_number = self
+                    .provider()
+                    .block_number(block_hash)
+                    .map_err(EthApiError::from)?
+                    .ok_or_else(|| {
+                        EthApiError::from(ProviderError::HeaderNotFound(block_hash.into()))
+                    })?;
+                (block_number, block_number)
+            }
+            FilterBlockOption::Range { from_block, to_block } => {
+                let info = self.provider().chain_info().map_err(EthApiError::from)?;
+                let start_block = info.best_number;
+                let from = from_block
+                    .map(|num| self.provider().convert_block_number(num))
+                    .transpose()
+                    .map_err(EthApiError::from)?
+                    .flatten();
+                let to = to_block
+                    .map(|num| self.provider().convert_block_number(num))
+                    .transpose()
+                    .map_err(EthApiError::from)?
+                    .flatten();
+
+                if let Some(t) = to &&
+                    t > info.best_number
+                {
+                    return Err(EthFilterError::BlockRangeExceedsHead {
+                        requested: t,
+                        head: info.best_number,
+                    }
+                    .into());
+                }
+
+                logs_utils::get_filter_block_range(from, to, start_block, info)
+                    .map_err(EthFilterError::from)?
+            }
+        };
+
+        // Cursor overrides the resolved from_block; cursor was validated against the same
+        // filter so it's safe to trust its next_block here.
+        let from_block_number = cursor_start_block.unwrap_or(resolved_from);
+
+        // If the cursor points past the resolved to_block, the prior page already exhausted
+        // the range — return an empty terminal page.
+        if from_block_number > to_block_number {
+            return Ok(LogsResponseWithCursor { logs: Vec::new(), next_cursor: None });
+        }
+
+        let (logs, next_block) = self
+            .inner
+            .clone()
+            .get_logs_in_block_range(filter, from_block_number, to_block_number, limits, true)
+            .await?;
+
+        let next_cursor = next_block.map(|nb| LogsCursor::new(filter_hash, nb).encode());
+
+        Ok(LogsResponseWithCursor { logs, next_cursor })
     }
 }
 
@@ -586,8 +677,16 @@ where
                     return Err(EthApiError::PrunedHistoryUnavailable.into());
                 }
 
-                self.get_logs_in_block_range(filter, from_block_number, to_block_number, limits)
-                    .await
+                let (logs, _) = self
+                    .get_logs_in_block_range(
+                        filter,
+                        from_block_number,
+                        to_block_number,
+                        limits,
+                        false,
+                    )
+                    .await?;
+                Ok(logs)
             }
         }
     }
@@ -627,7 +726,8 @@ where
         from_block: u64,
         to_block: u64,
         limits: QueryLimits,
-    ) -> Result<Vec<Log>, EthFilterError> {
+        paginated: bool,
+    ) -> Result<(Vec<Log>, Option<u64>), EthFilterError> {
         trace!(target: "rpc::eth::filter", from=from_block, to=to_block, ?filter, "finding logs in range");
 
         // perform boundary checks first
@@ -644,8 +744,9 @@ where
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.task_spawner.spawn_blocking_task(async move {
-            let res =
-                this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits).await;
+            let res = this
+                .get_logs_in_block_range_inner(&filter, from_block, to_block, limits, paginated)
+                .await;
             let _ = tx.send(res);
         });
 
@@ -666,7 +767,8 @@ where
         from_block: u64,
         to_block: u64,
         limits: QueryLimits,
-    ) -> Result<Vec<Log>, EthFilterError> {
+        paginated: bool,
+    ) -> Result<(Vec<Log>, Option<u64>), EthFilterError> {
         let mut all_logs = Vec::new();
         let mut matching_headers = Vec::new();
 
@@ -737,6 +839,12 @@ where
                 is_multi_block_range &&
                 all_logs.len() > max_logs_per_response
             {
+                // In paginated mode, return a cursor pointing to the next unprocessed block
+                // instead of erroring. The current block is fully processed and included.
+                if paginated && num_hash.number < to_block {
+                    return Ok((all_logs, Some(num_hash.number + 1)));
+                }
+
                 let retry_to_block =
                     if num_hash.number == from_block { from_block } else { num_hash.number - 1 };
 
@@ -756,7 +864,7 @@ where
             }
         }
 
-        Ok(all_logs)
+        Ok((all_logs, None))
     }
 }
 
@@ -968,6 +1076,15 @@ pub enum EthFilterError {
         /// End block of the suggested retry range (last successfully processed block)
         to_block: u64,
     },
+    /// Cursor passed to `eth_getLogsWithCursor` could not be decoded.
+    #[error("invalid cursor")]
+    InvalidCursor,
+    /// Cursor was encoded with a version this server does not understand.
+    #[error("unsupported cursor version: {0}")]
+    UnsupportedCursorVersion(u8),
+    /// Cursor was issued for a different filter than the one passed in this call.
+    #[error("cursor was issued for a different filter")]
+    CursorFilterMismatch,
     /// Error serving request in `eth_` namespace.
     #[error(transparent)]
     EthAPIError(#[from] EthApiError),
@@ -990,9 +1107,21 @@ impl From<EthFilterError> for jsonrpsee::types::error::ErrorObject<'static> {
             err @ (EthFilterError::InvalidBlockRangeParams |
             EthFilterError::QueryExceedsMaxBlocks(_) |
             EthFilterError::QueryExceedsMaxResults { .. } |
-            EthFilterError::BlockRangeExceedsHead { .. }) => {
+            EthFilterError::BlockRangeExceedsHead { .. } |
+            EthFilterError::InvalidCursor |
+            EthFilterError::UnsupportedCursorVersion(_) |
+            EthFilterError::CursorFilterMismatch) => {
                 rpc_error_with_code(jsonrpsee::types::error::INVALID_PARAMS_CODE, err.to_string())
             }
+        }
+    }
+}
+
+impl From<logs_utils::LogsCursorError> for EthFilterError {
+    fn from(err: logs_utils::LogsCursorError) -> Self {
+        match err {
+            logs_utils::LogsCursorError::Invalid => Self::InvalidCursor,
+            logs_utils::LogsCursorError::UnsupportedVersion(v) => Self::UnsupportedCursorVersion(v),
         }
     }
 }
@@ -1887,6 +2016,7 @@ mod tests {
                 100,
                 102,
                 QueryLimits { max_blocks_per_filter: None, max_logs_per_response: Some(2) },
+                false,
             )
             .await
             .expect_err("range should exceed max logs");
@@ -1987,10 +2117,10 @@ mod tests {
         let filter = Filter::default();
 
         // Get logs in the range - this will trigger the bloom filtering
-        let logs = eth_filter
+        let (logs, _) = eth_filter
             .inner
             .clone()
-            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default())
+            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default(), false)
             .await
             .expect("should succeed");
 


### PR DESCRIPTION
Closes #19472

Adds `eth_getLogsWithCursor`, a new RPC method that paginates log queries via opaque server-issued cursors. Resolves the response-bloat pain that callers hit on `eth_getLogs` over long block ranges, without changing `eth_getLogs`'s wire shape (the spec leaves no room for cursor extension on the existing method).

Pagination happens at block boundaries (existing `eth_getLogs` invariant), and the per-page response is strictly capped at `max_logs_per_response` in multi-block mode.

The cursor is a versioned 25-byte payload `[version: 1][filter_hash: 16][next_block: 8 BE]` encoded as base64url-no-pad. This effectively binds the cursor to match the exact same filters that were used for the page `i-1` query.

Example request:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "eth_getLogsWithCursor",
  "params": [
    {
      "fromBlock": "0x64",
      "toBlock":   "0xc8",
      "address":   "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
      "topics":    []
    },
    null
  ]
}
```

Example response (mid-pagination — `nextCursor` is the token to pass back on the next call; absent when the range is exhausted):

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "logs": [
      {
        "address":          "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
        "blockHash":        "0x4f9c8a3b8d6e2c1a09f8b4d7e2c1a9f3b8d6e2c1a09f8b4d7e2c1a9f3b8d6e2c1",
        "blockNumber":      "0x96",
        "blockTimestamp":   "0x6648c510",
        "data":             "0x0000000000000000000000000000000000000000000000056bc75e2d63100000",
        "logIndex":         "0x0",
        "removed":          false,
        "topics": [
          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
          "0x000000000000000000000000abc1234567890abcdef1234567890abcdef12345",
          "0x000000000000000000000000def1234567890abcdef1234567890abcdef67890"
        ],
        "transactionHash":  "0x66e7a140c8fa27fe98fde923defea7562c3ca2d6bb89798aabec65782c08f63d",
        "transactionIndex": "0x0"
      }
    ],
    "nextCursor": "AaN_K8lOjW9RCSS3qBNl4v0AAAAAAAAAlw"
  }
}
```

Continuation request (same filter as the first call, with the `nextCursor` from the prior response passed back):

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "eth_getLogsWithCursor",
  "params": [
    {
      "fromBlock": "0x64",
      "toBlock":   "0xc8",
      "address":   "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
      "topics":    []
    },
    "AaN_K8lOjW9RCSS3qBNl4v0AAAAAAAAAlw"
  ]
}
```

Picks up the trait-extension idea from #22755 (now stale; co-author credit in commit). Uses a block-level cursor with filter binding and a version byte rather than the intra-block `(block_num, log_idx)` shape in that prototype, which would have broken single-block atomicity.

Inspired by ethereum/go-ethereum#17487