### PR TITLE
refactor: split execution cache state metrics labels

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -271,6 +271,23 @@ pub struct CachedStateMetrics {
     /// Code cache misses
     code_cache_misses: Gauge,
 
+    /// Storage cache hits
+    storage_cache_hits: Gauge,
+
+    /// Storage cache misses
+    storage_cache_misses: Gauge,
+
+    /// Account cache hits
+    account_cache_hits: Gauge,
+
+    /// Account cache misses
+    account_cache_misses: Gauge,
+}
+
+/// Metrics for shared execution cache state.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "sync.caching")]
+pub struct CachedStateCacheMetrics {
     /// Code cache size (number of entries)
     code_cache_size: Gauge,
 
@@ -280,12 +297,6 @@ pub struct CachedStateMetrics {
     /// Code cache collisions (hash collisions causing eviction)
     code_cache_collisions: Gauge,
 
-    /// Storage cache hits
-    storage_cache_hits: Gauge,
-
-    /// Storage cache misses
-    storage_cache_misses: Gauge,
-
     /// Storage cache size (number of entries)
     storage_cache_size: Gauge,
 
@@ -294,12 +305,6 @@ pub struct CachedStateMetrics {
 
     /// Storage cache collisions (hash collisions causing eviction)
     storage_cache_collisions: Gauge,
-
-    /// Account cache hits
-    account_cache_hits: Gauge,
-
-    /// Account cache misses
-    account_cache_misses: Gauge,
 
     /// Account cache size (number of entries)
     account_cache_size: Gauge,
@@ -317,17 +322,14 @@ impl CachedStateMetrics {
         // code cache
         self.code_cache_hits.set(0);
         self.code_cache_misses.set(0);
-        self.code_cache_collisions.set(0);
 
         // storage cache
         self.storage_cache_hits.set(0);
         self.storage_cache_misses.set(0);
-        self.storage_cache_collisions.set(0);
 
         // account cache
         self.account_cache_hits.set(0);
         self.account_cache_misses.set(0);
-        self.account_cache_collisions.set(0);
     }
 
     /// Returns a new zeroed-out instance of [`CachedStateMetrics`] with a `source` label
@@ -968,7 +970,7 @@ impl ExecutionCache {
 
     /// Updates the provided metrics with the current stats from the cache's stats handlers,
     /// and resets the hit/miss/collision counters.
-    pub fn update_metrics(&self, metrics: &CachedStateMetrics) {
+    pub fn update_metrics(&self, metrics: &CachedStateCacheMetrics) {
         metrics.code_cache_size.set(self.0.code_stats.size() as f64);
         metrics.code_cache_capacity.set(self.0.code_stats.capacity() as f64);
         metrics.code_cache_collisions.set(self.0.code_stats.collisions() as f64);
@@ -1028,7 +1030,7 @@ impl SavedCache {
     }
 
     /// Updates the cache metrics (size/capacity/collisions) from the stats handlers.
-    pub fn update_metrics(&self, metrics: Option<&CachedStateMetrics>) {
+    pub fn update_metrics(&self, metrics: Option<&CachedStateCacheMetrics>) {
         if let Some(metrics) = metrics {
             self.caches.update_metrics(metrics);
         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -72,8 +72,8 @@ pub use payload_validator::{BasicEngineValidator, EngineValidator};
 pub use persistence_state::PersistenceState;
 pub use reth_engine_primitives::TreeConfig;
 pub use reth_execution_cache::{
-    CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider, ExecutionCache,
-    PayloadExecutionCache, SavedCache,
+    CachedStateCacheMetrics, CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider,
+    ExecutionCache, PayloadExecutionCache, SavedCache,
 };
 pub use types::{ValidationOutcome, ValidationOutput};
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -4,8 +4,9 @@ use super::precompile_cache::PrecompileCacheMap;
 use crate::tree::{
     payload_processor::prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
     sparse_trie::SparseTrieCacheTask,
-    CacheWaitDurations, CachedStateMetrics, CachedStateMetricsSource, ExecutionCache,
-    PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig, WaitForCaches,
+    CacheWaitDurations, CachedStateCacheMetrics, CachedStateMetrics, CachedStateMetricsSource,
+    ExecutionCache, PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig,
+    WaitForCaches,
 };
 use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal};
@@ -121,6 +122,8 @@ where
     execution_cache: PayloadExecutionCache,
     /// Metrics for the execution cache.
     cache_metrics: Option<CachedStateMetrics>,
+    /// Metrics for shared execution cache state.
+    cache_state_metrics: Option<CachedStateCacheMetrics>,
     /// Metrics for trie operations
     trie_metrics: MultiProofTaskMetrics,
     /// Cross-block cache size in bytes.
@@ -185,6 +188,8 @@ where
             disable_sparse_trie_cache_pruning: config.disable_sparse_trie_cache_pruning(),
             cache_metrics: (!config.disable_cache_metrics())
                 .then(|| CachedStateMetrics::zeroed(CachedStateMetricsSource::Engine)),
+            cache_state_metrics: (!config.disable_cache_metrics())
+                .then(CachedStateCacheMetrics::default),
             disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
             disable_bal_batch_io: config.disable_bal_batch_io(),
         }
@@ -527,6 +532,7 @@ where
             provider: provider_builder,
             metrics: PrewarmMetrics::default(),
             cache_metrics: self.cache_metrics.clone(),
+            cache_state_metrics: self.cache_state_metrics.clone(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
             executed_tx_index: Arc::clone(&executed_tx_index),
             precompile_cache_disabled: self.precompile_cache_disabled,
@@ -722,7 +728,7 @@ where
         block_with_parent: BlockWithParent,
         bundle_state: &BundleState,
     ) {
-        let cache_metrics = self.cache_metrics.clone();
+        let cache_state_metrics = self.cache_state_metrics.clone();
         self.execution_cache.update_with_guard(|cached| {
             if cached.as_ref().is_some_and(|c| c.executed_block_hash() != block_with_parent.parent) {
                 debug!(
@@ -756,7 +762,7 @@ where
                 debug!(target: "engine::caching", "cleared execution cache on update error");
                 return
             }
-            new_cache.update_metrics(cache_metrics.as_ref());
+            new_cache.update_metrics(cache_state_metrics.as_ref());
 
             // Replace with the updated cache
             *cached = Some(new_cache);

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -14,8 +14,8 @@
 use crate::tree::{
     payload_processor::multiproof::StateRootMessage,
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
-    CachedStateMetrics, CachedStateProvider, ExecutionEnv, PayloadExecutionCache, SavedCache,
-    StateProviderBuilder,
+    CachedStateCacheMetrics, CachedStateMetrics, CachedStateProvider, ExecutionEnv,
+    PayloadExecutionCache, SavedCache, StateProviderBuilder,
 };
 use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::bal::DecodedBal;
@@ -279,7 +279,7 @@ where
 
         let Self {
             execution_cache,
-            ctx: PrewarmContext { env, metrics, cache_metrics, saved_cache, .. },
+            ctx: PrewarmContext { env, metrics, cache_state_metrics, saved_cache, .. },
             ..
         } = self;
         let hash = env.hash;
@@ -301,7 +301,7 @@ where
                     return;
                 }
 
-                new_cache.update_metrics(cache_metrics.as_ref());
+                new_cache.update_metrics(cache_state_metrics.as_ref());
 
                 if valid_block_rx.recv().is_ok() {
                     // Replace the shared cache with the new one; the previous cache (if any) is
@@ -528,6 +528,8 @@ where
     /// Metrics for the execution cache.
     /// Metrics for the execution cache. `None` disables metrics recording.
     pub cache_metrics: Option<CachedStateMetrics>,
+    /// Metrics for shared execution cache state. `None` disables metrics recording.
+    pub cache_state_metrics: Option<CachedStateCacheMetrics>,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
     pub terminate_execution: Arc<AtomicBool>,
     /// Shared counter tracking the next transaction index to be executed by the main execution


### PR DESCRIPTION
## Summary
- split source-labeled cache usage metrics from shared cache state gauges
- keep hit/miss and cache creation metrics on `CachedStateMetrics` with `source`
- publish size/capacity/collision gauges via an unlabeled `CachedStateCacheMetrics` handle

## Validation
- `cargo check -p reth-engine-tree -p reth-execution-cache`

Prompted by: @shekhirin