### PR TITLE
feat: derive OTLP auth from endpoint URL credentials

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -718,6 +718,27 @@ jobs:
         continue-on-error: true
       - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
 
+      - name: Mask OTLP endpoints
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            for (const envName of ['BENCH_OTLP_TRACES_ENDPOINT', 'BENCH_OTLP_LOGS_ENDPOINT']) {
+              const endpoint = process.env[envName] || '';
+              if (!endpoint) {
+                continue;
+              }
+
+              core.setSecret(endpoint);
+              try {
+                const url = new URL(endpoint);
+                url.username = '';
+                url.password = '';
+                core.setSecret(url.toString());
+              } catch {
+                // The CLI parser will report malformed endpoints later; this step only masks.
+              }
+            }
+
       - name: Install dependencies
         env:
           DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10486,6 +10486,7 @@ dependencies = [
 name = "reth-tracing-otlp"
 version = "2.2.0"
 dependencies = [
+ "base64 0.22.1",
  "clap",
  "eyre",
  "opentelemetry",

--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -20,6 +20,7 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 
 # misc
+base64 = "0.22"
 clap = { workspace = true, features = ["derive"] }
 eyre.workspace = true
 url.workspace = true

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -23,10 +23,14 @@ use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
 use url::Url;
 
+use base64::{prelude::BASE64_STANDARD, Engine};
+
 // Otlp http endpoint is expected to end with this path.
 // See also <https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_traces_endpoint>.
 const HTTP_TRACE_ENDPOINT: &str = "/v1/traces";
 const HTTP_LOGS_ENDPOINT: &str = "/v1/logs";
+const OTEL_EXPORTER_OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+const OTEL_EXPORTER_OTLP_LOGS_HEADERS: &str = "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
 
 /// Creates a tracing [`OpenTelemetryLayer`] that exports spans to an OTLP endpoint.
 ///
@@ -139,10 +143,11 @@ impl OtlpConfig {
             );
         }
 
+        set_otlp_auth_header_from_endpoint(&endpoint, OTEL_EXPORTER_OTLP_TRACES_HEADERS)?;
         Ok(Self {
             service_name: service_name.into(),
             service_version: None,
-            endpoint,
+            endpoint: endpoint_without_credentials(endpoint),
             protocol,
             sample_ratio,
         })
@@ -195,7 +200,13 @@ impl OtlpLogsConfig {
         endpoint: Url,
         protocol: OtlpProtocol,
     ) -> eyre::Result<Self> {
-        Ok(Self { service_name: service_name.into(), service_version: None, endpoint, protocol })
+        set_otlp_auth_header_from_endpoint(&endpoint, OTEL_EXPORTER_OTLP_LOGS_HEADERS)?;
+        Ok(Self {
+            service_name: service_name.into(),
+            service_version: None,
+            endpoint: endpoint_without_credentials(endpoint),
+            protocol,
+        })
     }
 
     /// Sets the service version for OTLP resource identification.
@@ -227,6 +238,55 @@ fn build_resource(service_name: impl Into<Value>, service_version: Option<&str>)
         .with_service_name(service_name)
         .with_schema_url([KeyValue::new(SERVICE_VERSION, version.to_string())], SCHEMA_URL)
         .build()
+}
+
+/// Returns an OTLP endpoint URL with username and password removed.
+fn endpoint_without_credentials(mut endpoint: Url) -> Url {
+    if !endpoint.username().is_empty() {
+        endpoint.set_username("").ok();
+    }
+    if endpoint.password().is_some() {
+        endpoint.set_password(None).ok();
+    }
+    endpoint
+}
+
+/// Builds an OTLP `Authorization` header from endpoint `username:password` credentials.
+fn otlp_auth_header_from_endpoint(endpoint: &Url) -> eyre::Result<Option<String>> {
+    let username = endpoint.username();
+    if username.is_empty() && endpoint.password().is_none() {
+        return Ok(None);
+    }
+
+    let Some(password) = endpoint.password() else {
+        eyre::bail!("OTLP endpoint credentials must include both username and password");
+    };
+    if username.is_empty() {
+        eyre::bail!("OTLP endpoint credentials must include both username and password");
+    }
+
+    let credentials = format!("{username}:{password}");
+    let encoded = BASE64_STANDARD.encode(credentials.as_bytes());
+    Ok(Some(format!("Authorization=Basic {encoded}")))
+}
+
+/// Sets the OTLP signal-specific header env var from endpoint credentials if it is unset.
+fn set_otlp_auth_header_from_endpoint(endpoint: &Url, header_env: &str) -> eyre::Result<()> {
+    if std::env::var_os(header_env).is_some() {
+        return Ok(());
+    }
+
+    let Some(auth_header) = otlp_auth_header_from_endpoint(endpoint)? else {
+        return Ok(());
+    };
+
+    // SAFETY: OTLP exporters are initialized during process startup before exporter worker threads
+    // are spawned.
+    unsafe {
+        std::env::set_var(header_env, auth_header);
+    }
+
+    Ok(())
 }
 
 /// Builds the appropriate sampler based on the sample ratio.
