### PR TITLE
fix(rpc): guard eth_callMany with blocking IO semaphore

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -316,6 +316,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into());
             }
 
+            let _permit = self.acquire_owned_blocking_io().await;
+
             let StateContext { transaction_index, block_number } =
                 state_context.unwrap_or_default();
             let transaction_index = transaction_index.unwrap_or_default();


### PR DESCRIPTION
Adds the blocking-IO semaphore guard to `eth_callMany` before it resolves state or executes bundles. This aligns the method with other EVM-executing RPC handlers and makes it respect `--rpc.max-blocking-io-requests` for concurrent bundle simulations.

The issue was that `call_many` could spawn EVM work and accumulate nested `EthCallResponse` results without first consuming a blocking IO permit.