### PR TITLE
fix(docs): handle Vocs search index fallback path

### DIFF
--- a/docs/vocs/scripts/fix-search-index.ts
+++ b/docs/vocs/scripts/fix-search-index.ts
@@ -13,12 +13,19 @@ async function fixSearchIndex() {
       files = await readdir(vocsDir);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        const assetsDir = join(distDir, 'assets');
-        const assets = await readdir(assetsDir);
-        const searchIndexFile = assets.find(f => f.startsWith('search-index-') && f.endsWith('.json'));
-        if (searchIndexFile) {
-          console.log(`✅ Vocs 2 search index found at ${join(assetsDir, searchIndexFile)}; no legacy fix needed.`);
-          return;
+        for (const assetsDir of [join(distDir, 'assets'), join(distDir, 'public', 'assets')]) {
+          try {
+            const assets = await readdir(assetsDir);
+            const searchIndexFile = assets.find(f => f.startsWith('search-index-') && f.endsWith('.json'));
+            if (searchIndexFile) {
+              console.log(`✅ Vocs 2 search index found at ${join(assetsDir, searchIndexFile)}; no legacy fix needed.`);
+              return;
+            }
+          } catch (assetsError) {
+            if ((assetsError as NodeJS.ErrnoException).code !== 'ENOENT') {
+              throw assetsError;
+            }
+          }
         }
       }
       throw error;


### PR DESCRIPTION
Fixes the Vocs search-index postprocessor when Vocs 2 emits the generated search index under `docs/dist/public/assets` and `.vocs` is absent.

This keeps the legacy `.vocs` copy path intact while allowing the clean CI output shape observed in the failing book job: https://github.com/paradigmxyz/reth/actions/runs/26814681882/job/79053336150?pr=24765
