### PR TITLE
test(prune-types): add unit tests for prune helpers

### DIFF
--- a/crates/prune/types/Cargo.toml
+++ b/crates/prune/types/Cargo.toml
@@ -28,6 +28,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 reth-codecs.workspace = true
 
 alloy-primitives = { workspace = true, features = ["serde"] }
+modular-bitfield.workspace = true
 serde.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 assert_matches.workspace = true

--- a/crates/prune/types/src/pruner.rs
+++ b/crates/prune/types/src/pruner.rs
@@ -204,4 +204,108 @@ mod tests {
             HasMoreData(DeletedEntriesLimitReached)
         ));
     }
+
+    #[test]
+    fn test_pruner_output_from_progress() {
+        let finished: PrunerOutput = PruneProgress::Finished.into();
+        assert_eq!(finished.progress, PruneProgress::Finished);
+        assert!(finished.segments.is_empty());
+
+        let interrupted: PrunerOutput =
+            PruneProgress::HasMoreData(PruneInterruptReason::Timeout).into();
+        assert_eq!(interrupted.progress, PruneProgress::HasMoreData(PruneInterruptReason::Timeout));
+        assert!(interrupted.segments.is_empty());
+    }
+
+    #[test]
+    fn test_segment_output_done() {
+        assert_eq!(
+            SegmentOutput::done(),
+            SegmentOutput { progress: PruneProgress::Finished, pruned: 0, checkpoint: None }
+        );
+    }
+
+    #[test]
+    fn test_segment_output_not_done() {
+        let checkpoint = SegmentOutputCheckpoint { block_number: Some(42), tx_number: Some(7) };
+
+        assert_eq!(
+            SegmentOutput::not_done(
+                PruneInterruptReason::WaitingOnSegment(PruneSegment::TransactionLookup),
+                Some(checkpoint)
+            ),
+            SegmentOutput {
+                progress: PruneProgress::HasMoreData(PruneInterruptReason::WaitingOnSegment(
+                    PruneSegment::TransactionLookup
+                )),
+                pruned: 0,
+                checkpoint: Some(checkpoint),
+            }
+        );
+    }
+
+    #[test]
+    fn test_segment_output_checkpoint_conversions() {
+        let checkpoint = PruneCheckpoint {
+            block_number: Some(10),
+            tx_number: Some(20),
+            prune_mode: PruneMode::Before(30),
+        };
+
+        let segment_checkpoint = SegmentOutputCheckpoint::from_prune_checkpoint(checkpoint);
+        assert_eq!(
+            segment_checkpoint,
+            SegmentOutputCheckpoint { block_number: Some(10), tx_number: Some(20) }
+        );
+
+        assert_eq!(
+            segment_checkpoint.as_prune_checkpoint(PruneMode::Distance(64)),
+            PruneCheckpoint {
+                block_number: Some(10),
+                tx_number: Some(20),
+                prune_mode: PruneMode::Distance(64),
+            }
+        );
+    }
+
+    #[test]
+    fn test_prune_interrupt_reason_classifiers() {
+        use PruneInterruptReason::*;
+
+        assert!(Timeout.is_timeout());
+        assert!(!DeletedEntriesLimitReached.is_timeout());
+        assert!(!WaitingOnSegment(PruneSegment::Receipts).is_timeout());
+        assert!(!Unknown.is_timeout());
+
+        assert!(DeletedEntriesLimitReached.is_entries_limit_reached());
+        assert!(!Timeout.is_entries_limit_reached());
+        assert!(!WaitingOnSegment(PruneSegment::Receipts).is_entries_limit_reached());
+        assert!(!Unknown.is_entries_limit_reached());
+    }
+
+    #[test]
+    fn test_prune_progress_is_finished() {
+        use PruneInterruptReason::*;
+        use PruneProgress::*;
+
+        assert!(Finished.is_finished());
+        assert!(!HasMoreData(Timeout).is_finished());
+        assert!(!HasMoreData(DeletedEntriesLimitReached).is_finished());
+        assert!(!HasMoreData(WaitingOnSegment(PruneSegment::Receipts)).is_finished());
+        assert!(!HasMoreData(Unknown).is_finished());
+    }
+
+    #[test]
+    fn test_pruned_segment_info_display() {
+        let segment_info = PrunedSegmentInfo {
+            segment: PruneSegment::StorageHistory,
+            pruned: 7,
+            progress: PruneProgress::HasMoreData(PruneInterruptReason::Timeout),
+        };
+
+        assert_eq!(
+            segment_info.to_string(),
+            "(table=StorageHistory, pruned=7, status=HasMoreData(Timeout))"
+        );
+    }
 }

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -223,6 +223,7 @@ fn serde_deserialize_validate<'a, 'de, const MIN_BLOCKS: u64, D: serde::Deserial
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::Address;
     use assert_matches::assert_matches;
     use serde::Deserialize;
 
