### PR TITLE
chore(payload): prefer named thread for payload builds

### DIFF
--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -111,7 +111,7 @@ where
             );
 
         ctx.task_executor().spawn_critical_os_thread(
-            "payload-builder",
+            "payload-service",
             "payload builder service",
             payload_service,
         );
@@ -141,7 +141,7 @@ where
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         ctx.task_executor().spawn_critical_os_thread(
-            "payload-builder",
+            "payload-service",
             "payload builder",
             async move {
                 #[expect(clippy::collection_is_never_read)]

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -142,7 +142,7 @@ where
 
         ctx.task_executor().spawn_critical_os_thread(
             "payload-service",
-            "payload builder",
+            "payload builder service",
             async move {
                 #[expect(clippy::collection_is_never_read)]
                 let mut subscriptions = Vec::new();

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -47,6 +47,8 @@ mod stack;
 pub use better_payload_emitter::BetterPayloadEmitter;
 pub use stack::PayloadBuilderStack;
 
+const PAYLOAD_BUILDER_THREAD_NAME: &str = "payload-builder";
+
 /// Helper to access [`NodePrimitives::BlockHeader`] from [`PayloadBuilder::BuiltPayload`].
 pub type HeaderForPayload<P> = <<P as BuiltPayload>::Primitives as NodePrimitives>::BlockHeader;
 
@@ -240,6 +242,11 @@ impl PayloadTaskGuard {
     pub fn new(max_payload_tasks: usize) -> Self {
         Self(Arc::new(Semaphore::new(max_payload_tasks)))
     }
+
+    /// Acquires an owned permit for a payload build task.
+    async fn acquire_owned(&self) -> tokio::sync::OwnedSemaphorePermit {
+        self.0.clone().acquire_owned().await.expect("payload task semaphore closed")
+    }
 }
 
 /// Settings for the [`BasicPayloadJobGenerator`].
@@ -359,19 +366,25 @@ where
         let execution_cache = self.execution_cache.clone();
         let trie_handle = self.trie_handle.take();
         let builder = self.builder.clone();
-        self.executor.spawn_blocking_task(async move {
+        let executor = self.executor.clone();
+        self.executor.spawn_task(async move {
             // acquire the permit for executing the task
-            let _permit = guard.acquire().await;
-            let args = BuildArguments {
-                cached_reads,
-                execution_cache,
-                trie_handle,
-                config: payload_config,
-                cancel,
-                best_payload,
+            let permit = guard.acquire_owned().await;
+            let build = move || {
+                let _permit = permit;
+                let args = BuildArguments {
+                    cached_reads,
+                    execution_cache,
+                    trie_handle,
+                    config: payload_config,
+                    cancel,
+                    best_payload,
+                };
+                let result = builder.try_build(args);
+                let _ = tx.send(result);
             };
-            let result = builder.try_build(args);
-            let _ = tx.send(result);
+
+            executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, build);
         });
 
         self.pending_block = Some(PendingPayload { _cancel, payload: rx });
@@ -519,10 +532,11 @@ where
                     let (tx, rx) = oneshot::channel();
                     let config = self.config.clone();
                     let builder = self.builder.clone();
-                    self.executor.spawn_blocking_task(async move {
+                    let build = move || {
                         let res = builder.build_empty_payload(config);
                         let _ = tx.send(res);
-                    });
+                    };
+                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, build);
 
                     empty_payload = Some(rx);
                 }
@@ -530,9 +544,10 @@ where
                     debug!(target: "payload_builder", id=%self.config.payload_id(), "racing fallback payload");
                     // race the in progress job with this job
                     let (tx, rx) = oneshot::channel();
-                    self.executor.spawn_blocking_task(async move {
+                    let build = move || {
                         let _ = tx.send(job());
-                    });
+                    };
+                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, build);
                     empty_payload = Some(rx);
                 }
             };

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -530,10 +530,13 @@ where
                     let (tx, rx) = oneshot::channel();
                     let config = self.config.clone();
                     let builder = self.builder.clone();
-                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, move || {
-                        let res = builder.build_empty_payload(config);
-                        let _ = tx.send(res);
-                    });
+                    self.executor.spawn_blocking_named_or_tokio(
+                        PAYLOAD_BUILDER_THREAD_NAME,
+                        move || {
+                            let res = builder.build_empty_payload(config);
+                            let _ = tx.send(res);
+                        },
+                    );
 
                     empty_payload = Some(rx);
                 }
