### PR TITLE
ci(bench): allow rkrasiuk to trigger PR benches

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -145,7 +145,9 @@ jobs:
           github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN }}
           script: |
             const org = 'paradigmxyz';
+            const allowedUsers = new Set(['rkrasiuk']);
             const checkMembership = async (username) => {
+              if (allowedUsers.has(username)) return true;
               try {
                 const { status } = await github.rest.orgs.checkMembershipForUser({ org, username });
                 return status === 204 || status === 302;


### PR DESCRIPTION
## Summary
- Allow GitHub user `rkrasiuk` through the PR bench membership gate.
- Keep the same check path for both comment author and PR author.

## Testing
- Not run; GitHub Actions workflow-only change.

Prompted by: @shekhirin