### PR TITLE
perf(network): use FbBuildHasher for transaction manager maps

### DIFF
--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -19,25 +19,21 @@ where
     inner: LruMap<T, (), ByLength, S>,
 }
 
-impl<T: Hash + Eq + fmt::Debug, S: BuildHasher + Default> LruCache<T, S> {
+impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
     /// Creates a new [`LruCache`] using the given limit
     pub fn new(limit: u32) -> Self {
-        // limit of lru map is one element more, so can give eviction feedback, which isn't
-        // supported by LruMap
-        Self { inner: LruMap::new(limit + 1), limit }
+        Self::with_hasher(limit, Default::default())
     }
 }
 
 impl<T: Hash + Eq + fmt::Debug, S: BuildHasher> LruCache<T, S> {
     /// Creates a new [`LruCache`] using the given limit and hash builder.
-    pub const fn with_hasher(limit: u32, hasher: S) -> Self {
+    pub fn with_hasher(limit: u32, hash_builder: S) -> Self {
         // limit of lru map is one element more, so can give eviction feedback, which isn't
         // supported by LruMap
-        Self { limit, inner: LruMap::with_hasher(limit + 1, hasher) }
+        Self { inner: LruMap::with_hasher(limit + 1, hash_builder), limit }
     }
-}
 
-impl<T: Hash + Eq + fmt::Debug, S: BuildHasher> LruCache<T, S> {
     /// Insert an element into the set.
     ///
     /// This operation uses `get_or_insert` from the underlying `schnellru::LruMap` which:
@@ -183,14 +179,13 @@ where
     }
 }
 
-impl<K, V, S> LruMap<K, V, ByLength, S>
+impl<K, V> LruMap<K, V>
 where
     K: Hash + PartialEq,
-    S: BuildHasher + Default,
 {
-    /// Returns a new cache with given limiter and default hash builder.
+    /// Returns a new cache with default limiter and hash builder.
     pub fn new(max_length: u32) -> Self {
-        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), S::default()))
+        Self::with_hasher(max_length, Default::default())
     }
 }
 
@@ -199,9 +194,9 @@ where
     K: Hash + PartialEq,
     S: BuildHasher,
 {
-    /// Returns a new map with given limiter and hash builder.
-    pub const fn with_hasher(max_length: u32, hasher: S) -> Self {
-        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), hasher))
+    /// Returns a new cache with default limiter and the given hash builder.
+    pub fn with_hasher(max_length: u32, hash_builder: S) -> Self {
+        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), hash_builder))
     }
 }
 
