### PR TITLE
fix: state provider creation

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -92,7 +92,7 @@ type FixedCache<K, V, H = DefaultHashBuilder> = fixed_cache::Cache<K, V, H, Epoc
 /// final [`BundleState`]. See also [`ExecutionCache::insert_state`].
 ///
 /// Normal cache hit/miss metrics are recorded when [`CachedStateMetrics`] is provided. Slow-block
-/// [`CacheStats`] are controlled separately by [`Self::with_cache_stats`].
+/// [`CacheStats`] are controlled separately by [`Self::new_with_mode`].
 #[derive(Debug)]
 pub struct CachedStateProvider<S> {
     /// The state provider
@@ -120,39 +120,26 @@ impl<S> CachedStateProvider<S> {
         caches: ExecutionCache,
         metrics: Option<CachedStateMetrics>,
     ) -> Self {
-        Self::new_with_mode(state_provider, caches, CacheFillMode::LookupOnly, metrics)
+        Self::new_with_mode(state_provider, caches, CacheFillMode::LookupOnly, metrics, None)
     }
 
     /// Creates a cache-filling [`CachedStateProvider`].
     ///
     /// Doesn't accept metrics because prewarming path does not need to report hit/misses.
     pub const fn new_prewarm(state_provider: S, caches: ExecutionCache) -> Self {
-        Self::new_with_mode(state_provider, caches, CacheFillMode::FillOnMiss, None)
+        Self::new_with_mode(state_provider, caches, CacheFillMode::FillOnMiss, None, None)
     }
 
-    /// Creates a cache-filling [`CachedStateProvider`] that also reports hit/miss metrics.
-    pub const fn new_cache_filling(
-        state_provider: S,
-        caches: ExecutionCache,
-        metrics: Option<CachedStateMetrics>,
-    ) -> Self {
-        Self::new_with_mode(state_provider, caches, CacheFillMode::FillOnMiss, metrics)
-    }
-
-    /// Creates a [`CachedStateProvider`] with an explicit cache fill mode.
+    /// Creates a [`CachedStateProvider`] with explicit cache fill behavior and optional
+    /// block-local cache stats.
     pub const fn new_with_mode(
         state_provider: S,
         caches: ExecutionCache,
         fill_mode: CacheFillMode,
         metrics: Option<CachedStateMetrics>,
+        cache_stats: Option<Arc<CacheStats>>,
     ) -> Self {
-        Self { state_provider, caches, metrics, fill_mode, cache_stats: None }
-    }
-
-    /// Enables cache statistics tracking for detailed block logging.
-    pub fn with_cache_stats(mut self, stats: Option<Arc<CacheStats>>) -> Self {
-        self.cache_stats = stats;
-        self
+        Self { state_provider, caches, metrics, fill_mode, cache_stats }
     }
 
     fn record_account_hit(&self) {

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -2,9 +2,9 @@
 //!
 //! Read `execute_block` as two execution paths over the same parent state.
 //!
-//! Worker states run transactions speculatively. Each worker gets one fresh database from
-//! `make_db`, installs the received BAL, sets the transaction BAL index for each streamed
-//! transaction, and returns uncommitted transaction results.
+//! Worker states run transactions speculatively. Each worker gets one fresh cache-filling database
+//! from `make_db(true)`, installs the received BAL, sets the transaction BAL index for each
+//! streamed transaction, and returns uncommitted transaction results.
 //!
 //! The canonical state owns block effects. It runs the normal pre/post block hooks, commits
 //! worker results in transaction order, tracks block gas admission, and builds the BAL that this
@@ -60,7 +60,7 @@ where
     Tx: ExecutableTxFor<Evm> + Send + 'a,
     Err: core::error::Error + Send + Sync + 'static,
     DB: Database + Send + 'a,
-    MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'a,
+    MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'a,
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let worker_pool = runtime.bal_streaming_pool();
@@ -103,7 +103,7 @@ where
     Tx: ExecutableTxFor<Evm> + Send + 'scope,
     Err: core::error::Error + Send + Sync + 'static,
     DB: Database + Send + 'scope,
-    MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'scope,
+    MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let bal = input_bal.as_bal();
@@ -112,8 +112,11 @@ where
     let block_gas_limit = evm_env.block_env.gas_limit();
     let enable_amsterdam_eip8037 = evm_env.cfg_env.enable_amsterdam_eip8037;
     let tx_gas_limit_cap = evm_env.cfg_env.tx_gas_limit_cap;
-    let mut canonical_state =
-        State::builder().with_database(make_db()?).with_bundle_update().with_bal_builder().build();
+    let mut canonical_state = State::builder()
+        .with_database(make_db(false)?)
+        .with_bundle_update()
+        .with_bal_builder()
+        .build();
 
     let (block_result, senders) = {
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
@@ -498,6 +501,7 @@ mod tests {
         let (receipt_tx, _receipt_rx) = crossbeam_channel::unbounded();
         let evm_env = evm_config.evm_env(block.header()).unwrap();
         let execution_ctx = evm_config.context_for_block(block).unwrap();
+        let make_db = |_: bool| make_db();
         execute_block(
             runtime,
             &evm_config,
@@ -1122,11 +1126,13 @@ mod tests {
         let (receipt_tx, _receipt_rx) = crossbeam_channel::unbounded();
         let evm_env = evm_config.evm_env(block.header()).unwrap();
         let execution_ctx = evm_config.context_for_block(&block).unwrap();
+        let make_db = db_factory(system_contracts_db());
+        let make_db = |_: bool| make_db();
 
         let result = execute_block(
             &Runtime::test(),
             &evm_config,
-            &db_factory(system_contracts_db()),
+            &make_db,
             to_arc_decoded(BlockAccessList::default()),
             evm_env,
             execution_ctx,

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -64,12 +64,15 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
     Tx: ExecutableTxFor<Evm> + Send + 'scope,
     Err: core::error::Error + Send + Sync + 'static,
     DB: Database + Send + 'scope,
-    MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync + 'scope,
+    MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
 {
     scope.spawn(move |_| {
         let worker_result = (|| -> Result<(), BalWorkerError> {
+            // Create a database with fill_on_miss=true ensuring misses
+            // are inserted for the other workers.
+            let database = make_db(true).map_err(BalWorkerError::Setup)?;
             let mut worker_state = State::builder()
-                .with_database(make_db().map_err(BalWorkerError::Setup)?)
+                .with_database(database)
                 .with_bal(received_bal_revm)
                 .with_bundle_update()
                 .build();

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -70,7 +70,7 @@ use reth_evm::{
     block::BlockExecutor, execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
     OnStateHook, SpecFor,
 };
-use reth_execution_cache::{CacheStats, SavedCache};
+use reth_execution_cache::{CacheFillMode, CacheStats, SavedCache};
 use reth_payload_primitives::{
     BuiltPayload, BuiltPayloadExecutedBlock, InvalidPayloadAttributesError, NewPayloadError,
     PayloadTypes,
@@ -442,7 +442,6 @@ where
             )
             .into())
         };
-        let mut state_provider = ensure_ok!(provider_builder.build());
         drop(_enter);
 
         let evm_env = debug_span!(target: "engine::tree::payload_validator", "evm_env")
@@ -494,10 +493,7 @@ where
             OverlayStateProviderFactory::new(provider_factory.clone(), overlay_builder.clone());
         let changeset_provider = self.spawn_changeset_provider_task(overlay_factory.clone());
 
-        // BAL execute path eligibility. Computed up front because the BAL arm needs a clone of
-        // `provider_builder` (consumed by `spawn_payload_processor` below).
         let bal_eligible = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
-        let bal_provider_builder = bal_eligible.then(|| provider_builder.clone());
 
         // Spawn the appropriate processor based on strategy
         let mut handle = ensure_ok!(self.spawn_payload_processor(
@@ -511,46 +507,61 @@ where
         // Create optional cache stats for detailed block logging
         let slow_block_enabled = self.config.slow_block_threshold().is_some();
         let cache_stats = slow_block_enabled.then(|| Arc::new(CacheStats::default()));
-
-        // Use cached state provider before executing, used in execution after prewarming threads
-        // complete
-        if let Some(caches) = handle.caches() {
-            state_provider = Box::new(
-                CachedStateProvider::new(state_provider, caches, handle.cache_metrics())
-                    .with_cache_stats(cache_stats.clone()),
-            );
-        };
-
         let instrument_state_provider = slow_block_enabled || self.config.state_provider_metrics();
         let state_provider_metrics =
             instrument_state_provider.then(|| StateProviderMetrics::with_source("engine"));
         let state_provider_stats =
             instrument_state_provider.then(|| Arc::new(StateProviderStats::default()));
+        let execution_cache = handle.caches().map(|caches| (caches, handle.cache_metrics()));
 
-        if instrument_state_provider {
-            let stats = state_provider_stats
-                .as_ref()
-                .expect("instrumented state provider requires shared stats");
-            let metrics = state_provider_metrics
-                .as_ref()
-                .expect("instrumented state provider requires metrics");
-            state_provider = Box::new(InstrumentedStateProvider::with_stats(
-                state_provider,
-                metrics.clone(),
-                Arc::clone(stats),
-            ));
-        }
+        let make_state_provider = |fill_on_miss: bool| -> ProviderResult<StateProviderBox> {
+            let provider = provider_builder.build()?;
+            let mut provider = if let Some((caches, cache_metrics)) = &execution_cache {
+                let fill_mode = if fill_on_miss {
+                    CacheFillMode::FillOnMiss
+                } else {
+                    CacheFillMode::LookupOnly
+                };
+                Box::new(CachedStateProvider::new_with_mode(
+                    provider,
+                    caches.clone(),
+                    fill_mode,
+                    cache_metrics.clone(),
+                    cache_stats.clone(),
+                )) as StateProviderBox
+            } else {
+                provider
+            };
+
+            if instrument_state_provider {
+                let stats = state_provider_stats
+                    .as_ref()
+                    .expect("instrumented state provider requires shared stats");
+                let metrics = state_provider_metrics
+                    .as_ref()
+                    .expect("instrumented state provider requires metrics");
+                provider = Box::new(InstrumentedStateProvider::with_stats(
+                    provider,
+                    metrics.clone(),
+                    Arc::clone(stats),
+                ));
+            }
+
+            Ok(provider)
+        };
 
         // Execute the block and handle any execution errors.
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
         let execution_result = if bal_eligible {
-            let provider_builder =
-                bal_provider_builder.expect("eligibility implies builder was cloned");
-            self.execute_block_bal(state_provider, env, &input, &handle, provider_builder)
+            self.execute_block_bal(env, &input, &handle, &make_state_provider)
         } else {
-            self.execute_block(state_provider, env, &input, &mut handle)
+            let state_provider = make_state_provider(false);
+            match state_provider {
+                Ok(state_provider) => self.execute_block(state_provider, env, &input, &mut handle),
+                Err(err) => Err(err.into()),
+            }
         };
         let execution_duration = execute_block_start.elapsed();
         if let (Some(metrics), Some(stats)) = (&state_provider_metrics, &state_provider_stats) {
@@ -1117,13 +1128,12 @@ where
     /// 5. Returns the rebuilt BAL for post-execution consensus validation.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     #[expect(clippy::type_complexity)]
-    fn execute_block_bal<S, Tx, Err, BalP, T>(
+    fn execute_block_bal<Tx, Err, MakeStateProvider, T>(
         &self,
-        _state_provider: S,
         env: ExecutionEnv<Evm>,
         input: &BlockOrPayload<T>,
         handle: &PayloadHandle<Tx, Err, N::Receipt>,
-        provider_builder: StateProviderBuilder<N, BalP>,
+        make_state_provider: &MakeStateProvider,
     ) -> Result<
         (
             BlockExecutionOutput<N::Receipt>,
@@ -1134,34 +1144,24 @@ where
         InsertBlockErrorKind,
     >
     where
-        S: StateProvider + Send,
         Tx: ExecutableTxFor<Evm> + Send,
         Err: core::error::Error + Send + Sync + 'static,
-        BalP: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+        MakeStateProvider: Fn(bool) -> ProviderResult<StateProviderBox> + Sync,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
         T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
         V: PayloadValidator<T, Block = N::Block>,
     {
         debug!(target: "engine::tree::payload_validator", "Executing block via BAL path");
 
-        let cache = handle.caches().ok_or_else(|| {
-            InsertBlockErrorKind::Other("BAL execute path: no execution cache available".into())
-        })?;
-        let saved_cache = SavedCache::new(env.parent_hash, cache);
-
         let (receipt_tx, result_rx) = self.spawn_receipt_root_task(env.transaction_count);
         let input_bal = env.decoded_bal.ok_or_else(|| {
             InsertBlockErrorKind::Other("BAL execute path: no decoded BAL available".into())
         })?;
 
-        let make_db = move || {
-            let provider = provider_builder
-                .build()
+        let make_db = |fill_on_miss| {
+            let provider = make_state_provider(fill_on_miss)
                 .map_err(crate::tree::payload_processor::bal::BalExecutionError::Provider)?;
-            Ok(StateProviderDatabase::new(CachedStateProvider::new_prewarm(
-                provider,
-                saved_cache.cache().clone(),
-            )))
+            Ok(StateProviderDatabase::new(provider))
         };
         let execution_start = Instant::now();
         let ctx =


### PR DESCRIPTION
Aligns the state provider creation between the BAL and non-BAL execution paths by introducing a single factory for creating the state provider used by both paths.

This has several effects:

1. Now the canonical database doesn't fill the loaded value on miss, aligning this logic with the non-BAL execution.
2. If enabled, BAL path can now use the instrumented state provider.
3. Not sure how useful, but now it's possible to run the BAL path with cache disabled. This is however still gated by the condition check atm and it will be lifted in the following PR.