### PR TITLE
fix(rpc): gap-fill empty blocks in eth_simulateV1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9990,6 +9990,7 @@ dependencies = [
 name = "reth-rpc-eth-types"
 version = "2.2.0"
 dependencies = [
+ "alloy-chains",
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -18,6 +18,7 @@ use alloy_rpc_types_eth::{
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
 use futures::Future;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
@@ -93,42 +94,29 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             let base_block =
                 self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
-            let mut parent = base_block.sealed_header().clone();
+            let parent = base_block.sealed_header().clone();
+            let max_simulate_blocks = self.max_simulate_blocks();
 
             self.spawn_with_state_at_block(block, move |this, mut db| {
+                let mut parent = parent;
+
+                let chain_id = this.provider().chain_spec().chain_id();
+
+                // Validate block ordering and fill gaps with empty blocks so every entry has an
+                // explicit `number` and `time` override and the chain is contiguous (see the
+                // execution-apis spec note: "If the block number is increased more than 1 compared
+                // to the previous block, new empty blocks are generated in between.").
+                let block_state_calls = simulate::sanitize_chain(
+                    block_state_calls,
+                    &parent,
+                    chain_id,
+                    max_simulate_blocks,
+                )?;
+
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
 
-                // Track previous block number and timestamp for validation
-                let mut prev_block_number = parent.number();
-                let mut prev_timestamp = parent.timestamp();
-
                 for block in block_state_calls {
-                    // Validate block number ordering if overridden
-                    if let Some(number) = block.block_overrides.as_ref().and_then(|o| o.number) {
-                        let number: u64 = number.try_into().unwrap_or(u64::MAX);
-                        if number <= prev_block_number {
-                            return Err(EthApiError::other(EthSimulateError::BlockNumberInvalid {
-                                got: number,
-                                parent: prev_block_number,
-                            })
-                            .into());
-                        }
-                    }
-                    // Validate timestamp ordering if overridden
-                    if let Some(time) = block
-                        .block_overrides
-                        .as_ref()
-                        .and_then(|o| o.time)
-                        .filter(|&t| t <= prev_timestamp)
-                    {
-                        return Err(EthApiError::other(EthSimulateError::BlockTimestampInvalid {
-                            got: time,
-                            parent: prev_timestamp,
-                        })
-                        .into());
-                    }
-
                     let attributes = this.next_env_attributes(&parent)?;
 
                     let mut evm_env = this
@@ -175,7 +163,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     }
 
                     let block_gas_limit = evm_env.block_env.gas_limit();
-                    let chain_id = evm_env.cfg_env.chain_id;
 
                     let default_gas_limit = {
                         let total_specified_gas =
@@ -267,10 +254,6 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     };
 
                     parent = result.block.clone_sealed_header();
-
-                    // Update tracking for next iteration's validation
-                    prev_block_number = parent.number();
-                    prev_timestamp = parent.timestamp();
 
                     let block = simulate::build_simulated_block::<Self::Error, _>(
                         result.block,

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -29,6 +29,7 @@ reth-transaction-pool.workspace = true
 reth-trie.workspace = true
 
 # ethereum
+alloy-chains.workspace = true
 alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-evm = { workspace = true, features = ["overrides", "call-util"] }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -4,21 +4,24 @@ use crate::{
     error::{api::FromEthApiError, FromEvmError, ToRpcError},
     EthApiError,
 };
+use alloy_chains::Chain;
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_evm::{block::TxResult, precompiles::PrecompilesMap};
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy_rpc_types_eth::{
-    simulate::{SimCallResult, SimulateError, SimulatedBlock},
+    simulate::{SimBlock, SimCallResult, SimulateError, SimulatedBlock},
     state::StateOverride,
-    BlockTransactionsKind,
+    BlockOverrides, BlockTransactionsKind,
 };
 use jsonrpsee_types::ErrorObject;
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutor},
     Evm, HaltReasonFor,
 };
-use reth_primitives_traits::{BlockBody as _, BlockTy, NodePrimitives, Recovered, RecoveredBlock};
+use reth_primitives_traits::{
+    BlockBody as _, BlockTy, NodePrimitives, Recovered, RecoveredBlock, SealedHeader,
+};
 use reth_rpc_convert::{RpcBlock, RpcConvert, RpcTxReq};
 use reth_rpc_server_types::result::rpc_err;
 use reth_storage_api::noop::NoopProvider;
@@ -28,6 +31,10 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
+
+/// Fallback seconds added between simulated block timestamps when neither the user nor the chain
+/// hint provides a value.
+const SIMULATE_FALLBACK_TIMESTAMP_INCREMENT: u64 = 12;
 
 /// Error code for execution reverted in `eth_simulateV1`.
 ///
@@ -133,6 +140,107 @@ impl ToRpcError for EthSimulateError {
     fn to_rpc_error(&self) -> ErrorObject<'static> {
         rpc_err(self.error_code(), self.to_string(), None)
     }
+}
+
+/// Sanitizes and gap-fills the chain of [`SimBlock`]s for `eth_simulateV1`.
+///
+/// Walks the provided block-state calls in order and:
+/// - validates that each block number and timestamp strictly increases relative to the parent and
+///   prior simulated block;
+/// - inserts empty filler blocks for every gap in block numbers, so a request like `[block at
+///   number N + k]` over a parent at `N` expands to `k - 1` empty blocks followed by the requested
+///   one (per the execution-apis spec: "If the block number is increased more than `1` compared to
+///   the previous block, new empty blocks are generated in between.");
+/// - assigns default block numbers (`prev_number + 1`) and timestamps (`prev_timestamp + chain
+///   block time`) when missing, so every returned entry has explicit `number` and `time` overrides.
+///   The block time defaults to [`Chain::average_blocktime_hint`] for the chain id, falling back to
+///   `SIMULATE_FALLBACK_TIMESTAMP_INCREMENT` when no hint is registered. Sub-second chain hints are
+///   rounded up because block timestamps are second-granular;
+/// - enforces the global `max_simulate_blocks` cap on the total number of blocks (including
+///   generated fillers).
+pub fn sanitize_chain<TxReq, H>(
+    blocks: Vec<SimBlock<TxReq>>,
+    parent: &SealedHeader<H>,
+    chain_id: u64,
+    max_simulate_blocks: u64,
+) -> Result<Vec<SimBlock<TxReq>>, EthApiError>
+where
+    H: BlockHeader,
+{
+    let timestamp_increment = Chain::from(chain_id)
+        .average_blocktime_hint()
+        .map(|d| d.as_secs().saturating_add(u64::from(d.subsec_nanos() > 0)))
+        .filter(|&s| s > 0)
+        .unwrap_or(SIMULATE_FALLBACK_TIMESTAMP_INCREMENT);
+
+    let mut out = Vec::with_capacity(blocks.len());
+    let base_number = parent.number();
+    let mut prev_number = base_number;
+    let mut prev_timestamp = parent.timestamp();
+
+    for mut block in blocks {
+        let overrides = block.block_overrides.get_or_insert_with(BlockOverrides::default);
+
+        // Default block number to prev + 1 if not specified.
+        let target_number = if let Some(n) = overrides.number {
+            u64::try_from(n).unwrap_or(u64::MAX)
+        } else {
+            let n = prev_number.saturating_add(1);
+            overrides.number = Some(U256::from(n));
+            n
+        };
+
+        if target_number <= prev_number {
+            return Err(EthApiError::other(EthSimulateError::BlockNumberInvalid {
+                got: target_number,
+                parent: prev_number,
+            }));
+        }
+
+        if target_number.saturating_sub(base_number) > max_simulate_blocks {
+            return Err(EthApiError::other(EthSimulateError::TooManyBlocks));
+        }
+
+        // Insert empty filler blocks for any gap between prev_number and target_number.
+        let gap = target_number - prev_number;
+        if gap > 1 {
+            for i in 1..gap {
+                let filler_number = prev_number + i;
+                let filler_time = prev_timestamp + timestamp_increment;
+                out.push(SimBlock {
+                    block_overrides: Some(BlockOverrides {
+                        number: Some(U256::from(filler_number)),
+                        time: Some(filler_time),
+                        ..Default::default()
+                    }),
+                    state_overrides: None,
+                    calls: Vec::new(),
+                });
+                prev_timestamp = filler_time;
+            }
+        }
+
+        prev_number = target_number;
+        // Default timestamp to prev + increment if not specified, otherwise validate ordering.
+        let block_time = if let Some(t) = overrides.time {
+            if t <= prev_timestamp {
+                return Err(EthApiError::other(EthSimulateError::BlockTimestampInvalid {
+                    got: t,
+                    parent: prev_timestamp,
+                }));
+            }
+            t
+        } else {
+            let t = prev_timestamp + timestamp_increment;
+            overrides.time = Some(t);
+            t
+        };
+        prev_timestamp = block_time;
+
+        out.push(block);
+    }
+
+    Ok(out)
 }
 
 /// Applies precompile move overrides from state overrides to the EVM's precompiles map.
@@ -385,11 +493,33 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_precompile_overrides, EthSimulateError};
+    use super::{apply_precompile_overrides, sanitize_chain, EthSimulateError};
+    use crate::EthApiError;
+    use alloy_chains::Chain;
+    use alloy_consensus::Header;
     use alloy_evm::precompiles::PrecompilesMap;
-    use alloy_primitives::address;
-    use alloy_rpc_types_eth::state::{AccountOverride, StateOverride};
+    use alloy_primitives::{address, U256};
+    use alloy_rpc_types_eth::{
+        simulate::SimBlock,
+        state::{AccountOverride, StateOverride},
+        BlockOverrides, TransactionRequest,
+    };
+    use reth_primitives_traits::SealedHeader;
     use revm::precompile::Precompiles;
+
+    fn parent_at(number: u64, timestamp: u64) -> SealedHeader<Header> {
+        SealedHeader::seal_slow(Header { number, timestamp, ..Default::default() })
+    }
+
+    fn block_with_number(number: u64) -> SimBlock<TransactionRequest> {
+        SimBlock {
+            block_overrides: Some(BlockOverrides {
+                number: Some(U256::from(number)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn precompile_self_move_requires_existing_precompile() {
@@ -436,5 +566,101 @@ mod tests {
 
         assert!(precompiles.get(&source).is_none());
         assert!(precompiles.get(&dest).is_some());
+    }
+
+    #[test]
+    fn sanitize_chain_fills_gaps_with_empty_blocks() {
+        // parent at block 5; user requests one block at 8 — sanitize should insert fillers at 6
+        // and 7 before the requested block.
+        let parent = parent_at(5, 100);
+        let blocks = vec![block_with_number(8)];
+
+        let out = sanitize_chain(blocks, &parent, Chain::mainnet().id(), 256).unwrap();
+        assert_eq!(out.len(), 3);
+
+        let numbers: Vec<u64> = out
+            .iter()
+            .map(|b| b.block_overrides.as_ref().unwrap().number.unwrap().try_into().unwrap())
+            .collect();
+        assert_eq!(numbers, vec![6, 7, 8]);
+
+        assert!(out[0].calls.is_empty());
+        assert!(out[1].calls.is_empty());
+
+        // Mainnet hint is 12s, so timestamps should auto-increment from 100 by 12.
+        let times: Vec<u64> =
+            out.iter().map(|b| b.block_overrides.as_ref().unwrap().time.unwrap()).collect();
+        assert_eq!(times, vec![112, 124, 136]);
+    }
+
+    #[test]
+    fn sanitize_chain_defaults_missing_number_and_time() {
+        let parent = parent_at(10, 1000);
+        let blocks: Vec<SimBlock<TransactionRequest>> =
+            vec![SimBlock::default(), SimBlock::default()];
+
+        let out = sanitize_chain(blocks, &parent, Chain::mainnet().id(), 256).unwrap();
+        assert_eq!(out.len(), 2);
+
+        let overrides = out[0].block_overrides.as_ref().unwrap();
+        assert_eq!(overrides.number.unwrap(), U256::from(11));
+        assert_eq!(overrides.time, Some(1012));
+
+        let overrides = out[1].block_overrides.as_ref().unwrap();
+        assert_eq!(overrides.number.unwrap(), U256::from(12));
+        assert_eq!(overrides.time, Some(1024));
+    }
+
+    #[test]
+    fn sanitize_chain_uses_chain_blocktime_hint() {
+        // Optimism has a 2s blocktime hint; filler/auto timestamps should reflect that.
+        let parent = parent_at(0, 0);
+        let blocks = vec![block_with_number(3)];
+
+        let out = sanitize_chain(blocks, &parent, Chain::optimism_mainnet().id(), 256).unwrap();
+        let times: Vec<u64> =
+            out.iter().map(|b| b.block_overrides.as_ref().unwrap().time.unwrap()).collect();
+        assert_eq!(times, vec![2, 4, 6]);
+    }
+
+    #[test]
+    fn sanitize_chain_rounds_subsecond_blocktime_hint_up() {
+        // Arbitrum has a 260ms blocktime hint. Simulated timestamps are second-granular, so this
+        // rounds up to a 1s increment instead of falling back to the default.
+        let parent = parent_at(0, 0);
+        let blocks = vec![block_with_number(3)];
+
+        let out = sanitize_chain(blocks, &parent, Chain::arbitrum_mainnet().id(), 256).unwrap();
+        let times: Vec<u64> =
+            out.iter().map(|b| b.block_overrides.as_ref().unwrap().time.unwrap()).collect();
+        assert_eq!(times, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn sanitize_chain_falls_back_when_chain_has_no_hint() {
+        // An unknown chain id has no blocktime hint — fall back to the 12s default.
+        let parent = parent_at(0, 0);
+        let blocks = vec![block_with_number(2)];
+
+        let out = sanitize_chain(blocks, &parent, Chain::from_id(123_456_789).id(), 256).unwrap();
+        let times: Vec<u64> =
+            out.iter().map(|b| b.block_overrides.as_ref().unwrap().time.unwrap()).collect();
+        assert_eq!(times, vec![12, 24]);
+    }
+
+    #[test]
+    fn sanitize_chain_rejects_non_increasing_number() {
+        let parent = parent_at(10, 100);
+        let err = sanitize_chain(vec![block_with_number(10)], &parent, Chain::mainnet().id(), 256)
+            .unwrap_err();
+        assert!(matches!(err, EthApiError::Other(_)));
+    }
+
+    #[test]
+    fn sanitize_chain_enforces_max_blocks() {
+        let parent = parent_at(0, 0);
+        let err = sanitize_chain(vec![block_with_number(257)], &parent, Chain::mainnet().id(), 256)
+            .unwrap_err();
+        assert!(matches!(err, EthApiError::Other(_)));
     }
 }


### PR DESCRIPTION
Closes #15460

Per the execution-apis spec: *"If the block number is increased more than 1 compared to the previous block, new empty blocks are generated in between."* Reth was applying each `BlockStateCalls` entry as-is, jumping directly to the requested block number without producing the intermediate empty blocks.

Adds `simulate::sanitize_chain`: validates strictly-increasing numbers and timestamps, defaults missing values to `prev + 1` / `prev + chain block time`, inserts empty filler blocks for gaps, and enforces the global block cap including fillers.

Filler / auto-generated timestamps use `alloy_chains::Chain::average_blocktime_hint` for the active chain (e.g. 12s on mainnet, 2s on optimism), falling back to 12s when the chain has no registered hint. The chain id is derived once per request from the active chain spec.
