### PR TITLE
Use latest provider for latest state builder

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -125,7 +125,15 @@ where
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        let mut provider = self.provider_factory.state_by_block_hash(self.historical)?;
+        let mut provider = if let Some(latest_hash) =
+            self.provider_factory.block_hash(self.provider_factory.best_block_number()?)?
+            && latest_hash == self.historical
+        {
+            self.provider_factory.latest()?
+        } else {
+            self.provider_factory.state_by_block_hash(self.historical)?
+        };
+
         if let Some(overlay) = self.overlay.clone() {
             provider = Box::new(MemoryOverlayStateProvider::new(provider, overlay))
         }


### PR DESCRIPTION
Fixes #20497.\n\nWhen a StateProviderBuilder anchor is already the current canonical tip, build from latest state instead of going through state_by_block_hash/history lookup. Any in-memory overlay remains applied on top of the selected base provider.\n\nValidation:\n- cargo check -p reth-engine-tree\n\nNote: cargo fmt --check was not useful in this checkout because the current stable rustfmt reports many unrelated pre-existing diffs across the repo due nightly-only rustfmt options.