### PR TITLE
fix(rpc): align simulate response fields

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -3,6 +3,7 @@
 name: hive
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -28,9 +29,9 @@ jobs:
     secrets: inherit
 
   prepare-hive:
-    if: github.repository == 'paradigmxyz/reth'
+    if: github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss'
     timeout-minutes: 45
-    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-16' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss') && 'depot-ubuntu-latest-16' || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:
@@ -149,6 +150,7 @@ jobs:
               - eth_getTransactionCount
               - eth_getTransactionReceipt
               - eth_sendRawTransaction
+              - eth_simulateV1
               - eth_syncing
               # debug_ rpc methods
               - debug_
@@ -201,7 +203,7 @@ jobs:
       - prepare-hive
     name: Hive-Amsterdam / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
     # Use larger runners for eels tests to avoid OOM runner crashes
-    runs-on: ${{ github.repository == 'paradigmxyz/reth' && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss') && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: write
@@ -333,6 +335,7 @@ jobs:
               - eth_getTransactionCount
               - eth_getTransactionReceipt
               - eth_sendRawTransaction
+              - eth_simulateV1
               - eth_syncing
               # debug_ rpc methods
               - debug_
@@ -381,7 +384,7 @@ jobs:
       - prepare-hive
     name: Hive-Osaka / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
     # Use larger runners for eels tests to avoid OOM runner crashes
-    runs-on: ${{ github.repository == 'paradigmxyz/reth' && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss') && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -3,7 +3,6 @@
 name: hive
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
@@ -29,9 +28,9 @@ jobs:
     secrets: inherit
 
   prepare-hive:
-    if: github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss'
+    if: github.repository == 'paradigmxyz/reth'
     timeout-minutes: 45
-    runs-on: ${{ (github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss') && 'depot-ubuntu-latest-16' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && 'depot-ubuntu-latest-16' || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:
@@ -150,7 +149,6 @@ jobs:
               - eth_getTransactionCount
               - eth_getTransactionReceipt
               - eth_sendRawTransaction
-              - eth_simulateV1
               - eth_syncing
               # debug_ rpc methods
               - debug_
@@ -203,7 +201,7 @@ jobs:
       - prepare-hive
     name: Hive-Amsterdam / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
     # Use larger runners for eels tests to avoid OOM runner crashes
-    runs-on: ${{ (github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss') && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: write
@@ -335,7 +333,6 @@ jobs:
               - eth_getTransactionCount
               - eth_getTransactionReceipt
               - eth_sendRawTransaction
-              - eth_simulateV1
               - eth_syncing
               # debug_ rpc methods
               - debug_
@@ -384,7 +381,7 @@ jobs:
       - prepare-hive
     name: Hive-Osaka / ${{ matrix.scenario.sim }}${{ matrix.scenario.limit && format(' - {0}', matrix.scenario.limit) }}
     # Use larger runners for eels tests to avoid OOM runner crashes
-    runs-on: ${{ (github.repository == 'paradigmxyz/reth' || github.repository == 'paradigmxyz/reth-oss') && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'paradigmxyz/reth' && (contains(matrix.scenario.sim, 'eels') && 'depot-ubuntu-latest-8' || 'depot-ubuntu-latest-4') || 'ubuntu-latest' }}
     permissions:
       contents: read
       issues: write

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -314,7 +314,7 @@ where
                         ..SimulateError::invalid_params()
                     }),
                     gas_used: gas.tx_gas_used(),
-                    max_used_gas: Some(gas.tx_gas_used()),
+                    max_used_gas: Some(gas.total_gas_spent()),
                     logs: Vec::new(),
                     status: false,
                 }
@@ -329,7 +329,7 @@ where
                         data: Some(output),
                     }),
                     gas_used: gas.tx_gas_used(),
-                    max_used_gas: Some(gas.tx_gas_used()),
+                    max_used_gas: Some(gas.total_gas_spent()),
                     status: false,
                     logs: Vec::new(),
                 }
@@ -338,7 +338,7 @@ where
                 return_data: output.into_data(),
                 error: None,
                 gas_used: gas.tx_gas_used(),
-                max_used_gas: Some(gas.tx_gas_used()),
+                max_used_gas: Some(gas.total_gas_spent()),
                 logs: logs
                     .into_iter()
                     .map(|log| {

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -327,7 +327,6 @@ where
                         message: error.to_string(),
                         code: SIMULATE_REVERT_CODE,
                         data: Some(output),
-                        ..SimulateError::invalid_params()
                     }),
                     gas_used: gas.tx_gas_used(),
                     max_used_gas: Some(gas.tx_gas_used()),

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -314,7 +314,7 @@ where
                         ..SimulateError::invalid_params()
                     }),
                     gas_used: gas.tx_gas_used(),
-                    max_used_gas: Some(gas.total_gas_spent()),
+                    max_used_gas: Some(gas.tx_gas_used()),
                     logs: Vec::new(),
                     status: false,
                 }
@@ -322,14 +322,15 @@ where
             ExecutionResult::Revert { output, gas, .. } => {
                 let error = Err::from_revert(output.clone());
                 SimCallResult {
-                    return_data: output,
+                    return_data: Bytes::new(),
                     error: Some(SimulateError {
                         message: error.to_string(),
                         code: SIMULATE_REVERT_CODE,
+                        data: Some(output),
                         ..SimulateError::invalid_params()
                     }),
                     gas_used: gas.tx_gas_used(),
-                    max_used_gas: Some(gas.total_gas_spent()),
+                    max_used_gas: Some(gas.tx_gas_used()),
                     status: false,
                     logs: Vec::new(),
                 }
@@ -338,7 +339,7 @@ where
                 return_data: output.into_data(),
                 error: None,
                 gas_used: gas.tx_gas_used(),
-                max_used_gas: Some(gas.total_gas_spent()),
+                max_used_gas: Some(gas.tx_gas_used()),
                 logs: logs
                     .into_iter()
                     .map(|log| {

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -314,7 +314,7 @@ where
                         ..SimulateError::invalid_params()
                     }),
                     gas_used: gas.tx_gas_used(),
-                    max_used_gas: Some(gas.total_gas_spent()),
+                    max_used_gas: Some(gas.total_gas_spent().max(gas.floor_gas())),
                     logs: Vec::new(),
                     status: false,
                 }
@@ -329,7 +329,7 @@ where
                         data: Some(output),
                     }),
                     gas_used: gas.tx_gas_used(),
