### PR TITLE
fix(rpc): use builder gas limit for testing blocks

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -31,7 +31,7 @@ use reth_node_builder::{
         PayloadValidatorBuilder, RethAuthHttpMiddleware, RethRpcAddOns, RethRpcMiddleware,
         RpcAddOns, RpcHandle, Stack,
     },
-    BuilderContext, DebugNode, Node, NodeAdapter,
+    BuilderContext, DebugNode, Node, NodeAdapter, PayloadBuilderConfig,
 };
 use reth_payload_primitives::PayloadTypes;
 use reth_provider::{providers::ProviderFactoryBuilder, EthStorage};
@@ -301,7 +301,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware, AuthHttpMiddleware> NodeAddOns<N>
 where
     N: FullNodeComponents<
         Types: NodeTypes<
-            ChainSpec: Hardforks + EthereumHardforks,
+            ChainSpec: EthChainSpec + Hardforks + EthereumHardforks,
             Primitives = EthPrimitives,
             Payload: EngineTypes<ExecutionData = ExecutionData>,
         >,
@@ -336,6 +336,7 @@ where
 
         let testing_skip_invalid_transactions = ctx.config.rpc.testing_skip_invalid_transactions;
         let testing_gas_limit_override = ctx.config.rpc.testing_gas_limit;
