### PR TITLE
fix(rpc): collect eth_simulate transfer logs separately

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -44,7 +44,7 @@ use revm::{
     context_interface::{result::ResultAndState, Transaction},
     Database, DatabaseCommit,
 };
-use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
+use revm_inspectors::access_list::AccessListInspector;
 use tracing::{trace, warn};
 
 /// Result type for `eth_simulateV1` RPC method.
@@ -185,7 +185,8 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     let (result, results) = if trace_transfers {
                         // prepare inspector to capture transfer inside the evm so they are recorded
                         // and included in logs
-                        let inspector = TransferInspector::new(false).with_logs(true);
+                        let (inspector, transfer_logs) =
+                            simulate::SimulateTransferInspector::new(false);
                         let evm = this
                             .evm_config()
                             .evm_with_env_and_inspector(&mut db, evm_env, inspector);
@@ -205,6 +206,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             &mut remaining_call_gas_limit,
                             chain_id,
                             this.converter(),
+                            Some(&transfer_logs),
                         )
                         .map_err(map_err)?
                     } else {
@@ -225,6 +227,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             &mut remaining_call_gas_limit,
                             chain_id,
                             this.converter(),
+                            None,
                         )
                         .map_err(map_err)?
                     };
@@ -235,6 +238,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         result.block,
                         results,
                         return_full_transactions.into(),
+                        trace_transfers,
                         this.converter(),
                     )?;
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -9,11 +9,13 @@ use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_evm::{block::TxResult, precompiles::PrecompilesMap};
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
+use alloy_primitives::{Log, LogData, B256};
 use alloy_rpc_types_eth::{
     simulate::{SimBlock, SimCallResult, SimulateError, SimulatedBlock},
     state::StateOverride,
     BlockOverrides, BlockTransactionsKind,
 };
+use alloy_sol_types::SolValue;
 use jsonrpsee_types::ErrorObject;
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutor},
@@ -26,11 +28,16 @@ use reth_rpc_convert::{RpcBlock, RpcConvert, RpcTxReq};
 use reth_rpc_server_types::result::rpc_err;
 use reth_storage_api::noop::NoopProvider;
 use revm::{
-    context::Block,
-    context_interface::result::ExecutionResult,
+    context::{Block, JournalTr},
+    context_interface::{result::ExecutionResult, ContextTr},
+    interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, CreateScheme},
     primitives::{Address, Bytes, TxKind, U256},
-    Database,
+    Database, Inspector,
 };
