### PR TITLE
fix(rpc): acquire blocking IO permit in eth_estimateGas

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -317,6 +317,7 @@ pub trait EstimateCall: Call {
     {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
+            let _permit = self.acquire_owned_blocking_io().await;
 
             self.spawn_blocking_io_fut(async move |this| {
                 let state = this.state_at_block_id(at).await?;


### PR DESCRIPTION
`eth_estimateGas` was missing the `acquire_owned_blocking_io()` call
that `eth_call`, `eth_simulateV1`, and `call_many` all use to cap
concurrent blocking tasks at `max_blocking_io_requests` (default 256).

Because gas estimation runs a binary search with up to ~20 EVM
executions per request, the missing permit means an estimation storm can
exhaust the tokio blocking pool faster than a comparable `eth_call`
storm, stalling unrelated RPC methods.

The doc comment for `acquire_owned_blocking_io` in
`crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs` (line 83) already
listed `eth_estimateGas` as an intended caller:

This should be used for operations like `eth_call`, `eth_estimateGas`, and similar methods that require EVM execution and are spawned as blocking tasks.

## Validation

- `cargo +nightly fmt --all --check` 
- `cargo test -p reth-rpc-builder`  — 67 passed; 0 failed (includes `http::test_eth_*` integration tests covering `estimate_gas`)

Note: the behavioural effect (semaphore capping concurrent estimates) is not captured by a microbenchmark. Observable under load via `tokio-console` blocking thread count with 300+ concurrent `eth_estimateGas` requests.