### PR TITLE
fix(exex-test): register ExEx in test node pipeline

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -129,6 +129,8 @@ where
 pub type TmpDB = Arc<TempDatabase<DatabaseEnv>>;
 type TmpNodeAdapter<N, Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>> =
     FullNodeTypesAdapter<N, TmpDB, Provider>;
+/// Type alias for the ExEx installer builder stage
+pub type ExExInstallerBuilder<N> = reth_node_builder::WithLaunchContext<reth_node_builder::NodeBuilderWithComponents<reth_node_builder::RethFullAdapter<TmpDB, N>, <N as reth_node_builder::Node<TmpNodeAdapter<N>>>::ComponentsBuilder, <N as reth_node_builder::Node<TmpNodeAdapter<N>>>::AddOns>>;
 
 /// Type alias for a `NodeAdapter`
 pub type Adapter<N, Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>> = NodeAdapter<

--- a/crates/e2e-test-utils/src/setup_builder.rs
+++ b/crates/e2e-test-utils/src/setup_builder.rs
@@ -109,14 +109,46 @@ where
             config
         })
     }
-
-    /// Builds and launches the test nodes.
+    /// Builds and launches the test nodes with an optional ExEx installer.
+    ///
+    /// Use [`Self::build_with_exex`] to register ExEx instances.
     pub async fn build(
         self,
     ) -> eyre::Result<(
         Vec<NodeHelperType<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>,
         Wallet,
     )> {
+        self.build_inner(|b| b).await
+    }
+
+    /// Builds and launches the test nodes with an ExEx installer.
+    ///
+    /// The closure is called per-node after `with_add_ons`. Must be `Fn + Clone`
+    /// to support multi-node setups.
+    pub async fn build_with_exex<G>(
+        self,
+        exex_installer: G,
+    ) -> eyre::Result<(
+        Vec<NodeHelperType<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>,
+        Wallet,
+    )>
+    where
+        G: Fn(reth_node_builder::WithLaunchContext<reth_node_builder::NodeBuilderWithComponents<reth_node_builder::RethFullAdapter<TmpDB, N>, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::ComponentsBuilder, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::AddOns>>) -> reth_node_builder::WithLaunchContext<reth_node_builder::NodeBuilderWithComponents<reth_node_builder::RethFullAdapter<TmpDB, N>, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::ComponentsBuilder, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::AddOns>> + Clone + Send + 'static,
+    {
+        self.build_inner(exex_installer).await
+    }
+
+    /// Internal build implementation.
+    async fn build_inner<G>(
+        self,
+        exex_installer: G,
+    ) -> eyre::Result<(
+        Vec<NodeHelperType<N, BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>>>,
+        Wallet,
+    )>
+    where
+        G: Fn(reth_node_builder::WithLaunchContext<reth_node_builder::NodeBuilderWithComponents<reth_node_builder::RethFullAdapter<TmpDB, N>, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::ComponentsBuilder, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::AddOns>>) -> reth_node_builder::WithLaunchContext<reth_node_builder::NodeBuilderWithComponents<reth_node_builder::RethFullAdapter<TmpDB, N>, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::ComponentsBuilder, <N as reth_node_builder::Node<crate::TmpNodeAdapter<N>>>::AddOns>> + Clone + Send + 'static,
+    {
         let runtime = Runtime::test();
 
         let network_config = NetworkArgs {
@@ -155,11 +187,13 @@ where
 
                 let span = span!(Level::INFO, "node", idx);
                 let node = N::default();
-                let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+                let builder = NodeBuilder::new(node_config)
                     .testing_node(runtime.clone())
                     .with_types_and_provider::<N, BlockchainProvider<_>>()
                     .with_components(node.components_builder())
-                    .with_add_ons(node.add_ons())
+                    .with_add_ons(node.add_ons());
+                let builder = exex_installer.clone()(builder);
+                let NodeHandle { node, node_exit_future: _ } = builder
                     .launch_with_fn(|builder| {
                         let launcher = EngineNodeLauncher::new(
                             builder.task_executor().clone(),

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -367,4 +367,25 @@ where
 
         Ok(())
     }
+
+    /// Runs the test scenario with an ExEx installer.
+    pub async fn run_with_exex<N, G>(mut self, exex_installer: G) -> Result<()>
+    where
+        N: NodeBuilderHelper<Payload = I>,
+        G: Fn(crate::ExExInstallerBuilder<N>) -> crate::ExExInstallerBuilder<N>
+            + Clone
+            + Send
+            + 'static,
+    {
+        let mut setup = self.setup.take();
+        if let Some(ref mut s) = setup {
+            s.apply_with_exex::<N, G>(&mut self.env, exex_installer).await?;
+        }
+        let actions = std::mem::take(&mut self.actions);
+        for action in actions {
+            action.execute(&mut self.env).await?;
+        }
+        drop(setup);
+        Ok(())
+    }
 }

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -183,14 +183,34 @@ where
         N: NodeBuilderHelper<Payload = I>,
     {
         // Note: this future is quite large so we box it
-        Box::pin(self.apply_::<N>(env)).await
+        Box::pin(self.apply_::<N, _>(env, |b| b)).await
     }
 
-    /// Apply the setup to the environment
-    async fn apply_<N>(&mut self, env: &mut Environment<I>) -> Result<()>
+    /// Apply the setup with an ExEx installer.
+    pub async fn apply_with_exex<N, G>(
+        &mut self,
+        env: &mut Environment<I>,
+        exex_installer: G,
+    ) -> Result<()>
     where
         N: NodeBuilderHelper<Payload = I>,
-    {
+        G: Fn(crate::ExExInstallerBuilder<N>) -> crate::ExExInstallerBuilder<N>
+            + Clone
+            + Send
+            + 'static,
+{
+    // Store installer for use during node launch
+    // TODO: thread installer through apply_ to build_with_exex
+    let _ = exex_installer; // temporary until full plumbing
+    Box::pin(self.apply_::<N, G>(env, exex_installer)).await
+}  
+    /// Apply the setup to the environment
+    async fn apply_<N, G>(&mut self, env: &mut Environment<I>, exex_installer: G) -> Result<()>
+        where
+            N: NodeBuilderHelper<Payload = I>,
+            G: Fn(crate::ExExInstallerBuilder<N>) -> crate::ExExInstallerBuilder<N>
+                + Clone + Send + 'static,
+        {
         // If import_rlp_path is set, use apply_with_import instead
         if let Some(rlp_path) = self.import_rlp_path.take() {
             return self.apply_with_import::<N>(env, &rlp_path).await;
@@ -223,7 +243,7 @@ where
             builder = builder.with_storage_v2();
         }
 
-        let result = builder.build().await;
+        let result = builder.build_with_exex(exex_installer).await;
 
         let mut node_clients = Vec::new();
         match result {

--- a/examples/exex-test/src/main.rs
+++ b/examples/exex-test/src/main.rs
@@ -20,7 +20,6 @@ use std::sync::{
 
 mod wal_test;
 
-#[allow(unfulfilled_lint_expectations)]
 struct TestState {
     received_blocks: AtomicU64,
     saw_trie_updates: AtomicBool,
@@ -28,7 +27,6 @@ struct TestState {
 }
 
 /// ExEx that tests assertions about notifications and state
-#[expect(dead_code)]
 async fn test_assertion_exex<
     Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>,
 >(
@@ -42,38 +40,29 @@ async fn test_assertion_exex<
 
     println!("Assertion ExEx started");
 
-    // Clone state for the async block
-    let state_clone = state.clone();
-
     // Process notifications
     while let Some(result) = ctx.notifications.next().await {
-        // Handle the Result with ?
         let notification = result?;
 
-        // Check for committed chain
         if let Some(committed_chain) = notification.committed_chain() {
             let range = committed_chain.range();
             let blocks_count = *range.end() - *range.start() + 1;
             println!("Received committed chain: {range:?}");
 
-            // Increment blocks count
             #[expect(clippy::unnecessary_cast)]
-            state_clone.received_blocks.fetch_add(blocks_count as u64, Ordering::SeqCst);
+            state.received_blocks.fetch_add(blocks_count as u64, Ordering::SeqCst);
 
-            // Send event that we've processed this height
             ctx.events.send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))?;
 
-            // Check for finalization
-            state_clone.last_finalized_block.store(committed_chain.tip().number, Ordering::SeqCst);
+            state.last_finalized_block.store(committed_chain.tip().number, Ordering::SeqCst);
+            // Mark that we received at least one committed notification
+            state.saw_trie_updates.store(true, Ordering::SeqCst);
         }
-
-        // For example, if we see any block, we'll set saw_trie_updates to true
-        // This is a simplification
-        state_clone.saw_trie_updates.store(true, Ordering::SeqCst);
     }
 
     // Report results at the end
     report_test_results(&state);
+
 
     Ok(())
 }
@@ -91,7 +80,7 @@ fn report_test_results(state: &TestState) {
     println!("====================================");
 
     assert!(blocks_received > 0, "No blocks were received by the ExEx");
-    assert!(saw_trie_updates, "No trie updates were observed in any notifications");
+    assert!(saw_trie_updates, "No committed chain notifications were observed");
     assert!(last_finalized > 0, "No finalization events were observed");
 }
 
@@ -123,7 +112,11 @@ async fn run_exex_test() -> eyre::Result<()> {
 
     println!("Test built, running...");
 
-    test.run::<EthereumNode>().await?;
+    test.run_with_exex::<EthereumNode, _>(|builder| {
+            builder.install_exex("assertion-exex", |ctx| async move {
+                Ok(test_assertion_exex(ctx))
+            })
+        }).await?;
 
     println!("Test completed successfully");
 


### PR DESCRIPTION
test_assertion_exex was never registered, all assertions were dead code and the test always passed.

Added build_with_exex/run_with_exex support to E2ETestSetupBuilder and TestBuilder, threaded the installer transiently through the node launch pipeline. ExEx now receives committed chain notifications during test execution.