### PR TITLE
feat(node): add pruning mode to startup log

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -25,6 +25,7 @@ use reth_node_api::{
     BuiltPayload, ConsensusEngineHandle, FullNodeTypes, NodeTypes, NodeTypesWithDBAdapter,
 };
 use reth_node_core::{
+    args::PruneConfigKind,
     dirs::{ChainPath, DataDirPath},
     exit::NodeExitFuture,
     primitives::Head,
@@ -115,7 +116,9 @@ impl EngineNodeLauncher {
             .inspect(|this: &LaunchContextWith<Attached<WithConfigs<<T::Types as NodeTypes>::ChainSpec>, _>>| {
                 info!(target: "reth::cli", "\n{}", this.chain_spec().display_hardforks());
                 let settings = this.provider_factory().cached_storage_settings();
-                info!(target: "reth::cli", ?settings, "Loaded storage settings");
+                let pruning_mode =
+                    PruneConfigKind::from_config(&this.prune_config(), this.chain_spec().as_ref()).as_str();
+                info!(target: "reth::cli", ?settings, ?pruning_mode, "Loaded storage settings");
             })
             .with_metrics_task()
             // passing FullNodeTypes as type parameter here so that we can build


### PR DESCRIPTION
Same as `reth_storage_settings` metric, but printed in logs on startup.

```
2026-05-20T10:22:31.119276Z  INFO reth::cli: Loaded storage settings settings=StorageSettings { storage_v2: true } pruning_mode=minimal
```

Full log:
```
2026-05-20T10:22:30.507235Z  INFO reth::cli: Initialized tracing, debug log directory: /Users/shekhirin/Library/Caches/reth/logs/mainnet
2026-05-20T10:22:30.708222Z  INFO reth::cli: Starting Reth version="2.2.0 (fbe23f8)"
2026-05-20T10:22:30.708384Z  INFO reth::cli: Opening database path="/Users/shekhirin/Library/Application Support/reth/mainnet/db"
2026-05-20T10:22:30.714716Z  INFO reth::cli: Launching node
2026-05-20T10:22:30.718628Z  INFO reth::cli: Pruning configuration is present in the config file, but no CLI arguments are provided. Using config from file.
2026-05-20T10:22:30.718668Z  INFO reth::cli: Configuration loaded path="/Users/shekhirin/Library/Application Support/reth/mainnet/reth.toml"
2026-05-20T10:22:30.819309Z  INFO check_consistency: reth::cli: Healing static file inconsistencies.
2026-05-20T10:22:31.030657Z  INFO check_consistency: reth::providers::rocksdb: StoragesHistory: checkpoint is 0, clearing stale data
2026-05-20T10:22:31.032728Z  INFO check_consistency: reth::providers::rocksdb: AccountsHistory: checkpoint is 0, clearing stale data
2026-05-20T10:22:31.117039Z  INFO check_consistency:check_consistency{read_only=false}: reth::cli: Verifying storage consistency.
2026-05-20T10:22:31.118389Z  INFO reth::cli: Database opened
2026-05-20T10:22:31.119136Z  INFO reth::cli:
Pre-merge hard forks (block based):
- Frontier                         @0
- Homestead                        @1150000
- Dao                              @1920000
- Tangerine                        @2463000
- SpuriousDragon                   @2675000
- Byzantium                        @4370000
- Constantinople                   @7280000
- Petersburg                       @7280000
- Istanbul                         @9069000
- MuirGlacier                      @9200000
- Berlin                           @12244000
- London                           @12965000
- ArrowGlacier                     @13773000
- GrayGlacier                      @15050000
Merge hard forks:
- Paris                            @58750000000000000000000 (network is known to be merged)
Post-merge hard forks (timestamp based):
- Shanghai                         @1681338455
- Cancun                           @1710338135          blob: (target: 3, max: 6, fraction: 3338477)
- Prague                           @1746612311          blob: (target: 6, max: 9, fraction: 5007716)
- Osaka                            @1764798551          blob: (target: 6, max: 9, fraction: 5007716)
- Bpo1                             @1765290071          blob: (target: 10, max: 15, fraction: 8346193)
- Bpo2                             @1767747671          blob: (target: 14, max: 21, fraction: 11684671)
2026-05-20T10:22:31.119276Z  INFO reth::cli: Loaded storage settings settings=StorageSettings { storage_v2: true } pruning_mode=minimal
2026-05-20T10:22:31.123429Z  INFO reth::cli: Transaction pool initialized
2026-05-20T10:22:31.124148Z  INFO net::peers: Loading saved peers file=/Users/shekhirin/Library/Application Support/reth/mainnet/known-peers.json
2026-05-20T10:22:31.124361Z  INFO net::peers: Loaded persisted peers count=8
2026-05-20T10:22:32.353331Z  INFO reth::cli: P2P networking initialized enode=enode://64fd13a19627c2347a15e777e46af0598dccbce06ffd218e1dd9502d87bc8e415b13ea5e2b4dba110281d974a7d10b286f686745ceb4f708754772eab0e92e71@139.28.111.218:30303
2026-05-20T10:22:32.355315Z  INFO reth::cli: StaticFileProducer initialized
2026-05-20T10:22:32.356321Z  INFO reth::cli: Pruner initialized prune_config=PruneConfig { block_interval: 5, segments: PruneModes { sender_recovery: Some(Full), transaction_lookup: Some(Full), receipts: Some(Distance(64)), account_history: Some(Distance(10064)), storage_history: Some(Distance(10064)), bodies_history: Some(Distance(10064)), receipts_log_filter: ReceiptsLogPruneConfig({}) }, minimum_pruning_distance: 10064 }
2026-05-20T10:22:32.358238Z  INFO reth::cli: Consensus engine initialized
2026-05-20T10:22:32.358770Z  INFO reth::cli: Engine API handler initialized
2026-05-20T10:22:32.362775Z  INFO reth::cli: RPC auth server started url=127.0.0.1:8551
2026-05-20T10:22:32.362916Z  INFO reth::cli: RPC IPC server started path=/tmp/reth.ipc
2026-05-20T10:22:32.364274Z  INFO reth::cli: Starting consensus engine
```