@@ -245,7 +240,7 @@ mod test {
 
     #[test]
     fn test_cache_should_insert_into_empty_set() {
-        let mut cache = LruCache::with_hasher(5, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(5);
         let entry = "entry";
         assert!(cache.insert(entry));
         assert!(cache.contains(&entry));
@@ -253,7 +248,7 @@ mod test {
 
     #[test]
     fn test_cache_should_not_insert_same_value_twice() {
-        let mut cache = LruCache::with_hasher(5, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(5);
         let entry = "entry";
         assert!(cache.insert(entry));
         assert!(!cache.insert(entry));
@@ -261,7 +256,7 @@ mod test {
 
     #[test]
     fn test_cache_should_remove_oldest_element_when_exceeding_limit() {
-        let mut cache = LruCache::with_hasher(1, DefaultHashBuilder::default()); // LruCache limit will be 2, check LruCache::new
+        let mut cache = LruCache::new(1); // LruCache limit will be 2, check LruCache::new
         let old_entry = "old_entry";
         let new_entry = "new_entry";
         cache.insert(old_entry);
@@ -273,7 +268,7 @@ mod test {
 
     #[test]
     fn test_cache_should_extend_an_array() {
-        let mut cache = LruCache::with_hasher(5, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(5);
         let entries = ["some_entry", "another_entry"];
         cache.extend(entries);
         for e in entries {
@@ -287,7 +282,7 @@ mod test {
         #[derive(Debug)]
         struct Value(i8);
 
-        let mut cache = LruMap::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruMap::new(2);
         let key_1 = Key(1);
         let value_1 = Value(11);
         cache.insert(key_1, value_1);
@@ -303,7 +298,7 @@ mod test {
 
     #[test]
     fn test_debug_impl_lru_cache() {
-        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(2);
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -317,7 +312,7 @@ mod test {
 
     #[test]
     fn get() {
-        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(2);
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -334,7 +329,7 @@ mod test {
 
     #[test]
     fn get_ty_custom_eq_impl() {
-        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(2);
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
         let key_2 = CompoundKey::new(2, 22);
@@ -347,7 +342,7 @@ mod test {
 
     #[test]
     fn peek() {
-        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(2);
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -364,7 +359,7 @@ mod test {
 
     #[test]
     fn peek_ty_custom_eq_impl() {
-        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(2);
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
         let key_2 = CompoundKey::new(2, 22);
@@ -377,7 +372,7 @@ mod test {
 
     #[test]
     fn test_insert_methods() {
-        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
+        let mut cache = LruCache::new(2);
 
         // Test basic insert
         assert!(cache.insert("first")); // new entry

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -11,19 +11,24 @@ use std::{fmt, hash::Hash};
 ///
 /// If the length exceeds the set capacity, the oldest element will be removed
 /// In the limit, for each element inserted the oldest existing element will be removed.
-pub struct LruCache<T: Hash + Eq + fmt::Debug> {
+pub struct LruCache<T: Hash + Eq + fmt::Debug, S = DefaultHashBuilder>
+where
+    S: BuildHasher,
+{
     limit: u32,
-    inner: LruMap<T, ()>,
+    inner: LruMap<T, (), ByLength, S>,
 }
 
-impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
+impl<T: Hash + Eq + fmt::Debug, S: BuildHasher + Default> LruCache<T, S> {
     /// Creates a new [`LruCache`] using the given limit
     pub fn new(limit: u32) -> Self {
         // limit of lru map is one element more, so can give eviction feedback, which isn't
         // supported by LruMap
         Self { inner: LruMap::new(limit + 1), limit }
     }
+}
 
+impl<T: Hash + Eq + fmt::Debug, S: BuildHasher> LruCache<T, S> {
     /// Insert an element into the set.
     ///
     /// This operation uses `get_or_insert` from the underlying `schnellru::LruMap` which:
@@ -105,9 +110,10 @@ impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
     }
 }
 
-impl<T> Extend<T> for LruCache<T>
+impl<T, S> Extend<T> for LruCache<T, S>
 where
     T: Eq + Hash + fmt::Debug,
+    S: BuildHasher,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         for item in iter {
@@ -116,9 +122,10 @@ where
     }
 }
 
-impl<T> fmt::Debug for LruCache<T>
+impl<T, S> fmt::Debug for LruCache<T, S>
 where
     T: fmt::Debug + Hash + Eq,
+    S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_struct = f.debug_struct("LruCache");
@@ -167,13 +174,14 @@ where
     }
 }
 
-impl<K, V> LruMap<K, V>
+impl<K, V, S> LruMap<K, V, ByLength, S>
 where
     K: Hash + PartialEq,
+    S: BuildHasher + Default,
 {
-    /// Returns a new cache with default limiter and hash builder.
+    /// Returns a new cache with default limiter and the given hash builder.
     pub fn new(max_length: u32) -> Self {
-        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), Default::default()))
+        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), S::default()))
     }
 }
 
@@ -217,7 +225,7 @@ mod test {
 
     #[test]
     fn test_cache_should_insert_into_empty_set() {
-        let mut cache = LruCache::new(5);
+        let mut cache = LruCache::<&str>::new(5);
         let entry = "entry";
         assert!(cache.insert(entry));
         assert!(cache.contains(&entry));
@@ -225,7 +233,7 @@ mod test {
 
     #[test]
     fn test_cache_should_not_insert_same_value_twice() {
-        let mut cache = LruCache::new(5);
+        let mut cache = LruCache::<&str>::new(5);
         let entry = "entry";
         assert!(cache.insert(entry));
         assert!(!cache.insert(entry));
@@ -233,7 +241,7 @@ mod test {
 
     #[test]
     fn test_cache_should_remove_oldest_element_when_exceeding_limit() {
-        let mut cache = LruCache::new(1); // LruCache limit will be 2, check LruCache::new
+        let mut cache = LruCache::<&str>::new(1); // LruCache limit will be 2, check LruCache::new
         let old_entry = "old_entry";
         let new_entry = "new_entry";
         cache.insert(old_entry);
@@ -245,7 +253,7 @@ mod test {
 
     #[test]
     fn test_cache_should_extend_an_array() {
-        let mut cache = LruCache::new(5);
+        let mut cache = LruCache::<&str>::new(5);
         let entries = ["some_entry", "another_entry"];
         cache.extend(entries);
         for e in entries {
@@ -259,7 +267,7 @@ mod test {
         #[derive(Debug)]
         struct Value(i8);
 
-        let mut cache = LruMap::new(2);
+        let mut cache = LruMap::<Key, Value>::new(2);
         let key_1 = Key(1);
         let value_1 = Value(11);
         cache.insert(key_1, value_1);
@@ -275,7 +283,7 @@ mod test {
 
     #[test]
     fn test_debug_impl_lru_cache() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::<Key>::new(2);
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -289,7 +297,7 @@ mod test {
 
     #[test]
     fn get() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::<Key>::new(2);
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -306,7 +314,7 @@ mod test {
 
     #[test]
     fn get_ty_custom_eq_impl() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::<CompoundKey>::new(2);
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
         let key_2 = CompoundKey::new(2, 22);
@@ -319,7 +327,7 @@ mod test {
 
     #[test]
     fn peek() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::<Key>::new(2);
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -336,7 +344,7 @@ mod test {
 
     #[test]
     fn peek_ty_custom_eq_impl() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::<CompoundKey>::new(2);
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
         let key_2 = CompoundKey::new(2, 22);
@@ -349,7 +357,7 @@ mod test {
 
     #[test]
     fn test_insert_methods() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::<&str>::new(2);
 
         // Test basic insert
         assert!(cache.insert("first")); // new entry

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -29,6 +29,15 @@ impl<T: Hash + Eq + fmt::Debug, S: BuildHasher + Default> LruCache<T, S> {
 }
 
 impl<T: Hash + Eq + fmt::Debug, S: BuildHasher> LruCache<T, S> {
+    /// Creates a new [`LruCache`] using the given limit and hash builder.
+    pub const fn with_hasher(limit: u32, hasher: S) -> Self {
+        // limit of lru map is one element more, so can give eviction feedback, which isn't
+        // supported by LruMap
+        Self { limit, inner: LruMap::with_hasher(limit + 1, hasher) }
+    }
+}
+
+impl<T: Hash + Eq + fmt::Debug, S: BuildHasher> LruCache<T, S> {
     /// Insert an element into the set.
     ///
     /// This operation uses `get_or_insert` from the underlying `schnellru::LruMap` which:
@@ -179,9 +188,20 @@ where
     K: Hash + PartialEq,
     S: BuildHasher + Default,
 {
-    /// Returns a new cache with default limiter and the given hash builder.
+    /// Returns a new cache with given limiter and default hash builder.
     pub fn new(max_length: u32) -> Self {
         Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), S::default()))
+    }
+}
+
+impl<K, V, S> LruMap<K, V, ByLength, S>
+where
+    K: Hash + PartialEq,
+    S: BuildHasher,
+{
+    /// Returns a new map with given limiter and hash builder.
+    pub const fn with_hasher(max_length: u32, hasher: S) -> Self {
+        Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), hasher))
     }
 }
 
@@ -225,7 +245,7 @@ mod test {
 
     #[test]
     fn test_cache_should_insert_into_empty_set() {
-        let mut cache = LruCache::<&str>::new(5);
+        let mut cache = LruCache::with_hasher(5, DefaultHashBuilder::default());
         let entry = "entry";
         assert!(cache.insert(entry));
         assert!(cache.contains(&entry));
@@ -233,7 +253,7 @@ mod test {
 
     #[test]
     fn test_cache_should_not_insert_same_value_twice() {
-        let mut cache = LruCache::<&str>::new(5);
+        let mut cache = LruCache::with_hasher(5, DefaultHashBuilder::default());
         let entry = "entry";
         assert!(cache.insert(entry));
         assert!(!cache.insert(entry));
@@ -241,7 +261,7 @@ mod test {
 
     #[test]
     fn test_cache_should_remove_oldest_element_when_exceeding_limit() {
-        let mut cache = LruCache::<&str>::new(1); // LruCache limit will be 2, check LruCache::new
+        let mut cache = LruCache::with_hasher(1, DefaultHashBuilder::default()); // LruCache limit will be 2, check LruCache::new
         let old_entry = "old_entry";
         let new_entry = "new_entry";
         cache.insert(old_entry);
@@ -253,7 +273,7 @@ mod test {
 
     #[test]
     fn test_cache_should_extend_an_array() {
-        let mut cache = LruCache::<&str>::new(5);
+        let mut cache = LruCache::with_hasher(5, DefaultHashBuilder::default());
         let entries = ["some_entry", "another_entry"];
         cache.extend(entries);
         for e in entries {
@@ -267,7 +287,7 @@ mod test {
         #[derive(Debug)]
         struct Value(i8);
 
-        let mut cache = LruMap::<Key, Value>::new(2);
+        let mut cache = LruMap::with_hasher(2, DefaultHashBuilder::default());
         let key_1 = Key(1);
         let value_1 = Value(11);
         cache.insert(key_1, value_1);
@@ -283,7 +303,7 @@ mod test {
 
     #[test]
     fn test_debug_impl_lru_cache() {
-        let mut cache = LruCache::<Key>::new(2);
+        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -297,7 +317,7 @@ mod test {
 
     #[test]
     fn get() {
-        let mut cache = LruCache::<Key>::new(2);
+        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -314,7 +334,7 @@ mod test {
 
     #[test]
     fn get_ty_custom_eq_impl() {
-        let mut cache = LruCache::<CompoundKey>::new(2);
+        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
         let key_2 = CompoundKey::new(2, 22);
@@ -327,7 +347,7 @@ mod test {
 
     #[test]
     fn peek() {
-        let mut cache = LruCache::<Key>::new(2);
+        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
         let key_1 = Key(1);
         cache.insert(key_1);
         let key_2 = Key(2);
@@ -344,7 +364,7 @@ mod test {
 
     #[test]
     fn peek_ty_custom_eq_impl() {
-        let mut cache = LruCache::<CompoundKey>::new(2);
+        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
         let key_1 = CompoundKey::new(1, 11);
         cache.insert(key_1);
         let key_2 = CompoundKey::new(2, 22);
@@ -357,7 +377,7 @@ mod test {
 
     #[test]
     fn test_insert_methods() {
-        let mut cache = LruCache::<&str>::new(2);
+        let mut cache = LruCache::with_hasher(2, DefaultHashBuilder::default());
 
         // Test basic insert
         assert!(cache.insert("first")); // new entry

--- a/crates/net/network/src/cache.rs
+++ b/crates/net/network/src/cache.rs
@@ -28,7 +28,7 @@ impl<T: Hash + Eq + fmt::Debug> LruCache<T> {
 
 impl<T: Hash + Eq + fmt::Debug, S: BuildHasher> LruCache<T, S> {
     /// Creates a new [`LruCache`] using the given limit and hash builder.
-    pub fn with_hasher(limit: u32, hash_builder: S) -> Self {
+    pub const fn with_hasher(limit: u32, hash_builder: S) -> Self {
         // limit of lru map is one element more, so can give eviction feedback, which isn't
         // supported by LruMap
         Self { inner: LruMap::with_hasher(limit + 1, hash_builder), limit }
@@ -195,7 +195,7 @@ where
     S: BuildHasher,
 {
     /// Returns a new cache with default limiter and the given hash builder.
-    pub fn with_hasher(max_length: u32, hash_builder: S) -> Self {
+    pub const fn with_hasher(max_length: u32, hash_builder: S) -> Self {
         Self(schnellru::LruMap::with_hasher(ByLength::new(max_length), hash_builder))
     }
 }

--- a/crates/net/network/src/test_utils/transactions.rs
+++ b/crates/net/network/src/test_utils/transactions.rs
@@ -63,7 +63,7 @@ pub fn buffer_hash_to_tx_fetcher(
     match tx_fetcher.hashes_fetch_inflight_and_pending_fetch.get_or_insert(hash, || {
         TxFetchMetadata::new(
             retries,
-            LruCache::new(DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32),
+            LruCache::with_hasher(DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32, Default::default()),
             tx_encoded_length,
         )
     }) {

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -134,10 +134,14 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         metrics.capacity_inflight_requests.increment(max_inflight_requests as u64);
 
         Self {
-            active_peers: LruMap::new(max_inflight_requests),
-            hashes_pending_fetch: LruCache::new(max_capacity_cache_txns_pending_fetch),
-            hashes_fetch_inflight_and_pending_fetch: LruMap::new(
+            active_peers: LruMap::with_hasher(max_inflight_requests, Default::default()),
+            hashes_pending_fetch: LruCache::with_hasher(
+                max_capacity_cache_txns_pending_fetch,
+                Default::default(),
+            ),
+            hashes_fetch_inflight_and_pending_fetch: LruMap::with_hasher(
                 max_inflight_requests + max_capacity_cache_txns_pending_fetch,
+                Default::default(),
             ),
             info,
             metrics,
@@ -552,9 +556,18 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
 
             previously_unseen_hashes_count += 1;
 
-            if self.hashes_fetch_inflight_and_pending_fetch.get_or_insert(*hash, ||
-                TxFetchMetadata{retries: 0, fallback_peers: LruCache::new(DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32), tx_encoded_length: None}
-            ).is_none() {
+            if self
+                .hashes_fetch_inflight_and_pending_fetch
+                .get_or_insert(*hash, || TxFetchMetadata {
+                    retries: 0,
+                    fallback_peers: LruCache::with_hasher(
+                        DEFAULT_MAX_COUNT_FALLBACK_PEERS as u32,
+                        Default::default(),
+                    ),
+                    tx_encoded_length: None,
+                })
+                .is_none()
+            {
 
                 trace!(target: "net::tx",
                     peer_id=format!("{peer_id:#}"),
@@ -993,11 +1006,18 @@ impl<N: NetworkPrimitives> Stream for TransactionFetcher<N> {
 impl<T: NetworkPrimitives> Default for TransactionFetcher<T> {
     fn default() -> Self {
         Self {
-            active_peers: LruMap::new(DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS),
+            active_peers: LruMap::with_hasher(
+                DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS,
+                Default::default(),
+            ),
             inflight_requests: Default::default(),
-            hashes_pending_fetch: LruCache::new(DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH),
-            hashes_fetch_inflight_and_pending_fetch: LruMap::new(
+            hashes_pending_fetch: LruCache::with_hasher(
+                DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH,
+                Default::default(),
+            ),
+            hashes_fetch_inflight_and_pending_fetch: LruMap::with_hasher(
                 DEFAULT_MAX_CAPACITY_CACHE_INFLIGHT_AND_PENDING_FETCH,
+                Default::default(),
             ),
             info: TransactionFetcherInfo::default(),
             metrics: Default::default(),

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -36,7 +36,7 @@ use crate::{
     metrics::TransactionFetcherMetrics,
 };
 use alloy_consensus::transaction::PooledTransaction;
-use alloy_primitives::TxHash;
+use alloy_primitives::{map::FbBuildHasher, TxHash};
 use derive_more::{Constructor, Deref};
 use futures::{stream::FuturesUnordered, Future, FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
@@ -67,7 +67,7 @@ use tracing::trace;
 #[pin_project]
 pub struct TransactionFetcher<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// All peers with to which a [`GetPooledTransactions`] request is inflight.
-    pub active_peers: LruMap<PeerId, u8, ByLength>,
+    pub active_peers: LruMap<PeerId, u8, ByLength, FbBuildHasher<64>>,
     /// All currently active [`GetPooledTransactions`] requests.
     ///
     /// The set of hashes encompassed by these requests are a subset of all hashes in the fetcher.
@@ -79,9 +79,10 @@ pub struct TransactionFetcher<N: NetworkPrimitives = EthNetworkPrimitives> {
     ///
     /// This is a subset of all hashes in the fetcher, and is disjoint from the set of hashes for
     /// which a [`GetPooledTransactions`] request is inflight.
-    pub hashes_pending_fetch: LruCache<TxHash>,
+    pub hashes_pending_fetch: LruCache<TxHash, FbBuildHasher<32>>,
     /// Tracks all hashes in the transaction fetcher.
-    pub hashes_fetch_inflight_and_pending_fetch: LruMap<TxHash, TxFetchMetadata, ByLength>,
+    pub hashes_fetch_inflight_and_pending_fetch:
+        LruMap<TxHash, TxFetchMetadata, ByLength, FbBuildHasher<32>>,
     /// Info on capacity of the transaction fetcher.
     pub info: TransactionFetcherInfo,
     #[doc(hidden)]
@@ -686,7 +687,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     pub fn fill_request_from_hashes_pending_fetch(
         &mut self,
         hashes_to_request: &mut RequestTxHashes,
-        seen_hashes: &LruCache<TxHash>,
+        seen_hashes: &LruCache<TxHash, FbBuildHasher<32>>,
         mut budget_fill_request: Option<usize>, // check max `budget` lru pending hashes
     ) {
         let Some(hash) = hashes_to_request.iter().next() else { return };
@@ -1010,7 +1011,7 @@ pub struct TxFetchMetadata {
     /// The number of times a request attempt has been made for the hash.
     retries: u8,
     /// Peers that have announced the hash, but to which a request attempt has not yet been made.
-    fallback_peers: LruCache<PeerId>,
+    fallback_peers: LruCache<PeerId, FbBuildHasher<64>>,
     /// Size metadata of the transaction if it has been seen in an eth68 announcement.
     // todo: store all seen sizes as a `(size, peer_id)` tuple to catch peers that respond with
     // another size tx than they announced. alt enter in request (won't catch peers announcing
@@ -1020,7 +1021,7 @@ pub struct TxFetchMetadata {
 
 impl TxFetchMetadata {
     /// Returns a mutable reference to the fallback peers cache for this transaction hash.
-    pub const fn fallback_peers_mut(&mut self) -> &mut LruCache<PeerId> {
+    pub const fn fallback_peers_mut(&mut self) -> &mut LruCache<PeerId, FbBuildHasher<64>> {
         &mut self.fallback_peers
     }
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -405,7 +405,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             transactions_by_peers: Default::default(),
             pool_imports: Default::default(),
             pending_pool_imports_info,
-            bad_imports: LruCache::new(DEFAULT_MAX_COUNT_BAD_IMPORTS),
+            bad_imports: LruCache::with_hasher(DEFAULT_MAX_COUNT_BAD_IMPORTS, Default::default()),
             peers: Default::default(),
             command_tx,
             command_rx: UnboundedReceiverStream::new(command_rx),
@@ -2043,7 +2043,10 @@ impl<N: NetworkPrimitives> PeerMetadata<N> {
         peer_kind: PeerKind,
     ) -> Self {
         Self {
-            seen_transactions: LruCache::new(max_transactions_seen_by_peer),
+            seen_transactions: LruCache::with_hasher(
+                max_transactions_seen_by_peer,
+                Default::default(),
+            ),
             request_tx,
             version,
             client_version,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -37,7 +37,10 @@ use crate::{
     transactions::config::{StrictEthAnnouncementFilter, TransactionPropagationKind},
     NetworkHandle, TxTypesCounter,
 };
-use alloy_primitives::{TxHash, B256};
+use alloy_primitives::{
+    map::{B256Map, FbBuildHasher},
+    TxHash, B256,
+};
 use constants::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use reth_eth_wire::{
@@ -293,7 +296,7 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     ///
     /// This way we can track incoming transactions and prevent multiple pool imports for the same
     /// transaction
-    transactions_by_peers: HashMap<TxHash, HashSet<PeerId>>,
+    transactions_by_peers: B256Map<HashSet<PeerId>>,
     /// Transactions that are currently imported into the `Pool`.
     ///
     /// The import process includes:
@@ -309,7 +312,7 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     /// Stats on pending pool imports that help the node self-monitor.
     pending_pool_imports_info: PendingPoolImportsInfo,
     /// Bad imports.
-    bad_imports: LruCache<TxHash>,
+    bad_imports: LruCache<TxHash, FbBuildHasher<32>>,
     /// All the connected peers.
     peers: HashMap<PeerId, PeerMetadata<N>>,
     /// Send half for the command channel.
@@ -2019,7 +2022,7 @@ pub struct PeerMetadata<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Optimistically keeps track of transactions that we know the peer has seen. Optimistic, in
     /// the sense that transactions are preemptively marked as seen by peer when they are sent to
     /// the peer.
-    seen_transactions: LruCache<TxHash>,
+    seen_transactions: LruCache<TxHash, FbBuildHasher<32>>,
     /// A communication channel directly to the peer's session task.
     request_tx: PeerRequestSender<PeerRequest<N>>,
     /// negotiated version of the session.
@@ -2054,7 +2057,7 @@ impl<N: NetworkPrimitives> PeerMetadata<N> {
     }
 
     /// Returns a mutable reference to the seen transactions LRU cache.
-    pub const fn seen_transactions_mut(&mut self) -> &mut LruCache<TxHash> {
+    pub const fn seen_transactions_mut(&mut self) -> &mut LruCache<TxHash, FbBuildHasher<32>> {
         &mut self.seen_transactions
     }
 


### PR DESCRIPTION
perf(network): use FbBuildHasher for transaction manager maps

Use B256Map for transactions_by_peers and FbBuildHasher for TxHash/PeerId LRU caches on the transaction gossip path. TxHash keys are already cryptographically random, so SipHash adds cost without benefit.