+use revm_inspectors::transfer::{
+    TransferKind, TransferOperation, TRANSFER_EVENT_TOPIC, TRANSFER_LOG_EMITTER,
+};
+use std::sync::{Arc, Mutex};
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
@@ -139,6 +146,179 @@ impl EthSimulateError {
 impl ToRpcError for EthSimulateError {
     fn to_rpc_error(&self) -> ErrorObject<'static> {
         rpc_err(self.error_code(), self.to_string(), None)
+    }
+}
+
+/// Collects ETH transfers for `eth_simulateV1` without inserting them into the EVM journal.
+///
+/// `eth_simulateV1` represents ETH transfers as synthetic ERC-20-style logs when
+/// `traceTransfers` is enabled. These logs are part of the RPC response, not contract-emitted logs,
+/// so they should not be written into the journal where reverted frames could leak them into
+/// execution results. The inspector keeps transfer operations separately and exposes them through a
+/// collector so the RPC layer can append them only to successful simulated calls.
+#[derive(Clone, Debug, Default)]
+pub struct SimulateTransferInspector {
+    internal_only: bool,
+    transfers: Vec<TransferOperation>,
+    checkpoints: Vec<usize>,
+    collector: TransferLogCollector,
+}
+
+impl SimulateTransferInspector {
+    /// Creates a new transfer inspector and a collector for synthetic transfer logs.
+    pub fn new(internal_only: bool) -> (Self, TransferLogCollector) {
+        let collector = TransferLogCollector::default();
+        (
+            Self {
+                internal_only,
+                transfers: Vec::new(),
+                checkpoints: Vec::new(),
+                collector: collector.clone(),
+            },
+            collector,
+        )
+    }
+
+    fn sync_collector(&self) {
+        *self.collector.transfers.lock().expect("transfer collector lock poisoned") =
+            self.transfers.clone();
+    }
+
+    fn push_transfer<DB: Database, JOURNAL: JournalTr<Database = DB>>(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+        kind: TransferKind,
+        journaled_state: &JOURNAL,
+    ) {
+        if self.internal_only && journaled_state.depth() == 0 {
+            return
+        }
+
+        if value.is_zero() {
+            return
+        }
+
+        self.transfers.push(TransferOperation { kind, from, to, value });
+        self.sync_collector();
+    }
+}
+
+impl<CTX> Inspector<CTX> for SimulateTransferInspector
+where
+    CTX: ContextTr,
+{
+    fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        self.checkpoints.push(self.transfers.len());
+
+        if let Some(value) = inputs.transfer_value() {
+            self.push_transfer(
+                inputs.transfer_from(),
+                inputs.transfer_to(),
+                value,
+                TransferKind::Call,
+                context.journal(),
+            );
+        }
+
+        None
+    }
+
+    fn call_end(&mut self, _context: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
+        let Some(checkpoint) = self.checkpoints.pop() else { return };
+
+        if !outcome.instruction_result().is_ok() {
+            self.transfers.truncate(checkpoint);
+            self.sync_collector();
+        }
+    }
+
+    fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
+        self.checkpoints.push(self.transfers.len());
+
+        let kind = match inputs.scheme() {
+            CreateScheme::Create => TransferKind::Create,
+            CreateScheme::Create2 { .. } => TransferKind::Create2,
+            CreateScheme::Custom { .. } => return None,
+        };
+
+        let nonce = match context.journal_mut().load_account(inputs.caller()) {
+            Ok(account) => account.data.info.nonce,
+            Err(_) => return None,
+        };
+        let address = inputs.created_address(nonce);
+
+        self.push_transfer(inputs.caller(), address, inputs.value(), kind, context.journal());
+
+        None
+    }
+
+    fn create_end(
+        &mut self,
+        _context: &mut CTX,
+        _inputs: &CreateInputs,
+        outcome: &mut CreateOutcome,
+    ) {
+        let Some(checkpoint) = self.checkpoints.pop() else { return };
+
+        if !outcome.instruction_result().is_ok() {
+            self.transfers.truncate(checkpoint);
+            self.sync_collector();
+        }
+    }
+
+    fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
+        self.transfers.push(TransferOperation {
+            kind: TransferKind::SelfDestruct,
+            from: contract,
+            to: target,
+            value,
+        });
+        self.sync_collector();
+    }
+}
+
+/// Shared synthetic transfer log collector.
+///
+/// The inspector lives inside the EVM, while `execute_transactions` receives cloned execution
+/// results. This collector bridges those two layers: it snapshots collected transfers after each
+/// frame and appends newly collected transfers to the cloned result only when the transaction
+/// succeeds. Reverted and halted transactions advance the cursor but keep their call logs empty.
+#[derive(Clone, Debug, Default)]
+pub struct TransferLogCollector {
+    transfers: Arc<Mutex<Vec<TransferOperation>>>,
+}
+
+impl TransferLogCollector {
+    fn append_new_logs<HaltReasonTy>(
+        &self,
+        result: &mut ExecutionResult<HaltReasonTy>,
+        next_transfer: &mut usize,
+    ) {
+        let transfers = self.transfers.lock().expect("transfer collector lock poisoned");
+        if *next_transfer >= transfers.len() {
+            return
+        }
+
+        let ExecutionResult::Success { logs, .. } = result else {
+            *next_transfer = transfers.len();
+            return
+        };
+
+        logs.extend(transfers[*next_transfer..].iter().map(transfer_to_log));
+        *next_transfer = transfers.len();
+    }
+}
+
+fn transfer_to_log(transfer: &TransferOperation) -> Log {
+    let from = B256::from_slice(&transfer.from.abi_encode());
+    let to = B256::from_slice(&transfer.to.abi_encode());
+    let data = transfer.value.abi_encode();
+
+    Log {
+        address: TRANSFER_LOG_EMITTER,
+        data: LogData::new_unchecked(vec![TRANSFER_EVENT_TOPIC, from, to], data.into()),
     }
 }
 
