### PR TITLE
chore: downgrade tx execution span to trace

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1281,8 +1281,8 @@ where
 
             senders.push(tx_signer);
 
-            let _enter = tracing::enabled!(target: "engine::tree", Level::DEBUG).then(|| {
-                debug_span!(
+            let _enter = tracing::enabled!(target: "engine::tree", Level::TRACE).then(|| {
+                trace_span!(
                     target: "engine::tree",
                     "execute tx",
                     tx_index = senders.len() - 1,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1282,7 +1282,7 @@ where
             senders.push(tx_signer);
 
             let _enter = tracing::enabled!(target: "engine::tree", Level::TRACE).then(|| {
-                trace_span!(
+                tracing::trace_span!(
                     target: "engine::tree",
                     "execute tx",
                     tx_index = senders.len() - 1,


### PR DESCRIPTION
## Summary
- Downgrade the per-transaction `execute tx` span in `payload_validator.rs` from debug to trace.
- Keep the existing trace event unchanged.

## Verification
- `git diff --check`
- Started `cargo check -p reth-engine-tree --locked`; stopped after dependency/native build warmup to avoid delaying the requested Derek bench.

Prompted by: @klkvr
