### PR TITLE
fix(engine): correct backpressure default parsing

### DIFF
--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -316,6 +316,9 @@ pub struct EngineArgs {
 
     /// Configure the maximum canonical-minus-persisted gap before engine API processing stalls.
     ///
+    /// If omitted, this defaults to the larger of the default backpressure threshold and twice
+    /// `--engine.persistence-threshold`.
+    ///
     /// This value must be greater than `--engine.persistence-threshold`.
     #[arg(long = "engine.persistence-backpressure-threshold")]
     pub persistence_backpressure_threshold: Option<u64>,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -295,19 +295,10 @@ impl Default for DefaultEngineValues {
     }
 }
 
-fn default_persistence_backpressure_threshold(
-    persistence_threshold: u64,
-    memory_block_buffer_target: u64,
-) -> u64 {
-    let min_backpressure_threshold =
-        persistence_threshold.saturating_add(memory_block_buffer_target).saturating_add(1);
-    if DefaultEngineValues::get_global().persistence_backpressure_threshold
-        > min_backpressure_threshold
-    {
-        DefaultEngineValues::get_global().persistence_backpressure_threshold
-    } else {
-        min_backpressure_threshold
-    }
+fn default_persistence_backpressure_threshold(persistence_threshold: u64) -> u64 {
+    DefaultEngineValues::get_global()
+        .persistence_backpressure_threshold
+        .max(persistence_threshold.saturating_mul(2))
 }
 
 /// Parameters for configuring the engine driver.
@@ -639,10 +630,7 @@ impl EngineArgs {
     /// Returns the effective persistence backpressure threshold.
     pub fn persistence_backpressure_threshold(&self) -> u64 {
         self.persistence_backpressure_threshold.unwrap_or_else(|| {
-            default_persistence_backpressure_threshold(
-                self.persistence_threshold,
-                self.memory_block_buffer_target,
-            )
+            default_persistence_backpressure_threshold(self.persistence_threshold)
         })
     }
 
@@ -739,12 +727,27 @@ mod tests {
         ])
         .args;
 
-        assert_eq!(args.persistence_backpressure_threshold(), 151);
+        assert_eq!(args.persistence_backpressure_threshold(), 200);
 
         let tree_config = args.tree_config();
         assert_eq!(tree_config.persistence_threshold(), 100);
         assert_eq!(tree_config.memory_block_buffer_target(), 50);
-        assert_eq!(tree_config.persistence_backpressure_threshold(), 151);
+        assert_eq!(tree_config.persistence_backpressure_threshold(), 200);
+    }
+
+    #[test]
+    fn default_backpressure_threshold_uses_global_default_when_larger() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-threshold",
+            "4",
+        ])
+        .args;
+
+        assert_eq!(
+            args.persistence_backpressure_threshold(),
+            DefaultEngineValues::get_global().persistence_backpressure_threshold
+        );
     }
 
     #[test]

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -295,6 +295,21 @@ impl Default for DefaultEngineValues {
     }
 }
 
