### PR TITLE
ci(bench): unpin txgen install rev

### DIFF
--- a/.github/scripts/bench-txgen-install.sh
+++ b/.github/scripts/bench-txgen-install.sh
@@ -2,13 +2,9 @@
 #
 # Installs the txgen tools used by the benchmark workflows.
 #
-# Required env:
-#   TXGEN_REV   – pinned txgen git revision
 # Optional env:
 #   TXGEN_REPO  – txgen repository URL (default: https://github.com/tempoxyz/txgen)
 set -euxo pipefail
-
-: "${TXGEN_REV:?TXGEN_REV must be set to a pinned txgen revision}"
 
 TXGEN_REPO="${TXGEN_REPO:-https://github.com/tempoxyz/txgen}"
 
@@ -31,5 +27,4 @@ elif [ -n "${TXGEN_TOKEN:-${GH_PROJECT_TOKEN:-${DEREK_PAT:-${DEREK_TOKEN:-}}}}" 
 fi
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-cargo install --git "$TXGEN_REPO" --rev "$TXGEN_REV" txgen-ethereum --bin txgen-ethereum --locked
-cargo install --git "$TXGEN_REPO" --rev "$TXGEN_REV" bench-cli --bin bench --locked
+cargo install --git "$TXGEN_REPO" --locked txgen-ethereum bench-cli

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -311,7 +311,6 @@ jobs:
       BENCH_NODE_BIN: reth
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      TXGEN_REV: 5b04a80d557cc6658573db6ccf49ce04cbf07ea3
       BENCH_OTLP_DISABLED: "true"
       BASELINE_REF: ${{ needs.resolve-refs.outputs.baseline-ref }}
       FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -631,7 +631,6 @@ jobs:
       BENCH_NODE_BIN: ${{ needs.bench-ack.outputs.node-bin }}
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      TXGEN_REV: f439eec4e0f6dbe0675dd3bac8192d9f0299d409
       BENCH_OTLP_TRACES_ENDPOINT: ${{ needs.bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_TRACES_ENDPOINT || '' }}
       BENCH_OTLP_LOGS_ENDPOINT: ${{ needs.bench-ack.outputs.otlp != 'false' && secrets.BENCH_OTLP_LOGS_ENDPOINT || '' }}
       BENCH_VICTORIAMETRICS_URL: ${{ secrets.BENCH_VICTORIAMETRICS_URL }}


### PR DESCRIPTION
## Summary
- remove fixed TXGEN_REV env pins from benchmark workflows
- install txgen tools from the configured txgen repo default ref instead of passing --rev

## Testing
- rg -n "TXGEN_REV|--rev \"\\"|pinned txgen" .github
- bash -n .github/scripts/bench-txgen-install.sh .github/scripts/bench-txgen-build.sh .github/scripts/bench-txgen-run.sh .github/scripts/bench-txgen-extract.sh