### PR TITLE
fix(docs): load homepage styles in Vocs v2

### DIFF
--- a/docs/vocs/docs/pages/_root.css
+++ b/docs/vocs/docs/pages/_root.css
@@ -1,0 +1,1 @@
+@import "../styles.css";

--- a/docs/vocs/docs/styles.css
+++ b/docs/vocs/docs/styles.css
@@ -1,6 +1,6 @@
 @import "tailwindcss" important;
 
-@custom-variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where(.dark, .dark *, [data-vocs-theme="dark"], [data-vocs-theme="dark"] *));
 
 [data-layout="landing"] .vocs_Button_button {
   border-radius: 4px !important;


### PR DESCRIPTION
Loads the docs stylesheet through Vocs v2's _root.css page hook so Tailwind utilities are emitted for the landing page. Updates the dark variant selector to match Vocs' data-vocs-theme attribute.