### PR TITLE
ci: disable OTLP for release benches

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -386,6 +386,11 @@ jobs:
               return;
             }
 
+            const releaseRef = (ref) => /^v\d+\.\d+\.\d+/.test(ref || '');
+            if (releaseRef(baseline) || releaseRef(feature) || '${{ github.ref_type }}' === 'tag') {
+              otlp = 'false';
+            }
+
             // Resolve display names for baseline/feature
             let baselineName = baseline || 'main';
             let featureName = feature;


### PR DESCRIPTION
temp until next release, since missing flags

## Summary
- disable OTLP automatically when the benchmark compares release tag refs
- keep the existing OTLP behavior for non-release benchmarks
- leave the benchmark runner script unchanged

## Validation
- uv run python YAML parse for .github/workflows/bench.yml
- git diff --check