### PR TITLE
ci: suppress mixed bench on-win Slack notifications

### DIFF
--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -18,7 +18,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { fmtChange, fmtMs, verdict, loadSamplyUrls, blocksLabel, metricRows } = require('./bench-utils');
+const { fmtChange, fmtMs, verdict, isWin, loadSamplyUrls, blocksLabel, metricRows } = require('./bench-utils');
 
 const SLACK_API = 'https://slack.com/api/chat.postMessage';
 
@@ -263,24 +263,22 @@ async function success({ core, context }) {
 
   const slackMode = process.env.BENCH_SLACK || 'always';
 
-  // Post to public channel if any metric shows significant improvement or regression
+  // Post to public channel only when the overall verdict is a win.
   const channel = process.env.SLACK_BENCH_CHANNEL;
   let postedToChannel = false;
   if (channel) {
-    const changes = summary.changes || {};
-    const hasImprovement = Object.values(changes).some(c => !c.informational && c.sig === 'good');
-    if (hasImprovement) {
+    if (isWin(summary.changes)) {
       await postToSlack(token, channel, blocks, text, core);
       postedToChannel = true;
     } else {
-      core.info('No significant improvement, skipping public channel notification');
+      core.info('No unambiguous improvement, skipping public channel notification');
     }
   }
 
-  // In on-win mode, only notify on improvement — skip DM fallback entirely
+  // In on-win mode, only notify on unambiguous improvement. Mixed results are not wins.
   if (slackMode === 'on-win') {
     if (!postedToChannel) {
-      core.info('on-win mode: no improvement detected, skipping all notifications');
+      core.info('on-win mode: no unambiguous improvement detected, skipping all notifications');
     }
     return;
   }

--- a/.github/scripts/bench-utils.js
+++ b/.github/scripts/bench-utils.js
@@ -33,6 +33,11 @@ function verdict(changes) {
   return { emoji: '⚪', label: 'No Difference' };
 }
 
+function isWin(changes) {
+  const vals = Object.values(changes || {}).filter(v => !v.informational);
+  return vals.some(v => v.sig === 'good') && !vals.some(v => v.sig === 'bad');
+}
+
 function loadSamplyUrls(workDir) {
   const urls = {};
   let runs = [];
@@ -122,6 +127,7 @@ module.exports = {
   fmtS,
   fmtChange,
   verdict,
+  isWin,
   loadSamplyUrls,
   blocksLabel,
   metricRows,

--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -832,7 +832,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const { verdict, fmtChange, fmtMs, metricRows, waitTimeRows, blocksLabel } = require('./.github/scripts/bench-utils');
+            const { verdict, fmtChange, fmtMs, metricRows, waitTimeRows, blocksLabel, isWin } = require('./.github/scripts/bench-utils');
 
             const token = process.env.SLACK_BENCH_BOT_TOKEN;
             const channel = process.env.SLACK_BENCH_CHANNEL;
@@ -854,11 +854,10 @@ jobs:
             const mode = process.env.BENCH_MODE || 'nightly';
             const slackMode = process.env.BENCH_SLACK || 'always';
             const hasRegression = Object.values(changes).some(c => c.sig === 'bad');
-            const hasImprovement = Object.values(changes).some(c => c.sig === 'good');
 
-            // on-win mode: only notify on improvements
-            if (slackMode === 'on-win' && !hasImprovement) {
-              core.info('on-win mode: no improvement detected, skipping Slack notification');
+            // on-win mode: only notify on unambiguous improvements. Mixed results are not wins.
+            if (slackMode === 'on-win' && !isWin(changes)) {
+              core.info('on-win mode: no unambiguous improvement detected, skipping Slack notification');
               return;
             }
 


### PR DESCRIPTION
## Summary
- Treat `slack=on-win` as an unambiguous benchmark win: at least one significant improvement and no significant regressions.
- Share that win classification between PR bench Slack notifications and scheduled bench notifications.

## Testing
- `node - <<'NODE' ...` focused assertion check for `isWin` and mixed verdict behavior.

Prompted by: @mediocregopher