### PR TITLE
fix(rpc): align eth_simulateV1 with execution-apis spec

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -91,42 +91,21 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             let base_block =
                 self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
-            let mut parent = base_block.sealed_header().clone();
+            let parent = base_block.sealed_header().clone();
+            let max_simulate_blocks = self.max_simulate_blocks();
+
+            // Fill gaps with empty blocks and validate block ordering, mirroring geth's
+            // `sanitizeChain` (see go-ethereum `internal/ethapi/simulate.go`). After this step
+            // every entry has an explicit `number` and `time` override and the chain is contiguous.
+            let block_state_calls =
+                simulate::sanitize_chain(block_state_calls, &parent, max_simulate_blocks)?;
 
             self.spawn_with_state_at_block(block, move |this, mut db| {
+                let mut parent = parent;
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
 
-                // Track previous block number and timestamp for validation
-                let mut prev_block_number = parent.number();
-                let mut prev_timestamp = parent.timestamp();
-
                 for block in block_state_calls {
-                    // Validate block number ordering if overridden
-                    if let Some(number) = block.block_overrides.as_ref().and_then(|o| o.number) {
-                        let number: u64 = number.try_into().unwrap_or(u64::MAX);
-                        if number <= prev_block_number {
-                            return Err(EthApiError::other(EthSimulateError::BlockNumberInvalid {
-                                got: number,
-                                parent: prev_block_number,
-                            })
-                            .into());
-                        }
-                    }
-                    // Validate timestamp ordering if overridden
-                    if let Some(time) = block
-                        .block_overrides
-                        .as_ref()
-                        .and_then(|o| o.time)
-                        .filter(|&t| t <= prev_timestamp)
-                    {
-                        return Err(EthApiError::other(EthSimulateError::BlockTimestampInvalid {
-                            got: time,
-                            parent: prev_timestamp,
-                        })
-                        .into());
-                    }
-
                     let attributes = this.next_env_attributes(&parent)?;
 
                     let mut evm_env = this
@@ -175,35 +154,15 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     let block_gas_limit = evm_env.block_env.gas_limit();
                     let chain_id = evm_env.cfg_env.chain_id;
 
-                    let default_gas_limit = {
-                        let total_specified_gas =
-                            calls.iter().filter_map(|tx| tx.as_ref().gas_limit()).sum::<u64>();
-                        let txs_without_gas_limit =
-                            calls.iter().filter(|tx| tx.as_ref().gas_limit().is_none()).count();
-
-                        if total_specified_gas > block_gas_limit {
-                            return Err(EthApiError::Other(Box::new(
-                                EthSimulateError::BlockGasLimitExceeded,
-                            ))
-                            .into())
-                        }
-
-                        if txs_without_gas_limit > 0 {
-                            // Per spec: "gasLimit: blockGasLimit - soFarUsedGasInBlock"
-                            // Divide remaining gas equally among transactions without gas
-                            let gas_per_tx = (block_gas_limit - total_specified_gas) /
-                                txs_without_gas_limit as u64;
-                            // Cap to RPC gas limit, matching spec behavior
-                            let call_gas_limit = this.call_gas_limit();
-                            if call_gas_limit > 0 {
-                                gas_per_tx.min(call_gas_limit)
-                            } else {
-                                gas_per_tx
-                            }
-                        } else {
-                            0
-                        }
-                    };
+                    let total_specified_gas =
+                        calls.iter().filter_map(|tx| tx.as_ref().gas_limit()).sum::<u64>();
+                    if total_specified_gas > block_gas_limit {
+                        return Err(EthApiError::Other(Box::new(
+                            EthSimulateError::BlockGasLimitExceeded,
+                        ))
+                        .into())
+                    }
+                    let call_gas_cap = this.call_gas_limit();
 
                     let ctx = this
                         .evm_config()
@@ -237,7 +196,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             calls,
-                            default_gas_limit,
+                            block_gas_limit,
+                            call_gas_cap,
                             chain_id,
                             this.converter(),
                         )
@@ -257,7 +217,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             calls,
-                            default_gas_limit,
+                            block_gas_limit,
+                            call_gas_cap,
                             chain_id,
                             this.converter(),
                         )
@@ -265,10 +226,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     };
 
                     parent = result.block.clone_sealed_header();
