### PR TITLE
fix(grafana): replace expression datasource placeholder

### DIFF
--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -82,11 +82,12 @@ services:
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboards:/etc/grafana/provisioning_temp/dashboards
     # 1. Copy dashboards from temp directory to prevent modifying original host files
-    # 2. Replace Prometheus datasource placeholders with the actual name
+    # 2. Replace dashboard placeholders with actual datasource names and labels
     # 3. Run Grafana
     entrypoint: >
       sh -c "cp -r /etc/grafana/provisioning_temp/dashboards/. /etc/grafana/provisioning/dashboards &&
              find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${DS_PROMETHEUS}/Prometheus/g' {} \+ &&
+             find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${DS_EXPRESSION}/__expr__/g' {} \+ &&
              find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${datasource}/Prometheus/g' {} \+ &&
              find /etc/grafana/provisioning/dashboards/ -name '*.json' -exec sed -i 's/$${VAR_INSTANCE_LABEL}/instance/g' {} \+ &&
              /run.sh"


### PR DESCRIPTION
Replaces the `${DS_EXPRESSION}` placeholder with Grafana's built-in `__expr__` datasource UID when docker compose copies provisioned dashboards.

`overview.json` uses expression targets, and provisioned dashboards do not resolve `__inputs`, so this keeps those panels wired up alongside the existing Prometheus and label replacements.