### PR TITLE
fix(trie): proof_v2 panic on root-level cached branch with empty stack

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1069,9 +1069,11 @@ where
             );
 
             // If the branch_path != cached_path it means the branch_stack is either empty, or the
-            // top branch is the parent of this cached branch. Either way we push a branch
+            // top branch is the parent of this cached branch. The `is_empty()` clause additionally
+            // covers the initial-state case where both paths are equal (both empty, e.g. fresh
+            // calculator with a root-level cached branch). Either way we push a branch
             // corresponding to the cached one onto the stack, so we can begin constructing it.
-            if self.branch_path != cached_path {
+            if self.branch_path != cached_path || self.branch_stack.is_empty() {
                 self.push_cached_branch(targets, cached_path, &cached_branch)?;
             }
 


### PR DESCRIPTION
## Summary

Fixes a panic at `crates/trie/trie/src/proof_v2/mod.rs:1089` (`self.branch_stack.last().expect("top of branch_stack corresponds to cached branch")`) that fires when `next_uncached_key_range`'s conditional push is skipped because `branch_path == cached_path`, leaving `branch_stack` empty for the very next line.

## Scenario

On the first iteration of a fresh `ProofCalculator` (or one reset via `clear_computation_state`), if the first cached branch encountered is at the root (`cached_path` is the empty `Nibbles`), then `branch_path == cached_path == empty`, the old conditional skips the push, and the stack stays empty for `.last().expect(...)`.

## Fix

Widen the conditional to also push when `branch_stack` is empty. `push_cached_branch`'s both-stacks-empty early-return handles the rest correctly.

## Reproducer

Reth node booted against a genesis with ~25 GB of bulk pre-state (synthetic EOAs each owning many storage slots), then any transaction sent through (we drove this via [spamoor](https://github.com/ethpandaops/spamoor)). The panic reliably fires while reth computes the execution proof for the first post-genesis block in a `proof-acct-XX` worker thread. Affects both the v1 and v2 storage layouts; the bug is in the shared `ProofCalculator` logic.

The genesis was produced by [state-actor](https://github.com/ethereum/state-actor) which writes a reth datadir directly. I'm happy to package a minimal genesis if maintainers would find it useful.

## Tests

`cargo test -p reth-trie --release` passes locally with the patch applied. No new unit test added — constructing the panic-triggering state requires either substantial mocking of `TrieCursorState` / `try_pop_cached_branch` or a deep multi-branch integration trie. Happy to add a focused test in `proof_v2::tests` if maintainers want (the field-manipulation pattern from `test_proof_calculator_reuse_after_error` is the closest existing template).
