### PR TITLE
fix(docs): stabilize Vocs builds

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,9 @@ name: book
 on:
   push:
     branches: [main]
+    paths:
+      - ".github/workflows/book.yml"
+      - "docs/vocs/**"
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, closed]
@@ -48,6 +51,7 @@ jobs:
           test -f docs/dist/public/index.html
           test -f docs/dist/public/overview/index.html
           test -f docs/dist/public/sdk/index.html
+          test -f docs/dist/public/docs/index.html
           test -f docs/dist/public/logo.png
           test -f docs/dist/public/reth-prod.png
           echo "Vocs Build Complete"

--- a/docs/vocs/docs/pages/index.mdx
+++ b/docs/vocs/docs/pages/index.mdx
@@ -56,17 +56,17 @@ import { TrustedBy } from "../components/TrustedBy";
 
         :::
       </div>
-      <div className="flex gap-x-5 gap-y-2 flex-wrap text-[15px] font-medium max-md:justify-center">
-        <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Run a Node</a>
-        <a href="/sdk" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Build a Node</a>
-        <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless text-black dark:text-white hover:opacity-70">Why Reth?</a>
+      <div className="flex flex-wrap gap-3 max-md:justify-center">
+        <a href="/run/ethereum" className="vocs_Link vocs_Link_styleless inline-flex h-10 items-center justify-center rounded-lg bg-black px-4 text-[15px] font-medium text-white transition-colors hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80">Run a Node</a>
+        <a href="/sdk" className="vocs_Link vocs_Link_styleless inline-flex h-10 items-center justify-center rounded-lg border border-black/10 bg-black/[0.03] px-4 text-[15px] font-medium text-black transition-colors hover:bg-black/[0.06] dark:border-white/10 dark:bg-white/[0.06] dark:text-white dark:hover:bg-white/[0.1]">Build a Node</a>
+        <a href="/introduction/why-reth" className="vocs_Link vocs_Link_styleless inline-flex h-10 items-center justify-center rounded-lg border border-black/10 bg-black/[0.03] px-4 text-[15px] font-medium text-black transition-colors hover:bg-black/[0.06] dark:border-white/10 dark:bg-white/[0.06] dark:text-white dark:hover:bg-white/[0.1]">Why Reth?</a>
       </div>
     </div>
   </div>
-  <div className="flex justify-between flex-wrap mt-10 lg:mt-16">
-      <div className="pr-2 w-1/4 max-lg:pb-3 max-sm:px-0 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full min-h-[220px] overflow-hidden">
-          <a href="/run/ethereum" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+  <div className="grid grid-cols-1 gap-4 mt-10 md:grid-cols-2 lg:mt-16">
+      <div className="z-0">
+        <div className="relative h-full min-h-[168px] overflow-hidden">
+          <a href="/run/ethereum" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[168px] h-full px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
             <div className="text-lg leading-tight font-medium text-black dark:text-white">Institutional Security</div>
             <div className="text-[15px] leading-6 text-[#919193]">Run reliable staking nodes trusted by Coinbase Staking</div>
           </a>
@@ -74,9 +74,9 @@ import { TrustedBy } from "../components/TrustedBy";
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
-      <div className="pl-2 pr-2 max-sm:px-0 max-lg:pb-3 max-lg:pr-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full min-h-[220px] overflow-hidden">
-          <a href="/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+      <div className="z-0">
+        <div className="relative h-full min-h-[168px] overflow-hidden">
+          <a href="/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[168px] h-full px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
             <div className="text-lg leading-tight font-medium text-black dark:text-white">Performant</div>
             <div className="text-[15px] leading-6 text-[#919193]">Sync faster with optimal transaction processing</div>
           </a>
@@ -84,9 +84,9 @@ import { TrustedBy } from "../components/TrustedBy";
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
-      <div className="pl-2 pr-2 max-lg:pb-3 max-sm:px-0 max-lg:pl-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full min-h-[220px] overflow-hidden">
-          <a href="/sdk" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+      <div className="z-0">
+        <div className="relative h-full min-h-[168px] overflow-hidden">
+          <a href="/sdk" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[168px] h-full px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
             <div className="text-lg leading-tight font-medium text-black dark:text-white">Customizable</div>
             <div className="text-[15px] leading-6 text-[#919193]">Build custom nodes with tailored transaction handling</div>
           </a>
