### PR TITLE
feat(trie): replace state root computation with lattice hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8893,6 +8893,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
+ "reth-trie-parallel",
  "revm",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1150,19 +1150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ed-on-bls12-381-bandersnatch"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1786b2e3832f6f0f7c8d62d5d5a282f6952a1ab99981c54cd52b6ac1d8f02df5"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-r1cs-std",
- "ark-std 0.5.0",
-]
-
-[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,7 +1638,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1739,6 +1726,15 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.3.0",
  "zeroize",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1981,7 +1977,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -2411,7 +2407,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2427,7 +2423,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.6",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2445,7 +2441,7 @@ dependencies = [
  "generic-array",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "thiserror 1.0.69",
 ]
@@ -2489,9 +2485,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a771439216c7b5813e743937cb9b8dd700bce435c47fc73cd9aae1492f8696ce"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -2506,24 +2501,21 @@ dependencies = [
 
 [[package]]
 name = "commonware-conformance"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1072e14595f5c8a8efd1465077f3072bf631021b2b40a56aa66cf7ddb3e25f53"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "commonware-conformance-macros",
- "commonware-formatting",
  "commonware-macros",
  "futures",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "toml",
 ]
 
 [[package]]
 name = "commonware-conformance-macros"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c0f470c2eb1bfd978883156bc4f2c811e329d5c2c5dc2bab74f8defadb076b"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2532,18 +2524,11 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b13a9a7f8870ed9b65f387aedd56c3859a487317871cdb5d0baf8b0f7f99d37"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "anyhow",
  "arbitrary",
- "ark-ec",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff 0.5.0",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize 0.5.0",
  "aws-lc-rs",
  "blake3",
  "blst",
