### PR TITLE
fix(docs): simplify homepage hero layout

### DIFF
--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -12,64 +12,53 @@ import { TrustedBy } from "../components/TrustedBy";
 
 <div className="max-w-[1120px] mx-auto vp-doc relative px-[24px] mb-[64px] mt-[32px] md:px-0 md:mb-[32px]">
   <div className="pt-[48px] max-sm:pt-0">
-    <div className="max-sm:px-0 space-x-2 flex justify-between z-0 max-md:justify-center max-md:flex-col max-md:items-center max-md:space-y-6">
-      <div className="space-y-4 max-w-[500px] flex flex-col justify-between items-start max-md:items-center">
-        <div className="space-y-4 w-full lg:mb-[40px]">
-          <img
-          src="/reth-prod.png"
-          alt="Reth"
-          className="w-full h-auto rounded-xl"
-          />
-          <div className="font-regular text-[21px] max-sm:text-[18px] text-[#919193] max-md:text-center"><span className="text-black dark:text-white">Secure</span>, <span className="text-black dark:text-white">performant</span>, and <span className="text-black dark:text-white">modular</span> blockchain SDK and node.</div>
-        </div>
-        <div className="flex justify-center gap-2 flex-wrap w-full max-md:justify-start" style={{ marginTop: 28, marginBottom: 16 }}>
-          <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless" style={{ background: "light-dark(#1f1f1f, #ffffff)", borderRadius: 8, color: "light-dark(#ffffff, #000000)", fontSize: 16, fontWeight: 600, lineHeight: 1.2, minHeight: 44, padding: "13px 16px", textAlign: "center", whiteSpace: "nowrap" }}>Run a Node</a>
-          <a href="/sdk" className="vocs_Link vocs_Link_styleless" style={{ background: "light-dark(#1f1f1f, #ffffff)", borderRadius: 8, color: "light-dark(#ffffff, #000000)", fontSize: 16, fontWeight: 600, lineHeight: 1.2, minHeight: 44, padding: "13px 16px", textAlign: "center", whiteSpace: "nowrap" }}>Build a Node</a>
-          <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless" style={{ border: "1px solid light-dark(rgb(0 0 0 / 0.12), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", fontSize: 16, fontWeight: 600, lineHeight: 1.2, minHeight: 44, padding: "13px 16px", textAlign: "center", whiteSpace: "nowrap" }}>Why Reth?</a>
-        </div>
+    <div className="max-sm:px-0 space-y-6">
+      <img
+        src="/reth-prod.png"
+        alt="Reth"
+        className="w-full h-auto rounded-xl"
+      />
+      <div className="font-regular max-w-[760px] text-[21px] max-sm:text-[18px] text-[#919193] max-md:text-center"><span className="text-black dark:text-white">Secure</span>, <span className="text-black dark:text-white">performant</span>, and <span className="text-black dark:text-white">modular</span> blockchain SDK and node.</div>
+      <div className="flex gap-2 flex-wrap max-md:justify-center">
+          <a href="https://github.com/paradigmxyz/reth/stargazers" aria-label="4.7K GitHub stars" title="4.7K stars" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid light-dark(rgb(0 0 0 / 0.1), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", display: "inline-flex", gap: 6, height: 36, justifyContent: "center", minWidth: 0, padding: "0 12px", whiteSpace: "nowrap" }} rel="noreferrer noopener" target="_blank">
+            <span style={{ color: "light-dark(#000, #fff)", fontSize: 14, fontWeight: 700, lineHeight: 1 }}>4.7K</span>
+            <span style={{ color: "light-dark(rgb(0 0 0 / 0.62), rgb(255 255 255 / 0.62))", fontSize: 13, fontWeight: 500, lineHeight: 1 }}>stars</span>
+          </a>
+          <a href="https://github.com/paradigmxyz/reth/graphs/contributors" aria-label="580+ GitHub contributors" title="580+ contributors" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid rgb(74 222 128 / 0.5)", borderRadius: 8, color: "inherit", display: "inline-flex", gap: 6, height: 36, justifyContent: "center", minWidth: 0, padding: "0 12px", whiteSpace: "nowrap" }} rel="noreferrer noopener" target="_blank">
+            <span style={{ color: "#4ade80", fontSize: 14, fontWeight: 700, lineHeight: 1 }}>580+</span>
+            <span style={{ color: "light-dark(rgb(0 0 0 / 0.62), rgb(255 255 255 / 0.62))", fontSize: 13, fontWeight: 500, lineHeight: 1 }}>contributors</span>
+          </a>
+          <a href="https://github.com/paradigmxyz/reth/blob/main/LICENSE-MIT" aria-label="MIT license" title="MIT license" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid light-dark(rgb(0 0 0 / 0.1), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", display: "inline-flex", gap: 6, height: 36, justifyContent: "center", minWidth: 0, padding: "0 12px", whiteSpace: "nowrap" }} rel="noreferrer noopener" target="_blank">
+            <span style={{ color: "light-dark(#000, #fff)", fontSize: 14, fontWeight: 700, lineHeight: 1 }}>MIT</span>
+            <span style={{ color: "light-dark(rgb(0 0 0 / 0.62), rgb(255 255 255 / 0.62))", fontSize: 13, fontWeight: 500, lineHeight: 1 }}>license</span>
+          </a>
       </div>
-        <div className="flex flex-col justify-between space-y-4 w-full max-w-[500px]">
-          <div id="home-install">
-            :::code-group
+      <div id="home-install">
+        :::code-group
 
-            ```bash [Run a Node]
-            # Install the binary
-            brew install paradigmxyz/brew/reth
+        ```bash [CLI]
+        # Install the binary
+        brew install paradigmxyz/brew/reth
 
-            # Run the node with JSON-RPC enabled
-            reth node --http --http.api eth,trace
-            ```
+        # Run the node with JSON-RPC enabled
+        reth node --http --http.api eth,trace
+        ```
 
-            ```rust [Build a Node]
-            // .. snip ..
-            let handle = node_builder
-              .with_types::<EthereumNode>()
-              .with_components(EthereumNode::components())
-              .with_add_ons(EthereumAddOns::default())
-              .launch()
-              .await?;
-            ```
+        ```rust [Rust SDK]
+        // .. snip ..
+        let handle = node_builder
+          .with_types::<EthereumNode>()
+          .with_components(EthereumNode::components())
+          .with_add_ons(EthereumAddOns::default())
+          .launch()
+          .await?;
+        ```
 
-            :::
-          </div>
-          <div className="grid grid-cols-2 lg:grid-cols-3 gap-2">
-            <a href="https://github.com/paradigmxyz/reth/stargazers" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid light-dark(rgb(0 0 0 / 0.1), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", display: "flex", gap: 8, height: 36, justifyContent: "center", minWidth: 0, padding: "0 10px" }} rel="noreferrer noopener" target="_blank">
-              <span style={{ background: "light-dark(rgb(255 255 255 / 0.64), rgb(0 0 0 / 0.32))", borderRadius: 6, color: "light-dark(rgb(0 0 0 / 0.76), rgb(255 255 255 / 0.76))", fontSize: 14, fontWeight: 500, lineHeight: 1, overflow: "hidden", padding: "5px 8px", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>stars</span>
-              <span style={{ color: "light-dark(#000, #fff)", fontSize: 14, fontWeight: 600, lineHeight: 1, whiteSpace: "nowrap" }}>4.7K</span>
-            </a>
-            <a href="https://github.com/paradigmxyz/reth/graphs/contributors" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid rgb(74 222 128 / 0.5)", borderRadius: 8, color: "inherit", display: "flex", gap: 8, height: 36, justifyContent: "center", minWidth: 0, padding: "0 10px" }} rel="noreferrer noopener" target="_blank">
-              <span style={{ background: "light-dark(rgb(255 255 255 / 0.64), rgb(0 0 0 / 0.32))", borderRadius: 6, color: "light-dark(rgb(0 0 0 / 0.76), rgb(255 255 255 / 0.76))", fontSize: 14, fontWeight: 500, lineHeight: 1, overflow: "hidden", padding: "5px 8px", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>contributors</span>
-              <span style={{ color: "#4ade80", fontSize: 14, fontWeight: 600, lineHeight: 1, whiteSpace: "nowrap" }}>580+</span>
-            </a>
-            <a href="https://github.com/paradigmxyz/reth/blob/main/LICENSE-MIT" className="vocs_Link vocs_Link_styleless" style={{ alignItems: "center", background: "light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.05))", border: "1px solid light-dark(rgb(0 0 0 / 0.1), rgb(255 255 255 / 0.16))", borderRadius: 8, color: "inherit", display: "flex", gap: 8, height: 36, justifyContent: "center", minWidth: 0, padding: "0 10px" }} rel="noreferrer noopener" target="_blank">
-              <span style={{ background: "light-dark(rgb(255 255 255 / 0.64), rgb(0 0 0 / 0.32))", borderRadius: 6, color: "light-dark(rgb(0 0 0 / 0.76), rgb(255 255 255 / 0.76))", fontSize: 14, fontWeight: 500, lineHeight: 1, overflow: "hidden", padding: "5px 8px", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>license</span>
-              <span style={{ color: "light-dark(#000, #fff)", fontSize: 14, fontWeight: 600, lineHeight: 1, whiteSpace: "nowrap" }}>MIT</span>
-            </a>
-          </div>
-        </div>
-
+        :::
+      </div>
+    </div>
   </div>
-  <div className="flex justify-between flex-wrap mt-10 lg:mt-30">
+  <div className="flex justify-between flex-wrap mt-10 lg:mt-16">
       <div className="pr-2 w-1/4 max-lg:pb-3 max-sm:px-0 max-lg:w-1/2 max-sm:w-full z-0">
         <div className="relative w-full h-[168px] max-lg:h-[142px] overflow-hidden">
           <a href="/run/ethereum" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
@@ -110,7 +99,6 @@ import { TrustedBy } from "../components/TrustedBy";
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
-    </div>
     </div>
 </div>
 <article className="vocs_Content max-w-5xl mx-auto">

--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -33,10 +33,15 @@ import { TrustedBy } from "../components/TrustedBy";
             <span style={{ color: "light-dark(rgb(0 0 0 / 0.62), rgb(255 255 255 / 0.62))", fontSize: 13, fontWeight: 500, lineHeight: 1 }}>license</span>
           </a>
       </div>
+      <div className="flex gap-x-5 gap-y-2 flex-wrap text-[15px] font-medium max-md:justify-center">
+        <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Run a Node</a>
+        <a href="/sdk" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Build a Node</a>
+        <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Why Reth?</a>
+      </div>
       <div id="home-install">
         :::code-group
 
-        ```bash [CLI]
+        ```bash [Run a Node]
         # Install the binary
         brew install paradigmxyz/brew/reth
 
@@ -44,7 +49,7 @@ import { TrustedBy } from "../components/TrustedBy";
         reth node --http --http.api eth,trace
         ```
 
-        ```rust [Rust SDK]
+        ```rust [Build a Node]
         // .. snip ..
         let handle = node_builder
           .with_types::<EthereumNode>()


### PR DESCRIPTION
Makes the homepage hero single-column so the product image and install snippet use the full content width. Keeps the existing hero links for Run a Node, Build a Node, and Why Reth while preserving the original code-group tab labels. Tightens the homepage card and section layout so wrapped text no longer overflows or stretches awkwardly at narrower widths.