### PR TITLE
perf: avoid hashing the state twice

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -26,7 +26,9 @@ use reth_provider::{
 };
 use reth_revm::db::BundleState;
 use reth_tasks::{utils::increase_thread_priority, ForEachOrdered, Runtime};
-use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
+use reth_trie::{
+    hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, HashedPostState,
+};
 use reth_trie_parallel::{
     proof_task::{ProofTaskCtx, ProofWorkerHandle},
     root::ParallelStateRootError,
@@ -381,16 +383,18 @@ where
         let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
 
         let (state_root_tx, state_root_rx) = channel();
+        let (hashed_state_tx, hashed_state_rx) = channel();
 
         self.spawn_sparse_trie_task(
             proof_handle,
             state_root_tx,
+            hashed_state_tx,
             from_multi_proof,
             parent_state_root,
             config.multiproof_chunk_size(),
         );
 
-        StateRootHandle::new(parent_state_root, updates_tx, state_root_rx)
+        StateRootHandle::new(parent_state_root, updates_tx, state_root_rx, hashed_state_rx)
     }
 
     /// Transaction count threshold below which proof workers are halved, since fewer transactions
@@ -580,6 +584,7 @@ where
         &self,
         proof_worker_handle: ProofWorkerHandle,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
+        hashed_state_tx: mpsc::Sender<HashedPostState>,
         from_multi_proof: CrossbeamReceiver<StateRootMessage>,
         parent_state_root: B256,
         chunk_size: usize,
