### PR TITLE
fix(consensus): validate Amsterdam header fields

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -330,6 +330,14 @@ pub enum ConsensusError {
     #[error("missing requests hash")]
     RequestsHashMissing,
 
+    /// Error when the block access list hash is missing.
+    #[error("missing block access list hash")]
+    BlockAccessListHashMissing,
+
+    /// Error when the slot number is missing.
+    #[error("missing slot number")]
+    SlotNumberMissing,
+
     /// Error when an unexpected withdrawals root is encountered.
     #[error("unexpected withdrawals root")]
     WithdrawalsRootUnexpected,
@@ -337,6 +345,14 @@ pub enum ConsensusError {
     /// Error when an unexpected requests hash is encountered.
     #[error("unexpected requests hash")]
     RequestsHashUnexpected,
+
+    /// Error when an unexpected block access list hash is encountered.
+    #[error("unexpected block access list hash")]
+    BlockAccessListHashUnexpected,
+
+    /// Error when an unexpected slot number is encountered.
+    #[error("unexpected slot number")]
+    SlotNumberUnexpected,
 
     /// Error when withdrawals are missing.
     #[error("missing withdrawals")]

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -235,6 +235,22 @@ where
             return Err(ConsensusError::RequestsHashUnexpected)
         }
 
+        if self.chain_spec.is_amsterdam_active_at_timestamp(header.timestamp()) {
+            if header.block_access_list_hash().is_none() {
+                return Err(ConsensusError::BlockAccessListHashMissing)
+            }
+            if header.slot_number().is_none() {
+                return Err(ConsensusError::SlotNumberMissing)
+            }
+        } else {
+            if header.block_access_list_hash().is_some() {
+                return Err(ConsensusError::BlockAccessListHashUnexpected)
+            }
+            if header.slot_number().is_some() {
+                return Err(ConsensusError::SlotNumberUnexpected)
+            }
+        }
+
         Ok(())
     }
 
@@ -270,6 +286,7 @@ where
 mod tests {
     use super::*;
     use alloy_consensus::Header;
+    use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
     use alloy_primitives::B256;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder};
     use reth_consensus_common::validation::validate_against_parent_gas_limit;
@@ -281,6 +298,18 @@ mod tests {
     fn header_with_gas_limit(gas_limit: u64) -> SealedHeader {
         let header = reth_primitives_traits::Header { gas_limit, ..Default::default() };
         SealedHeader::new(header, B256::ZERO)
+    }
+
+    fn valid_prague_header() -> reth_primitives_traits::Header {
+        reth_primitives_traits::Header {
+            base_fee_per_gas: Some(1337),
+            withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            parent_beacon_block_root: Some(B256::ZERO),
+            requests_hash: Some(EMPTY_REQUESTS_HASH),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -360,6 +389,74 @@ mod tests {
             withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
             ..Default::default()
         };
+
+        assert!(EthBeaconConsensus::new(chain_spec)
+            .validate_header(&SealedHeader::seal_slow(header,))
+            .is_ok());
+    }
+
+    #[test]
+    fn prague_header_rejects_block_access_list_hash_before_amsterdam() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
+        let mut header = valid_prague_header();
+        header.block_access_list_hash = Some(B256::ZERO);
+
+        assert!(matches!(
+            EthBeaconConsensus::new(chain_spec)
+                .validate_header(&SealedHeader::seal_slow(header,))
+                .unwrap_err(),
+            ConsensusError::BlockAccessListHashUnexpected
+        ));
+    }
+
+    #[test]
+    fn prague_header_rejects_slot_number_before_amsterdam() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
+        let mut header = valid_prague_header();
+        header.slot_number = Some(0);
+
+        assert!(matches!(
+            EthBeaconConsensus::new(chain_spec)
+                .validate_header(&SealedHeader::seal_slow(header,))
+                .unwrap_err(),
+            ConsensusError::SlotNumberUnexpected
+        ));
+    }
+
+    #[test]
+    fn amsterdam_header_requires_block_access_list_hash() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().amsterdam_activated().build());
+        let mut header = valid_prague_header();
+        header.slot_number = Some(0);
+
+        assert!(matches!(
+            EthBeaconConsensus::new(chain_spec)
+                .validate_header(&SealedHeader::seal_slow(header,))
+                .unwrap_err(),
+            ConsensusError::BlockAccessListHashMissing
+        ));
+    }
+
+    #[test]
+    fn amsterdam_header_requires_slot_number() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().amsterdam_activated().build());
+        let mut header = valid_prague_header();
+        header.block_access_list_hash = Some(B256::ZERO);
+
+        assert!(matches!(
+            EthBeaconConsensus::new(chain_spec)
+                .validate_header(&SealedHeader::seal_slow(header,))
+                .unwrap_err(),
+            ConsensusError::SlotNumberMissing
+        ));
+    }
+
+    #[test]
+    fn amsterdam_header_accepts_block_access_list_hash_and_slot_number() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().amsterdam_activated().build());
+        let mut header = valid_prague_header();
+        header.block_access_list_hash = Some(B256::ZERO);
+        header.slot_number = Some(0);
 
         assert!(EthBeaconConsensus::new(chain_spec)
             .validate_header(&SealedHeader::seal_slow(header,))


### PR DESCRIPTION
Reject pre-Amsterdam headers that include Amsterdam-only `block_access_list_hash` or `slot_number`, and require both fields once Amsterdam is active.

This mirrors the existing fork-specific presence checks for Shanghai, Cancun, and Prague header extensions, preventing Prague blocks from carrying Amsterdam-only fields.