### PR TITLE
ci: expose bench observability links

### DIFF
--- a/.github/scripts/bench-job-summary.js
+++ b/.github/scripts/bench-job-summary.js
@@ -11,7 +11,7 @@
 //
 // Usage from actions/github-script:
 //   const jobSummary = require('./.github/scripts/bench-job-summary.js');
-//   await jobSummary({ core, context, chartSha, grafanaUrl, runId });
+//   await jobSummary({ core, context, chartSha, grafanaUrl, logsUrl, tracesUrl, runId });
 
 const fs = require('fs');
 const { verdict, loadSamplyUrls, blocksLabel, metricRows, waitTimeRows, fmtChange } = require('./bench-utils');
@@ -30,7 +30,7 @@ function fmtTargetMetricValue(metric, v) {
   return fmtMetricValue(v);
 }
 
-module.exports = async function ({ core, context, chartSha, grafanaUrl, runId }) {
+module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl, tracesUrl, runId }) {
   let summary;
   try {
     summary = JSON.parse(fs.readFileSync(process.env.BENCH_WORK_DIR + '/summary.json', 'utf8'));
@@ -45,6 +45,11 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, runId })
   const commitUrl = `https://github.com/${repo}/commit`;
 
   const { emoji, label } = verdict(summary.changes);
+  const observability = summary.observability || {};
+  const benchmarkId = summary.benchmark_id || observability.benchmark_id;
+  const resolvedGrafanaUrl = grafanaUrl || observability.grafana_url;
+  const resolvedLogsUrl = logsUrl || observability.logs_url;
+  const resolvedTracesUrl = tracesUrl || observability.traces_url;
   const baselineLink = `[\`${summary.baseline.name}\`](${commitUrl}/${summary.baseline.ref})`;
   const featureLink = `[\`${summary.feature.name}\`](${commitUrl}/${summary.feature.ref})`;
   const diffUrl = `https://github.com/${repo}/compare/${summary.baseline.ref}...${summary.feature.ref}`;
@@ -122,9 +127,14 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, runId })
     md += `### Samply Profiles\n\n${samplyLinks.join('\n')}\n\n`;
   }
 
