### PR TITLE
feat(payload): cache parent block info for payload jobs

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -166,7 +166,7 @@ where
         cancel,
         best_payload,
     } = args;
-    let PayloadConfig { parent_header, attributes, payload_id } = config;
+    let PayloadConfig { parent_header, attributes, payload_id, .. } = config;
 
     let mut state_provider = client.state_by_block_hash(parent_header.hash())?;
     if let Some(execution_cache) = execution_cache {

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -69,6 +69,8 @@ pub struct BasicPayloadJobGenerator<Client, Builder> {
     builder: Builder,
     /// Stored `cached_reads` for new payload jobs.
     pre_cached: Option<PrecachedState>,
+    /// Stored parent block information for new payload jobs.
+    pre_cached_parent_block_info: Option<PrecachedParentBlockInfo>,
 }
 
 // === impl BasicPayloadJobGenerator ===
@@ -89,6 +91,7 @@ impl<Client, Builder> BasicPayloadJobGenerator<Client, Builder> {
             config,
             builder,
             pre_cached: None,
+            pre_cached_parent_block_info: None,
         }
     }
 
@@ -127,6 +130,14 @@ impl<Client, Builder> BasicPayloadJobGenerator<Client, Builder> {
     fn maybe_pre_cached(&self, parent: B256) -> Option<CachedReads> {
         self.pre_cached.as_ref().filter(|pc| pc.block == parent).map(|pc| pc.cached.clone())
     }
+
+    /// Returns the cached parent block information if it matches the requested parent.
+    fn maybe_parent_block_info(&self, parent: B256) -> Option<PayloadParentBlockInfo> {
+        self.pre_cached_parent_block_info
+            .as_ref()
+            .filter(|info| info.block == parent)
+            .map(|info| info.parent_block_info)
+    }
 }
 
 // === impl BasicPayloadJobGenerator ===
@@ -163,9 +174,12 @@ where
                 .ok_or_else(|| PayloadBuilderError::MissingParentHeader(input.parent_hash))?
         };
 
-        let cached_reads = self.maybe_pre_cached(parent_header.hash());
+        let parent_hash = parent_header.hash();
+        let cached_reads = self.maybe_pre_cached(parent_hash);
+        let parent_block_info = self.maybe_parent_block_info(parent_hash);
 
-        let config = PayloadConfig::new(Arc::new(parent_header), input.attributes, id);
+        let config = PayloadConfig::new(Arc::new(parent_header), input.attributes, id)
+            .with_parent_block_info(parent_block_info);
 
         let until = self.job_deadline(config.attributes.timestamp());
         let deadline = Box::pin(tokio::time::sleep_until(until));
@@ -208,7 +222,14 @@ where
             }
         }
 
-        self.pre_cached = Some(PrecachedState { block: committed.tip().hash(), cached });
+        let tip = committed.tip();
+        let block = tip.hash();
+        let parent_block_info =
+            PayloadParentBlockInfo { transaction_count: tip.transaction_count() };
+
+        self.pre_cached = Some(PrecachedState { block, cached });
+        self.pre_cached_parent_block_info =
+            Some(PrecachedParentBlockInfo { block, parent_block_info });
     }
 }
 
@@ -221,6 +242,15 @@ pub struct PrecachedState {
     pub block: B256,
     /// Cached state for the block.
     pub cached: CachedReads,
+}
+
+/// Pre-filled parent block information for a specific block.
+#[derive(Debug, Clone, Copy)]
+struct PrecachedParentBlockInfo {
+    /// The block for which the parent block information is cached.
+    block: B256,
+    /// Cached parent block information.
+    parent_block_info: PayloadParentBlockInfo,
 }
 
 /// Restricts how many generator tasks can be executed at once.
@@ -703,10 +733,19 @@ impl<P> Future for PendingPayload<P> {
 pub struct PayloadConfig<Attributes, Header = alloy_consensus::Header> {
     /// The parent header.
     pub parent_header: Arc<SealedHeader<Header>>,
+    /// Additional parent block information, if available.
+    pub parent_block_info: Option<PayloadParentBlockInfo>,
     /// Requested attributes for the payload.
     pub attributes: Attributes,
     /// The payload id.
     pub payload_id: PayloadId,
+}
+
+/// Additional information about the parent block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PayloadParentBlockInfo {
+    /// Number of transactions in the parent block.
+    pub transaction_count: usize,
 }
 
 impl<Attributes, Header> PayloadConfig<Attributes, Header>
