### PR TITLE
fix(engine): gate BAL storage prefetch on parent account existence

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -851,7 +851,7 @@ impl ExecutionCache {
             // If the account was not modified, as in not changed and not destroyed, then we have
             // nothing to do w.r.t. this particular account and can move on
             if account.status.is_not_modified() {
-                continue
+                continue;
             }
 
             // If the original account had code (was a contract), we must clear the entire cache
@@ -874,7 +874,7 @@ impl ExecutionCache {
                         );
                     });
                     self.clear();
-                    return Ok(())
+                    return Ok(());
                 }
 
                 self.0.account_cache.remove(addr);
@@ -886,7 +886,7 @@ impl ExecutionCache {
             // `None` current info, should be destroyed.
             let Some(ref account_info) = account.info else {
                 trace!(target: "engine::caching", ?account, "Account with None account info found in state updates");
-                return Err(())
+                return Err(());
             };
 
             // Now we iterate over all storage and make updates to the cached storage values
@@ -1264,6 +1264,78 @@ mod tests {
         assert!(caches.insert_state(&bundle).is_ok());
         assert_eq!(caches.0.account_stats.size(), 0);
         assert!(caches.0.account_cache.get(&addr).is_none());
+    }
+
+    /// Regression test for <https://github.com/paradigmxyz/reth/issues/24300>
+    ///
+    /// When BAL prefetch caches `(addr, slot) → 0` for a non-existent account, and
+    /// that account is later CREATE2'd + SELFDESTRUCT'd + re-CREATE2'd in the same
+    /// block, `insert_state` takes the `was_destroyed() && !had_code` fast-path
+    /// which only removes the account entry but skips storage cleanup. This leaves
+    /// the stale prefetched zero in the storage cache, which poisons the next
+    /// block's SLOAD.
+    #[test]
+    fn test_insert_state_destroyed_codeless_account_stale_storage_from_prefetch() {
+        let caches = ExecutionCache::new(1000);
+
+        let addr = Address::random();
+        let storage_key = StorageKey::random();
+
+        // Simulate what BAL prefetch does: cache (addr, slot) → 0 for an address
+        // that doesn't exist in the parent state
+        caches.insert_storage(addr, storage_key, Some(U256::ZERO));
+
+        // Verify the stale entry exists
+        assert_eq!(
+            caches.0.storage_cache.get(&(addr, storage_key)),
+            Some(U256::ZERO),
+            "Prefetched zero should be in storage cache"
+        );
+
+        // Now simulate insert_state after block execution where the account was
+        // CREATE2'd → SSTORE(slot, 99) → SELFDESTRUCT'd (same tx) → re-CREATE2'd
+        // → SSTORE(slot, 99). The BundleState shows:
+        // - was_destroyed() = true (SELFDESTRUCT happened)
+        // - original_info = None (didn't exist in parent = no code hash)
+        // - current info exists (re-created)
+        // - storage has the final value
+        let bundle = BundleState {
+            state: HashMap::from_iter([(
+                addr,
+                BundleAccount::new(
+                    None, // No original info — account didn't exist in parent
+                    None, // Destroyed
+                    Default::default(),
+                    AccountStatus::Destroyed,
+                ),
+            )]),
+            contracts: Default::default(),
+            reverts: Default::default(),
+            state_size: 0,
+            reverts_size: 0,
+        };
+
+        assert!(caches.insert_state(&bundle).is_ok());
+
+        // The account should be removed
+        assert!(caches.0.account_cache.get(&addr).is_none());
+
+        // CRITICAL: The stale storage entry from BAL prefetch should ideally also
+        // be removed. Currently, the `continue` in insert_state skips storage
+        // cleanup for codeless destroyed accounts, so this stale zero persists.
+        //
+        // The fix is applied at the prefetch site (prefetch_bal_storage) which
+        // gates on account existence in parent state, preventing the stale entry
+        // from being created in the first place. This test documents the
+        // insert_state behavior as-is.
+        //
+        // If insert_state is later hardened to also evict storage for destroyed
+        // accounts, this assertion should be flipped to is_none().
+        assert_eq!(
+            caches.0.storage_cache.get(&(addr, storage_key)),
+            Some(U256::ZERO),
+            "insert_state currently does not clean up storage for codeless destroyed accounts"
+        );
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -178,9 +178,9 @@ where
                 }
 
                 // Send withdrawal prefetch targets after all transactions dispatched
-                if let Some(to_sparse_trie_task) = to_sparse_trie_task &&
-                    let Some(withdrawals) = &ctx.env.withdrawals &&
-                    !withdrawals.is_empty()
+                if let Some(to_sparse_trie_task) = to_sparse_trie_task
+                    && let Some(withdrawals) = &ctx.env.withdrawals
+                    && !withdrawals.is_empty()
                 {
                     let targets = multiproof_targets_from_withdrawals(withdrawals);
                     let _ = to_sparse_trie_task.send(StateRootMessage::PrefetchProofs(targets));
@@ -483,7 +483,7 @@ where
 
                     if finished_execution {
                         // all tasks are done, we can exit, which will save caches and exit
-                        break
+                        break;
                     }
                 }
                 PrewarmTaskEvent::FinishedTxExecution { executed_transactions } => {
@@ -495,7 +495,7 @@ where
 
                     if final_execution_outcome.is_some() {
                         // all tasks are done, we can exit, which will save caches and exit
-                        break
+                        break;
                     }
                 }
             }
