### PR TITLE
perf(tree): fold sparse trie final state accumulation

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -472,14 +472,34 @@ where
         skip_all
     )]
     fn on_hashed_state_update(&mut self, hashed_state_update: HashedPostState) {
+        let Self {
+            trie,
+            new_storage_updates,
+            storage_updates,
+            new_account_updates,
+            pending_account_updates,
+            final_hashed_state,
+            ..
+        } = self;
+
+        final_hashed_state.accounts.reserve(hashed_state_update.accounts.len());
+        final_hashed_state.storages.reserve(hashed_state_update.storages.len());
+
         for (&address, storage) in &hashed_state_update.storages {
+            let final_storage = final_hashed_state.storages.entry(address).or_default();
+            if storage.wiped {
+                final_storage.wiped = true;
+                final_storage.storage.clear();
+            }
+            final_storage.storage.reserve(storage.storage.len());
+
             if !storage.storage.is_empty() {
                 // Look up outer maps once per address instead of once per slot.
-                let new_updates = self.new_storage_updates.entry(address).or_default();
-                let mut existing_updates = self.storage_updates.get_mut(&address);
+                let new_updates = new_storage_updates.entry(address).or_default();
+                let mut existing_updates = storage_updates.get_mut(&address);
 
                 for (&slot, &value) in &storage.storage {
-                    self.trie.record_slot_touch(address, slot);
+                    trie.record_slot_touch(address, slot);
 
                     let encoded = if value.is_zero() {
                         Vec::new()
@@ -487,6 +507,7 @@ where
                         alloy_rlp::encode_fixed_size(&value).to_vec()
                     };
                     new_updates.insert(slot, LeafUpdate::Changed(encoded));
+                    final_storage.storage.insert(slot, value);
 
                     // Remove an existing storage update if it exists.
                     if let Some(ref mut existing) = existing_updates {
@@ -497,28 +518,27 @@ where
 
             // Make sure account is tracked in `account_updates` so that it is revealed in accounts
             // trie for storage root update.
-            self.new_account_updates.entry(address).or_insert(LeafUpdate::Touched);
+            new_account_updates.entry(address).or_insert(LeafUpdate::Touched);
 
             // Make sure account is tracked in `pending_account_updates` so that once storage root
             // is computed, it will be updated in the accounts trie.
-            self.pending_account_updates.entry(address).or_insert(None);
+            pending_account_updates.entry(address).or_insert(None);
         }
 
         for (&address, &account) in &hashed_state_update.accounts {
-            self.trie.record_account_touch(address);
+            trie.record_account_touch(address);
+            final_hashed_state.accounts.insert(address, account);
 
             // Track account as touched.
             //
             // This might overwrite an existing update, which is fine, because storage root from it
             // is already tracked in the trie and can be easily fetched again.
-            self.new_account_updates.insert(address, LeafUpdate::Touched);
+            new_account_updates.insert(address, LeafUpdate::Touched);
 
             // Track account in `pending_account_updates` so that once storage root is computed,
             // it will be updated in the accounts trie.
-            self.pending_account_updates.insert(address, Some(account));
+            pending_account_updates.insert(address, Some(account));
         }
-
-        self.final_hashed_state.extend(hashed_state_update);
     }
 
     fn on_proof_result(


### PR DESCRIPTION
Folds final hashed state accumulation into the sparse trie hashed-state update loop so each update is walked once while leaf updates are built.