### PR TITLE
perf(txpool): add best transaction size hints

### DIFF
--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -72,6 +72,11 @@ impl<T: TransactionOrdering> Iterator for BestTransactionsWithFees<T> {
             );
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.best.size_hint();
+        (0, upper)
+    }
 }
 
 /// An iterator that returns transactions that can be executed on the current state (*best*
@@ -287,6 +292,10 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.next_tx_and_priority().map(|(tx, _)| tx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.new_transaction_receiver.is_none().then_some(self.all.len()))
+    }
 }
 
 /// A [`BestTransactions`](crate::traits::BestTransactions) implementation that filters the
@@ -324,6 +333,11 @@ where
                 InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported),
             );
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.best.size_hint();
+        (0, upper)
     }
 }
 
@@ -414,6 +428,16 @@ where
             self.inner.next()
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let buffered = self.buffer.len();
+        let (inner_lower, inner_upper) = self.inner.size_hint();
+
+        (
+            buffered.saturating_add(inner_lower),
+            inner_upper.and_then(|upper| upper.checked_add(buffered)),
+        )
+    }
 }
 
 impl<I, T> crate::traits::BestTransactions for BestTransactionsWithPrioritizedSenders<I>
@@ -470,6 +494,90 @@ mod tests {
             let tx = best.next().unwrap();
             assert_eq!(tx.nonce(), nonce);
         }
+    }
+
+    #[test]
+    fn test_best_transactions_size_hint() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        for nonce in 0..3 {
+            let tx = MockTransaction::eip1559().rng_hash().with_nonce(nonce);
+            pool.add_transaction(Arc::new(f.validated(tx)), 0);
+        }
+
+        let mut best = pool.best();
+        assert_eq!(best.size_hint(), (0, None));
+
+        best.no_updates();
+        assert_eq!(best.size_hint(), (0, Some(3)));
+
+        assert_eq!(best.next().unwrap().nonce(), 0);
+        assert_eq!(best.size_hint(), (0, Some(2)));
+    }
+
+    #[test]
+    fn test_best_transactions_with_fees_size_hint() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        for nonce in 0..3 {
+            let tx = MockTransaction::eip1559().rng_hash().with_nonce(nonce).with_max_fee(100);
+            pool.add_transaction(Arc::new(f.validated(tx)), 0);
+        }
+
+        let mut best = pool.best_with_basefee_and_blobfee(10, 0);
+        best.no_updates();
+
+        assert_eq!(best.size_hint(), (0, Some(3)));
+        assert_eq!(best.next().unwrap().nonce(), 0);
+        assert_eq!(best.size_hint(), (0, Some(2)));
+    }
+
+    #[test]
+    fn test_best_transaction_filter_size_hint() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        for nonce in 0..3 {
+            let tx = MockTransaction::eip1559().rng_hash().with_nonce(nonce);
+            pool.add_transaction(Arc::new(f.validated(tx)), 0);
+        }
+
+        let best = pool.best().without_updates();
+        let mut filter =
+            BestTransactionFilter::new(best, |_: &Arc<ValidPoolTransaction<MockTransaction>>| {
+                false
+            });
+
+        assert_eq!(filter.size_hint(), (0, Some(3)));
+        assert!(filter.next().is_none());
+        assert_eq!(filter.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn test_best_transactions_with_prioritized_senders_size_hint() {
+        let mut pool = PendingPool::new(MockOrdering::default());
+        let mut f = MockTransactionFactory::default();
+
+        for gas_price in 0..5 {
+            let tx = MockTransaction::eip1559().with_gas_price((gas_price + 1) * 10);
+            pool.add_transaction(Arc::new(f.validated(tx)), 0);
+        }
+
+        let prioritized_tx = MockTransaction::eip1559().with_gas_price(5).with_gas_limit(200);
+        let prioritized_sender = prioritized_tx.sender();
+        pool.add_transaction(Arc::new(f.validated(prioritized_tx)), 0);
+
+        let mut best = BestTransactionsWithPrioritizedSenders::new(
+            AddressSet::from_iter([prioritized_sender]),
+            200,
+            pool.best().without_updates(),
+        );
+
+        assert_eq!(best.size_hint(), (0, Some(6)));
+        assert_eq!(best.next().unwrap().sender(), prioritized_sender);
+        assert_eq!(best.size_hint(), (5, Some(5)));
     }
 
     #[test]


### PR DESCRIPTION
Adds `size_hint` implementations for `BestTransactions` and the wrapper iterators so callers can get finite upper bounds when updates are disabled.

Filtering wrappers keep conservative lower bounds while forwarding upper bounds from their inner iterator, and prioritized-sender wrapping accounts for buffered transactions.