### PR TITLE
chore: name payload builder worker thread

### DIFF
--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -111,7 +111,7 @@ where
             );
 
         ctx.task_executor().spawn_critical_os_thread(
-            "payload-builder",
+            "payload-service",
             "payload builder service",
             payload_service,
         );

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -359,7 +359,7 @@ where
         let execution_cache = self.execution_cache.clone();
         let trie_handle = self.trie_handle.take();
         let builder = self.builder.clone();
-        self.executor.spawn_blocking_task(async move {
+        self.executor.spawn_blocking_named_task("payload-builder", async move {
             // acquire the permit for executing the task
             let _permit = guard.acquire().await;
             let args = BuildArguments {

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -359,19 +359,22 @@ where
         let execution_cache = self.execution_cache.clone();
         let trie_handle = self.trie_handle.take();
         let builder = self.builder.clone();
-        self.executor.spawn_blocking_named_task("payload-builder", async move {
+        let executor = self.executor.clone();
+        self.executor.spawn_task(async move {
             // acquire the permit for executing the task
             let _permit = guard.acquire().await;
-            let args = BuildArguments {
-                cached_reads,
-                execution_cache,
-                trie_handle,
-                config: payload_config,
-                cancel,
-                best_payload,
-            };
-            let result = builder.try_build(args);
-            let _ = tx.send(result);
+            executor.spawn_blocking_named("payload-builder", move || {
+                let args = BuildArguments {
+                    cached_reads,
+                    execution_cache,
+                    trie_handle,
+                    config: payload_config,
+                    cancel,
+                    best_payload,
+                };
+                let result = builder.try_build(args);
+                let _ = tx.send(result);
+            });
         });
 
         self.pending_block = Some(PendingPayload { _cancel, payload: rx });

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -512,6 +512,39 @@ impl Runtime {
         self.spawn_task_as(fut, TaskKind::Blocking)
     }
 
+    /// Spawns a blocking task onto a named OS thread.
+    ///
+    /// The given future resolves as soon as the [Shutdown] signal is received.
+    ///
+    /// Unlike [`spawn_blocking_task`](Self::spawn_blocking_task), this creates a new OS thread
+    /// with the given `name`.
+    pub fn spawn_blocking_named_task<F>(&self, name: &'static str, fut: F) -> thread::JoinHandle<()>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.0.metrics.inc_regular_blocking_tasks();
+
+        let on_shutdown = self.0.on_shutdown.clone();
+        let finished_counter = self.0.metrics.finished_regular_blocking_tasks_total.clone();
+        let task = {
+            async move {
+                let _inc_counter_on_drop = IncCounterOnDrop::new(finished_counter);
+                let fut = pin!(fut);
+                let _ = select(on_shutdown, fut).await;
+            }
+        }
+        .in_current_span();
+
+        let handle = self.0.handle.clone();
+        thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || {
+                let _guard = handle.enter();
+                handle.block_on(task);
+            })
+            .unwrap_or_else(|e| panic!("failed to spawn blocking OS thread {name:?}: {e}"))
+    }
+
     /// Spawns a blocking closure directly on the tokio runtime, bypassing shutdown
     /// awareness. Useful for raw CPU-bound work.
     pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -512,39 +512,6 @@ impl Runtime {
         self.spawn_task_as(fut, TaskKind::Blocking)
     }
 
-    /// Spawns a blocking task onto a named OS thread.
-    ///
-    /// The given future resolves as soon as the [Shutdown] signal is received.
-    ///
-    /// Unlike [`spawn_blocking_task`](Self::spawn_blocking_task), this creates a new OS thread
-    /// with the given `name`.
-    pub fn spawn_blocking_named_task<F>(&self, name: &'static str, fut: F) -> thread::JoinHandle<()>
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        self.0.metrics.inc_regular_blocking_tasks();
-
-        let on_shutdown = self.0.on_shutdown.clone();
-        let finished_counter = self.0.metrics.finished_regular_blocking_tasks_total.clone();
-        let task = {
-            async move {
-                let _inc_counter_on_drop = IncCounterOnDrop::new(finished_counter);
-                let fut = pin!(fut);
-                let _ = select(on_shutdown, fut).await;
-            }
-        }
-        .in_current_span();
-
-        let handle = self.0.handle.clone();
-        thread::Builder::new()
-            .name(name.to_string())
-            .spawn(move || {
-                let _guard = handle.enter();
-                handle.block_on(task);
-            })
-            .unwrap_or_else(|e| panic!("failed to spawn blocking OS thread {name:?}: {e}"))
-    }
-
     /// Spawns a blocking closure directly on the tokio runtime, bypassing shutdown
     /// awareness. Useful for raw CPU-bound work.
     pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>


### PR DESCRIPTION
Renames the payload builder service OS thread to `payload-service` and runs payload build jobs on a named blocking worker `payload-builder`, so profiler thread names point at the heavy build execution rather than the service poll loop.

This moves payload builder threads from tokio blocking pool to a dedicated OS thread.