### PR TITLE
refactor(evm): add chain transaction hash iterator

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -210,6 +210,11 @@ impl<N: NodePrimitives> Chain<N> {
         self.blocks_iter().flat_map(|block| block.body().transactions())
     }
 
+    /// Returns an iterator over all transaction hashes in the chain.
+    pub fn transaction_hashes(&self) -> impl Iterator<Item = &TxHash> + '_ {
+        self.transactions_iter().map(|tx| tx.tx_hash())
+    }
+
     /// Returns an iterator over all [`Recovered`] transaction references in the chain.
     pub fn transactions_recovered_iter(
         &self,


### PR DESCRIPTION
Adds `Chain::transaction_hashes()` so callers can iterate borrowed transaction hashes directly from a chain segment. This mirrors the existing transaction iterator while avoiding repeated block/body traversal at call sites.