### PR TITLE
chore: bump fixed-cache to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,9 +3944,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-cache"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41c7aa69c00ebccf06c3fa7ffe2a6cf26a58b5fe4deabfe646285ff48136a8f"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
 dependencies = [
  "equivalent",
  "rapidhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -541,7 +541,7 @@ tracing-appender = "0.2.5"
 url = { version = "2.3", default-features = false }
 zstd = "0.13"
 byteorder = "1"
-fixed-cache = { version = "0.1.7", features = ["stats"] }
+fixed-cache = { version = "0.1.10", features = ["stats"] }
 moka = "0.12"
 tar-no-std = { version = "0.4.2", default-features = false }
 miniz_oxide = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
## Summary
- bump workspace fixed-cache dependency to 0.1.10
- refresh Cargo.lock for fixed-cache 0.1.10

## Validation
- cargo check -p reth-execution-cache

Prompted by: @shekhirin