### PR TITLE
fix(grafana): fix state growth dashboard tables

### DIFF
--- a/etc/grafana/dashboards/reth-state-growth.json
+++ b/etc/grafana/dashboards/reth-state-growth.json
@@ -574,12 +574,12 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"PlainAccountState\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedAccounts\"}[$interval]))",
           "instant": false,
-          "interval": "$interval",
-          "legendFormat": "Account",
+          "legendFormat": "Flat accounts",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "interval": "$interval"
         },
         {
           "datasource": {
@@ -587,13 +587,12 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"PlainStorageState\"}[$interval]))",
-          "hide": false,
+          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedStorages\"}[$interval]))",
           "instant": false,
-          "interval": "$interval",
-          "legendFormat": "Storage",
+          "legendFormat": "Flat storage",
           "range": true,
-          "refId": "B"
+          "refId": "B",
+          "interval": "$interval"
         },
         {
           "datasource": {
@@ -602,12 +601,11 @@
           },
           "editorMode": "code",
           "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"}[$interval]))",
-          "hide": false,
           "instant": false,
-          "interval": "$interval",
           "legendFormat": "Bytecodes",
           "range": true,
-          "refId": "C"
+          "refId": "C",
+          "interval": "$interval"
         },
         {
           "datasource": {
@@ -615,13 +613,25 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"PlainAccountState\"}[$interval])) + avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"PlainStorageState\"}[$interval])) + avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"}[$interval]))",
-          "hide": false,
+          "expr": "sum(delta(reth_db_table_size{instance=~\"$instance\", table=~\"AccountsTrie|StoragesTrie\"}[$interval]))",
           "instant": false,
-          "interval": "$interval",
+          "legendFormat": "Trie",
+          "range": true,
+          "refId": "D",
+          "interval": "$interval"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(delta(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}[$interval]))",
+          "instant": false,
           "legendFormat": "Total",
           "range": true,
-          "refId": "D"
+          "refId": "E",
+          "interval": "$interval"
         }
       ],
       "title": "State Growth (interval = ${interval})",
@@ -714,12 +724,12 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"PlainAccountState\"})",
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"HashedAccounts\"})",
           "instant": false,
-          "interval": "$interval",
-          "legendFormat": "Account",
+          "legendFormat": "Flat accounts",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "interval": "$interval"
         },
         {
           "datasource": {
@@ -727,13 +737,12 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"PlainStorageState\"})",
-          "hide": false,
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"HashedStorages\"})",
           "instant": false,
-          "interval": "$interval",
-          "legendFormat": "Storage",
+          "legendFormat": "Flat storage",
           "range": true,
-          "refId": "B"
+          "refId": "B",
+          "interval": "$interval"
         },
         {
           "datasource": {
@@ -742,12 +751,11 @@
           },
           "editorMode": "code",
           "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"})",
-          "hide": false,
           "instant": false,
-          "interval": "$interval",
           "legendFormat": "Bytecodes",
           "range": true,
-          "refId": "C"
+          "refId": "C",
+          "interval": "$interval"
         },
         {
           "datasource": {
@@ -755,17 +763,236 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"PlainAccountState|PlainStorageState|Bytecodes\"})",
-          "hide": false,
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"AccountsTrie|StoragesTrie\"})",
           "instant": false,
-          "interval": "$interval",
+          "legendFormat": "Trie",
+          "range": true,
+          "refId": "D",
+          "interval": "$interval"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})",
+          "instant": false,
           "legendFormat": "Total",
           "range": true,
-          "refId": "D"
+          "refId": "E",
+          "interval": "$interval"
         }
       ],
       "title": "State Size",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 198,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) + (sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) - sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"} offset 7d)) / 7 * 7",
+          "instant": true,
+          "legendFormat": "Projected total state",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Projected Total State Size in 7d",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 199,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) + (sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) - sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"} offset 7d)) / 7 * 14",
+          "instant": true,
+          "legendFormat": "Projected total state",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Projected Total State Size in 14d",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 200,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) + (sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) - sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"} offset 7d)) / 7 * 30",
+          "instant": true,
+          "legendFormat": "Projected total state",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Projected Total State Size in 30d",
+      "transparent": true,
+      "type": "stat"
     },
     {
       "datasource": {
@@ -830,7 +1057,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 18
       },
       "id": 1,
       "options": {
@@ -852,15 +1079,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"PlainAccountState\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedAccounts\"}[$interval]))",
           "instant": false,
-          "interval": "$interval",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "interval": "$interval"
         }
       ],
