### PR TITLE
chore(db): address static file cursor clippy lint

### DIFF
--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -48,7 +48,7 @@ impl<'a> StaticFileCursor<'a> {
                 None => Ok(None),
             },
         }
-        .map_or(None, |v| v);
+        .unwrap_or(None);
 
         Ok(row)
     }


### PR DESCRIPTION
Unblocks the lint failure observed on #24671 by replacing the static file cursor's identity `map_or` with the equivalent `unwrap_or(None)`. This preserves the existing error-to-`None` behavior while satisfying `clippy::map_or_identity`.