### PR TITLE
fix(docs): polish homepage layout

### DIFF
--- a/docs/vocs/docs/components/SdkShowcase.tsx
+++ b/docs/vocs/docs/components/SdkShowcase.tsx
@@ -40,29 +40,29 @@ const projects: SdkProject[] = [
 
 export function SdkShowcase() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="grid max-w-full grid-cols-1 gap-5 overflow-hidden xl:grid-cols-2">
       {projects.map((project) => (
         <div
           key={project.name}
-          className="relative bg-white/5 dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-xl p-6 hover:bg-black/5 dark:hover:bg-white/10 transition-colors group"
+          className="group relative min-w-0 overflow-hidden rounded-lg border border-black/10 bg-white/5 p-6 transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
         >
           {/* LoC Badge */}
-          <div className="absolute top-4 right-4 bg-black/10 dark:bg-white/10 text-black dark:text-white px-3 py-1 rounded-full text-sm font-medium">
+          <div className="absolute right-5 top-5 rounded-full bg-black/10 px-3 py-1 text-sm font-medium text-black dark:bg-white/10 dark:text-white">
             {project.loc} LoC
           </div>
 
           {/* Content */}
           <div className="space-y-3">
-            <div>
-              <h3 className="text-xl font-semibold text-black dark:text-white mb-1">
+            <div className="min-w-0 pr-24">
+              <h3 className="mb-1 break-words text-xl font-semibold leading-tight text-black dark:text-white">
                 {project.name}
               </h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="break-words text-sm text-gray-600 dark:text-gray-400">
                 {project.company}
               </p>
             </div>
 
-            <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
+            <p className="break-words text-sm leading-relaxed text-gray-700 dark:text-gray-300">
               {project.description}
             </p>
 
@@ -71,7 +71,7 @@ export function SdkShowcase() {
               href={project.githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-sm text-black dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium transition-colors"
+              className="inline-flex items-center gap-2 whitespace-nowrap text-sm font-medium text-black transition-colors hover:text-gray-700 dark:text-white dark:hover:text-gray-300"
             >
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>

--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -65,40 +65,40 @@ import { TrustedBy } from "../components/TrustedBy";
   </div>
   <div className="flex justify-between flex-wrap mt-10 lg:mt-16">
       <div className="pr-2 w-1/4 max-lg:pb-3 max-sm:px-0 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full h-[168px] max-lg:h-[142px] overflow-hidden">
-          <a href="/run/ethereum" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
-            <div className="text-xl font-medium text-black dark:text-white">Institutional Security</div>
-            <div className="text-[17px] text-[#919193]">Run reliable staking nodes trusted by Coinbase Staking</div>
+        <div className="relative w-full min-h-[220px] overflow-hidden">
+          <a href="/run/ethereum" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+            <div className="text-lg leading-tight font-medium text-black dark:text-white">Institutional Security</div>
+            <div className="text-[15px] leading-6 text-[#919193]">Run reliable staking nodes trusted by Coinbase Staking</div>
           </a>
           <div className="absolute left-0 right-0 top-0 bottom-0 dark:bg-[#313136] opacity-20 z-0" />
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
       <div className="pl-2 pr-2 max-sm:px-0 max-lg:pb-3 max-lg:pr-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full h-[168px] max-lg:h-[142px]">
-          <a href="/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
-            <div className="text-xl font-medium text-black dark:text-white">Performant</div>
-            <div className="text-[17px] text-[#919193]">Sync faster with optimal transaction processing</div>
+        <div className="relative w-full min-h-[220px] overflow-hidden">
+          <a href="/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+            <div className="text-lg leading-tight font-medium text-black dark:text-white">Performant</div>
+            <div className="text-[15px] leading-6 text-[#919193]">Sync faster with optimal transaction processing</div>
           </a>
           <div className="absolute left-0 right-0 top-0 bottom-0 dark:bg-[#313136] opacity-20 z-0" />
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
       <div className="pl-2 pr-2 max-lg:pb-3 max-sm:px-0 max-lg:pl-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full h-[168px] max-lg:h-[142px]">
-          <a href="/sdk" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
-            <div className="text-xl font-medium text-black dark:text-white">Customizable</div>
-            <div className="text-[17px] text-[#919193]">Build custom nodes with tailored transaction handling</div>
+        <div className="relative w-full min-h-[220px] overflow-hidden">
+          <a href="/sdk" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+            <div className="text-lg leading-tight font-medium text-black dark:text-white">Customizable</div>
+            <div className="text-[15px] leading-6 text-[#919193]">Build custom nodes with tailored transaction handling</div>
           </a>
           <div className="absolute left-0 right-0 top-0 bottom-0 dark:bg-[#313136] opacity-20 z-0" />
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
       <div className="pl-2 w-1/4 max-sm:px-0 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full h-[168px] max-lg:h-[142px]">
-          <a href="/exex/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full vocs_Link vocs_Link_styleless">
-            <div className="text-xl font-medium text-black dark:text-white">Extensible</div>
-            <div className="text-[17px] text-[#919193]">Build indexers and offchain services with ExExs</div>
+        <div className="relative w-full min-h-[220px] overflow-hidden">
+          <a href="/exex/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+            <div className="text-lg leading-tight font-medium text-black dark:text-white">Extensible</div>
+            <div className="text-[15px] leading-6 text-[#919193]">Build indexers and offchain services with ExExs</div>
           </a>
           <div className="absolute left-0 right-0 top-0 bottom-0 dark:bg-[#313136] opacity-20 z-0" />
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />

--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -33,11 +33,6 @@ import { TrustedBy } from "../components/TrustedBy";
             <span style={{ color: "light-dark(rgb(0 0 0 / 0.62), rgb(255 255 255 / 0.62))", fontSize: 13, fontWeight: 500, lineHeight: 1 }}>license</span>
           </a>
       </div>
-      <div className="flex gap-x-5 gap-y-2 flex-wrap text-[15px] font-medium max-md:justify-center">
-        <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Run a Node</a>
-        <a href="/sdk" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Build a Node</a>
-        <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Why Reth?</a>
-      </div>
       <div id="home-install">
         :::code-group
 
@@ -60,6 +55,11 @@ import { TrustedBy } from "../components/TrustedBy";
         ```
 
         :::
+      </div>
+      <div className="flex gap-x-5 gap-y-2 flex-wrap text-[15px] font-medium max-md:justify-center">
+        <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Run a Node</a>
+        <a href="/sdk" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Build a Node</a>
+        <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Why Reth?</a>
       </div>
     </div>
   </div>

--- a/docs/vocs/docs/styles.css
+++ b/docs/vocs/docs/styles.css
@@ -9,7 +9,33 @@
 }
 
 [data-layout="landing"] .vocs_Content {
+  overflow-x: clip;
+  padding-left: 24px;
+  padding-right: 24px;
   position: inherit;
+}
+
+@media (min-width: 768px) {
+  [data-layout="landing"] .vocs_Content {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+[data-layout="landing"] .vocs_Content > h2 {
+  font-size: 32px;
+  letter-spacing: 0;
+  line-height: 1.15;
+  margin-bottom: 8px;
+  margin-top: 64px;
+}
+
+[data-layout="landing"] .vocs_Content > p {
+  font-size: 18px;
+  line-height: 1.55;
+  margin-bottom: 24px;
+  margin-top: 0;
+  max-width: 820px;
 }
 
 #home-install .vocs_CodeGroup {


### PR DESCRIPTION
Tightens the homepage card and section layout so wrapped text no longer clips or stretches awkwardly at narrower widths. Moves the homepage destination links below the install snippet while keeping their existing targets.