### PR TITLE
chore(ci): increase stale workflow operation budget

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,5 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
           exempt-all-milestones: true
           exempt-all-assignees: true
+          operations-per-run: 1000
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Raises the stale action operation budget so the daily job can process both high-churn PRs and older stale issues in the same run. This prevents the default budget from stopping before older stale-labelled items are considered for closure.