@@ -2551,15 +2536,14 @@ dependencies = [
  "cfg-if",
  "chacha20poly1305",
  "commonware-codec",
- "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
  "crc-fast",
  "ctutils",
- "curve25519-dalek",
  "ecdsa",
+ "ed25519-consensus",
  "getrandom 0.2.17",
  "num-rational",
  "num-traits",
@@ -2567,31 +2551,20 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
-name = "commonware-formatting"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134e31411b32f337a60bb19e5bb0397fafa0a92b7c156cb0643b729e7135b49"
-dependencies = [
- "commonware-macros",
- "const-hex",
-]
-
-[[package]]
 name = "commonware-invariants"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9277faee9193157b9910a6f96ff13d13bd9fb94671b7b8b83780b17578d323"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "arbitrary",
- "commonware-formatting",
  "commonware-macros",
+ "commonware-utils",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -2599,9 +2572,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419e6eb2c4c9e56517cfc07062a984b882dabf573d53191a73b98358cd9782a"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2609,9 +2581,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82dd7062336fc7d2107e9a63312ef1b9811d06bfe56dfd56f97e6ce5d4aa0565"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2622,9 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94e682199bad2c4b18a6704711b3e8fd7e6dbd5b7b87224882d8be350e3f7a2"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -2638,9 +2608,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6a412b4c868174963b38ff2dad6686c573ec56834d9b39d20b73437c6d9726"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2649,15 +2618,13 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfad44dd2c8e97d55dbe271802740e919d2ce8839277ea53d958381caab92a44"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "arbitrary",
  "bytes",
  "cfg-if",
  "commonware-codec",
- "commonware-formatting",
  "commonware-macros",
  "futures",
  "getrandom 0.2.17",
@@ -3054,6 +3021,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "custom-hardforks"
 version = "0.1.0"
 dependencies = [
@@ -3175,7 +3155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3475,6 +3455,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,7 +3478,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -3661,7 +3655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3672,7 +3666,7 @@ checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
 dependencies = [
  "cpufeatures 0.2.17",
  "ring",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4453,7 +4447,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -5378,7 +5372,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5733,7 +5727,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -5882,7 +5876,7 @@ dependencies = [
  "k256",
  "multihash",
  "quick-protobuf",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tracing",
  "zeroize",
@@ -6422,7 +6416,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6735,7 +6729,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7344,7 +7338,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8469,7 +8463,7 @@ dependencies = [
  "rand 0.8.6",
  "reth-network-peers",
  "secp256k1 0.30.0",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -8640,7 +8634,7 @@ dependencies = [
  "reqwest 0.13.3",
  "reth-era-downloader",
  "reth-ethereum-primitives",
- "sha2",
+ "sha2 0.10.9",
  "snap",
  "tempfile",
  "test-case",
@@ -8660,7 +8654,7 @@ dependencies = [
  "reqwest 0.13.3",
  "reth-era",
  "reth-fs-util",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "test-case",
  "tokio",
@@ -9760,7 +9754,7 @@ dependencies = [
  "reth-trie-common",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -10014,7 +10008,7 @@ dependencies = [
  "revm-primitives",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -11069,7 +11063,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -11302,7 +11296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11382,7 +11376,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11770,6 +11764,19 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -12098,6 +12105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12231,7 +12244,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13491,7 +13504,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10751,6 +10751,7 @@ dependencies = [
  "arrayvec",
  "bincode",
  "bytes",
+ "commonware-codec",
  "commonware-cryptography",
  "derive_more",
  "hash-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ed-on-bls12-381-bandersnatch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1786b2e3832f6f0f7c8d62d5d5a282f6952a1ab99981c54cd52b6ac1d8f02df5"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1724,6 +1738,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2166,6 +2181,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -2173,6 +2199,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -2224,6 +2263,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -2285,6 +2325,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
 
 [[package]]
 name = "cobs"
@@ -2439,6 +2485,193 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "commonware-codec"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a771439216c7b5813e743937cb9b8dd700bce435c47fc73cd9aae1492f8696ce"
+dependencies = [
+ "arbitrary",
+ "bytes",
+ "cfg-if",
+ "commonware-conformance",
+ "commonware-macros",
+ "paste",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "commonware-conformance"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1072e14595f5c8a8efd1465077f3072bf631021b2b40a56aa66cf7ddb3e25f53"
+dependencies = [
+ "commonware-conformance-macros",
+ "commonware-formatting",
+ "commonware-macros",
+ "futures",
+ "serde",
+ "sha2",
+ "toml",
+]
+
+[[package]]
+name = "commonware-conformance-macros"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c0f470c2eb1bfd978883156bc4f2c811e329d5c2c5dc2bab74f8defadb076b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "commonware-cryptography"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b13a9a7f8870ed9b65f387aedd56c3859a487317871cdb5d0baf8b0f7f99d37"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "ark-ec",
+ "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize 0.5.0",
+ "aws-lc-rs",
+ "blake3",
+ "blst",
+ "bytes",
+ "cfg-if",
+ "chacha20poly1305",
+ "commonware-codec",
+ "commonware-formatting",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-parallel",
+ "commonware-utils",
+ "crc-fast",
+ "ctutils",
+ "curve25519-dalek",
+ "ecdsa",
+ "getrandom 0.2.17",
+ "num-rational",
+ "num-traits",
+ "p256",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2",
+ "thiserror 2.0.18",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "commonware-formatting"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134e31411b32f337a60bb19e5bb0397fafa0a92b7c156cb0643b729e7135b49"
+dependencies = [
+ "commonware-macros",
+ "const-hex",
+]
+
+[[package]]
+name = "commonware-invariants"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9277faee9193157b9910a6f96ff13d13bd9fb94671b7b8b83780b17578d323"
+dependencies = [
+ "arbitrary",
+ "commonware-formatting",
+ "commonware-macros",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "commonware-macros"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419e6eb2c4c9e56517cfc07062a984b882dabf573d53191a73b98358cd9782a"
+dependencies = [
+ "commonware-macros-impl",
+ "tokio",
+]
+
+[[package]]
+name = "commonware-macros-impl"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82dd7062336fc7d2107e9a63312ef1b9811d06bfe56dfd56f97e6ce5d4aa0565"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "toml",
+]
+
+[[package]]
+name = "commonware-math"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94e682199bad2c4b18a6704711b3e8fd7e6dbd5b7b87224882d8be350e3f7a2"
+dependencies = [
+ "arbitrary",
+ "bytes",
+ "commonware-codec",
+ "commonware-invariants",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-utils",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "commonware-parallel"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6a412b4c868174963b38ff2dad6686c573ec56834d9b39d20b73437c6d9726"
+dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "rayon",
+]
+
+[[package]]
+name = "commonware-utils"
+version = "2026.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfad44dd2c8e97d55dbe271802740e919d2ce8839277ea53d958381caab92a44"
+dependencies = [
+ "arbitrary",
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-formatting",
+ "commonware-macros",
+ "futures",
+ "getrandom 0.2.17",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.6",
+ "thiserror 2.0.18",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]
@@ -2633,6 +2866,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,6 +3015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -4479,7 +4731,7 @@ dependencies = [
  "hash32",
  "rustc_version 0.4.1",
  "serde",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -6193,6 +6445,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
+ "arbitrary",
  "num-integer",
  "num-traits",
  "serde",
@@ -6740,6 +6993,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7139,7 +7403,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -7665,6 +7929,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
+ "reth-trie-common",
  "serde_json",
 ]
 
@@ -10492,6 +10757,7 @@ dependencies = [
  "arrayvec",
  "bincode",
  "bytes",
+ "commonware-cryptography",
  "derive_more",
  "hash-db",
  "itertools 0.14.0",
@@ -11759,6 +12025,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -13816,6 +14088,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -485,6 +485,7 @@ alloy-transport-ws = { version = "2.0.5", default-features = false }
 
 # misc
 commonware-cryptography = { version = "2026.4.0", default-features = false }
+commonware-codec = { version = "2026.4.0", default-features = false }
 either = { version = "1.16.0", default-features = false }
 arrayvec = { version = "0.7.6", default-features = false }
 aquamarine = "0.6"
@@ -703,3 +704,4 @@ ipnet = "2.11"
 
 [patch.crates-io]
 commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,7 +484,7 @@ alloy-transport-ipc = { version = "2.0.5", default-features = false }
 alloy-transport-ws = { version = "2.0.5", default-features = false }
 
 # misc
-commonware-cryptography = { version = "2026.5.0", default-features = false }
+commonware-cryptography = { version = "2026.4.0", default-features = false }
 either = { version = "1.16.0", default-features = false }
 arrayvec = { version = "0.7.6", default-features = false }
 aquamarine = "0.6"
@@ -700,3 +700,6 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,6 +484,7 @@ alloy-transport-ipc = { version = "2.0.5", default-features = false }
 alloy-transport-ws = { version = "2.0.5", default-features = false }
 
 # misc
+commonware-cryptography = { version = "2026.5.0", default-features = false }
 either = { version = "1.16.0", default-features = false }
 arrayvec = { version = "0.7.6", default-features = false }
 aquamarine = "0.6"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -109,6 +109,12 @@ js-tracer = [
 ]
 
 dev = ["reth-ethereum-cli/dev"]
+lattice-state-root = [
+    "reth-chainspec/lattice-state-root",
+    "reth-node-builder/lattice-state-root",
+    "reth-node-ethereum/lattice-state-root",
+    "reth-provider/lattice-state-root",
+]
 
 asm-keccak = [
     "reth-node-core/asm-keccak",

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -59,6 +59,7 @@ rand.workspace = true
 revm-state.workspace = true
 
 [features]
+lattice-state-root = ["reth-trie/lattice-state-root"]
 serde = [
     "dep:serde",
     "alloy-consensus/serde",

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -1,5 +1,7 @@
 use parking_lot::Mutex;
 use reth_metrics::{metrics::Counter, Metrics};
+#[cfg(feature = "lattice-state-root")]
+use reth_trie::lattice::LatticeAccumulatorUpdates;
 use reth_trie::{
     updates::{TrieUpdates, TrieUpdatesSorted},
     HashedPostState, HashedPostStateSorted,
@@ -30,6 +32,9 @@ pub struct ComputedTrieData {
     pub hashed_state: Arc<HashedPostStateSorted>,
     /// Sorted trie updates produced by state root computation.
     pub trie_updates: Arc<TrieUpdatesSorted>,
+    /// Lattice accumulator updates produced by lattice state root computation.
+    #[cfg(feature = "lattice-state-root")]
+    pub lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
 }
 
 /// Metrics for deferred trie computation.
@@ -62,6 +67,9 @@ struct PendingInputs {
     hashed_state: Arc<HashedPostState>,
     /// Unsorted trie updates from state root computation.
     trie_updates: Arc<TrieUpdates>,
+    /// Lattice accumulator updates from state root computation.
+    #[cfg(feature = "lattice-state-root")]
+    lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
 }
 
 impl fmt::Debug for DeferredTrieData {
@@ -81,10 +89,38 @@ impl fmt::Debug for DeferredTrieData {
 impl DeferredTrieData {
     /// Create a new pending handle with fallback inputs for synchronous computation.
     pub fn pending(hashed_state: Arc<HashedPostState>, trie_updates: Arc<TrieUpdates>) -> Self {
+        #[cfg(feature = "lattice-state-root")]
+        {
+            Self::pending_with_lattice(
+                hashed_state,
+                trie_updates,
+                Arc::new(LatticeAccumulatorUpdates::default()),
+            )
+        }
+
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            Self {
+                state: Arc::new(Mutex::new(DeferredTrieDataInner::Pending(Some(PendingInputs {
+                    hashed_state,
+                    trie_updates,
+                })))),
+            }
+        }
+    }
+
+    /// Create a new pending handle with lattice accumulator updates.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn pending_with_lattice(
+        hashed_state: Arc<HashedPostState>,
+        trie_updates: Arc<TrieUpdates>,
+        lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
+    ) -> Self {
         Self {
             state: Arc::new(Mutex::new(DeferredTrieDataInner::Pending(Some(PendingInputs {
                 hashed_state,
                 trie_updates,
+                lattice_accumulator_updates,
             })))),
         }
     }
@@ -128,6 +164,18 @@ impl DeferredTrieData {
         ComputedTrieData::new(Arc::new(sorted_hashed_state), Arc::new(sorted_trie_updates))
     }
 
+    /// Sorts block execution outputs and attaches lattice accumulator updates.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn sort_with_lattice(
+        hashed_state: Arc<HashedPostState>,
+        trie_updates: Arc<TrieUpdates>,
+        lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
+    ) -> ComputedTrieData {
+        let mut computed = Self::sort(hashed_state, trie_updates);
+        computed.lattice_accumulator_updates = lattice_accumulator_updates;
+        computed
+    }
+
     /// Returns trie data, computing synchronously if the async task hasn't completed.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
@@ -141,6 +189,13 @@ impl DeferredTrieData {
                 DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
 
                 let inputs = maybe_inputs.take().expect("inputs must be present in Pending state");
+                #[cfg(feature = "lattice-state-root")]
+                let computed = Self::sort_with_lattice(
+                    inputs.hashed_state,
+                    inputs.trie_updates,
+                    inputs.lattice_accumulator_updates,
+                );
+                #[cfg(not(feature = "lattice-state-root"))]
                 let computed = Self::sort(inputs.hashed_state, inputs.trie_updates);
                 *state = DeferredTrieDataInner::Ready(computed.clone());
 
@@ -152,11 +207,29 @@ impl DeferredTrieData {
 
 impl ComputedTrieData {
     /// Construct sorted trie data for one block.
-    pub const fn new(
+    pub fn new(
         hashed_state: Arc<HashedPostStateSorted>,
         trie_updates: Arc<TrieUpdatesSorted>,
     ) -> Self {
-        Self { hashed_state, trie_updates }
+        Self {
+            hashed_state,
+            trie_updates,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_accumulator_updates: Arc::new(LatticeAccumulatorUpdates {
+                state: reth_trie::lattice::LatticeHashState::default(),
+                storage: alloy_primitives::map::B256Map::default(),
+            }),
+        }
+    }
+
+    /// Construct sorted trie data for one block with lattice accumulator updates.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn new_with_lattice(
+        hashed_state: Arc<HashedPostStateSorted>,
+        trie_updates: Arc<TrieUpdatesSorted>,
+        lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
+    ) -> Self {
+        Self { hashed_state, trie_updates, lattice_accumulator_updates }
     }
 }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -168,12 +168,22 @@ impl DeferredTrieData {
     #[cfg(feature = "lattice-state-root")]
     pub fn sort_with_lattice(
         hashed_state: Arc<HashedPostState>,
-        trie_updates: Arc<TrieUpdates>,
+        _trie_updates: Arc<TrieUpdates>,
         lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
     ) -> ComputedTrieData {
-        let mut computed = Self::sort(hashed_state, trie_updates);
-        computed.lattice_accumulator_updates = lattice_accumulator_updates;
-        computed
+        let _span =
+            debug_span!(target: "engine::tree::deferred_trie", "sort_lattice_inputs").entered();
+
+        let sorted_hashed_state = match Arc::try_unwrap(hashed_state) {
+            Ok(state) => state.into_sorted(),
+            Err(arc) => arc.clone_into_sorted(),
+        };
+
+        ComputedTrieData::new_with_lattice(
+            Arc::new(sorted_hashed_state),
+            Arc::new(TrieUpdatesSorted::default()),
+            lattice_accumulator_updates,
+        )
     }
 
     /// Returns trie data, computing synchronously if the async task hasn't completed.

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -227,7 +227,6 @@ impl ComputedTrieData {
             #[cfg(feature = "lattice-state-root")]
             lattice_accumulator_updates: Arc::new(LatticeAccumulatorUpdates {
                 state: reth_trie::lattice::LatticeHashState::default(),
-                storage: alloy_primitives::map::B256Map::default(),
             }),
         }
     }

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -881,6 +881,21 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     }
 }
 
+fn computed_to_sorted_trie_data(trie_data: ComputedTrieData) -> SortedTrieData {
+    #[cfg(feature = "lattice-state-root")]
+    {
+        SortedTrieData::new_with_lattice(
+            trie_data.hashed_state,
+            trie_data.trie_updates,
+            trie_data.lattice_accumulator_updates,
+        )
+    }
+    #[cfg(not(feature = "lattice-state-root"))]
+    {
+        SortedTrieData::new(trie_data.hashed_state, trie_data.trie_updates)
+    }
+}
+
 /// Non-empty chain of blocks.
 #[derive(Debug)]
 pub enum NewCanonicalChain<N: NodePrimitives = EthPrimitives> {
@@ -942,10 +957,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
                     )),
                     LazyTrieData::deferred(move || {
                         let trie_data = trie_data_handle.wait_cloned();
-                        SortedTrieData {
-                            hashed_state: trie_data.hashed_state,
-                            trie_updates: trie_data.trie_updates,
-                        }
+                        computed_to_sorted_trie_data(trie_data)
                     }),
                 );
                 for exec in rest {
@@ -958,10 +970,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
                         )),
                         LazyTrieData::deferred(move || {
                             let trie_data = trie_data_handle.wait_cloned();
-                            SortedTrieData {
-                                hashed_state: trie_data.hashed_state,
-                                trie_updates: trie_data.trie_updates,
-                            }
+                            computed_to_sorted_trie_data(trie_data)
                         }),
                     );
                 }

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -139,28 +139,17 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_state_root_with_updates(
+    fn lattice_state_root(
         &self,
         bundle_state: &BundleState,
-        hashed_state: HashedPostState,
-        precomputed_trie_updates: Option<TrieUpdates>,
-    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
-        let trie_updates = match precomputed_trie_updates {
-            Some(updates) => updates,
-            None => self.state_root_with_updates(hashed_state.clone())?.1,
-        };
-
+    ) -> ProviderResult<(B256, reth_trie::lattice::LatticeAccumulatorUpdates)> {
         let mut cumulative_state = BundleState::default();
         for block in self.in_memory.iter().rev() {
             cumulative_state.extend(block.execution_outcome().state.clone());
         }
         cumulative_state.extend(bundle_state.clone());
 
-        self.historical.lattice_state_root_with_updates(
-            &cumulative_state,
-            hashed_state,
-            Some(trie_updates),
-        )
+        self.historical.lattice_state_root(&cumulative_state)
     }
 
     #[cfg(feature = "lattice-state-root")]
@@ -176,13 +165,7 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
             cumulative_state.extend(block.execution_outcome().state.clone());
         }
 
-        self.historical
-            .lattice_state_root_with_updates(
-                &cumulative_state,
-                HashedPostState::default(),
-                Some(TrieUpdates::default()),
-            )
-            .map(|(_, _, updates)| updates)
+        self.historical.lattice_state_root(&cumulative_state).map(|(_, updates)| updates)
     }
 
     #[cfg(feature = "lattice-state-root")]

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -163,6 +163,36 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
         )
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_accumulator_seed(
+        &self,
+    ) -> ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates> {
+        if self.in_memory.is_empty() {
+            return self.historical.lattice_accumulator_seed()
+        }
+
+        let mut cumulative_state = BundleState::default();
+        for block in self.in_memory.iter().rev() {
+            cumulative_state.extend(block.execution_outcome().state.clone());
+        }
+
+        self.historical
+            .lattice_state_root_with_updates(
+                &cumulative_state,
+                HashedPostState::default(),
+                Some(TrieUpdates::default()),
+            )
+            .map(|(_, _, updates)| updates)
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_storage_accumulator(
+        &self,
+        hashed_address: B256,
+    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
+        self.historical.lattice_storage_accumulator(hashed_address)
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         mut input: TrieInput,

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -138,6 +138,31 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
         self.state_root_from_nodes_with_updates(TrieInput::from_state(state))
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_state_root_with_updates(
+        &self,
+        bundle_state: &BundleState,
+        hashed_state: HashedPostState,
+        precomputed_trie_updates: Option<TrieUpdates>,
+    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        let trie_updates = match precomputed_trie_updates {
+            Some(updates) => updates,
+            None => self.state_root_with_updates(hashed_state.clone())?.1,
+        };
+
+        let mut cumulative_state = BundleState::default();
+        for block in self.in_memory.iter().rev() {
+            cumulative_state.extend(block.execution_outcome().state.clone());
+        }
+        cumulative_state.extend(bundle_state.clone());
+
+        self.historical.lattice_state_root_with_updates(
+            &cumulative_state,
+            hashed_state,
+            Some(trie_updates),
+        )
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         mut input: TrieInput,

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -169,11 +169,39 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_storage_accumulator(
+    fn lattice_account_storage(
         &self,
         hashed_address: B256,
-    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
-        self.historical.lattice_storage_accumulator(hashed_address)
+    ) -> ProviderResult<Vec<(B256, alloy_primitives::U256)>> {
+        let mut storage = self
+            .historical
+            .lattice_account_storage(hashed_address)?
+            .into_iter()
+            .collect::<alloy_primitives::map::B256Map<_>>();
+
+        for block in self.in_memory.iter().rev() {
+            for (address, account) in &block.execution_outcome().state.state {
+                if keccak256(address) != hashed_address {
+                    continue
+                }
+
+                if account.was_destroyed() {
+                    storage.clear();
+                }
+
+                for (slot, value) in &account.storage {
+                    let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                    let present_value = value.present_value();
+                    if present_value.is_zero() {
+                        storage.remove(&hashed_slot);
+                    } else {
+                        storage.insert(hashed_slot, present_value);
+                    }
+                }
+            }
+        }
+
+        Ok(storage.into_iter().collect())
     }
 
     fn state_root_from_nodes_with_updates(

--- a/crates/chain-state/src/state_trie_overlay.rs
+++ b/crates/chain-state/src/state_trie_overlay.rs
@@ -452,7 +452,15 @@ fn compute_overlay<N: NodePrimitives>(
 fn merge_blocks<N: NodePrimitives>(blocks: Vec<ExecutedBlock<N>>) -> TrieInputSorted {
     let trie_data = blocks.iter().map(ExecutedBlock::trie_data).collect::<Vec<_>>();
 
-    #[cfg(feature = "rayon")]
+    #[cfg(feature = "lattice-state-root")]
+    let (nodes, state) = (
+        Arc::new(TrieUpdatesSorted::default()),
+        HashedPostStateSorted::merge_batch(
+            trie_data.iter().map(|data| Arc::clone(&data.hashed_state)),
+        ),
+    );
+
+    #[cfg(all(feature = "rayon", not(feature = "lattice-state-root")))]
     let (nodes, state) = rayon::join(
         || {
             TrieUpdatesSorted::merge_batch(
@@ -466,7 +474,7 @@ fn merge_blocks<N: NodePrimitives>(blocks: Vec<ExecutedBlock<N>>) -> TrieInputSo
         },
     );
 
-    #[cfg(not(feature = "rayon"))]
+    #[cfg(all(not(feature = "rayon"), not(feature = "lattice-state-root")))]
     let (nodes, state) = (
         TrieUpdatesSorted::merge_batch(trie_data.iter().map(|data| Arc::clone(&data.trie_updates))),
         HashedPostStateSorted::merge_batch(

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -16,6 +16,7 @@ reth-ethereum-forks.workspace = true
 reth-network-peers.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
 reth-primitives-traits.workspace = true
+reth-trie-common = { workspace = true, optional = true }
 
 # ethereum
 alloy-evm.workspace = true
@@ -52,6 +53,7 @@ std = [
     "reth-network-peers/std",
     "serde_json/std",
     "alloy-evm/std",
+    "reth-trie-common?/std",
 ]
 arbitrary = [
     "alloy-chains/arbitrary",
@@ -61,7 +63,10 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
     "alloy-trie/arbitrary",
+    "reth-trie-common?/arbitrary",
 ]
 test-utils = [
     "reth-primitives-traits/test-utils",
+    "reth-trie-common?/test-utils",
 ]
+lattice-state-root = ["dep:reth-trie-common", "reth-trie-common/lattice-state-root"]

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -11,6 +11,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "lattice-state-root")]
+use alloy_trie as _;
+
 /// Chain specific constants
 mod constants;
 pub use constants::*;

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -31,7 +31,10 @@ use alloy_eips::{
     eip7892::BlobScheduleBlobParams, eip7928::EMPTY_BLOCK_ACCESS_LIST_HASH,
 };
 use alloy_genesis::{ChainConfig, Genesis};
+#[cfg(feature = "lattice-state-root")]
+use alloy_primitives::keccak256;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};
+#[cfg(not(feature = "lattice-state-root"))]
 use alloy_trie::root::state_root_ref_unhashed;
 use core::fmt::Debug;
 use derive_more::From;
@@ -40,7 +43,11 @@ use reth_ethereum_forks::{
     ForkFilter, ForkFilterKey, ForkHash, ForkId, Hardfork, Hardforks, Head, DEV_HARDFORKS,
 };
 use reth_network_peers::{holesky_nodes, hoodi_nodes, mainnet_nodes, sepolia_nodes, NodeRecord};
+#[cfg(feature = "lattice-state-root")]
+use reth_primitives_traits::Account;
 use reth_primitives_traits::{sync::LazyLock, BlockHeader, SealedHeader};
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_common::lattice::{LatticeStateRoot, LatticeStorageRoot};
 
 /// Helper method building a [`Header`] given [`Genesis`] and [`ChainHardforks`].
 pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Header {
@@ -95,7 +102,7 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
         difficulty: genesis.difficulty,
         nonce: genesis.nonce.into(),
         extra_data: genesis.extra_data.clone(),
-        state_root: state_root_ref_unhashed(&genesis.alloc),
+        state_root: genesis_state_root(genesis),
         timestamp: genesis.timestamp,
         mix_hash: genesis.mix_hash,
         beneficiary: genesis.coinbase,
@@ -109,6 +116,35 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
         slot_number,
         ..Default::default()
     }
+}
+
+#[cfg(not(feature = "lattice-state-root"))]
+fn genesis_state_root(genesis: &Genesis) -> B256 {
+    state_root_ref_unhashed(&genesis.alloc)
+}
+
+#[cfg(feature = "lattice-state-root")]
+fn genesis_state_root(genesis: &Genesis) -> B256 {
+    let mut state_root = LatticeStateRoot::default();
+
+    for (address, genesis_account) in &genesis.alloc {
+        let mut storage_root = LatticeStorageRoot::default();
+        if let Some(storage) = &genesis_account.storage {
+            for (slot, value) in storage {
+                if !value.is_zero() {
+                    storage_root.add_slot(keccak256(slot), U256::from_be_bytes(value.0));
+                }
+            }
+        }
+
+        state_root.add_account(
+            keccak256(address),
+            Account::from(genesis_account),
+            storage_root.root(),
+        );
+    }
+
+    state_root.root()
 }
 
 /// The Ethereum mainnet spec

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -47,7 +47,7 @@ use reth_network_peers::{holesky_nodes, hoodi_nodes, mainnet_nodes, sepolia_node
 use reth_primitives_traits::Account;
 use reth_primitives_traits::{sync::LazyLock, BlockHeader, SealedHeader};
 #[cfg(feature = "lattice-state-root")]
-use reth_trie_common::lattice::{LatticeStateRoot, LatticeStorageRoot};
+use reth_trie_common::lattice::LatticeRoot;
 
 /// Helper method building a [`Header`] given [`Genesis`] and [`ChainHardforks`].
 pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Header {
@@ -125,26 +125,26 @@ fn genesis_state_root(genesis: &Genesis) -> B256 {
 
 #[cfg(feature = "lattice-state-root")]
 fn genesis_state_root(genesis: &Genesis) -> B256 {
-    let mut state_root = LatticeStateRoot::default();
+    let mut lattice_root = LatticeRoot::default();
 
     for (address, genesis_account) in &genesis.alloc {
-        let mut storage_root = LatticeStorageRoot::default();
+        let hashed_address = keccak256(address);
+        lattice_root.add_account(hashed_address, Account::from(genesis_account));
+
         if let Some(storage) = &genesis_account.storage {
             for (slot, value) in storage {
                 if !value.is_zero() {
-                    storage_root.add_slot(keccak256(slot), U256::from_be_bytes(value.0));
+                    lattice_root.add_slot(
+                        hashed_address,
+                        keccak256(slot),
+                        U256::from_be_bytes(value.0),
+                    );
                 }
             }
         }
-
-        state_root.add_account(
-            keccak256(address),
-            Account::from(genesis_account),
-            storage_root.root(),
-        );
     }
 
-    state_root.root()
+    lattice_root.root()
 }
 
 /// The Ethereum mainnet spec

--- a/crates/engine/execution-cache/Cargo.toml
+++ b/crates/engine/execution-cache/Cargo.toml
@@ -31,6 +31,7 @@ reth-revm = { workspace = true, features = ["test-utils"] }
 revm-state.workspace = true
 
 [features]
+lattice-state-root = ["reth-provider/lattice-state-root", "reth-trie/lattice-state-root"]
 test-utils = [
     "reth-primitives-traits/test-utils",
     "reth-revm/test-utils",

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -622,11 +622,11 @@ impl<S: StateRootProvider> StateRootProvider for CachedStateProvider<S> {
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_storage_accumulator(
+    fn lattice_account_storage(
         &self,
         hashed_address: B256,
-    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
-        self.state_provider.lattice_storage_accumulator(hashed_address)
+    ) -> ProviderResult<Vec<(B256, alloy_primitives::U256)>> {
+        self.state_provider.lattice_account_storage(hashed_address)
     }
 
     fn state_root_from_nodes_with_updates(

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -607,17 +607,11 @@ impl<S: StateRootProvider> StateRootProvider for CachedStateProvider<S> {
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_state_root_with_updates(
+    fn lattice_state_root(
         &self,
         bundle_state: &reth_revm::db::BundleState,
-        hashed_state: HashedPostState,
-        precomputed_trie_updates: Option<TrieUpdates>,
-    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
-        self.state_provider.lattice_state_root_with_updates(
-            bundle_state,
-            hashed_state,
-            precomputed_trie_updates,
-        )
+    ) -> ProviderResult<(B256, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        self.state_provider.lattice_state_root(bundle_state)
     }
 
     #[cfg(feature = "lattice-state-root")]

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -606,6 +606,20 @@ impl<S: StateRootProvider> StateRootProvider for CachedStateProvider<S> {
         self.state_provider.state_root_with_updates(hashed_state)
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_state_root_with_updates(
+        &self,
+        bundle_state: &reth_revm::db::BundleState,
+        hashed_state: HashedPostState,
+        precomputed_trie_updates: Option<TrieUpdates>,
+    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        self.state_provider.lattice_state_root_with_updates(
+            bundle_state,
+            hashed_state,
+            precomputed_trie_updates,
+        )
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -620,6 +620,21 @@ impl<S: StateRootProvider> StateRootProvider for CachedStateProvider<S> {
         )
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_accumulator_seed(
+        &self,
+    ) -> ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates> {
+        self.state_provider.lattice_accumulator_seed()
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_storage_accumulator(
+        &self,
+        hashed_address: B256,
+    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
+        self.state_provider.lattice_storage_accumulator(hashed_address)
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -110,9 +110,11 @@ lattice-state-root = [
     "reth-chain-state/lattice-state-root",
     "reth-execution-cache/lattice-state-root",
     "reth-evm/lattice-state-root",
+    "reth-payload-builder/lattice-state-root",
     "reth-payload-primitives/lattice-state-root",
     "reth-provider/lattice-state-root",
     "reth-trie/lattice-state-root",
+    "reth-trie-parallel/lattice-state-root",
 ]
 test-utils = [
     "reth-chain-state/test-utils",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -106,7 +106,14 @@ rand.workspace = true
 rand_08.workspace = true
 
 [features]
-lattice-state-root = ["reth-provider/lattice-state-root", "reth-trie/lattice-state-root"]
+lattice-state-root = [
+    "reth-chain-state/lattice-state-root",
+    "reth-execution-cache/lattice-state-root",
+    "reth-evm/lattice-state-root",
+    "reth-payload-primitives/lattice-state-root",
+    "reth-provider/lattice-state-root",
+    "reth-trie/lattice-state-root",
+]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -106,6 +106,7 @@ rand.workspace = true
 rand_08.workspace = true
 
 [features]
+lattice-state-root = ["reth-provider/lattice-state-root", "reth-trie/lattice-state-root"]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/engine/tree/src/lib.rs
+++ b/crates/engine/tree/src/lib.rs
@@ -92,6 +92,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+#[cfg(feature = "lattice-state-root")]
+use reth_db as _;
+
 /// Support for backfill sync mode.
 pub mod backfill;
 /// The type that drives the chain forward.

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -219,17 +219,11 @@ impl<S: StateRootProvider> StateRootProvider for InstrumentedStateProvider<S> {
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_state_root_with_updates(
+    fn lattice_state_root(
         &self,
         bundle_state: &reth_revm::db::BundleState,
-        hashed_state: HashedPostState,
-        precomputed_trie_updates: Option<TrieUpdates>,
-    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
-        self.state_provider.lattice_state_root_with_updates(
-            bundle_state,
-            hashed_state,
-            precomputed_trie_updates,
-        )
+    ) -> ProviderResult<(B256, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        self.state_provider.lattice_state_root(bundle_state)
     }
 
     #[cfg(feature = "lattice-state-root")]

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -234,11 +234,11 @@ impl<S: StateRootProvider> StateRootProvider for InstrumentedStateProvider<S> {
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_storage_accumulator(
+    fn lattice_account_storage(
         &self,
         hashed_address: B256,
-    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
-        self.state_provider.lattice_storage_accumulator(hashed_address)
+    ) -> ProviderResult<Vec<(B256, alloy_primitives::U256)>> {
+        self.state_provider.lattice_account_storage(hashed_address)
     }
 
     fn state_root_from_nodes_with_updates(

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -232,6 +232,21 @@ impl<S: StateRootProvider> StateRootProvider for InstrumentedStateProvider<S> {
         )
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_accumulator_seed(
+        &self,
+    ) -> ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates> {
+        self.state_provider.lattice_accumulator_seed()
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_storage_accumulator(
+        &self,
+        hashed_address: B256,
+    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
+        self.state_provider.lattice_storage_accumulator(hashed_address)
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -218,6 +218,20 @@ impl<S: StateRootProvider> StateRootProvider for InstrumentedStateProvider<S> {
         self.state_provider.state_root_with_updates(hashed_state)
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_state_root_with_updates(
+        &self,
+        bundle_state: &reth_revm::db::BundleState,
+        hashed_state: HashedPostState,
+        precomputed_trie_updates: Option<TrieUpdates>,
+    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        self.state_provider.lattice_state_root_with_updates(
+            bundle_state,
+            hashed_state,
+            precomputed_trie_updates,
+        )
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3262,6 +3262,12 @@ where
         } else {
             None
         };
+        #[cfg(feature = "lattice-state-root")]
+        let lattice_handle = if self.config.share_sparse_trie_with_payload_builder() {
+            self.payload_validator.lattice_root_handle_for(state.head_block_hash, &self.state)
+        } else {
+            None
+        };
 
         // send the payload to the builder and return the receiver for the pending payload
         // id, initiating payload job is handled asynchronously
@@ -3270,6 +3276,8 @@ where
             attributes,
             cache,
             trie_handle,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_handle,
         });
 
         // Client software MUST respond to this method call in the following way:

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -60,6 +60,7 @@ mod persistence_state;
 pub mod precompile_cache;
 #[cfg(test)]
 mod tests;
+#[cfg(not(feature = "lattice-state-root"))]
 mod trie_updates;
 pub mod types;
 
@@ -2169,17 +2170,22 @@ where
             .ok_or_else(|| ProviderError::StateForNumberNotFound(block.header().number()))?;
         let hashed_state = self.provider.hashed_post_state(execution_output.state());
 
-        debug!(
-            target: "engine::tree",
-            number = ?block.number(),
-            "computing block trie updates",
-        );
-        let db_provider = self.provider.database_provider_ro()?;
-        let trie_updates = reth_trie_db::compute_block_trie_updates(
-            &self.changeset_cache,
-            &db_provider,
-            block.number(),
-        )?;
+        #[cfg(not(feature = "lattice-state-root"))]
+        let trie_updates = {
+            debug!(
+                target: "engine::tree",
+                number = ?block.number(),
+                "computing block trie updates",
+            );
+            let db_provider = self.provider.database_provider_ro()?;
+            reth_trie_db::compute_block_trie_updates(
+                &self.changeset_cache,
+                &db_provider,
+                block.number(),
+            )?
+        };
+        #[cfg(feature = "lattice-state-root")]
+        let trie_updates = reth_trie::updates::TrieUpdatesSorted::default();
 
         let sorted_hashed_state = Arc::new(hashed_state.into_sorted());
         let sorted_trie_updates = Arc::new(trie_updates);

--- a/crates/engine/tree/src/tree/payload_processor/lattice.rs
+++ b/crates/engine/tree/src/tree/payload_processor/lattice.rs
@@ -1,16 +1,17 @@
 //! Streaming lattice state root task.
 
 use crate::tree::StateProviderBuilder;
-use alloy_primitives::{keccak256, map::B256Map, B256};
+use alloy_primitives::{
+    keccak256,
+    map::{B256Map, B256Set},
+    B256, U256,
+};
 use crossbeam_channel::Receiver as CrossbeamReceiver;
-use rayon::prelude::*;
 use reth_primitives_traits::{Account, NodePrimitives};
 use reth_provider::{
     BlockReader, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
 };
-use reth_trie::lattice::{
-    LatticeAccumulatorUpdates, LatticeHashState, LatticeStateRoot, LatticeStorageRoot,
-};
+use reth_trie::lattice::{LatticeAccumulatorUpdates, LatticeRoot};
 use reth_trie_parallel::{
     root::ParallelStateRootError,
     state_root_task::{LatticeRootComputeOutcome, LatticeRootMessage},
@@ -45,21 +46,21 @@ where
 
 struct LatticeRootTask {
     provider: StateProviderBox,
-    state_root: LatticeStateRoot,
-    pending_accounts: B256Map<PendingAccountUpdate>,
-    storage_updates: B256Map<Option<LatticeHashState>>,
+    lattice_root: LatticeRoot,
+    storage_overrides: B256Map<B256Map<U256>>,
+    wiped_storage_accounts: B256Set,
 }
 
 impl LatticeRootTask {
     fn new(provider: StateProviderBox) -> Result<Self, ParallelStateRootError> {
         let seed = provider.lattice_accumulator_seed()?;
-        let state_root = LatticeStateRoot::from_state(&seed.state).map_err(lattice_error)?;
+        let lattice_root = LatticeRoot::from_state(&seed.state).map_err(lattice_error)?;
 
         Ok(Self {
             provider,
-            state_root,
-            pending_accounts: B256Map::default(),
-            storage_updates: seed.storage,
+            lattice_root,
+            storage_overrides: B256Map::default(),
+            wiped_storage_accounts: B256Set::default(),
         })
     }
 
@@ -73,18 +74,29 @@ impl LatticeRootTask {
             }
 
             let hashed_address = keccak256(address);
-            let pending = self.pending_account(hashed_address, &account)?;
-            pending.new_account = new_account(&account);
+            let old_account = old_account(&account);
+            let new_account = new_account(&account);
+
+            if old_account != new_account {
+                if let Some(old_account) = old_account {
+                    self.lattice_root.subtract_account(hashed_address, old_account);
+                }
+                if let Some(new_account) = new_account {
+                    self.lattice_root.add_account(hashed_address, new_account);
+                }
+            }
 
             if account.is_selfdestructed() {
-                pending.storage_root.reset();
-                pending.storage_reset = true;
+                self.subtract_current_storage(hashed_address)?;
                 for (slot, value) in &account.storage {
                     let present_value = value.present_value();
                     if !present_value.is_zero() {
-                        pending
-                            .storage_root
-                            .add_slot(keccak256(slot.to_be_bytes::<32>()), present_value);
+                        let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                        self.lattice_root.add_slot(hashed_address, hashed_slot, present_value);
+                        self.storage_overrides
+                            .entry(hashed_address)
+                            .or_default()
+                            .insert(hashed_slot, present_value);
                     }
                 }
             } else {
@@ -97,11 +109,19 @@ impl LatticeRootTask {
 
                     let hashed_slot = keccak256(slot.to_be_bytes::<32>());
                     if !original_value.is_zero() {
-                        pending.storage_root.subtract_slot(hashed_slot, original_value);
+                        self.lattice_root.subtract_slot(
+                            hashed_address,
+                            hashed_slot,
+                            original_value,
+                        );
                     }
                     if !present_value.is_zero() {
-                        pending.storage_root.add_slot(hashed_slot, present_value);
+                        self.lattice_root.add_slot(hashed_address, hashed_slot, present_value);
                     }
+                    self.storage_overrides
+                        .entry(hashed_address)
+                        .or_default()
+                        .insert(hashed_slot, present_value);
                 }
             }
         }
@@ -109,119 +129,44 @@ impl LatticeRootTask {
         Ok(())
     }
 
-    fn pending_account(
+    fn subtract_current_storage(
         &mut self,
         hashed_address: B256,
-        account: &RevmAccount,
-    ) -> Result<&mut PendingAccountUpdate, ParallelStateRootError> {
-        if !self.pending_accounts.contains_key(&hashed_address) {
-            let seeded_storage_state = self.storage_updates.remove(&hashed_address);
-            let persist_storage_update = seeded_storage_state.is_some();
-            let old_storage_state = match seeded_storage_state {
-                Some(storage_state) => storage_state,
-                None => self.provider.lattice_storage_accumulator(hashed_address)?,
-            };
-            let storage_root = match &old_storage_state {
-                Some(state) => LatticeStorageRoot::from_state(state).map_err(lattice_error)?,
-                None => LatticeStorageRoot::default(),
-            };
+    ) -> Result<(), ParallelStateRootError> {
+        let base_storage = if self.wiped_storage_accounts.contains(&hashed_address) {
+            B256Map::default()
+        } else {
+            self.provider
+                .lattice_account_storage(hashed_address)?
+                .into_iter()
+                .collect::<B256Map<_>>()
+        };
+        let overrides = self.storage_overrides.remove(&hashed_address).unwrap_or_default();
+        let mut current_storage = base_storage;
 
-            self.pending_accounts.insert(
-                hashed_address,
-                PendingAccountUpdate {
-                    old_account: old_account(account),
-                    new_account: new_account(account),
-                    old_storage_state,
-                    storage_root,
-                    storage_reset: false,
-                    persist_storage_update,
-                },
-            );
+        for (hashed_slot, value) in overrides {
+            if value.is_zero() {
+                current_storage.remove(&hashed_slot);
+            } else {
+                current_storage.insert(hashed_slot, value);
+            }
         }
 
-        Ok(self.pending_accounts.get_mut(&hashed_address).expect("pending account exists"))
+        for (hashed_slot, value) in current_storage {
+            self.lattice_root.subtract_slot(hashed_address, hashed_slot, value);
+        }
+        self.wiped_storage_accounts.insert(hashed_address);
+
+        Ok(())
     }
 
     fn finish(self) -> Result<LatticeRootComputeOutcome, ParallelStateRootError> {
-        let Self { provider: _, mut state_root, pending_accounts, mut storage_updates } = self;
-        let mut account_updates = pending_accounts
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .map(|(hashed_address, pending)| pending.finish(hashed_address))
-            .collect::<Result<Vec<_>, _>>()?;
-        account_updates.sort_unstable_by_key(|update| update.hashed_address);
-
-        for update in account_updates {
-            if update.old_account != update.new_account ||
-                update.old_storage_root != update.new_storage_root
-            {
-                if let Some(old_account) = update.old_account {
-                    state_root.subtract_account(
-                        update.hashed_address,
-                        old_account,
-                        update.old_storage_root,
-                    );
-                }
-                if let Some(new_account) = update.new_account {
-                    state_root.add_account(
-                        update.hashed_address,
-                        new_account,
-                        update.new_storage_root,
-                    );
-                }
-            }
-
-            if let Some(storage_update) = update.storage_update {
-                storage_updates.insert(update.hashed_address, storage_update);
-            }
-        }
-
-        let state_root_hash = state_root.root();
-        let accumulator_updates =
-            LatticeAccumulatorUpdates::new(state_root.state(), storage_updates);
+        let state_root = self.lattice_root.root();
+        let accumulator_updates = LatticeAccumulatorUpdates::new(self.lattice_root.state());
 
         Ok(LatticeRootComputeOutcome {
-            state_root: state_root_hash,
+            state_root,
             accumulator_updates: Arc::new(accumulator_updates),
-        })
-    }
-}
-
-struct PendingAccountUpdate {
-    old_account: Option<Account>,
-    new_account: Option<Account>,
-    old_storage_state: Option<LatticeHashState>,
-    storage_root: LatticeStorageRoot,
-    storage_reset: bool,
-    persist_storage_update: bool,
-}
-
-struct FinishedAccountUpdate {
-    hashed_address: B256,
-    old_account: Option<Account>,
-    new_account: Option<Account>,
-    old_storage_root: B256,
-    new_storage_root: B256,
-    storage_update: Option<Option<LatticeHashState>>,
-}
-
-impl PendingAccountUpdate {
-    fn finish(self, hashed_address: B256) -> Result<FinishedAccountUpdate, ParallelStateRootError> {
-        let old_storage_root = storage_root_from_state(self.old_storage_state.as_ref())?;
-        let new_storage_root = self.storage_root.root();
-        let storage_update = (self.persist_storage_update ||
-            self.storage_reset ||
-            old_storage_root != new_storage_root)
-            .then(|| (!self.storage_root.is_zero()).then_some(self.storage_root.state()));
-
-        Ok(FinishedAccountUpdate {
-            hashed_address,
-            old_account: self.old_account,
-            new_account: self.new_account,
-            old_storage_root,
-            new_storage_root,
-            storage_update,
         })
     }
 }
@@ -242,18 +187,6 @@ fn new_account(account: &RevmAccount) -> Option<Account> {
 
 fn existing_account(info: AccountInfo) -> Option<Account> {
     (!info.is_empty()).then(|| info.into())
-}
-
-fn storage_root_from_state(
-    state: Option<&LatticeHashState>,
-) -> Result<B256, ParallelStateRootError> {
-    match state {
-        Some(state) => {
-            let storage_root = LatticeStorageRoot::from_state(state).map_err(lattice_error)?;
-            Ok(storage_root.root())
-        }
-        None => Ok(LatticeStorageRoot::default().root()),
-    }
 }
 
 fn lattice_error(err: &'static str) -> ParallelStateRootError {

--- a/crates/engine/tree/src/tree/payload_processor/lattice.rs
+++ b/crates/engine/tree/src/tree/payload_processor/lattice.rs
@@ -1,0 +1,185 @@
+//! Streaming lattice state root task.
+
+use crate::tree::StateProviderBuilder;
+use alloy_primitives::{keccak256, map::B256Map, B256};
+use crossbeam_channel::Receiver as CrossbeamReceiver;
+use reth_primitives_traits::{Account, NodePrimitives};
+use reth_provider::{
+    BlockReader, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
+};
+use reth_trie::lattice::{
+    LatticeAccumulatorUpdates, LatticeHashState, LatticeStateRoot, LatticeStorageRoot,
+};
+use reth_trie_parallel::{
+    root::ParallelStateRootError,
+    state_root_task::{LatticeRootComputeOutcome, LatticeRootMessage},
+};
+use revm_state::{Account as RevmAccount, AccountInfo, EvmState};
+use std::sync::Arc;
+
+/// Runs the streaming lattice root task until all state updates have been received.
+pub(crate) fn run_lattice_root_task<N, P>(
+    provider_builder: StateProviderBuilder<N, P>,
+    updates: CrossbeamReceiver<LatticeRootMessage>,
+) -> Result<LatticeRootComputeOutcome, ParallelStateRootError>
+where
+    N: NodePrimitives,
+    P: BlockReader + StateProviderFactory + StateReader + Clone,
+{
+    let provider = provider_builder.build()?;
+    let mut task = LatticeRootTask::new(provider)?;
+
+    loop {
+        match updates.recv() {
+            Ok(LatticeRootMessage::StateUpdate(update)) => task.apply_state_update(update)?,
+            Ok(LatticeRootMessage::FinishedStateUpdates) => return task.finish(),
+            Err(_) => {
+                return Err(ParallelStateRootError::Other(
+                    "lattice root update stream closed".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+struct LatticeRootTask {
+    provider: StateProviderBox,
+    state_root: LatticeStateRoot,
+    storage_roots: B256Map<LatticeStorageRoot>,
+    storage_updates: B256Map<Option<LatticeHashState>>,
+}
+
+impl LatticeRootTask {
+    fn new(provider: StateProviderBox) -> Result<Self, ParallelStateRootError> {
+        let seed = provider.lattice_accumulator_seed()?;
+        let state_root = LatticeStateRoot::from_state(&seed.state).map_err(lattice_error)?;
+        let mut storage_roots = B256Map::default();
+
+        for (hashed_address, storage_state) in &seed.storage {
+            let storage_root = match storage_state {
+                Some(state) => LatticeStorageRoot::from_state(state).map_err(lattice_error)?,
+                None => LatticeStorageRoot::default(),
+            };
+            storage_roots.insert(*hashed_address, storage_root);
+        }
+
+        Ok(Self { provider, state_root, storage_roots, storage_updates: seed.storage })
+    }
+
+    fn apply_state_update(&mut self, update: EvmState) -> Result<(), ParallelStateRootError> {
+        let mut accounts = update.into_iter().collect::<Vec<_>>();
+        accounts.sort_unstable_by_key(|(address, _)| keccak256(address));
+
+        for (address, account) in accounts {
+            if !account.is_touched() {
+                continue
+            }
+
+            let hashed_address = keccak256(address);
+            let (old_storage_root, new_storage_root, storage_update) = {
+                let storage_root = self.storage_root(hashed_address)?;
+                let old_storage_root = storage_root.root();
+
+                if account.is_selfdestructed() {
+                    storage_root.reset();
+                    for (slot, value) in &account.storage {
+                        let present_value = value.present_value();
+                        if !present_value.is_zero() {
+                            storage_root
+                                .add_slot(keccak256(slot.to_be_bytes::<32>()), present_value);
+                        }
+                    }
+                } else {
+                    for (slot, value) in account.changed_storage_slots() {
+                        let original_value = value.original_value();
+                        let present_value = value.present_value();
+                        if original_value == present_value {
+                            continue
+                        }
+
+                        let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                        if !original_value.is_zero() {
+                            storage_root.subtract_slot(hashed_slot, original_value);
+                        }
+                        if !present_value.is_zero() {
+                            storage_root.add_slot(hashed_slot, present_value);
+                        }
+                    }
+                }
+
+                let new_storage_root = storage_root.root();
+                let storage_update = (old_storage_root != new_storage_root ||
+                    account.is_selfdestructed())
+                .then(|| (!storage_root.is_zero()).then_some(storage_root.state()));
+
+                (old_storage_root, new_storage_root, storage_update)
+            };
+
+            let old_account = old_account(&account);
+            let new_account = new_account(&account);
+
+            if old_account != new_account || old_storage_root != new_storage_root {
+                if let Some(old_account) = old_account {
+                    self.state_root.subtract_account(hashed_address, old_account, old_storage_root);
+                }
+                if let Some(new_account) = new_account {
+                    self.state_root.add_account(hashed_address, new_account, new_storage_root);
+                }
+            }
+
+            if let Some(storage_update) = storage_update {
+                self.storage_updates.insert(hashed_address, storage_update);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn storage_root(
+        &mut self,
+        hashed_address: B256,
+    ) -> Result<&mut LatticeStorageRoot, ParallelStateRootError> {
+        if !self.storage_roots.contains_key(&hashed_address) {
+            let storage_root = match self.provider.lattice_storage_accumulator(hashed_address)? {
+                Some(state) => LatticeStorageRoot::from_state(&state).map_err(lattice_error)?,
+                None => LatticeStorageRoot::default(),
+            };
+            self.storage_roots.insert(hashed_address, storage_root);
+        }
+
+        Ok(self.storage_roots.get_mut(&hashed_address).expect("storage root exists"))
+    }
+
+    fn finish(self) -> Result<LatticeRootComputeOutcome, ParallelStateRootError> {
+        let state_root = self.state_root.root();
+        let accumulator_updates =
+            LatticeAccumulatorUpdates::new(self.state_root.state(), self.storage_updates);
+
+        Ok(LatticeRootComputeOutcome {
+            state_root,
+            accumulator_updates: Arc::new(accumulator_updates),
+        })
+    }
+}
+
+fn old_account(account: &RevmAccount) -> Option<Account> {
+    let original = account.original_info();
+    existing_account(original)
+        .filter(|_| !account.is_created() && !account.is_loaded_as_not_existing())
+}
+
+fn new_account(account: &RevmAccount) -> Option<Account> {
+    if account.is_selfdestructed() {
+        return None
+    }
+
+    existing_account(account.info.clone())
+}
+
+fn existing_account(info: AccountInfo) -> Option<Account> {
+    (!info.is_empty()).then(|| info.into())
+}
+
+fn lattice_error(err: &'static str) -> ParallelStateRootError {
+    ParallelStateRootError::Other(err.to_string())
+}

--- a/crates/engine/tree/src/tree/payload_processor/lattice.rs
+++ b/crates/engine/tree/src/tree/payload_processor/lattice.rs
@@ -3,6 +3,7 @@
 use crate::tree::StateProviderBuilder;
 use alloy_primitives::{keccak256, map::B256Map, B256};
 use crossbeam_channel::Receiver as CrossbeamReceiver;
+use rayon::prelude::*;
 use reth_primitives_traits::{Account, NodePrimitives};
 use reth_provider::{
     BlockReader, StateProviderBox, StateProviderFactory, StateReader, StateRootProvider,
@@ -45,7 +46,7 @@ where
 struct LatticeRootTask {
     provider: StateProviderBox,
     state_root: LatticeStateRoot,
-    storage_roots: B256Map<LatticeStorageRoot>,
+    pending_accounts: B256Map<PendingAccountUpdate>,
     storage_updates: B256Map<Option<LatticeHashState>>,
 }
 
@@ -53,17 +54,13 @@ impl LatticeRootTask {
     fn new(provider: StateProviderBox) -> Result<Self, ParallelStateRootError> {
         let seed = provider.lattice_accumulator_seed()?;
         let state_root = LatticeStateRoot::from_state(&seed.state).map_err(lattice_error)?;
-        let mut storage_roots = B256Map::default();
 
-        for (hashed_address, storage_state) in &seed.storage {
-            let storage_root = match storage_state {
-                Some(state) => LatticeStorageRoot::from_state(state).map_err(lattice_error)?,
-                None => LatticeStorageRoot::default(),
-            };
-            storage_roots.insert(*hashed_address, storage_root);
-        }
-
-        Ok(Self { provider, state_root, storage_roots, storage_updates: seed.storage })
+        Ok(Self {
+            provider,
+            state_root,
+            pending_accounts: B256Map::default(),
+            storage_updates: seed.storage,
+        })
     }
 
     fn apply_state_update(&mut self, update: EvmState) -> Result<(), ParallelStateRootError> {
@@ -76,88 +73,155 @@ impl LatticeRootTask {
             }
 
             let hashed_address = keccak256(address);
-            let (old_storage_root, new_storage_root, storage_update) = {
-                let storage_root = self.storage_root(hashed_address)?;
-                let old_storage_root = storage_root.root();
+            let pending = self.pending_account(hashed_address, &account)?;
+            pending.new_account = new_account(&account);
 
-                if account.is_selfdestructed() {
-                    storage_root.reset();
-                    for (slot, value) in &account.storage {
-                        let present_value = value.present_value();
-                        if !present_value.is_zero() {
-                            storage_root
-                                .add_slot(keccak256(slot.to_be_bytes::<32>()), present_value);
-                        }
-                    }
-                } else {
-                    for (slot, value) in account.changed_storage_slots() {
-                        let original_value = value.original_value();
-                        let present_value = value.present_value();
-                        if original_value == present_value {
-                            continue
-                        }
-
-                        let hashed_slot = keccak256(slot.to_be_bytes::<32>());
-                        if !original_value.is_zero() {
-                            storage_root.subtract_slot(hashed_slot, original_value);
-                        }
-                        if !present_value.is_zero() {
-                            storage_root.add_slot(hashed_slot, present_value);
-                        }
+            if account.is_selfdestructed() {
+                pending.storage_root.reset();
+                pending.storage_reset = true;
+                for (slot, value) in &account.storage {
+                    let present_value = value.present_value();
+                    if !present_value.is_zero() {
+                        pending
+                            .storage_root
+                            .add_slot(keccak256(slot.to_be_bytes::<32>()), present_value);
                     }
                 }
+            } else {
+                for (slot, value) in account.changed_storage_slots() {
+                    let original_value = value.original_value();
+                    let present_value = value.present_value();
+                    if original_value == present_value {
+                        continue
+                    }
 
-                let new_storage_root = storage_root.root();
-                let storage_update = (old_storage_root != new_storage_root ||
-                    account.is_selfdestructed())
-                .then(|| (!storage_root.is_zero()).then_some(storage_root.state()));
-
-                (old_storage_root, new_storage_root, storage_update)
-            };
-
-            let old_account = old_account(&account);
-            let new_account = new_account(&account);
-
-            if old_account != new_account || old_storage_root != new_storage_root {
-                if let Some(old_account) = old_account {
-                    self.state_root.subtract_account(hashed_address, old_account, old_storage_root);
+                    let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                    if !original_value.is_zero() {
+                        pending.storage_root.subtract_slot(hashed_slot, original_value);
+                    }
+                    if !present_value.is_zero() {
+                        pending.storage_root.add_slot(hashed_slot, present_value);
+                    }
                 }
-                if let Some(new_account) = new_account {
-                    self.state_root.add_account(hashed_address, new_account, new_storage_root);
-                }
-            }
-
-            if let Some(storage_update) = storage_update {
-                self.storage_updates.insert(hashed_address, storage_update);
             }
         }
 
         Ok(())
     }
 
-    fn storage_root(
+    fn pending_account(
         &mut self,
         hashed_address: B256,
-    ) -> Result<&mut LatticeStorageRoot, ParallelStateRootError> {
-        if !self.storage_roots.contains_key(&hashed_address) {
-            let storage_root = match self.provider.lattice_storage_accumulator(hashed_address)? {
-                Some(state) => LatticeStorageRoot::from_state(&state).map_err(lattice_error)?,
+        account: &RevmAccount,
+    ) -> Result<&mut PendingAccountUpdate, ParallelStateRootError> {
+        if !self.pending_accounts.contains_key(&hashed_address) {
+            let seeded_storage_state = self.storage_updates.remove(&hashed_address);
+            let persist_storage_update = seeded_storage_state.is_some();
+            let old_storage_state = match seeded_storage_state {
+                Some(storage_state) => storage_state,
+                None => self.provider.lattice_storage_accumulator(hashed_address)?,
+            };
+            let storage_root = match &old_storage_state {
+                Some(state) => LatticeStorageRoot::from_state(state).map_err(lattice_error)?,
                 None => LatticeStorageRoot::default(),
             };
-            self.storage_roots.insert(hashed_address, storage_root);
+
+            self.pending_accounts.insert(
+                hashed_address,
+                PendingAccountUpdate {
+                    old_account: old_account(account),
+                    new_account: new_account(account),
+                    old_storage_state,
+                    storage_root,
+                    storage_reset: false,
+                    persist_storage_update,
+                },
+            );
         }
 
-        Ok(self.storage_roots.get_mut(&hashed_address).expect("storage root exists"))
+        Ok(self.pending_accounts.get_mut(&hashed_address).expect("pending account exists"))
     }
 
     fn finish(self) -> Result<LatticeRootComputeOutcome, ParallelStateRootError> {
-        let state_root = self.state_root.root();
+        let Self { provider: _, mut state_root, pending_accounts, mut storage_updates } = self;
+        let mut account_updates = pending_accounts
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_par_iter()
+            .map(|(hashed_address, pending)| pending.finish(hashed_address))
+            .collect::<Result<Vec<_>, _>>()?;
+        account_updates.sort_unstable_by_key(|update| update.hashed_address);
+
+        for update in account_updates {
+            if update.old_account != update.new_account ||
+                update.old_storage_root != update.new_storage_root
+            {
+                if let Some(old_account) = update.old_account {
+                    state_root.subtract_account(
+                        update.hashed_address,
+                        old_account,
+                        update.old_storage_root,
+                    );
+                }
+                if let Some(new_account) = update.new_account {
+                    state_root.add_account(
+                        update.hashed_address,
+                        new_account,
+                        update.new_storage_root,
+                    );
+                }
+            }
+
+            if let Some(storage_update) = update.storage_update {
+                storage_updates.insert(update.hashed_address, storage_update);
+            }
+        }
+
+        let state_root_hash = state_root.root();
         let accumulator_updates =
-            LatticeAccumulatorUpdates::new(self.state_root.state(), self.storage_updates);
+            LatticeAccumulatorUpdates::new(state_root.state(), storage_updates);
 
         Ok(LatticeRootComputeOutcome {
-            state_root,
+            state_root: state_root_hash,
             accumulator_updates: Arc::new(accumulator_updates),
+        })
+    }
+}
+
+struct PendingAccountUpdate {
+    old_account: Option<Account>,
+    new_account: Option<Account>,
+    old_storage_state: Option<LatticeHashState>,
+    storage_root: LatticeStorageRoot,
+    storage_reset: bool,
+    persist_storage_update: bool,
+}
+
+struct FinishedAccountUpdate {
+    hashed_address: B256,
+    old_account: Option<Account>,
+    new_account: Option<Account>,
+    old_storage_root: B256,
+    new_storage_root: B256,
+    storage_update: Option<Option<LatticeHashState>>,
+}
+
+impl PendingAccountUpdate {
+    fn finish(self, hashed_address: B256) -> Result<FinishedAccountUpdate, ParallelStateRootError> {
+        let old_storage_root = storage_root_from_state(self.old_storage_state.as_ref())?;
+        let new_storage_root = self.storage_root.root();
+        let storage_update = (self.persist_storage_update ||
+            self.storage_reset ||
+            old_storage_root != new_storage_root)
+            .then(|| (!self.storage_root.is_zero()).then_some(self.storage_root.state()));
+
+        Ok(FinishedAccountUpdate {
+            hashed_address,
+            old_account: self.old_account,
+            new_account: self.new_account,
+            old_storage_root,
+            new_storage_root,
+            storage_update,
         })
     }
 }
@@ -178,6 +242,18 @@ fn new_account(account: &RevmAccount) -> Option<Account> {
 
 fn existing_account(info: AccountInfo) -> Option<Account> {
     (!info.is_empty()).then(|| info.into())
+}
+
+fn storage_root_from_state(
+    state: Option<&LatticeHashState>,
+) -> Result<B256, ParallelStateRootError> {
+    match state {
+        Some(state) => {
+            let storage_root = LatticeStorageRoot::from_state(state).map_err(lattice_error)?;
+            Ok(storage_root.root())
+        }
+        None => Ok(LatticeStorageRoot::default().root()),
+    }
 }
 
 fn lattice_error(err: &'static str) -> ParallelStateRootError {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -346,6 +346,9 @@ where
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + Send + 'static,
     {
+        #[cfg(not(feature = "lattice-state-root"))]
+        let _ = parallel_bal_execution;
+
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count);
         #[cfg(feature = "lattice-state-root")]

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -48,6 +48,8 @@ use std::{
 use tracing::{debug, debug_span, instrument, trace, warn, Span};
 
 pub mod bal;
+#[cfg(feature = "lattice-state-root")]
+mod lattice;
 pub mod multiproof;
 mod preserved_sparse_trie;
 pub mod prewarm;
@@ -279,7 +281,7 @@ where
         parallel_bal_execution: bool,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
-        P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+        P: BlockReader + StateProviderFactory + StateReader + Clone + Send + 'static,
         F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
             + Send
@@ -308,6 +310,9 @@ where
         // `saved_cache` is absent below, so prewarm skips cache-backed state prefetching.
         // `disable_bal_batch_io` controls the prefetch half when a cache exists.
         let install_state_hook = !parallel_bal_execution;
+        #[cfg(feature = "lattice-state-root")]
+        let lattice_root_handle =
+            install_state_hook.then(|| self.spawn_lattice_root(provider_builder.clone()));
         let prewarm_handle = self.spawn_caching_with(
             env,
             prewarm_rx,
@@ -318,6 +323,8 @@ where
 
         PayloadHandle {
             state_root_handle: Some(state_root_handle),
+            #[cfg(feature = "lattice-state-root")]
+            lattice_root_handle,
             install_state_hook,
             prewarm_handle,
             transactions: execution_rx,
@@ -334,16 +341,22 @@ where
         env: ExecutionEnv<Evm>,
         transactions: I,
         provider_builder: StateProviderBuilder<N, P>,
+        parallel_bal_execution: bool,
     ) -> IteratorPayloadHandle<Evm, I, N>
     where
-        P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+        P: BlockReader + StateProviderFactory + StateReader + Clone + Send + 'static,
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count);
+        #[cfg(feature = "lattice-state-root")]
+        let lattice_root_handle =
+            (!parallel_bal_execution).then(|| self.spawn_lattice_root(provider_builder.clone()));
         let prewarm_handle =
             self.spawn_caching_with(env, prewarm_rx, provider_builder, None, false);
         PayloadHandle {
             state_root_handle: None,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_root_handle,
             install_state_hook: false,
             prewarm_handle,
             transactions: execution_rx,
@@ -398,6 +411,27 @@ where
         );
 
         StateRootHandle::new(parent_state_root, updates_tx, state_root_rx, hashed_state_rx)
+    }
+
+    /// Spawns a streaming lattice root task.
+    #[cfg(feature = "lattice-state-root")]
+    #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
+    pub fn spawn_lattice_root<P>(
+        &self,
+        provider_builder: StateProviderBuilder<N, P>,
+    ) -> LatticeRootHandle
+    where
+        P: BlockReader + StateProviderFactory + StateReader + Clone + Send + 'static,
+    {
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (lattice_root_tx, lattice_root_rx) = channel();
+
+        self.executor.spawn_blocking_named("lattice-root", move || {
+            let result = lattice::run_lattice_root_task(provider_builder, updates_rx);
+            let _ = lattice_root_tx.send(result);
+        });
+
+        LatticeRootHandle::new(updates_tx, lattice_root_rx)
     }
 
     /// Transaction count threshold below which proof workers are halved, since fewer transactions
@@ -799,6 +833,9 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
 pub struct PayloadHandle<Tx, Err, R> {
     /// Handle to the background state root computation, if spawned.
     state_root_handle: Option<StateRootHandle>,
+    /// Handle to the background lattice root computation, if spawned.
+    #[cfg(feature = "lattice-state-root")]
+    lattice_root_handle: Option<LatticeRootHandle>,
     /// Whether main execution should stream per-tx state updates into the sparse trie task.
     install_state_hook: bool,
     // must include the receiver of the state root wired to the sparse trie
@@ -825,6 +862,14 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
         self.state_root_handle.as_mut().expect("state_root_handle is None").state_root()
     }
 
+    /// Awaits the lattice state root, if a lattice task was spawned.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn lattice_root(
+        &mut self,
+    ) -> Option<Result<LatticeRootComputeOutcome, ParallelStateRootError>> {
+        self.lattice_root_handle.as_mut().map(|handle| handle.lattice_root())
+    }
+
     /// Takes the state root receiver out of the handle for use with custom waiting logic
     /// (e.g., timeout-based waiting).
     ///
@@ -837,13 +882,46 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
         self.state_root_handle.as_mut().expect("state_root_handle is None").take_state_root_rx()
     }
 
-    /// Returns a state hook to stream execution state updates to the sparse trie cache task.
+    /// Returns a state hook to stream execution state updates to background root tasks.
     ///
     /// Returns `None` when BAL-driven hashed state streaming feeds the sparse trie task.
     pub fn state_hook(&self) -> Option<impl OnStateHook> {
-        self.install_state_hook
-            .then(|| self.state_root_handle.as_ref().map(|handle| handle.state_hook()))
-            .flatten()
+        let sparse_sender = self
+            .install_state_hook
+            .then(|| {
+                self.state_root_handle
+                    .as_ref()
+                    .map(|handle| StateHookSender::new(handle.updates_tx().clone()))
+            })
+            .flatten();
+        #[cfg(feature = "lattice-state-root")]
+        let lattice_sender = self
+            .lattice_root_handle
+            .as_ref()
+            .map(|handle| LatticeStateHookSender::new(handle.updates_tx().clone()));
+
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            sparse_sender.map(|sender| {
+                move |state: &reth_revm::state::EvmState| {
+                    let _ = sender.send(StateRootMessage::StateUpdate(state.clone()));
+                }
+            })
+        }
+
+        #[cfg(feature = "lattice-state-root")]
+        {
+            (sparse_sender.is_some() || lattice_sender.is_some()).then(move || {
+                move |state: &reth_revm::state::EvmState| {
+                    if let Some(sender) = &sparse_sender {
+                        let _ = sender.send(StateRootMessage::StateUpdate(state.clone()));
+                    }
+                    if let Some(sender) = &lattice_sender {
+                        let _ = sender.send(LatticeRootMessage::StateUpdate(state.clone()));
+                    }
+                }
+            })
+        }
     }
 
     /// Returns a clone of the sender that streams updates into the sparse-trie task. The BAL

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -7,6 +7,10 @@ pub use reth_trie_parallel::state_root_task::{
     evm_state_to_hashed_post_state, StateHookSender, StateRootComputeOutcome, StateRootHandle,
     StateRootMessage,
 };
+#[cfg(feature = "lattice-state-root")]
+pub use reth_trie_parallel::state_root_task::{
+    LatticeRootComputeOutcome, LatticeRootHandle, LatticeRootMessage, LatticeStateHookSender,
+};
 
 /// The default max targets, for limiting the number of account and storage proof targets to be
 /// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -40,10 +40,12 @@
 
 #[cfg(feature = "lattice-state-root")]
 use crate::tree::multiproof::LatticeRootHandle;
+#[cfg(not(feature = "lattice-state-root"))]
+use crate::tree::multiproof::StateRootComputeOutcome;
 use crate::tree::{
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
     instrumented_state::{InstrumentedStateProvider, StateProviderMetrics, StateProviderStats},
-    multiproof::{StateRootComputeOutcome, StateRootHandle},
+    multiproof::StateRootHandle,
     payload_processor::PayloadProcessor,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     types::{InsertPayloadResult, ValidationOutput},
@@ -81,29 +83,35 @@ use reth_primitives_traits::{
     AlloyBlockHeader, BlockBody, BlockTy, FastInstant as Instant, GotExpected, NodePrimitives,
     RecoveredBlock, SealedBlock, SealedHeader, SignerRecoverable,
 };
+#[cfg(not(feature = "lattice-state-root"))]
+use reth_provider::{providers::OverlayStateProvider, DatabaseProviderROFactory};
 use reth_provider::{
-    providers::{OverlayBuilder, OverlayStateProvider, OverlayStateProviderFactory},
+    providers::{OverlayBuilder, OverlayStateProviderFactory},
     BlockExecutionOutput, BlockNumReader, BlockReader, ChangeSetReader, DatabaseProviderFactory,
-    DatabaseProviderROFactory, HashedPostStateProvider, ProviderError, PruneCheckpointReader,
-    StageCheckpointReader, StateProvider, StateProviderBox, StateProviderFactory, StateReader,
-    StorageChangeSetReader, StorageSettingsCache,
+    HashedPostStateProvider, ProviderError, PruneCheckpointReader, StageCheckpointReader,
+    StateProvider, StateProviderBox, StateProviderFactory, StateReader, StorageChangeSetReader,
+    StorageSettingsCache,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
-use reth_trie::{trie_cursor::TrieCursorFactory, updates::TrieUpdates, HashedPostState};
+#[cfg(not(feature = "lattice-state-root"))]
+use reth_trie::trie_cursor::TrieCursorFactory;
+use reth_trie::{updates::TrieUpdates, HashedPostState};
 use reth_trie_db::ChangesetCache;
+#[cfg(not(feature = "lattice-state-root"))]
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::{Address, KECCAK_EMPTY};
+#[cfg(not(feature = "lattice-state-root"))]
+use std::sync::mpsc::RecvTimeoutError;
 use std::{
     collections::HashMap,
     panic::{self, AssertUnwindSafe},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        mpsc::RecvTimeoutError,
         Arc,
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, error, info, instrument, trace, warn, Level, Span};
+use tracing::{debug, debug_span, error, instrument, trace, warn, Level, Span};
 
 pub use crate::tree::types::ValidationOutcome;
 
@@ -494,6 +502,7 @@ where
         );
         let overlay_factory =
             OverlayStateProviderFactory::new(provider_factory.clone(), overlay_builder.clone());
+        #[cfg(not(feature = "lattice-state-root"))]
         let changeset_provider = self.spawn_changeset_provider_task(overlay_factory.clone());
 
         let parallel_bal_execution = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
@@ -610,7 +619,7 @@ where
         let hashed_state_output = output.clone();
         let hashed_state_provider = self.provider.clone();
         let mut hashed_state_rx = handle.take_hashed_state_rx();
-        let mut hashed_state: LazyHashedPostState =
+        let hashed_state: LazyHashedPostState =
             self.payload_processor.executor().spawn_blocking_named("hash-post-state", move || {
                 let _span = debug_span!(
                     target: "engine::tree::payload_validator",
@@ -624,6 +633,8 @@ where
                 };
                 Arc::new(state)
             });
+        #[cfg(not(feature = "lattice-state-root"))]
+        let mut hashed_state = hashed_state;
 
         let block = validated_block.try_into_inner().expect("sole handle")?;
         let block = block.with_senders(senders);
@@ -661,7 +672,7 @@ where
 
         // Run the hashed state validation hook but don't propagate the error yet. If the state root
         // task fails, we might need to re-run this check against a fallback state.
-        let mut hashed_state_validate_result = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").in_scope(|| {
+        let hashed_state_validate_result = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").in_scope(|| {
             // Wait for the background keccak256 hashing task to complete. This blocks until
             // all changed addresses and storage slots have been hashed.
             let hashed_state_ref =
@@ -670,220 +681,230 @@ where
 
             self.validator.validate_block_post_execution_with_hashed_state(hashed_state_ref, &block)
         });
+        #[cfg(not(feature = "lattice-state-root"))]
+        let mut hashed_state_validate_result = hashed_state_validate_result;
 
-        let root_time = Instant::now();
-        let mut maybe_state_root = None;
-        let mut state_root_task_failed = false;
-        #[cfg(feature = "trie-debug")]
-        let mut trie_debug_recorders = Vec::new();
+        #[cfg(not(feature = "lattice-state-root"))]
+        let (state_root, trie_output, root_elapsed) = {
+            let root_time = Instant::now();
+            let mut maybe_state_root = None;
+            let mut state_root_task_failed = false;
+            #[cfg(feature = "trie-debug")]
+            let mut trie_debug_recorders = Vec::new();
 
-        match strategy {
-            StateRootStrategy::StateRootTask => {
-                debug!(target: "engine::tree::payload_validator", "Using sparse trie state root algorithm");
+            match strategy {
+                StateRootStrategy::StateRootTask => {
+                    debug!(target: "engine::tree::payload_validator", "Using sparse trie state root algorithm");
 
-                let task_result = ensure_ok_post_block!(
-                    self.await_state_root_with_timeout(
-                        &mut handle,
-                        provider_builder.clone(),
-                        output.clone(),
-                    ),
-                    block
-                );
+                    let task_result = ensure_ok_post_block!(
+                        self.await_state_root_with_timeout(
+                            &mut handle,
+                            provider_builder.clone(),
+                            output.clone(),
+                        ),
+                        block
+                    );
 
-                let maybe_new_hashed_state = match task_result {
-                    Ok((
-                        StateRootComputeOutcome {
-                            state_root,
-                            trie_updates,
+                    let maybe_new_hashed_state = match task_result {
+                        Ok((
+                            StateRootComputeOutcome {
+                                state_root,
+                                trie_updates,
+                                #[cfg(feature = "trie-debug")]
+                                debug_recorders,
+                            },
+                            maybe_new_hashed_state,
+                        )) => {
+                            let elapsed = root_time.elapsed();
+                            tracing::info!(target: "engine::tree::payload_validator", ?state_root, ?elapsed, "State root task finished");
+
                             #[cfg(feature = "trie-debug")]
-                            debug_recorders,
-                        },
-                        maybe_new_hashed_state,
-                    )) => {
-                        let elapsed = root_time.elapsed();
-                        info!(target: "engine::tree::payload_validator", ?state_root, ?elapsed, "State root task finished");
+                            {
+                                trie_debug_recorders = debug_recorders;
+                            }
 
-                        #[cfg(feature = "trie-debug")]
-                        {
-                            trie_debug_recorders = debug_recorders;
-                        }
+                            // Compare trie updates with serial computation if configured
+                            if self.config.always_compare_trie_updates() {
+                                let _has_diff = self.compare_trie_updates_with_serial(
+                                    provider_builder.clone(),
+                                    provider_factory,
+                                    overlay_builder,
+                                    &output,
+                                    trie_updates.as_ref().clone(),
+                                );
+                                #[cfg(feature = "trie-debug")]
+                                if _has_diff {
+                                    Self::write_trie_debug_recorders(
+                                        block.header().number(),
+                                        &trie_debug_recorders,
+                                    );
+                                }
+                            }
 
-                        // Compare trie updates with serial computation if configured
-                        if self.config.always_compare_trie_updates() {
-                            let _has_diff = self.compare_trie_updates_with_serial(
-                                provider_builder.clone(),
-                                provider_factory,
-                                overlay_builder,
-                                &output,
-                                trie_updates.as_ref().clone(),
-                            );
-                            #[cfg(feature = "trie-debug")]
-                            if _has_diff {
+                            // we double check the state root here for good measure
+                            if state_root == block.header().state_root() {
+                                maybe_state_root = Some((state_root, trie_updates, elapsed))
+                            } else {
+                                warn!(
+                                    target: "engine::tree::payload_validator",
+                                    ?state_root,
+                                    block_state_root = ?block.header().state_root(),
+                                    "State root task returned incorrect state root"
+                                );
+                                #[cfg(feature = "trie-debug")]
                                 Self::write_trie_debug_recorders(
                                     block.header().number(),
                                     &trie_debug_recorders,
                                 );
+                                state_root_task_failed = true;
                             }
-                        }
 
-                        // we double check the state root here for good measure
-                        if state_root == block.header().state_root() {
-                            maybe_state_root = Some((state_root, trie_updates, elapsed))
-                        } else {
-                            warn!(
-                                target: "engine::tree::payload_validator",
-                                ?state_root,
-                                block_state_root = ?block.header().state_root(),
-                                "State root task returned incorrect state root"
-                            );
-                            #[cfg(feature = "trie-debug")]
-                            Self::write_trie_debug_recorders(
-                                block.header().number(),
-                                &trie_debug_recorders,
-                            );
+                            maybe_new_hashed_state
+                        }
+                        Err(error) => {
+                            debug!(target: "engine::tree::payload_validator", %error, "State root task failed");
                             state_root_task_failed = true;
+                            None
                         }
+                    };
 
-                        maybe_new_hashed_state
+                    // If the state root task failed or we got a new hashed state from the fallback
+                    // that won the race, we need to replace the hashed state
+                    // handle and re-run the validation.
+                    if maybe_new_hashed_state.is_some() || state_root_task_failed {
+                        hashed_state = maybe_new_hashed_state.unwrap_or_else(|| {
+                            LazyHandle::ready(Arc::new(
+                                self.provider.hashed_post_state(&output.state),
+                            ))
+                        });
+                        hashed_state_validate_result =
+                            self.validator.validate_block_post_execution_with_hashed_state(
+                                hashed_state.get(),
+                                &block,
+                            );
                     }
-                    Err(error) => {
-                        debug!(target: "engine::tree::payload_validator", %error, "State root task failed");
-                        state_root_task_failed = true;
-                        None
+                }
+                StateRootStrategy::Parallel => {
+                    debug!(target: "engine::tree::payload_validator", "Using parallel state root algorithm");
+                    match self.compute_state_root_parallel(
+                        provider_factory,
+                        overlay_builder,
+                        &hashed_state,
+                    ) {
+                        Ok(result) => {
+                            let elapsed = root_time.elapsed();
+                            tracing::info!(
+                                target: "engine::tree::payload_validator",
+                                regular_state_root = ?result.0,
+                                ?elapsed,
+                                "Regular root task finished"
+                            );
+                            maybe_state_root = Some((result.0, Arc::new(result.1), elapsed));
+                        }
+                        Err(error) => {
+                            debug!(target: "engine::tree::payload_validator", %error, "Parallel state root computation failed");
+                        }
                     }
+                }
+                StateRootStrategy::Synchronous => {}
+                StateRootStrategy::Custom(ref custom) => {
+                    let (state_root, trie_updates) = ensure_ok_post_block!(
+                        custom(CustomStateRootInput {
+                            block: &block,
+                            parent_block: &parent_block,
+                            output: &output,
+                            hashed_state: &hashed_state,
+                        }),
+                        block
+                    );
+                    maybe_state_root =
+                        Some((state_root, Arc::new(trie_updates), root_time.elapsed()));
+                }
+            }
+
+            if let Some(maybe_state_root) = maybe_state_root {
+                maybe_state_root
+            } else {
+                // fallback is to compute the state root regularly in sync
+                match strategy {
+                    StateRootStrategy::Synchronous => {
+                        debug!(target: "engine::tree::payload_validator", "Computing state root synchronously");
+                    }
+                    _ if self.config.state_root_fallback() => {
+                        debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
+                    }
+                    _ => {
+                        warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
+                        self.metrics
+                            .block_validation
+                            .state_root_parallel_fallback_total
+                            .increment(1);
+                    }
+                }
+
+                let (root, updates) = ensure_ok_post_block!(
+                    provider_builder.build().and_then(|provider| Self::compute_state_root_serial(
+                        provider,
+                        &hashed_state
+                    )),
+                    block
+                );
+
+                if state_root_task_failed {
+                    self.metrics
+                        .block_validation
+                        .state_root_task_fallback_success_total
+                        .increment(1);
+                }
+
+                (root, Arc::new(updates), root_time.elapsed())
+            }
+        };
+
+        #[cfg(feature = "lattice-state-root")]
+        let (state_root, trie_output, lattice_accumulator_updates, root_elapsed) = {
+            let root_time = Instant::now();
+            let streamed_lattice_root = match handle.lattice_root() {
+                Some(Ok(outcome)) => {
+                    debug!(
+                        target: "engine::tree::payload_validator",
+                        state_root = ?outcome.state_root,
+                        "Lattice root task finished"
+                    );
+                    Some(outcome)
+                }
+                Some(Err(err)) => {
+                    warn!(
+                        target: "engine::tree::payload_validator",
+                        %err,
+                        "Lattice root task failed, falling back to bundle lattice root"
+                    );
+                    None
+                }
+                None => None,
+            };
+
+            let (state_root, lattice_accumulator_updates) =
+                if let Some(outcome) = streamed_lattice_root {
+                    (outcome.state_root, outcome.accumulator_updates)
+                } else {
+                    ensure_ok_post_block!(
+                        provider_builder.build().and_then(|provider| {
+                            provider
+                                .lattice_state_root(&output.state)
+                                .map(|(root, lattice_updates)| (root, Arc::new(lattice_updates)))
+                        }),
+                        block
+                    )
                 };
 
-                // If the state root task failed or we got a new hashed state from the fallback that
-                // won the race, we need to replace the hashed state handle and re-run the
-                // validation.
-                if maybe_new_hashed_state.is_some() || state_root_task_failed {
-                    hashed_state = maybe_new_hashed_state.unwrap_or_else(|| {
-                        LazyHandle::ready(Arc::new(self.provider.hashed_post_state(&output.state)))
-                    });
-                    hashed_state_validate_result =
-                        self.validator.validate_block_post_execution_with_hashed_state(
-                            hashed_state.get(),
-                            &block,
-                        );
-                }
-            }
-            StateRootStrategy::Parallel => {
-                debug!(target: "engine::tree::payload_validator", "Using parallel state root algorithm");
-                match self.compute_state_root_parallel(
-                    provider_factory,
-                    overlay_builder,
-                    &hashed_state,
-                ) {
-                    Ok(result) => {
-                        let elapsed = root_time.elapsed();
-                        info!(
-                            target: "engine::tree::payload_validator",
-                            regular_state_root = ?result.0,
-                            ?elapsed,
-                            "Regular root task finished"
-                        );
-                        maybe_state_root = Some((result.0, Arc::new(result.1), elapsed));
-                    }
-                    Err(error) => {
-                        debug!(target: "engine::tree::payload_validator", %error, "Parallel state root computation failed");
-                    }
-                }
-            }
-            StateRootStrategy::Synchronous => {}
-            StateRootStrategy::Custom(ref custom) => {
-                let (state_root, trie_updates) = ensure_ok_post_block!(
-                    custom(CustomStateRootInput {
-                        block: &block,
-                        parent_block: &parent_block,
-                        output: &output,
-                        hashed_state: &hashed_state,
-                    }),
-                    block
-                );
-                maybe_state_root = Some((state_root, Arc::new(trie_updates), root_time.elapsed()));
-            }
-        }
-
-        // Determine the state root.
-        // If the state root was computed in parallel, we use it.
-        // Otherwise, we fall back to computing it synchronously.
-        let (state_root, trie_output, root_elapsed) = if let Some(maybe_state_root) =
-            maybe_state_root
-        {
-            maybe_state_root
-        } else {
-            // fallback is to compute the state root regularly in sync
-            match strategy {
-                StateRootStrategy::Synchronous => {
-                    debug!(target: "engine::tree::payload_validator", "Computing state root synchronously");
-                }
-                _ if self.config.state_root_fallback() => {
-                    debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
-                }
-                _ => {
-                    warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
-                    self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
-                }
-            }
-
-            let (root, updates) = ensure_ok_post_block!(
-                provider_builder
-                    .build()
-                    .and_then(|provider| Self::compute_state_root_serial(provider, &hashed_state)),
-                block
-            );
-
-            if state_root_task_failed {
-                self.metrics.block_validation.state_root_task_fallback_success_total.increment(1);
-            }
-
-            (root, Arc::new(updates), root_time.elapsed())
+            (
+                state_root,
+                Arc::new(TrieUpdates::default()),
+                lattice_accumulator_updates,
+                root_time.elapsed(),
+            )
         };
-
-        #[cfg(feature = "lattice-state-root")]
-        let _mpt_state_root = state_root;
-
-        #[cfg(feature = "lattice-state-root")]
-        let streamed_lattice_root = match handle.lattice_root() {
-            Some(Ok(outcome)) => {
-                debug!(
-                    target: "engine::tree::payload_validator",
-                    state_root = ?outcome.state_root,
-                    "Lattice root task finished"
-                );
-                Some(outcome)
-            }
-            Some(Err(err)) => {
-                warn!(
-                    target: "engine::tree::payload_validator",
-                    %err,
-                    "Lattice root task failed, falling back to bundle lattice root"
-                );
-                None
-            }
-            None => None,
-        };
-
-        #[cfg(feature = "lattice-state-root")]
-        let (state_root, trie_output, lattice_accumulator_updates) =
-            if let Some(outcome) = streamed_lattice_root {
-                (outcome.state_root, trie_output, outcome.accumulator_updates)
-            } else {
-                ensure_ok_post_block!(
-                    provider_builder.build().and_then(|provider| {
-                        provider
-                            .lattice_state_root_with_updates(
-                                &output.state,
-                                hashed_state.get().as_ref().clone(),
-                                Some(trie_output.as_ref().clone()),
-                            )
-                            .map(|(root, updates, lattice_updates)| {
-                                (root, Arc::new(updates), Arc::new(lattice_updates))
-                            })
-                    }),
-                    block
-                )
-            };
 
         if let Err(err) = hashed_state_validate_result {
             // call post-block hook
@@ -898,7 +919,7 @@ where
 
         // ensure state root matches
         if state_root != block.header().state_root() {
-            #[cfg(feature = "trie-debug")]
+            #[cfg(all(feature = "trie-debug", not(feature = "lattice-state-root")))]
             Self::write_trie_debug_recorders(block.header().number(), &trie_debug_recorders);
 
             // call post-block hook
@@ -935,6 +956,7 @@ where
             let _ = valid_block_tx.send(());
         }
 
+        #[cfg(not(feature = "lattice-state-root"))]
         let changeset_provider = ensure_ok_post_block!(
             changeset_provider
                 .try_into_inner()
@@ -950,6 +972,7 @@ where
             trie_output,
             #[cfg(feature = "lattice-state-root")]
             lattice_accumulator_updates,
+            #[cfg(not(feature = "lattice-state-root"))]
             changeset_provider,
         );
         Ok(ValidationOutput::new(executed_block, timing_stats))
@@ -1014,6 +1037,7 @@ where
     ///
     /// This is started before execution so overlay construction can run concurrently with payload
     /// validation, then awaited before the deferred trie task is spawned.
+    #[cfg(not(feature = "lattice-state-root"))]
     fn spawn_changeset_provider_task(
         &self,
         overlay_factory: OverlayStateProviderFactory<P, N>,
@@ -1386,6 +1410,7 @@ where
     ///
     /// Returns `Ok(_)` if computed successfully.
     /// Returns `Err(_)` if error was encountered during computation.
+    #[cfg(not(feature = "lattice-state-root"))]
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn compute_state_root_parallel(
         &self,
@@ -1410,6 +1435,7 @@ where
     /// Uses the same provider construction path as main execution and computes the state root and
     /// trie updates for this block directly via
     /// [`reth_provider::StateRootProvider::state_root_with_updates`].
+    #[cfg(not(feature = "lattice-state-root"))]
     fn compute_state_root_serial(
         state_provider: StateProviderBox,
         hashed_state: &LazyHashedPostState,
@@ -1436,6 +1462,7 @@ where
         name = "await_state_root",
         skip_all
     )]
+    #[cfg(not(feature = "lattice-state-root"))]
     fn await_state_root_with_timeout<Tx, Err, R: Send + Sync + 'static>(
         &self,
         handle: &mut PayloadHandle<Tx, Err, R>,
@@ -1541,6 +1568,7 @@ where
     /// task implementation. When enabled via `--engine.state-root-task-compare-updates`, this
     /// method runs a separate serial state root computation and compares the resulting trie
     /// updates.
+    #[cfg(not(feature = "lattice-state-root"))]
     fn compare_trie_updates_with_serial(
         &self,
         state_provider_builder: StateProviderBuilder<N, P>,
@@ -1881,7 +1909,9 @@ where
         #[cfg(feature = "lattice-state-root")] lattice_accumulator_updates: Arc<
             reth_trie::lattice::LatticeAccumulatorUpdates,
         >,
-        changeset_provider: impl TrieCursorFactory + Send + 'static,
+        #[cfg(not(feature = "lattice-state-root"))] changeset_provider: impl TrieCursorFactory
+            + Send
+            + 'static,
     ) -> ExecutedBlock<N> {
         // Create deferred handle with fallback inputs in case the background task hasn't completed.
         // Resolve the lazy handle into Arc<HashedPostState>. By this point the hashed state has
@@ -1902,12 +1932,14 @@ where
         let block_validation_metrics = self.metrics.block_validation.clone();
 
         // Capture block info and cache handle for changeset computation
+        #[cfg(not(feature = "lattice-state-root"))]
         let block_hash = block.hash();
         let block_number = block.number();
 
         // Register a pending changeset entry so that concurrent readers will wait for
         // this computation to finish rather than falling back to the expensive DB path.
         // The guard ensures the pending entry is cancelled if the task panics.
+        #[cfg(not(feature = "lattice-state-root"))]
         let pending_changeset_guard = self.changeset_cache.register_pending(block_hash);
 
         // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
@@ -1931,35 +1963,40 @@ where
                 block_validation_metrics
                     .hashed_post_state_size
                     .record(computed.hashed_state.total_len() as f64);
-                block_validation_metrics
-                    .trie_updates_sorted_size
-                    .record(computed.trie_updates.total_len() as f64);
-                // Compute and cache changesets using the computed trie_updates.
-                // Use the pre-created provider to avoid races with changeset cache
-                // eviction that can happen between task spawn and execution.
-                let changeset_start = Instant::now();
+                #[cfg(feature = "lattice-state-root")]
+                block_validation_metrics.trie_updates_sorted_size.record(0.0);
+                #[cfg(not(feature = "lattice-state-root"))]
+                {
+                    block_validation_metrics
+                        .trie_updates_sorted_size
+                        .record(computed.trie_updates.total_len() as f64);
+                    // Compute and cache changesets using the computed trie_updates.
+                    // Use the pre-created provider to avoid races with changeset cache
+                    // eviction that can happen between task spawn and execution.
+                    let changeset_start = Instant::now();
 
-                match reth_trie::changesets::compute_trie_changesets(
-                    &changeset_provider,
-                    &computed.trie_updates,
-                ) {
-                    Ok(changesets) => {
-                        debug!(
-                            target: "engine::tree::changeset",
-                            ?block_number,
-                            elapsed = ?changeset_start.elapsed(),
-                            "Computed and caching changesets"
-                        );
+                    match reth_trie::changesets::compute_trie_changesets(
+                        &changeset_provider,
+                        &computed.trie_updates,
+                    ) {
+                        Ok(changesets) => {
+                            debug!(
+                                target: "engine::tree::changeset",
+                                ?block_number,
+                                elapsed = ?changeset_start.elapsed(),
+                                "Computed and caching changesets"
+                            );
 
-                        pending_changeset_guard.resolve(block_number, Arc::new(changesets));
-                    }
-                    Err(e) => {
-                        warn!(
-                            target: "engine::tree::changeset",
-                            ?block_number,
-                            ?e,
-                            "Failed to compute changesets in deferred trie task"
-                        );
+                            pending_changeset_guard.resolve(block_number, Arc::new(changesets));
+                        }
+                        Err(e) => {
+                            warn!(
+                                target: "engine::tree::changeset",
+                                ?block_number,
+                                ?e,
+                                "Failed to compute changesets in deferred trie task"
+                            );
+                        }
                     }
                 }
             }));
@@ -2275,6 +2312,7 @@ where
             &block.execution_output.state,
         );
 
+        #[cfg(not(feature = "lattice-state-root"))]
         let overlay_factory = OverlayStateProviderFactory::new(
             self.provider.clone(),
             Self::overlay_builder_for_parent(
@@ -2283,7 +2321,10 @@ where
                 self.changeset_cache.clone(),
             ),
         );
+        #[cfg(not(feature = "lattice-state-root"))]
         let changeset_provider = overlay_factory.database_provider_ro()?;
+        #[cfg(feature = "lattice-state-root")]
+        let _ = state;
 
         Ok(self.spawn_deferred_trie_task(
             block.recovered_block,
@@ -2292,6 +2333,7 @@ where
             block.trie_updates,
             #[cfg(feature = "lattice-state-root")]
             block.lattice_accumulator_updates,
+            #[cfg(not(feature = "lattice-state-root"))]
             changeset_provider,
         ))
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -787,7 +787,7 @@ where
                 }
             }
             StateRootStrategy::Synchronous => {}
-            StateRootStrategy::Custom(custom) => {
+            StateRootStrategy::Custom(ref custom) => {
                 let (state_root, trie_updates) = ensure_ok_post_block!(
                     custom(CustomStateRootInput {
                         block: &block,
@@ -810,11 +810,17 @@ where
             maybe_state_root
         } else {
             // fallback is to compute the state root regularly in sync
-            if self.config.state_root_fallback() {
-                debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
-            } else {
-                warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
-                self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
+            match strategy {
+                StateRootStrategy::Synchronous => {
+                    debug!(target: "engine::tree::payload_validator", "Computing state root synchronously");
+                }
+                _ if self.config.state_root_fallback() => {
+                    debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
+                }
+                _ => {
+                    warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
+                    self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
+                }
             }
 
             let (root, updates) = ensure_ok_post_block!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1754,14 +1754,22 @@ where
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
     fn plan_state_root_computation(&self) -> StateRootStrategy<N> {
-        if let Some(custom_state_root) = &self.custom_state_root {
-            StateRootStrategy::Custom(custom_state_root.clone())
-        } else if self.config.state_root_fallback() {
+        #[cfg(feature = "lattice-state-root")]
+        {
             StateRootStrategy::Synchronous
-        } else if self.config.use_state_root_task() {
-            StateRootStrategy::StateRootTask
-        } else {
-            StateRootStrategy::Parallel
+        }
+
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            if let Some(custom_state_root) = &self.custom_state_root {
+                StateRootStrategy::Custom(custom_state_root.clone())
+            } else if self.config.state_root_fallback() {
+                StateRootStrategy::Synchronous
+            } else if self.config.use_state_root_task() {
+                StateRootStrategy::StateRootTask
+            } else {
+                StateRootStrategy::Parallel
+            }
         }
     }
 
@@ -2039,6 +2047,7 @@ where
 }
 
 /// Strategy describing how to compute the state root.
+#[cfg_attr(feature = "lattice-state-root", allow(dead_code))]
 #[derive(derive_more::Debug, Clone)]
 enum StateRootStrategy<N: NodePrimitives> {
     /// Use the state root task (background sparse trie computation).
@@ -2217,18 +2226,27 @@ where
         parent_state_root: B256,
         state: &EngineApiTreeState<N>,
     ) -> Option<StateRootHandle> {
-        let overlay_factory = OverlayStateProviderFactory::new(
-            self.provider.clone(),
-            Self::overlay_builder_for_parent(parent_hash, state, self.changeset_cache.clone()),
-        );
+        #[cfg(feature = "lattice-state-root")]
+        {
+            let _ = (parent_hash, parent_state_root, state);
+            None
+        }
 
-        Some(self.payload_processor.spawn_state_root(
-            overlay_factory,
-            parent_state_root,
-            // Full proof workers — tx count unknown at FCU time (block built incrementally)
-            false,
-            &self.config,
-        ))
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            let overlay_factory = OverlayStateProviderFactory::new(
+                self.provider.clone(),
+                Self::overlay_builder_for_parent(parent_hash, state, self.changeset_cache.clone()),
+            );
+
+            Some(self.payload_processor.spawn_state_root(
+                overlay_factory,
+                parent_state_root,
+                // Full proof workers — tx count unknown at FCU time (block built incrementally)
+                false,
+                &self.config,
+            ))
+        }
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -38,6 +38,8 @@
 //! [`FullConsensus::validate_block_post_execution`]: reth_consensus::FullConsensus::validate_block_post_execution
 //! [`SealedBlock`]: reth_primitives_traits::SealedBlock
 
+#[cfg(feature = "lattice-state-root")]
+use crate::tree::multiproof::LatticeRootHandle;
 use crate::tree::{
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
     instrumented_state::{InstrumentedStateProvider, StateProviderMetrics, StateProviderStats},
@@ -226,6 +228,7 @@ where
         + StateReader
         + HashedPostStateProvider
         + Clone
+        + Send
         + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
@@ -841,20 +844,46 @@ where
         let _mpt_state_root = state_root;
 
         #[cfg(feature = "lattice-state-root")]
-        let (state_root, trie_output, lattice_accumulator_updates) = ensure_ok_post_block!(
-            provider_builder.build().and_then(|provider| {
-                provider
-                    .lattice_state_root_with_updates(
-                        &output.state,
-                        hashed_state.get().as_ref().clone(),
-                        Some(trie_output.as_ref().clone()),
-                    )
-                    .map(|(root, updates, lattice_updates)| {
-                        (root, Arc::new(updates), Arc::new(lattice_updates))
-                    })
-            }),
-            block
-        );
+        let streamed_lattice_root = match handle.lattice_root() {
+            Some(Ok(outcome)) => {
+                debug!(
+                    target: "engine::tree::payload_validator",
+                    state_root = ?outcome.state_root,
+                    "Lattice root task finished"
+                );
+                Some(outcome)
+            }
+            Some(Err(err)) => {
+                warn!(
+                    target: "engine::tree::payload_validator",
+                    %err,
+                    "Lattice root task failed, falling back to bundle lattice root"
+                );
+                None
+            }
+            None => None,
+        };
+
+        #[cfg(feature = "lattice-state-root")]
+        let (state_root, trie_output, lattice_accumulator_updates) =
+            if let Some(outcome) = streamed_lattice_root {
+                (outcome.state_root, trie_output, outcome.accumulator_updates)
+            } else {
+                ensure_ok_post_block!(
+                    provider_builder.build().and_then(|provider| {
+                        provider
+                            .lattice_state_root_with_updates(
+                                &output.state,
+                                hashed_state.get().as_ref().clone(),
+                                Some(trie_output.as_ref().clone()),
+                            )
+                            .map(|(root, updates, lattice_updates)| {
+                                (root, Arc::new(updates), Arc::new(lattice_updates))
+                            })
+                    }),
+                    block
+                )
+            };
 
         if let Err(err) = hashed_state_validate_result {
             // call post-block hook
@@ -1731,8 +1760,12 @@ where
             StateRootStrategy::Synchronous |
             StateRootStrategy::Custom(_) => {
                 let start = Instant::now();
-                let handle =
-                    self.payload_processor.spawn_cache_exclusive(env, txs, provider_builder);
+                let handle = self.payload_processor.spawn_cache_exclusive(
+                    env,
+                    txs,
+                    provider_builder,
+                    parallel_bal_execution,
+                );
 
                 // Record prewarming initialization duration
                 self.metrics
@@ -2167,6 +2200,14 @@ pub trait EngineValidator<
         parent_state_root: B256,
         state: &EngineApiTreeState<N>,
     ) -> Option<StateRootHandle>;
+
+    /// Spawns a streaming lattice root pipeline and returns a handle for the payload builder.
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_root_handle_for(
+        &self,
+        parent_hash: B256,
+        state: &EngineApiTreeState<N>,
+    ) -> Option<LatticeRootHandle>;
 }
 
 impl<N, Types, P, Evm, V> EngineValidator<Types> for BasicEngineValidator<P, Evm, V>
@@ -2285,6 +2326,29 @@ where
                 false,
                 &self.config,
             ))
+        }
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_root_handle_for(
+        &self,
+        parent_hash: B256,
+        state: &EngineApiTreeState<N>,
+    ) -> Option<LatticeRootHandle> {
+        match self.state_provider_builder(parent_hash, state) {
+            Ok(Some(provider_builder)) => {
+                Some(self.payload_processor.spawn_lattice_root(provider_builder))
+            }
+            Ok(None) => None,
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::payload_validator",
+                    %err,
+                    ?parent_hash,
+                    "failed to create state provider for payload builder lattice root task"
+                );
+                None
+            }
         }
     }
 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -837,6 +837,25 @@ where
             (root, Arc::new(updates), root_time.elapsed())
         };
 
+        #[cfg(feature = "lattice-state-root")]
+        let _mpt_state_root = state_root;
+
+        #[cfg(feature = "lattice-state-root")]
+        let (state_root, trie_output, lattice_accumulator_updates) = ensure_ok_post_block!(
+            provider_builder.build().and_then(|provider| {
+                provider
+                    .lattice_state_root_with_updates(
+                        &output.state,
+                        hashed_state.get().as_ref().clone(),
+                        Some(trie_output.as_ref().clone()),
+                    )
+                    .map(|(root, updates, lattice_updates)| {
+                        (root, Arc::new(updates), Arc::new(lattice_updates))
+                    })
+            }),
+            block
+        );
+
         if let Err(err) = hashed_state_validate_result {
             // call post-block hook
             self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
@@ -900,6 +919,8 @@ where
             output,
             hashed_state,
             trie_output,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_accumulator_updates,
             changeset_provider,
         );
         Ok(ValidationOutput::new(executed_block, timing_stats))
@@ -1824,6 +1845,9 @@ where
         execution_outcome: Arc<BlockExecutionOutput<N::Receipt>>,
         hashed_state: LazyHashedPostState,
         trie_output: Arc<TrieUpdates>,
+        #[cfg(feature = "lattice-state-root")] lattice_accumulator_updates: Arc<
+            reth_trie::lattice::LatticeAccumulatorUpdates,
+        >,
         changeset_provider: impl TrieCursorFactory + Send + 'static,
     ) -> ExecutedBlock<N> {
         // Create deferred handle with fallback inputs in case the background task hasn't completed.
@@ -1833,6 +1857,13 @@ where
             Ok(state) => state,
             Err(handle) => handle.get().clone(),
         };
+        #[cfg(feature = "lattice-state-root")]
+        let deferred_trie_data = DeferredTrieData::pending_with_lattice(
+            hashed_state,
+            trie_output,
+            lattice_accumulator_updates,
+        );
+        #[cfg(not(feature = "lattice-state-root"))]
         let deferred_trie_data = DeferredTrieData::pending(hashed_state, trie_output);
         let deferred_handle_task = deferred_trie_data.clone();
         let block_validation_metrics = self.metrics.block_validation.clone();
@@ -2218,6 +2249,8 @@ where
             block.execution_output,
             LazyHashedPostState::ready(block.hashed_state),
             block.trie_updates,
+            #[cfg(feature = "lattice-state-root")]
+            block.lattice_accumulator_updates,
             changeset_provider,
         ))
     }

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -91,6 +91,11 @@ reth-rpc-layer.workspace = true
 
 [features]
 default = []
+lattice-state-root = [
+    "reth-chainspec/lattice-state-root",
+    "reth-node-builder/lattice-state-root",
+    "reth-provider/lattice-state-root",
+]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-node-core/asm-keccak",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -93,6 +93,7 @@ reth-rpc-layer.workspace = true
 default = []
 lattice-state-root = [
     "reth-chainspec/lattice-state-root",
+    "reth-ethereum-payload-builder/lattice-state-root",
     "reth-node-builder/lattice-state-root",
     "reth-provider/lattice-state-root",
 ]

--- a/crates/ethereum/payload/Cargo.toml
+++ b/crates/ethereum/payload/Cargo.toml
@@ -29,6 +29,7 @@ reth-evm-ethereum = { workspace = true, features = ["std"] }
 reth-errors.workspace = true
 reth-chainspec.workspace = true
 reth-payload-validator.workspace = true
+reth-trie-parallel.workspace = true
 
 # ethereum
 alloy-rlp.workspace = true
@@ -42,3 +43,10 @@ alloy-primitives.workspace = true
 
 # misc
 tracing.workspace = true
+
+[features]
+lattice-state-root = [
+    "reth-basic-payload-builder/lattice-state-root",
+    "reth-evm/lattice-state-root",
+    "reth-trie-parallel/lattice-state-root",
+]

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -38,10 +38,10 @@ use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
     ValidPoolTransaction,
 };
+#[cfg(not(feature = "lattice-state-root"))]
+use reth_trie_parallel as _;
 #[cfg(feature = "lattice-state-root")]
-use reth_trie_parallel::state_root_task::{
-    LatticeRootMessage, LatticeStateHookSender, StateHookSender, StateRootMessage,
-};
+use reth_trie_parallel::state_root_task::{LatticeRootMessage, LatticeStateHookSender};
 use revm::context_interface::{Block as _, Cfg as _};
 use std::sync::Arc;
 use tracing::{debug, trace, warn};
@@ -167,7 +167,10 @@ where
     let BuildArguments {
         mut cached_reads,
         execution_cache,
+        #[cfg(not(feature = "lattice-state-root"))]
         trie_handle,
+        #[cfg(feature = "lattice-state-root")]
+            trie_handle: _,
         #[cfg(feature = "lattice-state-root")]
         lattice_handle,
         config,
@@ -234,18 +237,13 @@ where
     }
     #[cfg(feature = "lattice-state-root")]
     {
-        let sparse_sender =
-            trie_handle.as_ref().map(|handle| StateHookSender::new(handle.updates_tx().clone()));
         let lattice_sender = lattice_handle
             .as_ref()
             .map(|handle| LatticeStateHookSender::new(handle.updates_tx().clone()));
 
-        if sparse_sender.is_some() || lattice_sender.is_some() {
+        if lattice_sender.is_some() {
             builder.evm_mut().db_mut().set_state_hook(Some(Box::new(
                 move |state: &reth_revm::state::EvmState| {
-                    if let Some(sender) = &sparse_sender {
-                        let _ = sender.send(StateRootMessage::StateUpdate(state.clone()));
-                    }
                     if let Some(sender) = &lattice_sender {
                         let _ = sender.send(LatticeRootMessage::StateUpdate(state.clone()));
                     }
@@ -507,24 +505,9 @@ where
 
     #[cfg(feature = "lattice-state-root")]
     let BlockBuilderOutcome { execution_result, block, block_access_list, .. } = {
-        if trie_handle.is_some() || lattice_handle.is_some() {
+        if lattice_handle.is_some() {
             builder.evm_mut().db_mut().set_state_hook(None);
         }
-
-        let state_root_precomputed = if let Some(mut handle) = trie_handle {
-            match handle.state_root() {
-                Ok(outcome) => {
-                    debug!(target: "payload_builder", id=%payload_id, state_root=?outcome.state_root, "received state root from sparse trie");
-                    Some((outcome.state_root, Arc::unwrap_or_clone(outcome.trie_updates)))
-                }
-                Err(err) => {
-                    warn!(target: "payload_builder", id=%payload_id, %err, "sparse trie failed, falling back to sync trie updates");
-                    None
-                }
-            }
-        } else {
-            None
-        };
 
         let lattice_root_precomputed = if let Some(mut handle) = lattice_handle {
             match handle.lattice_root() {
@@ -541,11 +524,7 @@ where
             None
         };
 
-        builder.finish_with_lattice(
-            state_provider.as_ref(),
-            state_root_precomputed,
-            lattice_root_precomputed,
-        )?
+        builder.finish_with_lattice(state_provider.as_ref(), None, lattice_root_precomputed)?
     };
 
     let requests = chain_spec

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -38,6 +38,10 @@ use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, PoolTransaction, TransactionPool,
     ValidPoolTransaction,
 };
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_parallel::state_root_task::{
+    LatticeRootMessage, LatticeStateHookSender, StateHookSender, StateRootMessage,
+};
 use revm::context_interface::{Block as _, Cfg as _};
 use std::sync::Arc;
 use tracing::{debug, trace, warn};
@@ -120,6 +124,8 @@ where
             Default::default(),
             Default::default(),
             None,
+            #[cfg(feature = "lattice-state-root")]
+            None,
             config,
             Default::default(),
             None,
@@ -162,6 +168,8 @@ where
         mut cached_reads,
         execution_cache,
         trie_handle,
+        #[cfg(feature = "lattice-state-root")]
+        lattice_handle,
         config,
         cancel,
         best_payload,
@@ -218,10 +226,32 @@ where
     ));
     let mut total_fees = U256::ZERO;
 
-    // If we have a sparse trie handle, wire a state hook that streams per-tx state diffs
-    // to the background trie pipeline for incremental state root computation.
+    // If we have root-task handles, wire a state hook that streams per-tx state diffs to the
+    // background pipelines.
+    #[cfg(not(feature = "lattice-state-root"))]
     if let Some(ref handle) = trie_handle {
         builder.evm_mut().db_mut().set_state_hook(Some(Box::new(handle.state_hook())));
+    }
+    #[cfg(feature = "lattice-state-root")]
+    {
+        let sparse_sender =
+            trie_handle.as_ref().map(|handle| StateHookSender::new(handle.updates_tx().clone()));
+        let lattice_sender = lattice_handle
+            .as_ref()
+            .map(|handle| LatticeStateHookSender::new(handle.updates_tx().clone()));
+
+        if sparse_sender.is_some() || lattice_sender.is_some() {
+            builder.evm_mut().db_mut().set_state_hook(Some(Box::new(
+                move |state: &reth_revm::state::EvmState| {
+                    if let Some(sender) = &sparse_sender {
+                        let _ = sender.send(StateRootMessage::StateUpdate(state.clone()));
+                    }
+                    if let Some(sender) = &lattice_sender {
+                        let _ = sender.send(LatticeRootMessage::StateUpdate(state.clone()));
+                    }
+                },
+            )));
+        }
     }
 
     builder.apply_pre_execution_changes().map_err(|err| {
@@ -446,6 +476,7 @@ where
         return Ok(BuildOutcome::Aborted { fees: total_fees, cached_reads })
     }
 
+    #[cfg(not(feature = "lattice-state-root"))]
     let BlockBuilderOutcome { execution_result, block, block_access_list, .. } = if let Some(
         mut handle,
     ) = trie_handle
@@ -472,6 +503,49 @@ where
         }
     } else {
         builder.finish(state_provider.as_ref(), None)?
+    };
+
+    #[cfg(feature = "lattice-state-root")]
+    let BlockBuilderOutcome { execution_result, block, block_access_list, .. } = {
+        if trie_handle.is_some() || lattice_handle.is_some() {
+            builder.evm_mut().db_mut().set_state_hook(None);
+        }
+
+        let state_root_precomputed = if let Some(mut handle) = trie_handle {
+            match handle.state_root() {
+                Ok(outcome) => {
+                    debug!(target: "payload_builder", id=%payload_id, state_root=?outcome.state_root, "received state root from sparse trie");
+                    Some((outcome.state_root, Arc::unwrap_or_clone(outcome.trie_updates)))
+                }
+                Err(err) => {
+                    warn!(target: "payload_builder", id=%payload_id, %err, "sparse trie failed, falling back to sync trie updates");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let lattice_root_precomputed = if let Some(mut handle) = lattice_handle {
+            match handle.lattice_root() {
+                Ok(outcome) => {
+                    debug!(target: "payload_builder", id=%payload_id, state_root=?outcome.state_root, "received state root from lattice task");
+                    Some((outcome.state_root, Arc::unwrap_or_clone(outcome.accumulator_updates)))
+                }
+                Err(err) => {
+                    warn!(target: "payload_builder", id=%payload_id, %err, "lattice root task failed, falling back to bundle lattice root");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        builder.finish_with_lattice(
+            state_provider.as_ref(),
+            state_root_precomputed,
+            lattice_root_precomputed,
+        )?
     };
 
     let requests = chain_spec

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -183,3 +183,11 @@ provider = ["storage-api", "tasks", "dep:reth-provider", "dep:reth-db", "dep:ret
 storage-api = ["dep:reth-storage-api"]
 trie = ["dep:reth-trie"]
 trie-db = ["trie", "dep:reth-trie-db"]
+lattice-state-root = [
+    "reth-chainspec/lattice-state-root",
+    "reth-node-builder?/lattice-state-root",
+    "reth-node-ethereum?/lattice-state-root",
+    "reth-provider?/lattice-state-root",
+    "reth-trie?/lattice-state-root",
+    "reth-trie-db?/lattice-state-root",
+]

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -59,6 +59,10 @@ std = [
     "alloy-eip7928/std",
 ]
 metrics = ["std", "dep:metrics", "dep:reth-metrics"]
+lattice-state-root = [
+    "reth-storage-api/lattice-state-root",
+    "reth-trie-common/lattice-state-root",
+]
 test-utils = [
     "reth-primitives-traits/test-utils",
     "reth-trie-common/test-utils",

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -523,6 +523,8 @@ where
         state: impl StateProvider,
         state_root_precomputed: Option<(B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
+        #[cfg(feature = "lattice-state-root")]
+        let _ = state_root_precomputed;
         let (evm, result) = self.executor.finish()?;
         let (db, evm_env) = evm.finish();
 
@@ -535,13 +537,10 @@ where
 
         let hashed_state = state.hashed_post_state(&db.bundle_state);
         #[cfg(feature = "lattice-state-root")]
-        let (state_root, trie_updates, lattice_accumulator_updates) = state
-            .lattice_state_root_with_updates(
-                &db.bundle_state,
-                hashed_state.clone(),
-                state_root_precomputed.map(|(_, trie_updates)| trie_updates),
-            )
-            .map_err(BlockExecutionError::other)?;
+        let (state_root, lattice_accumulator_updates) =
+            state.lattice_state_root(&db.bundle_state).map_err(BlockExecutionError::other)?;
+        #[cfg(feature = "lattice-state-root")]
+        let trie_updates = TrieUpdates::default();
         #[cfg(not(feature = "lattice-state-root"))]
         let (state_root, trie_updates) = match state_root_precomputed {
             Some(precomputed) => precomputed,
@@ -582,7 +581,7 @@ where
     fn finish_with_lattice(
         self,
         state: impl StateProvider,
-        state_root_precomputed: Option<(B256, TrieUpdates)>,
+        _state_root_precomputed: Option<(B256, TrieUpdates)>,
         lattice_root_precomputed: Option<(B256, LatticeAccumulatorUpdates)>,
     ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
         let (evm, result) = self.executor.finish()?;
@@ -596,27 +595,13 @@ where
             block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
 
         let hashed_state = state.hashed_post_state(&db.bundle_state);
-        let (state_root, trie_updates, lattice_accumulator_updates) =
+        let (state_root, lattice_accumulator_updates) =
             if let Some((lattice_root, lattice_updates)) = lattice_root_precomputed {
-                let trie_updates = match state_root_precomputed {
-                    Some((_, trie_updates)) => trie_updates,
-                    None => {
-                        state
-                            .state_root_with_updates(hashed_state.clone())
-                            .map_err(BlockExecutionError::other)?
-                            .1
-                    }
-                };
-                (lattice_root, trie_updates, lattice_updates)
+                (lattice_root, lattice_updates)
             } else {
-                state
-                    .lattice_state_root_with_updates(
-                        &db.bundle_state,
-                        hashed_state.clone(),
-                        state_root_precomputed.map(|(_, trie_updates)| trie_updates),
-                    )
-                    .map_err(BlockExecutionError::other)?
+                state.lattice_state_root(&db.bundle_state).map_err(BlockExecutionError::other)?
             };
+        let trie_updates = TrieUpdates::default();
 
         let (transactions, senders) =
             self.transactions.into_iter().map(|tx| tx.into_parts()).unzip();

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -21,6 +21,8 @@ use reth_primitives_traits::{
 };
 use reth_storage_api::StateProvider;
 pub use reth_storage_errors::provider::ProviderError;
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_common::lattice::LatticeAccumulatorUpdates;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 use revm::{
     database::{states::bundle_state::BundleRetention, BundleState, State},
@@ -381,6 +383,20 @@ pub trait BlockBuilder {
         state_root_precomputed: Option<(B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<Self::Primitives>, BlockExecutionError>;
 
+    /// Completes the block building process with an optional precomputed lattice root.
+    #[cfg(feature = "lattice-state-root")]
+    fn finish_with_lattice(
+        self,
+        state_provider: impl StateProvider,
+        state_root_precomputed: Option<(B256, TrieUpdates)>,
+        _lattice_root_precomputed: Option<(B256, LatticeAccumulatorUpdates)>,
+    ) -> Result<BlockBuilderOutcome<Self::Primitives>, BlockExecutionError>
+    where
+        Self: Sized,
+    {
+        self.finish(state_provider, state_root_precomputed)
+    }
+
     /// Provides mutable access to the inner [`BlockExecutor`].
     fn executor_mut(&mut self) -> &mut Self::Executor;
 
@@ -556,6 +572,73 @@ where
             hashed_state,
             trie_updates,
             #[cfg(feature = "lattice-state-root")]
+            lattice_accumulator_updates,
+            block,
+            block_access_list,
+        })
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn finish_with_lattice(
+        self,
+        state: impl StateProvider,
+        state_root_precomputed: Option<(B256, TrieUpdates)>,
+        lattice_root_precomputed: Option<(B256, LatticeAccumulatorUpdates)>,
+    ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
+        let (evm, result) = self.executor.finish()?;
+        let (db, evm_env) = evm.finish();
+
+        // merge all transitions into bundle state
+        db.merge_transitions(BundleRetention::Reverts);
+
+        let block_access_list = db.take_built_alloy_bal();
+        let block_access_list_hash =
+            block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
+
+        let hashed_state = state.hashed_post_state(&db.bundle_state);
+        let (state_root, trie_updates, lattice_accumulator_updates) =
+            if let Some((lattice_root, lattice_updates)) = lattice_root_precomputed {
+                let trie_updates = match state_root_precomputed {
+                    Some((_, trie_updates)) => trie_updates,
+                    None => {
+                        state
+                            .state_root_with_updates(hashed_state.clone())
+                            .map_err(BlockExecutionError::other)?
+                            .1
+                    }
+                };
+                (lattice_root, trie_updates, lattice_updates)
+            } else {
+                state
+                    .lattice_state_root_with_updates(
+                        &db.bundle_state,
+                        hashed_state.clone(),
+                        state_root_precomputed.map(|(_, trie_updates)| trie_updates),
+                    )
+                    .map_err(BlockExecutionError::other)?
+            };
+
+        let (transactions, senders) =
+            self.transactions.into_iter().map(|tx| tx.into_parts()).unzip();
+
+        let block = self.assembler.assemble_block(BlockAssemblerInput {
+            evm_env,
+            execution_ctx: self.ctx,
+            parent: self.parent,
+            transactions,
+            output: &result,
+            bundle_state: &db.bundle_state,
+            state_provider: &state,
+            state_root,
+            block_access_list_hash,
+        })?;
+
+        let block = RecoveredBlock::new_unhashed(block, senders);
+
+        Ok(BlockBuilderOutcome {
+            execution_result: result,
+            hashed_state,
+            trie_updates,
             lattice_accumulator_updates,
             block,
             block_access_list,

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -312,6 +312,9 @@ pub struct BlockBuilderOutcome<N: NodePrimitives> {
     pub hashed_state: HashedPostState,
     /// Trie updates collected during state root calculation.
     pub trie_updates: TrieUpdates,
+    /// Lattice accumulator updates collected during lattice state root calculation.
+    #[cfg(feature = "lattice-state-root")]
+    pub lattice_accumulator_updates: reth_trie_common::lattice::LatticeAccumulatorUpdates,
     /// The built block.
     pub block: RecoveredBlock<N::Block>,
     /// Block access list built during execution (EIP-7928, Amsterdam).
@@ -515,6 +518,15 @@ where
             block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
 
         let hashed_state = state.hashed_post_state(&db.bundle_state);
+        #[cfg(feature = "lattice-state-root")]
+        let (state_root, trie_updates, lattice_accumulator_updates) = state
+            .lattice_state_root_with_updates(
+                &db.bundle_state,
+                hashed_state.clone(),
+                state_root_precomputed.map(|(_, trie_updates)| trie_updates),
+            )
+            .map_err(BlockExecutionError::other)?;
+        #[cfg(not(feature = "lattice-state-root"))]
         let (state_root, trie_updates) = match state_root_precomputed {
             Some(precomputed) => precomputed,
             None => state
@@ -543,6 +555,8 @@ where
             execution_result: result,
             hashed_state,
             trie_updates,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_accumulator_updates,
             block,
             block_access_list,
         })

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -95,6 +95,13 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = []
+lattice-state-root = [
+    "reth-chainspec/lattice-state-root",
+    "reth-engine-tree/lattice-state-root",
+    "reth-provider/lattice-state-root",
+    "reth-stages/lattice-state-root",
+    "reth-trie-db/lattice-state-root",
+]
 js-tracer = [
     "reth-rpc/js-tracer",
     "reth-node-ethereum/js-tracer",

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -97,6 +97,7 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 default = []
 lattice-state-root = [
     "reth-chainspec/lattice-state-root",
+    "reth-db-common/lattice-state-root",
     "reth-engine-tree/lattice-state-root",
     "reth-provider/lattice-state-root",
     "reth-stages/lattice-state-root",

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -96,9 +96,11 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 [features]
 default = []
 lattice-state-root = [
+    "reth-basic-payload-builder/lattice-state-root",
     "reth-chainspec/lattice-state-root",
     "reth-db-common/lattice-state-root",
     "reth-engine-tree/lattice-state-root",
+    "reth-payload-builder/lattice-state-root",
     "reth-provider/lattice-state-root",
     "reth-stages/lattice-state-root",
     "reth-trie-db/lattice-state-root",

--- a/crates/payload/basic/Cargo.toml
+++ b/crates/payload/basic/Cargo.toml
@@ -41,3 +41,9 @@ metrics.workspace = true
 # misc
 tracing.workspace = true
 serde.workspace = true
+
+[features]
+lattice-state-root = [
+    "reth-payload-builder/lattice-state-root",
+    "reth-trie-parallel/lattice-state-root",
+]

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -24,6 +24,8 @@ use reth_primitives_traits::{HeaderTy, NodePrimitives, SealedHeader};
 use reth_revm::{cached::CachedReads, cancelled::CancelOnDrop};
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::Runtime;
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_parallel::state_root_task::LatticeRootHandle;
 use reth_trie_parallel::state_root_task::StateRootHandle;
 use std::{
     fmt,
@@ -181,6 +183,8 @@ where
             cached_reads,
             execution_cache: input.cache,
             trie_handle: input.trie_handle,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_handle: input.lattice_handle,
             payload_task_guard: self.payload_task_guard.clone(),
             metrics: Default::default(),
             builder: self.builder.clone(),
@@ -338,6 +342,9 @@ where
     execution_cache: Option<SavedCache>,
     /// Optional state root task handle, shared with the engine.
     trie_handle: Option<StateRootHandle>,
+    /// Optional lattice root task handle, shared with the engine.
+    #[cfg(feature = "lattice-state-root")]
+    lattice_handle: Option<LatticeRootHandle>,
     /// metrics for this type
     metrics: PayloadBuilderMetrics,
     /// The type responsible for building payloads.
@@ -365,6 +372,8 @@ where
         let cached_reads = self.cached_reads.take().unwrap_or_default();
         let execution_cache = self.execution_cache.clone();
         let trie_handle = self.trie_handle.take();
+        #[cfg(feature = "lattice-state-root")]
+        let lattice_handle = self.lattice_handle.take();
         let builder = self.builder.clone();
         let executor = self.executor.clone();
         self.executor.spawn_task(async move {
@@ -376,6 +385,8 @@ where
                     cached_reads,
                     execution_cache,
                     trie_handle,
+                    #[cfg(feature = "lattice-state-root")]
+                    lattice_handle,
                     config: payload_config,
                     cancel,
                     best_payload,
@@ -512,6 +523,8 @@ where
                 cached_reads: self.cached_reads.take().unwrap_or_default(),
                 execution_cache: self.execution_cache.clone(),
                 trie_handle: None,
+                #[cfg(feature = "lattice-state-root")]
+                lattice_handle: None,
                 config: self.config.clone(),
                 cancel: CancelOnDrop::default(),
                 best_payload: None,
@@ -854,6 +867,9 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     /// root, so if the next `newPayload` is not on top of that block, the trie cache is
     /// invalidated and cleared.
     pub trie_handle: Option<StateRootHandle>,
+    /// Optional lattice root task handle, shared with the engine.
+    #[cfg(feature = "lattice-state-root")]
+    pub lattice_handle: Option<LatticeRootHandle>,
     /// How to configure the payload.
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
@@ -868,11 +884,21 @@ impl<Attributes, Payload: BuiltPayload> BuildArguments<Attributes, Payload> {
         cached_reads: CachedReads,
         execution_cache: Option<SavedCache>,
         trie_handle: Option<StateRootHandle>,
+        #[cfg(feature = "lattice-state-root")] lattice_handle: Option<LatticeRootHandle>,
         config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
         cancel: CancelOnDrop,
         best_payload: Option<Payload>,
     ) -> Self {
-        Self { cached_reads, execution_cache, trie_handle, config, cancel, best_payload }
+        Self {
+            cached_reads,
+            execution_cache,
+            trie_handle,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_handle,
+            config,
+            cancel,
+            best_payload,
+        }
     }
 }
 

--- a/crates/payload/basic/src/stack.rs
+++ b/crates/payload/basic/src/stack.rs
@@ -171,6 +171,8 @@ where
             cached_reads,
             execution_cache,
             trie_handle,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_handle,
             config,
             cancel,
             best_payload,
@@ -183,6 +185,8 @@ where
                     cached_reads,
                     execution_cache,
                     trie_handle,
+                    #[cfg(feature = "lattice-state-root")]
+                    lattice_handle,
                     config: PayloadConfig { parent_header, attributes: left_attr, payload_id },
                     cancel,
                     best_payload: best_payload.and_then(|payload| {
@@ -200,6 +204,8 @@ where
                     cached_reads,
                     execution_cache,
                     trie_handle,
+                    #[cfg(feature = "lattice-state-root")]
+                    lattice_handle,
                     config: PayloadConfig { parent_header, attributes: right_attr, payload_id },
                     cancel,
                     best_payload: best_payload.and_then(|payload| {

--- a/crates/payload/builder/Cargo.toml
+++ b/crates/payload/builder/Cargo.toml
@@ -43,6 +43,7 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 
 [features]
+lattice-state-root = ["reth-trie-parallel/lattice-state-root"]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-primitives-traits/test-utils",

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -16,6 +16,8 @@ use reth_execution_cache::SavedCache;
 use reth_payload_builder_primitives::{Events, PayloadBuilderError, PayloadEvents};
 use reth_payload_primitives::{BuiltPayload, PayloadAttributes, PayloadKind, PayloadTypes};
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_parallel::state_root_task::LatticeRootHandle;
 use reth_trie_parallel::state_root_task::StateRootHandle;
 use std::{
     future::Future,
@@ -546,6 +548,9 @@ pub struct BuildNewPayload<T> {
     pub cache: Option<SavedCache>,
     /// Optional handle to a background sparse trie task.
     pub trie_handle: Option<StateRootHandle>,
+    /// Optional handle to a background lattice root task.
+    #[cfg(feature = "lattice-state-root")]
+    pub lattice_handle: Option<LatticeRootHandle>,
 }
 
 impl<T: PayloadAttributes> BuildNewPayload<T> {

--- a/crates/payload/primitives/Cargo.toml
+++ b/crates/payload/primitives/Cargo.toml
@@ -56,3 +56,4 @@ std = [
     "serde_json/std",
     "sha2/std",
 ]
+lattice-state-root = ["reth-trie-common/lattice-state-root"]

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -26,6 +26,9 @@ pub struct BuiltPayloadExecutedBlock<N: NodePrimitives> {
     pub hashed_state: Arc<HashedPostState>,
     /// Trie updates that result from calculating the state root for the block (unsorted).
     pub trie_updates: Arc<TrieUpdates>,
+    /// Lattice accumulator updates that should be persisted when the block is canonicalized.
+    #[cfg(feature = "lattice-state-root")]
+    pub lattice_accumulator_updates: Arc<reth_trie_common::lattice::LatticeAccumulatorUpdates>,
 }
 
 /// Represents a successfully built execution payload (block).

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -97,6 +97,11 @@ paste.workspace = true
 tempfile.workspace = true
 
 [features]
+lattice-state-root = [
+    "reth-provider/lattice-state-root",
+    "reth-trie/lattice-state-root",
+    "reth-trie-db/lattice-state-root",
+]
 test-utils = [
     "reth-network-p2p/test-utils",
     "reth-db/test-utils",

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -480,6 +480,18 @@ tables! {
         type SubKey = B256;
     }
 
+    /// Stores the full Commonware LtHash accumulator for the current lattice state root.
+    table LatticeStateAccumulator {
+        type Key = u8;
+        type Value = Vec<u8>;
+    }
+
+    /// Stores full Commonware LtHash accumulators for current per-account lattice storage roots.
+    table LatticeStorageAccumulators {
+        type Key = B256;
+        type Value = Vec<u8>;
+    }
+
     /// Stores the current state's Merkle Patricia Tree.
     table AccountsTrie {
         type Key = StoredNibbles;

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -46,5 +46,12 @@ reth-db = { workspace = true, features = ["mdbx"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
 
+[features]
+default = []
+lattice-state-root = [
+    "reth-provider/lattice-state-root",
+    "reth-trie/lattice-state-root",
+]
+
 [lints]
 workspace = true

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -10,8 +10,10 @@ use alloy_primitives::{
 use reth_chainspec::EthChainSpec;
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
+#[cfg(feature = "lattice-state-root")]
+use reth_db_api::cursor::{DbCursorRO, DbDupCursorRO};
 use reth_db_api::{
-    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
+    cursor::{DbCursorRW, DbDupCursorRW},
     models::{
         storage_sharded_key::StorageShardedKey, AccountBeforeTx, BlockNumberAddress, IntegerList,
         ShardedKey,
@@ -35,12 +37,15 @@ use reth_provider::{
 };
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
+#[cfg(not(feature = "lattice-state-root"))]
 use reth_trie::{
     prefix_set::TriePrefixSets, IntermediateStateRootState, StateRoot as StateRootComputer,
     StateRootProgress,
 };
+#[cfg(not(feature = "lattice-state-root"))]
 use reth_trie_db::DatabaseStateRoot;
 
+#[cfg(not(feature = "lattice-state-root"))]
 type DbStateRoot<'a, TX, A> = StateRootComputer<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
     reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
@@ -62,6 +67,7 @@ pub use reth_provider::init::{
 pub const DEFAULT_SOFT_LIMIT_BYTE_LEN_ACCOUNTS_CHUNK: usize = 1_000_000_000;
 
 /// Soft limit for the number of flushed updates after which to log progress summary.
+#[cfg(not(feature = "lattice-state-root"))]
 const SOFT_LIMIT_COUNT_FLUSHED_UPDATES: usize = 1_000_000;
 
 /// Max number of storage "units" (1 per account + 1 per storage slot) before committing
@@ -70,6 +76,7 @@ const SOFT_LIMIT_COUNT_FLUSHED_UPDATES: usize = 1_000_000;
 const STORAGE_COMMIT_THRESHOLD: usize = 100_000;
 
 /// Max number of trie updates retained before init-state state root computation commits progress.
+#[cfg(not(feature = "lattice-state-root"))]
 const STATE_ROOT_COMMIT_THRESHOLD: u64 = 25_000;
 
 /// Storage initialization error type.
@@ -294,9 +301,10 @@ where
     insert_genesis_state(&provider_rw, alloc.iter())?;
 
     // compute state root to populate trie tables
+    #[cfg(not(feature = "lattice-state-root"))]
     compute_state_root(&provider_rw, None)?;
     #[cfg(feature = "lattice-state-root")]
-    rebuild_lattice_accumulators(&provider_rw)?;
+    let _ = rebuild_lattice_accumulators(&provider_rw)?;
 
     // set stage checkpoint to genesis block number for all stages
     let checkpoint = StageCheckpoint::new(genesis_block_number);
@@ -595,6 +603,7 @@ where
     info!(target: "reth::cli", "All accounts written to database, starting state root computation (may take some time)");
 
     // clear trie tables so state root is computed from scratch
+    #[cfg(not(feature = "lattice-state-root"))]
     {
         let provider_rw = provider_factory.database_provider_rw()?;
         provider_rw.tx_ref().clear::<tables::AccountsTrie>()?;
@@ -1124,6 +1133,7 @@ where
 
 /// Computes the state root (from scratch) based on the accounts and storages present in the
 /// database.
+#[cfg(not(feature = "lattice-state-root"))]
 fn compute_state_root<Provider>(
     provider: &Provider,
     prefix_sets: Option<TriePrefixSets>,
@@ -1136,6 +1146,7 @@ where
     })
 }
 
+#[cfg(not(feature = "lattice-state-root"))]
 fn compute_state_root_inner<Provider, A>(
     provider: &Provider,
     prefix_sets: Option<TriePrefixSets>,
@@ -1197,7 +1208,7 @@ where
 }
 
 #[cfg(feature = "lattice-state-root")]
-fn rebuild_lattice_accumulators<Provider>(provider: &Provider) -> Result<(), InitStorageError>
+fn rebuild_lattice_accumulators<Provider>(provider: &Provider) -> Result<B256, InitStorageError>
 where
     Provider: DBProvider<Tx: DbTx + DbTxMut>,
 {
@@ -1234,7 +1245,7 @@ where
         storage_write_cursor.upsert(hashed_address, &storage_state.into_vec())?;
     }
 
-    Ok(())
+    Ok(state_root.root())
 }
 
 /// Computes the state root (from scratch) with periodic commits to free MDBX dirty pages.
@@ -1244,17 +1255,29 @@ where
 fn compute_state_root_chunked<PF>(provider_factory: &PF) -> Result<B256, InitStorageError>
 where
     PF: DatabaseProviderFactory<
-        ProviderRW: DBProvider<Tx: DbTxMut> + TrieWriter + StorageSettingsCache,
+        ProviderRW: DBProvider<Tx: DbTx + DbTxMut> + TrieWriter + StorageSettingsCache,
     >,
 {
-    let provider_rw = provider_factory.database_provider_rw().map_err(provider_db_err)?;
+    #[cfg(feature = "lattice-state-root")]
+    {
+        let provider_rw = provider_factory.database_provider_rw().map_err(provider_db_err)?;
+        let root = rebuild_lattice_accumulators(&provider_rw)?;
+        provider_rw.commit().map_err(provider_db_err)?;
+        return Ok(root)
+    }
 
-    reth_trie_db::with_adapter!(&provider_rw, |A| {
-        drop(provider_rw);
-        compute_state_root_chunked_inner::<PF, A>(provider_factory)
-    })
+    #[cfg(not(feature = "lattice-state-root"))]
+    {
+        let provider_rw = provider_factory.database_provider_rw().map_err(provider_db_err)?;
+
+        reth_trie_db::with_adapter!(&provider_rw, |A| {
+            drop(provider_rw);
+            compute_state_root_chunked_inner::<PF, A>(provider_factory)
+        })
+    }
 }
 
+#[cfg(not(feature = "lattice-state-root"))]
 fn compute_state_root_chunked_inner<PF, A>(provider_factory: &PF) -> Result<B256, InitStorageError>
 where
     PF: DatabaseProviderFactory<

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -11,13 +11,13 @@ use reth_chainspec::EthChainSpec;
 use reth_codecs::Compact;
 use reth_config::config::EtlConfig;
 use reth_db_api::{
-    cursor::{DbCursorRW, DbDupCursorRW},
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     models::{
         storage_sharded_key::StorageShardedKey, AccountBeforeTx, BlockNumberAddress, IntegerList,
         ShardedKey,
     },
     tables,
-    transaction::DbTxMut,
+    transaction::{DbTx, DbTxMut},
     DatabaseError,
 };
 use reth_etl::Collector;
@@ -295,6 +295,8 @@ where
 
     // compute state root to populate trie tables
     compute_state_root(&provider_rw, None)?;
+    #[cfg(feature = "lattice-state-root")]
+    rebuild_lattice_accumulators(&provider_rw)?;
 
     // set stage checkpoint to genesis block number for all stages
     let checkpoint = StageCheckpoint::new(genesis_block_number);
@@ -1194,6 +1196,47 @@ where
     }
 }
 
+#[cfg(feature = "lattice-state-root")]
+fn rebuild_lattice_accumulators<Provider>(provider: &Provider) -> Result<(), InitStorageError>
+where
+    Provider: DBProvider<Tx: DbTx + DbTxMut>,
+{
+    use reth_trie::lattice::{LatticeStateRoot, LatticeStorageRoot};
+
+    let tx = provider.tx_ref();
+    let mut state_root = LatticeStateRoot::default();
+    let mut storage_updates = B256Map::default();
+
+    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+    let mut account_entry = account_cursor.seek(B256::ZERO)?;
+    while let Some((hashed_address, account)) = account_entry {
+        let mut storage_root = LatticeStorageRoot::default();
+        let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+        for entry in storage_cursor.walk_dup(Some(hashed_address), None)? {
+            let (_, StorageEntry { key, value }) = entry?;
+            if !value.is_zero() {
+                storage_root.add_slot(key, value);
+            }
+        }
+
+        state_root.add_account(hashed_address, account, storage_root.root());
+        if !storage_root.is_zero() {
+            storage_updates.insert(hashed_address, storage_root.state());
+        }
+
+        account_entry = account_cursor.next()?;
+    }
+
+    tx.clear::<tables::LatticeStorageAccumulators>()?;
+    tx.put::<tables::LatticeStateAccumulator>(0, state_root.state().into_vec())?;
+    let mut storage_write_cursor = tx.cursor_write::<tables::LatticeStorageAccumulators>()?;
+    for (hashed_address, storage_state) in storage_updates {
+        storage_write_cursor.upsert(hashed_address, &storage_state.into_vec())?;
+    }
+
+    Ok(())
+}
+
 /// Computes the state root (from scratch) with periodic commits to free MDBX dirty pages.
 ///
 /// Opens a fresh transaction each iteration to release dirty pages, preventing OOM on large
@@ -1257,6 +1300,9 @@ where
                     total_flushed_updates,
                     "State root computation complete"
                 );
+
+                #[cfg(feature = "lattice-state-root")]
+                rebuild_lattice_accumulators(&provider_rw)?;
 
                 provider_rw.commit().map_err(provider_db_err)?;
                 return Ok(root)

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -1212,40 +1212,31 @@ fn rebuild_lattice_accumulators<Provider>(provider: &Provider) -> Result<B256, I
 where
     Provider: DBProvider<Tx: DbTx + DbTxMut>,
 {
-    use reth_trie::lattice::{LatticeStateRoot, LatticeStorageRoot};
+    use reth_trie::lattice::LatticeRoot;
 
     let tx = provider.tx_ref();
-    let mut state_root = LatticeStateRoot::default();
-    let mut storage_updates = B256Map::default();
+    let mut lattice_root = LatticeRoot::default();
 
     let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
     let mut account_entry = account_cursor.seek(B256::ZERO)?;
     while let Some((hashed_address, account)) = account_entry {
-        let mut storage_root = LatticeStorageRoot::default();
+        lattice_root.add_account(hashed_address, account);
+
         let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
         for entry in storage_cursor.walk_dup(Some(hashed_address), None)? {
             let (_, StorageEntry { key, value }) = entry?;
             if !value.is_zero() {
-                storage_root.add_slot(key, value);
+                lattice_root.add_slot(hashed_address, key, value);
             }
-        }
-
-        state_root.add_account(hashed_address, account, storage_root.root());
-        if !storage_root.is_zero() {
-            storage_updates.insert(hashed_address, storage_root.state());
         }
 
         account_entry = account_cursor.next()?;
     }
 
     tx.clear::<tables::LatticeStorageAccumulators>()?;
-    tx.put::<tables::LatticeStateAccumulator>(0, state_root.state().into_vec())?;
-    let mut storage_write_cursor = tx.cursor_write::<tables::LatticeStorageAccumulators>()?;
-    for (hashed_address, storage_state) in storage_updates {
-        storage_write_cursor.upsert(hashed_address, &storage_state.into_vec())?;
-    }
+    tx.put::<tables::LatticeStateAccumulator>(0, lattice_root.state().into_vec())?;
 
-    Ok(state_root.root())
+    Ok(lattice_root.root())
 }
 
 /// Computes the state root (from scratch) with periodic commits to free MDBX dirty pages.

--- a/crates/storage/db-common/src/lib.rs
+++ b/crates/storage/db-common/src/lib.rs
@@ -8,6 +8,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_db as _;
+
 pub mod init;
 
 mod db_tool;

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -91,6 +91,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 
 [features]
 jemalloc = ["rocksdb/jemalloc"]
+lattice-state-root = ["reth-trie/lattice-state-root", "reth-trie-db/lattice-state-root"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -91,7 +91,12 @@ tokio-stream = { workspace = true, features = ["sync"] }
 
 [features]
 jemalloc = ["rocksdb/jemalloc"]
-lattice-state-root = ["reth-trie/lattice-state-root", "reth-trie-db/lattice-state-root"]
+lattice-state-root = [
+    "reth-chain-state/lattice-state-root",
+    "reth-storage-api/lattice-state-root",
+    "reth-trie/lattice-state-root",
+    "reth-trie-db/lattice-state-root",
+]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -749,11 +749,6 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     for block in &blocks {
                         let lattice_updates = block.trie_data().lattice_accumulator_updates;
                         merged_lattice_updates.state = lattice_updates.state.clone();
-                        merged_lattice_updates.storage.extend(lattice_updates.storage.iter().map(
-                            |(hashed_address, storage_state)| {
-                                (*hashed_address, storage_state.clone())
-                            },
-                        ));
                     }
                     if merged_lattice_updates.is_empty() {
                         self.rebuild_lattice_accumulators()?;
@@ -1437,19 +1432,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
             crate::providers::state::lattice::lattice_state_accumulator_key(),
             updates.state.clone().into_vec(),
         )?;
-
-        let mut storage_cursor =
-            self.tx_ref().cursor_write::<tables::LatticeStorageAccumulators>()?;
-        for (hashed_address, storage_state) in &updates.storage {
-            if storage_cursor.seek_exact(*hashed_address)?.is_some() {
-                storage_cursor.delete_current()?;
-            }
-
-            if let Some(storage_state) = storage_state {
-                let encoded = storage_state.clone().into_vec();
-                storage_cursor.upsert(*hashed_address, &encoded)?;
-            }
-        }
+        self.tx_ref().clear::<tables::LatticeStorageAccumulators>()?;
 
         Ok(())
     }
@@ -1458,7 +1441,6 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     fn rebuild_lattice_accumulators(&self) -> ProviderResult<()> {
         let updates =
             crate::providers::state::lattice::rebuild_lattice_accumulators(self.tx_ref())?;
-        self.tx_ref().clear::<tables::LatticeStorageAccumulators>()?;
         self.write_lattice_accumulator_updates(&updates)
     }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -729,13 +729,17 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 }
                 timings.write_hashed_state += start.elapsed();
 
-                let start = Instant::now();
-                let merged_trie =
-                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
-                if !merged_trie.is_empty() {
-                    self.write_trie_updates_sorted(&merged_trie)?;
+                #[cfg(not(feature = "lattice-state-root"))]
+                {
+                    let start = Instant::now();
+                    let merged_trie = TrieUpdatesSorted::merge_batch(
+                        blocks.iter().rev().map(|b| b.trie_updates()),
+                    );
+                    if !merged_trie.is_empty() {
+                        self.write_trie_updates_sorted(&merged_trie)?;
+                    }
+                    timings.write_trie_updates += start.elapsed();
                 }
-                timings.write_trie_updates += start.elapsed();
 
                 #[cfg(feature = "lattice-state-root")]
                 {
@@ -882,19 +886,26 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         // Unwind storage history indices.
         self.unwind_storage_history_indices(changed_storages.iter().copied())?;
 
-        // Unwind accounts/storages trie tables using the revert.
-        // Get the database tip block number
-        let db_tip_block = self
-            .get_stage_checkpoint(reth_stages_types::StageId::Finish)?
-            .as_ref()
-            .map(|chk| chk.block_number)
-            .ok_or_else(|| ProviderError::InsufficientChangesets {
-                requested: from,
-                available: 0..=0,
-            })?;
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            // Unwind accounts/storages trie tables using the revert.
+            // Get the database tip block number
+            let db_tip_block = self
+                .get_stage_checkpoint(reth_stages_types::StageId::Finish)?
+                .as_ref()
+                .map(|chk| chk.block_number)
+                .ok_or_else(|| ProviderError::InsufficientChangesets {
+                    requested: from,
+                    available: 0..=0,
+                })?;
 
-        let trie_revert = self.changeset_cache.get_or_compute_range(self, from..=db_tip_block)?;
-        self.write_trie_updates_sorted(&trie_revert)?;
+            let trie_revert =
+                self.changeset_cache.get_or_compute_range(self, from..=db_tip_block)?;
+            self.write_trie_updates_sorted(&trie_revert)?;
+        }
+
+        #[cfg(feature = "lattice-state-root")]
+        self.rebuild_lattice_accumulators()?;
 
         Ok(())
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -736,6 +736,28 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }
                 timings.write_trie_updates += start.elapsed();
+
+                #[cfg(feature = "lattice-state-root")]
+                {
+                    let start = Instant::now();
+                    let mut merged_lattice_updates =
+                        reth_trie::lattice::LatticeAccumulatorUpdates::default();
+                    for block in &blocks {
+                        let lattice_updates = block.trie_data().lattice_accumulator_updates;
+                        merged_lattice_updates.state = lattice_updates.state.clone();
+                        merged_lattice_updates.storage.extend(lattice_updates.storage.iter().map(
+                            |(hashed_address, storage_state)| {
+                                (*hashed_address, storage_state.clone())
+                            },
+                        ));
+                    }
+                    if merged_lattice_updates.is_empty() {
+                        self.rebuild_lattice_accumulators()?;
+                    } else {
+                        self.write_lattice_accumulator_updates(&merged_lattice_updates)?;
+                    }
+                    timings.write_trie_updates += start.elapsed();
+                }
             }
 
             // Full mode: update history indices
@@ -1395,6 +1417,40 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    #[cfg(feature = "lattice-state-root")]
+    fn write_lattice_accumulator_updates(
+        &self,
+        updates: &reth_trie::lattice::LatticeAccumulatorUpdates,
+    ) -> ProviderResult<()> {
+        self.tx_ref().put::<tables::LatticeStateAccumulator>(
+            crate::providers::state::lattice::lattice_state_accumulator_key(),
+            updates.state.clone().into_vec(),
+        )?;
+
+        let mut storage_cursor =
+            self.tx_ref().cursor_write::<tables::LatticeStorageAccumulators>()?;
+        for (hashed_address, storage_state) in &updates.storage {
+            if storage_cursor.seek_exact(*hashed_address)?.is_some() {
+                storage_cursor.delete_current()?;
+            }
+
+            if let Some(storage_state) = storage_state {
+                let encoded = storage_state.clone().into_vec();
+                storage_cursor.upsert(*hashed_address, &encoded)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn rebuild_lattice_accumulators(&self) -> ProviderResult<()> {
+        let updates =
+            crate::providers::state::lattice::rebuild_lattice_accumulators(self.tx_ref())?;
+        self.tx_ref().clear::<tables::LatticeStorageAccumulators>()?;
+        self.write_lattice_accumulator_updates(&updates)
+    }
+
     /// Insert history index to the database.
     ///
     /// For each updated partial key, this function retrieves the last shard from the database
@@ -2817,6 +2873,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                     }
                 }
             }
+
+            #[cfg(feature = "lattice-state-root")]
+            self.rebuild_lattice_accumulators()?;
         } else {
             // This is not working for blocks that are not at tip. as plain state is not the last
             // state of end range. We should rename the functions or add support to access
@@ -2980,6 +3039,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                     }
                 }
             }
+
+            #[cfg(feature = "lattice-state-root")]
+            self.rebuild_lattice_accumulators()?;
 
             (state, reverts)
         } else {
@@ -3730,6 +3792,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
 
         // insert hashes and intermediate merkle nodes
         self.write_hashed_state(&hashed_state)?;
+        #[cfg(feature = "lattice-state-root")]
+        self.rebuild_lattice_accumulators()?;
         durations_recorder.record_relative(metrics::Action::InsertHashes);
 
         // Use pre-computed transitions for history indices since static file

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -445,20 +445,11 @@ where
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_state_root_with_updates(
+    fn lattice_state_root(
         &self,
         bundle_state: &revm_database::BundleState,
-        hashed_state: HashedPostState,
-        precomputed_trie_updates: Option<TrieUpdates>,
-    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
-        reth_trie_db::with_adapter!(self.provider, |A| {
-            crate::providers::state::lattice::lattice_state_root_with_updates::<_, A>(
-                self.tx(),
-                bundle_state,
-                hashed_state,
-                precomputed_trie_updates,
-            )
-        })
+    ) -> ProviderResult<(B256, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        crate::providers::state::lattice::lattice_state_root(self.tx(), bundle_state)
     }
 
     #[cfg(feature = "lattice-state-root")]

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -444,6 +444,23 @@ where
         })
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_state_root_with_updates(
+        &self,
+        bundle_state: &revm_database::BundleState,
+        hashed_state: HashedPostState,
+        precomputed_trie_updates: Option<TrieUpdates>,
+    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        reth_trie_db::with_adapter!(self.provider, |A| {
+            crate::providers::state::lattice::lattice_state_root_with_updates::<_, A>(
+                self.tx(),
+                bundle_state,
+                hashed_state,
+                precomputed_trie_updates,
+            )
+        })
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -460,11 +460,11 @@ where
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_storage_accumulator(
+    fn lattice_account_storage(
         &self,
         hashed_address: B256,
-    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
-        crate::providers::state::lattice::lattice_storage_accumulator(self.tx(), hashed_address)
+    ) -> ProviderResult<Vec<(B256, alloy_primitives::U256)>> {
+        crate::providers::state::lattice::lattice_account_storage(self.tx(), hashed_address)
     }
 
     fn state_root_from_nodes_with_updates(

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -461,6 +461,21 @@ where
         })
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_accumulator_seed(
+        &self,
+    ) -> ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates> {
+        crate::providers::state::lattice::lattice_accumulator_seed(self.tx())
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_storage_accumulator(
+        &self,
+        hashed_address: B256,
+    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
+        crate::providers::state::lattice::lattice_storage_accumulator(self.tx(), hashed_address)
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -129,6 +129,23 @@ impl<Provider: DBProvider + StorageSettingsCache> StateRootProvider
         })
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_state_root_with_updates(
+        &self,
+        bundle_state: &revm_database::BundleState,
+        hashed_state: HashedPostState,
+        precomputed_trie_updates: Option<TrieUpdates>,
+    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        reth_trie_db::with_adapter!(self.0, |A| {
+            crate::providers::state::lattice::lattice_state_root_with_updates::<_, A>(
+                self.tx(),
+                bundle_state,
+                hashed_state,
+                precomputed_trie_updates,
+            )
+        })
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -145,11 +145,11 @@ impl<Provider: DBProvider + StorageSettingsCache> StateRootProvider
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_storage_accumulator(
+    fn lattice_account_storage(
         &self,
         hashed_address: B256,
-    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
-        crate::providers::state::lattice::lattice_storage_accumulator(self.tx(), hashed_address)
+    ) -> ProviderResult<Vec<(B256, alloy_primitives::U256)>> {
+        crate::providers::state::lattice::lattice_account_storage(self.tx(), hashed_address)
     }
 
     fn state_root_from_nodes_with_updates(

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -146,6 +146,21 @@ impl<Provider: DBProvider + StorageSettingsCache> StateRootProvider
         })
     }
 
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_accumulator_seed(
+        &self,
+    ) -> ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates> {
+        crate::providers::state::lattice::lattice_accumulator_seed(self.tx())
+    }
+
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_storage_accumulator(
+        &self,
+        hashed_address: B256,
+    ) -> ProviderResult<Option<reth_trie::lattice::LatticeHashState>> {
+        crate::providers::state::lattice::lattice_storage_accumulator(self.tx(), hashed_address)
+    }
+
     fn state_root_from_nodes_with_updates(
         &self,
         input: TrieInput,

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -130,20 +130,11 @@ impl<Provider: DBProvider + StorageSettingsCache> StateRootProvider
     }
 
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_state_root_with_updates(
+    fn lattice_state_root(
         &self,
         bundle_state: &revm_database::BundleState,
-        hashed_state: HashedPostState,
-        precomputed_trie_updates: Option<TrieUpdates>,
-    ) -> ProviderResult<(B256, TrieUpdates, reth_trie::lattice::LatticeAccumulatorUpdates)> {
-        reth_trie_db::with_adapter!(self.0, |A| {
-            crate::providers::state::lattice::lattice_state_root_with_updates::<_, A>(
-                self.tx(),
-                bundle_state,
-                hashed_state,
-                precomputed_trie_updates,
-            )
-        })
+    ) -> ProviderResult<(B256, reth_trie::lattice::LatticeAccumulatorUpdates)> {
+        crate::providers::state::lattice::lattice_state_root(self.tx(), bundle_state)
     }
 
     #[cfg(feature = "lattice-state-root")]

--- a/crates/storage/provider/src/providers/state/lattice.rs
+++ b/crates/storage/provider/src/providers/state/lattice.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{keccak256, map::B256Map, B256};
+use alloy_primitives::{keccak256, B256};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     tables,
@@ -6,9 +6,7 @@ use reth_db_api::{
 };
 use reth_primitives_traits::{Account, StorageEntry};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
-use reth_trie::lattice::{
-    LatticeAccumulatorUpdates, LatticeHashState, LatticeStateRoot, LatticeStorageRoot,
-};
+use reth_trie::lattice::{LatticeAccumulatorUpdates, LatticeHashState, LatticeRoot};
 use revm_database::BundleState;
 use std::io::{Error as IoError, ErrorKind};
 
@@ -22,7 +20,7 @@ pub(crate) fn lattice_state_root<TX>(
 where
     TX: DbTx,
 {
-    let (mut state_root, mut storage_updates) = state_accumulator(tx)?;
+    let mut lattice_root = state_accumulator(tx)?;
 
     let mut accounts = bundle_state.state.iter().collect::<Vec<_>>();
     accounts.sort_unstable_by_key(|(address, _)| keccak256(address));
@@ -32,15 +30,25 @@ where
         let old_account: Option<Account> = account.original_info.as_ref().map(Into::into);
         let new_account: Option<Account> = account.info.as_ref().map(Into::into);
 
-        let mut storage_root = storage_accumulator(tx, hashed_address)?;
-        let old_storage_root = storage_root.root();
+        if old_account != new_account {
+            if let Some(old_account) = old_account {
+                lattice_root.subtract_account(hashed_address, old_account);
+            }
+            if let Some(new_account) = new_account {
+                lattice_root.add_account(hashed_address, new_account);
+            }
+        }
 
         if account.was_destroyed() {
-            storage_root.reset();
+            subtract_existing_storage(tx, &mut lattice_root, hashed_address)?;
             for (slot, value) in &account.storage {
                 let present_value = value.present_value();
                 if !present_value.is_zero() {
-                    storage_root.add_slot(keccak256(slot.to_be_bytes::<32>()), present_value);
+                    lattice_root.add_slot(
+                        hashed_address,
+                        keccak256(slot.to_be_bytes::<32>()),
+                        present_value,
+                    );
                 }
             }
         } else {
@@ -53,32 +61,17 @@ where
 
                 let hashed_slot = keccak256(slot.to_be_bytes::<32>());
                 if !original_value.is_zero() {
-                    storage_root.subtract_slot(hashed_slot, original_value);
+                    lattice_root.subtract_slot(hashed_address, hashed_slot, original_value);
                 }
                 if !present_value.is_zero() {
-                    storage_root.add_slot(hashed_slot, present_value);
+                    lattice_root.add_slot(hashed_address, hashed_slot, present_value);
                 }
             }
-        }
-
-        let new_storage_root = storage_root.root();
-        if old_account != new_account || old_storage_root != new_storage_root {
-            if let Some(old_account) = old_account {
-                state_root.subtract_account(hashed_address, old_account, old_storage_root);
-            }
-            if let Some(new_account) = new_account {
-                state_root.add_account(hashed_address, new_account, new_storage_root);
-            }
-        }
-
-        if old_storage_root != new_storage_root || account.was_destroyed() {
-            storage_updates
-                .insert(hashed_address, (!storage_root.is_zero()).then_some(storage_root.state()));
         }
     }
 
-    let root = state_root.root();
-    let updates = LatticeAccumulatorUpdates::new(state_root.state(), storage_updates);
+    let root = lattice_root.root();
+    let updates = LatticeAccumulatorUpdates::new(lattice_root.state());
     Ok((root, updates))
 }
 
@@ -87,18 +80,8 @@ pub(crate) fn rebuild_lattice_accumulators<TX>(tx: &TX) -> ProviderResult<Lattic
 where
     TX: DbTx,
 {
-    let state_root = build_state_accumulator(tx)?;
-    let mut storage = B256Map::default();
-
-    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
-    let mut account_entry = account_cursor.seek(B256::ZERO)?;
-    while let Some((hashed_address, _)) = account_entry {
-        let storage_root = build_storage_accumulator(tx, hashed_address)?;
-        storage.insert(hashed_address, (!storage_root.is_zero()).then_some(storage_root.state()));
-        account_entry = account_cursor.next()?;
-    }
-
-    Ok(LatticeAccumulatorUpdates::new(state_root.state(), storage))
+    let lattice_root = build_lattice_accumulator(tx)?;
+    Ok(LatticeAccumulatorUpdates::new(lattice_root.state()))
 }
 
 /// Returns the lattice accumulator seed for incremental updates.
@@ -106,88 +89,110 @@ pub(crate) fn lattice_accumulator_seed<TX>(tx: &TX) -> ProviderResult<LatticeAcc
 where
     TX: DbTx,
 {
-    let (state_root, storage) = state_accumulator(tx)?;
-    Ok(LatticeAccumulatorUpdates::new(state_root.state(), storage))
+    let lattice_root = state_accumulator(tx)?;
+    Ok(LatticeAccumulatorUpdates::new(lattice_root.state()))
 }
 
-/// Returns the stored or rebuilt storage accumulator state for `hashed_address`.
-pub(crate) fn lattice_storage_accumulator<TX>(
+/// Returns nonzero hashed storage entries for `hashed_address`.
+pub(crate) fn lattice_account_storage<TX>(
     tx: &TX,
     hashed_address: B256,
-) -> ProviderResult<Option<LatticeHashState>>
+) -> ProviderResult<Vec<(B256, alloy_primitives::U256)>>
 where
     TX: DbTx,
 {
-    let storage_root = storage_accumulator(tx, hashed_address)?;
-    Ok((!storage_root.is_zero()).then_some(storage_root.state()))
-}
-
-fn state_accumulator<TX>(
-    tx: &TX,
-) -> ProviderResult<(LatticeStateRoot, B256Map<Option<LatticeHashState>>)>
-where
-    TX: DbTx,
-{
-    if let Some(state) = tx.get::<tables::LatticeStateAccumulator>(LATTICE_STATE_ACCUMULATOR_KEY)? {
-        let state_root = LatticeHashState::from_slice(&state)
-            .and_then(|state| LatticeStateRoot::from_state(&state))
-            .map_err(lattice_decode_error)?;
-        return Ok((state_root, B256Map::default()))
-    }
-
-    let updates = rebuild_lattice_accumulators(tx)?;
-    let state_root = LatticeStateRoot::from_state(&updates.state).map_err(lattice_decode_error)?;
-    Ok((state_root, updates.storage))
-}
-
-fn storage_accumulator<TX>(tx: &TX, hashed_address: B256) -> ProviderResult<LatticeStorageRoot>
-where
-    TX: DbTx,
-{
-    if let Some(state) = tx.get::<tables::LatticeStorageAccumulators>(hashed_address)? {
-        return LatticeHashState::from_slice(&state)
-            .and_then(|state| LatticeStorageRoot::from_state(&state))
-            .map_err(lattice_decode_error)
-    }
-
-    build_storage_accumulator(tx, hashed_address)
-}
-
-fn build_state_accumulator<TX>(tx: &TX) -> ProviderResult<LatticeStateRoot>
-where
-    TX: DbTx,
-{
-    let mut state_root = LatticeStateRoot::default();
-    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
-    let mut account_entry = account_cursor.seek(B256::ZERO)?;
-
-    while let Some((hashed_address, account)) = account_entry {
-        let storage_root = build_storage_accumulator(tx, hashed_address)?;
-        state_root.add_account(hashed_address, account, storage_root.root());
-        account_entry = account_cursor.next()?;
-    }
-
-    Ok(state_root)
-}
-
-fn build_storage_accumulator<TX>(
-    tx: &TX,
-    hashed_address: B256,
-) -> ProviderResult<LatticeStorageRoot>
-where
-    TX: DbTx,
-{
-    let mut storage_root = LatticeStorageRoot::default();
+    let mut storage = Vec::new();
     let mut cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
 
     for entry in cursor.walk_dup(Some(hashed_address), None)? {
         let (_, StorageEntry { key, value }) = entry?;
         if !value.is_zero() {
-            storage_root.add_slot(key, value);
+            storage.push((key, value));
         }
     }
 
-    Ok(storage_root)
+    Ok(storage)
+}
+
+fn state_accumulator<TX>(tx: &TX) -> ProviderResult<LatticeRoot>
+where
+    TX: DbTx,
+{
+    if let Some(state) = tx.get::<tables::LatticeStateAccumulator>(LATTICE_STATE_ACCUMULATOR_KEY)? &&
+        !has_legacy_storage_accumulators(tx)?
+    {
+        return LatticeHashState::from_slice(&state)
+            .and_then(|state| LatticeRoot::from_state(&state))
+            .map_err(lattice_decode_error)
+    }
+
+    let updates = rebuild_lattice_accumulators(tx)?;
+    LatticeRoot::from_state(&updates.state).map_err(lattice_decode_error)
+}
+
+fn has_legacy_storage_accumulators<TX>(tx: &TX) -> ProviderResult<bool>
+where
+    TX: DbTx,
+{
+    let mut cursor = tx.cursor_read::<tables::LatticeStorageAccumulators>()?;
+    Ok(cursor.first()?.is_some())
+}
+
+fn build_lattice_accumulator<TX>(tx: &TX) -> ProviderResult<LatticeRoot>
+where
+    TX: DbTx,
+{
+    let mut lattice_root = LatticeRoot::default();
+    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+    let mut account_entry = account_cursor.seek(B256::ZERO)?;
+
+    while let Some((hashed_address, account)) = account_entry {
+        lattice_root.add_account(hashed_address, account);
+        add_existing_storage(tx, &mut lattice_root, hashed_address)?;
+        account_entry = account_cursor.next()?;
+    }
+
+    Ok(lattice_root)
+}
+
+fn add_existing_storage<TX>(
+    tx: &TX,
+    lattice_root: &mut LatticeRoot,
+    hashed_address: B256,
+) -> ProviderResult<()>
+where
+    TX: DbTx,
+{
+    let mut cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+    for entry in cursor.walk_dup(Some(hashed_address), None)? {
+        let (_, StorageEntry { key, value }) = entry?;
+        if !value.is_zero() {
+            lattice_root.add_slot(hashed_address, key, value);
+        }
+    }
+
+    Ok(())
+}
+
+fn subtract_existing_storage<TX>(
+    tx: &TX,
+    lattice_root: &mut LatticeRoot,
+    hashed_address: B256,
+) -> ProviderResult<()>
+where
+    TX: DbTx,
+{
+    let mut cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+    for entry in cursor.walk_dup(Some(hashed_address), None)? {
+        let (_, StorageEntry { key, value }) = entry?;
+        if !value.is_zero() {
+            lattice_root.subtract_slot(hashed_address, key, value);
+        }
+    }
+
+    Ok(())
 }
 
 pub(crate) fn lattice_decode_error(err: &'static str) -> ProviderError {

--- a/crates/storage/provider/src/providers/state/lattice.rs
+++ b/crates/storage/provider/src/providers/state/lattice.rs
@@ -1,0 +1,200 @@
+use alloy_primitives::{keccak256, map::B256Map, B256};
+use reth_db_api::{
+    cursor::{DbCursorRO, DbDupCursorRO},
+    tables,
+    transaction::DbTx,
+};
+use reth_primitives_traits::{Account, StorageEntry};
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
+use reth_trie::{
+    lattice::{LatticeAccumulatorUpdates, LatticeHashState, LatticeStateRoot, LatticeStorageRoot},
+    updates::TrieUpdates,
+    HashedPostState, StateRoot,
+};
+use reth_trie_db::{
+    DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, TrieTableAdapter,
+};
+use revm_database::BundleState;
+use std::io::{Error as IoError, ErrorKind};
+
+const LATTICE_STATE_ACCUMULATOR_KEY: u8 = 0;
+
+type DbStateRoot<'a, TX, A> =
+    StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
+
+/// Computes a lattice state root from an EVM bundle state and returns trie updates to persist.
+pub(crate) fn lattice_state_root_with_updates<TX, A>(
+    tx: &TX,
+    bundle_state: &BundleState,
+    hashed_state: HashedPostState,
+    precomputed_trie_updates: Option<TrieUpdates>,
+) -> ProviderResult<(B256, TrieUpdates, LatticeAccumulatorUpdates)>
+where
+    TX: DbTx,
+    A: TrieTableAdapter,
+{
+    let trie_updates = match precomputed_trie_updates {
+        Some(updates) => updates,
+        None => {
+            let sorted = hashed_state.into_sorted();
+            <DbStateRoot<'_, TX, A> as DatabaseStateRoot<'_, TX>>::overlay_root_with_updates(
+                tx, &sorted,
+            )?
+            .1
+        }
+    };
+
+    let (mut state_root, mut storage_updates) = state_accumulator(tx)?;
+
+    let mut accounts = bundle_state.state.iter().collect::<Vec<_>>();
+    accounts.sort_unstable_by_key(|(address, _)| keccak256(address));
+
+    for (address, account) in accounts {
+        let hashed_address = keccak256(address);
+        let old_account: Option<Account> = account.original_info.as_ref().map(Into::into);
+        let new_account: Option<Account> = account.info.as_ref().map(Into::into);
+
+        let mut storage_root = storage_accumulator(tx, hashed_address)?;
+        let old_storage_root = storage_root.root();
+
+        if account.was_destroyed() {
+            storage_root.reset();
+            for (slot, value) in &account.storage {
+                let present_value = value.present_value();
+                if !present_value.is_zero() {
+                    storage_root.add_slot(keccak256(slot.to_be_bytes::<32>()), present_value);
+                }
+            }
+        } else {
+            for (slot, value) in &account.storage {
+                let original_value = value.original_value();
+                let present_value = value.present_value();
+                if original_value == present_value {
+                    continue
+                }
+
+                let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                if !original_value.is_zero() {
+                    storage_root.subtract_slot(hashed_slot, original_value);
+                }
+                if !present_value.is_zero() {
+                    storage_root.add_slot(hashed_slot, present_value);
+                }
+            }
+        }
+
+        let new_storage_root = storage_root.root();
+        if old_account != new_account || old_storage_root != new_storage_root {
+            if let Some(old_account) = old_account {
+                state_root.subtract_account(hashed_address, old_account, old_storage_root);
+            }
+            if let Some(new_account) = new_account {
+                state_root.add_account(hashed_address, new_account, new_storage_root);
+            }
+        }
+
+        if old_storage_root != new_storage_root || account.was_destroyed() {
+            storage_updates
+                .insert(hashed_address, (!storage_root.is_zero()).then_some(storage_root.state()));
+        }
+    }
+
+    let root = state_root.root();
+    let updates = LatticeAccumulatorUpdates::new(state_root.state(), storage_updates);
+    Ok((root, trie_updates, updates))
+}
+
+/// Rebuilds lattice accumulators from the current hashed state tables.
+pub(crate) fn rebuild_lattice_accumulators<TX>(tx: &TX) -> ProviderResult<LatticeAccumulatorUpdates>
+where
+    TX: DbTx,
+{
+    let state_root = build_state_accumulator(tx)?;
+    let mut storage = B256Map::default();
+
+    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+    let mut account_entry = account_cursor.seek(B256::ZERO)?;
+    while let Some((hashed_address, _)) = account_entry {
+        let storage_root = build_storage_accumulator(tx, hashed_address)?;
+        storage.insert(hashed_address, (!storage_root.is_zero()).then_some(storage_root.state()));
+        account_entry = account_cursor.next()?;
+    }
+
+    Ok(LatticeAccumulatorUpdates::new(state_root.state(), storage))
+}
+
+fn state_accumulator<TX>(
+    tx: &TX,
+) -> ProviderResult<(LatticeStateRoot, B256Map<Option<LatticeHashState>>)>
+where
+    TX: DbTx,
+{
+    if let Some(state) = tx.get::<tables::LatticeStateAccumulator>(LATTICE_STATE_ACCUMULATOR_KEY)? {
+        let state_root = LatticeHashState::from_slice(&state)
+            .and_then(|state| LatticeStateRoot::from_state(&state))
+            .map_err(lattice_decode_error)?;
+        return Ok((state_root, B256Map::default()))
+    }
+
+    let updates = rebuild_lattice_accumulators(tx)?;
+    let state_root = LatticeStateRoot::from_state(&updates.state).map_err(lattice_decode_error)?;
+    Ok((state_root, updates.storage))
+}
+
+fn storage_accumulator<TX>(tx: &TX, hashed_address: B256) -> ProviderResult<LatticeStorageRoot>
+where
+    TX: DbTx,
+{
+    if let Some(state) = tx.get::<tables::LatticeStorageAccumulators>(hashed_address)? {
+        return LatticeHashState::from_slice(&state)
+            .and_then(|state| LatticeStorageRoot::from_state(&state))
+            .map_err(lattice_decode_error)
+    }
+
+    build_storage_accumulator(tx, hashed_address)
+}
+
+fn build_state_accumulator<TX>(tx: &TX) -> ProviderResult<LatticeStateRoot>
+where
+    TX: DbTx,
+{
+    let mut state_root = LatticeStateRoot::default();
+    let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+    let mut account_entry = account_cursor.seek(B256::ZERO)?;
+
+    while let Some((hashed_address, account)) = account_entry {
+        let storage_root = build_storage_accumulator(tx, hashed_address)?;
+        state_root.add_account(hashed_address, account, storage_root.root());
+        account_entry = account_cursor.next()?;
+    }
+
+    Ok(state_root)
+}
+
+fn build_storage_accumulator<TX>(
+    tx: &TX,
+    hashed_address: B256,
+) -> ProviderResult<LatticeStorageRoot>
+where
+    TX: DbTx,
+{
+    let mut storage_root = LatticeStorageRoot::default();
+    let mut cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+    for entry in cursor.walk_dup(Some(hashed_address), None)? {
+        let (_, StorageEntry { key, value }) = entry?;
+        if !value.is_zero() {
+            storage_root.add_slot(key, value);
+        }
+    }
+
+    Ok(storage_root)
+}
+
+pub(crate) fn lattice_decode_error(err: &'static str) -> ProviderError {
+    ProviderError::other(IoError::new(ErrorKind::InvalidData, err))
+}
+
+pub(crate) const fn lattice_state_accumulator_key() -> u8 {
+    LATTICE_STATE_ACCUMULATOR_KEY
+}

--- a/crates/storage/provider/src/providers/state/lattice.rs
+++ b/crates/storage/provider/src/providers/state/lattice.rs
@@ -6,44 +6,22 @@ use reth_db_api::{
 };
 use reth_primitives_traits::{Account, StorageEntry};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
-use reth_trie::{
-    lattice::{LatticeAccumulatorUpdates, LatticeHashState, LatticeStateRoot, LatticeStorageRoot},
-    updates::TrieUpdates,
-    HashedPostState, StateRoot,
-};
-use reth_trie_db::{
-    DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, TrieTableAdapter,
+use reth_trie::lattice::{
+    LatticeAccumulatorUpdates, LatticeHashState, LatticeStateRoot, LatticeStorageRoot,
 };
 use revm_database::BundleState;
 use std::io::{Error as IoError, ErrorKind};
 
 const LATTICE_STATE_ACCUMULATOR_KEY: u8 = 0;
 
-type DbStateRoot<'a, TX, A> =
-    StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
-
-/// Computes a lattice state root from an EVM bundle state and returns trie updates to persist.
-pub(crate) fn lattice_state_root_with_updates<TX, A>(
+/// Computes a lattice state root from an EVM bundle state.
+pub(crate) fn lattice_state_root<TX>(
     tx: &TX,
     bundle_state: &BundleState,
-    hashed_state: HashedPostState,
-    precomputed_trie_updates: Option<TrieUpdates>,
-) -> ProviderResult<(B256, TrieUpdates, LatticeAccumulatorUpdates)>
+) -> ProviderResult<(B256, LatticeAccumulatorUpdates)>
 where
     TX: DbTx,
-    A: TrieTableAdapter,
 {
-    let trie_updates = match precomputed_trie_updates {
-        Some(updates) => updates,
-        None => {
-            let sorted = hashed_state.into_sorted();
-            <DbStateRoot<'_, TX, A> as DatabaseStateRoot<'_, TX>>::overlay_root_with_updates(
-                tx, &sorted,
-            )?
-            .1
-        }
-    };
-
     let (mut state_root, mut storage_updates) = state_accumulator(tx)?;
 
     let mut accounts = bundle_state.state.iter().collect::<Vec<_>>();
@@ -101,7 +79,7 @@ where
 
     let root = state_root.root();
     let updates = LatticeAccumulatorUpdates::new(state_root.state(), storage_updates);
-    Ok((root, trie_updates, updates))
+    Ok((root, updates))
 }
 
 /// Rebuilds lattice accumulators from the current hashed state tables.

--- a/crates/storage/provider/src/providers/state/lattice.rs
+++ b/crates/storage/provider/src/providers/state/lattice.rs
@@ -123,6 +123,27 @@ where
     Ok(LatticeAccumulatorUpdates::new(state_root.state(), storage))
 }
 
+/// Returns the lattice accumulator seed for incremental updates.
+pub(crate) fn lattice_accumulator_seed<TX>(tx: &TX) -> ProviderResult<LatticeAccumulatorUpdates>
+where
+    TX: DbTx,
+{
+    let (state_root, storage) = state_accumulator(tx)?;
+    Ok(LatticeAccumulatorUpdates::new(state_root.state(), storage))
+}
+
+/// Returns the stored or rebuilt storage accumulator state for `hashed_address`.
+pub(crate) fn lattice_storage_accumulator<TX>(
+    tx: &TX,
+    hashed_address: B256,
+) -> ProviderResult<Option<LatticeHashState>>
+where
+    TX: DbTx,
+{
+    let storage_root = storage_accumulator(tx, hashed_address)?;
+    Ok((!storage_root.is_zero()).then_some(storage_root.state()))
+}
+
 fn state_accumulator<TX>(
     tx: &TX,
 ) -> ProviderResult<(LatticeStateRoot, B256Map<Option<LatticeHashState>>)>

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,4 +1,6 @@
 //! [`StateProvider`](crate::StateProvider) implementations
 pub(crate) mod historical;
 pub(crate) mod latest;
+#[cfg(feature = "lattice-state-root")]
+pub(crate) mod lattice;
 pub(crate) mod overlay;

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -68,6 +68,8 @@ db-api = [
     "dep:serde_json",
 ]
 
+lattice-state-root = ["reth-trie-common/lattice-state-root"]
+
 serde = [
     "reth-ethereum-primitives/serde",
     "reth-db-models/serde",

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -55,7 +55,7 @@ macro_rules! delegate_provider_impls {
                 #[cfg(feature = "lattice-state-root")]
                 fn lattice_accumulator_seed(&self) -> reth_storage_api::errors::provider::ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates>;
                 #[cfg(feature = "lattice-state-root")]
-                fn lattice_storage_accumulator(&self, hashed_address: alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_trie::lattice::LatticeHashState>>;
+                fn lattice_account_storage(&self, hashed_address: alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Vec<(alloy_primitives::B256, alloy_primitives::U256)>>;
                 fn state_root_from_nodes_with_updates(&self, input: reth_trie::TrieInput) -> reth_storage_api::errors::provider::ProviderResult<(alloy_primitives::B256, reth_trie::updates::TrieUpdates)>;
             }
             StorageRootProvider $(where [$($generics)*])? {

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -6,12 +6,13 @@
 /// Used to implement provider traits.
 #[macro_export]
 macro_rules! delegate_impls_to_as_ref {
-    (for $target:ty => $($trait:ident $(where [$($generics:tt)*])? {  $(fn $func:ident$(<$($generic_arg:ident: $generic_arg_ty:path),*>)?(&self, $($arg:ident: $argty:ty),*) -> $ret:path;)* })* ) => {
+    (for $target:ty => $($trait:ident $(where [$($generics:tt)*])? {  $($(#[$meta:meta])* fn $func:ident$(<$($generic_arg:ident: $generic_arg_ty:path),*>)?(&self $(, $arg:ident: $argty:ty)*) -> $ret:ty;)* })* ) => {
 
         $(
           impl<'a, $($($generics)*)?> $trait for $target {
               $(
-                  fn $func$(<$($generic_arg: $generic_arg_ty),*>)?(&self, $($arg: $argty),*) -> $ret {
+                  $(#[$meta])*
+                  fn $func$(<$($generic_arg: $generic_arg_ty),*>)?(&self $(, $arg: $argty)*) -> $ret {
                     self.as_ref().$func($($arg),*)
                   }
               )*
@@ -49,6 +50,12 @@ macro_rules! delegate_provider_impls {
                 fn state_root(&self, state: reth_trie::HashedPostState) -> reth_storage_api::errors::provider::ProviderResult<alloy_primitives::B256>;
                 fn state_root_from_nodes(&self, input: reth_trie::TrieInput) -> reth_storage_api::errors::provider::ProviderResult<alloy_primitives::B256>;
                 fn state_root_with_updates(&self, state: reth_trie::HashedPostState) -> reth_storage_api::errors::provider::ProviderResult<(alloy_primitives::B256, reth_trie::updates::TrieUpdates)>;
+                #[cfg(feature = "lattice-state-root")]
+                fn lattice_state_root(&self, bundle_state: &revm_database::BundleState) -> reth_storage_api::errors::provider::ProviderResult<(alloy_primitives::B256, reth_trie::lattice::LatticeAccumulatorUpdates)>;
+                #[cfg(feature = "lattice-state-root")]
+                fn lattice_accumulator_seed(&self) -> reth_storage_api::errors::provider::ProviderResult<reth_trie::lattice::LatticeAccumulatorUpdates>;
+                #[cfg(feature = "lattice-state-root")]
+                fn lattice_storage_accumulator(&self, hashed_address: alloy_primitives::B256) -> reth_storage_api::errors::provider::ProviderResult<Option<reth_trie::lattice::LatticeHashState>>;
                 fn state_root_from_nodes_with_updates(&self, input: reth_trie::TrieInput) -> reth_storage_api::errors::provider::ProviderResult<(alloy_primitives::B256, reth_trie::updates::TrieUpdates)>;
             }
             StorageRootProvider $(where [$($generics)*])? {

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -35,20 +35,14 @@ pub trait StateRootProvider {
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)>;
 
-    /// Returns a lattice state root, MPT trie updates, and full lattice accumulator updates for
-    /// the provided EVM bundle state.
+    /// Returns a lattice state root and full lattice accumulator updates for the provided EVM
+    /// bundle state.
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_state_root_with_updates(
+    fn lattice_state_root(
         &self,
         _bundle_state: &BundleState,
-        hashed_state: HashedPostState,
-        precomputed_trie_updates: Option<TrieUpdates>,
-    ) -> ProviderResult<(B256, TrieUpdates, LatticeAccumulatorUpdates)> {
-        let (root, trie_updates) = match precomputed_trie_updates {
-            Some(updates) => (self.state_root(hashed_state)?, updates),
-            None => self.state_root_with_updates(hashed_state)?,
-        };
-        Ok((root, trie_updates, Default::default()))
+    ) -> ProviderResult<(B256, LatticeAccumulatorUpdates)> {
+        Ok((B256::ZERO, Default::default()))
     }
 
     /// Returns the current lattice accumulator seed for incremental updates.

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes, B256};
 use reth_storage_errors::provider::ProviderResult;
 #[cfg(feature = "lattice-state-root")]
-use reth_trie_common::lattice::LatticeAccumulatorUpdates;
+use reth_trie_common::lattice::{LatticeAccumulatorUpdates, LatticeHashState};
 use reth_trie_common::{
     updates::{StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
     AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
@@ -49,6 +49,25 @@ pub trait StateRootProvider {
             None => self.state_root_with_updates(hashed_state)?,
         };
         Ok((root, trie_updates, Default::default()))
+    }
+
+    /// Returns the current lattice accumulator seed for incremental updates.
+    ///
+    /// The state accumulator is always returned. Storage entries are returned only when they need
+    /// to be repaired or overlaid before block-local deltas are applied.
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_accumulator_seed(&self) -> ProviderResult<LatticeAccumulatorUpdates> {
+        Ok(Default::default())
+    }
+
+    /// Returns the storage accumulator state for `hashed_address`, if the account has non-empty
+    /// storage.
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_storage_accumulator(
+        &self,
+        _hashed_address: B256,
+    ) -> ProviderResult<Option<LatticeHashState>> {
+        Ok(None)
     }
 
     /// Returns state root and trie updates.

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -1,8 +1,10 @@
 use alloc::vec::Vec;
+#[cfg(feature = "lattice-state-root")]
+use alloy_primitives::U256;
 use alloy_primitives::{Address, Bytes, B256};
 use reth_storage_errors::provider::ProviderResult;
 #[cfg(feature = "lattice-state-root")]
-use reth_trie_common::lattice::{LatticeAccumulatorUpdates, LatticeHashState};
+use reth_trie_common::lattice::LatticeAccumulatorUpdates;
 use reth_trie_common::{
     updates::{StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
     AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
@@ -45,23 +47,17 @@ pub trait StateRootProvider {
         Ok((B256::ZERO, Default::default()))
     }
 
-    /// Returns the current lattice accumulator seed for incremental updates.
-    ///
-    /// The state accumulator is always returned. Storage entries are returned only when they need
-    /// to be repaired or overlaid before block-local deltas are applied.
+    /// Returns the current flat lattice accumulator seed for incremental updates.
     #[cfg(feature = "lattice-state-root")]
     fn lattice_accumulator_seed(&self) -> ProviderResult<LatticeAccumulatorUpdates> {
         Ok(Default::default())
     }
 
-    /// Returns the storage accumulator state for `hashed_address`, if the account has non-empty
-    /// storage.
+    /// Returns nonzero hashed storage slots for `hashed_address`, used when flattening storage
+    /// wipe deltas into the single lattice accumulator.
     #[cfg(feature = "lattice-state-root")]
-    fn lattice_storage_accumulator(
-        &self,
-        _hashed_address: B256,
-    ) -> ProviderResult<Option<LatticeHashState>> {
-        Ok(None)
+    fn lattice_account_storage(&self, _hashed_address: B256) -> ProviderResult<Vec<(B256, U256)>> {
+        Ok(Vec::new())
     }
 
     /// Returns state root and trie updates.

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -1,11 +1,15 @@
 use alloc::vec::Vec;
 use alloy_primitives::{Address, Bytes, B256};
 use reth_storage_errors::provider::ProviderResult;
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_common::lattice::LatticeAccumulatorUpdates;
 use reth_trie_common::{
     updates::{StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
     AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
+#[cfg(feature = "lattice-state-root")]
+use revm_database::BundleState;
 
 /// A type that can compute the state root of a given post state.
 #[auto_impl::auto_impl(&, Box, Arc)]
@@ -30,6 +34,22 @@ pub trait StateRootProvider {
         &self,
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)>;
+
+    /// Returns a lattice state root, MPT trie updates, and full lattice accumulator updates for
+    /// the provided EVM bundle state.
+    #[cfg(feature = "lattice-state-root")]
+    fn lattice_state_root_with_updates(
+        &self,
+        _bundle_state: &BundleState,
+        hashed_state: HashedPostState,
+        precomputed_trie_updates: Option<TrieUpdates>,
+    ) -> ProviderResult<(B256, TrieUpdates, LatticeAccumulatorUpdates)> {
+        let (root, trie_updates) = match precomputed_trie_updates {
+            Some(updates) => (self.state_root(hashed_state)?, updates),
+            None => self.state_root_with_updates(hashed_state)?,
+        };
+        Ok((root, trie_updates, Default::default()))
+    }
 
     /// Returns state root and trie updates.
     /// See [`StateRootProvider::state_root_from_nodes`] for more info.

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -19,6 +19,7 @@ alloy-trie = { workspace = true, features = ["ethereum"] }
 alloy-consensus.workspace = true
 reth-primitives-traits.workspace = true
 reth-codecs = { workspace = true, optional = true }
+commonware-cryptography = { workspace = true, optional = true }
 
 alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
@@ -88,7 +89,9 @@ std = [
     "revm-state/std",
     "reth-codecs?/std",
     "alloy-eips/std",
+    "commonware-cryptography?/std",
 ]
+lattice-state-root = ["dep:commonware-cryptography"]
 eip1186 = ["alloy-rpc-types-eth/serde", "dep:alloy-serde"]
 serde = [
     "dep:serde",
@@ -134,5 +137,6 @@ arbitrary = [
     "reth-codecs/arbitrary",
     "alloy-rpc-types-eth?/arbitrary",
     "alloy-eips/arbitrary",
+    "commonware-cryptography?/arbitrary",
 ]
 rayon = ["dep:rayon"]

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -20,6 +20,7 @@ alloy-consensus.workspace = true
 reth-primitives-traits.workspace = true
 reth-codecs = { workspace = true, optional = true }
 commonware-cryptography = { workspace = true, optional = true }
+commonware-codec = { workspace = true, optional = true }
 
 alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
@@ -89,9 +90,10 @@ std = [
     "revm-state/std",
     "reth-codecs?/std",
     "alloy-eips/std",
+    "commonware-codec?/std",
     "commonware-cryptography?/std",
 ]
-lattice-state-root = ["dep:commonware-cryptography"]
+lattice-state-root = ["dep:commonware-codec", "dep:commonware-cryptography"]
 eip1186 = ["alloy-rpc-types-eth/serde", "dep:alloy-serde"]
 serde = [
     "dep:serde",

--- a/crates/trie/common/src/lattice.rs
+++ b/crates/trie/common/src/lattice.rs
@@ -2,13 +2,13 @@
 
 use alloc::vec::Vec;
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_primitives::{map::B256Map, B256, U256};
+use alloy_primitives::{B256, U256};
 use commonware_codec::{FixedSize, Read, Write};
 use commonware_cryptography::lthash::LtHash;
 use reth_primitives_traits::Account;
 
-const STORAGE_SLOT_DOMAIN: u8 = 0;
-const ACCOUNT_DOMAIN: u8 = 1;
+const ACCOUNT_DOMAIN: u8 = 0;
+const STORAGE_SLOT_DOMAIN: u8 = 1;
 
 /// Size in bytes of a serialized Commonware LtHash accumulator.
 pub const LATTICE_HASH_STATE_BYTES: usize = <LtHash as FixedSize>::SIZE;
@@ -80,93 +80,56 @@ impl Default for LatticeHashState {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LatticeAccumulatorUpdates {
-    /// Final global account-state accumulator.
+    /// Final flat account and storage accumulator.
     pub state: LatticeHashState,
-    /// Final per-account storage accumulators. `None` removes an empty storage accumulator.
-    pub storage: B256Map<Option<LatticeHashState>>,
 }
 
 impl LatticeAccumulatorUpdates {
     /// Creates new accumulator updates.
-    pub const fn new(state: LatticeHashState, storage: B256Map<Option<LatticeHashState>>) -> Self {
-        Self { state, storage }
+    pub const fn new(state: LatticeHashState) -> Self {
+        Self { state }
     }
 
-    /// Returns true if this update only contains the zero global accumulator and no storage
-    /// changes.
+    /// Returns true if this update only contains the zero accumulator.
     pub fn is_empty(&self) -> bool {
-        self.state == LatticeHashState::default() && self.storage.is_empty()
+        self.state == LatticeHashState::default()
     }
 }
 
-/// LtHash accumulator for one account's storage slots.
+/// Flat LtHash accumulator for account and storage elements.
 #[derive(Clone, Debug, Default)]
-pub struct LatticeStorageRoot {
+pub struct LatticeRoot {
     hash: LtHash,
     buf: Vec<u8>,
 }
 
-impl LatticeStorageRoot {
-    /// Creates a storage accumulator from serialized state.
+impl LatticeRoot {
+    /// Creates an accumulator from serialized state.
     pub fn from_state(state: &LatticeHashState) -> Result<Self, &'static str> {
         Ok(Self { hash: state.to_hash()?, buf: Vec::new() })
     }
 
-    /// Adds a storage slot to the storage accumulator.
-    pub fn add_slot(&mut self, hashed_slot: B256, value: U256) {
-        encode_storage_slot(&mut self.buf, hashed_slot, value);
+    /// Adds an account element to the accumulator.
+    pub fn add_account(&mut self, hashed_address: B256, account: Account) {
+        encode_account(&mut self.buf, hashed_address, account);
         self.hash.add(&self.buf);
     }
 
-    /// Subtracts a storage slot from the storage accumulator.
-    pub fn subtract_slot(&mut self, hashed_slot: B256, value: U256) {
-        encode_storage_slot(&mut self.buf, hashed_slot, value);
+    /// Subtracts an account element from the accumulator.
+    pub fn subtract_account(&mut self, hashed_address: B256, account: Account) {
+        encode_account(&mut self.buf, hashed_address, account);
         self.hash.subtract(&self.buf);
     }
 
-    /// Resets the storage accumulator to the empty state.
-    pub const fn reset(&mut self) {
-        self.hash.reset();
-    }
-
-    /// Returns true if the accumulator is in its zero state.
-    pub fn is_zero(&self) -> bool {
-        self.hash.is_zero()
-    }
-
-    /// Returns the full serialized LtHash state.
-    pub fn state(&self) -> LatticeHashState {
-        LatticeHashState::from_hash(&self.hash)
-    }
-
-    /// Returns the checksum root for the accumulated storage slots.
-    pub fn root(&self) -> B256 {
-        checksum(&self.hash)
-    }
-}
-
-/// LtHash accumulator for the global account state.
-#[derive(Clone, Debug, Default)]
-pub struct LatticeStateRoot {
-    hash: LtHash,
-    buf: Vec<u8>,
-}
-
-impl LatticeStateRoot {
-    /// Creates a state accumulator from serialized state.
-    pub fn from_state(state: &LatticeHashState) -> Result<Self, &'static str> {
-        Ok(Self { hash: state.to_hash()?, buf: Vec::new() })
-    }
-
-    /// Adds an account to the global state accumulator.
-    pub fn add_account(&mut self, hashed_address: B256, account: Account, storage_root: B256) {
-        encode_account(&mut self.buf, hashed_address, account, storage_root);
+    /// Adds a storage slot element to the accumulator.
+    pub fn add_slot(&mut self, hashed_address: B256, hashed_slot: B256, value: U256) {
+        encode_storage_slot(&mut self.buf, hashed_address, hashed_slot, value);
         self.hash.add(&self.buf);
     }
 
-    /// Subtracts an account from the global state accumulator.
-    pub fn subtract_account(&mut self, hashed_address: B256, account: Account, storage_root: B256) {
-        encode_account(&mut self.buf, hashed_address, account, storage_root);
+    /// Subtracts a storage slot element from the accumulator.
+    pub fn subtract_slot(&mut self, hashed_address: B256, hashed_slot: B256, value: U256) {
+        encode_storage_slot(&mut self.buf, hashed_address, hashed_slot, value);
         self.hash.subtract(&self.buf);
     }
 
@@ -181,23 +144,23 @@ impl LatticeStateRoot {
     }
 }
 
-fn encode_storage_slot(buf: &mut Vec<u8>, hashed_slot: B256, value: U256) {
+fn encode_storage_slot(buf: &mut Vec<u8>, hashed_address: B256, hashed_slot: B256, value: U256) {
     buf.clear();
-    buf.reserve(1 + 32 + 32);
+    buf.reserve(1 + 32 + 32 + 32);
     buf.push(STORAGE_SLOT_DOMAIN);
+    buf.extend_from_slice(hashed_address.as_slice());
     buf.extend_from_slice(hashed_slot.as_slice());
     buf.extend_from_slice(&value.to_be_bytes::<32>());
 }
 
-fn encode_account(buf: &mut Vec<u8>, hashed_address: B256, account: Account, storage_root: B256) {
+fn encode_account(buf: &mut Vec<u8>, hashed_address: B256, account: Account) {
     buf.clear();
-    buf.reserve(1 + 32 + 8 + 32 + 32 + 32);
+    buf.reserve(1 + 32 + 8 + 32 + 32);
     buf.push(ACCOUNT_DOMAIN);
     buf.extend_from_slice(hashed_address.as_slice());
     buf.extend_from_slice(&account.nonce.to_be_bytes());
     buf.extend_from_slice(&account.balance.to_be_bytes::<32>());
     buf.extend_from_slice(account.bytecode_hash.unwrap_or(KECCAK_EMPTY).as_slice());
-    buf.extend_from_slice(storage_root.as_slice());
 }
 
 fn checksum(hash: &LtHash) -> B256 {
@@ -211,11 +174,11 @@ mod tests {
 
     #[test]
     fn lthash_state_roundtrip() {
-        let mut root = LatticeStorageRoot::default();
-        root.add_slot(B256::with_last_byte(1), U256::from(2));
+        let mut root = LatticeRoot::default();
+        root.add_slot(B256::with_last_byte(1), B256::with_last_byte(2), U256::from(3));
 
         let state = root.state();
-        let restored = LatticeStorageRoot::from_state(&state).unwrap();
+        let restored = LatticeRoot::from_state(&state).unwrap();
 
         assert_eq!(state.as_slice().len(), LATTICE_HASH_STATE_BYTES);
         assert_eq!(root.root(), restored.root());
@@ -226,15 +189,15 @@ mod tests {
         let slot = B256::with_last_byte(1);
         let value = U256::from(2);
 
-        let mut root = LatticeStorageRoot::default();
+        let hashed_address = B256::with_last_byte(7);
+        let mut root = LatticeRoot::default();
         let empty = root.root();
 
-        root.add_slot(slot, value);
+        root.add_slot(hashed_address, slot, value);
         assert_ne!(root.root(), empty);
 
-        root.subtract_slot(slot, value);
+        root.subtract_slot(hashed_address, slot, value);
         assert_eq!(root.root(), empty);
-        assert!(root.is_zero());
     }
 
     #[test]
@@ -245,15 +208,13 @@ mod tests {
             bytecode_hash: Some(B256::with_last_byte(3)),
         };
         let hashed_address = B256::with_last_byte(4);
-        let storage_root = B256::with_last_byte(5);
-
-        let mut root = LatticeStateRoot::default();
+        let mut root = LatticeRoot::default();
         let empty = root.root();
 
-        root.add_account(hashed_address, account, storage_root);
+        root.add_account(hashed_address, account);
         assert_ne!(root.root(), empty);
 
-        root.subtract_account(hashed_address, account, storage_root);
+        root.subtract_account(hashed_address, account);
         assert_eq!(root.root(), empty);
     }
 }

--- a/crates/trie/common/src/lattice.rs
+++ b/crates/trie/common/src/lattice.rs
@@ -1,0 +1,65 @@
+//! Commonware LtHash state root helpers.
+
+use alloc::vec::Vec;
+use alloy_consensus::constants::KECCAK_EMPTY;
+use alloy_primitives::{B256, U256};
+use commonware_cryptography::lthash::LtHash;
+use reth_primitives_traits::Account;
+
+const STORAGE_SLOT_DOMAIN: u8 = 0;
+const ACCOUNT_DOMAIN: u8 = 1;
+
+/// LtHash accumulator for one account's storage slots.
+#[derive(Debug, Default)]
+pub struct LatticeStorageRoot {
+    hash: LtHash,
+    buf: Vec<u8>,
+}
+
+impl LatticeStorageRoot {
+    /// Adds a storage slot to the storage accumulator.
+    pub fn add_slot(&mut self, hashed_slot: B256, value: U256) {
+        self.buf.clear();
+        self.buf.reserve(1 + 32 + 32);
+        self.buf.push(STORAGE_SLOT_DOMAIN);
+        self.buf.extend_from_slice(hashed_slot.as_slice());
+        self.buf.extend_from_slice(&value.to_be_bytes::<32>());
+        self.hash.add(&self.buf);
+    }
+
+    /// Returns the checksum root for the accumulated storage slots.
+    pub fn root(&self) -> B256 {
+        checksum(&self.hash)
+    }
+}
+
+/// LtHash accumulator for the global account state.
+#[derive(Debug, Default)]
+pub struct LatticeStateRoot {
+    hash: LtHash,
+    buf: Vec<u8>,
+}
+
+impl LatticeStateRoot {
+    /// Adds an account to the global state accumulator.
+    pub fn add_account(&mut self, hashed_address: B256, account: Account, storage_root: B256) {
+        self.buf.clear();
+        self.buf.reserve(1 + 32 + 8 + 32 + 32 + 32);
+        self.buf.push(ACCOUNT_DOMAIN);
+        self.buf.extend_from_slice(hashed_address.as_slice());
+        self.buf.extend_from_slice(&account.nonce.to_be_bytes());
+        self.buf.extend_from_slice(&account.balance.to_be_bytes::<32>());
+        self.buf.extend_from_slice(account.bytecode_hash.unwrap_or(KECCAK_EMPTY).as_slice());
+        self.buf.extend_from_slice(storage_root.as_slice());
+        self.hash.add(&self.buf);
+    }
+
+    /// Returns the checksum root for the accumulated accounts.
+    pub fn root(&self) -> B256 {
+        checksum(&self.hash)
+    }
+}
+
+fn checksum(hash: &LtHash) -> B256 {
+    B256::from(hash.checksum().0)
+}

--- a/crates/trie/common/src/lattice.rs
+++ b/crates/trie/common/src/lattice.rs
@@ -2,29 +2,141 @@
 
 use alloc::vec::Vec;
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{map::B256Map, B256, U256};
+use commonware_codec::{FixedSize, Read, Write};
 use commonware_cryptography::lthash::LtHash;
 use reth_primitives_traits::Account;
 
 const STORAGE_SLOT_DOMAIN: u8 = 0;
 const ACCOUNT_DOMAIN: u8 = 1;
 
+/// Size in bytes of a serialized Commonware LtHash accumulator.
+pub const LATTICE_HASH_STATE_BYTES: usize = <LtHash as FixedSize>::SIZE;
+
+/// Serialized Commonware LtHash accumulator state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LatticeHashState([u8; LATTICE_HASH_STATE_BYTES]);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for LatticeHashState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(self.as_slice())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LatticeHashState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes = <Vec<u8> as serde::Deserialize<'de>>::deserialize(deserializer)?;
+        Self::from_slice(&bytes).map_err(serde::de::Error::custom)
+    }
+}
+
+impl LatticeHashState {
+    /// Creates a lattice hash state from raw bytes.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, &'static str> {
+        let state = bytes.try_into().map_err(|_| "invalid lattice hash state length")?;
+        Ok(Self(state))
+    }
+
+    /// Returns the encoded LtHash bytes.
+    pub const fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Converts the state into an owned byte vector.
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0.into()
+    }
+
+    /// Reads the Commonware LtHash accumulator represented by this state.
+    pub fn to_hash(&self) -> Result<LtHash, &'static str> {
+        let mut bytes = self.as_slice();
+        LtHash::read_cfg(&mut bytes, &()).map_err(|_| "invalid lattice hash state")
+    }
+
+    /// Creates a serialized state from a Commonware LtHash accumulator.
+    pub fn from_hash(hash: &LtHash) -> Self {
+        let mut bytes = Vec::with_capacity(LATTICE_HASH_STATE_BYTES);
+        hash.write(&mut bytes);
+        debug_assert_eq!(bytes.len(), LATTICE_HASH_STATE_BYTES);
+        Self::from_slice(&bytes).expect("LtHash writes fixed-size state")
+    }
+}
+
+impl Default for LatticeHashState {
+    fn default() -> Self {
+        Self::from_hash(&LtHash::default())
+    }
+}
+
+/// Lattice accumulator state that should be persisted after a block is canonicalized.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LatticeAccumulatorUpdates {
+    /// Final global account-state accumulator.
+    pub state: LatticeHashState,
+    /// Final per-account storage accumulators. `None` removes an empty storage accumulator.
+    pub storage: B256Map<Option<LatticeHashState>>,
+}
+
+impl LatticeAccumulatorUpdates {
+    /// Creates new accumulator updates.
+    pub const fn new(state: LatticeHashState, storage: B256Map<Option<LatticeHashState>>) -> Self {
+        Self { state, storage }
+    }
+
+    /// Returns true if this update only contains the zero global accumulator and no storage
+    /// changes.
+    pub fn is_empty(&self) -> bool {
+        self.state == LatticeHashState::default() && self.storage.is_empty()
+    }
+}
+
 /// LtHash accumulator for one account's storage slots.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct LatticeStorageRoot {
     hash: LtHash,
     buf: Vec<u8>,
 }
 
 impl LatticeStorageRoot {
+    /// Creates a storage accumulator from serialized state.
+    pub fn from_state(state: &LatticeHashState) -> Result<Self, &'static str> {
+        Ok(Self { hash: state.to_hash()?, buf: Vec::new() })
+    }
+
     /// Adds a storage slot to the storage accumulator.
     pub fn add_slot(&mut self, hashed_slot: B256, value: U256) {
-        self.buf.clear();
-        self.buf.reserve(1 + 32 + 32);
-        self.buf.push(STORAGE_SLOT_DOMAIN);
-        self.buf.extend_from_slice(hashed_slot.as_slice());
-        self.buf.extend_from_slice(&value.to_be_bytes::<32>());
+        encode_storage_slot(&mut self.buf, hashed_slot, value);
         self.hash.add(&self.buf);
+    }
+
+    /// Subtracts a storage slot from the storage accumulator.
+    pub fn subtract_slot(&mut self, hashed_slot: B256, value: U256) {
+        encode_storage_slot(&mut self.buf, hashed_slot, value);
+        self.hash.subtract(&self.buf);
+    }
+
+    /// Resets the storage accumulator to the empty state.
+    pub const fn reset(&mut self) {
+        self.hash.reset();
+    }
+
+    /// Returns true if the accumulator is in its zero state.
+    pub fn is_zero(&self) -> bool {
+        self.hash.is_zero()
+    }
+
+    /// Returns the full serialized LtHash state.
+    pub fn state(&self) -> LatticeHashState {
+        LatticeHashState::from_hash(&self.hash)
     }
 
     /// Returns the checksum root for the accumulated storage slots.
@@ -34,24 +146,33 @@ impl LatticeStorageRoot {
 }
 
 /// LtHash accumulator for the global account state.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct LatticeStateRoot {
     hash: LtHash,
     buf: Vec<u8>,
 }
 
 impl LatticeStateRoot {
+    /// Creates a state accumulator from serialized state.
+    pub fn from_state(state: &LatticeHashState) -> Result<Self, &'static str> {
+        Ok(Self { hash: state.to_hash()?, buf: Vec::new() })
+    }
+
     /// Adds an account to the global state accumulator.
     pub fn add_account(&mut self, hashed_address: B256, account: Account, storage_root: B256) {
-        self.buf.clear();
-        self.buf.reserve(1 + 32 + 8 + 32 + 32 + 32);
-        self.buf.push(ACCOUNT_DOMAIN);
-        self.buf.extend_from_slice(hashed_address.as_slice());
-        self.buf.extend_from_slice(&account.nonce.to_be_bytes());
-        self.buf.extend_from_slice(&account.balance.to_be_bytes::<32>());
-        self.buf.extend_from_slice(account.bytecode_hash.unwrap_or(KECCAK_EMPTY).as_slice());
-        self.buf.extend_from_slice(storage_root.as_slice());
+        encode_account(&mut self.buf, hashed_address, account, storage_root);
         self.hash.add(&self.buf);
+    }
+
+    /// Subtracts an account from the global state accumulator.
+    pub fn subtract_account(&mut self, hashed_address: B256, account: Account, storage_root: B256) {
+        encode_account(&mut self.buf, hashed_address, account, storage_root);
+        self.hash.subtract(&self.buf);
+    }
+
+    /// Returns the full serialized LtHash state.
+    pub fn state(&self) -> LatticeHashState {
+        LatticeHashState::from_hash(&self.hash)
     }
 
     /// Returns the checksum root for the accumulated accounts.
@@ -60,6 +181,79 @@ impl LatticeStateRoot {
     }
 }
 
+fn encode_storage_slot(buf: &mut Vec<u8>, hashed_slot: B256, value: U256) {
+    buf.clear();
+    buf.reserve(1 + 32 + 32);
+    buf.push(STORAGE_SLOT_DOMAIN);
+    buf.extend_from_slice(hashed_slot.as_slice());
+    buf.extend_from_slice(&value.to_be_bytes::<32>());
+}
+
+fn encode_account(buf: &mut Vec<u8>, hashed_address: B256, account: Account, storage_root: B256) {
+    buf.clear();
+    buf.reserve(1 + 32 + 8 + 32 + 32 + 32);
+    buf.push(ACCOUNT_DOMAIN);
+    buf.extend_from_slice(hashed_address.as_slice());
+    buf.extend_from_slice(&account.nonce.to_be_bytes());
+    buf.extend_from_slice(&account.balance.to_be_bytes::<32>());
+    buf.extend_from_slice(account.bytecode_hash.unwrap_or(KECCAK_EMPTY).as_slice());
+    buf.extend_from_slice(storage_root.as_slice());
+}
+
 fn checksum(hash: &LtHash) -> B256 {
     B256::from(hash.checksum().0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+
+    #[test]
+    fn lthash_state_roundtrip() {
+        let mut root = LatticeStorageRoot::default();
+        root.add_slot(B256::with_last_byte(1), U256::from(2));
+
+        let state = root.state();
+        let restored = LatticeStorageRoot::from_state(&state).unwrap();
+
+        assert_eq!(state.as_slice().len(), LATTICE_HASH_STATE_BYTES);
+        assert_eq!(root.root(), restored.root());
+    }
+
+    #[test]
+    fn storage_add_subtract_inverse() {
+        let slot = B256::with_last_byte(1);
+        let value = U256::from(2);
+
+        let mut root = LatticeStorageRoot::default();
+        let empty = root.root();
+
+        root.add_slot(slot, value);
+        assert_ne!(root.root(), empty);
+
+        root.subtract_slot(slot, value);
+        assert_eq!(root.root(), empty);
+        assert!(root.is_zero());
+    }
+
+    #[test]
+    fn account_add_subtract_inverse() {
+        let account = Account {
+            nonce: 1,
+            balance: U256::from(2),
+            bytecode_hash: Some(B256::with_last_byte(3)),
+        };
+        let hashed_address = B256::with_last_byte(4);
+        let storage_root = B256::with_last_byte(5);
+
+        let mut root = LatticeStateRoot::default();
+        let empty = root.root();
+
+        root.add_account(hashed_address, account, storage_root);
+        assert_ne!(root.root(), empty);
+
+        root.subtract_account(hashed_address, account, storage_root);
+        assert_eq!(root.root(), empty);
+    }
 }

--- a/crates/trie/common/src/lazy.rs
+++ b/crates/trie/common/src/lazy.rs
@@ -39,7 +39,6 @@ impl SortedTrieData {
             #[cfg(feature = "lattice-state-root")]
             lattice_accumulator_updates: Arc::new(LatticeAccumulatorUpdates {
                 state: crate::lattice::LatticeHashState::default(),
-                storage: alloy_primitives::map::B256Map::default(),
             }),
         }
     }

--- a/crates/trie/common/src/lazy.rs
+++ b/crates/trie/common/src/lazy.rs
@@ -3,6 +3,8 @@
 //! Provides a no-std compatible [`LazyTrieData`] type for lazily initialized
 //! trie-related data containing sorted hashed state and trie updates.
 
+#[cfg(feature = "lattice-state-root")]
+use crate::lattice::LatticeAccumulatorUpdates;
 use crate::{updates::TrieUpdatesSorted, HashedPostStateSorted};
 use alloc::sync::Arc;
 use core::fmt;
@@ -19,15 +21,37 @@ pub struct SortedTrieData {
     pub hashed_state: Arc<HashedPostStateSorted>,
     /// Sorted trie updates produced by state root computation.
     pub trie_updates: Arc<TrieUpdatesSorted>,
+    /// Lattice accumulator updates produced by lattice state root computation.
+    #[cfg(feature = "lattice-state-root")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
 }
 
 impl SortedTrieData {
     /// Creates a new [`SortedTrieData`] with the given values.
-    pub const fn new(
+    pub fn new(
         hashed_state: Arc<HashedPostStateSorted>,
         trie_updates: Arc<TrieUpdatesSorted>,
     ) -> Self {
-        Self { hashed_state, trie_updates }
+        Self {
+            hashed_state,
+            trie_updates,
+            #[cfg(feature = "lattice-state-root")]
+            lattice_accumulator_updates: Arc::new(LatticeAccumulatorUpdates {
+                state: crate::lattice::LatticeHashState::default(),
+                storage: alloy_primitives::map::B256Map::default(),
+            }),
+        }
+    }
+
+    /// Creates a new [`SortedTrieData`] with lattice accumulator updates.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn new_with_lattice(
+        hashed_state: Arc<HashedPostStateSorted>,
+        trie_updates: Arc<TrieUpdatesSorted>,
+        lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
+    ) -> Self {
+        Self { hashed_state, trie_updates, lattice_accumulator_updates }
     }
 }
 
@@ -81,6 +105,22 @@ impl LazyTrieData {
         Self { data: Arc::new(data), compute: None }
     }
 
+    /// Creates a new [`LazyTrieData`] that is already initialized with lattice updates.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn ready_with_lattice(
+        hashed_state: Arc<HashedPostStateSorted>,
+        trie_updates: Arc<TrieUpdatesSorted>,
+        lattice_accumulator_updates: Arc<LatticeAccumulatorUpdates>,
+    ) -> Self {
+        let data = OnceLock::new();
+        let _ = data.set(SortedTrieData::new_with_lattice(
+            hashed_state,
+            trie_updates,
+            lattice_accumulator_updates,
+        ));
+        Self { data: Arc::new(data), compute: None }
+    }
+
     /// Creates a new [`LazyTrieData`] from pre-computed [`SortedTrieData`].
     pub fn from_sorted(sorted: SortedTrieData) -> Self {
         let data = OnceLock::new();
@@ -119,6 +159,12 @@ impl LazyTrieData {
     /// If not initialized, computes from the deferred source or panics.
     pub fn trie_updates(&self) -> Arc<TrieUpdatesSorted> {
         Arc::clone(&self.get().trie_updates)
+    }
+
+    /// Returns a clone of the lattice accumulator updates Arc.
+    #[cfg(feature = "lattice-state-root")]
+    pub fn lattice_accumulator_updates(&self) -> Arc<LatticeAccumulatorUpdates> {
+        Arc::clone(&self.get().lattice_accumulator_updates)
     }
 
     /// Returns a clone of the [`SortedTrieData`].

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -36,6 +36,10 @@ pub use constants::*;
 mod account;
 pub use account::TrieAccount;
 
+/// Lattice hash based state root utilities.
+#[cfg(feature = "lattice-state-root")]
+pub mod lattice;
+
 /// V2 proof targets and chunking.
 pub mod target_v2;
 pub use target_v2::{ChunkedMultiProofTargetsV2, MultiProofTargetsV2, ProofV2Target};

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -60,6 +60,7 @@ similar-asserts.workspace = true
 
 [features]
 metrics = ["reth-trie/metrics", "dep:reth-metrics", "dep:metrics"]
+lattice-state-root = ["reth-trie/lattice-state-root"]
 serde = [
     "similar-asserts/serde",
     "alloy-consensus/serde",

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -65,6 +65,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["metrics"]
+lattice-state-root = ["reth-trie/lattice-state-root"]
 metrics = ["reth-metrics", "dep:metrics", "reth-trie/metrics"]
 trie-debug = [
     "dep:rand",

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -4,6 +4,8 @@ use crate::root::ParallelStateRootError;
 use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{keccak256, B256};
 use derive_more::derive::Deref;
+#[cfg(feature = "lattice-state-root")]
+use reth_trie::lattice::LatticeAccumulatorUpdates;
 use reth_trie::{updates::TrieUpdates, HashedPostState, HashedStorage, MultiProofTargetsV2};
 use revm_state::EvmState;
 use std::sync::Arc;
@@ -44,6 +46,26 @@ pub struct StateRootComputeOutcome {
     pub debug_recorders: Vec<(Option<B256>, reth_trie_sparse::debug_recorder::TrieDebugRecorder)>,
 }
 
+/// Messages used internally by the lattice root task.
+#[cfg(feature = "lattice-state-root")]
+#[derive(Debug)]
+pub enum LatticeRootMessage {
+    /// New state update from transaction execution.
+    StateUpdate(EvmState),
+    /// Signals state update stream end.
+    FinishedStateUpdates,
+}
+
+/// Outcome of the lattice root computation.
+#[cfg(feature = "lattice-state-root")]
+#[derive(Debug, Clone)]
+pub struct LatticeRootComputeOutcome {
+    /// The lattice state root checksum used as the header state root.
+    pub state_root: B256,
+    /// Full accumulator states to persist after the block is canonicalized.
+    pub accumulator_updates: Arc<LatticeAccumulatorUpdates>,
+}
+
 /// Handle to a background sparse trie state root computation.
 ///
 /// Used by both the engine (during `newPayload`) and the payload builder (during `FCU`-triggered
@@ -62,6 +84,60 @@ pub struct StateRootHandle {
         Option<std::sync::mpsc::Receiver<Result<StateRootComputeOutcome, ParallelStateRootError>>>,
     /// Receiver for the hashed post state.
     hashed_state_rx: Option<std::sync::mpsc::Receiver<HashedPostState>>,
+}
+
+/// Handle to a background lattice state root computation.
+#[cfg(feature = "lattice-state-root")]
+#[derive(Debug)]
+pub struct LatticeRootHandle {
+    /// Channel for streaming state updates into the lattice accumulator pipeline.
+    updates_tx: crossbeam_channel::Sender<LatticeRootMessage>,
+    /// Receiver for the final lattice root result.
+    lattice_root_rx: Option<
+        std::sync::mpsc::Receiver<Result<LatticeRootComputeOutcome, ParallelStateRootError>>,
+    >,
+}
+
+#[cfg(feature = "lattice-state-root")]
+impl LatticeRootHandle {
+    /// Creates a new [`LatticeRootHandle`].
+    pub const fn new(
+        updates_tx: crossbeam_channel::Sender<LatticeRootMessage>,
+        lattice_root_rx: std::sync::mpsc::Receiver<
+            Result<LatticeRootComputeOutcome, ParallelStateRootError>,
+        >,
+    ) -> Self {
+        Self { updates_tx, lattice_root_rx: Some(lattice_root_rx) }
+    }
+
+    /// Returns a reference to the updates sender channel.
+    pub const fn updates_tx(&self) -> &crossbeam_channel::Sender<LatticeRootMessage> {
+        &self.updates_tx
+    }
+
+    /// Returns a state hook that streams state updates to the background lattice task.
+    ///
+    /// The hook must be dropped after execution completes to signal the end of state updates.
+    pub fn state_hook(&self) -> impl alloy_evm::block::OnStateHook {
+        let sender = LatticeStateHookSender::new(self.updates_tx.clone());
+
+        move |state: &EvmState| {
+            let _ = sender.send(LatticeRootMessage::StateUpdate(state.clone()));
+        }
+    }
+
+    /// Awaits the lattice root computation result.
+    ///
+    /// # Panics
+    ///
+    /// If called more than once.
+    pub fn lattice_root(&mut self) -> Result<LatticeRootComputeOutcome, ParallelStateRootError> {
+        self.lattice_root_rx
+            .take()
+            .expect("lattice_root already taken")
+            .recv()
+            .map_err(|_| ParallelStateRootError::Other("lattice root task dropped".to_string()))?
+    }
 }
 
 impl StateRootHandle {
@@ -134,6 +210,26 @@ impl StateRootHandle {
     /// If called more than once.
     pub const fn take_hashed_state_rx(&mut self) -> std::sync::mpsc::Receiver<HashedPostState> {
         self.hashed_state_rx.take().expect("hashed_state already taken")
+    }
+}
+
+/// A wrapper for the lattice sender that signals completion when dropped.
+#[cfg(feature = "lattice-state-root")]
+#[derive(Deref, Debug)]
+pub struct LatticeStateHookSender(crossbeam_channel::Sender<LatticeRootMessage>);
+
+#[cfg(feature = "lattice-state-root")]
+impl LatticeStateHookSender {
+    /// Creates a new [`LatticeStateHookSender`] wrapping the given channel sender.
+    pub const fn new(inner: crossbeam_channel::Sender<LatticeRootMessage>) -> Self {
+        Self(inner)
+    }
+}
+
+#[cfg(feature = "lattice-state-root")]
+impl Drop for LatticeStateHookSender {
+    fn drop(&mut self) {
+        let _ = self.0.send(LatticeRootMessage::FinishedStateUpdates);
     }
 }
 

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -67,6 +67,7 @@ rand.workspace = true
 
 [features]
 metrics = ["reth-metrics", "dep:metrics"]
+lattice-state-root = ["reth-trie-common/lattice-state-root"]
 serde = [
     "alloy-primitives/serde",
     "alloy-consensus/serde",

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -19,7 +19,7 @@ use alloy_trie::proof::AddedRemovedKeys;
 use reth_execution_errors::{StateRootError, StorageRootError};
 use reth_primitives_traits::Account;
 #[cfg(feature = "lattice-state-root")]
-use reth_trie_common::lattice::{LatticeStateRoot, LatticeStorageRoot};
+use reth_trie_common::lattice::LatticeRoot;
 use tracing::{debug, instrument, trace, Span};
 
 /// The default updates after which root algorithms should return intermediate progress rather than
@@ -372,7 +372,7 @@ fn lattice_root<H>(hashed_cursor_factory: &H) -> Result<(B256, usize), StateRoot
 where
     H: HashedCursorFactory,
 {
-    let mut state_root = LatticeStateRoot::default();
+    let mut lattice_root = LatticeRoot::default();
     let mut hashed_entries_walked = 0;
 
     let mut account_cursor = hashed_cursor_factory.hashed_account_cursor()?;
@@ -380,22 +380,22 @@ where
     while let Some((hashed_address, account)) = account_entry {
         hashed_entries_walked += 1;
 
-        let mut storage_root = LatticeStorageRoot::default();
+        lattice_root.add_account(hashed_address, account);
+
         let mut storage_cursor = hashed_cursor_factory.hashed_storage_cursor(hashed_address)?;
         let mut storage_entry = storage_cursor.seek(B256::ZERO)?;
         while let Some((hashed_slot, value)) = storage_entry {
             hashed_entries_walked += 1;
             if !value.is_zero() {
-                storage_root.add_slot(hashed_slot, value);
+                lattice_root.add_slot(hashed_address, hashed_slot, value);
             }
             storage_entry = storage_cursor.next()?;
         }
 
-        state_root.add_account(hashed_address, account, storage_root.root());
         account_entry = account_cursor.next()?;
     }
 
-    Ok((state_root.root(), hashed_entries_walked))
+    Ok((lattice_root.root(), hashed_entries_walked))
 }
 
 /// Contains state mutated during state root calculation and storage root result handling.

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -18,6 +18,8 @@ use alloy_rlp::{BufMut, Encodable};
 use alloy_trie::proof::AddedRemovedKeys;
 use reth_execution_errors::{StateRootError, StorageRootError};
 use reth_primitives_traits::Account;
+#[cfg(feature = "lattice-state-root")]
+use reth_trie_common::lattice::{LatticeStateRoot, LatticeStorageRoot};
 use tracing::{debug, instrument, trace, Span};
 
 /// The default updates after which root algorithms should return intermediate progress rather than
@@ -128,9 +130,22 @@ where
     ///
     /// The state root and the trie updates.
     pub fn root_with_updates(self) -> Result<(B256, TrieUpdates), StateRootError> {
-        match self.with_no_threshold().calculate(true)? {
-            StateRootProgress::Complete(root, _, updates) => Ok((root, updates)),
-            StateRootProgress::Progress(..) => unreachable!(), // unreachable threshold
+        #[cfg(feature = "lattice-state-root")]
+        {
+            let (lattice_root, _) = lattice_root(&self.hashed_cursor_factory)?;
+            let updates = match self.with_no_threshold().calculate(true)? {
+                StateRootProgress::Complete(_, _, updates) => updates,
+                StateRootProgress::Progress(..) => unreachable!(), // unreachable threshold
+            };
+            Ok((lattice_root, updates))
+        }
+
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            match self.with_no_threshold().calculate(true)? {
+                StateRootProgress::Complete(root, _, updates) => Ok((root, updates)),
+                StateRootProgress::Progress(..) => unreachable!(), // unreachable threshold
+            }
         }
     }
 
@@ -141,9 +156,17 @@ where
     ///
     /// The state root hash.
     pub fn root(self) -> Result<B256, StateRootError> {
-        match self.calculate(false)? {
-            StateRootProgress::Complete(root, _, _) => Ok(root),
-            StateRootProgress::Progress(..) => unreachable!(), // update retention is disabled
+        #[cfg(feature = "lattice-state-root")]
+        {
+            lattice_root(&self.hashed_cursor_factory).map(|(root, _)| root)
+        }
+
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            match self.calculate(false)? {
+                StateRootProgress::Complete(root, _, _) => Ok(root),
+                StateRootProgress::Progress(..) => unreachable!(), // update retention is disabled
+            }
         }
     }
 
@@ -154,7 +177,21 @@ where
     ///
     /// The intermediate progress of state root computation.
     pub fn root_with_progress(self) -> Result<StateRootProgress, StateRootError> {
-        self.calculate(true)
+        #[cfg(feature = "lattice-state-root")]
+        {
+            let (lattice_root, _) = lattice_root(&self.hashed_cursor_factory)?;
+            match self.with_no_threshold().calculate(true)? {
+                StateRootProgress::Complete(_, walked, updates) => {
+                    Ok(StateRootProgress::Complete(lattice_root, walked, updates))
+                }
+                StateRootProgress::Progress(..) => unreachable!(), // unreachable threshold
+            }
+        }
+
+        #[cfg(not(feature = "lattice-state-root"))]
+        {
+            self.calculate(true)
+        }
     }
 
     fn calculate(self, retain_updates: bool) -> Result<StateRootProgress, StateRootError> {
@@ -328,6 +365,37 @@ where
 
         Ok(StateRootProgress::Complete(root, hashed_entries_walked, trie_updates))
     }
+}
+
+#[cfg(feature = "lattice-state-root")]
+fn lattice_root<H>(hashed_cursor_factory: &H) -> Result<(B256, usize), StateRootError>
+where
+    H: HashedCursorFactory,
+{
+    let mut state_root = LatticeStateRoot::default();
+    let mut hashed_entries_walked = 0;
+
+    let mut account_cursor = hashed_cursor_factory.hashed_account_cursor()?;
+    let mut account_entry = account_cursor.seek(B256::ZERO)?;
+    while let Some((hashed_address, account)) = account_entry {
+        hashed_entries_walked += 1;
+
+        let mut storage_root = LatticeStorageRoot::default();
+        let mut storage_cursor = hashed_cursor_factory.hashed_storage_cursor(hashed_address)?;
+        let mut storage_entry = storage_cursor.seek(B256::ZERO)?;
+        while let Some((hashed_slot, value)) = storage_entry {
+            hashed_entries_walked += 1;
+            if !value.is_zero() {
+                storage_root.add_slot(hashed_slot, value);
+            }
+            storage_entry = storage_cursor.next()?;
+        }
+
+        state_root.add_account(hashed_address, account, storage_root.root());
+        account_entry = account_cursor.next()?;
+    }
+
+    Ok((state_root.root(), hashed_entries_walked))
 }
 
 /// Contains state mutated during state root calculation and storage root result handling.

--- a/crates/trie/trie/tests/lattice.rs
+++ b/crates/trie/trie/tests/lattice.rs
@@ -4,17 +4,15 @@
 
 use alloy_primitives::{B256, U256};
 use reth_primitives_traits::Account;
-use reth_trie::lattice::{
-    LatticeHashState, LatticeStateRoot, LatticeStorageRoot, LATTICE_HASH_STATE_BYTES,
-};
+use reth_trie::lattice::{LatticeHashState, LatticeRoot, LATTICE_HASH_STATE_BYTES};
 
 #[test]
 fn lattice_hash_state_roundtrip() {
-    let mut root = LatticeStorageRoot::default();
-    root.add_slot(B256::with_last_byte(1), U256::from(2));
+    let mut root = LatticeRoot::default();
+    root.add_slot(B256::with_last_byte(1), B256::with_last_byte(2), U256::from(3));
 
     let state = root.state();
-    let restored = LatticeStorageRoot::from_state(&state).unwrap();
+    let restored = LatticeRoot::from_state(&state).unwrap();
 
     assert_eq!(state.as_slice().len(), LATTICE_HASH_STATE_BYTES);
     assert_eq!(root.root(), restored.root());
@@ -23,18 +21,18 @@ fn lattice_hash_state_roundtrip() {
 
 #[test]
 fn lattice_storage_add_subtract_inverse() {
+    let hashed_address = B256::with_last_byte(9);
     let slot = B256::with_last_byte(1);
     let value = U256::from(2);
 
-    let mut root = LatticeStorageRoot::default();
+    let mut root = LatticeRoot::default();
     let empty = root.root();
 
-    root.add_slot(slot, value);
+    root.add_slot(hashed_address, slot, value);
     assert_ne!(root.root(), empty);
 
-    root.subtract_slot(slot, value);
+    root.subtract_slot(hashed_address, slot, value);
     assert_eq!(root.root(), empty);
-    assert!(root.is_zero());
 }
 
 #[test]
@@ -42,50 +40,45 @@ fn lattice_account_add_subtract_inverse() {
     let account =
         Account { nonce: 1, balance: U256::from(2), bytecode_hash: Some(B256::with_last_byte(3)) };
     let hashed_address = B256::with_last_byte(4);
-    let storage_root = B256::with_last_byte(5);
 
-    let mut root = LatticeStateRoot::default();
+    let mut root = LatticeRoot::default();
     let empty = root.root();
 
-    root.add_account(hashed_address, account, storage_root);
+    root.add_account(hashed_address, account);
     assert_ne!(root.root(), empty);
 
-    root.subtract_account(hashed_address, account, storage_root);
+    root.subtract_account(hashed_address, account);
     assert_eq!(root.root(), empty);
 }
 
 #[test]
-fn lattice_storage_root_is_order_independent() {
+fn lattice_flat_root_is_order_independent() {
+    let hashed_address = B256::with_last_byte(9);
     let slot_a = B256::with_last_byte(1);
     let slot_b = B256::with_last_byte(2);
 
-    let mut first = LatticeStorageRoot::default();
-    first.add_slot(slot_a, U256::from(1));
-    first.add_slot(slot_b, U256::from(2));
+    let mut first = LatticeRoot::default();
+    first.add_slot(hashed_address, slot_a, U256::from(1));
+    first.add_slot(hashed_address, slot_b, U256::from(2));
 
-    let mut second = LatticeStorageRoot::default();
-    second.add_slot(slot_b, U256::from(2));
-    second.add_slot(slot_a, U256::from(1));
+    let mut second = LatticeRoot::default();
+    second.add_slot(hashed_address, slot_b, U256::from(2));
+    second.add_slot(hashed_address, slot_a, U256::from(1));
 
     assert_eq!(first.root(), second.root());
 }
 
 #[test]
-fn lattice_state_root_includes_nested_storage_root() {
+fn lattice_flat_root_includes_address_in_storage_element() {
     let hashed_address = B256::with_last_byte(1);
-    let account = Account { nonce: 1, balance: U256::from(2), bytecode_hash: None };
+    let other_address = B256::with_last_byte(2);
+    let slot = B256::with_last_byte(3);
 
-    let mut storage_a = LatticeStorageRoot::default();
-    storage_a.add_slot(B256::with_last_byte(1), U256::from(1));
+    let mut first = LatticeRoot::default();
+    first.add_slot(hashed_address, slot, U256::from(1));
 
-    let mut storage_b = LatticeStorageRoot::default();
-    storage_b.add_slot(B256::with_last_byte(1), U256::from(2));
-
-    let mut first = LatticeStateRoot::default();
-    first.add_account(hashed_address, account, storage_a.root());
-
-    let mut second = LatticeStateRoot::default();
-    second.add_account(hashed_address, account, storage_b.root());
+    let mut second = LatticeRoot::default();
+    second.add_slot(other_address, slot, U256::from(1));
 
     assert_ne!(first.root(), second.root());
 }

--- a/crates/trie/trie/tests/lattice.rs
+++ b/crates/trie/trie/tests/lattice.rs
@@ -1,0 +1,43 @@
+//! Tests for the Commonware LtHash state root helpers.
+
+#![cfg(feature = "lattice-state-root")]
+
+use alloy_primitives::{B256, U256};
+use reth_primitives_traits::Account;
+use reth_trie::lattice::{LatticeStateRoot, LatticeStorageRoot};
+
+#[test]
+fn storage_root_is_order_independent() {
+    let slot_a = B256::with_last_byte(1);
+    let slot_b = B256::with_last_byte(2);
+
+    let mut first = LatticeStorageRoot::default();
+    first.add_slot(slot_a, U256::from(1));
+    first.add_slot(slot_b, U256::from(2));
+
+    let mut second = LatticeStorageRoot::default();
+    second.add_slot(slot_b, U256::from(2));
+    second.add_slot(slot_a, U256::from(1));
+
+    assert_eq!(first.root(), second.root());
+}
+
+#[test]
+fn state_root_includes_nested_storage_root() {
+    let hashed_address = B256::with_last_byte(1);
+    let account = Account { nonce: 1, balance: U256::from(2), bytecode_hash: None };
+
+    let mut storage_a = LatticeStorageRoot::default();
+    storage_a.add_slot(B256::with_last_byte(1), U256::from(1));
+
+    let mut storage_b = LatticeStorageRoot::default();
+    storage_b.add_slot(B256::with_last_byte(1), U256::from(2));
+
+    let mut first = LatticeStateRoot::default();
+    first.add_account(hashed_address, account, storage_a.root());
+
+    let mut second = LatticeStateRoot::default();
+    second.add_account(hashed_address, account, storage_b.root());
+
+    assert_ne!(first.root(), second.root());
+}

--- a/crates/trie/trie/tests/lattice.rs
+++ b/crates/trie/trie/tests/lattice.rs
@@ -4,10 +4,58 @@
 
 use alloy_primitives::{B256, U256};
 use reth_primitives_traits::Account;
-use reth_trie::lattice::{LatticeStateRoot, LatticeStorageRoot};
+use reth_trie::lattice::{
+    LatticeHashState, LatticeStateRoot, LatticeStorageRoot, LATTICE_HASH_STATE_BYTES,
+};
 
 #[test]
-fn storage_root_is_order_independent() {
+fn lattice_hash_state_roundtrip() {
+    let mut root = LatticeStorageRoot::default();
+    root.add_slot(B256::with_last_byte(1), U256::from(2));
+
+    let state = root.state();
+    let restored = LatticeStorageRoot::from_state(&state).unwrap();
+
+    assert_eq!(state.as_slice().len(), LATTICE_HASH_STATE_BYTES);
+    assert_eq!(root.root(), restored.root());
+    assert!(LatticeHashState::from_slice(state.as_slice()).is_ok());
+}
+
+#[test]
+fn lattice_storage_add_subtract_inverse() {
+    let slot = B256::with_last_byte(1);
+    let value = U256::from(2);
+
+    let mut root = LatticeStorageRoot::default();
+    let empty = root.root();
+
+    root.add_slot(slot, value);
+    assert_ne!(root.root(), empty);
+
+    root.subtract_slot(slot, value);
+    assert_eq!(root.root(), empty);
+    assert!(root.is_zero());
+}
+
+#[test]
+fn lattice_account_add_subtract_inverse() {
+    let account =
+        Account { nonce: 1, balance: U256::from(2), bytecode_hash: Some(B256::with_last_byte(3)) };
+    let hashed_address = B256::with_last_byte(4);
+    let storage_root = B256::with_last_byte(5);
+
+    let mut root = LatticeStateRoot::default();
+    let empty = root.root();
+
+    root.add_account(hashed_address, account, storage_root);
+    assert_ne!(root.root(), empty);
+
+    root.subtract_account(hashed_address, account, storage_root);
+    assert_eq!(root.root(), empty);
+}
+
+#[test]
+fn lattice_storage_root_is_order_independent() {
     let slot_a = B256::with_last_byte(1);
     let slot_b = B256::with_last_byte(2);
 
@@ -23,7 +71,7 @@ fn storage_root_is_order_independent() {
 }
 
 #[test]
-fn state_root_includes_nested_storage_root() {
+fn lattice_state_root_includes_nested_storage_root() {
     let hashed_address = B256::with_last_byte(1);
     let account = Account { nonce: 1, balance: U256::from(2), bytecode_hash: None };
 


### PR DESCRIPTION
## Summary
- Adds a lattice-hash based state root path using Commonware `LtHash` and exposes it behind the `lattice-state-root` feature.
- Routes genesis, trie root computation, and engine payload validation through the new hash-based path.
- Propagates the new feature through the relevant workspace crates and adds lattice-specific trie tests.

## Testing
- `cargo +nightly fmt --all --check`
- `zepter run check`
- `make SHELL=/usr/bin/bash lint-toml`
- `cargo test -p reth-trie --features lattice-state-root --test lattice`
- `cargo check -p reth --features lattice-state-root`
- `cargo check -p reth-trie-common --no-default-features --features lattice-state-root`