### PR TITLE
feat(txpool): add block attributes to best transactions

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use alloy_consensus::Transaction;
+use alloy_consensus::{conditional::BlockConditionalAttributes, Transaction};
 use alloy_primitives::{Bytes, U256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes as EthPayloadAttributes;
@@ -215,6 +215,10 @@ where
     let mut best_txs = best_txs(BestTransactionsAttributes::new(
         base_fee,
         builder.evm_mut().block().blob_gasprice().map(|gasprice| gasprice as u64),
+    ))
+    .with_block_attributes(BlockConditionalAttributes::new(
+        parent_header.number.saturating_add(1),
+        attributes.timestamp(),
     ));
     let mut total_fees = U256::ZERO;
 

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -4,7 +4,7 @@ use crate::{
     pool::pending::PendingTransaction,
     PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction,
 };
-use alloy_consensus::Transaction;
+use alloy_consensus::{conditional::BlockConditionalAttributes, Transaction};
 use alloy_primitives::map::AddressSet;
 use core::fmt;
 use imbl::OrdMap;
@@ -46,6 +46,10 @@ impl<T: TransactionOrdering> crate::traits::BestTransactions for BestTransaction
 
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
         self.best.set_skip_blobs(skip_blobs)
+    }
+
+    fn set_block_attributes(&mut self, block_attributes: BlockConditionalAttributes) {
+        self.best.set_block_attributes(block_attributes)
     }
 }
 
@@ -347,6 +351,10 @@ where
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
         self.best.set_skip_blobs(skip_blobs)
     }
+
+    fn set_block_attributes(&mut self, block_attributes: BlockConditionalAttributes) {
+        self.best.set_block_attributes(block_attributes)
+    }
 }
 
 impl<I: fmt::Debug, P> fmt::Debug for BestTransactionFilter<I, P> {
@@ -434,6 +442,10 @@ where
             self.buffer.retain(|tx| !tx.transaction.is_eip4844())
         }
         self.inner.set_skip_blobs(skip_blobs)
+    }
+
+    fn set_block_attributes(&mut self, block_attributes: BlockConditionalAttributes) {
+        self.inner.set_block_attributes(block_attributes)
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -60,7 +60,10 @@ use crate::{
     validate::ValidPoolTransaction,
     AddedTransactionOutcome, AllTransactionsEvents,
 };
-use alloy_consensus::{error::ValueError, transaction::TxHashRef, BlockHeader, Signed, Typed2718};
+use alloy_consensus::{
+    conditional::BlockConditionalAttributes, error::ValueError, transaction::TxHashRef,
+    BlockHeader, Signed, Typed2718,
+};
 use alloy_eips::{
     eip2718::{Encodable2718, WithEncoded},
     eip2930::AccessList,
@@ -1097,6 +1100,21 @@ pub trait BestTransactions: Iterator + Send {
     /// If set to true, no blob transactions will be returned.
     fn set_skip_blobs(&mut self, skip_blobs: bool);
 
+    /// Sets the block attributes used for conditional transaction filtering.
+    ///
+    /// The default implementation is a no-op. Iterators that support conditional transactions can
+    /// use this to pre-filter transactions whose block constraints do not match.
+    fn set_block_attributes(&mut self, _block_attributes: BlockConditionalAttributes) {}
+
+    /// Convenience function for [`Self::set_block_attributes`] that returns the iterator again.
+    fn with_block_attributes(mut self, block_attributes: BlockConditionalAttributes) -> Self
+    where
+        Self: Sized,
+    {
+        self.set_block_attributes(block_attributes);
+        self
+    }
+
     /// Convenience function for [`Self::skip_blobs`] that returns the iterator again.
     fn without_blobs(mut self) -> Self
     where
@@ -1138,6 +1156,10 @@ where
 
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
         (**self).set_skip_blobs(skip_blobs);
+    }
+
+    fn set_block_attributes(&mut self, block_attributes: BlockConditionalAttributes) {
+        (**self).set_block_attributes(block_attributes);
     }
 }
 

--- a/crates/transaction-pool/tests/it/best.rs
+++ b/crates/transaction-pool/tests/it/best.rs
@@ -1,11 +1,16 @@
 //! Best transaction and filter testing
 
+use alloy_consensus::conditional::BlockConditionalAttributes;
 use reth_transaction_pool::{noop::NoopTransactionPool, BestTransactions, TransactionPool};
 
 #[test]
 fn test_best_transactions() {
     let noop = NoopTransactionPool::default();
-    let mut best =
-        noop.best_transactions().filter_transactions(|_| true).without_blobs().without_updates();
+    let mut best = noop
+        .best_transactions()
+        .filter_transactions(|_| true)
+        .with_block_attributes(BlockConditionalAttributes::new(1, 2))
+        .without_blobs()
+        .without_updates();
     assert!(best.next().is_none());
 }


### PR DESCRIPTION
Adds a block-attributes hook to `BestTransactions` so iterator implementations can pre-filter conditional transactions while callers keep using `Box<dyn BestTransactions>`.

Payload and pending-block builders now pass the next block number and timestamp into the best transactions iterator.