### PR TITLE
fix(rpc): default eth_simulateV1 fee fields to 0 per spec

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -256,22 +256,21 @@ where
         tx.as_mut().set_kind(TxKind::Create);
     }
 
-    // if we can't build the _entire_ transaction yet, we need to check the fee values
+    // if we can't build the _entire_ transaction yet, fill the fee fields.
+    //
+    // Per the eth_simulateV1 spec, unspecified fee fields default to 0 (not the block base fee),
+    // matching geth's `CallDefaults` behavior. This lets simulation behave like a free-gas
+    // `eth_call` when validation is off, and surfaces "max fee per gas less than block base fee"
+    // errors when validation is on with a real base fee.
+    let _ = block_base_fee_per_gas;
     if tx.as_ref().output_tx_type_checked().is_none() {
         if tx_type.is_legacy() || tx_type.is_eip2930() {
             if tx.as_ref().gas_price().is_none() {
-                tx.as_mut().set_gas_price(block_base_fee_per_gas as u128);
+                tx.as_mut().set_gas_price(0);
             }
         } else {
-            // set dynamic 1559 fees
             if tx.as_ref().max_fee_per_gas().is_none() {
-                let mut max_fee_per_gas = block_base_fee_per_gas as u128;
-                if let Some(prio_fee) = tx.as_ref().max_priority_fee_per_gas() {
-                    // if a prio fee is provided we need to select the max fee accordingly
-                    // because the base fee must be higher than the prio fee.
-                    max_fee_per_gas = prio_fee.max(max_fee_per_gas);
-                }
-                tx.as_mut().set_max_fee_per_gas(max_fee_per_gas);
+                tx.as_mut().set_max_fee_per_gas(0);
             }
             if tx.as_ref().max_priority_fee_per_gas().is_none() {
                 tx.as_mut().set_max_priority_fee_per_gas(0);


### PR DESCRIPTION
The execution-apis spec specifies that unspecified \`gasPrice\`, \`maxFeePerGas\`, and \`maxPriorityFeePerGas\` default to \`0x0\`, and geth's \`CallDefaults\` follows this. Reth was instead substituting the block base fee, producing transactions that hash differently from geth and skipping the "max fee per gas less than block base fee" check when validation is on with a non-zero base fee.

Spec reference: https://github.com/ethereum/execution-apis/blob/main/docs-api/docs/ethsimulatev1-notes.mdx (Default values for transactions).