### PR TITLE
fix(network): append high priority fetches when queue has no normal work

### DIFF
--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -258,7 +258,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
                                     .queued_requests
                                     .iter()
                                     .position(|req| req.is_normal_priority())
-                                    .unwrap_or(0);
+                                    .unwrap_or(self.queued_requests.len());
                                 self.queued_requests.insert(pos, request);
                             }
                             Priority::Normal => {


### PR DESCRIPTION
Without a normal-priority entry, index 0 prepended new high-priority downloads ahead of existing high-priority items. Use `queued_requests.len()` so they land at the tail of the high-priority run, consistent with queueing before the first normal request once one exists.