### PR TITLE
fix(import): skip invalid blocks during file decode instead of aborting

### DIFF
--- a/crates/cli/commands/src/import_core.rs
+++ b/crates/cli/commands/src/import_core.rs
@@ -131,13 +131,24 @@ where
     let mut bad_block_number: Option<u64> = None;
     let mut last_valid_block_number: Option<u64> = None;
 
-    while let Some(file_client) =
-        reader.next_chunk::<BlockTy<N>>(consensus.clone(), Some(sealed_header)).await?
+    let skip_invalid_blocks = !import_config.fail_on_invalid_block;
+    while let Some(file_client) = reader
+        .next_chunk_with_invalid_block_handling::<BlockTy<N>>(
+            consensus.clone(),
+            Some(sealed_header.clone()),
+            skip_invalid_blocks,
+        )
+        .await?
     {
         // create a new FileClient from chunk read from file
         info!(target: "reth::import",
             "Importing chain file chunk"
         );
+
+        if file_client.headers_len() == 0 {
+            debug!(target: "reth::import", "Skipping chain file chunk without valid blocks");
+            continue;
+        }
 
         let tip = file_client.tip().ok_or(eyre::eyre!("file client has no tip"))?;
         info!(target: "reth::import", "Chain file chunk read");

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -126,7 +126,7 @@ impl<B: FullBlock> FileClient<B> {
         let mut reader = vec![];
         file.read_to_end(&mut reader).await?;
 
-        Ok(FileClientBuilder { consensus, parent_header: None }
+        Ok(FileClientBuilder { consensus, parent_header: None, skip_invalid_blocks: false }
             .build(&reader[..], file_len)
             .await?
             .file_client)
@@ -216,6 +216,7 @@ impl<B: FullBlock> FileClient<B> {
 struct FileClientBuilder<B: Block> {
     pub consensus: Arc<dyn Consensus<B>>,
     pub parent_header: Option<SealedHeader<B::Header>>,
+    pub skip_invalid_blocks: bool,
 }
 
 impl<B: FullBlock<Header: reth_primitives_traits::BlockHeader>> FromReader
@@ -285,6 +286,9 @@ impl<B: FullBlock<Header: reth_primitives_traits::BlockHeader>> FromReader
                         self.consensus.validate_block_pre_execution(&block)
                     });
                 if let Err(err) = validation {
+                    if !self.skip_invalid_blocks {
+                        return Err(err.into())
+                    }
                     warn!(target: "downloaders::file",
                         block_number = block.number(),
                         block_hash = %block.hash(),
@@ -594,11 +598,21 @@ impl ChunkedFileReader {
         consensus: Arc<dyn Consensus<B>>,
         parent_header: Option<SealedHeader<B::Header>>,
     ) -> Result<Option<FileClient<B>>, FileClientError> {
+        self.next_chunk_with_invalid_block_handling(consensus, parent_header, false).await
+    }
+
+    /// Read next chunk from file, optionally skipping blocks that fail consensus pre-checks.
+    pub async fn next_chunk_with_invalid_block_handling<B: FullBlock>(
+        &mut self,
+        consensus: Arc<dyn Consensus<B>>,
+        parent_header: Option<SealedHeader<B::Header>>,
+        skip_invalid_blocks: bool,
+    ) -> Result<Option<FileClient<B>>, FileClientError> {
         let Some(chunk_len) = self.read_next_chunk().await? else { return Ok(None) };
 
         // make new file client from chunk
         let DecodedFileChunk { file_client, remaining_bytes, .. } =
-            FileClientBuilder { consensus, parent_header }
+            FileClientBuilder { consensus, parent_header, skip_invalid_blocks }
                 .build(&self.chunk[..], chunk_len)
                 .await?;
 
@@ -683,7 +697,7 @@ mod tests {
     use async_compression::tokio::write::GzipEncoder;
     use futures_util::stream::StreamExt;
     use rand::Rng;
-    use reth_consensus::{noop::NoopConsensus, test_utils::TestConsensus};
+    use reth_consensus::{noop::NoopConsensus, test_utils::TestConsensus, ConsensusError};
     use reth_ethereum_primitives::Block;
     use reth_network_p2p::{
         bodies::downloader::BodyDownloader,
@@ -810,6 +824,37 @@ mod tests {
             downloader.next().await,
             Some(Ok(res)) => assert_eq!(res, zip_blocks(headers.iter(), &mut bodies))
         );
+    }
+
+    #[tokio::test]
+    async fn strict_chunk_decode_fails_on_invalid_block() {
+        let (file, _, _) = generate_bodies_file(0..=2).await;
+        let chunk_byte_len = file.metadata().await.unwrap().len();
+        let mut reader = ChunkedFileReader::from_file(file, chunk_byte_len, false).await.unwrap();
+        let consensus = Arc::new(TestConsensus::default());
+        consensus.set_fail_validation(true);
+
+        let err = reader.next_chunk::<Block>(consensus, None).await.unwrap_err();
+
+        assert_matches!(err, FileClientError::Consensus(ConsensusError::BaseFeeMissing));
+    }
+
+    #[tokio::test]
+    async fn lenient_chunk_decode_skips_invalid_blocks() {
+        let (file, _, _) = generate_bodies_file(0..=2).await;
+        let chunk_byte_len = file.metadata().await.unwrap().len();
+        let mut reader = ChunkedFileReader::from_file(file, chunk_byte_len, false).await.unwrap();
+        let consensus = Arc::new(TestConsensus::default());
+        consensus.set_fail_validation(true);
+
+        let client = reader
+            .next_chunk_with_invalid_block_handling::<Block>(consensus, None, true)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(client.headers_len(), 0);
+        assert!(client.tip().is_none());
     }
 
     #[tokio::test]

--- a/crates/net/downloaders/src/file_client.rs
+++ b/crates/net/downloaders/src/file_client.rs
@@ -272,15 +272,30 @@ impl<B: FullBlock<Header: reth_primitives_traits::BlockHeader>> FromReader
 
                 let block = SealedBlock::seal_slow(block);
 
-                // Validate standalone header
-                self.consensus.validate_header(block.sealed_header())?;
-                if let Some(parent) = &parent_header {
-                    self.consensus.validate_header_against_parent(block.sealed_header(), parent)?;
+                // Run consensus pre-checks. An invalid block here (e.g. mid-file in a
+                // BlockchainTest sequence that intentionally interleaves invalid block proposals
+                // with the valid chain) is not a hard failure: skip the block and keep decoding
+                // so the pipeline can still apply the valid prefix.
+                let validation =
+                    self.consensus.validate_header(block.sealed_header()).and_then(|_| {
+                        if let Some(parent) = &parent_header {
+                            self.consensus
+                                .validate_header_against_parent(block.sealed_header(), parent)?;
+                        }
+                        self.consensus.validate_block_pre_execution(&block)
+                    });
+                if let Err(err) = validation {
+                    warn!(target: "downloaders::file",
+                        block_number = block.number(),
+                        block_hash = %block.hash(),
+                        %err,
+                        "skipping invalid block while decoding file"
+                    );
+                    continue
+                }
+                if parent_header.is_some() {
                     parent_header = Some(block.sealed_header().clone());
                 }
-
-                // Validate block against header
-                self.consensus.validate_block_pre_execution(&block)?;
 
                 // add to the internal maps
                 let block_hash = block.hash();


### PR DESCRIPTION
The file client used by `reth import` aborted the entire chunk decode the moment any block failed consensus pre-checks. Hive's `consensus` simulator feeds blockchain tests as a sequence that intentionally interleaves invalid block proposals with the valid chain; the first invalid block would prevent every following valid block from reaching the import pipeline, so the chain never advanced past genesis and every such test reported a last block hash mismatch.

By default, treat consensus validation failures during decode the same way an Rlp error is handled: log a warning, skip the offending block, and keep decoding. Strict import mode still returns the validation error, and chunks with no valid decoded blocks are skipped so invalid-only chunks do not abort the import before the next valid block can be decoded.

The pipeline still re-validates and can still gracefully stop at the last valid block via the existing `fail_on_invalid_block=false` path; this change only prevents one bad block from poisoning the whole import.

Verified locally against hive's consensus simulator: the `InvalidBlocks` Cancun subset went from 11 failing tests (all `blockhashmismatch`) to 1 (an unrelated reorg-only test, `bcMultiChainTest/UncleFromSideChain`, that would need real side-chain handling in `reth import`). Remaining failures in the legacy/Constantinople suite are due to a separate spec-id mapping gap in alloy-evm and are out of scope here.