@@ -628,6 +633,7 @@ where
             let mut task = SparseTrieCacheTask::new_with_trie(
                 &executor,
                 from_multi_proof,
+                hashed_state_tx,
                 proof_worker_handle,
                 trie_metrics.clone(),
                 sparse_state_trie,
@@ -894,6 +900,11 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
     /// Returns a clone of the indexed transaction receiver.
     pub fn clone_transaction_receiver(&self) -> IndexedTxReceiver<Tx, Err> {
         self.transactions.clone()
+    }
+
+    /// Takes the hashed state receiver out of the handle for use with custom waiting logic
+    pub fn take_hashed_state_rx(&mut self) -> Option<mpsc::Receiver<HashedPostState>> {
+        self.state_root_handle.as_mut().map(|handle| handle.take_hashed_state_rx())
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1335,7 +1335,7 @@ mod tests {
         }
 
         for update in &state_updates {
-            hashed_state.extend(evm_state_to_hashed_post_state(update.clone(), false));
+            hashed_state.extend(evm_state_to_hashed_post_state(update.clone()));
 
             for (address, account) in update {
                 let storage: HashMap<B256, U256> = account

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1335,7 +1335,7 @@ mod tests {
         }
 
         for update in &state_updates {
-            hashed_state.extend(evm_state_to_hashed_post_state(update.clone()));
+            hashed_state.extend(evm_state_to_hashed_post_state(update.clone(), false));
 
             for (address, account) in update {
                 let storage: HashMap<B256, U256> = account

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -827,12 +827,6 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
             continue
         }
 
-        if *account.original_info == account.info &&
-            account.storage.iter().all(|(_, value)| !value.is_changed())
-        {
-            continue;
-        }
-
         let hashed_address = keccak256(addr);
 
         if account.info != account.original_info() {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -827,6 +827,12 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
             continue
         }
 
+        if *account.original_info == account.info &&
+            account.storage.iter().all(|(_, value)| !value.is_changed())
+        {
+            continue;
+        }
+
         let hashed_address = keccak256(addr);
 
         if account.info != account.original_info() {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -4,11 +4,12 @@ use std::sync::Arc;
 
 use crate::tree::{
     multiproof::{
-        dispatch_with_chunking, evm_state_to_hashed_post_state, StateRootComputeOutcome,
+        dispatch_with_chunking, evm_state_to_hashed_post_state, Source, StateRootComputeOutcome,
         StateRootMessage, DEFAULT_MAX_TARGETS_FOR_CHUNKING,
     },
     payload_processor::multiproof::MultiProofTaskMetrics,
 };
+use alloy_evm::block::StateChangeSource;
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
@@ -193,9 +194,15 @@ where
                 StateRootMessage::PrefetchProofs(targets) => {
                     SparseTrieTaskMessage::PrefetchProofs(targets)
                 }
-                StateRootMessage::StateUpdate(_, state) => {
+                StateRootMessage::StateUpdate(source, state) => {
                     let _span = trace_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
-                    let hashed = evm_state_to_hashed_post_state(state);
+                    // Only EVM transaction updates have reliable `original_info` set to the
+                    // pre-tx state. System call and post-block balance increment updates set
+                    // `original_info` equal to `info`, so we must not skip touched-but-equal
+                    // accounts for those — doing so would drop real state changes.
+                    let skip_unchanged =
+                        matches!(source, Source::Evm(StateChangeSource::Transaction(_)));
+                    let hashed = evm_state_to_hashed_post_state(state, skip_unchanged);
                     SparseTrieTaskMessage::HashedState(hashed)
                 }
                 StateRootMessage::FinishedStateUpdates => {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -4,12 +4,11 @@ use std::sync::Arc;
 
 use crate::tree::{
     multiproof::{
-        dispatch_with_chunking, evm_state_to_hashed_post_state, Source, StateRootComputeOutcome,
+        dispatch_with_chunking, evm_state_to_hashed_post_state, StateRootComputeOutcome,
         StateRootMessage, DEFAULT_MAX_TARGETS_FOR_CHUNKING,
     },
     payload_processor::multiproof::MultiProofTaskMetrics,
 };
-use alloy_evm::block::StateChangeSource;
 use alloy_primitives::B256;
 use alloy_rlp::{Decodable, Encodable};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
@@ -194,15 +193,9 @@ where
                 StateRootMessage::PrefetchProofs(targets) => {
                     SparseTrieTaskMessage::PrefetchProofs(targets)
                 }
-                StateRootMessage::StateUpdate(source, state) => {
+                StateRootMessage::StateUpdate(_, state) => {
                     let _span = trace_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
-                    // Only EVM transaction updates have reliable `original_info` set to the
-                    // pre-tx state. System call and post-block balance increment updates set
-                    // `original_info` equal to `info`, so we must not skip touched-but-equal
-                    // accounts for those — doing so would drop real state changes.
-                    let skip_unchanged =
-                        matches!(source, Source::Evm(StateChangeSource::Transaction(_)));
-                    let hashed = evm_state_to_hashed_post_state(state, skip_unchanged);
+                    let hashed = evm_state_to_hashed_post_state(state);
                     SparseTrieTaskMessage::HashedState(hashed)
                 }
                 StateRootMessage::FinishedStateUpdates => {

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -45,6 +45,8 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
     /// Receives updates from execution and prewarming.
     updates: CrossbeamReceiver<SparseTrieTaskMessage>,
+    /// Sender half for the channel to send final hashed state to.
+    final_hashed_state_tx: Option<std::sync::mpsc::Sender<HashedPostState>>,
     /// `SparseStateTrie` used for computing the state root.
     trie: SparseStateTrie<A, S>,
     /// The parent block's state root.
@@ -106,6 +108,12 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
+    /// Combined final hashed state.
+    ///
+    /// Sparse trie task observes and hashes all state updates, allowing it to cheaply construct a
+    /// final [`HashedPostState`] and share it with main engine thread without requiring any extra
+    /// hashing work.
+    final_hashed_state: HashedPostState,
 
     /// Metrics for the sparse trie.
     metrics: MultiProofTaskMetrics,
@@ -117,9 +125,11 @@ where
     S: SparseTrie + Default + Clone,
 {
     /// Creates a new sparse trie, pre-populating with an existing [`SparseStateTrie`].
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new_with_trie(
         executor: &Runtime,
         updates: CrossbeamReceiver<StateRootMessage>,
+        final_hashed_state_tx: std::sync::mpsc::Sender<HashedPostState>,
         proof_worker_handle: ProofWorkerHandle,
         metrics: MultiProofTaskMetrics,
         trie: SparseStateTrie<A, S>,
@@ -141,6 +151,7 @@ where
             proof_result_rx,
             updates: hashed_state_rx,
             proof_worker_handle,
+            final_hashed_state_tx: Some(final_hashed_state_tx),
             trie,
             parent_state_root,
             chunk_size,
@@ -160,6 +171,7 @@ where
             storage_cache_misses: 0,
             pending_targets: Default::default(),
             pending_updates: Default::default(),
+            final_hashed_state: Default::default(),
             metrics,
         }
     }
@@ -415,7 +427,14 @@ where
             SparseTrieTaskMessage::HashedState(hashed_state) => {
                 self.on_hashed_state_update(hashed_state)
             }
-            SparseTrieTaskMessage::FinishedStateUpdates => self.finished_state_updates = true,
+            SparseTrieTaskMessage::FinishedStateUpdates => {
+                let _ = self
+                    .final_hashed_state_tx
+                    .take()
+                    .unwrap()
+                    .send(core::mem::take(&mut self.final_hashed_state));
+                self.finished_state_updates = true
+            }
         }
     }
 
@@ -453,13 +472,13 @@ where
         skip_all
     )]
     fn on_hashed_state_update(&mut self, hashed_state_update: HashedPostState) {
-        for (address, storage) in hashed_state_update.storages {
+        for (&address, storage) in &hashed_state_update.storages {
             if !storage.storage.is_empty() {
                 // Look up outer maps once per address instead of once per slot.
                 let new_updates = self.new_storage_updates.entry(address).or_default();
                 let mut existing_updates = self.storage_updates.get_mut(&address);
 
-                for (slot, value) in storage.storage {
+                for (&slot, &value) in &storage.storage {
                     self.trie.record_slot_touch(address, slot);
 
                     let encoded = if value.is_zero() {
@@ -485,7 +504,7 @@ where
             self.pending_account_updates.entry(address).or_insert(None);
         }
 
-        for (address, account) in hashed_state_update.accounts {
+        for (&address, &account) in &hashed_state_update.accounts {
             self.trie.record_account_touch(address);
 
             // Track account as touched.
@@ -498,6 +517,8 @@ where
             // it will be updated in the accounts trie.
             self.pending_account_updates.insert(address, Some(account));
         }
+
+        self.final_hashed_state.extend(hashed_state_update);
     }
 
     fn on_proof_result(
@@ -1009,6 +1030,7 @@ mod tests {
         let mut task = SparseTrieCacheTask::new_with_trie(
             &runtime,
             updates_rx,
+            std::sync::mpsc::channel().0,
             proof_worker_handle,
             MultiProofTaskMetrics::default(),
             trie,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -565,6 +565,7 @@ where
         // (keccak256 hashing of all changed addresses and storage slots).
         let hashed_state_output = output.clone();
         let hashed_state_provider = self.provider.clone();
+        let mut hashed_state_rx = handle.take_hashed_state_rx();
         let hashed_state: LazyHashedPostState =
             self.payload_processor.executor().spawn_blocking_named("hash-post-state", move || {
                 let _span = debug_span!(
@@ -572,7 +573,12 @@ where
                     "hashed_post_state",
                 )
                 .entered();
-                Arc::new(hashed_state_provider.hashed_post_state(&hashed_state_output.state))
+                let state = if let Some(Ok(state)) = hashed_state_rx.as_mut().map(|rx| rx.recv()) {
+                    state
+                } else {
+                    hashed_state_provider.hashed_post_state(&hashed_state_output.state)
+                };
+                Arc::new(state)
             });
 
         let block = validated_block.try_into_inner().expect("sole handle")?;

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -189,7 +189,13 @@ pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
     let mut hashed_state = HashedPostState::with_capacity(update.len());
 
     for (address, account) in update {
-        if account.is_touched() && !account.is_empty() {
+        if account.is_touched() {
+            if *account.original_info == account.info &&
+                account.storage.iter().all(|(_, value)| !value.is_changed())
+            {
+                continue;
+            }
+
             let hashed_address = keccak256(address);
             trace!(target: "trie::parallel::sparse", ?address, ?hashed_address, "Adding account to state update");
 

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -85,6 +85,8 @@ pub struct StateRootHandle {
     /// Receiver for the final state root result.
     state_root_rx:
         Option<std::sync::mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
+    /// Receiver for the hashed post state.
+    hashed_state_rx: Option<std::sync::mpsc::Receiver<HashedPostState>>,
 }
 
 impl StateRootHandle {
@@ -95,8 +97,14 @@ impl StateRootHandle {
         state_root_rx: std::sync::mpsc::Receiver<
             Result<StateRootComputeOutcome, ParallelStateRootError>,
         >,
+        hashed_state_rx: std::sync::mpsc::Receiver<HashedPostState>,
     ) -> Self {
-        Self { cached_trie_state_root, updates_tx, state_root_rx: Some(state_root_rx) }
+        Self {
+            cached_trie_state_root,
+            updates_tx,
+            state_root_rx: Some(state_root_rx),
+            hashed_state_rx: Some(hashed_state_rx),
+        }
     }
 
     /// Returns the state root that the cached sparse trie is anchored at.
@@ -142,6 +150,15 @@ impl StateRootHandle {
         &mut self,
     ) -> std::sync::mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>> {
         self.state_root_rx.take().expect("state_root already taken")
+    }
+
+    /// Takes the hashed state receiver
+    ///
+    /// # Panics
+    ///
+    /// If called more than once.
+    pub const fn take_hashed_state_rx(&mut self) -> std::sync::mpsc::Receiver<HashedPostState> {
+        self.hashed_state_rx.take().expect("hashed_state already taken")
     }
 }
 

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -185,13 +185,6 @@ impl Drop for StateHookSender {
 }
 
 /// Converts [`EvmState`] to [`HashedPostState`] by keccak256-hashing addresses and storage slots.
-///
-/// When `skip_unchanged` is `true`, touched accounts whose `info` equals `original_info` and whose
-/// storage has no changed slots are dropped from the output. This must only be enabled for state
-/// updates that come from real EVM transaction execution; updates synthesized by other paths
-/// (e.g. post-block balance increments built by `alloy_evm::block::state_changes::
-/// balance_increment_state`) set `original_info` equal to the post-increment `info`, so applying
-/// the skip there would silently discard real state changes.
 pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
     let mut hashed_state = HashedPostState::with_capacity(update.len());
 

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -185,12 +185,20 @@ impl Drop for StateHookSender {
 }
 
 /// Converts [`EvmState`] to [`HashedPostState`] by keccak256-hashing addresses and storage slots.
-pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
+///
+/// When `skip_unchanged` is `true`, touched accounts whose `info` equals `original_info` and whose
+/// storage has no changed slots are dropped from the output. This must only be enabled for state
+/// updates that come from real EVM transaction execution; updates synthesized by other paths
+/// (e.g. post-block balance increments built by `alloy_evm::block::state_changes::
+/// balance_increment_state`) set `original_info` equal to the post-increment `info`, so applying
+/// the skip there would silently discard real state changes.
+pub fn evm_state_to_hashed_post_state(update: EvmState, skip_unchanged: bool) -> HashedPostState {
     let mut hashed_state = HashedPostState::with_capacity(update.len());
 
     for (address, account) in update {
         if account.is_touched() {
-            if *account.original_info == account.info &&
+            if skip_unchanged &&
+                *account.original_info == account.info &&
                 account.storage.iter().all(|(_, value)| !value.is_changed())
             {
                 continue;

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -192,18 +192,11 @@ impl Drop for StateHookSender {
 /// (e.g. post-block balance increments built by `alloy_evm::block::state_changes::
 /// balance_increment_state`) set `original_info` equal to the post-increment `info`, so applying
 /// the skip there would silently discard real state changes.
-pub fn evm_state_to_hashed_post_state(update: EvmState, skip_unchanged: bool) -> HashedPostState {
+pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
     let mut hashed_state = HashedPostState::with_capacity(update.len());
 
     for (address, account) in update {
         if account.is_touched() {
-            if skip_unchanged &&
-                *account.original_info == account.info &&
-                account.storage.iter().all(|(_, value)| !value.is_changed())
-            {
-                continue;
-            }
-
             let hashed_address = keccak256(address);
             trace!(target: "trie::parallel::sparse", ?address, ?hashed_address, "Adding account to state update");
 

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -189,7 +189,7 @@ pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
     let mut hashed_state = HashedPostState::with_capacity(update.len());
 
     for (address, account) in update {
-        if account.is_touched() {
+        if account.is_touched() && !account.is_empty() {
             let hashed_address = keccak256(address);
             trace!(target: "trie::parallel::sparse", ?address, ?hashed_address, "Adding account to state update");
 


### PR DESCRIPTION
This is probably not too big of a bottleneck but still shows up on traces for larger blocks. We don't have to hash the state in the engine loop because the sparse trie task already hashes every state update it gets and we can just aggregate them there