-      "title": "Account State Growth (interval = ${interval})",
+      "title": "Flat Account State Growth (interval = ${interval})",
       "type": "timeseries"
     },
     {
@@ -926,7 +1153,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 18
       },
       "id": 2,
       "options": {
@@ -948,15 +1175,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"PlainStorageState\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedStorages\"}[$interval]))",
           "instant": false,
-          "interval": "$interval",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "interval": "$interval"
         }
       ],
-      "title": "Storage State Growth (interval = ${interval})",
+      "title": "Flat Storage State Growth (interval = ${interval})",
       "type": "timeseries"
     },
     {
@@ -1022,7 +1249,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 28
       },
       "id": 9,
       "options": {
@@ -1046,13 +1273,109 @@
           "editorMode": "code",
           "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"}[$interval]))",
           "instant": false,
-          "interval": "$interval",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "interval": "$interval"
         }
       ],
-      "title": "Bytecodes Growth (interval = ${interval})",
+      "title": "Contract Code Growth (interval = ${interval})",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 201,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(delta(reth_db_table_size{instance=~\"$instance\", table=~\"AccountsTrie|StoragesTrie\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "interval": "$interval"
+        }
+      ],
+      "title": "Trie State Growth (interval = ${interval})",
       "type": "timeseries"
     },
     {
@@ -1061,7 +1384,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 38
       },
       "id": 8,
       "panels": [],
@@ -1131,7 +1454,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 39
       },
       "id": 12,
       "options": {
@@ -1278,7 +1601,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 39
       },
       "id": 14,
       "options": {
@@ -1420,7 +1743,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 49
       },
       "id": 3,
       "options": {
@@ -1516,7 +1839,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 49
       },
       "id": 5,
       "options": {
@@ -1612,7 +1935,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 59
       },
       "id": 4,
       "options": {

--- a/etc/grafana/dashboards/reth-state-growth.json
+++ b/etc/grafana/dashboards/reth-state-growth.json
@@ -845,7 +845,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) + (sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) - sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"} offset 7d)) / 7 * 7",
+          "expr": "predict_linear(sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 7 * 24 * 60 * 60)",
           "instant": true,
           "legendFormat": "Projected total state",
           "range": false,
@@ -914,7 +914,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) + (sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) - sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"} offset 7d)) / 7 * 14",
+          "expr": "predict_linear(sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 14 * 24 * 60 * 60)",
           "instant": true,
           "legendFormat": "Projected total state",
           "range": false,
@@ -983,7 +983,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) + (sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}) - sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"} offset 7d)) / 7 * 30",
+          "expr": "predict_linear(sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 30 * 24 * 60 * 60)",
           "instant": true,
           "legendFormat": "Projected total state",
           "range": false,

--- a/etc/grafana/dashboards/reth-state-growth.json
+++ b/etc/grafana/dashboards/reth-state-growth.json
@@ -1,12 +1,11 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "name": "VAR_INSTANCE_LABEL",
+      "type": "constant",
+      "label": "Instance Label",
+      "value": "job",
+      "description": ""
     }
   ],
   "__elements": {},
@@ -63,7 +62,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -114,11 +113,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "reth_info{instance=~\"$instance\"}",
+          "expr": "reth_info{$instance_label=\"$instance\"}",
           "instant": true,
           "legendFormat": "{{version}}",
           "range": false,
@@ -132,7 +131,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -183,11 +182,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "reth_info{instance=~\"$instance\"}",
+          "expr": "reth_info{$instance_label=\"$instance\"}",
           "instant": true,
           "legendFormat": "{{build_timestamp}}",
           "range": false,
@@ -201,7 +200,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -252,11 +251,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "reth_info{instance=~\"$instance\"}",
+          "expr": "reth_info{$instance_label=\"$instance\"}",
           "instant": true,
           "legendFormat": "{{git_sha}}",
           "range": false,
@@ -270,7 +269,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -321,11 +320,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "reth_info{instance=~\"$instance\"}",
+          "expr": "reth_info{$instance_label=\"$instance\"}",
           "instant": true,
           "legendFormat": "{{build_profile}}",
           "range": false,
@@ -339,7 +338,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -390,11 +389,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "reth_info{instance=~\"$instance\"}",
+          "expr": "reth_info{$instance_label=\"$instance\"}",
           "instant": true,
           "legendFormat": "{{target_triple}}",
           "range": false,
@@ -408,7 +407,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -459,11 +458,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "reth_info{instance=~\"$instance\"}",
+          "expr": "reth_info{$instance_label=\"$instance\"}",
           "instant": true,
           "legendFormat": "{{cargo_features}}",
           "range": false,
