### PR TITLE
feat(evm): add WithTxEnv constructor

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -471,8 +471,7 @@ where
                     })
                     .for_each_ordered_in(executor.cpu_pool(), |(idx, tx)| {
                         let tx = tx.map(|tx| {
-                            let (tx_env, tx) = tx.into_parts();
-                            let tx = WithTxEnv { tx_env, tx: Arc::new(tx) };
+                            let tx = WithTxEnv::new(tx);
                             let _ = prewarm_tx.send((idx, tx.clone()));
                             tx
                         });
@@ -763,10 +762,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
 {
     for (idx, raw_tx) in iter.enumerate() {
         let tx = convert.convert(raw_tx);
-        let tx = tx.map(|tx| {
-            let (tx_env, tx) = tx.into_parts();
-            WithTxEnv { tx_env, tx: Arc::new(tx) }
-        });
+        let tx = tx.map(|tx| WithTxEnv::new(tx));
         if let Ok(tx) = &tx {
             let _ = prewarm_tx.send((idx, tx.clone()));
         }

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -664,13 +664,28 @@ impl<T, Evm: ConfigureEvm> ExecutableTxFor<Evm> for T where
 {
 }
 
-/// A container for a transaction and a transaction environment.
+/// A transaction stored together with its `TxEnv`.
+///
+/// See also [`ExecutableTxParts`] for types that can be split into a transaction environment and
+/// recovered transaction.
 #[derive(Debug)]
 pub struct WithTxEnv<TxEnv, T> {
     /// The transaction environment for EVM.
     pub tx_env: TxEnv,
     /// The recovered transaction.
     pub tx: Arc<T>,
+}
+
+impl<TxEnv, T> WithTxEnv<TxEnv, T> {
+    /// Creates a transaction/environment pair from a type that can be split with
+    /// [`ExecutableTxParts::into_parts`].
+    pub fn new<Tx, InnerTx>(tx: Tx) -> Self
+    where
+        Tx: ExecutableTxParts<TxEnv, InnerTx, Recovered = T>,
+    {
+        let (tx_env, tx) = tx.into_parts();
+        Self { tx_env, tx: Arc::new(tx) }
+    }
 }
 
 impl<TxEnv: Clone, T> Clone for WithTxEnv<TxEnv, T> {


### PR DESCRIPTION
## Summary

Clarifies that `WithTxEnv` stores a recovered transaction with the `TxEnv` produced by alloy-evm's `ExecutableTxParts::into_parts`.

Adds `WithTxEnv::new` for the common `into_parts` plus `Arc::new` construction, then uses it in the payload processor conversion paths.

## Impact

This keeps the prewarming conversion code aligned with the documented abstraction and avoids repeating the same transaction/environment wrapping pattern at call sites.