### PR TITLE
fix(cli): make `--datadir` a global arg so it works after `db` subcommands

### DIFF
--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -273,4 +273,37 @@ mod tests {
         .unwrap();
         assert_eq!(cmd.env.datadir.resolve_datadir(cmd.env.chain.chain).as_ref(), Path::new(&path));
     }
+     #[test]
+    fn parse_datadir_after_subcommand() {
+        let path = format!("../{}", SUPPORTED_CHAINS[0]);
+
+        // --datadir after migrate-v2
+        let cmd = Command::<EthereumChainSpecParser>::try_parse_from([
+            "reth",
+            "migrate-v2",
+            "--datadir",
+            &path,
+        ])
+        .unwrap();
+        assert_eq!(cmd.env.datadir.resolve_datadir(cmd.env.chain.chain).as_ref(), Path::new(&path));
+
+        // --datadir after stats
+        let cmd = Command::<EthereumChainSpecParser>::try_parse_from([
+            "reth",
+            "stats",
+            "--datadir",
+            &path,
+        ])
+        .unwrap();
+        assert_eq!(cmd.env.datadir.resolve_datadir(cmd.env.chain.chain).as_ref(), Path::new(&path));
+
+        // --datadir after repair-trie (fixes #19586)
+        let cmd = Command::<EthereumChainSpecParser>::try_parse_from([
+            "reth",
+            "repair-trie",
+            "--datadir",
+            &path,
+        ]);
+        assert!(cmd.is_ok());
+    }
 }

--- a/crates/node/core/src/args/datadir_args.rs
+++ b/crates/node/core/src/args/datadir_args.rs
@@ -16,7 +16,7 @@ pub struct DatadirArgs {
     /// - Linux: `$XDG_DATA_HOME/reth/` or `$HOME/.local/share/reth/`
     /// - Windows: `{FOLDERID_RoamingAppData}/reth/`
     /// - macOS: `$HOME/Library/Application Support/reth/`
-    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t)]
+    #[arg(long, value_name = "DATA_DIR", verbatim_doc_comment, default_value_t, global = true)]
     pub datadir: MaybePlatformPath<DataDirPath>,
 
     /// The absolute path to store static files in.
@@ -24,16 +24,17 @@ pub struct DatadirArgs {
         long = "datadir.static-files",
         alias = "datadir.static_files",
         value_name = "PATH",
-        verbatim_doc_comment
+        verbatim_doc_comment,
+        global = true
     )]
     pub static_files_path: Option<PathBuf>,
 
     /// The absolute path to store `RocksDB` database in.
-    #[arg(long = "datadir.rocksdb", value_name = "PATH", verbatim_doc_comment)]
+    #[arg(long = "datadir.rocksdb", value_name = "PATH", verbatim_doc_comment, global = true)]
     pub rocksdb_path: Option<PathBuf>,
 
     /// The absolute path to store pprof dumps in.
-    #[arg(long = "datadir.pprof-dumps", value_name = "PATH", verbatim_doc_comment)]
+    #[arg(long = "datadir.pprof-dumps", value_name = "PATH", verbatim_doc_comment, global = true)]
     pub pprof_dumps_path: Option<PathBuf>,
 }
 


### PR DESCRIPTION
## Summary

`--datadir` is rejected when placed after a `reth db` subcommand:
works
reth db --datadir /path/to/data migrate-v2
broken — "unexpected argument '--datadir' found"
reth db migrate-v2 --datadir /path/to/data

This is because `DatadirArgs` is flattened onto the parent `db::Command` struct
but not marked as `global`, so clap scopes it before the subcommand token. Once
the parser enters the subcommand (e.g. `migrate-v2`, `repair-trie`, `stats`),
`--datadir` is no longer recognized.

The `--chain` arg already has `global = true` in `EnvironmentArgs` — this PR
applies the same treatment to all `DatadirArgs` fields (`--datadir`,
`--datadir.static-files`, `--datadir.rocksdb`, `--datadir.pprof-dumps`).

## Changes

- **`crates/node/core/src/args/datadir_args.rs`**: Added `global = true` to all
  four args in `DatadirArgs`.
- **`crates/cli/commands/src/db/mod.rs`**: Added test
  `parse_datadir_after_subcommand` verifying `--datadir` parses correctly when
  placed after `migrate-v2`, `stats`, and `repair-trie` subcommands.

## Fixes

Closes #24394
Closes #19586