@@ -490,7 +489,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -571,10 +570,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedAccounts\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"HashedAccounts\"}[$interval]))",
           "instant": false,
           "legendFormat": "Flat accounts",
           "range": true,
@@ -584,10 +583,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedStorages\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"HashedStorages\"}[$interval]))",
           "instant": false,
           "legendFormat": "Flat storage",
           "range": true,
@@ -597,10 +596,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Bytecodes\"}[$interval]))",
           "instant": false,
           "legendFormat": "Bytecodes",
           "range": true,
@@ -610,10 +609,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(delta(reth_db_table_size{instance=~\"$instance\", table=~\"AccountsTrie|StoragesTrie\"}[$interval]))",
+          "expr": "sum(delta(reth_db_table_size{$instance_label=\"$instance\", table=~\"AccountsTrie|StoragesTrie\"}[$interval]))",
           "instant": false,
           "legendFormat": "Trie",
           "range": true,
@@ -623,10 +622,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(delta(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}[$interval]))",
+          "expr": "sum(delta(reth_db_table_size{$instance_label=\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"}[$interval]))",
           "instant": false,
           "legendFormat": "Total",
           "range": true,
@@ -640,7 +639,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -721,10 +720,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"HashedAccounts\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=\"HashedAccounts\"})",
           "instant": false,
           "legendFormat": "Flat accounts",
           "range": true,
@@ -734,10 +733,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"HashedStorages\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=\"HashedStorages\"})",
           "instant": false,
           "legendFormat": "Flat storage",
           "range": true,
@@ -747,10 +746,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=\"Bytecodes\"})",
           "instant": false,
           "legendFormat": "Bytecodes",
           "range": true,
@@ -760,10 +759,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"AccountsTrie|StoragesTrie\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=~\"AccountsTrie|StoragesTrie\"})",
           "instant": false,
           "legendFormat": "Trie",
           "range": true,
@@ -773,10 +772,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})",
           "instant": false,
           "legendFormat": "Total",
           "range": true,
@@ -790,7 +789,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -842,10 +841,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "predict_linear(sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 7 * 24 * 60 * 60)",
+          "expr": "predict_linear(sum(reth_db_table_size{$instance_label=\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 7 * 24 * 60 * 60)",
           "instant": true,
           "legendFormat": "Projected total state",
           "range": false,
@@ -859,7 +858,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -911,10 +910,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "predict_linear(sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 14 * 24 * 60 * 60)",
+          "expr": "predict_linear(sum(reth_db_table_size{$instance_label=\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 14 * 24 * 60 * 60)",
           "instant": true,
           "legendFormat": "Projected total state",
           "range": false,
@@ -928,7 +927,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -980,10 +979,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "predict_linear(sum(reth_db_table_size{instance=~\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 30 * 24 * 60 * 60)",
+          "expr": "predict_linear(sum(reth_db_table_size{$instance_label=\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:], 30 * 24 * 60 * 60)",
           "instant": true,
           "legendFormat": "Projected total state",
           "range": false,
@@ -997,7 +996,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1076,10 +1075,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedAccounts\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"HashedAccounts\"}[$interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1093,7 +1092,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1172,10 +1171,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"HashedStorages\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"HashedStorages\"}[$interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1189,7 +1188,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1268,10 +1267,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Bytecodes\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Bytecodes\"}[$interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1285,7 +1284,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1364,10 +1363,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(delta(reth_db_table_size{instance=~\"$instance\", table=~\"AccountsTrie|StoragesTrie\"}[$interval]))",
+          "expr": "sum(delta(reth_db_table_size{$instance_label=\"$instance\", table=~\"AccountsTrie|StoragesTrie\"}[$interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1394,7 +1393,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1475,10 +1474,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Headers\"}[$interval])) + avg(delta(reth_static_files_segment_size{instance=~\"$instance\", segment=\"headers\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Headers\"}[$interval])) + avg(delta(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"headers\"}[$interval]))",
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Headers",
@@ -1488,10 +1487,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Receipts\"}[$interval])) + avg(delta(reth_static_files_segment_size{instance=~\"$instance\", segment=\"receipts\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Receipts\"}[$interval])) + avg(delta(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"receipts\"}[$interval]))",
           "hide": false,
           "instant": false,
           "interval": "$interval",
@@ -1502,10 +1501,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Transactions\"}[$interval])) + avg(delta(reth_static_files_segment_size{instance=~\"$instance\", segment=\"transactions\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Transactions\"}[$interval])) + avg(delta(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"transactions\"}[$interval]))",
           "hide": false,
           "instant": false,
           "interval": "$interval",
