### PR TITLE
feat(trie): geth-compatible zero hashes for non-existent accounts in eth_getProof

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -724,18 +724,48 @@ pub struct AccountProof {
 
 #[cfg(feature = "eip1186")]
 impl AccountProof {
-    /// Convert into an EIP-1186 account proof response
+    /// Convert into an EIP-1186 account proof response.
+    ///
+    /// For non-existent accounts, this returns `KECCAK_EMPTY` for `codeHash` and
+    /// `EMPTY_ROOT_HASH` for `storageHash`, matching reth's default behavior.
+    ///
+    /// Use [`Self::into_eip1186_response_with`] to customize the behavior for
+    /// non-existent accounts (e.g. returning `B256::ZERO` for geth compatibility).
     pub fn into_eip1186_response(
         self,
         slots: Vec<alloy_serde::JsonStorageKey>,
     ) -> alloy_rpc_types_eth::EIP1186AccountProofResponse {
+        self.into_eip1186_response_with(slots, false)
+    }
+
+    /// Convert into an EIP-1186 account proof response, with optional geth-compatible
+    /// zero hashes for non-existent accounts.
+    ///
+    /// When `zero_empty_account` is `true`, non-existent accounts return `B256::ZERO`
+    /// for both `codeHash` and `storageHash`, matching geth's behavior since v1.13.4
+    /// ([go-ethereum#28357](https://github.com/ethereum/go-ethereum/pull/28357)).
+    ///
+    /// When `false`, returns `KECCAK_EMPTY` / `EMPTY_ROOT_HASH` (reth default).
+    ///
+    /// See: <https://github.com/ethereum/go-ethereum/issues/28441>
+    pub fn into_eip1186_response_with(
+        self,
+        slots: Vec<alloy_serde::JsonStorageKey>,
+        zero_empty_account: bool,
+    ) -> alloy_rpc_types_eth::EIP1186AccountProofResponse {
+        let is_non_existent = self.info.is_none();
         let info = self.info.unwrap_or_default();
+        let (code_hash, storage_hash) = if is_non_existent && zero_empty_account {
+            (B256::ZERO, B256::ZERO)
+        } else {
+            (info.get_bytecode_hash(), self.storage_root)
+        };
         alloy_rpc_types_eth::EIP1186AccountProofResponse {
             address: self.address,
             balance: info.balance,
-            code_hash: info.get_bytecode_hash(),
+            code_hash,
             nonce: info.nonce,
-            storage_hash: self.storage_root,
+            storage_hash,
             account_proof: self.proof,
             storage_proof: self
                 .storage_proofs
@@ -1254,6 +1284,50 @@ mod tests {
         let acc: AccountProof = proof.into();
         assert!(acc.info.is_none());
         assert_eq!(acc.storage_root, EMPTY_ROOT_HASH);
+    }
+
+    #[test]
+    #[cfg(feature = "eip1186")]
+    fn into_eip1186_response_zero_empty_account() {
+        // Non-existent account (info = None)
+        let acc = AccountProof {
+            address: Address::random(),
+            info: None,
+            proof: vec![],
+            storage_root: EMPTY_ROOT_HASH,
+            storage_proofs: vec![],
+        };
+
+        // Default behavior: KECCAK_EMPTY / EMPTY_ROOT_HASH
+        let rpc_default = acc.clone().into_eip1186_response(Vec::new());
+        assert_eq!(rpc_default.code_hash, KECCAK_EMPTY);
+        assert_eq!(rpc_default.storage_hash, EMPTY_ROOT_HASH);
+
+        // zero_empty_account = false: same as default
+        let rpc_compat_off = acc.clone().into_eip1186_response_with(Vec::new(), false);
+        assert_eq!(rpc_compat_off.code_hash, KECCAK_EMPTY);
+        assert_eq!(rpc_compat_off.storage_hash, EMPTY_ROOT_HASH);
+
+        // zero_empty_account = true: B256::ZERO (geth-compat)
+        let rpc_compat_on = acc.clone().into_eip1186_response_with(Vec::new(), true);
+        assert_eq!(rpc_compat_on.code_hash, B256::ZERO);
+        assert_eq!(rpc_compat_on.storage_hash, B256::ZERO);
+
+        // Existing account should NOT be affected by zero_empty_account
+        let existing_acc = AccountProof {
+            address: Address::random(),
+            info: Some(Account {
+                nonce: 42,
+                balance: U256::from(100),
+                bytecode_hash: Some(KECCAK_EMPTY),
+            }),
+            proof: vec![],
+            storage_root: B256::random(),
+            storage_proofs: vec![],
+        };
+        let rpc_existing = existing_acc.clone().into_eip1186_response_with(Vec::new(), true);
+        assert_eq!(rpc_existing.code_hash, KECCAK_EMPTY);
+        assert_eq!(rpc_existing.storage_hash, existing_acc.storage_root);
     }
 
     #[test]

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -1309,7 +1309,7 @@ mod tests {
         assert_eq!(rpc_compat_off.storage_hash, EMPTY_ROOT_HASH);
 
         // zero_empty_account = true: B256::ZERO (geth-compat)
-        let rpc_compat_on = acc.clone().into_eip1186_response_with(Vec::new(), true);
+        let rpc_compat_on = acc.into_eip1186_response_with(Vec::new(), true);
         assert_eq!(rpc_compat_on.code_hash, B256::ZERO);
         assert_eq!(rpc_compat_on.storage_hash, B256::ZERO);
 


### PR DESCRIPTION
## Summary

Add `into_eip1186_response_with(slots, zero_empty_account)` to `AccountProof` that optionally returns `B256::ZERO` for both `codeHash` and `storageHash` when the account does not exist in state, matching geth's behavior since v1.13.4.

### Motivation

geth changed its `eth_getProof` behavior in [go-ethereum#28357](https://github.com/ethereum/go-ethereum/pull/28357) (v1.13.4, late 2023): for non-existent accounts, `codeHash` and `storageHash` now return `0x000…000` instead of `KECCAK_EMPTY` / `EMPTY_ROOT_HASH`. The geth maintainers consider this ["more correct"](https://github.com/ethereum/go-ethereum/issues/28441#issuecomment-1800684941) — an exclusion proof has no valid account in the trie, so returning `KECCAK_EMPTY` would be semantically misleading.

EIP-1186 does **not** specify what to return for non-existent accounts (only for accounts "without code"), so there is no authoritative standard. The ecosystem is now split at the **L1 level**:

| Client/Provider | `codeHash` (non-existent) | `storageHash` (non-existent) |
|---|---|---|
| geth (≥v1.13.4) | `0x000…000` | `0x000…000` |
| erigon | `0x000…000` | `0x000…000` |
| Alchemy | `0x000…000` | `0x000…000` |
| ChainBase | `0x000…000` | `0x000…000` |
| **reth** | `KECCAK_EMPTY` | `EMPTY_ROOT_HASH` |
| Infura | `KECCAK_EMPTY` | `EMPTY_ROOT_HASH` |

This divergence affects anyone consuming `eth_getProof` responses in a mixed-client environment — both L1 and L2:

- **ZK proof systems**: [risc0/zeth#59](https://github.com/risc0/zeth/issues/59) documents sparse MPT construction failures caused by this exact format difference
- **Cross-client interop**: dapps and infrastructure switching between RPC providers (e.g. Alchemy → reth) get inconsistent results for the same query
- **L2 bridges / op-node**: L2 systems verifying state proofs from L1 geth nodes encounter mismatches when the verifier expects `KECCAK_EMPTY`

Without this option, any infrastructure that needs geth-compatible `eth_getProof` responses from reth must maintain out-of-tree patches.

### Changes

- Add `into_eip1186_response_with(slots, zero_empty_account)` — when `zero_empty_account` is `true`, returns `B256::ZERO` for non-existent accounts
- `into_eip1186_response(slots)` now delegates to the new method with `zero_empty_account = false` — **fully backward compatible, no behavior change**
- Add test `into_eip1186_response_zero_empty_account` covering default, compat-off, compat-on, and existing-account cases

### Design Notes

This is intentionally a method-level option rather than a global config, keeping the change minimal and non-invasive. Callers (e.g. the RPC layer) can wire this to a node-level configuration flag as needed.

Related: #24359 addresses the inverse direction (`from_eip1186_proof` accepting `B256::ZERO`).

## Test plan

- [x] New test `into_eip1186_response_zero_empty_account` — verifies all 4 cases:
  - Default method returns `KECCAK_EMPTY` / `EMPTY_ROOT_HASH`
  - `zero_empty_account = false` returns `KECCAK_EMPTY` / `EMPTY_ROOT_HASH`
  - `zero_empty_account = true` returns `B256::ZERO` / `B256::ZERO`
  - Existing accounts are NOT affected by the flag
- [x] Existing `eip_1186_roundtrip` test unchanged