### PR TITLE
fix(net): remove untrusted peers from resolver

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -969,6 +969,8 @@ impl PeersManager {
 
     /// Removes the tracked node from the trusted set.
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
+        self.trusted_peers_resolver.remove(peer_id);
+
         let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
         if !entry.get().is_trusted() {
             return

--- a/crates/net/network/src/trusted_peers_resolver.rs
+++ b/crates/net/network/src/trusted_peers_resolver.rs
@@ -33,6 +33,11 @@ impl TrustedPeersResolver {
         self.interval = interval;
     }
 
+    /// Remove a trusted peer from the resolver.
+    pub fn remove(&mut self, peer_id: PeerId) {
+        self.trusted_peers.retain(|trusted| trusted.id != peer_id);
+    }
+
     /// Poll the resolver.
     /// When the interval ticks, new resolution futures for each trusted peer are spawned.
     /// If a future completes successfully, it returns the resolved (`PeerId`, `NodeRecord`).


### PR DESCRIPTION
Split out from #24280.

Removes peers from the trusted DNS resolver when they are removed from the trusted set.

Previously, removing a trusted peer could leave its resolver entry behind, so periodic DNS resolution could continue after the peer was untrusted.