### PR TITLE
fix(rpc): align eth_simulate fork handling

### DIFF
--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -75,6 +75,11 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
             .chain_spec
             .is_prague_active_at_timestamp(timestamp)
             .then(|| requests.requests_hash());
+        let block_number = evm_env.block_env.number().saturating_to();
+        let base_fee_per_gas = self
+            .chain_spec
+            .is_london_active_at_block(block_number)
+            .then(|| evm_env.block_env.basefee());
 
         let mut excess_blob_gas = None;
         let mut block_blob_gas_used = None;
@@ -108,8 +113,8 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
             timestamp,
             mix_hash: evm_env.block_env.prevrandao().unwrap_or_default(),
             nonce: BEACON_NONCE.into(),
-            base_fee_per_gas: Some(evm_env.block_env.basefee()),
-            number: evm_env.block_env.number().saturating_to(),
+            base_fee_per_gas,
+            number: block_number,
             gas_limit: evm_env.block_env.gas_limit(),
             difficulty: evm_env.block_env.difficulty(),
             gas_used: *gas_used,

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -18,7 +18,7 @@ use alloy_rpc_types_eth::{
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
 use futures::Future;
-use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
@@ -38,6 +38,7 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, StateCacheDb,
 };
+use reth_rpc_server_types::result::{block_id_to_str, rpc_error_with_code};
 use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
 use revm::{
     context::Block,
@@ -92,8 +93,12 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             let _permit = self.acquire_owned_blocking_io().await;
 
-            let base_block =
-                self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
+            let base_block = self.recovered_block(block).await?.ok_or_else(|| {
+                EthApiError::other(rpc_error_with_code(
+                    -32000,
+                    format!("block not found: {}", block_id_to_str(block)),
+                ))
+            })?;
             let parent = base_block.sealed_header().clone();
             let max_simulate_blocks = self.max_simulate_blocks();
 
@@ -148,6 +153,13 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     // matching spec behavior where MixDigest is zero-initialized.
                     // If user provides an override, it will be applied by apply_block_overrides.
                     evm_env.block_env.inner_mut().prevrandao = Some(B256::ZERO);
+                    if !this
+                        .provider()
+                        .chain_spec()
+                        .is_paris_active_at_block(evm_env.block_env.number().saturating_to())
+                    {
+                        evm_env.block_env.inner_mut().difficulty = parent.difficulty();
+                    }
 
                     if let Some(block_overrides) = block_overrides {
                         // ensure we don't allow uncapped gas limit per block

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -92,7 +92,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             let _permit = self.acquire_owned_blocking_io().await;
 
-            let base_block = self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
+            let base_block =
+                self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
             let parent = base_block.sealed_header().clone();
             let max_simulate_blocks = self.max_simulate_blocks();
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -38,7 +38,6 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, StateCacheDb,
 };
-use reth_rpc_server_types::result::{block_id_to_str, rpc_error_with_code};
 use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
 use revm::{
     context::Block,
@@ -93,12 +92,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             let _permit = self.acquire_owned_blocking_io().await;
 
-            let base_block = self.recovered_block(block).await?.ok_or_else(|| {
-                EthApiError::other(rpc_error_with_code(
-                    -32000,
-                    format!("block not found: {}", block_id_to_str(block)),
-                ))
-            })?;
+            let base_block = self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
             let parent = base_block.sealed_header().clone();
             let max_simulate_blocks = self.max_simulate_blocks();
 


### PR DESCRIPTION
Fixes `eth_simulateV1` block construction so simulated headers respect the active hardforks.

Before this, simulated blocks could include fork-specific fields too early or use incorrect legacy values:
- pre-London blocks could include `baseFeePerGas`
- pre-Paris blocks could lose parent difficulty
- missing base blocks returned the wrong RPC error code for `eth_simulateV1`

This aligns the simulated block response with the expected fork state while keeping non-validating simulation behavior unchanged.