### PR TITLE
docs(engine): fix is_opstack comment

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -232,7 +232,7 @@ impl EngineApiKind {
         matches!(self, Self::Ethereum)
     }
 
-    /// Returns true if this is the ethereum variant
+    /// Returns true if this is the opstack variant
     pub const fn is_opstack(&self) -> bool {
         matches!(self, Self::OpStack)
     }


### PR DESCRIPTION
Corrects the `EngineApiKind::is_opstack` rustdoc to say it checks for the OpStack variant.