### PR TITLE
refactor: integrate state hook from `State<DB>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,8 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.1"
-source = "git+https://github.com/alloy-rs/evm?rev=e9bc4c4#e9bc4c41c315c2d1d12b81d0adc75b1368c43afd"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,9 +306,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3585808f81853af97c12b062496d6be382e902df0e4f4c508e1305355b9e4d49"
+version = "0.35.1"
+source = "git+https://github.com/alloy-rs/evm?rev=e9bc4c4#e9bc4c41c315c2d1d12b81d0adc75b1368c43afd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.0", default-features = false, features = ["rlp"] }
-alloy-evm = { version = "0.35.0", default-features = false }
+alloy-evm = { version = "0.35.1", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
@@ -699,3 +699,6 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "e9bc4c4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.0", default-features = false, features = ["rlp"] }
-alloy-evm = { version = "0.35.1", default-features = false }
+alloy-evm = { version = "0.36.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
@@ -699,6 +699,3 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
-
-[patch.crates-io]
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "e9bc4c4" }

--- a/bin/reth-bb/src/evm.rs
+++ b/bin/reth-bb/src/evm.rs
@@ -12,7 +12,7 @@ use alloy_eips::eip7685::Requests;
 use alloy_evm::{
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        ExecutableTx, GasOutput, OnStateHook, StateChangeSource, StateDB,
+        ExecutableTx, GasOutput, OnStateHook, StateDB,
     },
     eth::{EthBlockExecutionCtx, EthBlockExecutor, EthEvmContext, EthTxResult},
     precompiles::PrecompilesMap,
@@ -275,16 +275,6 @@ where
         Ok(())
     }
 
-    /// Creates a forwarding `OnStateHook` that delegates to the shared hook.
-    fn forwarding_hook(&self) -> Option<Box<dyn OnStateHook>> {
-        let shared = self.shared_hook.clone();
-        Some(Box::new(move |source: StateChangeSource, state: &revm::state::EvmState| {
-            if let Some(hook) = shared.lock().unwrap().as_mut() {
-                hook.on_state(source, state);
-            }
-        }))
-    }
-
     const fn inner(&self) -> &EthBlockExecutor<'a, EthEvm<DB, I, P>, Spec, RethReceiptBuilder> {
         self.inner.as_ref().expect("inner executor must exist")
     }
@@ -383,12 +373,6 @@ where
 
         // Carry forward receipts from prior segments.
         new_inner.receipts = result.receipts;
-
-        // Re-install the forwarding state hook so the parallel state root
-        // task continues to receive state changes.
-        if self.shared_hook.lock().unwrap().is_some() {
-            new_inner.set_state_hook(self.forwarding_hook());
-        }
 
         self.inner = Some(new_inner);
 
@@ -519,15 +503,6 @@ where
         }
 
         Ok((evm, result))
-    }
-
-    fn set_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
-        // Store the real hook in the shared slot and give the inner
-        // executor a lightweight forwarder. This way the hook survives
-        // inner executor finish/reconstruct cycles at segment boundaries.
-        *self.shared_hook.lock().unwrap() = hook;
-        let fwd = self.forwarding_hook();
-        self.inner_mut().set_state_hook(fwd);
     }
 
     fn evm_mut(&mut self) -> &mut Self::Evm {

--- a/bin/reth-bb/src/evm.rs
+++ b/bin/reth-bb/src/evm.rs
@@ -12,7 +12,7 @@ use alloy_eips::eip7685::Requests;
 use alloy_evm::{
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        ExecutableTx, GasOutput, OnStateHook, StateDB,
+        ExecutableTx, GasOutput, StateDB,
     },
     eth::{EthBlockExecutionCtx, EthBlockExecutor, EthEvmContext, EthTxResult},
     precompiles::PrecompilesMap,
@@ -29,7 +29,6 @@ use revm::{
     primitives::hardfork::SpecId,
     Inspector,
 };
-use std::sync::{Arc, Mutex};
 use tracing::{debug, trace};
 
 // ---------------------------------------------------------------------------
@@ -152,10 +151,6 @@ where
     /// Cumulative blob gas used by all segments that have been finished at
     /// boundaries.
     blob_gas_used_offset: u64,
-    /// Shared state hook that survives inner executor finish/reconstruct
-    /// cycles at segment boundaries. Each inner executor receives a
-    /// forwarding hook that delegates to this shared instance.
-    shared_hook: Arc<Mutex<Option<Box<dyn OnStateHook>>>>,
     /// Callback to reseed block hashes into the DB's cache at segment
     /// boundaries. See [`BlockHashSeeder`].
     block_hash_seeder: Option<BlockHashSeeder<DB>>,
@@ -207,7 +202,6 @@ where
             accumulated_requests: Requests::default(),
             gas_used_offset: 0,
             blob_gas_used_offset: 0,
-            shared_hook: Arc::new(Mutex::new(None)),
             block_hash_seeder,
             bal_index_reader,
             bal_index_bumper,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1375,7 +1375,7 @@ mod tests {
 
         let mut state_hook = handle.state_hook().expect("state hook is None");
 
-        for (i, update) in state_updates.into_iter().enumerate() {
+        for update in state_updates {
             state_hook.on_state(&update);
         }
         drop(state_hook);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1024,7 +1024,6 @@ mod tests {
         ExecutionCache, PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig,
     };
     use alloy_eips::eip1898::{BlockNumHash, BlockWithParent};
-    use alloy_evm::block::StateChangeSource;
     use rand::Rng;
     use reth_chainspec::ChainSpec;
     use reth_db_common::init::init_genesis;
@@ -1377,7 +1376,7 @@ mod tests {
         let mut state_hook = handle.state_hook().expect("state hook is None");
 
         for (i, update) in state_updates.into_iter().enumerate() {
-            state_hook.on_state(StateChangeSource::Transaction(i), &update);
+            state_hook.on_state(&update);
         }
         drop(state_hook);
 

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -4,8 +4,8 @@ use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 
 pub use reth_trie_parallel::state_root_task::{
-    evm_state_to_hashed_post_state, StateHookSender, StateRootComputeOutcome,
-    StateRootHandle, StateRootMessage,
+    evm_state_to_hashed_post_state, StateHookSender, StateRootComputeOutcome, StateRootHandle,
+    StateRootMessage,
 };
 
 /// The default max targets, for limiting the number of account and storage proof targets to be

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -4,7 +4,7 @@ use metrics::{Gauge, Histogram};
 use reth_metrics::Metrics;
 
 pub use reth_trie_parallel::state_root_task::{
-    evm_state_to_hashed_post_state, Source, StateHookSender, StateRootComputeOutcome,
+    evm_state_to_hashed_post_state, StateHookSender, StateRootComputeOutcome,
     StateRootHandle, StateRootMessage,
 };
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -193,7 +193,7 @@ where
                 StateRootMessage::PrefetchProofs(targets) => {
                     SparseTrieTaskMessage::PrefetchProofs(targets)
                 }
-                StateRootMessage::StateUpdate(_, state) => {
+                StateRootMessage::StateUpdate(state) => {
                     let _span = trace_span!(target: "engine::tree::payload_processor::sparse_trie", "hashing_state_update", n = state.len()).entered();
                     let hashed = evm_state_to_hashed_post_state(state);
                     SparseTrieTaskMessage::HashedState(hashed)

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1075,7 +1075,9 @@ where
         let transaction_count = input.transaction_count();
         let (receipt_tx, result_rx) = self.spawn_receipt_root_task(transaction_count);
         let executed_tx_index = Arc::clone(handle.executed_tx_index());
-        executor.evm_mut().db_mut().set_state_hook(handle.state_hook().map(|hook| Box::new(hook) as Box<dyn OnStateHook + 'static>));
+        executor.evm_mut().db_mut().set_state_hook(
+            handle.state_hook().map(|hook| Box::new(hook) as Box<dyn OnStateHook + 'static>),
+        );
 
         let execution_start = Instant::now();
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1075,9 +1075,7 @@ where
         let transaction_count = input.transaction_count();
         let (receipt_tx, result_rx) = self.spawn_receipt_root_task(transaction_count);
         let executed_tx_index = Arc::clone(handle.executed_tx_index());
-        let executor = executor.with_state_hook(
-            handle.state_hook().map(|hook| Box::new(hook) as Box<dyn OnStateHook>),
-        );
+        executor.evm_mut().db_mut().set_state_hook(handle.state_hook().map(|hook| Box::new(hook) as Box<dyn OnStateHook + 'static>));
 
         let execution_start = Instant::now();
 

--- a/crates/ethereum/evm/tests/execute.rs
+++ b/crates/ethereum/evm/tests/execute.rs
@@ -811,7 +811,7 @@ fn test_balance_increment_not_duplicated() {
     let tx_clone = tx.clone();
 
     let _output = executor
-        .execute_with_state_hook(block, move |_, state: &EvmState| {
+        .execute_with_state_hook(block, move |state: &EvmState| {
             if let Some(account) = state.get(&withdrawal_recipient) {
                 let _ = tx_clone.send(account.info.balance);
             }

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -22,7 +22,7 @@ use reth_errors::{BlockExecutionError, BlockValidationError, ConsensusError};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
     block::TxResult,
-    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutor},
+    execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm, Evm, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::EthEvmConfig;
@@ -221,7 +221,7 @@ where
     // If we have a sparse trie handle, wire a state hook that streams per-tx state diffs
     // to the background trie pipeline for incremental state root computation.
     if let Some(ref handle) = trie_handle {
-        builder.executor_mut().set_state_hook(Some(Box::new(handle.state_hook())));
+        builder.evm_mut().db_mut().set_state_hook(Some(Box::new(handle.state_hook())));
     }
 
     builder.apply_pre_execution_changes().map_err(|err| {
@@ -452,7 +452,7 @@ where
     {
         // Drop the state hook, which drops the StateHookSender and triggers
         // FinishedStateUpdates via its Drop impl, signaling the trie task to finalize.
-        builder.executor_mut().set_state_hook(None);
+        builder.evm_mut().db_mut().set_state_hook(None);
 
         // The sparse trie has been computing incrementally alongside tx execution.
         // This recv() waits for the final root hash — most work is already done.

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -633,16 +633,19 @@ where
     where
         H: OnStateHook + 'static,
     {
-        let result = self
+        let mut executor = self
             .strategy_factory
             .executor_for_block(&mut self.db, block)
-            .map_err(BlockExecutionError::other)?
-            .with_state_hook(Some(Box::new(state_hook)))
-            .execute_block(block.transactions_recovered())?;
+            .map_err(BlockExecutionError::other)?;
 
+        executor.evm_mut().db_mut().set_state_hook(Some(Box::new(state_hook)));
+
+        let result = executor.execute_block(block.transactions_recovered());
+
+        self.db.set_state_hook(None);
         self.db.merge_transitions(BundleRetention::Reverts);
 
-        Ok(result)
+        result
     }
 
     fn into_state(self) -> State<DB> {

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -2,7 +2,6 @@
 
 use crate::root::ParallelStateRootError;
 use alloy_eip7928::BlockAccessList;
-use alloy_evm::block::StateChangeSource;
 use alloy_primitives::{keccak256, B256};
 use derive_more::derive::Deref;
 use reth_trie::{updates::TrieUpdates, HashedPostState, HashedStorage, MultiProofTargetsV2};
@@ -10,37 +9,13 @@ use revm_state::EvmState;
 use std::sync::Arc;
 use tracing::trace;
 
-/// Source of state changes, either from EVM execution or from a Block Access List.
-#[derive(Clone, Copy)]
-pub enum Source {
-    /// State changes from EVM execution.
-    Evm(StateChangeSource),
-    /// State changes from Block Access List (EIP-7928).
-    BlockAccessList,
-}
-
-impl std::fmt::Debug for Source {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Evm(source) => source.fmt(f),
-            Self::BlockAccessList => f.write_str("BlockAccessList"),
-        }
-    }
-}
-
-impl From<StateChangeSource> for Source {
-    fn from(source: StateChangeSource) -> Self {
-        Self::Evm(source)
-    }
-}
-
 /// Messages used internally by the multi proof task.
 #[derive(Debug)]
 pub enum StateRootMessage {
     /// Prefetch proof targets
     PrefetchProofs(MultiProofTargetsV2),
     /// New state update from transaction execution with its source
-    StateUpdate(Source, EvmState),
+    StateUpdate(EvmState),
     /// Pre-hashed state update from BAL conversion that can be applied directly without proofs.
     HashedStateUpdate(HashedPostState),
     /// Block Access List (EIP-7928; BAL) containing complete state changes for the block.
@@ -123,8 +98,8 @@ impl StateRootHandle {
     pub fn state_hook(&self) -> impl alloy_evm::block::OnStateHook {
         let sender = StateHookSender::new(self.updates_tx.clone());
 
-        move |source: StateChangeSource, state: &EvmState| {
-            let _ = sender.send(StateRootMessage::StateUpdate(source.into(), state.clone()));
+        move |state: &EvmState| {
+            let _ = sender.send(StateRootMessage::StateUpdate(state.clone()));
         }
     }
 

--- a/examples/custom-beacon-withdrawals/src/main.rs
+++ b/examples/custom-beacon-withdrawals/src/main.rs
@@ -20,7 +20,6 @@ use reth_ethereum::{
             block::StateDB,
             execute::{BlockExecutionError, BlockExecutor, InternalBlockExecutionError},
             Evm, EvmEnv, EvmEnvFor, ExecutionCtxFor, InspectorFor, NextBlockEnvAttributes,
-            OnStateHook,
         },
         revm::{
             context::TxEnv,
@@ -225,10 +224,6 @@ where
 
         // Invoke inner finish method to apply Ethereum post-execution changes
         self.inner.finish()
-    }
-
-    fn set_state_hook(&mut self, _hook: Option<Box<dyn OnStateHook>>) {
-        self.inner.set_state_hook(_hook)
     }
 
     fn evm_mut(&mut self) -> &mut Self::Evm {


### PR DESCRIPTION
Changes state hook to be configured at `State<DB>` level, allowing to make sure that everything that is being commited to the database is propagated to the state hook

ref https://github.com/alloy-rs/evm/pull/366