-                    max_used_gas: Some(gas.total_gas_spent()),
+                    max_used_gas: Some(gas.total_gas_spent().max(gas.floor_gas())),
                     status: false,
                     logs: Vec::new(),
                 }
@@ -338,7 +338,7 @@ where
                 return_data: output.into_data(),
                 error: None,
                 gas_used: gas.tx_gas_used(),
-                max_used_gas: Some(gas.total_gas_spent()),
+                max_used_gas: Some(gas.total_gas_spent().max(gas.floor_gas())),
                 logs: logs
                     .into_iter()
                     .map(|log| {


### PR DESCRIPTION
 fixes this mismatch 
```json  
       {
          "gasUsed": "0x6266",
          "logs": [],
          "maxUsedGas": -- "0x5894" ++ "0x6266",
          "returnData": "0x",
          "status": "0x1"
        } 
```
and this 
```json
      "calls": [
        {
          "error": {
            "code": 3,
            ++ "data": "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000019416c7761797320726576657274696e6720636f6e747261637400000000000000"
          },
          "gasUsed": "0x5355",
          "logs": [],
          "maxUsedGas": "0x5355",
          "returnData": -- "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000019416c7761797320726576657274696e6720636f6e747261637400000000000000" ++ "0x",
          "status": "0x0"
        }
      ],
```