@@ -569,7 +569,7 @@ where
                     %err,
                     "Failed to build state provider in prewarm thread"
                 );
-                return None
+                return None;
             }
         };
 
@@ -710,10 +710,10 @@ where
             }
         });
 
-        if balance.is_none() &&
-            nonce.is_none() &&
-            code_hash.is_none() &&
-            account_changes.storage_changes.is_empty()
+        if balance.is_none()
+            && nonce.is_none()
+            && code_hash.is_none()
+            && account_changes.storage_changes.is_empty()
         {
             return;
         }
@@ -757,8 +757,8 @@ where
         provider: &mut Option<CachedStateProvider<reth_provider::StateProviderBox, true>>,
         account: &alloy_eip7928::AccountChanges,
     ) {
-        if self.disable_bal_batch_io ||
-            (account.storage_changes.is_empty() && account.storage_reads.is_empty())
+        if self.disable_bal_batch_io
+            || (account.storage_changes.is_empty() && account.storage_reads.is_empty())
         {
             return;
         }
@@ -795,6 +795,21 @@ where
             }
         };
 
+        // Skip storage prefetch for addresses that don't exist in the parent state.
+        //
+        // If the address has no account in the parent DB, reading its storage will cache
+        // `(address, slot) → 0`. This is dangerous when the address is CREATE2'd and
+        // SELFDESTRUCT'd within the same tx (EIP-6780 full delete) and then re-CREATE2'd:
+        // `insert_state` takes the `was_destroyed() && !had_code` fast-path which skips
+        // storage cache cleanup, so the stale zero survives into the next block's warm cache
+        // and poisons any SLOAD against the re-created contract.
+        //
+        // See: https://github.com/paradigmxyz/reth/issues/24300
+        match state_provider.basic_account(&account.address) {
+            Ok(Some(_)) => {}
+            _ => return,
+        }
+
         let start = Instant::now();
 
         for slot in &account.storage_changes {
@@ -824,7 +839,7 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         //
         // See: https://eips.ethereum.org/EIPS/eip-6780
         if !account.is_touched() || account.is_selfdestructed() {
-            continue
+            continue;
         }
 
         let hashed_address = keccak256(addr);
@@ -834,7 +849,7 @@ fn multiproof_targets_from_state(state: EvmState) -> (MultiProofTargetsV2, usize
         for (key, slot) in account.storage {
             // do nothing if unchanged
             if !slot.is_changed() {
-                continue
+                continue;
             }
 
             let hashed_slot = keccak256(B256::new(key.to_be_bytes()));


### PR DESCRIPTION
Skip storage prefetching for addresses that don't exist in the parent state during BAL (EIP-7928) prewarm. When an address is absent from the parent DB, CachedStateProvider::storage() in PREWARM mode caches (address, slot) → U256::ZERO via unwrap_or_default(). This stale zero becomes dangerous under the EIP-6780 destroy-then-recreate pattern:

1. BAL prefetch caches (X, s) → 0 (X absent in parent)
2. Block execution: CREATE2(X) → SSTORE(s, 99) → SELFDESTRUCT (same tx, full delete under EIP-6780) → CREATE2(X) → SSTORE(s, 99) account cache entry but continues past storage cleanup
4. Stale (X, s) → 0 survives in the Arc<ExecutionCacheInner>
5. Block N+1: SLOAD(X, s) hits warm cache → returns 0 instead of canonical 99 → state root divergence

The fix adds a basic_account() check in prefetch_bal_storage before iterating storage slots. If the account doesn't exist in the parent state, we skip the prefetch entirely.

Also adds a regression test documenting that insert_state does not clean up storage entries for codeless destroyed accounts.

Fixes #24300