@@ -94,9 +94,9 @@ import { TrustedBy } from "../components/TrustedBy";
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
         </div>
       </div>
-      <div className="pl-2 w-1/4 max-sm:px-0 max-lg:w-1/2 max-sm:w-full z-0">
-        <div className="relative w-full min-h-[220px] overflow-hidden">
-          <a href="/exex/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[220px] px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
+      <div className="z-0">
+        <div className="relative h-full min-h-[168px] overflow-hidden">
+          <a href="/exex/overview" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg min-h-[168px] h-full px-5 py-6 relative z-10 flex flex-col gap-4 w-full vocs_Link vocs_Link_styleless">
             <div className="text-lg leading-tight font-medium text-black dark:text-white">Extensible</div>
             <div className="text-[15px] leading-6 text-[#919193]">Build indexers and offchain services with ExExs</div>
           </a>

--- a/docs/vocs/package.json
+++ b/docs/vocs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vocs dev",
-    "build": "bash scripts/build-cargo-docs.sh && vocs build && bun scripts/generate-redirects.ts && bun scripts/inject-cargo-docs.ts && bun scripts/fix-search-index.ts",
+    "build": "bash scripts/build-cargo-docs.sh && bun scripts/build-vocs.ts && bun scripts/generate-redirects.ts && bun scripts/inject-cargo-docs.ts && bun scripts/fix-search-index.ts",
     "preview": "vocs preview",
     "check-links": "bun scripts/check-links.ts",
     "generate-redirects": "bun scripts/generate-redirects.ts",

--- a/docs/vocs/scripts/build-vocs.ts
+++ b/docs/vocs/scripts/build-vocs.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env bun
+import { createHash } from 'node:crypto';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import react from '@vitejs/plugin-react';
+import * as vite from 'vite';
+import { resolveConfig } from 'vocs/config';
+import { vocs } from 'vocs/vite';
+import { SearchDocuments } from '../node_modules/vocs/dist/internal/search.js';
+
+const HASH_INPUTS = [
+  'package.json',
+  'bun.lock',
+  'bunfig.toml',
+  'tsconfig.json',
+  'vocs.config.ts',
+  'redirects.config.ts',
+  'sidebar.ts',
+  'sidebar-cli-reth.ts',
+  'types.ts',
+  'docs',
+  'public',
+  'scripts',
+];
+
+function isIgnored(path: string) {
+  const normalized = relative(process.cwd(), path).split('\\').join('/');
+  return normalized === 'docs/dist' || normalized.startsWith('docs/dist/');
+}
+
+async function findFiles(path: string, files: string[] = []): Promise<string[]> {
+  if (isIgnored(path)) return files;
+
+  let metadata;
+  try {
+    metadata = await stat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return files;
+    throw error;
+  }
+
+  if (metadata.isFile()) {
+    files.push(path);
+    return files;
+  }
+
+  if (!metadata.isDirectory()) return files;
+
+  const entries = await readdir(path, { withFileTypes: true });
+  for (const entry of entries.sort((a, b) => compare(a.name, b.name))) {
+    await findFiles(join(path, entry.name), files);
+  }
+
+  return files;
+}
+
+async function getBuildId() {
+  const files = (await Promise.all(HASH_INPUTS.map(path => findFiles(path)))).flat().sort();
+  const hash = createHash('sha256');
+
+  for (const file of files) {
+    hash.update(relative(process.cwd(), file));
+    hash.update('\0');
+    hash.update(await readFile(file));
+    hash.update('\0');
+  }
+
+  return hash.digest('base64url').slice(0, 12);
+}
+
+function compare(a: string, b: string) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function normalizeSearchDocumentId(
+  id: string,
+  config: Parameters<typeof SearchDocuments.fromConfig>[0],
+) {
+  if (id.startsWith('nav:')) return id;
+
+  const [filePath, anchor = ''] = id.split('#');
+  const pagesDir = resolve(config.rootDir, config.srcDir, config.pagesDir);
+  const relativeFilePath = relative(pagesDir, filePath);
+
+  if (relativeFilePath.startsWith('..') || isAbsolute(relativeFilePath)) return id;
+
+  return `${relativeFilePath.split(sep).join('/')}${anchor ? `#${anchor}` : ''}`;
+}
+
+function configureDeterministicSearchDocuments() {
+  const searchDocuments = SearchDocuments as {
+    fromConfig: typeof SearchDocuments.fromConfig;
+  };
+  const fromConfig = searchDocuments.fromConfig;
+
+  // Vocs collects search docs concurrently; sort after collection so MiniSearch IDs stay stable.
+  searchDocuments.fromConfig = async config => {
+    const documents = await fromConfig(config);
+
+    return documents
+      .map(document => ({
+        ...document,
+        id: normalizeSearchDocumentId(document.id, config),
+      }))
+      .sort(
+        (a, b) =>
+          compare(a.id, b.id) ||
+          compare(a.href, b.href) ||
+          compare(a.title, b.title) ||
+          compare(a.type, b.type),
+      );
+  };
+}
+
+async function build() {
+  configureDeterministicSearchDocuments();
+
+  const config = await resolveConfig();
+  const buildId = await getBuildId();
+  console.log(`Using deterministic Vocs build id ${buildId}`);
+
+  const builder = await vite.createBuilder({
+    configFile: false,
+    define: {
+      'import.meta.env.WAKU_BUILD_ID': JSON.stringify(buildId),
+    },
+    plugins: [react(), vocs()],
+    build: {
+      outDir: config.outDir,
+    },
+  });
+
+  await builder.buildApp();
+}
+
+build().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/docs/vocs/scripts/inject-cargo-docs.ts
+++ b/docs/vocs/scripts/inject-cargo-docs.ts
@@ -3,7 +3,8 @@ import { glob } from 'glob';
 
 const CARGO_DOCS_PATH = '../../target/doc';
 const VOCS_DIST_ROOT = './docs/dist';
