### PR TITLE
ci: avoid redundant bench otlp features

### DIFF
--- a/.github/scripts/bench-txgen-build.sh
+++ b/.github/scripts/bench-txgen-build.sh
@@ -23,9 +23,6 @@ fi
 
 EXTRA_FEATURES=""
 EXTRA_RUSTFLAGS=""
-if [ "${BENCH_OTLP_DISABLED:-false}" != "true" ]; then
-  EXTRA_FEATURES="otlp,otlp-logs"
-fi
 if [ "${BENCH_TRACY:-off}" != "off" ]; then
   if [ -n "$EXTRA_FEATURES" ]; then
     EXTRA_FEATURES="${EXTRA_FEATURES},tracy,tracy-client/ondemand"


### PR DESCRIPTION
## Summary
- stop adding `otlp,otlp-logs` to benchmark build `EXTRA_FEATURES`
- rely on the default features in `reth` and `reth-bb` instead
- keep the existing Tracy opt-in feature path unchanged

## Why
`otlp` and `otlp-logs` are now enabled by default in both benchmarked binaries. Passing them explicitly makes the benchmark script add `--workspace --features otlp,otlp-logs`, which expands feature resolution across the workspace and can compile unnecessary targets such as examples before OOMing.

## Test
- `bash -n .github/scripts/bench-txgen-build.sh`
- `git diff --check`