+        let testing_desired_gas_limit = ctx.config.builder.gas_limit_for(ctx.config.chain.chain());
 
         self.inner
             .launch_add_ons_with(ctx, move |container| {
@@ -353,6 +354,7 @@ where
                 let mut testing_api = TestingApi::new(
                     container.registry.eth_api().clone(),
                     container.registry.evm_config().clone(),
+                    testing_desired_gas_limit,
                 );
                 if testing_skip_invalid_transactions {
                     testing_api = testing_api.with_skip_invalid_transactions();

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -650,8 +650,8 @@ pub struct RpcServerArgs {
 
     /// Override the gas limit used by `testing_buildBlockV1`.
     ///
-    /// When set, `testing_buildBlockV1` will use this value instead of inheriting
-    /// the parent block's gas limit. Accepts short notation: K for thousand, M for
+    /// When set, `testing_buildBlockV1` will use this exact value instead of moving toward the
+    /// payload builder's configured gas limit. Accepts short notation: K for thousand, M for
     /// million, G for billion (e.g., 1G = 1 billion).
     #[arg(long = "testing.gas-limit", value_name = "GAS_LIMIT", hide = true)]
     pub testing_gas_limit: Option<u64>,

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -29,6 +29,7 @@ use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::{execute::BlockBuilder, ConfigureEvm, NextBlockEnvAttributes};
 use reth_primitives_traits::{
+    constants::GAS_LIMIT_BOUND_DIVISOR,
     transaction::{recover::try_recover_signers, signed::RecoveryError},
     AlloyBlockHeader as BlockTrait, TxTy,
 };
@@ -37,6 +38,7 @@ use reth_rpc_api::{TestingApiServer, TestingBuildBlockRequestV1};
 use reth_rpc_eth_api::{helpers::Call, FromEthApiError};
 use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::{BlockReader, HeaderProvider};
+use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm::context::Block;
 use revm_primitives::map::DefaultHashBuilder;
 use std::sync::Arc;
@@ -47,16 +49,24 @@ use tracing::debug;
 pub struct TestingApi<Eth, Evm> {
     eth_api: Eth,
     evm_config: Evm,
+    /// Desired gas limit to move toward while respecting the consensus gas limit bounds.
+    desired_gas_limit: u64,
     /// If true, skip invalid transactions instead of failing.
     skip_invalid_transactions: bool,
-    /// If set, override the parent block's gas limit in `testing_buildBlockV1`.
+    /// If set, override the block gas limit in `testing_buildBlockV1`.
     gas_limit_override: Option<u64>,
 }
 
 impl<Eth, Evm> TestingApi<Eth, Evm> {
     /// Create a new testing API handler.
-    pub const fn new(eth_api: Eth, evm_config: Evm) -> Self {
-        Self { eth_api, evm_config, skip_invalid_transactions: false, gas_limit_override: None }
+    pub const fn new(eth_api: Eth, evm_config: Evm, desired_gas_limit: u64) -> Self {
+        Self {
+            eth_api,
+            evm_config,
+            desired_gas_limit,
+            skip_invalid_transactions: false,
+            gas_limit_override: None,
+        }
     }
 
     /// Enable skipping invalid transactions instead of failing.
@@ -67,8 +77,7 @@ impl<Eth, Evm> TestingApi<Eth, Evm> {
         self
     }
 
-    /// Override the gas limit used by `testing_buildBlockV1` instead of inheriting from the
-    /// parent block.
+    /// Override the gas limit used by `testing_buildBlockV1`.
     pub const fn with_gas_limit_override(mut self, gas_limit: u64) -> Self {
         self.gas_limit_override = Some(gas_limit);
         self
@@ -79,6 +88,7 @@ impl<Eth, Evm> TestingApi<Eth, Evm>
 where
     Eth: Call<
         Provider: BlockReader<Header = Header> + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>>>,
     >,
     Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
         + 'static,
@@ -89,6 +99,7 @@ where
     ) -> Result<ExecutionPayloadEnvelopeV5, Eth::Error> {
         let evm_config = self.evm_config.clone();
         let skip_invalid_transactions = self.skip_invalid_transactions;
+        let desired_gas_limit = self.desired_gas_limit;
         let gas_limit_override = self.gas_limit_override;
         self.eth_api
             .spawn_with_state_at_block(request.parent_block_hash, move |eth_api, state| {
@@ -115,7 +126,9 @@ where
                     timestamp: request.payload_attributes.timestamp,
                     suggested_fee_recipient: request.payload_attributes.suggested_fee_recipient,
                     prev_randao: request.payload_attributes.prev_randao,
-                    gas_limit: gas_limit_override.unwrap_or_else(|| parent.gas_limit()),
+                    gas_limit: gas_limit_override.unwrap_or_else(|| {
+                        calculate_block_gas_limit(parent.gas_limit(), desired_gas_limit)
+                    }),
                     parent_beacon_block_root: request.payload_attributes.parent_beacon_block_root,
                     withdrawals: withdrawals.map(Into::into),
                     extra_data: request.extra_data.unwrap_or_default(),
@@ -134,16 +147,23 @@ where
                 let mut invalid_senders: HashSet<Address, DefaultHashBuilder> = HashSet::default();
                 let mut block_transactions_rlp_length = 0usize;
 
-                // Decode and recover all transactions in parallel
-                let recovered_txs = try_recover_signers(&request.transactions, |tx| {
-                    TxTy::<Evm::Primitives>::decode_2718_exact(tx.as_ref())
-                        .map_err(RecoveryError::from_source)
-                })
-                .or(Err(EthApiError::InvalidTransactionSignature))?;
+                let use_pool_transactions = request.transactions.is_empty();
+                let recovered_txs = if use_pool_transactions {
+                    eth_api.pool().all_transactions().all().collect()
+                } else {
+                    // Decode and recover all transactions in parallel
+                    try_recover_signers(&request.transactions, |tx| {
+                        TxTy::<Evm::Primitives>::decode_2718_exact(tx.as_ref())
+                            .map_err(RecoveryError::from_source)
+                    })
+                    .or(Err(EthApiError::InvalidTransactionSignature))?
+                };
+                let allow_skip_invalid_transactions =
+                    skip_invalid_transactions && !use_pool_transactions;
 
                 for (idx, tx) in recovered_txs.into_iter().enumerate() {
                     let signer = tx.signer();
-                    if skip_invalid_transactions && invalid_senders.contains(&signer) {
+                    if allow_skip_invalid_transactions && invalid_senders.contains(&signer) {
                         continue;
                     }
 
@@ -156,7 +176,7 @@ where
                             withdrawals_rlp_length +
                             1024;
                         if estimated_block_size > MAX_RLP_BLOCK_SIZE {
-                            if skip_invalid_transactions {
+                            if allow_skip_invalid_transactions {
                                 debug!(
                                     target: "rpc::testing",
                                     tx_idx = idx,
@@ -181,7 +201,7 @@ where
                     let gas_used = match builder.execute_transaction(tx) {
                         Ok(gas_used) => gas_used.tx_gas_used(),
                         Err(err) => {
-                            if skip_invalid_transactions {
+                            if allow_skip_invalid_transactions {
                                 debug!(
                                     target: "rpc::testing",
                                     tx_idx = idx,
@@ -222,11 +242,20 @@ where
     }
 }
 
+/// Calculate the next block gas limit from the parent gas limit and desired target.
+fn calculate_block_gas_limit(parent_gas_limit: u64, desired_gas_limit: u64) -> u64 {
+    let delta = (parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR).saturating_sub(1);
+    let min_gas_limit = parent_gas_limit - delta;
+    let max_gas_limit = parent_gas_limit + delta;
+    desired_gas_limit.clamp(min_gas_limit, max_gas_limit)
+}
+
 #[async_trait]
 impl<Eth, Evm> TestingApiServer for TestingApi<Eth, Evm>
 where
     Eth: Call<
         Provider: BlockReader<Header = Header> + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>>>,
     >,
     Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
         + 'static,

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -147,7 +147,8 @@ where
                 let mut invalid_senders: HashSet<Address, DefaultHashBuilder> = HashSet::default();
                 let mut block_transactions_rlp_length = 0usize;
 
-                /// If no transactions are provided in the request, use all transactions from the pool.
+                /// If no transactions are provided in the request, use all transactions from the
+                /// pool.
                 let use_pool_transactions = request.transactions.is_empty();
                 let recovered_txs = if use_pool_transactions {
                     eth_api.pool().all_transactions().all().collect()

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -15,7 +15,7 @@
 //! on public-facing RPC endpoints without proper authentication.
 
 use alloy_consensus::{Header, Transaction};
-use alloy_eips::eip2718::Decodable2718;
+use alloy_eips::{eip1559::calculate_block_gas_limit, eip2718::Decodable2718};
 use alloy_evm::{Evm, RecoveredTx};
 use alloy_primitives::{map::HashSet, Address, U256};
 use alloy_rlp::Encodable;
@@ -29,7 +29,6 @@ use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::{execute::BlockBuilder, ConfigureEvm, NextBlockEnvAttributes};
 use reth_primitives_traits::{
-    constants::GAS_LIMIT_BOUND_DIVISOR,
     transaction::{recover::try_recover_signers, signed::RecoveryError},
     AlloyBlockHeader as BlockTrait, TxTy,
 };
@@ -38,7 +37,7 @@ use reth_rpc_api::{TestingApiServer, TestingBuildBlockRequestV1};
 use reth_rpc_eth_api::{helpers::Call, FromEthApiError};
 use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::{BlockReader, HeaderProvider};
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
+use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
 use revm::context::Block;
 use revm_primitives::map::DefaultHashBuilder;
 use std::sync::Arc;
@@ -147,11 +146,21 @@ where
                 let mut invalid_senders: HashSet<Address, DefaultHashBuilder> = HashSet::default();
                 let mut block_transactions_rlp_length = 0usize;
 
-                /// If no transactions are provided in the request, use all transactions from the
-                /// pool.
+                // If no transactions are provided in the request, use transactions from the pool.
                 let use_pool_transactions = request.transactions.is_empty();
                 let recovered_txs = if use_pool_transactions {
-                    eth_api.pool().all_transactions().all().collect()
+                    let mut best_txs = eth_api.pool().best_transactions_with_attributes(
+                        BestTransactionsAttributes::new(
+                            base_fee,
+                            builder
+                                .evm_mut()
+                                .block()
+                                .blob_gasprice()
+                                .map(|gasprice| gasprice as u64),
+                        ),
+                    );
+                    best_txs.no_updates();
+                    best_txs.map(|tx| tx.to_consensus()).collect()
                 } else {
                     // Decode and recover all transactions in parallel
                     try_recover_signers(&request.transactions, |tx| {
@@ -161,7 +170,7 @@ where
                     .or(Err(EthApiError::InvalidTransactionSignature))?
                 };
                 let allow_skip_invalid_transactions =
-                    skip_invalid_transactions && !use_pool_transactions;
+                    skip_invalid_transactions || use_pool_transactions;
 
                 for (idx, tx) in recovered_txs.into_iter().enumerate() {
                     let signer = tx.signer();
@@ -242,14 +251,6 @@ where
             })
             .await
     }
-}
-
-/// Calculate the next block gas limit from the parent gas limit and desired target.
-fn calculate_block_gas_limit(parent_gas_limit: u64, desired_gas_limit: u64) -> u64 {
-    let delta = (parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR).saturating_sub(1);
-    let min_gas_limit = parent_gas_limit - delta;
-    let max_gas_limit = parent_gas_limit + delta;
-    desired_gas_limit.clamp(min_gas_limit, max_gas_limit)
 }
 
 #[async_trait]

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -147,6 +147,7 @@ where
                 let mut invalid_senders: HashSet<Address, DefaultHashBuilder> = HashSet::default();
                 let mut block_transactions_rlp_length = 0usize;
 
+                /// If no transactions are provided in the request, use all transactions from the pool.
                 let use_pool_transactions = request.transactions.is_empty();
                 let recovered_txs = if use_pool_transactions {
                     eth_api.pool().all_transactions().all().collect()


### PR DESCRIPTION
Fixes `testing_buildBlockV1` block construction to use the payload builder gas-limit target instead of always inheriting the parent gas limit. The block gas limit now moves toward the configured target within consensus bounds, while `--testing.gas-limit` still forces an exact override.

Also builds the block body from the transaction pool when no explicit transactions are provided, and keeps explicit transaction lists strict so invalid forced transactions fail the request.