+fn default_persistence_backpressure_threshold(
+    persistence_threshold: u64,
+    memory_block_buffer_target: u64,
+) -> u64 {
+    let min_backpressure_threshold =
+        persistence_threshold.saturating_add(memory_block_buffer_target).saturating_add(1);
+    if DefaultEngineValues::get_global().persistence_backpressure_threshold
+        > min_backpressure_threshold
+    {
+        DefaultEngineValues::get_global().persistence_backpressure_threshold
+    } else {
+        min_backpressure_threshold
+    }
+}
+
 /// Parameters for configuring the engine driver.
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "Engine")]
@@ -311,8 +326,8 @@ pub struct EngineArgs {
     /// Configure the maximum canonical-minus-persisted gap before engine API processing stalls.
     ///
     /// This value must be greater than `--engine.persistence-threshold`.
-    #[arg(long = "engine.persistence-backpressure-threshold", default_value_t = DefaultEngineValues::get_global().persistence_backpressure_threshold)]
-    pub persistence_backpressure_threshold: u64,
+    #[arg(long = "engine.persistence-backpressure-threshold")]
+    pub persistence_backpressure_threshold: Option<u64>,
 
     /// Configure the target number of blocks to keep in memory.
     #[arg(long = "engine.memory-block-buffer-target", default_value_t = DefaultEngineValues::get_global().memory_block_buffer_target)]
@@ -544,7 +559,7 @@ impl Default for EngineArgs {
     fn default() -> Self {
         let DefaultEngineValues {
             persistence_threshold,
-            persistence_backpressure_threshold,
+            persistence_backpressure_threshold: _,
             memory_block_buffer_target,
             invalid_header_hit_eviction_threshold,
             legacy_state_root_task_enabled,
@@ -577,7 +592,7 @@ impl Default for EngineArgs {
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
-            persistence_backpressure_threshold,
+            persistence_backpressure_threshold: None,
             memory_block_buffer_target,
             invalid_header_hit_eviction_threshold,
             legacy_state_root_task_enabled,
@@ -621,12 +636,23 @@ impl Default for EngineArgs {
 }
 
 impl EngineArgs {
+    /// Returns the effective persistence backpressure threshold.
+    pub fn persistence_backpressure_threshold(&self) -> u64 {
+        self.persistence_backpressure_threshold.unwrap_or_else(|| {
+            default_persistence_backpressure_threshold(
+                self.persistence_threshold,
+                self.memory_block_buffer_target,
+            )
+        })
+    }
+
     /// Validates cross-field engine arguments.
     pub fn validate(&self) -> eyre::Result<()> {
+        let persistence_backpressure_threshold = self.persistence_backpressure_threshold();
         ensure!(
-            self.persistence_backpressure_threshold > self.persistence_threshold,
+            persistence_backpressure_threshold > self.persistence_threshold,
             "--engine.persistence-backpressure-threshold ({}) must be greater than --engine.persistence-threshold ({})",
-            self.persistence_backpressure_threshold,
+            persistence_backpressure_threshold,
             self.persistence_threshold
         );
         ensure!(
@@ -639,8 +665,8 @@ impl EngineArgs {
     /// Creates a [`TreeConfig`] from the engine arguments.
     pub fn tree_config(&self) -> TreeConfig {
         let config = TreeConfig::default()
+            .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold())
             .with_persistence_threshold(self.persistence_threshold)
-            .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
             .with_invalid_header_hit_eviction_threshold(self.invalid_header_hit_eviction_threshold)
             .with_legacy_state_root(self.legacy_state_root_task_enabled)
@@ -696,6 +722,45 @@ mod tests {
         let default_args = EngineArgs::default();
         let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
+        assert_eq!(
+            args.persistence_backpressure_threshold(),
+            DefaultEngineValues::get_global().persistence_backpressure_threshold
+        );
+    }
+
+    #[test]
+    fn default_backpressure_threshold_uses_parsed_persistence_args() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-threshold",
+            "100",
+            "--engine.memory-block-buffer-target",
+            "50",
+        ])
+        .args;
+
+        assert_eq!(args.persistence_backpressure_threshold(), 151);
+
+        let tree_config = args.tree_config();
+        assert_eq!(tree_config.persistence_threshold(), 100);
+        assert_eq!(tree_config.memory_block_buffer_target(), 50);
+        assert_eq!(tree_config.persistence_backpressure_threshold(), 151);
+    }
+
+    #[test]
+    fn explicit_backpressure_threshold_overrides_calculated_default() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-threshold",
+            "100",
+            "--engine.memory-block-buffer-target",
+            "50",
+            "--engine.persistence-backpressure-threshold",
+            "101",
+        ])
+        .args;
+
+        assert_eq!(args.persistence_backpressure_threshold(), 101);
     }
 
     #[test]
@@ -703,7 +768,7 @@ mod tests {
     fn engine_args() {
         let args = EngineArgs {
             persistence_threshold: 100,
-            persistence_backpressure_threshold: 101,
+            persistence_backpressure_threshold: Some(101),
             memory_block_buffer_target: 50,
             invalid_header_hit_eviction_threshold: 7,
             legacy_state_root_task_enabled: true,
@@ -795,7 +860,7 @@ mod tests {
     fn validate_rejects_invalid_backpressure_threshold() {
         let args = EngineArgs {
             persistence_threshold: 4,
-            persistence_backpressure_threshold: 4,
+            persistence_backpressure_threshold: Some(4),
             ..EngineArgs::default()
         };
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -973,8 +973,6 @@ Engine:
 
           This value must be greater than `--engine.persistence-threshold`.
 
-          [default: 16]
-
       --engine.memory-block-buffer-target <MEMORY_BLOCK_BUFFER_TARGET>
           Configure the target number of blocks to keep in memory
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -971,6 +971,8 @@ Engine:
       --engine.persistence-backpressure-threshold <PERSISTENCE_BACKPRESSURE_THRESHOLD>
           Configure the maximum canonical-minus-persisted gap before engine API processing stalls.
 
+          If omitted, this defaults to the larger of the default backpressure threshold and twice `--engine.persistence-threshold`.
+
           This value must be greater than `--engine.persistence-threshold`.
 
       --engine.memory-block-buffer-target <MEMORY_BLOCK_BUFFER_TARGET>


### PR DESCRIPTION
## Summary
- keep the persistence backpressure CLI value optional through clap parsing so omitted values can be resolved after related args are parsed
- compute the default from the parsed persistence threshold and memory block buffer target, while preserving explicit backpressure overrides
- add engine args coverage for dynamic default calculation and explicit override behavior

## Testing
- cargo test -p reth-node-core args::engine::tests:: --lib
- git diff --check

Note: cargo fmt --check / cargo fmt -p reth-node-core --check report pre-existing formatting diffs outside this change when run with the stable formatter in this workspace.