### PR TITLE
docs(txpool): fix grammar in TransactionPool::get_all doc

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -566,9 +566,9 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
     /// Returns the transaction for the given hash.
     fn get(&self, tx_hash: &TxHash) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
-    /// Returns all transactions objects for the given hashes.
+    /// Returns all transaction objects for the given hashes.
     ///
-    /// Caution: This in case of blob transactions, this does not include the sidecar.
+    /// Caution: In case of blob transactions, this does not include the sidecar.
     fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
     /// Notify the pool about transactions that are propagated to peers.


### PR DESCRIPTION
Fixes a grammatical error and a duplicated "This" in the doc comment for `TransactionPool::get_all`. No behavior change.