### PR TITLE
feat(rpc): add `eth_resend`

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -370,6 +370,15 @@ pub trait EthApi<
     #[method(name = "sendTransaction")]
     async fn send_transaction(&self, request: TxReq) -> RpcResult<B256>;
 
+    /// Resends a pending transaction with an updated gas price or gas limit.
+    #[method(name = "resend")]
+    async fn resend(
+        &self,
+        request: TxReq,
+        gas_price: Option<U256>,
+        gas_limit: Option<U64>,
+    ) -> RpcResult<B256>;
+
     /// Sends signed transaction, returning its hash.
     #[method(name = "sendRawTransaction")]
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<B256>;
@@ -890,6 +899,17 @@ where
     async fn send_transaction(&self, request: RpcTxReq<T::NetworkTypes>) -> RpcResult<B256> {
         trace!(target: "rpc::eth", ?request, "Serving eth_sendTransaction");
         Ok(EthTransactions::send_transaction_request(self, request).await?)
+    }
+
+    /// Handler for: `eth_resend`
+    async fn resend(
+        &self,
+        request: RpcTxReq<T::NetworkTypes>,
+        gas_price: Option<U256>,
+        gas_limit: Option<U64>,
+    ) -> RpcResult<B256> {
+        trace!(target: "rpc::eth", ?request, ?gas_price, ?gas_limit, "Serving eth_resend");
+        Ok(EthTransactions::resend_transaction(self, request, gas_price, gas_limit).await?)
     }
 
     /// Handler for: `eth_sendRawTransaction`

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -14,7 +14,7 @@ use alloy_consensus::{
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{eip2718::Encodable2718, BlockId};
 use alloy_network::{TransactionBuilder, TransactionBuilder4844};
-use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
+use alloy_primitives::{Address, Bytes, TxHash, B256, U256, U64};
 use alloy_rpc_types_eth::{state::EvmOverrides, TransactionInfo};
 use futures::{Future, StreamExt};
 use reth_chain_state::CanonStateSubscriptions;
@@ -497,6 +497,89 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 })?;
 
             // submit the transaction to the pool with a `Local` origin
