### PR TITLE
refactor(engine): flush state provider metrics explicitly

### DIFF
--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -74,36 +74,25 @@ where
     /// Creates a new [`InstrumentedStateProvider`] from a state provider with the provided label
     /// for metrics.
     pub fn new(state_provider: S, source: &'static str) -> Self {
-        Self {
+        Self::with_stats(
             state_provider,
-            metrics: StateProviderMetrics::new_with_labels(&[("source", source)]),
-            stats: Arc::new(StateProviderStats::default()),
-        }
+            StateProviderMetrics::with_source(source),
+            Arc::new(StateProviderStats::default()),
+        )
+    }
+
+    /// Creates a new [`InstrumentedStateProvider`] that writes into shared statistics.
+    pub(crate) const fn with_stats(
+        state_provider: S,
+        metrics: StateProviderMetrics,
+        stats: Arc<StateProviderStats>,
+    ) -> Self {
+        Self { state_provider, metrics, stats }
     }
 
     /// Returns a shared reference to the accumulated fetch statistics.
     pub fn stats(&self) -> Arc<StateProviderStats> {
         Arc::clone(&self.stats)
-    }
-}
-
-impl<S> Drop for InstrumentedStateProvider<S> {
-    fn drop(&mut self) {
-        let total_storage_fetch_latency = self.stats.total_storage_fetch_latency.duration();
-        self.metrics.total_storage_fetch_latency.record(total_storage_fetch_latency);
-        self.metrics
-            .total_storage_fetch_latency_gauge
-            .set(total_storage_fetch_latency.as_secs_f64());
-
-        let total_code_fetch_latency = self.stats.total_code_fetch_latency.duration();
-        self.metrics.total_code_fetch_latency.record(total_code_fetch_latency);
-        self.metrics.total_code_fetch_latency_gauge.set(total_code_fetch_latency.as_secs_f64());
-
-        let total_account_fetch_latency = self.stats.total_account_fetch_latency.duration();
-        self.metrics.total_account_fetch_latency.record(total_account_fetch_latency);
-        self.metrics
-            .total_account_fetch_latency_gauge
-            .set(total_account_fetch_latency.as_secs_f64());
     }
 }
 
@@ -142,6 +131,28 @@ pub(crate) struct StateProviderMetrics {
     /// A gauge of the total time we spend fetching accounts over the lifetime of this state
     /// provider
     total_account_fetch_latency_gauge: Gauge,
+}
+
+impl StateProviderMetrics {
+    /// Creates state-provider metrics with the given source label.
+    pub(crate) fn with_source(source: &'static str) -> Self {
+        Self::new_with_labels(&[("source", source)])
+    }
+
+    /// Records accumulated fetch latency totals.
+    pub(crate) fn record_totals(&self, stats: &StateProviderStats) {
+        let total_storage_fetch_latency = stats.total_storage_fetch_latency.duration();
+        self.total_storage_fetch_latency.record(total_storage_fetch_latency);
+        self.total_storage_fetch_latency_gauge.set(total_storage_fetch_latency.as_secs_f64());
+
+        let total_code_fetch_latency = stats.total_code_fetch_latency.duration();
+        self.total_code_fetch_latency.record(total_code_fetch_latency);
+        self.total_code_fetch_latency_gauge.set(total_code_fetch_latency.as_secs_f64());
+
+        let total_account_fetch_latency = stats.total_account_fetch_latency.duration();
+        self.total_account_fetch_latency.record(total_account_fetch_latency);
+        self.total_account_fetch_latency_gauge.set(total_account_fetch_latency.as_secs_f64());
+    }
 }
 
 impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -40,7 +40,7 @@
 
 use crate::tree::{
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
-    instrumented_state::{InstrumentedStateProvider, StateProviderStats},
+    instrumented_state::{InstrumentedStateProvider, StateProviderMetrics, StateProviderStats},
     multiproof::{StateRootComputeOutcome, StateRootHandle},
     payload_processor::PayloadProcessor,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
@@ -521,34 +521,42 @@ where
             );
         };
 
-        let state_provider_stats = if slow_block_enabled || self.config.state_provider_metrics() {
-            let instrumented_state_provider =
-                InstrumentedStateProvider::new(state_provider, "engine");
-            let stats = slow_block_enabled.then(|| instrumented_state_provider.stats());
-            state_provider = Box::new(instrumented_state_provider);
-            stats
-        } else {
-            None
-        };
+        let instrument_state_provider = slow_block_enabled || self.config.state_provider_metrics();
+        let state_provider_metrics =
+            instrument_state_provider.then(|| StateProviderMetrics::with_source("engine"));
+        let state_provider_stats =
+            instrument_state_provider.then(|| Arc::new(StateProviderStats::default()));
+
+        if instrument_state_provider {
+            let stats = state_provider_stats
+                .as_ref()
+                .expect("instrumented state provider requires shared stats");
+            let metrics = state_provider_metrics
+                .as_ref()
+                .expect("instrumented state provider requires metrics");
+            state_provider = Box::new(InstrumentedStateProvider::with_stats(
+                state_provider,
+                metrics.clone(),
+                Arc::clone(stats),
+            ));
+        }
 
         // Execute the block and handle any execution errors.
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
-        let (output, senders, receipt_root_rx, built_bal) = if bal_eligible {
+        let execution_result = if bal_eligible {
             let provider_builder =
                 bal_provider_builder.expect("eligibility implies builder was cloned");
-            ensure_ok!(self.execute_block_bal(
-                state_provider,
-                env,
-                &input,
-                &handle,
-                provider_builder
-            ))
+            self.execute_block_bal(state_provider, env, &input, &handle, provider_builder)
         } else {
-            ensure_ok!(self.execute_block(state_provider, env, &input, &mut handle))
+            self.execute_block(state_provider, env, &input, &mut handle)
         };
         let execution_duration = execute_block_start.elapsed();
+        if let (Some(metrics), Some(stats)) = (&state_provider_metrics, &state_provider_stats) {
+            metrics.record_totals(stats);
+        }
+        let (output, senders, receipt_root_rx, built_bal) = ensure_ok!(execution_result);
 
         // After executing the block we can stop prewarming transactions
         handle.stop_prewarming_execution();
@@ -827,7 +835,7 @@ where
             .into())
         }
 
-        let timing_stats = state_provider_stats.map(|stats| {
+        let timing_stats = state_provider_stats.filter(|_| slow_block_enabled).map(|stats| {
             self.calculate_timing_stats(
                 &block,
                 stats,


### PR DESCRIPTION
This refactor changes how metrics are recorded. Prior this change we recorded inside the Drop implementation of the InstrumentedStateProvider. That works for now but it does not quite fit the parbal pathway where in
addition to the canonical execution thread each
tx re-execution worker gets its own state provider. Therefore, each worker also would drop and as a result flush the metrics, which is undesirable.

In this change we explicitly record metrics once.
To preserve the existing behaviour we do it before bailing out due to the error, preserving the existing semantics.

In a follow up commit, the stats object is going to be shared between the cannonical execution and the workers at the same time to be flushed in a single place, precisely like we do it in this commit.