@@ -541,9 +544,12 @@ where
                     debug!(target: "payload_builder", id=%self.config.payload_id(), "racing fallback payload");
                     // race the in progress job with this job
                     let (tx, rx) = oneshot::channel();
-                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, move || {
-                        let _ = tx.send(job());
-                    });
+                    self.executor.spawn_blocking_named_or_tokio(
+                        PAYLOAD_BUILDER_THREAD_NAME,
+                        move || {
+                            let _ = tx.send(job());
+                        },
+                    );
                     empty_payload = Some(rx);
                 }
             };

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -370,7 +370,7 @@ where
         self.executor.spawn_task(async move {
             // acquire the permit for executing the task
             let permit = guard.acquire_owned().await;
-            let build = move || {
+            executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, move || {
                 let _permit = permit;
                 let args = BuildArguments {
                     cached_reads,
@@ -382,9 +382,7 @@ where
                 };
                 let result = builder.try_build(args);
                 let _ = tx.send(result);
-            };
-
-            executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, build);
+            });
         });
 
         self.pending_block = Some(PendingPayload { _cancel, payload: rx });
@@ -532,11 +530,10 @@ where
                     let (tx, rx) = oneshot::channel();
                     let config = self.config.clone();
                     let builder = self.builder.clone();
-                    let build = move || {
+                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, move || {
                         let res = builder.build_empty_payload(config);
                         let _ = tx.send(res);
-                    };
-                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, build);
+                    });
 
                     empty_payload = Some(rx);
                 }
@@ -544,10 +541,9 @@ where
                     debug!(target: "payload_builder", id=%self.config.payload_id(), "racing fallback payload");
                     // race the in progress job with this job
                     let (tx, rx) = oneshot::channel();
-                    let build = move || {
+                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, move || {
                         let _ = tx.send(job());
-                    };
-                    self.executor.spawn_blocking_named_or_tokio(PAYLOAD_BUILDER_THREAD_NAME, build);
+                    });
                     empty_payload = Some(rx);
                 }
             };

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -574,7 +574,7 @@ impl Runtime {
     where
         F: FnOnce() + Send + 'static,
     {
-        let func = std::sync::Arc::new(parking_lot::Mutex::new(Some(func)));
+        let func = Arc::new(parking_lot::Mutex::new(Some(func)));
         let named_func = func.clone();
 
         if self

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -550,6 +550,50 @@ impl Runtime {
         crate::LazyHandle::new(self.0.worker_map.spawn_on(name, func))
     }
 
+    /// Attempts to spawn a blocking closure on a dedicated, named OS thread.
+    ///
+    /// Returns `None` if the named worker already has a task running or queued, allowing the caller
+    /// to fall back to another executor instead of serializing behind the named worker.
+    pub fn try_spawn_blocking_named<F, R>(
+        &self,
+        name: &'static str,
+        func: F,
+    ) -> Option<crate::LazyHandle<R>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.0.worker_map.try_spawn_on(name, func).map(crate::LazyHandle::new)
+    }
+
+    /// Spawns a blocking closure on a named OS thread if it is idle, otherwise falls back to
+    /// tokio's unnamed blocking thread pool.
+    ///
+    /// Returns `true` if the closure was spawned on the named thread.
+    pub fn spawn_blocking_named_or_tokio<F>(&self, name: &'static str, func: F) -> bool
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let func = std::sync::Arc::new(parking_lot::Mutex::new(Some(func)));
+        let named_func = func.clone();
+
+        if self
+            .try_spawn_blocking_named(name, move || {
+                if let Some(func) = named_func.lock().take() {
+                    func();
+                }
+            })
+            .is_some()
+        {
+            return true
+        }
+
+        if let Some(func) = func.lock().take() {
+            self.spawn_blocking(func);
+        }
+        false
+    }
+
     /// Spawns the task onto the runtime.
     /// The given future resolves as soon as the [Shutdown] signal is received.
     ///

--- a/crates/tasks/src/worker_map.rs
+++ b/crates/tasks/src/worker_map.rs
@@ -5,7 +5,14 @@
 //! named task, like a 1-thread thread pool keyed by name.
 
 use dashmap::DashMap;
-use std::{panic::AssertUnwindSafe, thread};
+use std::{
+    panic::AssertUnwindSafe,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+};
 use tokio::sync::{mpsc, oneshot};
 
 type BoxedTask = Box<dyn FnOnce() + Send + 'static>;
@@ -14,6 +21,8 @@ type BoxedTask = Box<dyn FnOnce() + Send + 'static>;
 struct WorkerThread {
     /// Sender to submit work to this worker's thread.
     tx: mpsc::UnboundedSender<BoxedTask>,
+    /// Number of tasks currently running or queued on this worker.
+    pending: Arc<AtomicUsize>,
     /// The OS thread handle. Taken during shutdown to join.
     handle: Option<thread::JoinHandle<()>>,
 }
@@ -31,7 +40,63 @@ impl WorkerThread {
             })
             .unwrap_or_else(|e| panic!("failed to spawn worker thread {name:?}: {e}"));
 
