### PR TITLE
fix(cli): reject zero timer durations

### DIFF
--- a/crates/cli/util/src/lib.rs
+++ b/crates/cli/util/src/lib.rs
@@ -24,7 +24,8 @@ pub use load_secret_key::{get_secret_key, parse_secret_key_from_hex};
 pub mod parsers;
 pub use parsers::{
     hash_or_num_value_parser, parse_duration_from_secs, parse_duration_from_secs_or_ms,
-    parse_ether_value, parse_socket_address,
+    parse_ether_value, parse_non_zero_duration_from_secs, parse_non_zero_duration_from_secs_or_ms,
+    parse_socket_address,
 };
 
 #[cfg(all(unix, any(target_env = "gnu", target_os = "macos")))]

--- a/crates/cli/util/src/parsers.rs
+++ b/crates/cli/util/src/parsers.rs
@@ -31,6 +31,24 @@ pub fn parse_duration_from_secs_or_ms(
     }
 }
 
+/// Helper to parse a non-zero [`Duration`] from seconds.
+pub fn parse_non_zero_duration_from_secs(arg: &str) -> eyre::Result<Duration> {
+    ensure_non_zero_duration(parse_duration_from_secs(arg)?)
+}
+
+/// Helper to parse a non-zero [`Duration`] from seconds or milliseconds.
+pub fn parse_non_zero_duration_from_secs_or_ms(arg: &str) -> eyre::Result<Duration> {
+    ensure_non_zero_duration(parse_duration_from_secs_or_ms(arg)?)
+}
+
+fn ensure_non_zero_duration(duration: Duration) -> eyre::Result<Duration> {
+    if duration.is_zero() {
+        eyre::bail!("duration must be greater than zero")
+    }
+
+    Ok(duration)
+}
+
 /// Helper to format a [Duration] to the format that can be parsed by
 /// [`parse_duration_from_secs_or_ms`].
 pub fn format_duration_as_secs_or_ms(duration: Duration) -> String {

--- a/crates/node/core/src/args/dev.rs
+++ b/crates/node/core/src/args/dev.rs
@@ -1,9 +1,8 @@
 //! clap [Args](clap::Args) for Dev testnet configuration
 
-use std::time::Duration;
-
 use clap::Args;
 use humantime::parse_duration;
+use std::time::Duration;
 
 const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
 
@@ -37,7 +36,7 @@ pub struct DevArgs {
         long = "dev.block-time",
         help_heading = "Dev testnet",
         conflicts_with = "block_max_transactions",
-        value_parser = parse_duration,
+        value_parser = parse_non_zero_duration,
         verbatim_doc_comment
     )]
     pub block_time: Option<Duration>,
@@ -80,6 +79,15 @@ impl Default for DevArgs {
             dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
         }
     }
+}
+
+fn parse_non_zero_duration(arg: &str) -> eyre::Result<Duration> {
+    let duration = humantime::parse_duration(arg)?;
+    if duration.is_zero() {
+        eyre::bail!("duration must be greater than zero")
+    }
+
+    Ok(duration)
 }
 
 #[cfg(test)]
@@ -175,6 +183,14 @@ mod tests {
             "1s",
         ]);
         assert!(args.is_err());
+    }
+
+    #[test]
+    fn test_parse_dev_args_reject_zero_block_time() {
+        let result =
+            CommandParser::<DevArgs>::try_parse_from(["reth", "--dev", "--dev.block-time", "0s"]);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/node/core/src/args/metric.rs
+++ b/crates/node/core/src/args/metric.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use reth_cli_util::{parse_duration_from_secs, parse_socket_address};
+use reth_cli_util::{parse_non_zero_duration_from_secs, parse_socket_address};
 use std::{net::SocketAddr, time::Duration};
 
 /// Default push gateway interval in seconds.
@@ -30,7 +30,7 @@ pub struct MetricArgs {
     #[arg(
         long = "metrics.prometheus.push.interval",
         default_value = "5",
-        value_parser = parse_duration_from_secs,
+        value_parser = parse_non_zero_duration_from_secs,
         value_name = "SECONDS",
         help_heading = "Metrics"
     )]
@@ -44,5 +44,40 @@ impl Default for MetricArgs {
             push_gateway_url: None,
             push_gateway_interval: Duration::from_secs(DEFAULT_PUSH_GATEWAY_INTERVAL_SECS),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Args, Parser};
