### PR TITLE
ci: enable bench OTLP exports by default

### DIFF
--- a/.github/scripts/bench-txgen-build.sh
+++ b/.github/scripts/bench-txgen-build.sh
@@ -23,8 +23,15 @@ fi
 
 EXTRA_FEATURES=""
 EXTRA_RUSTFLAGS=""
+if [ "${BENCH_OTLP_DISABLED:-false}" != "true" ]; then
+  EXTRA_FEATURES="otlp,otlp-logs"
+fi
 if [ "${BENCH_TRACY:-off}" != "off" ]; then
-  EXTRA_FEATURES="tracy,tracy-client/ondemand"
+  if [ -n "$EXTRA_FEATURES" ]; then
+    EXTRA_FEATURES="${EXTRA_FEATURES},tracy,tracy-client/ondemand"
+  else
+    EXTRA_FEATURES="tracy,tracy-client/ondemand"
+  fi
   EXTRA_RUSTFLAGS=" -C force-frame-pointers=yes"
 fi
 

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -311,7 +311,8 @@ jobs:
       BENCH_NODE_BIN: reth
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
-      BENCH_OTLP_DISABLED: "true"
+      BENCH_OTLP_TRACES_ENDPOINT: ${{ secrets.BENCH_OTLP_TRACES_ENDPOINT }}
+      BENCH_OTLP_LOGS_ENDPOINT: ${{ secrets.BENCH_OTLP_LOGS_ENDPOINT }}
       BASELINE_REF: ${{ needs.resolve-refs.outputs.baseline-ref }}
       FEATURE_REF: ${{ needs.resolve-refs.outputs.feature-ref }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,7 +89,7 @@ on:
       otlp:
         description: "Export OTLP traces and logs"
         required: false
-        default: "false"
+        default: "true"
         type: boolean
 
 env:
@@ -223,7 +223,7 @@ jobs:
               bal = '${{ github.event.inputs.bal }}' || 'false';
               var runPairs = '${{ github.event.inputs.run_pairs }}' || '';
               explicitRunPairs = runPairs !== '';
-              var otlp = '${{ github.event.inputs.otlp }}' === 'true' ? 'true' : 'false';
+              var otlp = '${{ github.event.inputs.otlp }}' === 'false' ? 'false' : 'true';
               var waitTime = '${{ github.event.inputs.wait_time }}' || '';
               var baselineNodeArgs = '${{ github.event.inputs.baseline_args }}' || '';
               var featureNodeArgs = '${{ github.event.inputs.feature_args }}' || '';
@@ -252,7 +252,7 @@ jobs:
               const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes]]);
               const durationArgs = new Set(['wait-time']);
               const stringArgs = new Set(['baseline-args', 'feature-args']);
-              const defaults = { blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', slack: 'always', 'big-blocks': 'false', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'false', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
+              const defaults = { blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', slack: 'always', 'big-blocks': 'false', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');


### PR DESCRIPTION
## Summary
- default manual and comment-triggered bench runs to OTLP enabled while preserving `otlp=false` as the opt-out
- enable scheduled bench OTLP trace/log endpoints from bench secrets
- build bench binaries with `otlp,otlp-logs` features by default so the runtime export flags are available

## Validation
- `bash -n .github/scripts/bench-txgen-build.sh .github/scripts/bench-txgen-run.sh`
- `uv run --with pyyaml python -c 'import sys,yaml; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; [print(f"ok {f}") for f in sys.argv[1:]]' .github/workflows/bench.yml .github/workflows/bench-scheduled.yml`