### PR TITLE
fix: enforce secp256k1 feature propagation

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         "propagate-feature",
         # These are the features to check:
-        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,tracy,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,otlp-logs,js-tracer,portable,keccak-cache-global,trie-debug",
+        "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,tracy,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,otlp-logs,js-tracer,portable,keccak-cache-global,trie-debug,secp256k1",
         # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/crates/net/peers/Cargo.toml
+++ b/crates/net/peers/Cargo.toml
@@ -46,5 +46,9 @@ std = [
     "url/std",
     "serde_json/std",
 ]
-secp256k1 = ["dep:secp256k1", "enr/secp256k1"]
+secp256k1 = [
+    "dep:secp256k1",
+    "enr/secp256k1",
+    "alloy-primitives/secp256k1",
+]
 net = ["std", "dep:tokio", "tokio?/net"]


### PR DESCRIPTION
Adds `secp256k1` to zepter's propagated feature checks.

This surfaces and fixes the missing `alloy-primitives/secp256k1` propagation in `reth-network-peers`.
