### PR TITLE
fix(trie): accept B256::ZERO as non-existent account in from_eip1186_proof

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -768,7 +768,7 @@ impl AccountProof {
 
         let (storage_root, info) = if nonce == 0 &&
             balance.is_zero() &&
-            storage_hash.is_zero() &&
+            (storage_hash.is_zero() || storage_hash == EMPTY_ROOT_HASH) &&
             (code_hash == KECCAK_EMPTY || code_hash.is_zero())
         {
             // Account does not exist in state. Return `None` here to prevent proof
@@ -1234,6 +1234,24 @@ mod tests {
 
         let acc: AccountProof = geth_proof.into();
         // Should be interpreted as a non-existent account (info = None)
+        assert!(acc.info.is_none());
+        assert_eq!(acc.storage_root, EMPTY_ROOT_HASH);
+    }
+
+    #[test]
+    #[cfg(feature = "eip1186")]
+    fn from_eip1186_proof_accepts_empty_hashes() {
+        let proof = alloy_rpc_types_eth::EIP1186AccountProofResponse {
+            address: Address::random(),
+            balance: U256::ZERO,
+            code_hash: KECCAK_EMPTY,
+            nonce: 0,
+            storage_hash: EMPTY_ROOT_HASH,
+            account_proof: vec![],
+            storage_proof: vec![],
+        };
+
+        let acc: AccountProof = proof.into();
         assert!(acc.info.is_none());
         assert_eq!(acc.storage_root, EMPTY_ROOT_HASH);
     }

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -769,10 +769,16 @@ impl AccountProof {
         let (storage_root, info) = if nonce == 0 &&
             balance.is_zero() &&
             storage_hash.is_zero() &&
-            code_hash == KECCAK_EMPTY
+            (code_hash == KECCAK_EMPTY || code_hash.is_zero())
         {
             // Account does not exist in state. Return `None` here to prevent proof
             // verification.
+            //
+            // Note: geth (since v1.13.4, go-ethereum#28357) returns `B256::ZERO` for
+            // both `codeHash` and `storageHash` in exclusion proofs, while reth
+            // returns `KECCAK_EMPTY` / `EMPTY_ROOT_HASH`. We accept both formats here
+            // so that proofs obtained from any client can be deserialized correctly.
+            // See: https://github.com/ethereum/go-ethereum/issues/28441
             (EMPTY_ROOT_HASH, None)
         } else {
             (storage_hash, Some(Account { nonce, balance, bytecode_hash: code_hash.into() }))
@@ -1207,6 +1213,29 @@ mod tests {
         acc.info.take();
         acc.storage_root = EMPTY_ROOT_HASH;
         assert_eq!(acc, inverse);
+    }
+
+    #[test]
+    #[cfg(feature = "eip1186")]
+    fn from_eip1186_proof_accepts_geth_zero_hashes() {
+        // geth (since v1.13.4) returns B256::ZERO for codeHash and storageHash
+        // in exclusion proofs for non-existent accounts, instead of
+        // KECCAK_EMPTY / EMPTY_ROOT_HASH. Verify that from_eip1186_proof
+        // correctly recognizes this format as a non-existent account.
+        let geth_proof = alloy_rpc_types_eth::EIP1186AccountProofResponse {
+            address: Address::random(),
+            balance: U256::ZERO,
+            code_hash: B256::ZERO,
+            nonce: 0,
+            storage_hash: B256::ZERO,
+            account_proof: vec![],
+            storage_proof: vec![],
+        };
+
+        let acc: AccountProof = geth_proof.into();
+        // Should be interpreted as a non-existent account (info = None)
+        assert!(acc.info.is_none());
+        assert_eq!(acc.storage_root, EMPTY_ROOT_HASH);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`from_eip1186_proof` currently only recognizes `KECCAK_EMPTY` as the sentinel for a non-existent account. However, **geth (since v1.13.4, [go-ethereum#28357](https://github.com/ethereum/go-ethereum/pull/28357))** returns `B256::ZERO` for both `codeHash` and `storageHash` in exclusion proofs for non-existent accounts. Erigon and Alchemy follow the same convention.

This means any reth code that deserializes proofs obtained from a geth/erigon node will **incorrectly treat non-existent accounts as existing accounts** with zero-hash bytecode.

### Changes

- Accept both `B256::ZERO` and reth's empty hash sentinels for non-existent account proofs in `from_eip1186_proof`
- Add tests for geth-style zero hashes and reth/Infura-style empty hashes
- **No change to reth's outbound behavior** (`into_eip1186_response` still returns `KECCAK_EMPTY` / `EMPTY_ROOT_HASH`)

### Context

The ecosystem is split on what to return for non-existent accounts in `eth_getProof`:

| Client/Provider | `codeHash` | `storageHash` |
|---|---|---|
| geth (≥v1.13.4) | `0x000…000` | `0x000…000` |
| erigon | `0x000…000` | `0x000…000` |
| Alchemy | `0x000…000` | `0x000…000` |
| reth | `KECCAK_EMPTY` | `EMPTY_ROOT_HASH` |
| Infura | `KECCAK_EMPTY` | `EMPTY_ROOT_HASH` |

Regardless of which format reth *emits*, the deserialization path should accept both — any reth node may need to consume proofs from geth-compatible sources.

Ref: https://github.com/ethereum/go-ethereum/issues/28441

## Test plan

- [x] `from_eip1186_proof_accepts_geth_zero_hashes` — verifies geth-format proofs are deserialized as non-existent accounts
- [x] `from_eip1186_proof_accepts_empty_hashes` — verifies reth/Infura-format proofs are deserialized as non-existent accounts
- [x] Existing `eip_1186_roundtrip` test unchanged and still passes