-  // Grafana
-  if (grafanaUrl) {
-    md += `### Grafana Dashboard\n\n[View real-time metrics](${grafanaUrl})\n\n`;
+  // Observability
+  const observabilityLinks = [];
+  if (benchmarkId) observabilityLinks.push(`- Benchmark ID: \`${benchmarkId}\``);
+  if (resolvedGrafanaUrl) observabilityLinks.push(`- [Metrics dashboard](${resolvedGrafanaUrl})`);
+  if (resolvedLogsUrl) observabilityLinks.push(`- [Logs](${resolvedLogsUrl})`);
+  if (resolvedTracesUrl) observabilityLinks.push(`- [Traces](${resolvedTracesUrl})`);
+  if (observabilityLinks.length > 0) {
+    md += `### Observability\n\n${observabilityLinks.join('\n')}\n\n`;
   }
 
   // Node errors

--- a/.github/scripts/bench-job-summary.js
+++ b/.github/scripts/bench-job-summary.js
@@ -11,7 +11,7 @@
 //
 // Usage from actions/github-script:
 //   const jobSummary = require('./.github/scripts/bench-job-summary.js');
-//   await jobSummary({ core, context, chartSha, grafanaUrl, logsUrl, tracesUrl, runId });
+//   await jobSummary({ core, context, chartSha, logsUrl, tracesUrl, runId });
 
 const fs = require('fs');
 const { verdict, loadSamplyUrls, blocksLabel, metricRows, waitTimeRows, fmtChange } = require('./bench-utils');
@@ -30,7 +30,7 @@ function fmtTargetMetricValue(metric, v) {
   return fmtMetricValue(v);
 }
 
-module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl, tracesUrl, runId }) {
+module.exports = async function ({ core, context, chartSha, logsUrl, tracesUrl, runId }) {
   let summary;
   try {
     summary = JSON.parse(fs.readFileSync(process.env.BENCH_WORK_DIR + '/summary.json', 'utf8'));
@@ -46,7 +46,6 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl,
 
   const { emoji, label } = verdict(summary.changes);
   const observability = summary.observability || {};
-  const resolvedGrafanaUrl = grafanaUrl || observability.grafana_url;
   const resolvedLogsUrl = logsUrl || observability.logs_url;
   const resolvedTracesUrl = tracesUrl || observability.traces_url;
   const baselineLink = `[\`${summary.baseline.name}\`](${commitUrl}/${summary.baseline.ref})`;
@@ -128,7 +127,6 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl,
 
   // Observability
   const observabilityLinks = [];
-  if (resolvedGrafanaUrl) observabilityLinks.push(`- [Grafana](${resolvedGrafanaUrl})`);
   if (resolvedLogsUrl) observabilityLinks.push(`- [Logs](${resolvedLogsUrl})`);
   if (resolvedTracesUrl) observabilityLinks.push(`- [Traces](${resolvedTracesUrl})`);
   if (observabilityLinks.length > 0) {

--- a/.github/scripts/bench-job-summary.js
+++ b/.github/scripts/bench-job-summary.js
@@ -46,7 +46,6 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl,
 
   const { emoji, label } = verdict(summary.changes);
   const observability = summary.observability || {};
-  const benchmarkId = summary.benchmark_id || observability.benchmark_id;
   const resolvedGrafanaUrl = grafanaUrl || observability.grafana_url;
   const resolvedLogsUrl = logsUrl || observability.logs_url;
   const resolvedTracesUrl = tracesUrl || observability.traces_url;
@@ -129,8 +128,7 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl,
 
   // Observability
   const observabilityLinks = [];
-  if (benchmarkId) observabilityLinks.push(`- Benchmark ID: \`${benchmarkId}\``);
-  if (resolvedGrafanaUrl) observabilityLinks.push(`- [Metrics dashboard](${resolvedGrafanaUrl})`);
+  if (resolvedGrafanaUrl) observabilityLinks.push(`- [Grafana](${resolvedGrafanaUrl})`);
   if (resolvedLogsUrl) observabilityLinks.push(`- [Logs](${resolvedLogsUrl})`);
   if (resolvedTracesUrl) observabilityLinks.push(`- [Traces](${resolvedTracesUrl})`);
   if (observabilityLinks.length > 0) {

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -1797,20 +1797,17 @@ def target_metric_change_str(change: dict) -> str:
 
 def generate_observability_section(summary: dict) -> list[str]:
     observability = summary.get("observability") or {}
-    benchmark_id = summary.get("benchmark_id") or observability.get("benchmark_id")
     links = [
-        ("Metrics dashboard", observability.get("grafana_url")),
+        ("Grafana", observability.get("grafana_url")),
         ("Logs", observability.get("logs_url")),
         ("Traces", observability.get("traces_url")),
     ]
     links = [(label, url) for label, url in links if url]
 
-    if not benchmark_id and not links:
+    if not links:
         return []
 
     lines = ["", "### Observability", ""]
-    if benchmark_id:
-        lines.append(f"- Benchmark ID: `{benchmark_id}`")
     for label, url in links:
         lines.append(f"- [{label}]({url})")
     return lines

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -1795,12 +1795,32 @@ def target_metric_change_str(change: dict) -> str:
     )
 
 
+def generate_observability_section(summary: dict) -> list[str]:
+    observability = summary.get("observability") or {}
+    benchmark_id = summary.get("benchmark_id") or observability.get("benchmark_id")
+    links = [
+        ("Metrics dashboard", observability.get("grafana_url")),
+        ("Logs", observability.get("logs_url")),
+        ("Traces", observability.get("traces_url")),
+    ]
+    links = [(label, url) for label, url in links if url]
+
+    if not benchmark_id and not links:
+        return []
+
+    lines = ["", "### Observability", ""]
+    if benchmark_id:
+        lines.append(f"- Benchmark ID: `{benchmark_id}`")
+    for label, url in links:
+        lines.append(f"- [{label}]({url})")
+    return lines
+
+
 def generate_markdown(
     summary: dict, comparison_table: str,
     wait_time_tables: list[str] | None = None,
     target_metric_table: str = "",
     behind_baseline: int = 0, repo: str = "", baseline_ref: str = "", baseline_name: str = "",
-    grafana_url: str | None = None,
     derek_command: str | None = None,
 ) -> str:
     """Generate a markdown comment body."""
@@ -1827,9 +1847,7 @@ def generate_markdown(
     if target_metric_table:
         lines.append("")
         lines.append(target_metric_table)
-    if grafana_url:
-        lines.append("")
-        lines.append(f"**[Grafana Dashboard]({grafana_url})**")
+    lines.extend(generate_observability_section(summary))
     return "\n".join(lines)
 
 
@@ -1860,7 +1878,10 @@ def main():
     parser.add_argument("--warmup-blocks", default=None, help="Number of warmup blocks")
     parser.add_argument("--wait-time", default=None, help="Wait time interval used between blocks")
     parser.add_argument("--bal-mode", default=None, help="BAL mode (true, feature, baseline)")
+    parser.add_argument("--benchmark-id", default=os.environ.get("BENCH_ID"), help="Benchmark ID used for OTLP labels")
     parser.add_argument("--grafana-url", default=None, help="Grafana dashboard URL for this benchmark run")
+    parser.add_argument("--logs-url", default=None, help="Grafana Explore URL for benchmark logs")
+    parser.add_argument("--traces-url", default=None, help="Grafana Explore URL for benchmark traces")
     parser.add_argument("--target-metrics-config", default=None, help="Target metrics config path")
     parser.add_argument(
         "--derek-command",
@@ -1983,6 +2004,18 @@ def main():
         "changes": compute_changes(baseline_stats, feature_stats, ci_stats),
         "wait_times": wait_time_data,
     }
+    if args.benchmark_id:
+        summary["benchmark_id"] = args.benchmark_id
+    observability = {
+        key: value for key, value in {
+            "benchmark_id": args.benchmark_id,
+            "grafana_url": args.grafana_url,
+            "logs_url": args.logs_url,
+            "traces_url": args.traces_url,
+        }.items() if value
+    }
+    if observability:
+        summary["observability"] = observability
     if target_metric_summary:
         summary["target_metrics"] = target_metric_summary
     with open(args.output_summary, "w") as f:
@@ -1997,7 +2030,6 @@ def main():
         repo=args.repo,
         baseline_ref=baseline_ref,
         baseline_name=baseline_name,
-        grafana_url=args.grafana_url,
         derek_command=args.derek_command,
     )
 

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -1893,7 +1893,6 @@ def resolve_observability_range(
 def generate_observability_section(summary: dict) -> list[str]:
     observability = summary.get("observability") or {}
     links = [
-        ("Grafana", observability.get("grafana_url")),
         ("Logs", observability.get("logs_url")),
         ("Traces", observability.get("traces_url")),
     ]

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+from datetime import datetime, timezone
 import json
 import math
 import os
@@ -28,6 +29,8 @@ from pathlib import Path
 import random
 import re
 import sys
+import time
+from urllib.parse import quote
 
 BOOTSTRAP_ITERATIONS = 10_000
 EPSILON = 1e-9
@@ -49,6 +52,9 @@ PRACTICAL_FLOOR_PCT = {
     "wall_clock": 0.70,
     "persist_wait": 5.0,
 }
+LOGS_DATASOURCE_UID = "cfk1hzy08xekgd"
+TRACES_DATASOURCE_UID = "dfk1hrnxca9s0a"
+GRAFANA_EXPLORE_URL = "https://tempoxyz.grafana.net/explore"
 
 
 def _opt_int(row: dict, key: str) -> int | None:
@@ -1795,6 +1801,95 @@ def target_metric_change_str(change: dict) -> str:
     )
 
 
+def iso_from_epoch_ms(epoch_ms: int) -> str:
+    dt = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def grafana_explore_url(panes: dict) -> str:
+    encoded = quote(json.dumps(panes, separators=(",", ":")), safe="")
+    return f"{GRAFANA_EXPLORE_URL}?schemaVersion=1&panes={encoded}&orgId=1"
+
+
+def build_grafana_logs_url(benchmark_id: str, from_ms: int, to_ms: int) -> str:
+    return grafana_explore_url({
+        "pw4": {
+            "datasource": LOGS_DATASOURCE_UID,
+            "queries": [{
+                "refId": "A",
+                "datasource": {
+                    "type": "victoriametrics-logs-datasource",
+                    "uid": LOGS_DATASOURCE_UID,
+                },
+                "editorMode": "code",
+                "expr": f"benchmark_id:{benchmark_id}",
+                "queryType": "instant",
+            }],
+            "range": {
+                "from": iso_from_epoch_ms(from_ms),
+                "to": iso_from_epoch_ms(to_ms),
+            },
+            "panelsState": {
+                "logs": {
+                    "sortOrder": "Descending",
+                    "columns": ["Time", "Line"],
+                    "visualisationType": "table",
+                    "labelFieldName": "labels",
+                },
+            },
+            "compact": False,
+        },
+    })
+
+
+def build_grafana_traces_url(benchmark_id: str, from_ms: int, to_ms: int) -> str:
+    return grafana_explore_url({
+        "g39": {
+            "datasource": TRACES_DATASOURCE_UID,
+            "queries": [{
+                "refId": "A",
+                "datasource": {"type": "tempo", "uid": TRACES_DATASOURCE_UID},
+                "queryType": "traceqlSearch",
+                "serviceMapUseNativeHistograms": False,
+                "filters": [{
+                    "id": "benchmark-id",
+                    "operator": "=",
+                    "scope": "resource",
+                    "tag": "benchmark_id",
+                    "value": [benchmark_id],
+                    "valueType": "string",
+                    "isCustomValue": True,
+                }],
+                "query": "{resource.benchmark_id=" + json.dumps(benchmark_id) + "}",
+            }],
+            "range": {
+                "from": iso_from_epoch_ms(from_ms),
+                "to": iso_from_epoch_ms(to_ms),
+            },
+            "panelsState": {"logs": {"visualisationType": "table"}},
+            "compact": False,
+        },
+    })
+
+
+def resolve_observability_range(
+    from_ms: int | None = None,
+    to_ms: int | None = None,
+) -> tuple[int | None, int | None]:
+    if from_ms is None:
+        reference_epoch = os.environ.get("BENCH_REFERENCE_EPOCH")
+        if reference_epoch:
+            try:
+                from_ms = int(float(reference_epoch) * 1000)
+            except ValueError:
+                from_ms = None
+
+    if to_ms is None and from_ms is not None:
+        to_ms = int(time.time() * 1000)
+
+    return from_ms, to_ms
+
+
 def generate_observability_section(summary: dict) -> list[str]:
     observability = summary.get("observability") or {}
     links = [
@@ -1879,6 +1974,8 @@ def main():
     parser.add_argument("--grafana-url", default=None, help="Grafana dashboard URL for this benchmark run")
     parser.add_argument("--logs-url", default=None, help="Grafana Explore URL for benchmark logs")
     parser.add_argument("--traces-url", default=None, help="Grafana Explore URL for benchmark traces")
+    parser.add_argument("--observability-from-ms", type=int, default=None, help="Grafana observability range start in epoch milliseconds")
+    parser.add_argument("--observability-to-ms", type=int, default=None, help="Grafana observability range end in epoch milliseconds")
     parser.add_argument("--target-metrics-config", default=None, help="Target metrics config path")
     parser.add_argument(
         "--derek-command",
@@ -2003,12 +2100,31 @@ def main():
     }
     if args.benchmark_id:
         summary["benchmark_id"] = args.benchmark_id
+    observability_from_ms, observability_to_ms = resolve_observability_range(
+        args.observability_from_ms,
+        args.observability_to_ms,
+    )
+    logs_url = args.logs_url
+    traces_url = args.traces_url
+    if args.benchmark_id and observability_from_ms and observability_to_ms:
+        logs_url = logs_url or build_grafana_logs_url(
+            args.benchmark_id,
+            observability_from_ms,
+            observability_to_ms,
+        )
+        traces_url = traces_url or build_grafana_traces_url(
+            args.benchmark_id,
+            observability_from_ms,
+            observability_to_ms,
+        )
     observability = {
         key: value for key, value in {
             "benchmark_id": args.benchmark_id,
+            "from_ms": observability_from_ms,
+            "to_ms": observability_to_ms,
             "grafana_url": args.grafana_url,
-            "logs_url": args.logs_url,
-            "traces_url": args.traces_url,
+            "logs_url": logs_url,
+            "traces_url": traces_url,
         }.items() if value
     }
     if observability:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1229,6 +1229,8 @@ jobs:
           echo "grafana-url=${GRAFANA_URL}" >> "$GITHUB_OUTPUT"
           echo "logs-url=${LOGS_URL}" >> "$GITHUB_OUTPUT"
           echo "traces-url=${TRACES_URL}" >> "$GITHUB_OUTPUT"
+          echo "observability-from-ms=${FROM_MS}" >> "$GITHUB_OUTPUT"
+          echo "observability-to-ms=${TO_MS}" >> "$GITHUB_OUTPUT"
           echo "Grafana URL: ${GRAFANA_URL}"
           echo "Logs URL: ${LOGS_URL}"
           echo "Traces URL: ${TRACES_URL}"
@@ -1380,6 +1382,12 @@ jobs:
           TRACES_URL='${{ steps.metrics.outputs.traces-url }}'
           if [ -n "$TRACES_URL" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --traces-url $TRACES_URL"
+          fi
+          OBSERVABILITY_FROM_MS='${{ steps.metrics.outputs.observability-from-ms }}'
+          OBSERVABILITY_TO_MS='${{ steps.metrics.outputs.observability-to-ms }}'
+          if [ -n "$OBSERVABILITY_FROM_MS" ] && [ -n "$OBSERVABILITY_TO_MS" ]; then
+            SUMMARY_ARGS="$SUMMARY_ARGS --observability-from-ms $OBSERVABILITY_FROM_MS"
+            SUMMARY_ARGS="$SUMMARY_ARGS --observability-to-ms $OBSERVABILITY_TO_MS"
           fi
           if [ -n "${BENCH_TARGET_METRICS_CONFIG:-}" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --target-metrics-config $BENCH_TARGET_METRICS_CONFIG"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1142,15 +1142,68 @@ jobs:
 
           .github/scripts/bench-update-status.sh "Finalizing results..."
 
-      - name: Generate Grafana URL
+      - name: Generate observability URLs
         id: metrics
         if: "!cancelled()"
         run: |
           FROM_MS=$(( BENCH_REFERENCE_EPOCH * 1000 ))
           TO_MS=$(( $(date +%s) * 1000 ))
           GRAFANA_URL="https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=${FROM_MS}&to=${TO_MS}&timezone=browser&var-datasource=efk1hcn87dnnkd&var-job=github-reth-bench&var-benchmark_id=${BENCH_ID}&var-benchmark_run=\$__all"
+          OBSERVABILITY_URLS="$(python3 - "$BENCH_ID" "$FROM_MS" "$TO_MS" <<'PY'
+          import json
+          import sys
+          from urllib.parse import quote
+
+          bench_id, from_ms, to_ms = sys.argv[1:4]
+          logs_uid = "cfk1hzy08xekgd"
+          traces_uid = "dfk1hrnxca9s0a"
+
+          def explore_url(datasource_uid, queries):
+              panes = {
+                  "bench": {
+                      "datasource": {"uid": datasource_uid},
+                      "queries": queries,
+                      "range": {"from": str(from_ms), "to": str(to_ms)},
+                  },
+              }
+              encoded = quote(json.dumps(panes, separators=(",", ":")), safe="")
+              return f"https://tempoxyz.grafana.net/explore?schemaVersion=1&panes={encoded}&orgId=1"
+
+          logs_query = {
+              "refId": "A",
+              "datasource": {"uid": logs_uid},
+              "expr": f"benchmark_id:{bench_id}",
+              "query": f"benchmark_id:{bench_id}",
+          }
+          traces_query = {
+              "refId": "A",
+              "datasource": {"uid": traces_uid},
+              "query": f'{{resource.benchmark_id="{bench_id}"}}',
+              "queryType": "traceqlSearch",
+              "filters": [
+                  {
+                      "id": "resource.benchmark_id",
+                      "operator": "=",
+                      "scope": "resource",
+                      "tag": "benchmark_id",
+                      "value": [bench_id],
+                      "valueType": "string",
+                  },
+              ],
+          }
+
+          print(explore_url(logs_uid, [logs_query]))
+          print(explore_url(traces_uid, [traces_query]))
+          PY
+          )"
+          LOGS_URL="$(printf '%s\n' "$OBSERVABILITY_URLS" | sed -n '1p')"
+          TRACES_URL="$(printf '%s\n' "$OBSERVABILITY_URLS" | sed -n '2p')"
           echo "grafana-url=${GRAFANA_URL}" >> "$GITHUB_OUTPUT"
+          echo "logs-url=${LOGS_URL}" >> "$GITHUB_OUTPUT"
+          echo "traces-url=${TRACES_URL}" >> "$GITHUB_OUTPUT"
           echo "Grafana URL: ${GRAFANA_URL}"
+          echo "Logs URL: ${LOGS_URL}"
+          echo "Traces URL: ${TRACES_URL}"
 
       - name: Scan logs for errors
         if: "!cancelled()"
@@ -1285,9 +1338,20 @@ jobs:
           if [ -n "${BENCH_BAL:-}" ] && [ "${BENCH_BAL}" != "false" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --bal-mode $BENCH_BAL"
           fi
+          if [ -n "${BENCH_ID:-}" ]; then
+            SUMMARY_ARGS="$SUMMARY_ARGS --benchmark-id $BENCH_ID"
+          fi
           GRAFANA_URL='${{ steps.metrics.outputs.grafana-url }}'
           if [ -n "$GRAFANA_URL" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --grafana-url $GRAFANA_URL"
+          fi
+          LOGS_URL='${{ steps.metrics.outputs.logs-url }}'
+          if [ -n "$LOGS_URL" ]; then
+            SUMMARY_ARGS="$SUMMARY_ARGS --logs-url $LOGS_URL"
+          fi
+          TRACES_URL='${{ steps.metrics.outputs.traces-url }}'
+          if [ -n "$TRACES_URL" ]; then
+            SUMMARY_ARGS="$SUMMARY_ARGS --traces-url $TRACES_URL"
           fi
           if [ -n "${BENCH_TARGET_METRICS_CONFIG:-}" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --target-metrics-config $BENCH_TARGET_METRICS_CONFIG"
@@ -1418,12 +1482,6 @@ jobs:
               }
             }
 
-            // Grafana dashboard link
-            const grafanaUrl = '${{ steps.metrics.outputs.grafana-url }}';
-            if (grafanaUrl) {
-              comment += `\n\n### Grafana Dashboard\n\n[View real-time metrics](${grafanaUrl})\n`;
-            }
-
             // Node errors (panics / ERROR logs)
             try {
               const errors = fs.readFileSync(process.env.BENCH_WORK_DIR + '/errors.md', 'utf8');
@@ -1456,6 +1514,8 @@ jobs:
               context,
               chartSha: '${{ steps.push-charts.outputs.sha }}',
               grafanaUrl: '${{ steps.metrics.outputs.grafana-url }}',
+              logsUrl: '${{ steps.metrics.outputs.logs-url }}',
+              tracesUrl: '${{ steps.metrics.outputs.traces-url }}',
               runId: '${{ github.run_id }}',
             });
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1549,7 +1549,6 @@ jobs:
               core,
               context,
               chartSha: '${{ steps.push-charts.outputs.sha }}',
-              grafanaUrl: '${{ steps.metrics.outputs.grafana-url }}',
               logsUrl: '${{ steps.metrics.outputs.logs-url }}',
               tracesUrl: '${{ steps.metrics.outputs.traces-url }}',
               runId: '${{ github.run_id }}',

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1150,6 +1150,7 @@ jobs:
           TO_MS=$(( $(date +%s) * 1000 ))
           GRAFANA_URL="https://tempoxyz.grafana.net/d/reth-bench-ghr/reth-bench-ghr?orgId=1&from=${FROM_MS}&to=${TO_MS}&timezone=browser&var-datasource=efk1hcn87dnnkd&var-job=github-reth-bench&var-benchmark_id=${BENCH_ID}&var-benchmark_run=\$__all"
           OBSERVABILITY_URLS="$(python3 - "$BENCH_ID" "$FROM_MS" "$TO_MS" <<'PY'
+          from datetime import datetime, timezone
           import json
           import sys
           from urllib.parse import quote
@@ -1158,42 +1159,69 @@ jobs:
           logs_uid = "cfk1hzy08xekgd"
           traces_uid = "dfk1hrnxca9s0a"
 
-          def explore_url(datasource_uid, queries):
-              panes = {
-                  "bench": {
-                      "datasource": {"uid": datasource_uid},
-                      "queries": queries,
-                      "range": {"from": str(from_ms), "to": str(to_ms)},
-                  },
-              }
+          def iso_from_epoch_ms(ms):
+              dt = datetime.fromtimestamp(int(ms) / 1000, tz=timezone.utc)
+              return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+          from_time = iso_from_epoch_ms(from_ms)
+          to_time = iso_from_epoch_ms(to_ms)
+
+          def explore_url(panes):
               encoded = quote(json.dumps(panes, separators=(",", ":")), safe="")
               return f"https://tempoxyz.grafana.net/explore?schemaVersion=1&panes={encoded}&orgId=1"
 
-          logs_query = {
-              "refId": "A",
-              "datasource": {"uid": logs_uid},
-              "expr": f"benchmark_id:{bench_id}",
-              "query": f"benchmark_id:{bench_id}",
-          }
-          traces_query = {
-              "refId": "A",
-              "datasource": {"uid": traces_uid},
-              "query": f'{{resource.benchmark_id="{bench_id}"}}',
-              "queryType": "traceqlSearch",
-              "filters": [
-                  {
-                      "id": "resource.benchmark_id",
-                      "operator": "=",
-                      "scope": "resource",
-                      "tag": "benchmark_id",
-                      "value": [bench_id],
-                      "valueType": "string",
+          logs_pane = {
+              "pw4": {
+                  "datasource": logs_uid,
+                  "queries": [{
+                      "refId": "A",
+                      "datasource": {"type": "victoriametrics-logs-datasource", "uid": logs_uid},
+                      "editorMode": "code",
+                      "expr": f"benchmark_id:{bench_id}",
+                      "queryType": "instant",
+                  }],
+                  "range": {"from": from_time, "to": to_time},
+                  "panelsState": {
+                      "logs": {
+                          "sortOrder": "Descending",
+                          "columns": ["Time", "Line"],
+                          "visualisationType": "table",
+                          "labelFieldName": "labels",
+                      },
                   },
-              ],
+                  "compact": False,
+              },
+          }
+          traceql_query = "{resource.benchmark_id=" + json.dumps(bench_id) + "}"
+          traces_pane = {
+              "g39": {
+                  "datasource": traces_uid,
+                  "queries": [{
+                      "refId": "A",
+                      "datasource": {"type": "tempo", "uid": traces_uid},
+                      "queryType": "traceqlSearch",
+                      "serviceMapUseNativeHistograms": False,
+                      "filters": [
+                          {
+                              "id": "benchmark-id",
+                              "operator": "=",
+                              "scope": "resource",
+                              "tag": "benchmark_id",
+                              "value": [bench_id],
+                              "valueType": "string",
+                              "isCustomValue": True,
+                          },
+                      ],
+                      "query": traceql_query,
+                  }],
+                  "range": {"from": from_time, "to": to_time},
+                  "panelsState": {"logs": {"visualisationType": "table"}},
+                  "compact": False,
+              },
           }
 
-          print(explore_url(logs_uid, [logs_query]))
-          print(explore_url(traces_uid, [traces_query]))
+          print(explore_url(logs_pane))
+          print(explore_url(traces_pane))
           PY
           )"
           LOGS_URL="$(printf '%s\n' "$OBSERVABILITY_URLS" | sed -n '1p')"


### PR DESCRIPTION
Adds the benchmark ID to bench summary JSON and includes metrics, logs, and traces links in benchmark comments and job summaries.