### PR TITLE
fix(rpc): default eth_simulateV1 per-call gas to remaining block gas

### DIFF
--- a/crates/ethereum/node/tests/e2e/simulate.rs
+++ b/crates/ethereum/node/tests/e2e/simulate.rs
@@ -4,12 +4,143 @@ use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
 use alloy_rpc_types_eth::{
     simulate::{SimBlock, SimulatePayload, SimulatedBlock},
     state::StateOverridesBuilder,
-    BlockOverrides, TransactionRequest,
+    BlockOverrides, TransactionRequest, TransactionTrait as _,
 };
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::setup_engine;
 use reth_node_ethereum::EthereumNode;
 use std::sync::Arc;
+
+#[tokio::test]
+async fn test_simulate_v1_explicit_gas_uses_remaining_block_gas() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    let tx = TransactionRequest::default().to(Address::ZERO).gas_limit(3_000_000);
+    let sim_block = SimBlock::default().call(tx.clone()).call(tx);
+    let payload = SimulatePayload::default().extend(sim_block);
+
+    let result: Vec<SimulatedBlock> =
+        provider.raw_request("eth_simulateV1".into(), (&payload, "latest")).await?;
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].calls.len(), 2);
+    assert!(result[0].calls.iter().all(|call| call.status));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_simulate_v1_no_fields_call_defaults_to_remaining_block_gas() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    let first_tx_gas_limit = 21_000;
+    let sim_block = SimBlock::default()
+        .call(TransactionRequest::default().to(Address::ZERO).gas_limit(first_tx_gas_limit))
+        .call(TransactionRequest::default());
+    let payload = SimulatePayload::default().with_full_transactions().extend(sim_block);
+
+    let result: Vec<SimulatedBlock> =
+        provider.raw_request("eth_simulateV1".into(), (&payload, "latest")).await?;
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].calls.len(), 2);
+    assert!(result[0].calls.iter().all(|call| call.status));
+
+    let block = &result[0].inner;
+    let txs = block.transactions.as_transactions().expect("expected full transactions");
+    assert_eq!(txs.len(), 2);
+    assert_eq!(txs[0].gas_limit(), first_tx_gas_limit);
+
+    let expected_remaining_gas = block.header.inner.gas_limit - result[0].calls[0].gas_used;
+    assert_eq!(txs[1].gas_limit(), expected_remaining_gas);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_simulate_v1_explicit_gas_over_remaining_block_gas_errors() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    let sim_block = SimBlock::default()
+        .with_block_overrides(BlockOverrides { gas_limit: Some(50_000), ..Default::default() })
+        .call(TransactionRequest::default().to(Address::ZERO))
+        .call(TransactionRequest::default().to(Address::ZERO).gas_limit(30_000));
+    let payload = SimulatePayload::default().extend(sim_block);
+
+    let err = provider
+        .raw_request::<_, Vec<SimulatedBlock>>("eth_simulateV1".into(), (&payload, "latest"))
+        .await
+        .unwrap_err();
+    let err = err.as_error_resp().expect("expected JSON-RPC error response");
+
+    assert_eq!(err.code, -38015);
+    assert_eq!(err.message, "Block gas limit exceeded by the block's transactions");
+
+    Ok(())
+}
 
 /// Tests that `eth_simulateV1` handles a transaction with `maxFeePerBlobGas` set but no
 /// `blob_versioned_hashes` or sidecar. The transaction should be treated as EIP-1559, not

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -116,6 +116,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
 
+                let call_gas_limit = this.call_gas_limit();
+                let mut remaining_call_gas_limit = (call_gas_limit > 0).then_some(call_gas_limit);
+
                 for block in block_state_calls {
                     let attributes = this.next_env_attributes(&parent)?;
 
@@ -162,17 +165,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             .map_err(Self::Error::from_eth_err)?;
                     }
 
-                    let block_gas_limit = evm_env.block_env.gas_limit();
-
-                    let total_specified_gas =
-                        calls.iter().filter_map(|tx| tx.as_ref().gas_limit()).sum::<u64>();
-                    if total_specified_gas > block_gas_limit {
-                        return Err(EthApiError::Other(Box::new(
-                            EthSimulateError::BlockGasLimitExceeded,
-                        ))
-                        .into())
-                    }
-                    let call_gas_cap = this.call_gas_limit();
+                    let chain_id = evm_env.cfg_env.chain_id;
 
                     let ctx = this
                         .evm_config()
@@ -206,8 +199,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             calls,
-                            block_gas_limit,
-                            call_gas_cap,
+                            &mut remaining_call_gas_limit,
                             chain_id,
                             this.converter(),
                         )
@@ -227,8 +219,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             calls,
-                            block_gas_limit,
-                            call_gas_cap,
+                            &mut remaining_call_gas_limit,
                             chain_id,
                             this.converter(),
                         )

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -164,35 +164,15 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                     let block_gas_limit = evm_env.block_env.gas_limit();
 