+            let AddedTransactionOutcome { hash, .. } = self
+                .pool()
+                .add_transaction(TransactionOrigin::Local, pool_transaction)
+                .await
+                .map_err(Self::Error::from_eth_err)?;
+
+            Ok(hash)
+        }
+    }
+
+    /// Resends a pending transaction with an updated gas price or gas limit.
+    fn resend_transaction(
+        &self,
+        mut request: RpcTxReq<Self::NetworkTypes>,
+        gas_price: Option<U256>,
+        gas_limit: Option<U64>,
+    ) -> impl Future<Output = Result<B256, Self::Error>> + Send
+    where
+        Self: EthApiSpec + LoadBlock + EstimateCall + LoadFee,
+    {
+        async move {
+            let from = match request.as_ref().from() {
+                Some(from) => from,
+                None => return Err(SignError::NoAccount.into_eth_err()),
+            };
+            let nonce = request.as_ref().nonce().ok_or_else(|| {
+                EthApiError::InvalidParams(
+                    "missing transaction nonce in transaction spec".to_string(),
+                )
+            })?;
+
+            if self.find_signer(&from).is_err() {
+                return Err(SignError::NoAccount.into_eth_err())
+            }
+            if self.pool().get_transaction_by_sender_and_nonce(from, nonce).is_none() {
+                return Err(EthApiError::TransactionNotFound.into())
+            }
+
+            let chain_id = self.chain_id();
+            request.as_mut().set_chain_id(chain_id.to());
+
+            if let Some(gas_price) = gas_price &&
+                !gas_price.is_zero()
+            {
+                request.as_mut().set_gas_price(gas_price.to());
+            }
+            if let Some(gas_limit) = gas_limit &&
+                gas_limit != U64::ZERO
+            {
+                request.as_mut().set_gas_limit(gas_limit.to());
+            }
+
+            if request.as_ref().gas_limit().is_none() {
+                let estimated_gas = self
+                    .estimate_gas_at(request.clone(), BlockId::pending(), EvmOverrides::default())
+                    .await?;
+                request.as_mut().set_gas_limit(estimated_gas.to());
+            }
+            if gas_price.is_none() && request.as_ref().gas_price().is_none() {
+                let tip = if let Some(tip) = request.as_ref().max_priority_fee_per_gas() {
+                    tip
+                } else {
+                    let tip = self.suggested_priority_fee().await?.to::<u128>();
+                    request.as_mut().set_max_priority_fee_per_gas(tip);
+                    tip
+                };
+                if request.as_ref().max_fee_per_gas().is_none() {
+                    let header =
+                        self.provider().latest_header().map_err(Self::Error::from_eth_err)?;
+                    let base_fee = header.and_then(|h| h.base_fee_per_gas()).unwrap_or_default();
+                    request.as_mut().set_max_fee_per_gas(base_fee as u128 + tip);
+                }
+            }
+
+            let transaction = self.sign_request(&from, request).await?.with_signer(from);
+            let pool_transaction =
+                <<Self as RpcNodeCore>::Pool as TransactionPool>::Transaction::try_from_consensus(
+                    transaction,
+                )
+                .map_err(|e| {
+                    Self::Error::from_eth_err(TransactionConversionError::Other(e.to_string()))
+                })?;
+
             let AddedTransactionOutcome { hash, .. } = self
                 .pool()
                 .add_transaction(TransactionOrigin::Local, pool_transaction)

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -133,13 +133,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::helpers::types::EthRpcConverter;
+    use crate::eth::helpers::{signer::DevSigner, types::EthRpcConverter};
     use alloy_consensus::{
         BlobTransactionSidecar, Block, Header, SidecarBuilder, SimpleCoder, Transaction,
     };
     use alloy_primitives::{map::AddressMap, Address, U256};
     use alloy_rpc_types_eth::request::TransactionRequest;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder};
+    use reth_ethereum_primitives::TransactionSigned;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::{
@@ -212,6 +213,40 @@ mod tests {
 
         assert!(pool.get(&tx_1_result).is_some(), "tx1 not found in the pool");
         assert!(pool.get(&tx_2_result).is_some(), "tx2 not found in the pool");
+    }
+
+    #[tokio::test]
+    async fn resend_transaction_replaces_pending_transaction() {
+        let mut signers = DevSigner::random_signers::<TransactionSigned, TransactionRequest>(1);
+        let from = signers[0].accounts()[0];
+        let accounts = AddressMap::from_iter([(
+            from,
+            ExtendedAccount::new(0, U256::from(10_000_000_000_000_000_000u64)),
+        )]);
+        let eth_api = mock_eth_api(accounts);
+        eth_api.signers().write().append(&mut signers);
+
+        let request = TransactionRequest {
+            from: Some(from),
+            to: Some(Address::random().into()),
+            nonce: Some(0),
+            gas: Some(21_000),
+            gas_price: Some(1_000_000_000),
+            ..Default::default()
+        };
+
+        let original = eth_api.send_transaction_request(request.clone()).await.unwrap();
+        let replacement = eth_api
+            .resend_transaction(request, Some(U256::from(2_000_000_000u64)), None)
+            .await
+            .unwrap();
+
+        assert_ne!(original, replacement);
+        assert!(eth_api.pool().get(&original).is_none());
+
+        let tx = eth_api.pool().get_transaction_by_sender_and_nonce(from, 0).unwrap();
+        assert_eq!(*tx.hash(), replacement);
+        assert_eq!(tx.max_fee_per_gas(), 2_000_000_000);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Summary
- Adds `eth_resend` support for resubmitting a pending local transaction with an updated gas price or gas limit.

ref https://hackmd.io/@bomanaps/rJXLPhYRWl
