### PR TITLE
fix(rpc): guard eth_simulateV1 with blocking IO semaphore

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -89,6 +89,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into())
             }
 
+            let _permit = self.acquire_owned_blocking_io().await;
+
             let base_block =
                 self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
             let mut parent = base_block.sealed_header().clone();


### PR DESCRIPTION
Follow-up to #24499.

Adds the blocking IO semaphore guard to `eth_simulateV1` before resolving the base block and running simulated blocks. The method executes EVM work through blocking IO tasks, so it should consume `--rpc.max-blocking-io-requests` capacity like `eth_callMany`.