### PR TITLE
feat(rpc): add eth_getAddressesInBlock

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -1,7 +1,9 @@
 //! Implementation of the [`jsonrpsee`] generated [`EthApiServer`] trait. Handles RPC requests for
 //! the `eth_` namespace.
 use crate::{
-    helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
+    helpers::{
+        EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi, Trace,
+    },
     RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
 };
 use alloy_dyn_abi::TypedData;
@@ -121,6 +123,15 @@ pub trait EthApi<
     /// Returns all transaction receipts for a given block.
     #[method(name = "getBlockReceipts")]
     async fn block_receipts(&self, block_id: BlockId) -> RpcResult<Option<Vec<R>>>;
+
+    /// Returns the set of unique addresses that appear in a given block.
+    ///
+    /// The set includes the block beneficiary, transaction signers and
+    /// recipients, EIP-2930 access list entries, withdrawal recipients,
+    /// log emitters, and call/create targets and selfdestruct refund
+    /// recipients observed while replaying the block.
+    #[method(name = "getAddressesInBlock")]
+    async fn addresses_in_block(&self, block_id: BlockId) -> RpcResult<Option<Vec<Address>>>;
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "getUncleByBlockHashAndIndex")]
@@ -552,6 +563,13 @@ where
     ) -> RpcResult<Option<Vec<RpcReceipt<T::NetworkTypes>>>> {
         trace!(target: "rpc::eth", ?block_id, "Serving eth_getBlockReceipts");
         Ok(EthBlocks::block_receipts(self, block_id).await?)
+    }
+
+    /// Handler for: `eth_getAddressesInBlock`
+    async fn addresses_in_block(&self, block_id: BlockId) -> RpcResult<Option<Vec<Address>>> {
+        trace!(target: "rpc::eth", ?block_id, "Serving eth_getAddressesInBlock");
+        let _permit = self.tracing_task_guard().clone().acquire_owned().await;
+        Ok(Trace::addresses_in_block(self, block_id).await?.map(|set| set.into_iter().collect()))
     }
 
     /// Handler for: `eth_getUncleByBlockHashAndIndex`

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -2,8 +2,8 @@
 
 use super::{Call, LoadBlock, LoadState, LoadTransaction};
 use crate::{FromEthApiError, FromEvmError};
-use alloy_consensus::{transaction::TxHashRef, BlockHeader};
-use alloy_primitives::B256;
+use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction};
+use alloy_primitives::{Address, B256};
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
 use reth_errors::{ProviderError, RethError};
@@ -20,7 +20,7 @@ use reth_rpc_eth_types::cache::db::StateCacheDb;
 use reth_storage_api::{ProviderBlock, ProviderTx};
 use revm::{context::Block, context_interface::result::ResultAndState};
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 /// Executes CPU heavy tasks.
 pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
@@ -420,5 +420,74 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             .apply_pre_execution_changes()
             .map_err(Self::Error::from_eth_err)?;
         Ok(())
+    }
+
+    /// Returns all unique addresses that appear in the given block.
+    ///
+    /// Collects addresses from sources that do not require execution
+    /// (block beneficiary, transaction signers and recipients, access list
+    /// entries, withdrawal recipients) and then replays the block to pick up
+    /// addresses that are only visible at runtime: call/create targets,
+    /// selfdestruct refund recipients and log emitters.
+    ///
+    /// Implements the address set described by EIP draft `eth_getAddressesInBlock`.
+    fn addresses_in_block(
+        &self,
+        block_id: BlockId,
+    ) -> impl Future<Output = Result<Option<BTreeSet<Address>>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+    {
+        async move {
+            let Some(block) = self.recovered_block(block_id).await? else {
+                return Ok(None);
+            };
+
+            let mut addresses: BTreeSet<Address> = BTreeSet::new();
+            addresses.insert(block.beneficiary());
+            for tx in block.transactions_recovered() {
+                addresses.insert(tx.signer());
+                if let Some(to) = tx.to() {
+                    addresses.insert(to);
+                }
+                if let Some(access_list) = tx.access_list() {
+                    addresses.extend(access_list.iter().map(|item| item.address));
+                }
+            }
+            if let Some(withdrawals) = block.body().withdrawals() {
+                addresses.extend(withdrawals.iter().map(|w| w.address));
+            }
+
+            // Replay the block to collect runtime-only addresses.
+            let traced = self
+                .trace_block_with(
+                    block_id,
+                    Some(block),
+                    TracingInspectorConfig::default_parity(),
+                    |_tx_info, mut ctx| {
+                        let mut per_tx: BTreeSet<Address> = BTreeSet::new();
+                        for log in ctx.result.logs() {
+                            per_tx.insert(log.address);
+                        }
+                        for node in ctx.take_inspector().into_traces().into_nodes() {
+                            per_tx.insert(node.trace.caller);
+                            per_tx.insert(node.trace.address);
+                            if let Some(target) = node.trace.selfdestruct_refund_target {
+                                per_tx.insert(target);
+                            }
+                        }
+                        Ok(per_tx)
+                    },
+                )
+                .await?;
+
+            if let Some(per_tx_sets) = traced {
+                for set in per_tx_sets {
+                    addresses.extend(set);
+                }
+            }
+
+            Ok(Some(addresses))
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the `eth_getAddressesInBlock` RPC method, returning the unique set of addresses that appear in a given block, per draft [execution-apis#456](https://github.com/ethereum/execution-apis/pull/456).

Address sources collected:
- block beneficiary
- transaction signers and recipients
- EIP-2930 access list entries
- withdrawal recipients
- log emitters
- call / create targets and selfdestruct refund recipients observed while replaying the block

Implementation:
- new default method `Trace::addresses_in_block` in `crates/rpc/rpc-eth-api/src/helpers/trace.rs` — reuses `trace_block_with` with `TracingInspectorConfig::default_parity()` and walks `inspector.into_traces().into_nodes()` to pick up runtime-only addresses
- new `getAddressesInBlock` declaration + handler in `crates/rpc/rpc-eth-api/src/core.rs` — handler acquires the `tracing_task_guard` permit and converts the `BTreeSet<Address>` to `Vec<Address>`

## Follow-up from #19858

This picks up where the closed PR left off and addresses the review feedback from @mattsse and @klkvr:
- logic lives on the `Trace` helper (suggested namespace)
- uses `block.transactions_recovered()` instead of re-recovering senders
- avoids fetching the block twice by passing the loaded block into `trace_block_with`
- performs actual tracing so opcode address arguments (CALL/CALLCODE/STATICCALL/DELEGATECALL/SELFDESTRUCT) and CREATE/CREATE2 targets are included, as required by EIP-456

Not included in this PR: addresses extracted from internal RETURN data (32-byte aligned, modulo 32 bytes). That source can produce false positives on arbitrary `uint256` payloads and the EIP is still a draft, so it's better as a follow-up once the spec stabilizes.

Closes #19610

## Testing

- `cargo +nightly fmt --all`
- `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features`
- `cargo check --workspace --all-features`
- `cargo test -p reth-rpc-eth-api --lib`
- `cargo doc -p reth-rpc-eth-api --document-private-items --no-deps`