### PR TITLE
perf(network): reduce tx fetcher idle peer lookups

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -206,16 +206,27 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
         hashes_to_request: &mut RequestTxHashes,
         mut budget: Option<usize>, // search fallback peers for max `budget` lru pending hashes
     ) -> Option<PeerId> {
+        let saturated_peers =
+            SaturatedPeers::new(self.active_peers.iter().filter_map(|(peer_id, inflight)| {
+                (*inflight >= self.info.max_inflight_requests_per_peer).then_some(*peer_id)
+            }));
         let mut hashes_pending_fetch_iter = self.hashes_pending_fetch.iter();
 
         let idle_peer = loop {
             let &hash = hashes_pending_fetch_iter.next()?;
 
-            let idle_peer = self.get_idle_peer_for(hash);
+            let idle_peer = self.hashes_fetch_inflight_and_pending_fetch.peek(&hash).and_then(
+                |TxFetchMetadata { fallback_peers, .. }| {
+                    fallback_peers
+                        .iter()
+                        .find(|peer_id| !saturated_peers.contains(peer_id))
+                        .copied()
+                },
+            );
 
             if idle_peer.is_some() {
                 hashes_to_request.insert(hash);
-                break idle_peer.copied()
+                break idle_peer
             }
 
             if let Some(ref mut bud) = budget {
@@ -1025,6 +1036,41 @@ impl<T: NetworkPrimitives> Default for TransactionFetcher<T> {
     }
 }
 
+#[derive(Debug, Default)]
+struct SaturatedPeers {
+    peers: HashMap<[u8; 8], smallvec::SmallVec<[PeerId; 1]>, FbBuildHasher<8>>,
+}
+
+impl SaturatedPeers {
+    fn new(peers: impl IntoIterator<Item = PeerId>) -> Self {
+        let iter = peers.into_iter();
+        let mut saturated_peers: HashMap<
+            [u8; 8],
+            smallvec::SmallVec<[PeerId; 1]>,
+            FbBuildHasher<8>,
+        > = HashMap::with_capacity_and_hasher(iter.size_hint().0, Default::default());
+
+        for peer_id in iter {
+            saturated_peers.entry(peer_prefix(&peer_id)).or_default().push(peer_id);
+        }
+
+        Self { peers: saturated_peers }
+    }
+
+    #[inline]
+    fn contains(&self, peer_id: &PeerId) -> bool {
+        self.peers
+            .get(&peer_prefix(peer_id))
+            .is_some_and(|peers| peers.iter().any(|saturated_peer| saturated_peer == peer_id))
+    }
+}
+
+fn peer_prefix(peer_id: &PeerId) -> [u8; 8] {
+    let mut prefix = [0u8; 8];
+    prefix.copy_from_slice(&peer_id.as_slice()[..8]);
+    prefix
+}
+
 /// Metadata of a transaction hash that is yet to be fetched.
 #[derive(Debug, Constructor)]
 pub struct TxFetchMetadata {
@@ -1455,6 +1501,74 @@ mod test {
 
         assert_eq!(1, hashes_to_request.len());
         assert_eq!(2, surplus_hashes.len());
+    }
+
+    #[test]
+    fn saturated_peers_check_full_peer_id_on_prefix_match() {
+        let saturated_peer = PeerId::new([1; 64]);
+        let mut same_prefix_peer = [1; 64];
+        same_prefix_peer[63] = 2;
+        let same_prefix_peer = PeerId::new(same_prefix_peer);
+
+        let saturated_peers = SaturatedPeers::new([saturated_peer]);
+
+        assert!(saturated_peers.contains(&saturated_peer));
+        assert!(!saturated_peers.contains(&same_prefix_peer));
+    }
+
+    #[test]
+    fn find_any_idle_skips_saturated_only_fallback() {
+        let tx_fetcher = &mut TransactionFetcher::default();
+        let hash = B256::from_slice(&[1; 32]);
+        let busy_peer = PeerId::new([1; 64]);
+
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash, busy_peer, 0, None);
+        tx_fetcher.active_peers.insert(busy_peer, tx_fetcher.info.max_inflight_requests_per_peer);
+
+        let mut hashes_to_request = RequestTxHashes::default();
+        let found = tx_fetcher
+            .find_any_idle_fallback_peer_for_any_pending_hash(&mut hashes_to_request, None);
+
+        assert_eq!(found, None);
+        assert!(hashes_to_request.is_empty());
+    }
+
+    #[test]
+    fn find_any_idle_prefers_idle_over_saturated_fallback() {
+        let tx_fetcher = &mut TransactionFetcher::default();
+        let hash = B256::from_slice(&[1; 32]);
+        let busy_peer = PeerId::new([1; 64]);
+        let idle_peer = PeerId::new([2; 64]);
+
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash, busy_peer, 0, None);
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash, idle_peer, 0, None);
+        tx_fetcher.active_peers.insert(busy_peer, tx_fetcher.info.max_inflight_requests_per_peer);
+
+        let mut hashes_to_request = RequestTxHashes::default();
+        let found = tx_fetcher
+            .find_any_idle_fallback_peer_for_any_pending_hash(&mut hashes_to_request, None);
+
+        assert_eq!(found, Some(idle_peer));
+        assert!(hashes_to_request.contains(&hash));
+    }
+
+    #[test]
+    fn find_any_idle_treats_below_limit_peer_as_idle() {
+        let tx_fetcher = &mut TransactionFetcher::default();
+        tx_fetcher.info.max_inflight_requests_per_peer = 2;
+
+        let hash = B256::from_slice(&[1; 32]);
+        let peer = PeerId::new([1; 64]);
+
+        buffer_hash_to_tx_fetcher(tx_fetcher, hash, peer, 0, None);
+        tx_fetcher.active_peers.insert(peer, 1);
+
+        let mut hashes_to_request = RequestTxHashes::default();
+        let found = tx_fetcher
+            .find_any_idle_fallback_peer_for_any_pending_hash(&mut hashes_to_request, None);
+
+        assert_eq!(found, Some(peer));
+        assert!(hashes_to_request.contains(&hash));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This reduces CPU spent in the tx fetcher retry path for pending transaction hashes.

When the tx fetcher has hashes waiting for a fallback peer, it scans pending hashes until it finds a fallback peer that can accept another `GetPooledTransactions` request. On `main`, every fallback-peer check calls `active_peers.peek(peer_id)`, which hashes a 64-byte `PeerId`. Under load this repeats the same peer-id hash many times in one scan.

This PR builds a saturated-peer index once per pending-fetch scan. Fallback-peer checks hash only an 8-byte peer prefix, then do full `PeerId` equality only inside that prefix bucket. It does not change request limits, peer selection semantics, propagation, tx validation, or pool insertion.

Validation so far:

- `cargo +nightly fmt --all --check`
- `cargo test -p reth-network --lib transactions::fetcher::test`
- Fresh synced mainnet profile for this exact implementation, peers 89 -> 130, EL not syncing, CL non-optimistic: [Firefox profile](https://profiler.firefox.com/public/7hqf5sw56jt4gdm1gb3bpbaj5r6zv4xc2dqj8nr)

Controlled microbench, release build, current `origin/main` vs this PR. Scenario: no idle fallback peer, 711 pending hashes, 3 fallback peers per hash, 2,000 calls per run. Each row summarizes 15 sequential runs across fallback peers placed at the start, middle, and end of the saturated-peer set.

| saturated peers | `main` median ns/call (min - max) | this PR median ns/call (min - max) |
|---:|---:|---:|
| 3 | 17,192 (16,807 - 18,040) | 12,027 (11,393 - 12,479) |
| 20 | 17,219 (16,908 - 20,208) | 12,239 (11,814 - 12,793) |
| 80 | 17,325 (16,872 - 20,663) | 13,012 (12,637 - 13,937) |
| 130 | 17,317 (16,880 - 18,576) | 13,735 (13,449 - 14,513) |

This microbench only proves the targeted pending-fetch scan is cheaper under a fixed shape. It is not an end-to-end TPS benchmark.
