### PR TITLE
ci: raise state-root bench target thresholds

### DIFF
--- a/.github/config/bench-metrics-targets.json
+++ b/.github/config/bench-metrics-targets.json
@@ -17,8 +17,8 @@
     {
       "query": "reth_sync_block_validation_state_root_histogram",
       "target": "decrease",
-      "floor_pct": 2.5,
-      "min_value_pct_total_latency": 0.1
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 5.0
     },
     {
       "query": "reth_trie_proof_task_account_worker_idle_time_seconds",


### PR DESCRIPTION
Raises the state-root target metric floor to 5% and its materiality gate to 5% of total block latency. This avoids treating small self-compare movement in the state-root histogram as a target metric win/loss.