### PR TITLE
fix(bench): reduce noisy big-block verdicts

### DIFF
--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -28,6 +28,8 @@ import sys
 
 BOOTSTRAP_ITERATIONS = 10_000
 P99_MIN_VERDICT_BLOCKS = 125
+PERSIST_WAIT_MIN_VERDICT_MS = 0.5
+PERSIST_WAIT_MIN_TOTAL_PCT = 0.1
 PRACTICAL_FLOOR_PCT = {
     "mean": 0.70,
     "p50": 0.70,
@@ -404,8 +406,32 @@ def significance(pct: float, ci_pct: float, floor_pct: float, lower_is_better: b
     return "neutral"
 
 
-def is_informational_metric(metric: str, ci_stats: dict) -> bool:
-    return metric == "p99" and ci_stats["blocks"] < P99_MIN_VERDICT_BLOCKS
+def persist_wait_is_material(stats: dict) -> bool:
+    threshold = max(
+        PERSIST_WAIT_MIN_VERDICT_MS,
+        stats["mean_total_lat_ms"] * PERSIST_WAIT_MIN_TOTAL_PCT / 100.0,
+    )
+    return stats["mean_persist_ms"] >= threshold
+
+
+def informational_reason(
+    metric: str,
+    ci_stats: dict,
+    baseline_stats: dict,
+    feature_stats: dict,
+) -> str | None:
+    if metric == "p99" and ci_stats["blocks"] < P99_MIN_VERDICT_BLOCKS:
+        return f"informational <{P99_MIN_VERDICT_BLOCKS} blocks"
+    if (
+        metric == "persist_wait" and
+        not persist_wait_is_material(baseline_stats) and
+        not persist_wait_is_material(feature_stats)
+    ):
+        return (
+            f"informational <max({PERSIST_WAIT_MIN_VERDICT_MS:.1f}ms, "
+            f"{PERSIST_WAIT_MIN_TOTAL_PCT:.1f}% total latency)"
+        )
+    return None
 
 
 def change_str(
@@ -413,7 +439,7 @@ def change_str(
     ci_pct: float,
     floor_pct: float,
     lower_is_better: bool,
-    informational: bool = False,
+    informational: str | None = None,
 ) -> str:
     """Format change% with CI significance.
 
@@ -423,7 +449,7 @@ def change_str(
     emoji = {"good": "✅", "bad": "❌", "neutral": "⚪"}[sig]
     details = [f"±{ci_pct:.2f}%", f"floor {floor_pct:.2f}%"]
     if informational:
-        details.append(f"informational <{P99_MIN_VERDICT_BLOCKS} blocks")
+        details.append(informational)
     return f"{pct:+.2f}% {emoji} ({', '.join(details)})"
 
 
@@ -451,7 +477,7 @@ def compute_changes(
         p = pct(baseline_stats[stat_key], feature_stats[stat_key])
         c = ci_pct(ci_stats[ci_key], baseline_stats[base_key])
         floor = practical_floor_pct(name, baseline_stats[base_key])
-        informational = is_informational_metric(name, ci_stats)
+        informational = informational_reason(name, ci_stats, baseline_stats, feature_stats)
         sig = significance(p, c, floor, lower_is_better)
         changes[name] = {
             "pct": round(p, 4),
@@ -461,6 +487,7 @@ def compute_changes(
         }
         if informational:
             changes[name]["informational"] = True
+            changes[name]["informational_reason"] = informational
             changes[name]["raw_sig"] = sig
     return changes
 
@@ -514,7 +541,8 @@ def generate_comparison_table(
     mgas_floor = practical_floor_pct("mgas_s", run1["mean_mgas_s"])
     wall_floor = practical_floor_pct("wall_clock", run1["mean_total_lat_ms"])
     persist_floor = practical_floor_pct("persist_wait", run1["mean_persist_ms"])
-    p99_informational = is_informational_metric("p99", ci_stats)
+    p99_informational = informational_reason("p99", ci_stats, run1, run2)
+    persist_informational = informational_reason("persist_wait", ci_stats, run1, run2)
 
     base_url = f"https://github.com/{repo}/commit"
     baseline_label = f"[`{baseline_name}`]({base_url}/{baseline_ref})"
@@ -529,7 +557,7 @@ def generate_comparison_table(
         f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, p99_floor, lower_is_better=True, informational=p99_informational)} |",
         f"| Mgas/s | {fmt_mgas(run1['mean_mgas_s'])} | {fmt_mgas(run2['mean_mgas_s'])} | {change_str(gas_pct, mgas_ci_pct, mgas_floor, lower_is_better=False)} |",
         f"| Wall Clock | {fmt_s(run1['wall_clock_s'])} | {fmt_s(run2['wall_clock_s'])} | {change_str(wall_pct, wall_ci_pct, wall_floor, lower_is_better=True)} |",
-        f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, persist_floor, lower_is_better=True)} |",
+        f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, persist_floor, lower_is_better=True, informational=persist_informational)} |",
         "",
     ]
     meta_parts = [f"{n} {'big blocks' if big_blocks else 'blocks'}"]

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -27,6 +27,7 @@ import random
 import sys
 
 BOOTSTRAP_ITERATIONS = 10_000
+P99_MIN_VERDICT_BLOCKS = 125
 PRACTICAL_FLOOR_PCT = {
     "mean": 0.70,
     "p50": 0.70,
@@ -403,14 +404,27 @@ def significance(pct: float, ci_pct: float, floor_pct: float, lower_is_better: b
     return "neutral"
 
 
-def change_str(pct: float, ci_pct: float, floor_pct: float, lower_is_better: bool) -> str:
+def is_informational_metric(metric: str, ci_stats: dict) -> bool:
+    return metric == "p99" and ci_stats["blocks"] < P99_MIN_VERDICT_BLOCKS
+
+
+def change_str(
+    pct: float,
+    ci_pct: float,
+    floor_pct: float,
+    lower_is_better: bool,
+    informational: bool = False,
+) -> str:
     """Format change% with CI significance.
 
     Significant if the confidence interval clears the practical floor.
     """
-    sig = significance(pct, ci_pct, floor_pct, lower_is_better)
+    sig = "neutral" if informational else significance(pct, ci_pct, floor_pct, lower_is_better)
     emoji = {"good": "✅", "bad": "❌", "neutral": "⚪"}[sig]
-    return f"{pct:+.2f}% {emoji} (±{ci_pct:.2f}%, floor {floor_pct:.2f}%)"
+    details = [f"±{ci_pct:.2f}%", f"floor {floor_pct:.2f}%"]
+    if informational:
+        details.append(f"informational <{P99_MIN_VERDICT_BLOCKS} blocks")
+    return f"{pct:+.2f}% {emoji} ({', '.join(details)})"
 
 
 def compute_changes(
@@ -437,12 +451,17 @@ def compute_changes(
         p = pct(baseline_stats[stat_key], feature_stats[stat_key])
         c = ci_pct(ci_stats[ci_key], baseline_stats[base_key])
         floor = practical_floor_pct(name, baseline_stats[base_key])
+        informational = is_informational_metric(name, ci_stats)
+        sig = significance(p, c, floor, lower_is_better)
         changes[name] = {
             "pct": round(p, 4),
             "ci_pct": round(c, 4),
             "floor_pct": round(floor, 4),
-            "sig": significance(p, c, floor, lower_is_better),
+            "sig": "neutral" if informational else sig,
         }
+        if informational:
+            changes[name]["informational"] = True
+            changes[name]["raw_sig"] = sig
     return changes
 
 
@@ -495,6 +514,7 @@ def generate_comparison_table(
     mgas_floor = practical_floor_pct("mgas_s", run1["mean_mgas_s"])
     wall_floor = practical_floor_pct("wall_clock", run1["mean_total_lat_ms"])
     persist_floor = practical_floor_pct("persist_wait", run1["mean_persist_ms"])
+    p99_informational = is_informational_metric("p99", ci_stats)
 
     base_url = f"https://github.com/{repo}/commit"
     baseline_label = f"[`{baseline_name}`]({base_url}/{baseline_ref})"
@@ -506,7 +526,7 @@ def generate_comparison_table(
         f"| Mean | {fmt_ms(run1['mean_ms'])} | {fmt_ms(run2['mean_ms'])} | {change_str(mean_pct, mean_ci_pct, mean_floor, lower_is_better=True)} |",
         f"| P50 | {fmt_ms(run1['p50_ms'])} | {fmt_ms(run2['p50_ms'])} | {change_str(p50_pct, p50_ci_pct, p50_floor, lower_is_better=True)} |",
         f"| P90 | {fmt_ms(run1['p90_ms'])} | {fmt_ms(run2['p90_ms'])} | {change_str(p90_pct, p90_ci_pct, p90_floor, lower_is_better=True)} |",
-        f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, p99_floor, lower_is_better=True)} |",
+        f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, p99_floor, lower_is_better=True, informational=p99_informational)} |",
         f"| Mgas/s | {fmt_mgas(run1['mean_mgas_s'])} | {fmt_mgas(run2['mean_mgas_s'])} | {change_str(gas_pct, mgas_ci_pct, mgas_floor, lower_is_better=False)} |",
         f"| Wall Clock | {fmt_s(run1['wall_clock_s'])} | {fmt_s(run2['wall_clock_s'])} | {change_str(wall_pct, wall_ci_pct, wall_floor, lower_is_better=True)} |",
         f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, persist_floor, lower_is_better=True)} |",

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -124,6 +124,24 @@ def compute_stats(combined: list[dict]) -> dict:
     }
 
 
+def compute_point_stats(runs: list[list[dict]]) -> dict:
+    """Compute displayed point estimates for one side of a comparison.
+
+    Cluster CIs estimate percentile changes from one percentile value per run.
+    Match that estimator for displayed percentile point estimates instead of
+    pooling repeated block rows into one percentile sample.
+    """
+    combined = [row for run in runs for row in run]
+    stats = compute_stats(combined)
+    if len(runs) < 2:
+        return stats
+
+    per_run_stats = [compute_stats(run) for run in runs if run]
+    for key in ("p50_ms", "p90_ms", "p99_ms"):
+        stats[key] = _mean([run_stats[key] for run_stats in per_run_stats])
+    return stats
+
+
 def compute_wait_stats(combined: list[dict], field: str) -> dict:
     """Compute mean/p50/p95 for a wait time field (in ms)."""
     values_ms = []
@@ -613,8 +631,8 @@ def main():
     all_baseline = [r for run in baseline_runs for r in run]
     all_feature = [r for run in feature_runs for r in run]
 
-    baseline_stats = compute_stats(all_baseline)
-    feature_stats = compute_stats(all_feature)
+    baseline_stats = compute_point_stats(baseline_runs)
+    feature_stats = compute_point_stats(feature_runs)
     ci_stats = compute_ci_stats(baseline_runs, feature_runs)
 
     if not ci_stats:

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -449,7 +449,7 @@ def change_str(
     emoji = {"good": "✅", "bad": "❌", "neutral": "⚪"}[sig]
     details = [f"±{ci_pct:.2f}%", f"floor {floor_pct:.2f}%"]
     if informational:
-        details.append(informational)
+        details.append("informational")
     return f"{pct:+.2f}% {emoji} ({', '.join(details)})"
 
 

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -238,7 +238,7 @@ async function success({ core, context }) {
   let postedToChannel = false;
   if (channel) {
     const changes = summary.changes || {};
-    const hasImprovement = Object.values(changes).some(c => c.sig === 'good');
+    const hasImprovement = Object.values(changes).some(c => !c.informational && c.sig === 'good');
     if (hasImprovement) {
       await postToSlack(token, channel, blocks, text, core);
       postedToChannel = true;

--- a/.github/scripts/bench-utils.js
+++ b/.github/scripts/bench-utils.js
@@ -17,12 +17,14 @@ function fmtChange(ch) {
   const details = [];
   if (ch.ci_pct) details.push(`±${ch.ci_pct.toFixed(2)}%`);
   if (ch.floor_pct) details.push(`floor ${ch.floor_pct.toFixed(2)}%`);
+  if (ch.informational) details.push('informational');
   const detailStr = details.length ? ` (${details.join(', ')})` : '';
-  return `${pctStr}${detailStr} ${SIG_EMOJI[ch.sig]}`;
+  const sig = ch.informational ? 'neutral' : ch.sig;
+  return `${pctStr}${detailStr} ${SIG_EMOJI[sig]}`;
 }
 
 function verdict(changes) {
-  const vals = Object.values(changes);
+  const vals = Object.values(changes).filter(v => !v.informational);
   const hasBad = vals.some(v => v.sig === 'bad');
   const hasGood = vals.some(v => v.sig === 'good');
   if (hasBad && hasGood) return { emoji: '⚠️', label: 'Mixed Results' };

--- a/.github/scripts/bench-utils.js
+++ b/.github/scripts/bench-utils.js
@@ -17,7 +17,7 @@ function fmtChange(ch) {
   const details = [];
   if (ch.ci_pct) details.push(`±${ch.ci_pct.toFixed(2)}%`);
   if (ch.floor_pct) details.push(`floor ${ch.floor_pct.toFixed(2)}%`);
-  if (ch.informational) details.push('informational');
+  if (ch.informational) details.push(ch.informational_reason || 'informational');
   const detailStr = details.length ? ` (${details.join(', ')})` : '';
   const sig = ch.informational ? 'neutral' : ch.sig;
   return `${pctStr}${detailStr} ${SIG_EMOJI[sig]}`;

--- a/.github/scripts/bench-utils.js
+++ b/.github/scripts/bench-utils.js
@@ -17,7 +17,7 @@ function fmtChange(ch) {
   const details = [];
   if (ch.ci_pct) details.push(`±${ch.ci_pct.toFixed(2)}%`);
   if (ch.floor_pct) details.push(`floor ${ch.floor_pct.toFixed(2)}%`);
-  if (ch.informational) details.push(ch.informational_reason || 'informational');
+  if (ch.informational) details.push('informational');
   const detailStr = details.length ? ` (${details.join(', ')})` : '';
   const sig = ch.informational ? 'neutral' : ch.sig;
   return `${pctStr}${detailStr} ${SIG_EMOJI[sig]}`;

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       blocks:
-        description: "Number of blocks to benchmark (default: 500, big blocks: 65)"
+        description: "Number of blocks to benchmark (default: 500, big blocks: 30)"
         required: false
         default: ""
         type: string
@@ -191,7 +191,7 @@ jobs:
               if (/^\d+([kKmMgG])?$/.test(value)) return { enabled: 'true', targetGas: value };
               return null;
             };
-            const defaultBlocks = (isBigBlocks) => isBigBlocks ? '65' : '500';
+            const defaultBlocks = (isBigBlocks) => isBigBlocks ? '30' : '500';
             const defaultWarmup = (blockCount) => String(Math.floor(Number(blockCount) / 4));
             const defaultRunPairs = (isBigBlocks) => isBigBlocks ? '10' : '6';
             const benchRunOrder = (runPairs) => {


### PR DESCRIPTION
Uses run-level percentile point estimates for multi-run benchmark comparisons so displayed P50/P90/P99 changes match the run-cluster bootstrap CI estimator. P99 is now informational-only below 125 measured blocks, so low-sample big-block runs still display it without letting it decide the verdict.

Big-block benches now default to 10 pairs x 30 blocks, with warmup still defaulting to one-quarter of measured blocks. Persist wait remains displayed, but only contributes to verdicts if either side has material persist wait: at least max(0.5ms, 0.1% of mean total latency).

Verified by reparsing the noisy big-block artifact: the P99 and fractional persist-wait rows are marked informational and ignored by comment, job summary, and Slack verdicts.