### PR TITLE
refactor(payload): use alloy gas limit helper

### DIFF
--- a/crates/ethereum/payload/src/config.rs
+++ b/crates/ethereum/payload/src/config.rs
@@ -1,6 +1,6 @@
+pub use alloy_eips::eip1559::calculate_block_gas_limit;
 use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_primitives::Bytes;
-use reth_primitives_traits::constants::GAS_LIMIT_BOUND_DIVISOR;
 
 /// Settings for the Ethereum builder.
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -67,13 +67,4 @@ impl EthereumBuilderConfig {
     pub fn gas_limit(&self, parent_gas_limit: u64) -> u64 {
         calculate_block_gas_limit(parent_gas_limit, self.desired_gas_limit)
     }
-}
-
-/// Calculate the gas limit for the next block based on parent and desired gas limits.
-/// Ref: <https://github.com/ethereum/go-ethereum/blob/88cbfab332c96edfbe99d161d9df6a40721bd786/core/block_validator.go#L166>
-pub fn calculate_block_gas_limit(parent_gas_limit: u64, desired_gas_limit: u64) -> u64 {
-    let delta = (parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR).saturating_sub(1);
-    let min_gas_limit = parent_gas_limit - delta;
-    let max_gas_limit = parent_gas_limit + delta;
-    desired_gas_limit.clamp(min_gas_limit, max_gas_limit)
 }


### PR DESCRIPTION
Re-exports and uses `alloy_eips::eip1559::calculate_block_gas_limit` in the Ethereum payload builder config instead of keeping the duplicate local implementation.

This keeps the existing config-module export while sharing the canonical helper from alloy.