@@ -295,6 +475,7 @@ pub fn execute_transactions<S, T>(
     remaining_call_gas_limit: &mut Option<u64>,
     chain_id: u64,
     converter: &T,
+    transfer_logs: Option<&TransferLogCollector>,
 ) -> Result<
     (
         BlockBuilderOutcome<S::Primitives>,
@@ -315,6 +496,7 @@ where
     let block_gas_limit = builder.evm().block().gas_limit();
     let is_amsterdam = builder.evm().cfg_env().enable_amsterdam_eip8037;
     let tx_gas_limit_cap = builder.evm().cfg_env().tx_gas_limit_cap.unwrap_or(u64::MAX);
+    let mut next_transfer = 0;
     for mut call in calls {
         let block_gas_remaining = if is_amsterdam {
             block_gas_limit
@@ -368,7 +550,11 @@ where
         let mut tx_regular_gas_used = 0;
         let gas_output = builder.execute_transaction_with_result_closure(tx, |result| {
             tx_regular_gas_used = result.result().result.gas().block_regular_gas_used();
-            results.push(result.result().result.clone())
+            let mut result = result.result().result.clone();
+            if let Some(transfer_logs) = transfer_logs {
+                transfer_logs.append_new_logs(&mut result, &mut next_transfer);
+            }
+            results.push(result)
         })?;
 
         let gas_used = gas_output.tx_gas_used();
@@ -470,6 +656,7 @@ pub fn build_simulated_block<Err, T>(
     block: RecoveredBlock<BlockTy<T::Primitives>>,
     results: Vec<ExecutionResult<HaltReasonFor<T::Evm>>>,
     txs_kind: BlockTransactionsKind,
+    trace_transfers: bool,
     converter: &T,
 ) -> Result<SimulatedBlock<RpcBlock<T::Network>>, Err>
 where
@@ -486,6 +673,9 @@ where
     for (index, (result, tx)) in results.into_iter().zip(block.body().transactions()).enumerate() {
         let call = match result {
             ExecutionResult::Halt { reason, gas, .. } => {
+                if trace_transfers && !tx.value().is_zero() {
+                    log_index += 1;
+                }
                 let error = Err::from_evm_halt(reason, tx.gas_limit());
                 SimCallResult {
                     return_data: Bytes::new(),
@@ -501,6 +691,9 @@ where
                 }
             }
             ExecutionResult::Revert { output, gas, .. } => {
+                if trace_transfers && !tx.value().is_zero() {
+                    log_index += 1;
+                }
                 let error = Err::from_revert(output.clone());
                 SimCallResult {
                     return_data: Bytes::new(),


### PR DESCRIPTION
Fixes `eth_simulateV1` transfer-log handling when `traceTransfers` is enabled.

Previously, `eth_simulateV1` used `TransferInspector::with_logs(true)`, which writes synthetic ETH transfer logs into the EVM journal as if they were contract-emitted logs. That made reverted or halted execution paths difficult to handle correctly: transfer logs could be present in the execution result even though the simulated call failed, and log indexes could drift for later calls.

This adds a simulate-specific transfer inspector that records ETH transfer operations separately from the EVM journal. `execute_transactions` appends newly collected synthetic transfer logs only to successful simulated call results, while reverted and halted calls keep empty logs and only advance the transfer cursor.

This keeps `traceTransfers` behavior for successful ETH transfers while preventing synthetic response-only logs from leaking through reverted execution paths.