### PR TITLE
fix(docs): deploy Vocs v2 output root

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: "./docs/vocs/docs/dist/public"
+          path: "./docs/vocs/docs/dist"
 
   deploy:
     # Only deploy if a push to main

--- a/docs/vocs/scripts/build-cargo-docs.sh
+++ b/docs/vocs/scripts/build-cargo-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script to build cargo docs with the same flags as used in CI
 
@@ -9,6 +10,6 @@ echo "Building cargo docs..."
 
 # Build the documentation
 export RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options"
-cargo docs --exclude "example-*"
+cargo +nightly docs --exclude "example-*"
 
 echo "Cargo docs built successfully at ./target/doc"

--- a/docs/vocs/scripts/fix-search-index.ts
+++ b/docs/vocs/scripts/fix-search-index.ts
@@ -3,9 +3,8 @@ import { readdir, copyFile, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
 async function fixSearchIndex() {
-  const distDir = 'docs/dist/public';
-  const legacyDistDir = 'docs/dist';
-  const vocsDir = join(legacyDistDir, '.vocs');
+  const distDir = 'docs/dist';
+  const vocsDir = join(distDir, '.vocs');
   
   try {
     // 1. Find the search index file
@@ -36,13 +35,13 @@ async function fixSearchIndex() {
     
     // 2. Copy search index to root of dist
     const sourcePath = join(vocsDir, searchIndexFile);
-    const destPath = join(legacyDistDir, searchIndexFile);
+    const destPath = join(distDir, searchIndexFile);
     await copyFile(sourcePath, destPath);
     console.log(`✅ Copied search index to root: ${destPath}`);
     
     // 3. Find and update all HTML and JS files that reference the search index
-    const htmlFiles = await findFiles(legacyDistDir, '.html');
-    const jsFiles = await findFiles(legacyDistDir, '.js');
+    const htmlFiles = await findFiles(distDir, '.html');
+    const jsFiles = await findFiles(distDir, '.js');
     console.log(`📝 Found ${htmlFiles.length} HTML files and ${jsFiles.length} JS files to update`);
     
     // 4. Replace references in all files

--- a/docs/vocs/scripts/generate-redirects.ts
+++ b/docs/vocs/scripts/generate-redirects.ts
@@ -3,7 +3,7 @@ import { writeFileSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
 import { redirects, basePath } from '../redirects.config'
 // Base path for the site
-const DIST_DIR = './docs/dist/public'
+const DIST_DIR = './docs/dist'
 
 function generateRedirectHtml(targetPath: string): string {
   return `<!DOCTYPE html>

--- a/docs/vocs/scripts/inject-cargo-docs.ts
+++ b/docs/vocs/scripts/inject-cargo-docs.ts
@@ -2,8 +2,8 @@ import { promises as fs } from 'fs';
 import { glob } from 'glob';
 
 const CARGO_DOCS_PATH = '../../target/doc';
-const VOCS_PUBLIC_PATH = './docs/dist/public';
-const VOCS_DIST_PATH = `${VOCS_PUBLIC_PATH}/docs`;
+const VOCS_DIST_ROOT = './docs/dist';
+const VOCS_DIST_PATH = `${VOCS_DIST_ROOT}/docs`;
 const BASE_PATH = '/docs';
 
 async function injectCargoDocs() {
@@ -20,9 +20,9 @@ async function injectCargoDocs() {
 
   // Check if Vocs dist exists
   try {
-    await fs.access(VOCS_PUBLIC_PATH);
+    await fs.access(VOCS_DIST_ROOT);
   } catch {
-    console.error('Error: Vocs public dist not found. Please run: bun run build');
+    console.error('Error: Vocs dist not found. Please run: bun run build');
     process.exit(1);
   }
 


### PR DESCRIPTION
Fixes the Vocs v2 Pages artifact so GitHub Pages uploads `docs/dist`, where Vocs now writes generated HTML, instead of `docs/dist/public`.

Updates the post-build scripts to write redirects, search-index fixes, and injected Rustdocs into the same deploy root. Also makes Rustdoc generation fail fast and use nightly for nightly-only flags.