@@ -244,6 +245,65 @@ mod tests {
             serde_json::from_str::<V>(r#""full""#),
             Err(err) if err.to_string() == "invalid value: string \"full\", expected prune mode that leaves at least 10 blocks in the database"
         );
+    }
+
+    #[test]
+    fn test_prune_modes_all() {
+        let prune_modes = PruneModes::all();
+
+        assert_ne!(prune_modes, PruneModes::default());
+        assert_eq!(prune_modes.sender_recovery, Some(PruneMode::Full));
+        assert_eq!(prune_modes.transaction_lookup, Some(PruneMode::Full));
+        assert_eq!(prune_modes.receipts, Some(PruneMode::Full));
+        assert_eq!(prune_modes.account_history, Some(PruneMode::Full));
+        assert_eq!(prune_modes.storage_history, Some(PruneMode::Full));
+        assert_eq!(prune_modes.bodies_history, Some(PruneMode::Full));
+        assert!(prune_modes.receipts_log_filter.is_empty());
+    }
+
+    #[test]
+    fn test_prune_modes_has_receipts_pruning() {
+        assert!(!PruneModes::default().has_receipts_pruning());
+
+        let mut prune_modes = PruneModes { receipts: Some(PruneMode::Full), ..Default::default() };
+        assert!(prune_modes.has_receipts_pruning());
+
+        prune_modes.receipts = None;
+        prune_modes.receipts_log_filter.0.insert(Address::ZERO, PruneMode::Before(10));
+        assert!(prune_modes.has_receipts_pruning());
+
+        prune_modes.receipts = Some(PruneMode::Distance(MINIMUM_DISTANCE));
+        assert!(prune_modes.has_receipts_pruning());
+    }
+
+    #[test]
+    fn test_prune_modes_migrate() {
+        for (receipts, expected_migrated, expected_receipts) in [
+            (None, false, None),
+            (Some(PruneMode::Full), true, Some(PruneMode::Distance(MINIMUM_DISTANCE))),
+            (Some(PruneMode::Distance(0)), true, Some(PruneMode::Distance(MINIMUM_DISTANCE))),
+            (
+                Some(PruneMode::Distance(MINIMUM_DISTANCE - 1)),
+                true,
+                Some(PruneMode::Distance(MINIMUM_DISTANCE)),
+            ),
+            (
+                Some(PruneMode::Distance(MINIMUM_DISTANCE)),
+                false,
+                Some(PruneMode::Distance(MINIMUM_DISTANCE)),
+            ),
+            (
+                Some(PruneMode::Distance(MINIMUM_DISTANCE + 1)),
+                false,
+                Some(PruneMode::Distance(MINIMUM_DISTANCE + 1)),
+            ),
+            (Some(PruneMode::Before(10)), false, Some(PruneMode::Before(10))),
+        ] {
+            let mut prune_modes = PruneModes { receipts, ..Default::default() };
+
+            assert_eq!(prune_modes.migrate(), expected_migrated);
+            assert_eq!(prune_modes.receipts, expected_receipts);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds focused unit coverage for `reth-prune-types` helper behavior, including `PruneModes` migration/receipt pruning checks and pruner output/checkpoint helpers.

Adds `modular-bitfield` as a dev-dependency so `cargo test -p reth-prune-types --lib` works with the crate's test-time `reth_codecs::Compact` derives, matching the dependency shape used by `reth-stages-types`.

Validation:
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p reth-prune-types --all-targets --all-features --locked -- -D warnings`
- `cargo test -p reth-prune-types --lib`
- `cargo test -p reth-prune-types --all-features --lib`
- `cargo test --doc -p reth-prune-types --all-features --locked`
- `cargo hack check -p reth-prune-types --each-feature --locked`
- `cargo +nightly udeps -p reth-prune-types --lib --tests --all-features --locked`
- `make lint-toml`
- `zepter run check`
- `typos crates/prune/types`
