### PR TITLE
refactor(net): use B256 collections for tx hashes

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -3,7 +3,7 @@
 use crate::{EthMessage, EthVersion, NetworkPrimitives};
 use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::{
-    map::{HashMap, HashSet},
+    map::{B256Map, B256Set},
     Bytes, TxHash, B128, B256, U128,
 };
 use alloy_rlp::{
@@ -856,7 +856,7 @@ impl DedupPayload for NewPooledTransactionHashes72 {
     fn dedup(self) -> PartiallyValidData<Self::Value> {
         let Self { hashes, mut sizes, mut types, .. } = self;
 
-        let mut deduped_data = HashMap::with_capacity_and_hasher(hashes.len(), Default::default());
+        let mut deduped_data = B256Map::with_capacity_and_hasher(hashes.len(), Default::default());
 
         for hash in hashes.into_iter().rev() {
             if let (Some(ty), Some(size)) = (types.pop(), sizes.pop()) {
@@ -882,7 +882,7 @@ impl DedupPayload for NewPooledTransactionHashes68 {
     fn dedup(self) -> PartiallyValidData<Self::Value> {
         let Self { hashes, mut sizes, mut types } = self;
 
-        let mut deduped_data = HashMap::with_capacity_and_hasher(hashes.len(), Default::default());
+        let mut deduped_data = B256Map::with_capacity_and_hasher(hashes.len(), Default::default());
 
         for hash in hashes.into_iter().rev() {
             if let (Some(ty), Some(size)) = (types.pop(), sizes.pop()) {
@@ -908,7 +908,7 @@ impl DedupPayload for NewPooledTransactionHashes66 {
     fn dedup(self) -> PartiallyValidData<Self::Value> {
         let Self(hashes) = self;
 
-        let mut deduped_data = HashMap::with_capacity_and_hasher(hashes.len(), Default::default());
+        let mut deduped_data = B256Map::with_capacity_and_hasher(hashes.len(), Default::default());
 
         let noop_value: Eth68TxMetadata = None;
 
@@ -979,7 +979,7 @@ pub struct PartiallyValidData<V> {
     #[deref]
     #[deref_mut]
     #[into_iterator]
-    data: HashMap<TxHash, V>,
+    data: B256Map<V>,
     version: Option<EthVersion>,
 }
 
@@ -987,41 +987,41 @@ handle_mempool_data_map_impl!(PartiallyValidData<V>, <V>);
 
 impl<V> PartiallyValidData<V> {
     /// Wraps raw data.
-    pub const fn from_raw_data(data: HashMap<TxHash, V>, version: Option<EthVersion>) -> Self {
+    pub const fn from_raw_data(data: B256Map<V>, version: Option<EthVersion>) -> Self {
         Self { data, version }
     }
 
     /// Wraps raw data with version [`EthVersion::Eth72`].
-    pub const fn from_raw_data_eth72(data: HashMap<TxHash, V>) -> Self {
+    pub const fn from_raw_data_eth72(data: B256Map<V>) -> Self {
         Self::from_raw_data(data, Some(EthVersion::Eth72))
     }
 
     /// Wraps raw data with version [`EthVersion::Eth68`].
-    pub const fn from_raw_data_eth68(data: HashMap<TxHash, V>) -> Self {
+    pub const fn from_raw_data_eth68(data: B256Map<V>) -> Self {
         Self::from_raw_data(data, Some(EthVersion::Eth68))
     }
 
     /// Wraps raw data with version [`EthVersion::Eth66`].
-    pub const fn from_raw_data_eth66(data: HashMap<TxHash, V>) -> Self {
+    pub const fn from_raw_data_eth66(data: B256Map<V>) -> Self {
         Self::from_raw_data(data, Some(EthVersion::Eth66))
     }
 
     /// Returns a new [`PartiallyValidData`] with empty data from an [`Eth72`](EthVersion::Eth72)
     /// announcement.
     pub fn empty_eth72() -> Self {
-        Self::from_raw_data_eth72(HashMap::default())
+        Self::from_raw_data_eth72(B256Map::default())
     }
 
     /// Returns a new [`PartiallyValidData`] with empty data from an [`Eth68`](EthVersion::Eth68)
     /// announcement.
     pub fn empty_eth68() -> Self {
-        Self::from_raw_data_eth68(HashMap::default())
+        Self::from_raw_data_eth68(B256Map::default())
     }
 
     /// Returns a new [`PartiallyValidData`] with empty data from an [`Eth66`](EthVersion::Eth66)
     /// announcement.
     pub fn empty_eth66() -> Self {
-        Self::from_raw_data_eth66(HashMap::default())
+        Self::from_raw_data_eth66(B256Map::default())
     }
 
     /// Returns the version of the message this data was received in if different versions of the
@@ -1031,7 +1031,7 @@ impl<V> PartiallyValidData<V> {
     }
 
     /// Destructs returning the validated data.
-    pub fn into_data(self) -> HashMap<TxHash, V> {
+    pub fn into_data(self) -> B256Map<V> {
         self.data
     }
 }
@@ -1043,7 +1043,7 @@ pub struct ValidAnnouncementData {
     #[deref]
     #[deref_mut]
     #[into_iterator]
-    data: HashMap<TxHash, Eth68TxMetadata>,
+    data: B256Map<Eth68TxMetadata>,
     version: EthVersion,
 }
 
@@ -1053,7 +1053,7 @@ impl ValidAnnouncementData {
     /// Destructs returning only the valid hashes and the announcement message version. Caution! If
     /// this is [`Eth68`](EthVersion::Eth68) announcement data, this drops the metadata.
     pub fn into_request_hashes(self) -> (RequestTxHashes, EthVersion) {
-        let hashes = self.data.into_keys().collect::<HashSet<_>>();
+        let hashes = self.data.into_keys().collect::<B256Set>();
 
         (RequestTxHashes::new(hashes), self.version)
     }
@@ -1070,7 +1070,7 @@ impl ValidAnnouncementData {
     }
 
     /// Destructs returning the validated data.
-    pub fn into_data(self) -> HashMap<TxHash, Eth68TxMetadata> {
+    pub fn into_data(self) -> B256Map<Eth68TxMetadata> {
         self.data
     }
 }
@@ -1087,21 +1087,21 @@ pub struct RequestTxHashes {
     #[deref]
     #[deref_mut]
     #[into_iterator(owned, ref)]
-    hashes: HashSet<TxHash>,
+    hashes: B256Set,
 }
 
 impl RequestTxHashes {
     /// Returns a new [`RequestTxHashes`] with given capacity for hashes. Caution! Make sure to
-    /// call [`HashSet::shrink_to_fit`] on [`RequestTxHashes`] when full, especially where it will
+    /// call `shrink_to_fit` on [`RequestTxHashes`] when full, especially where it will
     /// be stored in its entirety like in the future waiting for a
     /// [`GetPooledTransactions`](crate::GetPooledTransactions) request to resolve.
     pub fn with_capacity(capacity: usize) -> Self {
-        Self::new(HashSet::with_capacity_and_hasher(capacity, Default::default()))
+        Self::new(B256Set::with_capacity_and_hasher(capacity, Default::default()))
     }
 
     /// Returns a new empty instance.
     fn empty() -> Self {
-        Self::new(HashSet::default())
+        Self::new(B256Set::default())
     }
 
     /// Retains the given number of elements, returning an iterator over the rest.
@@ -1389,7 +1389,7 @@ mod tests {
                 b256!("0x0000000000000000000000000000000000000000000000000000000000000005"),
             ]
             .into_iter()
-            .collect::<HashSet<_>>(),
+            .collect::<B256Set>(),
         );
 
         let rest = hashes.retain_count(3);
@@ -1409,7 +1409,7 @@ mod tests {
                 b256!("0x0000000000000000000000000000000000000000000000000000000000000005"),
             ]
             .into_iter()
-            .collect::<HashSet<_>>(),
+            .collect::<B256Set>(),
         );
 
         let _ = hashes.retain_count(6);
@@ -1428,7 +1428,7 @@ mod tests {
                 b256!("0x0000000000000000000000000000000000000000000000000000000000000005"),
             ]
             .into_iter()
-            .collect::<HashSet<_>>(),
+            .collect::<B256Set>(),
         );
 
         let rest = hashes.retain_count(0);

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -1309,12 +1309,16 @@ struct TxFetcherSearchDurations {
 mod test {
     use super::*;
     use crate::test_utils::transactions::{buffer_hash_to_tx_fetcher, new_mock_session};
-    use alloy_primitives::{hex, map::HashMap, B256};
+    use alloy_primitives::{
+        hex,
+        map::{B256Map, B256Set, HashMap},
+        B256,
+    };
     use alloy_rlp::Decodable;
     use derive_more::IntoIterator;
     use reth_eth_wire_types::EthVersion;
     use reth_ethereum_primitives::TransactionSigned;
-    use std::{collections::HashSet, str::FromStr};
+    use std::str::FromStr;
 
     #[derive(IntoIterator)]
     struct TestValidAnnouncementData(Vec<(TxHash, Option<(u8, usize)>)>);
@@ -1363,10 +1367,10 @@ mod test {
         ];
 
         let expected_request_hashes =
-            [eth68_hashes[0], eth68_hashes[2]].into_iter().collect::<HashSet<_>>();
+            [eth68_hashes[0], eth68_hashes[2]].into_iter().collect::<B256Set>();
 
         let expected_surplus_hashes =
-            [eth68_hashes[1], eth68_hashes[3], eth68_hashes[4]].into_iter().collect::<HashSet<_>>();
+            [eth68_hashes[1], eth68_hashes[3], eth68_hashes[4]].into_iter().collect::<B256Set>();
 
         let mut eth68_hashes_to_request = RequestTxHashes::with_capacity(3);
 
@@ -1383,8 +1387,8 @@ mod test {
         let surplus_eth68_hashes =
             tx_fetcher.pack_request_eth68(&mut eth68_hashes_to_request, valid_announcement_data);
 
-        let eth68_hashes_to_request = eth68_hashes_to_request.into_iter().collect::<HashSet<_>>();
-        let surplus_eth68_hashes = surplus_eth68_hashes.into_iter().collect::<HashSet<_>>();
+        let eth68_hashes_to_request = eth68_hashes_to_request.into_iter().collect::<B256Set>();
+        let surplus_eth68_hashes = surplus_eth68_hashes.into_iter().collect::<B256Set>();
 
         assert_eq!(expected_request_hashes, eth68_hashes_to_request);
         assert_eq!(expected_surplus_hashes, surplus_eth68_hashes);
@@ -1405,8 +1409,8 @@ mod test {
         ];
 
         let expected_request_hashes =
-            [eth68_hashes[0], eth68_hashes[2]].into_iter().collect::<HashSet<_>>();
-        let expected_surplus_hashes = std::iter::once(eth68_hashes[1]).collect::<HashSet<_>>();
+            [eth68_hashes[0], eth68_hashes[2]].into_iter().collect::<B256Set>();
+        let expected_surplus_hashes = std::iter::once(eth68_hashes[1]).collect::<B256Set>();
 
         let mut eth68_hashes_to_request = RequestTxHashes::with_capacity(3);
         let valid_announcement_data = TestValidAnnouncementData(
@@ -1420,8 +1424,8 @@ mod test {
         let surplus_eth68_hashes =
             tx_fetcher.pack_request_eth68(&mut eth68_hashes_to_request, valid_announcement_data);
 
-        let eth68_hashes_to_request = eth68_hashes_to_request.into_iter().collect::<HashSet<_>>();
-        let surplus_eth68_hashes = surplus_eth68_hashes.into_iter().collect::<HashSet<_>>();
+        let eth68_hashes_to_request = eth68_hashes_to_request.into_iter().collect::<B256Set>();
+        let surplus_eth68_hashes = surplus_eth68_hashes.into_iter().collect::<B256Set>();
 
         assert_eq!(expected_request_hashes, eth68_hashes_to_request);
         assert_eq!(expected_surplus_hashes, surplus_eth68_hashes);
@@ -1440,7 +1444,7 @@ mod test {
         let announcement_data = hashes
             .into_iter()
             .map(|hash| (hash, Some((0u8, announced_size))))
-            .collect::<HashMap<_, _>>();
+            .collect::<B256Map<_>>();
         let valid_announcement_data = ValidAnnouncementData::from_partially_valid_data(
             PartiallyValidData::from_raw_data_eth72(announcement_data),
         );
@@ -1533,8 +1537,8 @@ mod test {
         let GetPooledTransactions(requested_hashes) = request;
 
         assert_eq!(
-            requested_hashes.into_iter().collect::<HashSet<_>>(),
-            seen_hashes.into_iter().collect::<HashSet<_>>()
+            requested_hashes.into_iter().collect::<B256Set>(),
+            seen_hashes.into_iter().collect::<B256Set>()
         )
     }
 

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     NetworkHandle, TxTypesCounter,
 };
 use alloy_primitives::{
-    map::{B256Map, FbBuildHasher},
+    map::{B256Map, B256Set, FbBuildHasher},
     TxHash, B256,
 };
 use constants::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
@@ -187,7 +187,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
     pub async fn get_transaction_hashes(
         &self,
         peers: Vec<PeerId>,
-    ) -> Result<HashMap<PeerId, HashSet<TxHash>>, RecvError> {
+    ) -> Result<HashMap<PeerId, B256Set>, RecvError> {
         if peers.is_empty() {
             return Ok(Default::default())
         }
@@ -197,10 +197,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
     }
 
     /// Request the transaction hashes known by a specific peer.
-    pub async fn get_peer_transaction_hashes(
-        &self,
-        peer: PeerId,
-    ) -> Result<HashSet<TxHash>, RecvError> {
+    pub async fn get_peer_transaction_hashes(&self, peer: PeerId) -> Result<B256Set, RecvError> {
         let res = self.get_transaction_hashes(vec![peer]).await?;
         Ok(res.into_values().next().unwrap_or_default())
     }
@@ -1195,7 +1192,7 @@ where
                     let hashes = self
                         .peers
                         .get(&peer_id)
-                        .map(|peer| peer.seen_transactions.iter().copied().collect::<HashSet<_>>())
+                        .map(|peer| peer.seen_transactions.iter().copied().collect::<B256Set>())
                         .unwrap_or_default();
                     res.insert(peer_id, hashes);
                 }
@@ -2112,10 +2109,7 @@ enum TransactionsCommand<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Propagate a collection of broadcastable transactions in full to all peers.
     BroadcastTransactions(Vec<PropagateTransaction<N::BroadcastedTransaction>>),
     /// Request transaction hashes known by specific peers from the [`TransactionsManager`].
-    GetTransactionHashes {
-        peers: Vec<PeerId>,
-        tx: oneshot::Sender<HashMap<PeerId, HashSet<TxHash>>>,
-    },
+    GetTransactionHashes { peers: Vec<PeerId>, tx: oneshot::Sender<HashMap<PeerId, B256Set>> },
     /// Requests a clone of the sender channel to the peer.
     GetPeerSender {
         peer_id: PeerId,
@@ -2917,9 +2911,9 @@ mod tests {
         let PeerRequest::GetPooledTransactions { request, response } = req else { unreachable!() };
         let GetPooledTransactions(hashes) = request;
 
-        let hashes = hashes.into_iter().collect::<HashSet<_>>();
+        let hashes = hashes.into_iter().collect::<B256Set>();
 
-        assert_eq!(hashes, seen_hashes.into_iter().collect::<HashSet<_>>());
+        assert_eq!(hashes, seen_hashes.into_iter().collect::<B256Set>());
 
         // fail request to peer_1
         response
@@ -3197,7 +3191,7 @@ mod tests {
         })
         .await;
 
-        let mut requested_hashes_in_getpooled = HashSet::new();
+        let mut requested_hashes_in_getpooled = B256Set::default();
         let mut unexpected_request_received = false;
 
         match tokio::time::timeout(std::time::Duration::from_millis(200), mock_session_rx.recv())

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -1254,10 +1254,9 @@ mod tests {
     use super::*;
     use crate::{error::RequestError, test_utils::TestFullBlockClient};
     use alloy_consensus::Header;
-    use alloy_primitives::{keccak256, Bytes};
+    use alloy_primitives::{keccak256, map::B256Map, Bytes};
     use parking_lot::Mutex;
     use std::{
-        collections::HashMap,
         ops::Range,
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -1522,7 +1521,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct FullBlockWithAccessListsClient {
         inner: TestFullBlockClient,
-        access_lists: Arc<Mutex<HashMap<B256, Bytes>>>,
+        access_lists: Arc<Mutex<B256Map<Bytes>>>,
         access_list_requests: Arc<AtomicUsize>,
         access_list_soft_limit: Arc<AtomicUsize>,
         access_list_pending_polls: Arc<AtomicUsize>,
@@ -1537,7 +1536,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 inner: TestFullBlockClient::default(),
-                access_lists: Arc::new(Mutex::new(HashMap::default())),
+                access_lists: Arc::new(Mutex::new(B256Map::default())),
                 access_list_requests: Arc::new(AtomicUsize::new(0)),
                 access_list_soft_limit: Arc::new(AtomicUsize::new(usize::MAX)),
                 access_list_pending_polls: Arc::new(AtomicUsize::new(0)),


### PR DESCRIPTION
Uses alloy's B256Map and B256Set aliases for tx-hash keyed announcement and request collections in eth-wire and network transaction handling.

This keeps network tx hash collections aligned with other B256-keyed paths while leaving peer-id keyed maps unchanged.