### PR TITLE
chore: fix nonce related failures for eth_simulate

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -38,6 +38,7 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, StateCacheDb,
 };
+use reth_rpc_server_types::result::invalid_params_rpc_err;
 use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
 use revm::{
     context::Block,
@@ -177,6 +178,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         .map_err(Self::Error::from_eth_err)?;
                     let map_err = |e: EthApiError| -> Self::Error {
                         match e.as_simulate_error() {
+                            Some(sim_err) if validation => Self::Error::from_eth_err(
+                                EthApiError::other(invalid_params_rpc_err(sim_err.to_string())),
+                            ),
                             Some(sim_err) => Self::Error::from_eth_err(EthApiError::other(sim_err)),
                             None => Self::Error::from_eth_err(e),
                         }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -578,7 +578,7 @@ where
     Ok(SimulatedBlock { inner: block, calls })
 }
 
-fn validate_simulate_tx_nonce(tx: u64, state: u64) -> Result<(), EthApiError> {
+const fn validate_simulate_tx_nonce(tx: u64, state: u64) -> Result<(), EthApiError> {
     if tx < state {
         return Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow {
             tx,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::{api::FromEthApiError, FromEvmError, ToRpcError},
-    EthApiError,
+    EthApiError, RpcInvalidTransactionError,
 };
 use alloy_chains::Chain;
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
@@ -31,6 +31,8 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
+
+use std::collections::HashMap;
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
@@ -315,6 +317,8 @@ where
     let block_gas_limit = builder.evm().block().gas_limit();
     let is_amsterdam = builder.evm().cfg_env().enable_amsterdam_eip8037;
     let tx_gas_limit_cap = builder.evm().cfg_env().tx_gas_limit_cap.unwrap_or(u64::MAX);
+    let validate_nonces = !builder.evm().cfg_env().disable_nonce_check;
+    let mut next_nonces = HashMap::new();
     for mut call in calls {
         let block_gas_remaining = if is_amsterdam {
             block_gas_limit
@@ -349,6 +353,29 @@ where
             } else {
                 default_gas_limit = default_gas_limit.min(remaining_call_gas_limit);
             }
+        }
+
+        if validate_nonces {
+            let from = call.as_ref().from().unwrap_or_default();
+            let expected_nonce = if let Some(nonce) = next_nonces.get(&from).copied() {
+                nonce
+            } else {
+                let nonce = builder
+                    .evm_mut()
+                    .db_mut()
+                    .basic(from)
+                    .map_err(Into::into)?
+                    .map(|acc| acc.nonce)
+                    .unwrap_or_default();
+                next_nonces.insert(from, nonce);
+                nonce
+            };
+
+            if let Some(tx_nonce) = call.as_ref().nonce() {
+                validate_simulate_tx_nonce(tx_nonce, expected_nonce)?;
+            }
+
+            next_nonces.insert(from, expected_nonce.wrapping_add(1));
         }
 
         // Resolve transaction, populate missing fields and enforce calls
@@ -551,10 +578,27 @@ where
     Ok(SimulatedBlock { inner: block, calls })
 }
 
+fn validate_simulate_tx_nonce(tx: u64, state: u64) -> Result<(), EthApiError> {
+    if tx < state {
+        return Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow {
+            tx,
+            state,
+        }))
+    }
+
+    if tx > state {
+        return Err(EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceTooHigh))
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{apply_precompile_overrides, sanitize_chain, EthSimulateError};
-    use crate::EthApiError;
+    use super::{
+        apply_precompile_overrides, sanitize_chain, validate_simulate_tx_nonce, EthSimulateError,
+    };
+    use crate::{EthApiError, RpcInvalidTransactionError};
     use alloy_chains::Chain;
     use alloy_consensus::Header;
     use alloy_evm::precompiles::PrecompilesMap;
@@ -722,5 +766,25 @@ mod tests {
         let err = sanitize_chain(vec![block_with_number(257)], &parent, Chain::mainnet().id(), 256)
             .unwrap_err();
         assert!(matches!(err, EthApiError::Other(_)));
+    }
+
+    #[test]
+    fn validate_simulate_tx_nonce_rejects_out_of_sequence_nonce() {
+        let err = validate_simulate_tx_nonce(0, 2).unwrap_err();
+        assert!(matches!(
+            err,
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow {
+                tx: 0,
+                state: 2
+            })
+        ));
+
+        let err = validate_simulate_tx_nonce(2, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::NonceTooHigh)
+        ));
+
+        validate_simulate_tx_nonce(1, 1).unwrap();
     }
 }


### PR DESCRIPTION
```
"jsonrpc":"2.0","id":1,"error":{"code":-38012,"message":"max fee per gas less than block base fee"}}
2026-05-30T15:39:42.1533339Z note: error messages removed from comparison
2026-05-30T15:39:42.1533564Z response differs from expected (-- client, ++ test):
2026-05-30T15:39:42.1533761Z {
2026-05-30T15:39:42.1533895Z   "error": {
2026-05-30T15:39:42.1534055Z     "code": -- -38012 ++ -32602
2026-05-30T15:39:42.1534220Z   },
2026-05-30T15:39:42.1534354Z   "id": 1,
2026-05-30T15:39:42.1534495Z   "jsonrpc": "2.0"
2026-05-30T15:39:42.1534639Z }eth_simulateV1/ethSimulate-check-invalid-nonce (reth_default)
```
Fixes eth_simulateV1 validation so invalid explicit nonce sequences are reported before fee validation errors.