@@ -1541,7 +1540,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1622,10 +1621,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"Headers\"}) + sum(reth_static_files_segment_size{instance=~\"$instance\", segment=\"headers\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=\"Headers\"}) + sum(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"headers\"})",
           "instant": false,
           "interval": "$interval",
           "legendFormat": "Headers",
@@ -1635,10 +1634,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"Receipts\"}) + sum(reth_static_files_segment_size{instance=~\"$instance\", segment=\"receipts\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=\"Receipts\"}) + sum(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"receipts\"})",
           "hide": false,
           "instant": false,
           "interval": "$interval",
@@ -1649,10 +1648,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(reth_db_table_size{instance=~\"$instance\", table=\"Transactions\"}) + sum(reth_static_files_segment_size{instance=~\"$instance\", segment=\"transactions\"})",
+          "expr": "sum(reth_db_table_size{$instance_label=\"$instance\", table=\"Transactions\"}) + sum(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"transactions\"})",
           "hide": false,
           "instant": false,
           "interval": "$interval",
@@ -1683,7 +1682,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1762,10 +1761,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Headers\"}[$interval])) + avg(delta(reth_static_files_segment_size{instance=~\"$instance\", segment=\"headers\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Headers\"}[$interval])) + avg(delta(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"headers\"}[$interval]))",
           "instant": false,
           "interval": "$interval",
           "legendFormat": "__auto",
@@ -1779,7 +1778,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1858,10 +1857,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Receipts\"}[$interval])) + avg(delta(reth_static_files_segment_size{instance=~\"$instance\", segment=\"receipts\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Receipts\"}[$interval])) + avg(delta(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"receipts\"}[$interval]))",
           "instant": false,
           "interval": "$interval",
           "legendFormat": "__auto",
@@ -1875,7 +1874,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1954,10 +1953,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "avg(delta(reth_db_table_size{instance=~\"$instance\", table=\"Transactions\"}[$interval])) + avg(delta(reth_static_files_segment_size{instance=~\"$instance\", segment=\"transactions\"}[$interval]))",
+          "expr": "avg(delta(reth_db_table_size{$instance_label=\"$instance\", table=\"Transactions\"}[$interval])) + avg(delta(reth_static_files_segment_size{$instance_label=\"$instance\", segment=\"transactions\"}[$interval]))",
           "instant": false,
           "interval": "$interval",
           "legendFormat": "__auto",
@@ -1981,23 +1980,59 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
-        "definition": "query_result(reth_info)",
+        "definition": "label_values(reth_info,$instance_label)",
         "hide": 0,
         "includeAll": false,
+        "label": "Instance",
         "multi": false,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "query_result(reth_info)",
+          "qryType": 1,
+          "query": "label_values(reth_info,$instance_label)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "/.*instance=\\\"([^\\\"]*).*/",
+        "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "${VAR_INSTANCE_LABEL}",
+          "value": "${VAR_INSTANCE_LABEL}"
+        },
+        "hide": 2,
+        "label": "Instance Label",
+        "name": "instance_label",
+        "options": [
+          {
+            "selected": false,
+            "text": "${VAR_INSTANCE_LABEL}",
+            "value": "${VAR_INSTANCE_LABEL}"
+          }
+        ],
+        "query": "${VAR_INSTANCE_LABEL}",
+        "skipUrlSync": true,
+        "type": "constant"
       },
       {
         "current": {

--- a/etc/grafana/dashboards/reth-state-growth.json
+++ b/etc/grafana/dashboards/reth-state-growth.json
@@ -812,8 +812,77 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 6,
         "x": 0,
+        "y": 14
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "deriv(sum(reth_db_table_size{$instance_label=\"$instance\", table=~\"HashedAccounts|HashedStorages|Bytecodes|AccountsTrie|StoragesTrie\"})[$__range:]) * 24 * 60 * 60",
+          "instant": true,
+          "legendFormat": "State growth per day",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "State Growth Rate / Day",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
         "y": 14
       },
       "id": 198,
@@ -881,8 +950,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 14
       },
       "id": 199,
@@ -950,8 +1019,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 14
       },
       "id": 200,


### PR DESCRIPTION
## Summary
- update the state growth dashboard to track v2 flat state via HashedAccounts and HashedStorages instead of PlainAccountState and PlainStorageState
- include trie state via AccountsTrie and StoragesTrie in state size/growth totals
- add stat panels projecting total state size in 7d, 14d, and 30d from the trailing 7d growth rate

## Validation
- uv run python -m json.tool etc/grafana/dashboards/reth-state-growth.json >/dev/null
- git diff --check