### PR TITLE
fix(rpc): export Anvil and Hardhat server traits

### DIFF
--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -41,8 +41,10 @@ pub use servers::*;
 pub mod servers {
     pub use crate::{
         admin::AdminApiServer,
+        anvil::AnvilApiServer,
         debug::DebugApiServer,
         engine::{EngineApiServer, EngineEthApiServer, IntoEngineApiRpcModule},
+        hardhat::HardhatApiServer,
         mev::{MevFullApiServer, MevSimApiServer},
         miner::MinerApiServer,
         net::NetApiServer,


### PR DESCRIPTION
Exports `AnvilApiServer` and `HardhatApiServer` from the `reth_rpc_api::servers` aggregate.