-const VOCS_DIST_PATH = `${VOCS_DIST_ROOT}/docs`;
+const VOCS_PUBLIC_PATH = `${VOCS_DIST_ROOT}/public`;
+const VOCS_DIST_PATH = `${VOCS_PUBLIC_PATH}/docs`;
 const BASE_PATH = '/docs';
 
 async function injectCargoDocs() {
@@ -18,9 +19,9 @@ async function injectCargoDocs() {
     process.exit(1);
   }
 
-  // Check if Vocs dist exists
+  // Check if Vocs public dist exists
   try {
-    await fs.access(VOCS_DIST_ROOT);
+    await fs.access(VOCS_PUBLIC_PATH);
   } catch {
     console.error('Error: Vocs dist not found. Please run: bun run build');
     process.exit(1);
@@ -33,7 +34,7 @@ async function injectCargoDocs() {
   console.log(`Copying cargo docs to ${VOCS_DIST_PATH}...`);
   await fs.cp(CARGO_DOCS_PATH, VOCS_DIST_PATH, { recursive: true });
 
-  // Fix relative paths in HTML files to work from /reth/docs
+  // Fix relative paths in HTML files to work from /docs
   console.log('Fixing relative paths in HTML files...');
   
   const htmlFiles = await glob(`${VOCS_DIST_PATH}/**/*.html`);
@@ -44,7 +45,7 @@ async function injectCargoDocs() {
     // Extract the current crate name and module path from the file path
     // Remove the base path to get the relative path within the docs
     const relativePath = file.startsWith('./') ? file.slice(2) : file;
-    const docsRelativePath = relativePath.replace(/^docs\/dist\/docs\//, '');
+    const docsRelativePath = relativePath.replace(/^docs\/dist\/public\/docs\//, '');
     const pathParts = docsRelativePath.split('/');
     const fileName = pathParts[pathParts.length - 1];
     


### PR DESCRIPTION
Stops the docs Pages workflow from redeploying on non-doc pushes to main.

Replaces the Vocs CLI build with a wrapper that uses a content-derived Waku build id and deterministic search-index document ordering, so unchanged docs produce stable assets.

Copies generated Rustdocs into the uploaded Pages artifact under /docs and checks for docs/index.html during CI, so the Rustdocs nav link is not dead.

Replaces the homepage feature-card flex wrap with a stable two-column grid so the cards do not collapse into cramped columns or oversized empty boxes.

Converts the homepage CTA links into button-styled anchors for clearer primary and secondary actions.