@@ -719,7 +758,16 @@ where
         attributes: Attributes,
         payload_id: PayloadId,
     ) -> Self {
-        Self { parent_header, attributes, payload_id }
+        Self { parent_header, parent_block_info: None, attributes, payload_id }
+    }
+
+    /// Attaches cached parent block information.
+    pub const fn with_parent_block_info(
+        mut self,
+        parent_block_info: Option<PayloadParentBlockInfo>,
+    ) -> Self {
+        self.parent_block_info = parent_block_info;
+        self
     }
 
     /// Returns the payload id.

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -175,7 +175,7 @@ where
             cancel,
             best_payload,
         } = args;
-        let PayloadConfig { parent_header, attributes, payload_id } = config;
+        let PayloadConfig { parent_header, parent_block_info, attributes, payload_id } = config;
 
         match attributes {
             Either::Left(left_attr) => {
@@ -183,7 +183,12 @@ where
                     cached_reads,
                     execution_cache,
                     trie_handle,
-                    config: PayloadConfig { parent_header, attributes: left_attr, payload_id },
+                    config: PayloadConfig {
+                        parent_header,
+                        parent_block_info,
+                        attributes: left_attr,
+                        payload_id,
+                    },
                     cancel,
                     best_payload: best_payload.and_then(|payload| {
                         if let Either::Left(p) = payload {
@@ -200,7 +205,12 @@ where
                     cached_reads,
                     execution_cache,
                     trie_handle,
-                    config: PayloadConfig { parent_header, attributes: right_attr, payload_id },
+                    config: PayloadConfig {
+                        parent_header,
+                        parent_block_info,
+                        attributes: right_attr,
+                        payload_id,
+                    },
                     cancel,
                     best_payload: best_payload.and_then(|payload| {
                         if let Either::Right(p) = payload {
@@ -220,14 +230,32 @@ where
         config: PayloadConfig<Self::Attributes, HeaderForPayload<Self::BuiltPayload>>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         match config {
-            PayloadConfig { parent_header, attributes: Either::Left(left_attr), payload_id } => {
-                let left_config =
-                    PayloadConfig { parent_header, attributes: left_attr, payload_id };
+            PayloadConfig {
+                parent_header,
+                parent_block_info,
+                attributes: Either::Left(left_attr),
+                payload_id,
+            } => {
+                let left_config = PayloadConfig {
+                    parent_header,
+                    parent_block_info,
+                    attributes: left_attr,
+                    payload_id,
+                };
                 self.left.build_empty_payload(left_config).map(Either::Left)
             }
-            PayloadConfig { parent_header, attributes: Either::Right(right_attr), payload_id } => {
-                let right_config =
-                    PayloadConfig { parent_header, attributes: right_attr, payload_id };
+            PayloadConfig {
+                parent_header,
+                parent_block_info,
+                attributes: Either::Right(right_attr),
+                payload_id,
+            } => {
+                let right_config = PayloadConfig {
+                    parent_header,
+                    parent_block_info,
+                    attributes: right_attr,
+                    payload_id,
+                };
                 self.right.build_empty_payload(right_config).map(Either::Right)
             }
         }

--- a/examples/custom-engine-types/src/main.rs
+++ b/examples/custom-engine-types/src/main.rs
@@ -339,7 +339,7 @@ where
             cancel,
             best_payload,
         } = args;
-        let PayloadConfig { parent_header, attributes, payload_id } = config;
+        let PayloadConfig { parent_header, parent_block_info, attributes, payload_id } = config;
 
         // This reuses the default EthereumPayloadBuilder to build the payload
         // but any custom logic can be implemented here
@@ -347,7 +347,12 @@ where
             cached_reads,
             execution_cache,
             trie_handle,
-            config: PayloadConfig { parent_header, attributes: attributes.inner, payload_id },
+            config: PayloadConfig {
+                parent_header,
+                parent_block_info,
+                attributes: attributes.inner,
+                payload_id,
+            },
             cancel,
             best_payload,
         })
@@ -357,9 +362,10 @@ where
         &self,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        let PayloadConfig { parent_header, attributes, payload_id } = config;
+        let PayloadConfig { parent_header, parent_block_info, attributes, payload_id } = config;
         self.inner.build_empty_payload(PayloadConfig {
             parent_header,
+            parent_block_info,
             attributes: attributes.inner,
             payload_id,
         })


### PR DESCRIPTION
Adds optional parent block metadata to `PayloadConfig` and populates it from canonical state notifications when the requested parent hash matches the cached state.

The first cached field is the parent transaction count, giving payload builders access to parent block sizing without another block read.