### PR TITLE
docs(txpool): fix singular "transaction" in sub-pool limit docs

### DIFF
--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -50,11 +50,11 @@ where
 /// Convenience type to override cli or default pool configuration during build.
 #[derive(Debug, Clone, Default)]
 pub struct PoolBuilderConfigOverrides {
-    /// Max number of transaction in the pending sub-pool
+    /// Max number of transactions in the pending sub-pool
     pub pending_limit: Option<SubPoolLimit>,
-    /// Max number of transaction in the basefee sub-pool
+    /// Max number of transactions in the basefee sub-pool
     pub basefee_limit: Option<SubPoolLimit>,
-    /// Max number of transaction in the queued sub-pool
+    /// Max number of transactions in the queued sub-pool
     pub queued_limit: Option<SubPoolLimit>,
     /// Max number of transactions in the blob sub-pool
     pub blob_limit: Option<SubPoolLimit>,

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -290,28 +290,28 @@ impl Default for DefaultTxPoolValues {
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "TxPool")]
 pub struct TxPoolArgs {
-    /// Max number of transaction in the pending sub-pool.
+    /// Max number of transactions in the pending sub-pool.
     #[arg(long = "txpool.pending-max-count", alias = "txpool.pending_max_count", default_value_t = DefaultTxPoolValues::get_global().pending_max_count)]
     pub pending_max_count: usize,
     /// Max size of the pending sub-pool in megabytes.
     #[arg(long = "txpool.pending-max-size", alias = "txpool.pending_max_size", default_value_t = DefaultTxPoolValues::get_global().pending_max_size)]
     pub pending_max_size: usize,
 
-    /// Max number of transaction in the basefee sub-pool
+    /// Max number of transactions in the basefee sub-pool
     #[arg(long = "txpool.basefee-max-count", alias = "txpool.basefee_max_count", default_value_t = DefaultTxPoolValues::get_global().basefee_max_count)]
     pub basefee_max_count: usize,
     /// Max size of the basefee sub-pool in megabytes.
     #[arg(long = "txpool.basefee-max-size", alias = "txpool.basefee_max_size", default_value_t = DefaultTxPoolValues::get_global().basefee_max_size)]
     pub basefee_max_size: usize,
 
-    /// Max number of transaction in the queued sub-pool
+    /// Max number of transactions in the queued sub-pool
     #[arg(long = "txpool.queued-max-count", alias = "txpool.queued_max_count", default_value_t = DefaultTxPoolValues::get_global().queued_max_count)]
     pub queued_max_count: usize,
     /// Max size of the queued sub-pool in megabytes.
     #[arg(long = "txpool.queued-max-size", alias = "txpool.queued_max_size", default_value_t = DefaultTxPoolValues::get_global().queued_max_size)]
     pub queued_max_size: usize,
 
-    /// Max number of transaction in the blobpool
+    /// Max number of transactions in the blobpool
     #[arg(long = "txpool.blobpool-max-count", alias = "txpool.blobpool_max_count", default_value_t = DefaultTxPoolValues::get_global().blobpool_max_count)]
     pub blobpool_max_count: usize,
     /// Max size of the blobpool in megabytes.

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -37,11 +37,11 @@ pub const DEFAULT_MAX_INFLIGHT_DELEGATED_SLOTS: usize = 1;
 /// Configuration options for the Transaction pool.
 #[derive(Debug, Clone)]
 pub struct PoolConfig {
-    /// Max number of transaction in the pending sub-pool
+    /// Max number of transactions in the pending sub-pool
     pub pending_limit: SubPoolLimit,
-    /// Max number of transaction in the basefee sub-pool
+    /// Max number of transactions in the basefee sub-pool
     pub basefee_limit: SubPoolLimit,
-    /// Max number of transaction in the queued sub-pool
+    /// Max number of transactions in the queued sub-pool
     pub queued_limit: SubPoolLimit,
     /// Max number of transactions in the blob sub-pool
     pub blob_limit: SubPoolLimit,

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -574,7 +574,7 @@ Gas Price Oracle:
 
 TxPool:
       --txpool.pending-max-count <PENDING_MAX_COUNT>
-          Max number of transaction in the pending sub-pool
+          Max number of transactions in the pending sub-pool
 
           [default: 10000]
 
@@ -584,7 +584,7 @@ TxPool:
           [default: 20]
 
       --txpool.basefee-max-count <BASEFEE_MAX_COUNT>
-          Max number of transaction in the basefee sub-pool
+          Max number of transactions in the basefee sub-pool
 
           [default: 10000]
 
@@ -594,7 +594,7 @@ TxPool:
           [default: 20]
 
       --txpool.queued-max-count <QUEUED_MAX_COUNT>
-          Max number of transaction in the queued sub-pool
+          Max number of transactions in the queued sub-pool
 
           [default: 10000]
 
@@ -604,7 +604,7 @@ TxPool:
           [default: 20]
 
       --txpool.blobpool-max-count <BLOBPOOL_MAX_COUNT>
-          Max number of transaction in the blobpool
+          Max number of transactions in the blobpool
 
           [default: 10000]
 


### PR DESCRIPTION
Fix grammar in the pending/basefee/queued/blob sub-pool limit doc comments: `Max number of transaction` -> `Max number of transactions`. Covers the TxPool CLI args (regenerating the `node.mdx` CLI reference via `make update-book-cli`), `PoolBuilderConfigOverrides`, and `PoolConfig`.