-
-                    // Update tracking for next iteration's validation
-                    prev_block_number = parent.number();
-                    prev_timestamp = parent.timestamp();
 
                     let block = simulate::build_simulated_block::<Self::Error, _>(
                         result.block,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -9,16 +9,18 @@ use alloy_eips::eip2718::WithEncoded;
 use alloy_evm::{block::TxResult, precompiles::PrecompilesMap};
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy_rpc_types_eth::{
-    simulate::{SimCallResult, SimulateError, SimulatedBlock},
+    simulate::{SimBlock, SimCallResult, SimulateError, SimulatedBlock},
     state::StateOverride,
-    BlockTransactionsKind,
+    BlockOverrides, BlockTransactionsKind,
 };
 use jsonrpsee_types::ErrorObject;
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutor},
     Evm, HaltReasonFor,
 };
-use reth_primitives_traits::{BlockBody as _, BlockTy, NodePrimitives, Recovered, RecoveredBlock};
+use reth_primitives_traits::{
+    BlockBody as _, BlockTy, NodePrimitives, Recovered, RecoveredBlock, SealedHeader,
+};
 use reth_rpc_convert::{RpcBlock, RpcConvert, RpcTxReq};
 use reth_rpc_server_types::result::rpc_err;
 use reth_storage_api::noop::NoopProvider;
@@ -28,6 +30,11 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
+
+/// Default seconds added between simulated block timestamps when none is provided.
+///
+/// Matches geth's `timestampIncrement` constant.
+const SIMULATE_DEFAULT_TIMESTAMP_INCREMENT: u64 = 12;
 
 /// Error code for execution reverted in `eth_simulateV1`.
 ///
@@ -131,6 +138,95 @@ impl ToRpcError for EthSimulateError {
     }
 }
 
+/// Sanitizes and gap-fills the chain of [`SimBlock`]s for `eth_simulateV1`.
+///
+/// Walks the provided block-state calls in order and:
+/// - validates that each block number and timestamp strictly increases relative to the parent and
+///   prior simulated block;
+/// - inserts empty filler blocks for every gap in block numbers, mirroring geth's `sanitizeChain`
+///   (see `internal/ethapi/simulate.go`);
+/// - assigns default block numbers (`prev_number + 1`) and timestamps (`prev_timestamp + 12s`) when
+///   missing, so every returned entry has explicit `number` and `time` overrides;
+/// - enforces the global `max_simulate_blocks` cap on the total number of blocks (including
+///   generated fillers).
+pub fn sanitize_chain<TxReq, H>(
+    blocks: Vec<SimBlock<TxReq>>,
+    parent: &SealedHeader<H>,
+    max_simulate_blocks: u64,
+) -> Result<Vec<SimBlock<TxReq>>, EthApiError>
+where
+    H: BlockHeader,
+{
+    let mut out = Vec::with_capacity(blocks.len());
+    let base_number = parent.number();
+    let mut prev_number = base_number;
+    let mut prev_timestamp = parent.timestamp();
+
+    for mut block in blocks {
+        let overrides = block.block_overrides.get_or_insert_with(BlockOverrides::default);
+
+        // Default block number to prev + 1 if not specified.
+        let target_number = if let Some(n) = overrides.number {
+            u64::try_from(n).unwrap_or(u64::MAX)
+        } else {
+            let n = prev_number.saturating_add(1);
+            overrides.number = Some(U256::from(n));
+            n
+        };
+
+        if target_number <= prev_number {
+            return Err(EthApiError::other(EthSimulateError::BlockNumberInvalid {
+                got: target_number,
+                parent: prev_number,
+            }));
+        }
+
+        if target_number.saturating_sub(base_number) > max_simulate_blocks {
+            return Err(EthApiError::other(EthSimulateError::TooManyBlocks));
+        }
+
+        // Insert empty filler blocks for any gap between prev_number and target_number.
+        let gap = target_number - prev_number;
+        if gap > 1 {
+            for i in 1..gap {
+                let filler_number = prev_number + i;
+                let filler_time = prev_timestamp + SIMULATE_DEFAULT_TIMESTAMP_INCREMENT;
+                out.push(SimBlock {
+                    block_overrides: Some(BlockOverrides {
+                        number: Some(U256::from(filler_number)),
+                        time: Some(filler_time),
+                        ..Default::default()
+                    }),
+                    state_overrides: None,
+                    calls: Vec::new(),
+                });
+                prev_timestamp = filler_time;
+            }
+        }
+
+        // Default timestamp to prev + increment if not specified, otherwise validate ordering.
+        prev_number = target_number;
+        let block_time = if let Some(t) = overrides.time {
+            if t <= prev_timestamp {
+                return Err(EthApiError::other(EthSimulateError::BlockTimestampInvalid {
+                    got: t,
+                    parent: prev_timestamp,
+                }));
+            }
+            t
+        } else {
+            let t = prev_timestamp + SIMULATE_DEFAULT_TIMESTAMP_INCREMENT;
+            overrides.time = Some(t);
+            t
+        };
+        prev_timestamp = block_time;
+
+        out.push(block);
+    }
+
+    Ok(out)
+}
+
 /// Applies precompile move overrides from state overrides to the EVM's precompiles map.
 ///
 /// This function processes `movePrecompileToAddress` entries from the state overrides and
