### PR TITLE
perf: enable revm p256-aws-lc-rs feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -434,7 +434,7 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { version = "0.3.1", default-features = false }
 
 # revm
-revm = { version = "38.0.0", default-features = false }
+revm = { version = "38.0.0", default-features = false, features = ["secp256k1", "blst", "c-kzg", "p256-aws-lc-rs"] }
 revm-bytecode = { version = "10.0.0", default-features = false }
 revm-database = { version = "13.0.0", default-features = false }
 revm-state = { version = "11.0.0", default-features = false }

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -50,7 +50,7 @@ tokio = { workspace = true, features = ["sync"] }
 
 # revm with required ethereum features
 # Note: this must be kept to ensure all features are properly enabled/forwarded
-revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit", "p256-aws-lc-rs"] }
+revm = { workspace = true, features = ["memory_limit"] }
 
 # misc
 eyre.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -31,7 +31,7 @@ reth-revm.workspace = true
 reth-tracing.workspace = true
 reth-trie.workspace = true
 reth-trie-db.workspace = true
-revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit", "p256-aws-lc-rs"] }
+revm = { workspace = true, features = ["memory_limit"] }
 
 alloy-rlp.workspace = true
 alloy-primitives.workspace = true


### PR DESCRIPTION
Enables the revm `p256-aws-lc-rs` feature at the workspace dependency level so secp256r1 (RIP-7212) signature verification uses `aws-lc-rs` instead of the pure-Rust `p256` crate.

This ports the dependency feature layout from #23248 onto latest `main`. Since latest `main` already enabled `p256-aws-lc-rs` at the crate call sites, this PR centralizes the precompile backend features (`secp256k1`, `blst`, `c-kzg`, `p256-aws-lc-rs`) on the workspace `revm` dependency and leaves only `memory_limit` at the crate level.

Prompter: @DaniPopes

Validation:
- `cargo metadata --format-version 1 --locked`
- `cargo check -p reth-node-ethereum --locked`