### PR TITLE
fix(rpc): handle simulate precompile self moves

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -6,7 +6,10 @@ use crate::{
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
-use alloy_evm::{block::TxResult, precompiles::PrecompilesMap};
+use alloy_evm::{
+    block::TxResult,
+    precompiles::{DynPrecompile, PrecompilesMap},
+};
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy_rpc_types_eth::{
     simulate::{SimCallResult, SimulateError, SimulatedBlock},
@@ -28,6 +31,7 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
+use std::collections::HashMap;
 
 /// Error code for execution reverted in `eth_simulateV1`.
 ///
@@ -103,6 +107,9 @@ pub enum EthSimulateError {
     /// Attempted to move a non-precompile address.
     #[error("account {0} is not a precompile")]
     NotAPrecompile(Address),
+    /// Attempted to move a precompile to its own address.
+    #[error("cannot move precompile {0} to itself")]
+    MovePrecompileToSelf(Address),
 }
 
 impl EthSimulateError {
@@ -120,6 +127,7 @@ impl EthSimulateError {
             Self::SenderNotEOA => -38024,
             Self::MaxInitCodeSizeExceeded => -38025,
             Self::TooManyBlocks | Self::GasLimitReached => -38026,
+            Self::MovePrecompileToSelf(_) => -38022,
             Self::NotAPrecompile(_) => -32000,
         }
     }
@@ -147,11 +155,32 @@ pub fn apply_precompile_overrides(
         })
         .collect();
 
-    precompiles.move_precompiles(moves).map_err(
-        |alloy_evm::precompiles::MovePrecompileError::NotAPrecompile(addr)| {
-            EthSimulateError::NotAPrecompile(addr)
-        },
-    )?;
+    let mut moved_precompiles = HashMap::with_capacity(moves.len());
+    for (source, dest) in moves {
+        if source == dest {
+            if precompiles.get(&source).is_none() {
+                return Err(EthSimulateError::NotAPrecompile(source))
+            }
+            return Err(EthSimulateError::MovePrecompileToSelf(source))
+        }
+
+        let mut moved_precompile = None;
+        precompiles.apply_precompile(&source, |existing| {
+            moved_precompile = existing;
+            None
+        });
+
+        let Some(precompile) = moved_precompile else {
+            return Err(EthSimulateError::NotAPrecompile(source))
+        };
+        moved_precompiles.insert(dest, precompile);
+    }
+
+    if !moved_precompiles.is_empty() {
+        precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
+            moved_precompiles.get(address).cloned()
+        });
+    }
 
     Ok(())
 }
@@ -368,4 +397,61 @@ where
         |header, size| converter.convert_header(header, size),
     )?;
     Ok(SimulatedBlock { inner: block, calls })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_precompile_overrides, EthSimulateError};
+    use alloy_evm::precompiles::PrecompilesMap;
+    use alloy_primitives::address;
+    use alloy_rpc_types_eth::state::{AccountOverride, StateOverride};
+    use revm::precompile::Precompiles;
+
+    #[test]
+    fn precompile_self_move_requires_existing_precompile() {
+        let address = address!("c100000000000000000000000000000000000000");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            address,
+            AccountOverride { move_precompile_to: Some(address), ..Default::default() },
+        );
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+
+        let err = apply_precompile_overrides(&state_overrides, &mut precompiles).unwrap_err();
+
+        assert!(matches!(err, EthSimulateError::NotAPrecompile(addr) if addr == address));
+    }
+
+    #[test]
+    fn precompile_self_move_errors_for_existing_precompile() {
+        let address = address!("0000000000000000000000000000000000000001");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            address,
+            AccountOverride { move_precompile_to: Some(address), ..Default::default() },
+        );
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+
+        let err = apply_precompile_overrides(&state_overrides, &mut precompiles).unwrap_err();
+
+        assert!(matches!(err, EthSimulateError::MovePrecompileToSelf(addr) if addr == address));
+    }
+
+    #[test]
+    fn moved_precompile_is_callable_but_not_warm() {
+        let source = address!("0000000000000000000000000000000000000001");
+        let dest = address!("0000000000000000000000000000000000123456");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            source,
+            AccountOverride { move_precompile_to: Some(dest), ..Default::default() },
+        );
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+
+        apply_precompile_overrides(&state_overrides, &mut precompiles).unwrap();
+
+        assert!(precompiles.get(&source).is_none());
+        assert!(precompiles.get(&dest).is_some());
+        assert!(!precompiles.addresses().any(|address| address == &dest));
+    }
 }


### PR DESCRIPTION
Fixes `eth_simulateV1` handling for `movePrecompileToAddress` when the source and destination are the same.

A self-move should only return `-38022` if the source is an existing precompile. If the source is not a precompile, it should return `NotAPrecompile` with `-32000`, matching the failing Hive case:

`eth_simulateV1/ethSimulate-move-to-address-itself-reference-38022 (reth_default)`

Also keeps moved precompiles callable at the destination without adding the destination address to the warm precompile set.