### PR TITLE
ci(bench): show derek command in bench summary

### DIFF
--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -23,6 +23,7 @@ import argparse
 import csv
 import json
 import math
+import os
 import random
 import sys
 
@@ -601,9 +602,13 @@ def generate_markdown(
     wait_time_tables: list[str] | None = None,
     behind_baseline: int = 0, repo: str = "", baseline_ref: str = "", baseline_name: str = "",
     grafana_url: str | None = None,
+    derek_command: str | None = None,
 ) -> str:
     """Generate a markdown comment body."""
-    lines = ["## Benchmark Results", ""]
+    lines = ["## Benchmark Results", "", "## Configuration"]
+    if derek_command:
+        lines.append(f"- Derek command: `{derek_command}`")
+    lines.append("")
     if behind_baseline > 0:
         s = "s" if behind_baseline > 1 else ""
         diff_link = f"https://github.com/{repo}/compare/{baseline_ref[:12]}...{baseline_name}"
@@ -654,6 +659,11 @@ def main():
     parser.add_argument("--wait-time", default=None, help="Wait time interval used between blocks")
     parser.add_argument("--bal-mode", default=None, help="BAL mode (true, feature, baseline)")
     parser.add_argument("--grafana-url", default=None, help="Grafana dashboard URL for this benchmark run")
+    parser.add_argument(
+        "--derek-command",
+        default=os.environ.get("DEREK_BENCH_COMMAND"),
+        help="Full derek bench command",
+    )
     parser.add_argument("--run-pairs", type=int, default=None, help="Configured number of benchmark run pairs")
     args = parser.parse_args()
 
@@ -769,6 +779,7 @@ def main():
         baseline_ref=baseline_ref,
         baseline_name=baseline_name,
         grafana_url=args.grafana_url,
+        derek_command=args.derek_command,
     )
 
     with open(args.output_markdown, "w") as f:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1018,6 +1018,41 @@ jobs:
             echo "::add-mask::$BENCH_VICTORIAMETRICS_URL"
           fi
 
+          quote_arg() {
+            local value="$1"
+            if [[ "$value" =~ ^[A-Za-z0-9._/:=@+-]+$ ]]; then
+              printf '%s' "$value"
+            else
+              printf "'%s'" "${value//\'/\'\\\'\'}"
+            fi
+          }
+
+          derek_cmd=(derek bench)
+          [ "$BENCH_BIG_BLOCKS" = "true" ] && derek_cmd+=(big-blocks="${BENCH_BIG_BLOCKS_TARGET_GAS:-true}")
+          derek_cmd+=(
+            blocks="$BENCH_BLOCKS"
+            warmup="$BENCH_WARMUP_BLOCKS"
+            baseline="${{ needs.bench-ack.outputs.baseline-name }}"
+            feature="${{ needs.bench-ack.outputs.feature-name }}"
+            bal="$BENCH_BAL"
+            cores="$BENCH_CORES"
+            run-pairs="$BENCH_RUN_PAIRS"
+            otlp="$BENCH_OTLP"
+            slack="$BENCH_SLACK"
+          )
+          [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
+          [ -n "$BENCH_WAIT_TIME" ] && derek_cmd+=(wait-time="$BENCH_WAIT_TIME")
+          [ -n "$BENCH_BASELINE_ARGS" ] && derek_cmd+=(baseline-args="$BENCH_BASELINE_ARGS")
+          [ -n "$BENCH_FEATURE_ARGS" ] && derek_cmd+=(feature-args="$BENCH_FEATURE_ARGS")
+          DEREK_BENCH_COMMAND=""
+          for arg in "${derek_cmd[@]}"; do
+            if [ -n "$DEREK_BENCH_COMMAND" ]; then
+              DEREK_BENCH_COMMAND+=" "
+            fi
+            DEREK_BENCH_COMMAND+="$(quote_arg "$arg")"
+          done
+          echo "DEREK_BENCH_COMMAND=${DEREK_BENCH_COMMAND}" >> "$GITHUB_ENV"
+
           BENCH_ID="ci-${{ github.run_id }}"
           BENCH_REFERENCE_EPOCH=$(date +%s)
           echo "BENCH_ID=${BENCH_ID}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Adds the full reconstructed `derek bench ...` command to the reth bench Configuration section, including manual-dispatch runs.

Prompted by: @shekhirin