### PR TITLE
fix: use tx_hash for transaction identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10089,6 +10089,7 @@ name = "reth-stages"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9611,7 +9611,6 @@ name = "reth-prune"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "assert_matches",
  "itertools 0.14.0",
@@ -10090,7 +10089,6 @@ name = "reth-stages"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",

--- a/crates/chain-state/src/notifications.rs
+++ b/crates/chain-state/src/notifications.rs
@@ -1,6 +1,6 @@
 //! Canonical chain state notification trait and types.
 
-use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
+use alloy_eips::BlockNumHash;
 use derive_more::{Deref, DerefMut};
 use reth_execution_types::{BlockReceipts, Chain};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock, SealedHeader};
@@ -157,10 +157,7 @@ impl<N: NodePrimitives> CanonStateNotification<N> {
     ///
     /// The boolean in the tuple (2nd element) denotes whether the receipt was from the reverted
     /// chain segment.
-    pub fn block_receipts(&self) -> Vec<(BlockReceipts<N::Receipt>, bool)>
-    where
-        N::SignedTx: Encodable2718,
-    {
+    pub fn block_receipts(&self) -> Vec<(BlockReceipts<N::Receipt>, bool)> {
         let mut receipts = Vec::new();
 
         // get old receipts

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -6,6 +6,7 @@ use reth_node_api::{BlockBody, FullNodeComponents};
 use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::args::DevArgs;
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_primitives_traits::transaction::TxHashRef;
 use reth_provider::{providers::BlockchainProvider, CanonStateSubscriptions};
 use reth_rpc_eth_api::{helpers::EthTransactions, EthApiServer};
 use reth_tasks::Runtime;

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -1,4 +1,3 @@
-use alloy_eips::eip2718::Encodable2718;
 use alloy_genesis::Genesis;
 use alloy_primitives::{b256, hex, Address};
 use futures::StreamExt;
@@ -99,7 +98,7 @@ where
     let head = notifications.next().await.unwrap();
 
     let tx = &head.tip().body().transactions()[0];
-    assert_eq!(tx.trie_hash(), hash);
+    assert_eq!(*tx.tx_hash(), hash);
     println!("mined transaction: {hash}");
 }
 

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -2,8 +2,8 @@
 
 use crate::broadcast::decode_list_with_memory_budget;
 use alloc::vec::Vec;
-use alloy_consensus::transaction::PooledTransaction;
-use alloy_eips::{eip2718::Encodable2718, eip7594::Cell};
+use alloy_consensus::transaction::{PooledTransaction, TxHashRef};
+use alloy_eips::eip7594::Cell;
 use alloy_primitives::{B128, B256};
 use alloy_rlp::{Decodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use derive_more::{Constructor, Deref, IntoIterator};
@@ -82,10 +82,10 @@ impl<T: Decodable + InMemorySize> PooledTransactions<T> {
     }
 }
 
-impl<T: Encodable2718> PooledTransactions<T> {
+impl<T: TxHashRef> PooledTransactions<T> {
     /// Returns an iterator over the transaction hashes in this response.
     pub fn hashes(&self) -> impl Iterator<Item = B256> + '_ {
-        self.iter().map(|tx| tx.trie_hash())
+        self.iter().map(|tx| *tx.tx_hash())
     }
 }
 

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -27,7 +27,6 @@ reth-static-file-types.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true
-alloy-eips.workspace = true
 
 # metrics
 reth-metrics.workspace = true

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -1,5 +1,4 @@
 use crate::{segments::SegmentSet, Pruner};
-use alloy_eips::eip2718::Encodable2718;
 use reth_config::PruneConfig;
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_exex_types::FinishedExExHeight;
@@ -86,7 +85,7 @@ impl PrunerBuilder {
         PF: DatabaseProviderFactory<
                 ProviderRW: PruneCheckpointWriter
                                 + PruneCheckpointReader
-                                + BlockReader<Transaction: Encodable2718>
+                                + BlockReader
                                 + ChainStateBlockReader
                                 + StorageSettingsCache
                                 + StageCheckpointReader
@@ -126,7 +125,7 @@ impl PrunerBuilder {
         Provider: StaticFileProviderFactory<
                 Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
             > + DBProvider<Tx: DbTxMut>
-            + BlockReader<Transaction: Encodable2718>
+            + BlockReader
             + ChainStateBlockReader
             + PruneCheckpointWriter
             + PruneCheckpointReader

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -2,7 +2,6 @@ use crate::segments::{
     user::ReceiptsByLogs, AccountHistory, Bodies, Segment, SenderRecovery, StorageHistory,
     TransactionLookup, UserReceipts,
 };
-use alloy_eips::eip2718::Encodable2718;
 use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
@@ -52,7 +51,7 @@ where
         > + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
         + PruneCheckpointReader
-        + BlockReader<Transaction: Encodable2718>
+        + BlockReader
         + ChainStateBlockReader
         + StorageSettingsCache
         + ChangeSetReader

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -3,9 +3,10 @@ use crate::{
     segments::{PruneInput, Segment, SegmentOutput},
     PrunerError,
 };
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::transaction::TxHashRef;
 use rayon::prelude::*;
 use reth_db_api::{tables, transaction::DbTxMut};
+use reth_primitives_traits::SignedTransaction;
 use reth_provider::{
     BlockReader, DBProvider, PruneCheckpointReader, RocksDBProviderFactory,
     StaticFileProviderFactory,
@@ -31,7 +32,7 @@ impl TransactionLookup {
 impl<Provider> Segment<Provider> for TransactionLookup
 where
     Provider: DBProvider<Tx: DbTxMut>
-        + BlockReader<Transaction: Encodable2718>
+        + BlockReader<Transaction: SignedTransaction>
         + PruneCheckpointReader
         + StaticFileProviderFactory
         + StorageSettingsCache
@@ -131,11 +132,11 @@ where
                 .unwrap();
         let tx_range_end = *tx_range.end();
 
-        // Retrieve transactions in the range and calculate their hashes in parallel
+        // Retrieve transactions in the range and collect their hashes in parallel.
         let mut hashes = provider
             .transactions_by_tx_range(tx_range.clone())?
             .into_par_iter()
-            .map(|transaction| transaction.trie_hash())
+            .map(|transaction| *transaction.tx_hash())
             .collect::<Vec<_>>();
 
         // Sort hashes to enable efficient cursor traversal through the TransactionHashNumbers
@@ -204,7 +205,7 @@ impl TransactionLookup {
     ) -> Result<SegmentOutput, PrunerError>
     where
         Provider: DBProvider
-            + BlockReader<Transaction: Encodable2718>
+            + BlockReader<Transaction: SignedTransaction>
             + StaticFileProviderFactory
             + RocksDBProviderFactory,
     {
@@ -235,11 +236,11 @@ impl TransactionLookup {
             .map_or(end, |limited| limited.min(end));
         let tx_range = start..=tx_range_end;
 
-        // Retrieve transactions in the range and calculate their hashes in parallel
+        // Retrieve transactions in the range and collect their hashes in parallel.
         let hashes: Vec<_> = provider
             .transactions_by_tx_range(tx_range.clone())?
             .into_par_iter()
-            .map(|transaction| transaction.trie_hash())
+            .map(|transaction| *transaction.tx_hash())
             .collect();
 
         // Number of transactions retrieved from the database should match the tx range count

--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -2,8 +2,8 @@
 //!
 //! Log parsing for building filter.
 
-use alloy_consensus::TxReceipt;
-use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
+use alloy_consensus::{transaction::TxHashRef, TxReceipt};
+use alloy_eips::BlockNumHash;
 use alloy_primitives::TxHash;
 use alloy_rpc_types_eth::{Filter, Log};
 use reth_chainspec::ChainInfo;
@@ -102,7 +102,7 @@ where
                 if transaction_hash.is_none() {
                     transaction_hash = match &provider_or_block {
                         ProviderOrBlock::Block(block) => {
-                            block.body().transactions().get(receipt_idx).map(|t| t.trie_hash())
+                            block.body().transactions().get(receipt_idx).map(|t| *t.tx_hash())
                         }
                         ProviderOrBlock::Provider(provider) => {
                             let first_tx_num = match loaded_first_tx_num {
@@ -126,7 +126,7 @@ where
                                     ProviderError::TransactionNotFound(transaction_id.into())
                                 })?;
 
-                            Some(transaction.trie_hash())
+                            Some(*transaction.tx_hash())
                         }
                     };
                 }

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -2,6 +2,7 @@
 //!
 //! Transaction wrapper that labels transaction with its origin.
 
+use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::TransactionInfo;
 use reth_ethereum_primitives::TransactionSigned;
@@ -59,7 +60,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
                 base_fee,
             } => {
                 let tx_info = TransactionInfo {
-                    hash: Some(transaction.trie_hash()),
+                    hash: Some(*transaction.tx_hash()),
                     index: Some(index),
                     block_hash: Some(block_hash),
                     block_number: Some(block_number),
@@ -76,7 +77,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
     pub fn split(self) -> (Recovered<T>, TransactionInfo) {
         match self {
             Self::Pool(tx) => {
-                let hash = tx.trie_hash();
+                let hash = *tx.tx_hash();
                 (tx, TransactionInfo { hash: Some(hash), ..Default::default() })
             }
             Self::Block {
@@ -87,7 +88,7 @@ impl<T: SignedTransaction> TransactionSource<T> {
                 block_timestamp,
                 base_fee,
             } => {
-                let hash = transaction.trie_hash();
+                let hash = *transaction.tx_hash();
                 (
                     transaction,
                     TransactionInfo {

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -85,6 +85,7 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 reth-network-peers.workspace = true
 
 alloy-genesis.workspace = true
+alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["getrandom", "rand"] }
 reth-db-common.workspace = true
 reth-tracing.workspace = true

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -45,7 +45,6 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 
 reth-testing-utils = { workspace = true, optional = true }
 
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -1,4 +1,4 @@
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{TxHash, TxNumber};
 use num_traits::Zero;
 use reth_config::config::{EtlConfig, TransactionLookupConfig};
@@ -237,7 +237,7 @@ where
                 for transaction in
                     static_file_provider.transactions_by_tx_range(body.tx_num_range())?
                 {
-                    writer.delete_transaction_hash_number(transaction.trie_hash())?;
+                    writer.delete_transaction_hash_number(*transaction.tx_hash())?;
                 }
             }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -7,11 +7,11 @@ use crate::{
     StageCheckpointReader, StateReader, StaticFileProviderFactory, TransactionVariant,
     TransactionsProvider,
 };
-use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
-use alloy_eips::{
-    eip2718::Encodable2718, BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag,
-    HashOrNumber,
+use alloy_consensus::{
+    transaction::{TransactionMeta, TxHashRef},
+    BlockHeader,
 };
+use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, HashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStateProviderRef};
 use reth_chainspec::ChainInfo;
@@ -399,7 +399,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             for tx_index in 0..block.body().transactions().len() {
                 match id {
                     HashOrNumber::Hash(tx_hash) => {
-                        if tx_hash == block.body().transactions()[tx_index].trie_hash() {
+                        if tx_hash == *block.body().transactions()[tx_index].tx_hash() {
                             return fetch_from_block_state(tx_index, in_memory_tx_num, block_state)
                         }
                     }
@@ -914,7 +914,7 @@ impl<N: ProviderNodeTypes> ReceiptProvider for ConsistentProvider<N> {
             );
 
             if let Some(tx_index) =
-                block.body().transactions_iter().position(|tx| tx.trie_hash() == hash)
+                block.body().transactions_iter().position(|tx| *tx.tx_hash() == hash)
             {
                 // safe to use tx_index for receipts due to 1:1 correspondence
                 return Ok(receipts.get(tx_index).cloned());

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -6,7 +6,7 @@
 
 use super::RocksDBProvider;
 use crate::StaticFileProviderFactory;
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::BlockNumber;
 use rayon::prelude::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
@@ -45,7 +45,7 @@ impl RocksDBProvider {
     /// # Requirements
     ///
     /// For pruning `TransactionHashNumbers`, the provider must be able to supply transaction
-    /// data (typically from static files) so that transaction hashes can be computed. This
+    /// data (typically from static files) so that transaction hashes can be read. This
     /// implies that static files should be ahead of or in sync with `RocksDB`.
     pub fn check_consistency<Provider>(
         &self,
@@ -59,7 +59,7 @@ impl RocksDBProvider {
             + BlockBodyIndicesProvider
             + StorageChangeSetReader
             + ChangeSetReader
-            + TransactionsProvider<Transaction: Encodable2718>
+            + TransactionsProvider
             + ChainSpecProvider,
     {
         let mut unwind_target: Option<BlockNumber> = None;
@@ -103,7 +103,7 @@ impl RocksDBProvider {
             + StageCheckpointReader
             + StaticFileProviderFactory
             + BlockBodyIndicesProvider
-            + TransactionsProvider<Transaction: Encodable2718>,
+            + TransactionsProvider,
     {
         let checkpoint = provider
             .get_stage_checkpoint(StageId::TransactionLookup)?
@@ -205,7 +205,7 @@ impl RocksDBProvider {
 
     /// Prunes `TransactionHashNumbers` entries for transactions in the given range.
     ///
-    /// This fetches transactions from the provider, computes their hashes in parallel,
+    /// This fetches transactions from the provider, reads their hashes in parallel,
     /// and deletes the corresponding entries from `RocksDB` by key. This approach is more
     /// scalable than iterating all rows because it only processes the transactions that
     /// need to be pruned.
@@ -213,7 +213,7 @@ impl RocksDBProvider {
     /// # Requirements
     ///
     /// The provider must be able to supply transaction data (typically from static files)
-    /// so that transaction hashes can be computed. This implies that static files should
+    /// so that transaction hashes can be read. This implies that static files should
     /// be ahead of or in sync with `RocksDB`.
     fn prune_transaction_hash_numbers_in_range<Provider>(
         &self,
@@ -221,17 +221,17 @@ impl RocksDBProvider {
         tx_range: std::ops::RangeInclusive<u64>,
     ) -> ProviderResult<()>
     where
-        Provider: TransactionsProvider<Transaction: Encodable2718>,
+        Provider: TransactionsProvider,
     {
         if tx_range.is_empty() {
             return Ok(());
         }
 
-        // Fetch transactions in the range and compute their hashes in parallel
+        // Fetch transactions in the range and read their hashes in parallel.
         let hashes: Vec<_> = provider
             .transactions_by_tx_range(tx_range.clone())?
             .into_par_iter()
-            .map(|tx| tx.trie_hash())
+            .map(|tx| *tx.tx_hash())
             .collect();
 
         if !hashes.is_empty() {
@@ -632,7 +632,7 @@ mod tests {
                     .insert_block(&block.clone().try_recover().expect("recover block"))
                     .unwrap();
                 for tx in &block.body().transactions {
-                    let hash = tx.trie_hash();
+                    let hash = *tx.tx_hash();
                     tx_hashes.push(hash);
                     rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
                     tx_count += 1;
@@ -759,7 +759,7 @@ mod tests {
                     .insert_block(&block.clone().try_recover().expect("recover block"))
                     .unwrap();
                 for tx in &block.body().transactions {
-                    let hash = tx.trie_hash();
+                    let hash = *tx.tx_hash();
                     rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
                     tx_count += 1;
                 }
@@ -821,7 +821,7 @@ mod tests {
                     .insert_block(&block.clone().try_recover().expect("recover block"))
                     .unwrap();
                 for tx in &block.body().transactions {
-                    let hash = tx.trie_hash();
+                    let hash = *tx.tx_hash();
                     tx_hashes.push(hash);
                     rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
                     tx_count += 1;
@@ -972,7 +972,7 @@ mod tests {
         assert_eq!(result, Some(0), "sf_tip=0 < checkpoint=100 returns unwind target");
     }
 
-    /// Test that pruning works by fetching transactions and computing their hashes,
+    /// Test that pruning works by fetching transactions and reading their hashes,
     /// rather than iterating all rows. This test uses random blocks with unique
     /// transactions so we can verify the correct entries are pruned.
     #[test]
@@ -1010,7 +1010,7 @@ mod tests {
 
                 // Store transaction hash -> tx_number mappings in RocksDB
                 for tx in &block.body().transactions {
-                    let hash = tx.trie_hash();
+                    let hash = *tx.tx_hash();
                     tx_hashes.push(hash);
                     rocksdb.put::<tables::TransactionHashNumbers>(hash, &tx_count).unwrap();
                     tx_count += 1;
@@ -1045,13 +1045,13 @@ mod tests {
         let all_txs = provider.transactions_by_tx_range(0..tx_count).unwrap();
         assert_eq!(all_txs.len(), tx_count as usize, "Should be able to fetch all transactions");
 
-        // Verify the hashes match between what we stored and what we compute from fetched txs
+        // Verify the hashes match between what we stored and what we read from fetched txs.
         for (i, tx) in all_txs.iter().enumerate() {
-            let computed_hash = tx.trie_hash();
+            let fetched_hash = *tx.tx_hash();
             assert_eq!(
-                computed_hash, tx_hashes[i],
-                "Hash mismatch for tx {}: stored {:?} vs computed {:?}",
-                i, tx_hashes[i], computed_hash
+                fetched_hash, tx_hashes[i],
+                "Hash mismatch for tx {}: stored {:?} vs fetched {:?}",
+                i, tx_hashes[i], fetched_hash
             );
         }
 

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -6,8 +6,8 @@ use crate::{
     to_range, BlockHashReader, BlockNumReader, HeaderProvider, ReceiptProvider,
     TransactionsProvider,
 };
-use alloy_consensus::transaction::TransactionMeta;
-use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
+use alloy_consensus::transaction::{TransactionMeta, TxHashRef};
+use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 use reth_chainspec::ChainInfo;
 use reth_db::static_file::{
@@ -264,7 +264,7 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
 
         Ok(cursor
             .get_one::<TransactionMask<Self::Transaction>>((&hash).into())?
-            .and_then(|res| (res.trie_hash() == hash).then(|| cursor.number()).flatten()))
+            .and_then(|res| (*res.tx_hash() == hash).then(|| cursor.number()).flatten()))
     }
 
     fn transaction_by_id(&self, num: TxNumber) -> ProviderResult<Option<Self::Transaction>> {

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -8,9 +8,12 @@ use crate::{
     EitherWriterDestination, HeaderProvider, ReceiptProvider, StageCheckpointReader, StatsReader,
     TransactionVariant, TransactionsProvider, TransactionsProviderExt,
 };
-use alloy_consensus::{transaction::TransactionMeta, Header};
-use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
-use alloy_primitives::{b256, keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use alloy_consensus::{
+    transaction::{TransactionMeta, TxHashRef},
+    Header,
+};
+use alloy_eips::BlockHashOrNumber;
+use alloy_primitives::{b256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
 
 use parking_lot::RwLock;
 use reth_chain_state::ExecutedBlock;
@@ -2715,10 +2718,8 @@ impl<N: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>> Tra
             let manager = self.clone();
 
             // Spawn the task onto the global rayon pool
-            // This task will send the results through the channel after it has calculated
-            // the hash.
+            // This task will send the cached transaction hash through the channel.
             rayon::spawn(move || {
-                let mut rlp_buf = Vec::with_capacity(128);
                 let _ = manager.fetch_range_with_predicate(
                     StaticFileSegment::Transactions,
                     chunk_range,
@@ -2726,9 +2727,7 @@ impl<N: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>> Tra
                         Ok(cursor
                             .get_one::<TransactionMask<Self::Transaction>>(number.into())?
                             .map(|transaction| {
-                                rlp_buf.clear();
-                                let _ = channel_tx
-                                    .send(calculate_hash((number, transaction), &mut rlp_buf));
+                                let _ = channel_tx.send(transaction_hash((number, transaction)));
                             }))
                     },
                     |_| true,
@@ -2760,7 +2759,7 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
             let mut cursor = jar_provider.cursor()?;
             if cursor
                 .get_one::<TransactionMask<Self::Transaction>>((&tx_hash).into())?
-                .and_then(|tx| (tx.trie_hash() == tx_hash).then_some(tx))
+                .and_then(|tx| (*tx.tx_hash() == tx_hash).then_some(tx))
                 .is_some()
             {
                 Ok(cursor.number())
@@ -2802,7 +2801,7 @@ impl<N: NodePrimitives<SignedTx: Decompress + SignedTransaction>> TransactionsPr
             Ok(jar_provider
                 .cursor()?
                 .get_one::<TransactionMask<Self::Transaction>>((&hash).into())?
-                .and_then(|tx| (tx.trie_hash() == hash).then_some(tx)))
+                .and_then(|tx| (*tx.tx_hash() == hash).then_some(tx)))
         })
     }
 
@@ -3004,18 +3003,14 @@ impl<N: NodePrimitives> StatsReader for StaticFileProvider<N> {
     }
 }
 
-/// Calculates the tx hash for the given transaction and its id.
+/// Returns the tx hash for the given transaction and its id.
 #[inline]
-fn calculate_hash<T>(
-    entry: (TxNumber, T),
-    rlp_buf: &mut Vec<u8>,
-) -> Result<(B256, TxNumber), Box<ProviderError>>
+fn transaction_hash<T>(entry: (TxNumber, T)) -> Result<(B256, TxNumber), Box<ProviderError>>
 where
-    T: Encodable2718,
+    T: TxHashRef,
 {
     let (tx_id, tx) = entry;
-    tx.encode_2718(rlp_buf);
-    Ok((keccak256(rlp_buf), tx_id))
+    Ok((*tx.tx_hash(), tx_id))
 }
 
 #[cfg(test)]

--- a/crates/transaction-pool/src/blobstore/tracker.rs
+++ b/crates/transaction-pool/src/blobstore/tracker.rs
@@ -1,7 +1,6 @@
 //! Support for maintaining the blob pool.
 
-use alloy_consensus::Typed2718;
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::{transaction::TxHashRef, Typed2718};
 use alloy_primitives::{BlockNumber, B256};
 use reth_execution_types::ChainBlocks;
 use reth_primitives_traits::{Block, BlockBody, SignedTransaction};
@@ -50,7 +49,7 @@ impl BlobStoreCanonTracker {
                 .transactions()
                 .iter()
                 .filter(|tx| tx.is_eip4844())
-                .map(|tx| tx.trie_hash());
+                .map(|tx| *tx.tx_hash());
             (*num, iter)
         });
         self.add_blocks(blob_txs);


### PR DESCRIPTION
Replaces remaining transaction-identity uses of `Encodable2718::trie_hash` with cached `tx_hash()` values across lookup, provider, RPC, network, and pool paths.

This keeps `trie_hash` reserved for trie/proof commitments and avoids re-encoding transactions where the canonical transaction hash is already available. Also removes stale `Encodable2718` bounds and crate dependencies from prune and stages after the cleanup.