-                    let default_gas_limit = {
-                        let total_specified_gas =
-                            calls.iter().filter_map(|tx| tx.as_ref().gas_limit()).sum::<u64>();
-                        let txs_without_gas_limit =
-                            calls.iter().filter(|tx| tx.as_ref().gas_limit().is_none()).count();
-
-                        if total_specified_gas > block_gas_limit {
-                            return Err(EthApiError::Other(Box::new(
-                                EthSimulateError::BlockGasLimitExceeded,
-                            ))
-                            .into())
-                        }
-
-                        if txs_without_gas_limit > 0 {
-                            // Per spec: "gasLimit: blockGasLimit - soFarUsedGasInBlock"
-                            // Divide remaining gas equally among transactions without gas
-                            let gas_per_tx = (block_gas_limit - total_specified_gas) /
-                                txs_without_gas_limit as u64;
-                            // Cap to RPC gas limit, matching spec behavior
-                            let call_gas_limit = this.call_gas_limit();
-                            if call_gas_limit > 0 {
-                                gas_per_tx.min(call_gas_limit)
-                            } else {
-                                gas_per_tx
-                            }
-                        } else {
-                            0
-                        }
-                    };
+                    let total_specified_gas =
+                        calls.iter().filter_map(|tx| tx.as_ref().gas_limit()).sum::<u64>();
+                    if total_specified_gas > block_gas_limit {
+                        return Err(EthApiError::Other(Box::new(
+                            EthSimulateError::BlockGasLimitExceeded,
+                        ))
+                        .into())
+                    }
+                    let call_gas_cap = this.call_gas_limit();
 
                     let ctx = this
                         .evm_config()
@@ -226,7 +206,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             calls,
-                            default_gas_limit,
+                            block_gas_limit,
+                            call_gas_cap,
                             chain_id,
                             this.converter(),
                         )
