### PR TITLE
docs: fix assorted grammar typos in rustdoc comments

### DIFF
--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -610,7 +610,7 @@ where
         }
     }
 
-    /// Validate whether the header is valid in relation to it's parent
+    /// Validate whether the header is valid in relation to its parent
     fn validate(
         &self,
         header: &SealedHeader<H::Header>,

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -116,7 +116,7 @@ pub trait DebugApi<TxReq: RpcObject> {
     /// transactions.
     ///
     /// The first argument is a list of bundles. Each bundle can overwrite the block headers. This
-    /// will affect all transaction in that bundle.
+    /// will affect all transactions in that bundle.
     /// `BlockNumber` and `transaction_index` are optional. `Transaction_index`
     /// specifies the number of tx in the block to replay and -1 means all transactions should be
     /// replayed.

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -2260,7 +2260,7 @@ impl RpcServerHandle {
         Some(provider)
     }
 
-    /// Returns an ws provider from the rpc server handle for the
+    /// Returns a ws provider from the rpc server handle for the
     /// specified [`alloy_network::Network`].
     ///
     /// This installs the recommended fillers: [`RecommendedFillers`]

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -408,7 +408,7 @@ tables! {
     /// * `Address | 100`
     /// * `Address | u64::MAX`
     ///
-    /// What we need to find is number that is one greater than N. Db `seek` function allows us to fetch
+    /// What we need to find is the number that is one greater than N. Db `seek` function allows us to fetch
     /// the shard that equal or more than asked. For example:
     /// * For N=50 we would get first shard.
     /// * for N=150 we would get second shard.
@@ -430,7 +430,7 @@ tables! {
     /// * `Address | StorageKey | 100`
     /// * `Address | StorageKey | u64::MAX`
     ///
-    /// What we need to find is number that is one greater than N. Db `seek` function allows us to fetch
+    /// What we need to find is the number that is one greater than N. Db `seek` function allows us to fetch
     /// the shard that equal or more than asked. For example:
     /// * For N=50 we would get first shard.
     /// * for N=150 we would get second shard.

--- a/crates/storage/storage-api/src/account.rs
+++ b/crates/storage/storage-api/src/account.rs
@@ -21,7 +21,7 @@ pub trait AccountReader {
 /// Account reader
 #[auto_impl(&, Arc, Box)]
 pub trait AccountExtReader {
-    /// Iterate over account changesets and return all account address that were changed.
+    /// Iterate over account changesets and return all account addresses that were changed.
     fn changed_accounts_with_range(
         &self,
         _range: RangeInclusive<BlockNumber>,

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1255,7 +1255,7 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
         self
     }
 
-    /// Builds a the [`EthTransactionValidator`] without spawning validator tasks.
+    /// Builds the [`EthTransactionValidator`] without spawning validator tasks.
     pub fn build<Tx, S>(self, blob_store: S) -> EthTransactionValidator<Client, Tx, Evm>
     where
         S: BlobStore,

--- a/crates/trie/trie/src/proof_v2/node.rs
+++ b/crates/trie/trie/src/proof_v2/node.rs
@@ -97,7 +97,7 @@ impl<RF: DeferredValueEncoder> ProofTrieBranchChild<RF> {
         Ok(ProofTrieNodeV2 { node, path, masks })
     }
 
-    /// Returns the short key of the child, if it is a leaf or branch, or empty if its a
+    /// Returns the short key of the child, if it is a leaf or branch, or empty if it's a
     /// [`Self::RlpNode`].
     pub(crate) fn short_key(&self) -> &Nibbles {
         match self {


### PR DESCRIPTION
Fixes several grammar typos in rustdoc comments across various crates (its/it's, missing/duplicate articles, singular/plural). Doc-only, no behavior changes.