+
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn metrics_push_interval_rejects_zero() {
+        let result = CommandParser::<MetricArgs>::try_parse_from([
+            "reth",
+            "--metrics.prometheus.push.interval",
+            "0",
+        ]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn metrics_push_interval_accepts_positive_duration() {
+        let args = CommandParser::<MetricArgs>::parse_from([
+            "reth",
+            "--metrics.prometheus.push.interval",
+            "10",
+        ])
+        .args;
+
+        assert_eq!(args.push_gateway_interval, Duration::from_secs(10));
     }
 }

--- a/crates/node/core/src/args/payload_builder.rs
+++ b/crates/node/core/src/args/payload_builder.rs
@@ -6,7 +6,7 @@ use clap::{
     Arg, Args, Command,
 };
 use reth_cli_util::{
-    parse_duration_from_secs, parse_duration_from_secs_or_ms,
+    parse_duration_from_secs, parse_non_zero_duration_from_secs_or_ms,
     parsers::format_duration_as_secs_or_ms,
 };
 use std::{ffi::OsStr, sync::OnceLock, time::Duration};
@@ -102,7 +102,7 @@ pub struct PayloadBuilderArgs {
     ///   * `1` -> 1 second
     #[arg(
         long = "builder.interval",
-        value_parser = parse_duration_from_secs_or_ms,
+        value_parser = parse_non_zero_duration_from_secs_or_ms,
         default_value = DefaultPayloadBuilderValues::get_global().interval.as_str(),
         value_name = "DURATION"
     )]
@@ -135,7 +135,7 @@ impl Default for PayloadBuilderArgs {
         let defaults = DefaultPayloadBuilderValues::get_global();
         Self {
             extra_data: Bytes::from(defaults.extra_data.as_bytes().to_vec()),
-            interval: parse_duration_from_secs_or_ms(defaults.interval.as_str()).unwrap(),
+            interval: parse_non_zero_duration_from_secs_or_ms(defaults.interval.as_str()).unwrap(),
             gas_limit: None,
             deadline: Duration::from_secs(defaults.deadline.parse().unwrap()),
             max_payload_tasks: defaults.max_payload_tasks,
@@ -327,5 +327,15 @@ mod tests {
             CommandParser::<PayloadBuilderArgs>::parse_from(["reth", "--builder.interval", "50ms"])
                 .args;
         assert_eq!(args.interval, Duration::from_millis(50));
+    }
+
+    #[test]
+    fn test_args_reject_zero_interval() {
+        assert!(CommandParser::<PayloadBuilderArgs>::try_parse_from([
+            "reth",
+            "--builder.interval",
+            "0"
+        ])
+        .is_err());
     }
 }

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -4,7 +4,9 @@ use crate::cli::config::RethTransactionPoolConfig;
 use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::Address;
 use clap::{builder::Resettable, Args};
-use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
+use reth_cli_util::{
+    parse_non_zero_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms,
+};
 use reth_transaction_pool::{
     blobstore::disk::DEFAULT_MAX_CACHED_BLOBS,
     maintain::MAX_QUEUED_TRANSACTION_LIFETIME,
@@ -392,7 +394,7 @@ pub struct TxPoolArgs {
     pub max_new_pending_txs_notifications: usize,
 
     /// Maximum amount of time non-executable transaction are queued.
-    #[arg(long = "txpool.lifetime", value_parser = parse_duration_from_secs_or_ms, value_name = "DURATION", default_value = format_duration_as_secs_or_ms(DefaultTxPoolValues::get_global().max_queued_lifetime))]
+    #[arg(long = "txpool.lifetime", value_parser = parse_non_zero_duration_from_secs_or_ms, value_name = "DURATION", default_value = format_duration_as_secs_or_ms(DefaultTxPoolValues::get_global().max_queued_lifetime))]
     pub max_queued_lifetime: Duration,
 
     /// Path to store the local transaction backup at, to survive node restarts.
@@ -587,6 +589,14 @@ mod tests {
             CommandParser::<TxPoolArgs>::try_parse_from(["reth", "--txpool.lifetime", "invalid"]);
 
         assert!(result.is_err(), "Expected an error for invalid duration");
+    }
+
+    #[test]
+    fn txpool_parse_max_tx_lifetime_rejects_zero() {
+        let result =
+            CommandParser::<TxPoolArgs>::try_parse_from(["reth", "--txpool.lifetime", "0"]);
+
+        assert!(result.is_err(), "Expected an error for zero duration");
     }
 
     #[test]


### PR DESCRIPTION
Rejects zero-valued duration flags at clap parsing time for payload builder, txpool lifetime, metrics push interval, and dev block time.