@@ -161,12 +257,16 @@ pub fn apply_precompile_overrides(
 ///
 /// Returns all executed transactions and the result of the execution.
 ///
+/// For each call without an explicit `gas` field, the remaining block gas is used as the default,
+/// optionally capped by `call_gas_cap` (an RPC-level per-call gas cap, ignored when zero).
+///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 #[expect(clippy::type_complexity)]
 pub fn execute_transactions<S, T>(
     mut builder: S,
     calls: Vec<RpcTxReq<T::Network>>,
-    default_gas_limit: u64,
+    block_gas_limit: u64,
+    call_gas_cap: u64,
     chain_id: u64,
     converter: &T,
 ) -> Result<
@@ -183,7 +283,15 @@ where
     builder.apply_pre_execution_changes()?;
 
     let mut results = Vec::with_capacity(calls.len());
+    let mut cumulative_gas_used: u64 = 0;
     for call in calls {
+        // Per spec: "gasLimit: blockGasLimit - soFarUsedGasInBlock" - assign the remaining gas
+        // to each call without an explicit limit, matching geth's `sanitizeCall` behavior.
+        let mut default_gas_limit = block_gas_limit.saturating_sub(cumulative_gas_used);
+        if call_gas_cap > 0 {
+            default_gas_limit = default_gas_limit.min(call_gas_cap);
+        }
+
         // Resolve transaction, populate missing fields and enforce calls
         // correctness.
         let tx = resolve_transaction(
@@ -198,9 +306,10 @@ where
         // The effect for a layer-2 execution client is that it does not charge L1 cost.
         let tx = WithEncoded::new(Default::default(), tx);
 
-        builder.execute_transaction_with_result_closure(tx, |result| {
+        let gas_output = builder.execute_transaction_with_result_closure(tx, |result| {
             results.push(result.result().result.clone())
         })?;
+        cumulative_gas_used = cumulative_gas_used.saturating_add(gas_output.tx_gas_used());
     }
 
     // Pass noop provider to skip state root calculations.
@@ -256,22 +365,21 @@ where
         tx.as_mut().set_kind(TxKind::Create);
     }
 
-    // if we can't build the _entire_ transaction yet, we need to check the fee values
+    // if we can't build the _entire_ transaction yet, we need to fill the fee fields.
+    //
+    // Per the eth_simulateV1 spec, unspecified fee fields default to 0 (not the block base fee),
+    // matching geth's `CallDefaults` behavior. This lets simulation behave like a free-gas
+    // `eth_call` when validation is off, and surfaces "max fee per gas less than block base fee"
+    // errors when validation is on with a real base fee.
+    let _ = block_base_fee_per_gas;
     if tx.as_ref().output_tx_type_checked().is_none() {
         if tx_type.is_legacy() || tx_type.is_eip2930() {
             if tx.as_ref().gas_price().is_none() {
-                tx.as_mut().set_gas_price(block_base_fee_per_gas as u128);
+                tx.as_mut().set_gas_price(0);
             }
         } else {
-            // set dynamic 1559 fees
             if tx.as_ref().max_fee_per_gas().is_none() {
-                let mut max_fee_per_gas = block_base_fee_per_gas as u128;
-                if let Some(prio_fee) = tx.as_ref().max_priority_fee_per_gas() {
-                    // if a prio fee is provided we need to select the max fee accordingly
-                    // because the base fee must be higher than the prio fee.
-                    max_fee_per_gas = prio_fee.max(max_fee_per_gas);
-                }
-                tx.as_mut().set_max_fee_per_gas(max_fee_per_gas);
+                tx.as_mut().set_max_fee_per_gas(0);
             }
             if tx.as_ref().max_priority_fee_per_gas().is_none() {
                 tx.as_mut().set_max_priority_fee_per_gas(0);
@@ -369,4 +477,86 @@ where
         |header, size| converter.convert_header(header, size),
     )?;
     Ok(SimulatedBlock { inner: block, calls })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_rpc_types_eth::TransactionRequest;
+
+    fn parent_at(number: u64, timestamp: u64) -> SealedHeader<Header> {
+        SealedHeader::seal_slow(Header { number, timestamp, ..Default::default() })
+    }
+
+    fn block_with_number(number: u64) -> SimBlock<TransactionRequest> {
+        SimBlock {
+            block_overrides: Some(BlockOverrides {
+                number: Some(U256::from(number)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sanitize_chain_fills_gaps_with_empty_blocks() {
+        // parent at block 5; user requests one block at 8 — sanitize should insert fillers at 6
+        // and 7 before the requested block.
+        let parent = parent_at(5, 100);
+        let blocks = vec![block_with_number(8)];
+
+        let out = sanitize_chain(blocks, &parent, 256).unwrap();
+        assert_eq!(out.len(), 3);
+
+        let numbers: Vec<u64> = out
+            .iter()
+            .map(|b| b.block_overrides.as_ref().unwrap().number.unwrap().try_into().unwrap())
+            .collect();
+        assert_eq!(numbers, vec![6, 7, 8]);
+
+        // Fillers must have no calls.
+        assert!(out[0].calls.is_empty());
+        assert!(out[1].calls.is_empty());
+
+        // Timestamps should auto-increment by 12s starting from the parent.
+        let times: Vec<u64> =
+            out.iter().map(|b| b.block_overrides.as_ref().unwrap().time.unwrap()).collect();
+        assert_eq!(times, vec![112, 124, 136]);
+    }
+
+    #[test]
+    fn sanitize_chain_defaults_missing_number_and_time() {
+        // Blocks without explicit number/time should be assigned prev+1 / prev+12.
+        let parent = parent_at(10, 1000);
+        let blocks: Vec<SimBlock<TransactionRequest>> =
+            vec![SimBlock::default(), SimBlock::default()];
+
+        let out = sanitize_chain(blocks, &parent, 256).unwrap();
+        assert_eq!(out.len(), 2);
+
+        let overrides = out[0].block_overrides.as_ref().unwrap();
+        assert_eq!(overrides.number.unwrap(), U256::from(11));
+        assert_eq!(overrides.time, Some(1012));
+
+        let overrides = out[1].block_overrides.as_ref().unwrap();
+        assert_eq!(overrides.number.unwrap(), U256::from(12));
+        assert_eq!(overrides.time, Some(1024));
+    }
+
+    #[test]
+    fn sanitize_chain_rejects_non_increasing_number() {
+        let parent = parent_at(10, 100);
+        // Asking for the same block number as the parent must error.
+        let err = sanitize_chain(vec![block_with_number(10)], &parent, 256).unwrap_err();
+        assert!(matches!(err, EthApiError::Other(_)));
+    }
+
+    #[test]
+    fn sanitize_chain_enforces_max_blocks() {
+        let parent = parent_at(0, 0);
+        // Gap of 257 blocks exceeds the default 256 cap.
+        let err = sanitize_chain(vec![block_with_number(257)], &parent, 256).unwrap_err();
+        assert!(matches!(err, EthApiError::Other(_)));
+    }
 }


### PR DESCRIPTION
Several hive rpc-compat failures stem from eth_simulateV1 deviating from the execution-apis spec and geth's reference implementation.

This change brings reth's `eth_simulateV1` in line with geth's `internal/ethapi/simulate.go`:

- Gap-fill empty filler blocks between `blockStateCalls` whose numbers jump ahead of the previous block. Closes #15460. Mirrors geth's `sanitizeChain`, including default block numbers (`prev + 1`), default timestamps (`prev + 12s`), and the global cap on total blocks (including fillers).
- Default each call's gas limit to the remaining block gas at execution time, not `block_gas_limit` divided across calls, matching the spec rule `"gasLimit: blockGasLimit - soFarUsedGasInBlock"` and geth's per-call `sanitizeCall`.
- Default unspecified `gasPrice` / `maxFeePerGas` / `maxPriorityFeePerGas` to `0` instead of the block base fee, matching the [execution-apis spec defaults](https://github.com/ethereum/execution-apis/blob/main/docs-api/docs/ethsimulatev1-notes.mdx) and geth's `CallDefaults`. With this, simulated transactions produced from sparse `TransactionRequest`s hash identically to geth's.

This addresses the eth_simulateV1 mismatches in the hive rpc-compat suite that are not state-root / hash / parentBeaconBlockRoot related.

Out of scope (deferred):
- `parentBeaconBlockRoot` / `stateRoot` / `hash` mismatches for simulated blocks — we don't compute the state root for simulated blocks.
- Hex / number parsing error-message mismatches in `debug_getRaw*`, `eth_getLogs`, `eth_getStorageAt` — would need invasive RPC parsing changes.
- `eth_config` `DEPOSIT_CONTRACT_ADDRESS` value and pre-Byzantium receipt `root` field — chain-config dependent.
- `eth_syncing` returning `false` when synced — requires network sync state machine changes.
- `txpool_content` checksummed-address keys — alloy serialization concern.
- `testing_buildBlockV1` positional vs struct params — needs API change.