### PR TITLE
feat(evm): implement ExecutorTx for tx tuples

### DIFF
--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -436,6 +436,14 @@ impl<Executor: BlockExecutor> ExecutorTx<Executor> for Recovered<Executor::Trans
     }
 }
 
+impl<Executor: BlockExecutor> ExecutorTx<Executor>
+    for (<Executor::Evm as Evm>::Tx, Recovered<Executor::Transaction>)
+{
+    fn into_parts(self) -> (<Executor::Evm as Evm>::Tx, Recovered<Executor::Transaction>) {
+        self
+    }
+}
+
 impl<Executor> ExecutorTx<Executor>
     for WithTxEnv<<Executor::Evm as Evm>::Tx, Recovered<Executor::Transaction>>
 where


### PR DESCRIPTION
Allows `ExecutorTx` callers to pass precomputed EVM transaction environments together with recovered transactions as a plain tuple.

This avoids forcing tuple inputs through an extra wrapper when both executable parts are already available.