-        Self { tx, handle: Some(handle) }
+        Self { tx, pending: Arc::new(AtomicUsize::new(0)), handle: Some(handle) }
+    }
+
+    /// Spawns a closure on this worker.
+    fn spawn<F, R>(&self, f: F) -> oneshot::Receiver<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.pending.fetch_add(1, Ordering::AcqRel);
+
+        let (result_tx, result_rx) = oneshot::channel();
+        let pending = self.pending.clone();
+
+        let task: BoxedTask = Box::new(move || {
+            let _decrement_pending = DecrementPendingOnDrop(pending);
+            let _ = result_tx.send(f());
+        });
+
+        if self.tx.send(task).is_err() {
+            self.pending.fetch_sub(1, Ordering::AcqRel);
+        }
+
+        result_rx
+    }
+
+    /// Attempts to spawn a closure if this worker has no task running or queued.
+    fn try_spawn<F, R>(&self, f: F) -> Option<oneshot::Receiver<R>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.pending.compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire).ok()?;
+
+        let (result_tx, result_rx) = oneshot::channel();
+        let pending = self.pending.clone();
+
+        let task: BoxedTask = Box::new(move || {
+            let _decrement_pending = DecrementPendingOnDrop(pending);
+            let _ = result_tx.send(f());
+        });
+
+        if self.tx.send(task).is_err() {
+            self.pending.fetch_sub(1, Ordering::AcqRel);
+            return None
+        }
+
+        Some(result_rx)
+    }
+}
+
+/// Decrements a worker's pending task count when a task finishes, including after panic.
+struct DecrementPendingOnDrop(Arc<AtomicUsize>);
+
+impl Drop for DecrementPendingOnDrop {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -65,16 +130,24 @@ impl WorkerMap {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let (result_tx, result_rx) = oneshot::channel();
-
-        let task: BoxedTask = Box::new(move || {
-            let _ = result_tx.send(f());
-        });
-
         let worker = self.workers.entry(name).or_insert_with(|| WorkerThread::new(name));
-        let _ = worker.tx.send(task);
+        worker.spawn(f)
+    }
 
-        result_rx
+    /// Attempts to spawn a closure on the dedicated worker thread for the given name.
+    ///
+    /// Returns `None` if the named worker already has a task running or queued.
+    pub(crate) fn try_spawn_on<F, R>(
+        &self,
+        name: &'static str,
+        f: F,
+    ) -> Option<oneshot::Receiver<R>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let worker = self.workers.entry(name).or_insert_with(|| WorkerThread::new(name));
+        worker.try_spawn(f)
     }
 }
 
@@ -162,5 +235,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(name, "custom-worker");
+    }
+
+    #[tokio::test]
+    async fn worker_map_try_spawn_busy() {
+        let map = WorkerMap::new();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let first = map.try_spawn_on("busy-worker", move || {
+            release_rx.recv().unwrap();
+            1
+        });
+        assert!(first.is_some());
+
+        let second = map.try_spawn_on("busy-worker", || 2);
+        assert!(second.is_none(), "busy worker should reject queued work");
+
+        release_tx.send(()).unwrap();
+        assert_eq!(first.unwrap().await.unwrap(), 1);
+
+        let third = map.try_spawn_on("busy-worker", || 3).expect("worker should be idle");
+        assert_eq!(third.await.unwrap(), 3);
     }
 }


### PR DESCRIPTION
Payload build work now tries to run on the persistent `payload-builder` named worker thread. If that worker already has work running or queued, the runtime falls back to tokio's unnamed blocking pool so concurrent payload jobs do not serialize behind the named thread.

Validation:
- `cargo +nightly fmt --all --check`
- `cargo check -p reth-tasks -p reth-basic-payload-builder`
- `cargo test -p reth-tasks worker_map --lib`