### PR TITLE
refactor(payload): store recovered block in built payload

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -16,7 +16,7 @@ use alloy_rpc_types_engine::{
 };
 use reth_ethereum_primitives::EthPrimitives;
 use reth_payload_primitives::BuiltPayload;
-use reth_primitives_traits::{NodePrimitives, SealedBlock};
+use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedBlock};
 
 use crate::BuiltPayloadConversionError;
 
@@ -30,7 +30,7 @@ use crate::BuiltPayloadConversionError;
 #[derive(Debug, Clone)]
 pub struct EthBuiltPayload<N: NodePrimitives = EthPrimitives> {
     /// The built block
-    pub(crate) block: Arc<SealedBlock<N::Block>>,
+    pub(crate) block: Arc<RecoveredBlock<N::Block>>,
     /// The fees of the block
     pub(crate) fees: U256,
     /// The blobs, proofs, and commitments in the block. If the block is pre-cancun, this will be
@@ -49,7 +49,7 @@ impl<N: NodePrimitives> EthBuiltPayload<N> {
     ///
     /// Caution: This does not set any [`BlobSidecars`].
     pub const fn new(
-        block: Arc<SealedBlock<N::Block>>,
+        block: Arc<RecoveredBlock<N::Block>>,
         fees: U256,
         requests: Option<Requests>,
         block_access_list: Option<Bytes>,
@@ -59,11 +59,16 @@ impl<N: NodePrimitives> EthBuiltPayload<N> {
 
     /// Returns the built block(sealed)
     pub fn block(&self) -> &SealedBlock<N::Block> {
+        self.block.sealed_block()
+    }
+
+    /// Returns the built block with recovered senders.
+    pub fn recovered_block(&self) -> &RecoveredBlock<N::Block> {
         &self.block
     }
 
     /// Returns the built block with shared ownership.
-    pub const fn block_arc(&self) -> &Arc<SealedBlock<N::Block>> {
+    pub const fn block_arc(&self) -> &Arc<RecoveredBlock<N::Block>> {
         &self.block
     }
 
@@ -235,7 +240,7 @@ impl<N: NodePrimitives> BuiltPayload for EthBuiltPayload<N> {
     type Primitives = N;
 
     fn block(&self) -> &SealedBlock<N::Block> {
-        &self.block
+        self.block.sealed_block()
     }
 
     fn fees(&self) -> U256 {
@@ -412,7 +417,7 @@ impl From<alloc::vec::IntoIter<BlobTransactionSidecarEip7594>> for BlobSidecars 
 mod tests {
     use super::*;
     use alloy_primitives::B256;
-    use reth_primitives_traits::Block as _;
+    use reth_primitives_traits::{Block as _, RecoveredBlock};
 
     #[test]
     fn into_execution_data_preserves_requests() {
@@ -424,7 +429,7 @@ mod tests {
         block.header.requests_hash = Some(requests.requests_hash());
 
         let payload = EthBuiltPayload::new(
-            Arc::new(block.seal_slow()),
+            Arc::new(RecoveredBlock::new_sealed(block.seal_slow(), vec![])),
             U256::ZERO,
             Some(requests.clone()),
             None,
@@ -448,7 +453,7 @@ mod tests {
         block.header.block_access_list_hash = Some(B256::ZERO);
 
         let payload = EthBuiltPayload::new(
-            Arc::new(block.seal_slow()),
+            Arc::new(RecoveredBlock::new_sealed(block.seal_slow(), vec![])),
             U256::ZERO,
             None,
             Some(block_access_list.clone()),

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -478,19 +478,18 @@ where
         .is_prague_active_at_timestamp(attributes.timestamp)
         .then_some(execution_result.requests);
 
-    let sealed_block = Arc::new(block.into_sealed_block());
-    debug!(target: "payload_builder", id=%payload_id, sealed_block_header = ?sealed_block.sealed_header(), "sealed built block");
+    debug!(target: "payload_builder", id=%payload_id, sealed_block_header = ?block.sealed_header(), "sealed built block");
 
-    if is_osaka && sealed_block.rlp_length() > MAX_RLP_BLOCK_SIZE {
+    if is_osaka && block.rlp_length() > MAX_RLP_BLOCK_SIZE {
         return Err(PayloadBuilderError::other(ConsensusError::BlockTooLarge {
-            rlp_length: sealed_block.rlp_length(),
+            rlp_length: block.rlp_length(),
             max_rlp_length: MAX_RLP_BLOCK_SIZE,
         }));
     }
 
     let block_access_list: Option<Bytes> =
         block_access_list.map(|block_access_list| alloy_rlp::encode(&block_access_list).into());
-    let payload = EthBuiltPayload::new(sealed_block, total_fees, requests, block_access_list)
+    let payload = EthBuiltPayload::new(Arc::new(block), total_fees, requests, block_access_list)
         // add blob sidecars from the executed txs
         .with_sidecars(blob_sidecars);
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -33,7 +33,7 @@
 //! use reth_payload_builder::PayloadId;
 //! use alloy_primitives::U256;
 //! use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError, KeepPayloadJobAlive, PayloadJob, PayloadJobGenerator, PayloadKind};
-//! use reth_primitives_traits::SealedBlock;
+//! use reth_primitives_traits::{RecoveredBlock, SealedBlock};
 //! use alloy_rpc_types::engine::PayloadAttributes;
 //! use reth_payload_builder::BuildNewPayload;
 //!
@@ -72,7 +72,8 @@
 //!         },
 //!         ..Default::default()
 //!     };
-//!     let payload = EthBuiltPayload::new(Arc::new(SealedBlock::seal_slow(block)), U256::ZERO, None, None);
+//!     let block = RecoveredBlock::new_sealed(SealedBlock::seal_slow(block), vec![]);
+//!     let payload = EthBuiltPayload::new(Arc::new(block), U256::ZERO, None, None);
 //!     Ok(payload)
 //! }
 //!

--- a/crates/payload/builder/src/test_utils.rs
+++ b/crates/payload/builder/src/test_utils.rs
@@ -12,7 +12,7 @@ use reth_chain_state::CanonStateNotification;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::{PayloadKind, PayloadTypes};
-use reth_primitives_traits::Block as _;
+use reth_primitives_traits::{Block as _, RecoveredBlock};
 use std::{
     future::Future,
     pin::Pin,
@@ -86,7 +86,7 @@ impl PayloadJob for TestPayloadJob {
 
     fn best_payload(&self) -> Result<EthBuiltPayload, PayloadBuilderError> {
         Ok(EthBuiltPayload::new(
-            Arc::new(Block::<_>::default().seal_slow()),
+            Arc::new(RecoveredBlock::new_sealed(Block::<_>::default().seal_slow(), vec![])),
             U256::ZERO,
             Some(Default::default()),
             None,

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -209,11 +209,9 @@ where
                 let outcome = builder.finish(&state, None).map_err(Eth::Error::from_eth_err)?;
 
                 let has_requests = outcome.block.requests_hash().is_some();
-                let sealed_block = Arc::new(outcome.block.into_sealed_block());
-
                 let requests = has_requests.then_some(outcome.execution_result.requests);
 
-                EthBuiltPayload::new(sealed_block, total_fees, requests, None)
+                EthBuiltPayload::new(Arc::new(outcome.block), total_fees, requests, None)
                     .try_into_v5()
                     .map_err(RethError::other)
                     .map_err(Eth::Error::from_eth_err)


### PR DESCRIPTION
Stores the recovered block in `EthBuiltPayload` instead of converting the builder output to a sealed-only block immediately.

This keeps recovered sender data available to downstream payload users while preserving the sealed block view required by `BuiltPayload` and Engine API conversions.
