### PR TITLE
chore: bump revm to 40.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10618,9 +10618,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "40.0.2"
+version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d649306477c7153d0f4568976385ccb1789608e9a5b956ec781514612ccbc3"
+checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10637,9 +10637,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b0efe30093e26767c2eb4d86c369a9b3877cc034e843f074436111c4459832"
+checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
 dependencies = [
  "bitvec",
  "phf",
@@ -10649,9 +10649,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "18.0.2"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f54b599f334f7cd32c5de193d586f50d7cc2bd5aa07f83dfeaf85a277ad5d9a"
+checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10666,9 +10666,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "19.0.2"
+version = "19.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96259bca5af514ea4b92037908b0232afbc167f1f8355604118ec599caeca8c"
+checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10682,11 +10682,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "15.0.1"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73c2151aded4387d96f90c958bb67f34968d40d11d1495fe41091fe220af115"
+checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
  "alloy-eips",
+ "derive_more",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -10696,9 +10697,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "12.1.0"
+version = "12.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f753660705cf9e7b7e45fc5607d4cebf729094d5e96dc1d1cf98cf57b69507"
+checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
 dependencies = [
  "auto_impl",
  "either",
@@ -10710,9 +10711,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.2"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa038202a389d72b5c1b4d6f6e8f921a93171bf02f7cfdb5308eeea5780869c1"
+checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10729,9 +10730,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "21.0.2"
+version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4375c14860fa31232673f8e963510ddaccd10d511353e35771a1d5015fed327a"
+checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
@@ -10767,9 +10768,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "37.0.2"
+version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecec5a33daed0d84e3e1529203451d33ca50d2a30c2e3d9959ce18ee0229a06a"
+checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10780,9 +10781,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "36.0.2"
+version = "36.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cc580444ccf766456f7586edaf1bff9f09b7101f3a9ac0979969168e5debc6"
+checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10806,9 +10807,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "24.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4a4ed40c86155d1656e1744e90e23c96e1059f3cd146d70b6d4b2882708f1c"
+checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10817,9 +10818,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "12.0.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc740a183b0d4c0807f565df2420ccb6a662df1d878108faddb25560164a4022"
+checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,7 +432,7 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { version = "0.4.0", default-features = false }
 
 # revm
-revm = { version = "40.0.2", default-features = false }
+revm = { version = "40.0.3", default-features = false }
 revm-bytecode = { version = "11.0.0", default-features = false }
 revm-database = { version = "15.0.0", default-features = false }
 revm-state = { version = "12.0.0", default-features = false }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -34,7 +34,7 @@ use reth_primitives_traits::{
 use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, BytecodeReader, StateProviderFactory};
 use reth_tasks::Runtime;
 use revm::context_interface::Cfg;
-use revm_primitives::{eip8037::CPSB_GLAMSTERDAM, U256};
+use revm_primitives::U256;
 use std::{
     fmt,
     marker::PhantomData,
@@ -1424,7 +1424,6 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
             .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
             .unwrap_or_default() as u64,
         transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
-        CPSB_GLAMSTERDAM,
     );
 
     let gas_limit = transaction.gas_limit();


### PR DESCRIPTION
## Summary
- bump revm from 40.0.2 to 40.0.3
- update the transaction-pool intrinsic gas call for the revm 40.0.3 signature

## Validation
- `cargo check -p reth-transaction-pool`

Prompted by: @klkvr