### PR TITLE
feat(rpc): allow disabling rpc metrics

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -71,6 +71,7 @@ pub struct DefaultRpcServerArgs {
     auth_ipc_path: String,
     disable_auth_server: bool,
     rpc_jwtsecret: Option<JwtSecret>,
+    rpc_disable_metrics: bool,
     rpc_max_request_size: MaxU32,
     rpc_max_response_size: MaxU32,
     rpc_max_subscriptions_per_connection: MaxU32,
@@ -231,6 +232,12 @@ impl DefaultRpcServerArgs {
         self
     }
 
+    /// Set whether to disable RPC request metrics by default
+    pub const fn with_rpc_disable_metrics(mut self, v: bool) -> Self {
+        self.rpc_disable_metrics = v;
+        self
+    }
+
     /// Set the default max request size
     pub const fn with_rpc_max_request_size(mut self, v: MaxU32) -> Self {
         self.rpc_max_request_size = v;
@@ -382,6 +389,7 @@ impl Default for DefaultRpcServerArgs {
             auth_ipc_path: constants::DEFAULT_ENGINE_API_IPC_ENDPOINT.to_string(),
             disable_auth_server: false,
             rpc_jwtsecret: None,
+            rpc_disable_metrics: false,
             rpc_max_request_size: RPC_DEFAULT_MAX_REQUEST_SIZE_MB.into(),
             rpc_max_response_size: RPC_DEFAULT_MAX_RESPONSE_SIZE_MB.into(),
             rpc_max_subscriptions_per_connection: RPC_DEFAULT_MAX_SUBS_PER_CONN.into(),
@@ -510,6 +518,10 @@ pub struct RpcServerArgs {
     /// `--authrpc.jwtsecret`.
     #[arg(long = "rpc.jwtsecret", value_name = "HEX", global = true, required = false, default_value = Resettable::from(DefaultRpcServerArgs::get_global().rpc_jwtsecret.as_ref().map(|v| format!("{:?}", v).into())))]
     pub rpc_jwtsecret: Option<JwtSecret>,
+
+    /// Disable built-in RPC request metrics.
+    #[arg(long = "rpc.disable-metrics", default_value_t = DefaultRpcServerArgs::get_global().rpc_disable_metrics)]
+    pub rpc_disable_metrics: bool,
 
     /// Set the maximum RPC request payload size for both HTTP and WS in megabytes.
     #[arg(long = "rpc.max-request-size", alias = "rpc-max-request-size", default_value_t = DefaultRpcServerArgs::get_global().rpc_max_request_size)]
@@ -828,6 +840,7 @@ impl Default for RpcServerArgs {
             auth_ipc_path,
             disable_auth_server,
             rpc_jwtsecret,
+            rpc_disable_metrics,
             rpc_max_request_size,
             rpc_max_response_size,
             rpc_max_subscriptions_per_connection,
@@ -872,6 +885,7 @@ impl Default for RpcServerArgs {
             auth_ipc_path,
             disable_auth_server,
             rpc_jwtsecret,
+            rpc_disable_metrics,
             rpc_max_request_size,
             rpc_max_response_size,
             rpc_max_subscriptions_per_connection,
@@ -982,6 +996,16 @@ mod tests {
     }
 
     #[test]
+    fn test_rpc_disable_metrics_arg() {
+        let args = CommandParser::<RpcServerArgs>::parse_from(["reth"]).args;
+        assert!(!args.rpc_disable_metrics);
+
+        let args =
+            CommandParser::<RpcServerArgs>::parse_from(["reth", "--rpc.disable-metrics"]).args;
+        assert!(args.rpc_disable_metrics);
+    }
+
+    #[test]
     fn test_rpc_tx_fee_cap_parse_integer() {
         let args = CommandParser::<RpcServerArgs>::parse_from(["reth", "--rpc.txfeecap", "2"]).args;
         let expected = 2_000_000_000_000_000_000u128; // 2 ETH in wei
@@ -1038,6 +1062,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            rpc_disable_metrics: false,
             rpc_max_request_size: 15u32.into(),
             rpc_max_response_size: 160u32.into(),
             rpc_max_subscriptions_per_connection: 1024u32.into(),

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -9,7 +9,10 @@ use interprocess::local_socket::{
     GenericFilePath, ListenerOptions, ToFsName,
 };
 use jsonrpsee::{
-    core::{middleware::layer::RpcLoggerLayer, JsonRawValue, TEN_MB_SIZE_BYTES},
+    core::{
+        middleware::layer::{Either as RpcEither, RpcLoggerLayer},
+        JsonRawValue, TEN_MB_SIZE_BYTES,
+    },
     server::{
         middleware::rpc::RpcServiceT, stop_channel, ConnectionGuard, ConnectionPermit, IdProvider,
         RandomIntegerIdProvider, ServerHandle, StopHandle,
@@ -316,11 +319,11 @@ impl<L> RpcServiceBuilder<L> {
     pub fn option_layer<T>(
         self,
         layer: Option<T>,
-    ) -> RpcServiceBuilder<Stack<Either<T, Identity>, L>> {
+    ) -> RpcServiceBuilder<Stack<RpcEither<T, Identity>, L>> {
         let layer = if let Some(layer) = layer {
-            Either::Left(layer)
+            RpcEither::Left(layer)
         } else {
-            Either::Right(Identity::new())
+            RpcEither::Right(Identity::new())
         };
         self.layer(layer)
     }

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -57,6 +57,9 @@ pub trait RethRpcServerConfig {
     /// Creates the [`RpcServerConfig`] from cli args.
     fn rpc_server_config(&self) -> RpcServerConfig;
 
+    /// Returns whether built-in RPC request metrics are enabled.
+    fn rpc_metrics_enabled(&self) -> bool;
+
     /// Creates the [`AuthServerConfig`] from cli args.
     fn auth_server_config(&self, jwt_secret: JwtSecret) -> Result<AuthServerConfig, RpcError>;
 
@@ -185,7 +188,9 @@ impl RethRpcServerConfig for RpcServerArgs {
     }
 
     fn rpc_server_config(&self) -> RpcServerConfig {
-        let mut config = RpcServerConfig::default().with_jwt_secret(self.rpc_secret_key());
+        let mut config = RpcServerConfig::default()
+            .with_jwt_secret(self.rpc_secret_key())
+            .with_rpc_metrics_enabled(self.rpc_metrics_enabled());
 
         if self.http_api.is_some() && !self.http {
             warn!(
@@ -225,6 +230,10 @@ impl RethRpcServerConfig for RpcServerArgs {
         }
 
         config
+    }
+
+    fn rpc_metrics_enabled(&self) -> bool {
+        !self.rpc_disable_metrics
     }
 
     fn auth_server_config(&self, jwt_secret: JwtSecret) -> Result<AuthServerConfig, RpcError> {
@@ -370,6 +379,15 @@ mod tests {
             SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8888))
         );
         assert_eq!(config.ipc_endpoint().unwrap(), constants::DEFAULT_IPC_ENDPOINT);
+        assert!(config.rpc_metrics_enabled());
+    }
+
+    #[test]
+    fn test_rpc_server_config_disable_metrics() {
+        let args =
+            CommandParser::<RpcServerArgs>::parse_from(["reth", "--rpc.disable-metrics"]).args;
+        let config = args.rpc_server_config();
+        assert!(!config.rpc_metrics_enabled());
     }
 
     #[test]

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -1104,6 +1104,8 @@ pub struct RpcServerConfig<RpcMiddleware = Identity> {
     ipc_endpoint: Option<String>,
     /// JWT secret for authentication
     jwt_secret: Option<JwtSecret>,
+    /// Whether RPC request metrics are enabled.
+    rpc_metrics_enabled: bool,
     /// Configurable RPC middleware
     rpc_middleware: RpcMiddleware,
 }
@@ -1124,6 +1126,7 @@ impl Default for RpcServerConfig<Identity> {
             ipc_server_config: None,
             ipc_endpoint: None,
             jwt_secret: None,
+            rpc_metrics_enabled: true,
             rpc_middleware: Default::default(),
         }
     }
@@ -1188,8 +1191,15 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
             ipc_server_config: self.ipc_server_config,
             ipc_endpoint: self.ipc_endpoint,
             jwt_secret: self.jwt_secret,
+            rpc_metrics_enabled: self.rpc_metrics_enabled,
             rpc_middleware,
         }
+    }
+
+    /// Configures whether the built-in RPC request metrics layer is enabled.
+    pub const fn with_rpc_metrics_enabled(mut self, enabled: bool) -> Self {
+        self.rpc_metrics_enabled = enabled;
+        self
     }
 
     /// Configure the cors domains for http _and_ ws
@@ -1308,6 +1318,11 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
         self.ipc_endpoint.clone()
     }
 
+    /// Returns whether the built-in RPC request metrics layer is enabled.
+    pub const fn rpc_metrics_enabled(&self) -> bool {
+        self.rpc_metrics_enabled
+    }
+
     /// Creates the [`CorsLayer`] if any
     fn maybe_cors_layer(cors: Option<String>) -> Result<Option<CorsLayer>, CorsDomainError> {
         cors.as_deref().map(cors::create_cors_layer).transpose()
@@ -1351,13 +1366,19 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
             constants::DEFAULT_WS_RPC_PORT,
         )));
 
-        let metrics = modules.ipc.as_ref().map(RpcRequestMetrics::ipc).unwrap_or_default();
+        let rpc_metrics_enabled = self.rpc_metrics_enabled;
         let ipc_path =
             self.ipc_endpoint.clone().unwrap_or_else(|| constants::DEFAULT_IPC_ENDPOINT.into());
 
         if let Some(builder) = self.ipc_server_config {
             let ipc = builder
-                .set_rpc_middleware(IpcRpcServiceBuilder::new().layer(metrics))
+                .set_rpc_middleware(
+                    IpcRpcServiceBuilder::new().option_layer(
+                        rpc_metrics_enabled
+                            .then(|| modules.ipc.as_ref().map(RpcRequestMetrics::ipc))
+                            .flatten(),
+                    ),
+                )
                 .build(ipc_path);
             ipc_handle = Some(ipc.start(modules.ipc.clone().expect("ipc server error")).await?);
         }
@@ -1397,13 +1418,16 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                     )
                     .set_rpc_middleware(
                         RpcServiceBuilder::default()
-                            .layer(
-                                modules
-                                    .http
-                                    .as_ref()
-                                    .or(modules.ws.as_ref())
-                                    .map(RpcRequestMetrics::same_port)
-                                    .unwrap_or_default(),
+                            .option_layer(
+                                rpc_metrics_enabled
+                                    .then(|| {
+                                        modules
+                                            .http
+                                            .as_ref()
+                                            .or(modules.ws.as_ref())
+                                            .map(RpcRequestMetrics::same_port)
+                                    })
+                                    .flatten(),
                             )
                             .layer(self.rpc_middleware.clone()),
                     )
@@ -1448,7 +1472,11 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                 )
                 .set_rpc_middleware(
                     RpcServiceBuilder::default()
-                        .layer(modules.ws.as_ref().map(RpcRequestMetrics::ws).unwrap_or_default())
+                        .option_layer(
+                            rpc_metrics_enabled
+                                .then(|| modules.ws.as_ref().map(RpcRequestMetrics::ws))
+                                .flatten(),
+                        )
                         .layer(self.rpc_middleware.clone()),
                 )
                 .build(ws_socket_addr)
@@ -1474,8 +1502,10 @@ impl<RpcMiddleware> RpcServerConfig<RpcMiddleware> {
                 )
                 .set_rpc_middleware(
                     RpcServiceBuilder::default()
-                        .layer(
-                            modules.http.as_ref().map(RpcRequestMetrics::http).unwrap_or_default(),
+                        .option_layer(
+                            rpc_metrics_enabled
+                                .then(|| modules.http.as_ref().map(RpcRequestMetrics::http))
+                                .flatten(),
                         )
                         .layer(self.rpc_middleware.clone()),
                 )

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -409,6 +409,9 @@ RPC:
 
           This is __not__ used for the authenticated engine-API RPC server, see `--authrpc.jwtsecret`.
 
+      --rpc.disable-metrics
+          Disable built-in RPC request metrics
+
       --rpc.max-request-size <RPC_MAX_REQUEST_SIZE>
           Set the maximum RPC request payload size for both HTTP and WS in megabytes
 


### PR DESCRIPTION
Adds `--rpc.disable-metrics` to opt out of the built-in RPC request metrics layer while keeping metrics enabled by default.

The setting is carried through RPC args into `RpcServerConfig`, where HTTP, WS, same-port HTTP/WS, and IPC install the metrics layer via `option_layer`.

cc @cakevm 