### PR TITLE
fix: use latest state provider for tip hash

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -125,7 +125,11 @@ where
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        let mut provider = self.provider_factory.state_by_block_hash(self.historical)?;
+        let mut provider = if self.provider_factory.chain_info()?.best_hash == self.historical {
+            self.provider_factory.latest()?
+        } else {
+            self.provider_factory.state_by_block_hash(self.historical)?
+        };
         if let Some(overlay) = self.overlay.clone() {
             provider = Box::new(MemoryOverlayStateProvider::new(provider, overlay))
         }


### PR DESCRIPTION
Closes #20497

When the state provider builder anchor hash matches the provider's visible best hash, build from `latest()` instead of `state_by_block_hash()`. This avoids falling into the historical provider path during persistence races where the same hash is already the latest tip.

Validation:
- `cargo check -p reth-engine-tree`
- `cargo fmt --check` attempted, but the repository has pre-existing formatting drift outside this patch under stable rustfmt.
- `rustfmt --check crates/engine/tree/src/tree/mod.rs` attempted, but this rustfmt invocation rejects existing let-chain syntax in the file before this patch.

Prompted by: @klkvr