@@ -246,7 +227,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             calls,
-                            default_gas_limit,
+                            block_gas_limit,
+                            call_gas_cap,
                             chain_id,
                             this.converter(),
                         )

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -282,12 +282,18 @@ pub fn apply_precompile_overrides(
 ///
 /// Returns all executed transactions and the result of the execution.
 ///
+/// For each call without an explicit `gas` field, the remaining block gas is used as the default,
+/// optionally capped by `call_gas_cap` (an RPC-level per-call gas cap, ignored when zero). This
+/// matches the spec rule `"gasLimit: blockGasLimit - soFarUsedGasInBlock"` and geth's per-call
+/// `sanitizeCall` behavior.
+///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 #[expect(clippy::type_complexity)]
 pub fn execute_transactions<S, T>(
     mut builder: S,
     calls: Vec<RpcTxReq<T::Network>>,
-    default_gas_limit: u64,
+    block_gas_limit: u64,
+    call_gas_cap: u64,
     chain_id: u64,
     converter: &T,
 ) -> Result<
@@ -304,7 +310,13 @@ where
     builder.apply_pre_execution_changes()?;
 
     let mut results = Vec::with_capacity(calls.len());
+    let mut cumulative_gas_used: u64 = 0;
     for call in calls {
+        let mut default_gas_limit = block_gas_limit.saturating_sub(cumulative_gas_used);
+        if call_gas_cap > 0 {
+            default_gas_limit = default_gas_limit.min(call_gas_cap);
+        }
+
         // Resolve transaction, populate missing fields and enforce calls
         // correctness.
         let tx = resolve_transaction(
@@ -319,9 +331,10 @@ where
         // The effect for a layer-2 execution client is that it does not charge L1 cost.
         let tx = WithEncoded::new(Default::default(), tx);
 
-        builder.execute_transaction_with_result_closure(tx, |result| {
+        let gas_output = builder.execute_transaction_with_result_closure(tx, |result| {
             results.push(result.result().result.clone())
         })?;
+        cumulative_gas_used = cumulative_gas_used.saturating_add(gas_output.tx_gas_used());
     }
 
     // Pass noop provider to skip state root calculations.

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -282,18 +282,17 @@ pub fn apply_precompile_overrides(
 ///
 /// Returns all executed transactions and the result of the execution.
 ///
-/// For each call without an explicit `gas` field, the remaining block gas is used as the default,
-/// optionally capped by `call_gas_cap` (an RPC-level per-call gas cap, ignored when zero). This
-/// matches the spec rule `"gasLimit: blockGasLimit - soFarUsedGasInBlock"` and geth's per-call
-/// `sanitizeCall` behavior.
+/// For each call without an explicit `gas` field, the remaining block gas is used as the default.
+/// The RPC gas cap is tracked as a request-wide remaining budget and caps each call before
+/// execution. This matches the spec rule `"gasLimit: blockGasLimit - soFarUsedGasInBlock"` and
+/// geth's per-call `sanitizeCall` behavior.
 ///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 #[expect(clippy::type_complexity)]
 pub fn execute_transactions<S, T>(
     mut builder: S,
     calls: Vec<RpcTxReq<T::Network>>,
-    block_gas_limit: u64,
-    call_gas_cap: u64,
+    remaining_call_gas_limit: &mut Option<u64>,
     chain_id: u64,
     converter: &T,
 ) -> Result<
@@ -310,11 +309,46 @@ where
     builder.apply_pre_execution_changes()?;
 
     let mut results = Vec::with_capacity(calls.len());
-    let mut cumulative_gas_used: u64 = 0;
-    for call in calls {
-        let mut default_gas_limit = block_gas_limit.saturating_sub(cumulative_gas_used);
-        if call_gas_cap > 0 {
-            default_gas_limit = default_gas_limit.min(call_gas_cap);
+    let mut cumulative_tx_gas_used: u64 = 0;
+    let mut block_regular_gas_used: u64 = 0;
+    let mut block_state_gas_used: u64 = 0;
+    let block_gas_limit = builder.evm().block().gas_limit();
+    let is_amsterdam = builder.evm().cfg_env().enable_amsterdam_eip8037;
+    let tx_gas_limit_cap = builder.evm().cfg_env().tx_gas_limit_cap.unwrap_or(u64::MAX);
+    for mut call in calls {
+        let block_gas_remaining = if is_amsterdam {
+            block_gas_limit
+                .saturating_sub(block_regular_gas_used)
+                .min(block_gas_limit.saturating_sub(block_state_gas_used))
+        } else {
+            block_gas_limit.saturating_sub(cumulative_tx_gas_used)
+        };
+        let mut default_gas_limit = block_gas_remaining;
+
+        if let Some(gas_limit) = call.as_ref().gas_limit() {
+            let exceeds_gas_limit = if is_amsterdam {
+                let regular_available_gas = block_gas_limit.saturating_sub(block_regular_gas_used);
+                let state_available_gas = block_gas_limit.saturating_sub(block_state_gas_used);
+                let regular_tx_gas_limit = gas_limit.min(tx_gas_limit_cap);
+
+                regular_tx_gas_limit > regular_available_gas || gas_limit > state_available_gas
+            } else {
+                gas_limit > block_gas_remaining
+            };
+
+            if exceeds_gas_limit {
+                return Err(EthApiError::other(EthSimulateError::BlockGasLimitExceeded))
+            }
+        }
+
+        if let Some(remaining_call_gas_limit) = *remaining_call_gas_limit {
+            if let Some(gas_limit) = call.as_ref().gas_limit() {
+                if gas_limit > remaining_call_gas_limit {
+                    call.as_mut().set_gas_limit(remaining_call_gas_limit);
+                }
+            } else {
+                default_gas_limit = default_gas_limit.min(remaining_call_gas_limit);
+            }
         }
 
         // Resolve transaction, populate missing fields and enforce calls
@@ -331,10 +365,23 @@ where
         // The effect for a layer-2 execution client is that it does not charge L1 cost.
         let tx = WithEncoded::new(Default::default(), tx);
 
+        let mut tx_regular_gas_used = 0;
         let gas_output = builder.execute_transaction_with_result_closure(tx, |result| {
+            tx_regular_gas_used = result.result().result.gas().block_regular_gas_used();
             results.push(result.result().result.clone())
         })?;
-        cumulative_gas_used = cumulative_gas_used.saturating_add(gas_output.tx_gas_used());
+
+        let gas_used = gas_output.tx_gas_used();
+        if let Some(remaining_call_gas_limit) = remaining_call_gas_limit.as_mut() {
+            if gas_used > *remaining_call_gas_limit {
+                return Err(EthApiError::other(EthSimulateError::GasLimitReached))
+            }
+            *remaining_call_gas_limit -= gas_used;
+        }
+
+        cumulative_tx_gas_used = cumulative_tx_gas_used.saturating_add(gas_used);
+        block_regular_gas_used = block_regular_gas_used.saturating_add(tx_regular_gas_used);
+        block_state_gas_used = block_state_gas_used.saturating_add(gas_output.state_gas_used());
     }
 
     // Pass noop provider to skip state root calculations.


### PR DESCRIPTION
For calls without an explicit gas limit, reth was dividing the block gas limit evenly across calls without one. The spec rule is `gasLimit = blockGasLimit - soFarUsedGasInBlock`, and geth's per-call `sanitizeCall` assigns the gas pool's remaining gas at execution time.

This aligns `eth_simulateV1` gas budgeting with geth and reth payload-building behavior: omitted gas defaults to the current remaining block gas, explicit gas is checked against the remaining block gas at execution time, and the RPC gas cap is tracked as a request-wide budget consumed by actual gas used. Amsterdam block capacity tracks regular and state gas separately, matching `default_ethereum_payload`.

Spec reference: https://github.com/ethereum/execution-apis/blob/main/docs-api/docs/ethsimulatev1-notes.mdx (Default values for transactions).