### PR TITLE
feat(node): allow disabling stages via SDK config

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -159,6 +159,7 @@ impl EngineNodeLauncher {
             ctx.components().evm_config().clone(),
             maybe_exex_manager_handle.clone().unwrap_or_else(ExExManagerHandle::empty),
             ctx.era_import_source(),
+            &node_config.disabled_stages,
         )?;
 
         // The new engine writes directly to static files. This ensures that they're up to the tip.

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -20,7 +20,7 @@ use reth_provider::{providers::ProviderNodeTypes, ProviderFactory};
 use reth_stages::{
     prelude::DefaultStages,
     stages::{EraImportSource, ExecutionStage},
-    Pipeline, StageSet,
+    Pipeline, StageId, StageSet,
 };
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
@@ -42,6 +42,7 @@ pub fn build_networked_pipeline<N, Client, Evm>(
     evm_config: Evm,
     exex_manager_handle: ExExManagerHandle<N::Primitives>,
     era_import_source: Option<EraImportSource>,
+    disabled_stages: &[StageId],
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
@@ -70,6 +71,7 @@ where
         evm_config,
         exex_manager_handle,
         era_import_source,
+        disabled_stages,
     )?;
 
     Ok(pipeline)
@@ -90,6 +92,7 @@ pub fn build_pipeline<N, H, B, Evm>(
     evm_config: Evm,
     exex_manager_handle: ExExManagerHandle<N::Primitives>,
     era_import_source: Option<EraImportSource>,
+    disabled_stages: &[StageId],
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
@@ -127,7 +130,8 @@ where
                 stage_config.execution.into(),
                 stage_config.execution_external_clean_threshold(),
                 exex_manager_handle,
-            )),
+            ))
+            .disable_all(disabled_stages),
         )
         .build(provider_factory, static_file_producer);
 

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -154,6 +154,11 @@ pub struct NodeConfig<ChainSpec> {
 
     /// All storage related arguments with --storage prefix
     pub storage: StorageArgs,
+
+    /// Pipeline stages to disable when launching through the SDK.
+    ///
+    /// This is intentionally SDK-only and is not exposed as CLI arguments.
+    pub disabled_stages: Vec<StageId>,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -186,6 +191,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era: EraArgs::default(),
             static_files: StaticFilesArgs::default(),
             storage: StorageArgs::default(),
+            disabled_stages: Vec::new(),
         }
     }
 
@@ -230,6 +236,12 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self
     }
 
+    /// Sets pipeline stages to disable when launching the node.
+    pub fn with_disabled_stages(mut self, disabled_stages: impl Into<Vec<StageId>>) -> Self {
+        self.disabled_stages = disabled_stages.into();
+        self
+    }
+
     /// Set the config file for the node
     pub fn with_config(mut self, config: impl Into<PathBuf>) -> Self {
         self.config = Some(config.into());
@@ -261,6 +273,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era,
             static_files,
             storage,
+            disabled_stages,
             ..
         } = self;
         NodeConfig {
@@ -281,6 +294,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era,
             static_files,
             storage,
+            disabled_stages,
         }
     }
 
@@ -579,6 +593,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era: self.era,
             static_files: self.static_files,
             storage: self.storage,
+            disabled_stages: self.disabled_stages,
         }
     }
 
@@ -621,6 +636,7 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             era: self.era.clone(),
             static_files: self.static_files,
             storage: self.storage,
+            disabled_stages: self.disabled_stages.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add SDK-only `NodeConfig::disabled_stages` and `with_disabled_stages` helper
- thread disabled stage IDs into the networked pipeline builder
- apply the existing `StageSetBuilder::disable_all` hook after default stage construction

## Rationale
This is the least invasive path because it reuses the existing stage-disable primitive and avoids adding CLI args or a new pipeline customization hook.

## Testing
- `cargo check -p reth-node-core -p reth-node-builder`

Note: repository-wide `cargo fmt --check` currently reports unrelated formatting drift under stable rustfmt, so I did not apply broad formatting changes.