### PR TITLE
ci: update benchmark RPC endpoint

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -290,7 +290,7 @@ jobs:
       actions: read
     timeout-minutes: 120
     env:
-      BENCH_RPC_URL: https://ethereum.reth.rs/rpc
+      BENCH_RPC_URL: http://ethereum-mainnet-stable-reth-greedy-goose:8545
       SCHELK_MOUNT: /reth-bench
       RETH_SCOPE: reth-bench.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -612,7 +612,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 120
     env:
-      BENCH_RPC_URL: https://ethereum.reth.rs/rpc
+      BENCH_RPC_URL: http://ethereum-mainnet-stable-reth-greedy-goose:8545
       SCHELK_MOUNT: /reth-bench
       RETH_SCOPE: reth-bench.scope
       BENCH_WORK_DIR: ${{ github.workspace }}/bench-work


### PR DESCRIPTION
## Summary
- replace the benchmark workflow RPC URL with the MagicDNS reth endpoint
- update both `bench.yml` and `bench-scheduled.yml`

## Verification
- `rg -n "https://ethereum\.reth\.rs/rpc|ethereum\.reth\.rs/rpc" .github . --glob "*.yml" --glob "*.yaml" --glob "!target"` returns no matches
- `rg -n "ethereum-mainnet-stable-reth-greedy-goose" .github . --glob "*.yml" --glob "*.yaml" --glob "!target"` finds both benchmark workflow entries

Prompted by: @pepyakin