### PR TITLE
fix(ci): force reinstall txgen bench tools

### DIFF
--- a/.github/scripts/bench-txgen-install.sh
+++ b/.github/scripts/bench-txgen-install.sh
@@ -27,4 +27,4 @@ elif [ -n "${TXGEN_TOKEN:-${GH_PROJECT_TOKEN:-${DEREK_PAT:-${DEREK_TOKEN:-}}}}" 
 fi
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-cargo install --git "$TXGEN_REPO" --locked txgen-ethereum bench-cli
+cargo install --force --git "$TXGEN_REPO" --locked txgen-ethereum bench-cli


### PR DESCRIPTION
Forces `cargo install` for txgen benchmark tools so persistent self-hosted runners do not keep using already-installed binaries after the txgen repository advances.