### PR TITLE
feat(consensus): add experimental BAL validation toggle

### DIFF
--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -50,8 +50,8 @@ pub struct EthBeaconConsensus<ChainSpec> {
     skip_blob_gas_used_check: bool,
     /// When true, skips the requests hash check in post-execution validation.
     skip_requests_hash_check: bool,
-    /// When true, accepts and validates BAL hashes before Amsterdam activation.
-    validate_experimental_bal_hashes: bool,
+    /// When true, allows BAL hashes before Amsterdam activation.
+    allow_bal_hashes: bool,
 }
 
 impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> {
@@ -63,7 +63,7 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
             skip_gas_limit_ramp_check: false,
             skip_blob_gas_used_check: false,
             skip_requests_hash_check: false,
-            validate_experimental_bal_hashes: false,
+            allow_bal_hashes: false,
         }
     }
 
@@ -96,9 +96,9 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
         self
     }
 
-    /// Accepts and validates BAL hashes before Amsterdam activation.
-    pub const fn with_validate_experimental_bal_hashes(mut self, validate: bool) -> Self {
-        self.validate_experimental_bal_hashes = validate;
+    /// Allows BAL hashes before Amsterdam activation.
+    pub const fn with_allow_bal_hashes(mut self, allow: bool) -> Self {
+        self.allow_bal_hashes = allow;
         self
     }
 
@@ -120,13 +120,13 @@ where
         receipt_root_bloom: Option<ReceiptRootBloom>,
         block_access_list_hash: Option<B256>,
     ) -> Result<(), ConsensusError> {
-        let res = validation::validate_block_post_execution_with_experimental_bal_hashes(
+        let res = validation::validate_block_post_execution_with_bal_hashes(
             block,
             &self.chain_spec,
             result,
             receipt_root_bloom,
             block_access_list_hash,
-            self.validate_experimental_bal_hashes,
+            self.allow_bal_hashes,
         );
 
         if self.skip_requests_hash_check &&
@@ -253,9 +253,7 @@ where
                 return Err(ConsensusError::SlotNumberMissing)
             }
         } else {
-            if header.block_access_list_hash().is_some() &&
-                !self.validate_experimental_bal_hashes
-            {
+            if header.block_access_list_hash().is_some() && !self.allow_bal_hashes {
                 return Err(ConsensusError::BlockAccessListHashUnexpected)
             }
             if header.slot_number().is_some() {
@@ -429,13 +427,13 @@ mod tests {
     }
 
     #[test]
-    fn prague_header_accepts_experimental_block_access_list_hash_before_amsterdam() {
+    fn prague_header_allows_block_access_list_hash_before_amsterdam() {
         let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
         let mut header = valid_prague_header();
         header.block_access_list_hash = Some(B256::ZERO);
 
         assert!(EthBeaconConsensus::new(chain_spec)
-            .with_validate_experimental_bal_hashes(true)
+            .with_allow_bal_hashes(true)
             .validate_header(&SealedHeader::seal_slow(header,))
             .is_ok());
     }
@@ -455,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn prague_header_rejects_slot_number_with_experimental_bal_hashes_before_amsterdam() {
+    fn prague_header_rejects_slot_number_with_allowed_bal_hashes_before_amsterdam() {
         let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
         let mut header = valid_prague_header();
         header.block_access_list_hash = Some(B256::ZERO);
@@ -463,7 +461,7 @@ mod tests {
 
         assert!(matches!(
             EthBeaconConsensus::new(chain_spec)
-                .with_validate_experimental_bal_hashes(true)
+                .with_allow_bal_hashes(true)
                 .validate_header(&SealedHeader::seal_slow(header,))
                 .unwrap_err(),
             ConsensusError::SlotNumberUnexpected
@@ -471,13 +469,12 @@ mod tests {
     }
 
     #[test]
-    fn prague_post_execution_validates_experimental_block_access_list_hash_before_amsterdam() {
+    fn prague_post_execution_allows_block_access_list_hash_before_amsterdam() {
         let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
         let expected_hash = B256::repeat_byte(0x42);
         let block = prague_recovered_block_with_bal_hash(expected_hash);
         let result = BlockExecutionResult::<Receipt>::default();
-        let consensus =
-            EthBeaconConsensus::new(chain_spec).with_validate_experimental_bal_hashes(true);
+        let consensus = EthBeaconConsensus::new(chain_spec).with_allow_bal_hashes(true);
 
         assert!(FullConsensus::<EthPrimitives>::validate_block_post_execution(
             &consensus,
@@ -488,13 +485,10 @@ mod tests {
         )
         .is_ok());
 
-        assert!(matches!(
-            FullConsensus::<EthPrimitives>::validate_block_post_execution(
-                &consensus, &block, &result, None, None,
-            )
-            .unwrap_err(),
-            ConsensusError::BlockAccessListHashMissing
-        ));
+        assert!(FullConsensus::<EthPrimitives>::validate_block_post_execution(
+            &consensus, &block, &result, None, None,
+        )
+        .is_ok());
 
         assert!(matches!(
             FullConsensus::<EthPrimitives>::validate_block_post_execution(

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -50,6 +50,8 @@ pub struct EthBeaconConsensus<ChainSpec> {
     skip_blob_gas_used_check: bool,
     /// When true, skips the requests hash check in post-execution validation.
     skip_requests_hash_check: bool,
+    /// When true, accepts and validates BAL hashes before Amsterdam activation.
+    validate_experimental_bal_hashes: bool,
 }
 
 impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> {
@@ -61,6 +63,7 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
             skip_gas_limit_ramp_check: false,
             skip_blob_gas_used_check: false,
             skip_requests_hash_check: false,
+            validate_experimental_bal_hashes: false,
         }
     }
 
@@ -93,6 +96,12 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
         self
     }
 
+    /// Accepts and validates BAL hashes before Amsterdam activation.
+    pub const fn with_validate_experimental_bal_hashes(mut self, validate: bool) -> Self {
+        self.validate_experimental_bal_hashes = validate;
+        self
+    }
+
     /// Returns the chain spec associated with this consensus engine.
     pub const fn chain_spec(&self) -> &Arc<ChainSpec> {
         &self.chain_spec
@@ -111,12 +120,13 @@ where
         receipt_root_bloom: Option<ReceiptRootBloom>,
         block_access_list_hash: Option<B256>,
     ) -> Result<(), ConsensusError> {
-        let res = validate_block_post_execution(
+        let res = validation::validate_block_post_execution_with_experimental_bal_hashes(
             block,
             &self.chain_spec,
             result,
             receipt_root_bloom,
             block_access_list_hash,
+            self.validate_experimental_bal_hashes,
         );
 
         if self.skip_requests_hash_check &&
@@ -243,7 +253,9 @@ where
                 return Err(ConsensusError::SlotNumberMissing)
             }
         } else {
-            if header.block_access_list_hash().is_some() {
+            if header.block_access_list_hash().is_some() &&
+                !self.validate_experimental_bal_hashes
+            {
                 return Err(ConsensusError::BlockAccessListHashUnexpected)
             }
             if header.slot_number().is_some() {
@@ -290,6 +302,7 @@ mod tests {
     use alloy_primitives::B256;
     use reth_chainspec::{ChainSpec, ChainSpecBuilder};
     use reth_consensus_common::validation::validate_against_parent_gas_limit;
+    use reth_ethereum_primitives::{Block as EthBlock, EthPrimitives, Receipt};
     use reth_primitives_traits::{
         constants::{GAS_LIMIT_BOUND_DIVISOR, MINIMUM_GAS_LIMIT},
         proofs,
@@ -310,6 +323,12 @@ mod tests {
             requests_hash: Some(EMPTY_REQUESTS_HASH),
             ..Default::default()
         }
+    }
+
+    fn prague_recovered_block_with_bal_hash(hash: B256) -> RecoveredBlock<EthBlock> {
+        let mut header = valid_prague_header();
+        header.block_access_list_hash = Some(hash);
+        RecoveredBlock::new_unhashed(EthBlock { header, body: Default::default() }, Vec::new())
     }
 
     #[test]
@@ -410,6 +429,18 @@ mod tests {
     }
 
     #[test]
+    fn prague_header_accepts_experimental_block_access_list_hash_before_amsterdam() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
+        let mut header = valid_prague_header();
+        header.block_access_list_hash = Some(B256::ZERO);
+
+        assert!(EthBeaconConsensus::new(chain_spec)
+            .with_validate_experimental_bal_hashes(true)
+            .validate_header(&SealedHeader::seal_slow(header,))
+            .is_ok());
+    }
+
+    #[test]
     fn prague_header_rejects_slot_number_before_amsterdam() {
         let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
         let mut header = valid_prague_header();
@@ -420,6 +451,61 @@ mod tests {
                 .validate_header(&SealedHeader::seal_slow(header,))
                 .unwrap_err(),
             ConsensusError::SlotNumberUnexpected
+        ));
+    }
+
+    #[test]
+    fn prague_header_rejects_slot_number_with_experimental_bal_hashes_before_amsterdam() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
+        let mut header = valid_prague_header();
+        header.block_access_list_hash = Some(B256::ZERO);
+        header.slot_number = Some(0);
+
+        assert!(matches!(
+            EthBeaconConsensus::new(chain_spec)
+                .with_validate_experimental_bal_hashes(true)
+                .validate_header(&SealedHeader::seal_slow(header,))
+                .unwrap_err(),
+            ConsensusError::SlotNumberUnexpected
+        ));
+    }
+
+    #[test]
+    fn prague_post_execution_validates_experimental_block_access_list_hash_before_amsterdam() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
+        let expected_hash = B256::repeat_byte(0x42);
+        let block = prague_recovered_block_with_bal_hash(expected_hash);
+        let result = BlockExecutionResult::<Receipt>::default();
+        let consensus =
+            EthBeaconConsensus::new(chain_spec).with_validate_experimental_bal_hashes(true);
+
+        assert!(FullConsensus::<EthPrimitives>::validate_block_post_execution(
+            &consensus,
+            &block,
+            &result,
+            None,
+            Some(expected_hash),
+        )
+        .is_ok());
+
+        assert!(matches!(
+            FullConsensus::<EthPrimitives>::validate_block_post_execution(
+                &consensus, &block, &result, None, None,
+            )
+            .unwrap_err(),
+            ConsensusError::BlockAccessListHashMissing
+        ));
+
+        assert!(matches!(
+            FullConsensus::<EthPrimitives>::validate_block_post_execution(
+                &consensus,
+                &block,
+                &result,
+                None,
+                Some(B256::repeat_byte(0x24)),
+            )
+            .unwrap_err(),
+            ConsensusError::BlockAccessListHashMismatch(_)
         ));
     }
 

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -29,7 +29,7 @@ where
     R: Receipt,
     ChainSpec: EthereumHardforks,
 {
-    validate_block_post_execution_with_experimental_bal_hashes(
+    validate_block_post_execution_with_bal_hashes(
         block,
         chain_spec,
         result,
@@ -39,15 +39,14 @@ where
     )
 }
 
-/// Validate a block with regard to execution results, optionally validating pre-Amsterdam BAL
-/// hashes for experimental networks.
-pub(crate) fn validate_block_post_execution_with_experimental_bal_hashes<B, R, ChainSpec>(
+/// Validate a block with regard to execution results, optionally allowing pre-Amsterdam BAL hashes.
+pub(crate) fn validate_block_post_execution_with_bal_hashes<B, R, ChainSpec>(
     block: &RecoveredBlock<B>,
     chain_spec: &ChainSpec,
     result: &BlockExecutionResult<R>,
     receipt_root_bloom: Option<(B256, Bloom)>,
     block_access_list_hash: Option<B256>,
-    validate_experimental_bal_hashes: bool,
+    allow_bal_hashes: bool,
 ) -> Result<(), ConsensusError>
 where
     B: Block,
@@ -107,16 +106,12 @@ where
     }
 
     // Validate that the header block access list hash matches the calculated block access list hash
-    let is_experimental_bal_hash = validate_experimental_bal_hashes &&
+    let is_allowed_pre_amsterdam_bal_hash = allow_bal_hashes &&
         !chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
         block.header().block_access_list_hash().is_some();
 
-    if is_experimental_bal_hash && block_access_list_hash.is_none() {
-        return Err(ConsensusError::BlockAccessListHashMissing)
-    }
-
     if (chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) ||
-        is_experimental_bal_hash) &&
+        is_allowed_pre_amsterdam_bal_hash) &&
         let Some(block_access_list_hash) = block_access_list_hash
     {
         let Some(block_bal_hash) = block.header().block_access_list_hash() else {

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -29,6 +29,31 @@ where
     R: Receipt,
     ChainSpec: EthereumHardforks,
 {
+    validate_block_post_execution_with_experimental_bal_hashes(
+        block,
+        chain_spec,
+        result,
+        receipt_root_bloom,
+        block_access_list_hash,
+        false,
+    )
+}
+
+/// Validate a block with regard to execution results, optionally validating pre-Amsterdam BAL
+/// hashes for experimental networks.
+pub(crate) fn validate_block_post_execution_with_experimental_bal_hashes<B, R, ChainSpec>(
+    block: &RecoveredBlock<B>,
+    chain_spec: &ChainSpec,
+    result: &BlockExecutionResult<R>,
+    receipt_root_bloom: Option<(B256, Bloom)>,
+    block_access_list_hash: Option<B256>,
+    validate_experimental_bal_hashes: bool,
+) -> Result<(), ConsensusError>
+where
+    B: Block,
+    R: Receipt,
+    ChainSpec: EthereumHardforks,
+{
     // Check if gas used matches the value set in header.
     if block.header().gas_used() != result.gas_used {
         return Err(ConsensusError::BlockGasUsed {
@@ -82,10 +107,21 @@ where
     }
 
     // Validate that the header block access list hash matches the calculated block access list hash
-    if chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
+    let is_experimental_bal_hash = validate_experimental_bal_hashes &&
+        !chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
+        block.header().block_access_list_hash().is_some();
+
+    if is_experimental_bal_hash && block_access_list_hash.is_none() {
+        return Err(ConsensusError::BlockAccessListHashMissing)
+    }
+
+    if (chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) ||
+        is_experimental_bal_hash) &&
         let Some(block_access_list_hash) = block_access_list_hash
     {
-        let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
+        let Some(block_bal_hash) = block.header().block_access_list_hash() else {
+            return Err(ConsensusError::BlockAccessListHashMissing)
+        };
         if block_access_list_hash != block_bal_hash {
             return Err(ConsensusError::BlockAccessListHashMismatch(
                 GotExpected::new(block_access_list_hash, block_bal_hash).into(),

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -114,9 +114,7 @@ where
         is_allowed_pre_amsterdam_bal_hash) &&
         let Some(block_access_list_hash) = block_access_list_hash
     {
-        let Some(block_bal_hash) = block.header().block_access_list_hash() else {
-            return Err(ConsensusError::BlockAccessListHashMissing)
-        };
+        let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();
         if block_access_list_hash != block_bal_hash {
             return Err(ConsensusError::BlockAccessListHashMismatch(
                 GotExpected::new(block_access_list_hash, block_bal_hash).into(),


### PR DESCRIPTION
Adds an opt-in `EthBeaconConsensus` toggle for networks that need to build block access list hashes before Amsterdam activation.

## What changed

- Adds `EthBeaconConsensus::with_allow_bal_hashes(...)`.
- Allows pre-Amsterdam headers with `block_access_list_hash` when the toggle is enabled.
- Continues rejecting pre-Amsterdam `slot_number`.
- Validates supplied post-execution BAL hashes against the header hash for allowed pre-Amsterdam BAL headers.
- Does not require a computed BAL hash to be supplied before Amsterdam when the toggle is enabled.