@@ -285,5 +345,76 @@ impl OtlpProtocol {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_credentials_from_trace_endpoint_and_preserves_auth_header() {
+        let config = OtlpConfig::new(
+            "reth",
+            "https://user:pass@example.com/v1/traces".parse().unwrap(),
+            OtlpProtocol::Http,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(config.endpoint.as_str(), "https://example.com/v1/traces");
+        assert_eq!(
+            otlp_auth_header_from_endpoint(
+                &"https://user:pass@example.com/v1/traces".parse().unwrap()
+            )
+            .unwrap()
+            .as_deref(),
+            Some("Authorization=Basic dXNlcjpwYXNz")
+        );
+    }
+
+    #[test]
+    fn strips_credentials_from_logs_endpoint_and_preserves_auth_header() {
+        let config = OtlpLogsConfig::new(
+            "reth",
+            "https://logs:secret@example.com/v1/logs".parse().unwrap(),
+            OtlpProtocol::Http,
+        )
+        .unwrap();
+
+        assert_eq!(config.endpoint.as_str(), "https://example.com/v1/logs");
+        assert_eq!(
+            otlp_auth_header_from_endpoint(
+                &"https://logs:secret@example.com/v1/logs".parse().unwrap()
+            )
+            .unwrap()
+            .as_deref(),
+            Some("Authorization=Basic bG9nczpzZWNyZXQ=")
+        );
+    }
+
+    #[test]
+    fn leaves_endpoint_without_credentials_unchanged() {
+        let config = OtlpConfig::new(
+            "reth",
+            "https://example.com/v1/traces".parse().unwrap(),
+            OtlpProtocol::Http,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(config.endpoint.as_str(), "https://example.com/v1/traces");
+        assert_eq!(otlp_auth_header_from_endpoint(config.endpoint()).unwrap(), None);
+    }
+
+    #[test]
+    fn rejects_partial_credentials() {
+        assert!(OtlpConfig::new(
+            "reth",
+            "https://user@example.com/v1/traces".parse().unwrap(),
+            OtlpProtocol::Http,
+            None,
+        )
+        .is_err());
     }
 }


### PR DESCRIPTION
## Summary
- derive OTLP Basic auth from `username:password@` in trace/log endpoint URLs inside `reth-tracing-otlp`
- set `OTEL_EXPORTER_OTLP_TRACES_HEADERS` / `OTEL_EXPORTER_OTLP_LOGS_HEADERS` when those headers are not already set
- strip credentials before passing endpoints to the OpenTelemetry exporter
- reject partial endpoint credentials so auth does not silently fail
- mask both the original OTLP endpoint secrets and credential-stripped endpoint URLs in bench CI logs

This mirrors Tempo telemetry setup behavior: read credentials from the original URL, build `Authorization=Basic <base64(username:password)>`, then use the credential-stripped URL for exporters.

## Test
- `cargo test -p reth-tracing-otlp --features otlp-logs`