### PR TITLE
fix(rpc): support hostname resolution for trusted peers

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -151,6 +151,13 @@ pub trait Peers: PeersInfo {
         self.add_peer_kind(peer, Some(PeerKind::Trusted), tcp_addr, Some(udp_addr));
     }
 
+    /// Registers a trusted peer that may use a hostname instead of an IP address.
+    ///
+    /// Resolution is performed asynchronously by the periodic DNS resolver; the peer is
+    /// added to the peer set on first successful resolution and re-resolved periodically
+    /// so address changes are picked up automatically.
+    fn add_trusted_peer_node(&self, _peer: reth_network_peers::TrustedPeer) {}
+
     /// Adds a peer to the known peer set, with the given kind.
     ///
     /// If the peer already exists, then this will update its tracked info.

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -714,6 +714,11 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             NetworkHandleMessage::AddTrustedPeerId(peer_id) => {
                 self.swarm.state_mut().add_trusted_peer_id(peer_id);
             }
+            NetworkHandleMessage::AddTrustedPeerNode(trusted_peer) => {
+                if !self.swarm.is_shutting_down() {
+                    self.swarm.state_mut().add_trusted_peer_node(trusted_peer);
+                }
+            }
             NetworkHandleMessage::AddPeerAddress(peer, kind, addr) => {
                 // only add peer if we are not shutting down
                 if !self.swarm.is_shutting_down() {

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -21,7 +21,7 @@ use reth_network_api::{
     PeersInfo,
 };
 use reth_network_p2p::sync::{NetworkSyncUpdater, SyncState, SyncStateProvider};
-use reth_network_peers::{NodeRecord, PeerId};
+use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
 use reth_network_types::{PeerAddr, PeerKind, Reputation, ReputationChangeKind};
 use reth_tokio_util::{EventSender, EventStream};
 use secp256k1::SecretKey;
@@ -321,6 +321,10 @@ impl<N: NetworkPrimitives> Peers for NetworkHandle<N> {
         self.send_message(NetworkHandleMessage::AddTrustedPeerId(peer));
     }
 
+    fn add_trusted_peer_node(&self, peer: TrustedPeer) {
+        self.send_message(NetworkHandleMessage::AddTrustedPeerNode(peer));
+    }
+
     /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to add a peer to the known
     /// set, with the given kind.
     fn add_peer_kind(
@@ -532,6 +536,8 @@ pub trait NetworkProtocols: Send + Sync {
 pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Marks a peer as trusted.
     AddTrustedPeerId(PeerId),
+    /// Adds a trusted peer that may use a hostname, registering it for periodic DNS re-resolution.
+    AddTrustedPeerNode(TrustedPeer),
     /// Adds an address for a peer, including its ID, kind, and socket address.
     AddPeerAddress(PeerId, Option<PeerKind>, PeerAddr),
     /// Removes a peer from the peerset corresponding to the given kind.

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -12,7 +12,7 @@ use reth_eth_wire::{errors::EthStreamError, DisconnectReason};
 use reth_ethereum_forks::ForkId;
 use reth_net_banlist::BanList;
 use reth_network_api::test_utils::{PeerCommand, PeersHandle};
-use reth_network_peers::{NodeRecord, PeerId};
+use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
 use reth_network_types::{
     is_connection_failed_reputation,
     peers::{
@@ -819,6 +819,15 @@ impl PeersManager {
         self.add_peer_kind(peer_id, Some(PeerKind::Trusted), addr, None)
     }
 
+    /// Adds a trusted peer that may use a hostname instead of an IP address.
+    pub(crate) fn add_trusted_peer_node(&mut self, trusted: TrustedPeer) {
+        let peer_id = trusted.id;
+        self.trusted_peer_ids.insert(peer_id);
+        self.trusted_peers_resolver.remove(peer_id);
+        self.trusted_peers_resolver.trusted_peers.push(trusted);
+        self.trusted_peers_resolver.interval.reset_immediately();
+    }
+
     /// Called for a newly discovered peer.
     ///
     /// If the peer already exists, then the address, kind and `fork_id` will be updated.
@@ -971,7 +980,10 @@ impl PeersManager {
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         self.trusted_peers_resolver.remove(peer_id);
 
-        let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
+        let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else {
+            self.trusted_peer_ids.remove(&peer_id);
+            return
+        };
         if !entry.get().is_trusted() {
             return
         }
@@ -1063,17 +1075,25 @@ impl PeersManager {
     }
 
     fn on_resolved_peer(&mut self, peer_id: PeerId, new_record: NodeRecord) {
-        if let Some(peer) = self.peers.get_mut(&peer_id) {
-            let new_addr = PeerAddr::new_with_ports(
-                new_record.address,
-                new_record.tcp_port,
-                Some(new_record.udp_port),
-            );
+        if !self.trusted_peer_ids.contains(&peer_id) {
+            trace!(target: "net::peers", ?peer_id, "Ignoring resolved trusted peer after removal");
+            return
+        }
 
+        let new_addr = PeerAddr::new_with_ports(
+            new_record.address,
+            new_record.tcp_port,
+            Some(new_record.udp_port),
+        );
+
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
             if peer.addr != new_addr {
                 peer.addr = new_addr;
                 trace!(target: "net::peers", ?peer_id, addr=?peer.addr, "Updated resolved trusted peer address");
             }
+        } else {
+            trace!(target: "net::peers", ?peer_id, ?new_addr, "Adding trusted peer after first successful resolution");
+            self.add_peer_kind(peer_id, Some(PeerKind::Trusted), new_addr, None);
         }
     }
 
@@ -1349,7 +1369,7 @@ mod tests {
     use reth_ethereum_forks::{ForkHash, ForkId};
     use reth_net_banlist::BanList;
     use reth_network_api::Direction;
-    use reth_network_peers::{PeerId, TrustedPeer};
+    use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
     use reth_network_types::{
         peers::reputation::DEFAULT_REPUTATION, BackoffKind, Peer, ReputationChangeKind,
     };
@@ -3309,5 +3329,61 @@ mod tests {
 
         let (best_id, _) = peers.best_unconnected().unwrap();
         assert_eq!(best_id, with_fork, "fork_id should break tie when reputation is equal");
+    }
+
+    #[tokio::test]
+    async fn test_add_trusted_peer_node_resolves_absent_peer() {
+        let peer_id = PeerId::random();
+        let trusted = TrustedPeer {
+            host: url::Host::Domain("example.invalid".to_string()),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+
+        let mut manager = PeersManager::default();
+        manager.add_trusted_peer_node(trusted);
+
+        assert!(manager.trusted_peer_ids.contains(&peer_id));
+        assert_eq!(manager.trusted_peers_resolver.trusted_peers.len(), 1);
+        assert!(!manager.peers.contains_key(&peer_id));
+
+        let resolved = NodeRecord {
+            address: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+        manager.on_resolved_peer(peer_id, resolved);
+
+        let peer = manager.peers.get(&peer_id).expect("peer should be added after resolution");
+        assert!(peer.kind.is_trusted());
+        assert_eq!(peer.addr.tcp().ip(), "10.0.0.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_removed_trusted_peer_ignores_late_resolution() {
+        let peer_id = PeerId::random();
+        let trusted = TrustedPeer {
+            host: url::Host::Domain("example.invalid".to_string()),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+
+        let mut manager = PeersManager::default();
+        manager.add_trusted_peer_node(trusted);
+        manager.remove_peer_from_trusted_set(peer_id);
+
+        let resolved = NodeRecord {
+            address: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: peer_id,
+        };
+        manager.on_resolved_peer(peer_id, resolved);
+
+        assert!(!manager.peers.contains_key(&peer_id));
+        assert!(!manager.trusted_peer_ids.contains(&peer_id));
     }
 }

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -307,6 +307,11 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         self.peers_manager.add_trusted_peer_id(peer_id)
     }
 
+    /// Adds a trusted peer that may use a hostname, with periodic DNS re-resolution.
+    pub(crate) fn add_trusted_peer_node(&mut self, trusted: reth_network_peers::TrustedPeer) {
+        self.peers_manager.add_trusted_peer_node(trusted)
+    }
+
     /// Adds a peer and its address with the given kind to the peerset.
     pub(crate) fn add_peer_kind(
         &mut self,

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -18,9 +18,9 @@
 //! signed, versioned record that includes the information from a [`NodeRecord`] along with
 //! additional metadata. This is the data structure returned from discovery v5 queries.
 //!
-//! When we need to deserialize an identifier that could be any of these three types ([`PeerId`],
-//! [`NodeRecord`], and [`Enr`]), we use the [`AnyNode`] type, which is an enum over the three
-//! types. [`AnyNode`] is used in reth's `admin_addTrustedPeer` RPC method.
+//! When we need to deserialize an identifier that could be a [`PeerId`], [`NodeRecord`], [`Enr`],
+//! or [`TrustedPeer`], we use the [`AnyNode`] type. [`AnyNode`] is used in reth's
+//! `admin_addTrustedPeer` RPC method.
 //!
 //! The __final__ type is the [`TrustedPeer`] type, which is similar to a [`NodeRecord`] but may
 //! include a domain name instead of a direct IP address. It includes a `resolve` method, which can
@@ -34,8 +34,8 @@
 //! - [`NodeRecord`]: A more complete representation of a peer, including IP address and ports.
 //! - [`Enr`]: An Ethereum Node Record, which is a signed, versioned record that includes additional
 //!   metadata. Useful when interacting with discovery v5, or when custom metadata is required.
-//! - [`AnyNode`]: An enum over [`PeerId`], [`NodeRecord`], and [`Enr`], useful in deserialization
-//!   when the type of the node record is not known.
+//! - [`AnyNode`]: An enum over [`PeerId`], [`NodeRecord`], [`Enr`], and [`TrustedPeer`], useful in
+//!   deserialization when the type of the node record is not known.
 //! - [`TrustedPeer`]: A [`NodeRecord`] with an optional domain name, which can be resolved to a
 //!   [`NodeRecord`]. Useful for adding trusted peers at startup, whose IP address may not be
 //!   static.
@@ -121,6 +121,8 @@ pub enum AnyNode {
     Enr(Enr<secp256k1::SecretKey>),
     /// An incomplete "enode" with only a peer id
     PeerId(PeerId),
+    /// An "enode:" peer whose host may be a domain name instead of an IP address
+    TrustedPeer(TrustedPeer),
 }
 
 impl AnyNode {
@@ -130,6 +132,7 @@ impl AnyNode {
         match self {
             Self::NodeRecord(record) => record.id,
             Self::PeerId(peer_id) => *peer_id,
+            Self::TrustedPeer(peer) => peer.id,
         }
     }
 
@@ -140,6 +143,7 @@ impl AnyNode {
             Self::NodeRecord(record) => record.id,
             Self::Enr(enr) => pk2id(&enr.public_key()),
             Self::PeerId(peer_id) => *peer_id,
+            Self::TrustedPeer(peer) => peer.id,
         }
     }
 
@@ -148,7 +152,7 @@ impl AnyNode {
     pub const fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
-            Self::PeerId(_) => None,
+            Self::PeerId(_) | Self::TrustedPeer(_) => None,
         }
     }
 
@@ -170,7 +174,15 @@ impl AnyNode {
                 .into_ipv4_mapped();
                 Some(node_record)
             }
-            Self::PeerId(_) => None,
+            Self::PeerId(_) | Self::TrustedPeer(_) => None,
+        }
+    }
+
+    /// Returns the [`TrustedPeer`] if this is a `TrustedPeer` variant.
+    pub const fn trusted_peer(&self) -> Option<&TrustedPeer> {
+        match self {
+            Self::TrustedPeer(peer) => Some(peer),
+            _ => None,
         }
     }
 }
@@ -196,7 +208,11 @@ impl FromStr for AnyNode {
             if let Ok(record) = NodeRecord::from_str(s) {
                 return Ok(Self::NodeRecord(record))
             }
-            // incomplete enode
+            // NodeRecord parsing rejects domain hosts, but trusted peers may use DNS names.
+            if let Ok(trusted) = TrustedPeer::from_str(s) {
+                return Ok(Self::TrustedPeer(trusted))
+            }
+            // incomplete enode with only a peer id
             if let Ok(peer_id) = PeerId::from_str(rem) {
                 return Ok(Self::PeerId(peer_id))
             }
@@ -219,6 +235,7 @@ impl core::fmt::Display for AnyNode {
             Self::PeerId(peer_id) => {
                 write!(f, "enode://{}", alloy_primitives::hex::encode(peer_id.as_slice()))
             }
+            Self::TrustedPeer(peer) => write!(f, "{peer}"),
         }
     }
 }
@@ -339,6 +356,20 @@ mod tests {
                 .parse::<PeerId>()
                 .unwrap()
         );
+        assert_eq!(node.to_string(), url);
+    }
+
+    #[test]
+    fn test_trusted_peer_parse_hostname() {
+        let url = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@my-node.example.com:30303";
+        let node: AnyNode = url.parse().unwrap();
+        assert!(matches!(node, AnyNode::TrustedPeer(_)));
+        assert_eq!(
+            node.peer_id(),
+            "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0".parse::<PeerId>().unwrap()
+        );
+        assert!(node.node_record().is_none());
+        assert!(node.trusted_peer().is_some());
         assert_eq!(node.to_string(), url);
     }
 

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -56,10 +56,18 @@ where
 
     /// Handler for `admin_addTrustedPeer`
     fn add_trusted_peer(&self, record: AnyNode) -> RpcResult<bool> {
-        if let Some(record) = record.node_record() {
-            self.network.add_trusted_peer_with_udp(record.id, record.tcp_addr(), record.udp_addr())
+        if let Some(trusted) = record.trusted_peer().cloned() {
+            self.network.add_trusted_peer_node(trusted);
+        } else {
+            if let Some(record) = record.node_record() {
+                self.network.add_trusted_peer_with_udp(
+                    record.id,
+                    record.tcp_addr(),
+                    record.udp_addr(),
+                )
+            }
+            self.network.add_trusted_peer_id(record.peer_id());
         }
-        self.network.add_trusted_peer_id(record.peer_id());
         Ok(true)
     }
 


### PR DESCRIPTION
Supersedes #24280.

Allows `admin_addTrustedPeer` to accept trusted peer enodes with hostnames by registering them for DNS resolution before insertion. Late resolver results are ignored after a peer is removed, so removed trusted peers are not re-added by an in-flight lookup.

The unrelated resolver cleanup from #24280 was extracted in #24406.