### PR TITLE
fix(docs): improve reth vocs homepage buttons

### DIFF
--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -7,7 +7,6 @@ title: Reth
 description: Secure, performant and modular blockchain SDK and node.
 ---
 
-import { HomePage } from "vocs";
 import { SdkShowcase } from "../components/SdkShowcase";
 import { TrustedBy } from "../components/TrustedBy";
 
@@ -23,10 +22,10 @@ import { TrustedBy } from "../components/TrustedBy";
           />
           <div className="font-regular text-[21px] max-sm:text-[18px] text-[#919193] max-md:text-center"><span className="text-black dark:text-white">Secure</span>, <span className="text-black dark:text-white">performant</span>, and <span className="text-black dark:text-white">modular</span> blockchain SDK and node.</div>
         </div>
-        <div className="flex justify-center space-x-2">
-          <HomePage.Button href="/run/ethereum" variant="accent">Run a Node</HomePage.Button>
-          <HomePage.Button href="/sdk" variant="accent">Build a Node</HomePage.Button>
-          <HomePage.Button href="/introduction/why-reth">Why Reth?</HomePage.Button>
+        <div className="flex justify-center gap-2 flex-wrap w-full max-md:justify-start" style={{ marginTop: 28, marginBottom: 16 }}>
+          <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless" style={{ background: "light-dark(#1f1f1f, #ffffff)", borderRadius: 8, color: "light-dark(#ffffff, #000000)", fontSize: 16, fontWeight: 600, lineHeight: 1.2, minHeight: 44, padding: "13px 16px", textAlign: "center", whiteSpace: "nowrap" }}>Run a Node</a>
+          <a href="/sdk" className="vocs_Link vocs_Link_styleless" style={{ background: "light-dark(#1f1f1f, #ffffff)", borderRadius: 8, color: "light-dark(#ffffff, #000000)", fontSize: 16, fontWeight: 600, lineHeight: 1.2, minHeight: 44, padding: "13px 16px", textAlign: "center", whiteSpace: "nowrap" }}>Build a Node</a>
+          <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless" style={{ border: "1px solid light-dark(rgb(0 0 0 / 0.12), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", fontSize: 16, fontWeight: 600, lineHeight: 1.2, minHeight: 44, padding: "13px 16px", textAlign: "center", whiteSpace: "nowrap" }}>Why Reth?</a>
         </div>
       </div>
         <div className="flex flex-col justify-between space-y-4 w-full max-w-[500px]">
@@ -53,43 +52,19 @@ import { TrustedBy } from "../components/TrustedBy";
 
             :::
           </div>
-          <div className="flex justify-between space-x-2">
-                <a href="https://github.com/paradigmxyz/reth/stargazers" className="cursor-pointer h-[36px] max-w-[120px] flex-1 relative rounded-lg overflow-hidden border border-black/10 dark:border-white/20" style={{ color: 'inherit' }} rel="noreferrer noopener" target="_blank">
-      <div className="absolute flex z-[1] p-[6px] h-full w-full">
-        <div className="bg-white/60 dark:bg-black/40 flex items-center justify-center rounded-md px-3 py-1">
-          <span className="font-medium text-[15px] opacity-80 leading-none text-center">stars</span>
-        </div>
-        <div className="flex items-center h-full px-2 ml-1">
-          <span className="font-medium text-[15px] text-center leading-none w-full text-black dark:text-white">4.7K</span>
-        </div>
-      </div>
-      <div className="absolute left-0 right-0 top-0 bottom-0 bg-black/5 dark:bg-white/5 z-[0]" />
-      <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-blur-[2px] backdrop-filter z-0" />
-    </a>
-    <a href="https://github.com/paradigmxyz/reth/graphs/contributors" className="cursor-pointer h-[36px] max-w-[160px] flex-1 relative rounded-lg overflow-hidden border border-green-400/50" style={{ color: 'inherit' }} rel="noreferrer noopener" target="_blank">
-      <div className="absolute flex z-[1] p-[6px] h-full w-full">
-        <div className="flex-1 bg-white/60 dark:bg-black/40 flex items-center w-full h-full rounded-md">
-          <span className="font-medium text-[15px] leading-none opacity-80 w-full text-center">contributors</span>
-        </div>
-        <div className="flex items-center h-full px-2">
-          <span className="font-medium text-[15px] leading-none text-center w-full text-green-400">580+</span>
-        </div>
-      </div>
-      <div className="absolute left-0 right-0 top-0 bottom-0 bg-green-400 opacity-10 z-[0]" />
-      <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-blur-[2px] backdrop-filter z-[0]" />
-    </a>
-    <a href="https://github.com/paradigmxyz/reth/blob/main/LICENSE-MIT" className="cursor-pointer h-[36px] max-w-[130px] flex-1 relative rounded-lg overflow-hidden border border-black/10 dark:border-white/20 max-lg:hidden" style={{ color: 'inherit' }} rel="noreferrer noopener" target="_blank">
-      <div className="absolute flex z-[1] p-[6px] h-full w-full">
-        <div className="flex-1 bg-white/60 dark:bg-black/40 flex items-center w-full h-full rounded-md">
-          <span className="font-medium text-[15px] leading-none opacity-80 w-full text-center">license</span>
-        </div>
-        <div className="flex items-center h-full px-2">
-          <span className="font-medium text-[15px] leading-none text-center w-full text-black dark:text-white">MIT</span>
-        </div>
-      </div>
-      <div className="absolute left-0 right-0 top-0 bottom-0 bg-black/5 dark:bg-white/5 z-[0]" />
-      <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-blur-[2px] backdrop-filter z-[0]" />
-    </a>
+          <div className="grid grid-cols-2 lg:grid-cols-3 gap-2">
+            <a href="https://github.com/paradigmxyz/reth/stargazers" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid light-dark(rgb(0 0 0 / 0.1), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", display: "flex", gap: 8, height: 36, justifyContent: "center", minWidth: 0, padding: "0 10px" }} rel="noreferrer noopener" target="_blank">
+              <span style={{ background: "light-dark(rgb(255 255 255 / 0.64), rgb(0 0 0 / 0.32))", borderRadius: 6, color: "light-dark(rgb(0 0 0 / 0.76), rgb(255 255 255 / 0.76))", fontSize: 14, fontWeight: 500, lineHeight: 1, overflow: "hidden", padding: "5px 8px", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>stars</span>
+              <span style={{ color: "light-dark(#000, #fff)", fontSize: 14, fontWeight: 600, lineHeight: 1, whiteSpace: "nowrap" }}>4.7K</span>
+            </a>
+            <a href="https://github.com/paradigmxyz/reth/graphs/contributors" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid rgb(74 222 128 / 0.5)", borderRadius: 8, color: "inherit", display: "flex", gap: 8, height: 36, justifyContent: "center", minWidth: 0, padding: "0 10px" }} rel="noreferrer noopener" target="_blank">
+              <span style={{ background: "light-dark(rgb(255 255 255 / 0.64), rgb(0 0 0 / 0.32))", borderRadius: 6, color: "light-dark(rgb(0 0 0 / 0.76), rgb(255 255 255 / 0.76))", fontSize: 14, fontWeight: 500, lineHeight: 1, overflow: "hidden", padding: "5px 8px", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>contributors</span>
+              <span style={{ color: "#4ade80", fontSize: 14, fontWeight: 600, lineHeight: 1, whiteSpace: "nowrap" }}>580+</span>
+            </a>
+            <a href="https://github.com/paradigmxyz/reth/blob/main/LICENSE-MIT" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid light-dark(rgb(0 0 0 / 0.1), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", display: "flex", gap: 8, height: 36, justifyContent: "center", minWidth: 0, padding: "0 10px" }} rel="noreferrer noopener" target="_blank">
+              <span style={{ background: "light-dark(rgb(255 255 255 / 0.64), rgb(0 0 0 / 0.32))", borderRadius: 6, color: "light-dark(rgb(0 0 0 / 0.76), rgb(255 255 255 / 0.76))", fontSize: 14, fontWeight: 500, lineHeight: 1, overflow: "hidden", padding: "5px 8px", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>license</span>
+              <span style={{ color: "light-dark(#000, #fff)", fontSize: 14, fontWeight: 600, lineHeight: 1, whiteSpace: "nowrap" }}>MIT</span>
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- replace the homepage Vocs CTAs with first-paint-safe styled links
- simplify GitHub stat badges so they render as compact responsive buttons
- verify mobile/desktop via production Vocs preview screenshots

Prompted by: @mattsse