### PR TITLE
perf: use B256Map for hash-keyed maps

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1898::BlockWithParent, merge::EPOCH_SLOTS, BlockNumHash, NumHash};
-use alloy_primitives::B256;
+use alloy_primitives::{map::B256Map, B256};
 use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
@@ -40,7 +40,7 @@ use reth_tasks::{spawn_os_thread, utils::increase_thread_priority, WorkerPool};
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
 use state::TreeState;
-use std::{collections::HashMap, fmt::Debug, ops, sync::Arc, time::Duration};
+use std::{fmt::Debug, ops, sync::Arc, time::Duration};
 
 use crossbeam_channel::{Receiver, Sender};
 use tokio::sync::{
@@ -315,7 +315,7 @@ where
     /// Timing statistics for executed blocks, keyed by block hash.
     /// Stored here (not in `ExecutedBlock`) to avoid leaking observability concerns into the block
     /// type. Entries are removed when blocks are persisted or invalidated.
-    execution_timing_stats: HashMap<B256, Box<ExecutionTimingStats>>,
+    execution_timing_stats: B256Map<Box<ExecutionTimingStats>>,
     /// Set when an FCU with payload attributes is received, cleared on the next FCU without.
     /// Suppresses persistence cycles during payload building.
     building_payload: bool,
@@ -409,7 +409,7 @@ where
             engine_kind,
             evm_config,
             changeset_cache,
-            execution_timing_stats: HashMap::new(),
+            execution_timing_stats: B256Map::default(),
             building_payload: false,
             runtime,
         }

--- a/crates/transaction-pool/src/pool/listener.rs
+++ b/crates/transaction-pool/src/pool/listener.rs
@@ -8,10 +8,12 @@ use crate::{
     traits::{NewBlobSidecar, PropagateKind},
     PoolTransaction, ValidPoolTransaction,
 };
-use alloy_primitives::{TxHash, B256};
+use alloy_primitives::{
+    map::{hash_map::Entry, B256Map},
+    TxHash, B256,
+};
 use futures_util::Stream;
 use std::{
-    collections::{hash_map::Entry, HashMap},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -86,14 +88,14 @@ pub struct PoolEventBroadcast<T: PoolTransaction> {
     /// All listeners for all transaction events.
     all_events_broadcaster: AllPoolEventsBroadcaster<T>,
     /// All listeners for events for a certain transaction hash.
-    broadcasters_by_hash: HashMap<TxHash, PoolEventBroadcaster>,
+    broadcasters_by_hash: B256Map<PoolEventBroadcaster>,
 }
 
 impl<T: PoolTransaction> Default for PoolEventBroadcast<T> {
     fn default() -> Self {
         Self {
             all_events_broadcaster: AllPoolEventsBroadcaster::default(),
-            broadcasters_by_hash: HashMap::default(),
+            broadcasters_by_hash: B256Map::default(),
         }
     }
 }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -71,7 +71,10 @@ use alloy_eips::{
     eip7594::BlobTransactionSidecarVariant,
     eip7702::SignedAuthorization,
 };
-use alloy_primitives::{map::AddressSet, Address, Bytes, TxHash, TxKind, B128, B256, U256};
+use alloy_primitives::{
+    map::{AddressSet, B256Map},
+    Address, Bytes, TxHash, TxKind, B128, B256, U256,
+};
 use futures_util::{ready, Stream};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_ethereum_primitives::{PooledTransactionVariant, TransactionSigned};
@@ -79,7 +82,6 @@ use reth_execution_types::ChangedAccount;
 use reth_primitives_traits::{Block, InMemorySize, Recovered, SealedBlock, SignedTransaction};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
     fmt,
     fmt::Debug,
     future::Future,
@@ -830,7 +832,7 @@ impl<T: PoolTransaction> IntoIterator for AllPoolTransactions<T> {
 
 /// Represents transactions that were propagated over the network.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
-pub struct PropagatedTransactions(pub HashMap<TxHash, Vec<PropagateKind>>);
+pub struct PropagatedTransactions(pub B256Map<Vec<PropagateKind>>);
 
 impl PropagatedTransactions {
     /// Records a propagation of a transaction to a peer.
@@ -856,7 +858,7 @@ impl PropagatedTransactions {
 
 impl IntoIterator for PropagatedTransactions {
     type Item = (TxHash, Vec<PropagateKind>);
-    type IntoIter = std::collections::hash_map::IntoIter<TxHash, Vec<PropagateKind>>;
+    type IntoIter = alloy_primitives::map::hash_map::IntoIter<TxHash, Vec<PropagateKind>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()


### PR DESCRIPTION
Uses `B256Map` for maps keyed by fixed-byte hashes so they use Alloy's specialized hasher.