### PR TITLE
perf(evm): preallocate chain transaction hashes

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -447,6 +447,16 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
             .values()
             .flat_map(|block| block.body().transactions_iter().map(|tx| tx.trie_hash()))
     }
+
+    /// Returns all transaction hashes in a pre-allocated vector.
+    #[inline]
+    pub fn transaction_hashes_vec(&self) -> Vec<TxHash> {
+        let capacity = self.blocks.values().map(|block| block.body().transactions().len()).sum();
+
+        let mut hashes = Vec::with_capacity(capacity);
+        hashes.extend(self.transaction_hashes());
+        hashes
+    }
 }
 
 impl<B: Block> IntoIterator for ChainBlocks<'_, B> {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -416,7 +416,7 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                     pending_block_blob_fee,
                     changed_accounts,
                     // all transactions mined in the new chain need to be removed from the pool
-                    mined_transactions: new_blocks.transaction_hashes().collect(),
+                    mined_transactions: new_blocks.transaction_hashes_vec(),
                     update_kind: PoolUpdateKind::Reorg,
                 };
                 pool.on_canonical_state_change(update);
@@ -483,7 +483,7 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                     changed_accounts.push(acc);
                 }
 
-                let mined_transactions = blocks.transaction_hashes().collect();
+                let mined_transactions = blocks.transaction_hashes_vec();
 
                 // check if the range of the commit is canonical with the pool's block
                 if first_block.parent_hash() != pool_info.last_seen_block_hash {


### PR DESCRIPTION
Adds an exact-capacity helper for collecting chain transaction hashes into a vector and uses it for txpool canonical updates.

This avoids repeated generic `Vec` growth at the call sites that need mined transaction hashes as a `Vec`, while remaining compatible with the cached hash iteration in #24474.