### PR TITLE
Add sparse trie proof orchestrator

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -33,6 +33,7 @@ use reth_trie_sparse::{
     SparseTrie,
 };
 use revm_primitives::{hash_map::Entry, B256Map};
+use tokio::sync::mpsc as tokio_mpsc;
 use tracing::{debug, debug_span, error, instrument, trace_span};
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
@@ -40,7 +41,7 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     /// Receiver for proof results directly from workers.
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
     /// Sender for proof requests to the proof orchestrator.
-    proof_request_tx: CrossbeamSender<ProofRequest>,
+    proof_request_tx: tokio_mpsc::UnboundedSender<ProofRequest>,
     /// Receives updates from execution and prewarming.
     updates: CrossbeamReceiver<SparseTrieTaskMessage>,
     /// Sender half for the channel to send final hashed state to.
@@ -132,8 +133,8 @@ where
         chunk_size: usize,
     ) -> Self {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
-        let (worker_result_tx, worker_result_rx) = crossbeam_channel::unbounded();
-        let (proof_request_tx, proof_request_rx) = crossbeam_channel::unbounded();
+        let (worker_result_tx, worker_result_rx) = tokio_mpsc::unbounded_channel();
+        let (proof_request_tx, proof_request_rx) = tokio_mpsc::unbounded_channel();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
 
         let parent_span = tracing::Span::current();
@@ -348,9 +349,9 @@ where
                 self.promote_pending_account_updates()?;
                 self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
 
-                if self.finished_state_updates &&
-                    self.account_updates.is_empty() &&
-                    self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
+                if self.finished_state_updates
+                    && self.account_updates.is_empty()
+                    && self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
                 {
                     break;
                 }
@@ -699,8 +700,8 @@ where
         let mut tries_to_compute_roots: Vec<(B256, SendStorageTriePtr<S>)> =
             Vec::with_capacity(addresses_to_compute_roots.len());
         for address in addresses_to_compute_roots {
-            if let Some(trie) = self.trie.storage_tries_mut().get_mut(&address) &&
-                !trie.is_root_cached()
+            if let Some(trie) = self.trie.storage_tries_mut().get_mut(&address)
+                && !trie.is_root_cached()
             {
                 tries_to_compute_roots.push((address, SendStorageTriePtr(trie)));
             }
@@ -812,7 +813,7 @@ where
             // We need to keep iterating if any updates are being drained because that might
             // indicate that more pending account updates can be promoted.
             if num_promoted == 0 || !self.process_account_leaf_updates(false)? {
-                break
+                break;
             }
         }
 
@@ -864,11 +865,11 @@ struct ProofOrchestrator {
     /// Handle to the database-backed proof worker pools.
     proof_worker_handle: ProofWorkerHandle,
     /// Proof requests from the sparse trie task.
-    proof_request_rx: CrossbeamReceiver<ProofRequest>,
+    proof_request_rx: tokio_mpsc::UnboundedReceiver<ProofRequest>,
     /// Sender handed to proof workers.
-    worker_result_tx: CrossbeamSender<ProofWorkerResultMessage>,
+    worker_result_tx: tokio_mpsc::UnboundedSender<ProofWorkerResultMessage>,
     /// Receiver for completed proof worker responses.
-    worker_result_rx: CrossbeamReceiver<ProofWorkerResultMessage>,
+    worker_result_rx: tokio_mpsc::UnboundedReceiver<ProofWorkerResultMessage>,
     /// Sender used to return proof results to the sparse trie task.
     sparse_trie_result_tx: CrossbeamSender<ProofResultMessage>,
 }
@@ -876,18 +877,18 @@ struct ProofOrchestrator {
 impl ProofOrchestrator {
     /// Spawns the orchestrator as a background task.
     fn spawn(self, executor: &Runtime) {
-        executor.spawn_blocking_named("proof-orchestrator", move || self.run());
+        executor.spawn_with_signal(|_| self.run());
     }
 
     /// Runs the orchestrator until sparse trie proof requests are closed and all in-flight worker
     /// responses have been relayed.
-    fn run(self) {
+    async fn run(self) {
         let Self {
             executor,
             proof_worker_handle,
-            proof_request_rx,
+            mut proof_request_rx,
             worker_result_tx,
-            worker_result_rx,
+            mut worker_result_rx,
             sparse_trie_result_tx,
         } = self;
 
@@ -895,30 +896,26 @@ impl ProofOrchestrator {
         let mut in_flight = 0usize;
 
         loop {
-            crossbeam_channel::select! {
-                recv(proof_request_rx) -> message => {
-                    match message {
-                        Ok(request) => {
-                            Self::dispatch_request(
-                                &proof_worker_handle,
-                                &worker_result_tx,
-                                request,
-                                &mut in_flight,
-                            );
-                        }
-                        Err(_) => {
-                            proof_requests_closed = true;
-                            if in_flight == 0 {
-                                break;
-                            }
+            tokio::select! {
+                biased;
+
+                message = proof_request_rx.recv(), if !proof_requests_closed => {
+                    if let Some(request) = message {
+                        Self::dispatch_request(
+                            &proof_worker_handle,
+                            &worker_result_tx,
+                            request,
+                            &mut in_flight,
+                        );
+                    } else {
+                        proof_requests_closed = true;
+                        if in_flight == 0 {
+                            break;
                         }
                     }
                 }
-                recv(worker_result_rx) -> message => {
-                    let Ok(result) = message else {
-                        break;
-                    };
-
+                message = worker_result_rx.recv() => {
+                    let Some(result) = message else { break };
                     in_flight = in_flight.saturating_sub(1);
                     Self::spawn_join_task(&executor, sparse_trie_result_tx.clone(), result);
 
@@ -932,7 +929,7 @@ impl ProofOrchestrator {
 
     fn dispatch_request(
         proof_worker_handle: &ProofWorkerHandle,
-        worker_result_tx: &CrossbeamSender<ProofWorkerResultMessage>,
+        worker_result_tx: &tokio_mpsc::UnboundedSender<ProofWorkerResultMessage>,
         request: ProofRequest,
         in_flight: &mut usize,
     ) {
@@ -967,8 +964,8 @@ impl ProofOrchestrator {
         sparse_trie_result_tx: CrossbeamSender<ProofResultMessage>,
         result: ProofWorkerResultMessage,
     ) {
-        executor.spawn_blocking(move || {
-            let _ = sparse_trie_result_tx.send(result.finalize());
+        executor.spawn_with_signal(|_| async move {
+            let _ = sparse_trie_result_tx.send(result.finalize().await);
         });
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -23,6 +23,7 @@ use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
 use reth_trie_parallel::{
     proof_task::{
         AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        ProofWorkerResultMessage,
     },
     root::ParallelStateRootError,
 };
@@ -36,10 +37,10 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = ConfigurableSparseTrie> {
-    /// Sender for proof results.
-    proof_result_tx: CrossbeamSender<ProofResultMessage>,
     /// Receiver for proof results directly from workers.
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
+    /// Sender for proof requests to the proof orchestrator.
+    proof_request_tx: CrossbeamSender<ProofRequest>,
     /// Receives updates from execution and prewarming.
     updates: CrossbeamReceiver<SparseTrieTaskMessage>,
     /// Sender half for the channel to send final hashed state to.
@@ -48,9 +49,6 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     trie: SparseStateTrie<A, S>,
     /// The parent block's state root.
     parent_state_root: B256,
-    /// Handle to the proof worker pools (storage and account).
-    proof_worker_handle: ProofWorkerHandle,
-
     /// The size of proof targets chunk to spawn in one calculation.
     /// If None, chunking is disabled and all targets are processed in a single proof.
     chunk_size: usize,
@@ -134,6 +132,8 @@ where
         chunk_size: usize,
     ) -> Self {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let (worker_result_tx, worker_result_rx) = crossbeam_channel::unbounded();
+        let (proof_request_tx, proof_request_rx) = crossbeam_channel::unbounded();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
 
         let parent_span = tracing::Span::current();
@@ -143,11 +143,20 @@ where
             Self::run_hashing_task(updates, hashed_state_tx, hashing_metrics)
         });
 
-        Self {
-            proof_result_tx,
-            proof_result_rx,
-            updates: hashed_state_rx,
+        ProofOrchestrator {
+            executor: executor.clone(),
             proof_worker_handle,
+            proof_request_rx,
+            worker_result_tx,
+            worker_result_rx,
+            sparse_trie_result_tx: proof_result_tx.clone(),
+        }
+        .spawn(executor);
+
+        Self {
+            proof_result_rx,
+            proof_request_tx,
+            updates: hashed_state_rx,
             final_hashed_state_tx: Some(final_hashed_state_tx),
             trie,
             parent_state_root,
@@ -817,29 +826,150 @@ where
 
         let _span = trace_span!("dispatch_pending_targets").entered();
         let (targets, chunking_length) = self.pending_targets.take();
+        if self
+            .proof_request_tx
+            .send(ProofRequest {
+                targets,
+                chunking_length,
+                chunk_size: self.chunk_size,
+                max_targets_for_chunking: self.max_targets_for_chunking,
+            })
+            .is_err()
+        {
+            error!("failed to send proof request to orchestrator");
+        }
+    }
+}
+
+/// Request from the sparse trie task to the proof orchestrator.
+struct ProofRequest {
+    /// Multiproof targets that need to be calculated from the database.
+    targets: MultiProofTargetsV2,
+    /// Number of account + storage proof targets included in the request.
+    chunking_length: usize,
+    /// The configured proof target chunk size.
+    chunk_size: usize,
+    /// Target count that forces chunking even when worker availability is low.
+    max_targets_for_chunking: usize,
+}
+
+/// Single coordinator for proof requests emitted by the sparse trie task.
+///
+/// The sparse trie task only decides which proofs are needed. This orchestrator owns the proof
+/// worker handle, dispatches requests to the database-backed proof workers, and relays completed
+/// worker responses back to the sparse trie task.
+struct ProofOrchestrator {
+    /// Runtime used to spawn proof join tasks.
+    executor: Runtime,
+    /// Handle to the database-backed proof worker pools.
+    proof_worker_handle: ProofWorkerHandle,
+    /// Proof requests from the sparse trie task.
+    proof_request_rx: CrossbeamReceiver<ProofRequest>,
+    /// Sender handed to proof workers.
+    worker_result_tx: CrossbeamSender<ProofWorkerResultMessage>,
+    /// Receiver for completed proof worker responses.
+    worker_result_rx: CrossbeamReceiver<ProofWorkerResultMessage>,
+    /// Sender used to return proof results to the sparse trie task.
+    sparse_trie_result_tx: CrossbeamSender<ProofResultMessage>,
+}
+
+impl ProofOrchestrator {
+    /// Spawns the orchestrator as a background task.
+    fn spawn(self, executor: &Runtime) {
+        executor.spawn_blocking_named("proof-orchestrator", move || self.run());
+    }
+
+    /// Runs the orchestrator until sparse trie proof requests are closed and all in-flight worker
+    /// responses have been relayed.
+    fn run(self) {
+        let Self {
+            executor,
+            proof_worker_handle,
+            proof_request_rx,
+            worker_result_tx,
+            worker_result_rx,
+            sparse_trie_result_tx,
+        } = self;
+
+        let mut proof_requests_closed = false;
+        let mut in_flight = 0usize;
+
+        loop {
+            crossbeam_channel::select! {
+                recv(proof_request_rx) -> message => {
+                    match message {
+                        Ok(request) => {
+                            Self::dispatch_request(
+                                &proof_worker_handle,
+                                &worker_result_tx,
+                                request,
+                                &mut in_flight,
+                            );
+                        }
+                        Err(_) => {
+                            proof_requests_closed = true;
+                            if in_flight == 0 {
+                                break;
+                            }
+                        }
+                    }
+                }
+                recv(worker_result_rx) -> message => {
+                    let Ok(result) = message else {
+                        break;
+                    };
+
+                    in_flight = in_flight.saturating_sub(1);
+                    Self::spawn_join_task(&executor, sparse_trie_result_tx.clone(), result);
+
+                    if proof_requests_closed && in_flight == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn dispatch_request(
+        proof_worker_handle: &ProofWorkerHandle,
+        worker_result_tx: &CrossbeamSender<ProofWorkerResultMessage>,
+        request: ProofRequest,
+        in_flight: &mut usize,
+    ) {
         dispatch_with_chunking(
-            targets,
-            chunking_length,
-            self.chunk_size,
-            self.max_targets_for_chunking,
-            self.proof_worker_handle.has_multiple_idle_account_workers(),
-            self.proof_worker_handle.has_multiple_idle_storage_workers(),
+            request.targets,
+            request.chunking_length,
+            request.chunk_size,
+            request.max_targets_for_chunking,
+            proof_worker_handle.has_multiple_idle_account_workers(),
+            proof_worker_handle.has_multiple_idle_storage_workers(),
             MultiProofTargetsV2::chunks,
             |proof_targets| {
-                if let Err(e) =
-                    self.proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
+                *in_flight += 1;
+                if let Err(error) =
+                    proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
                         targets: proof_targets,
                         proof_result_sender: ProofResultContext::new(
-                            self.proof_result_tx.clone(),
+                            worker_result_tx.clone(),
                             HashedPostState::default(),
                             Instant::now(),
                         ),
                     })
                 {
-                    error!("failed to dispatch account multiproof: {e:?}");
+                    error!("failed to dispatch account multiproof: {error:?}");
                 }
             },
         );
+    }
+
+    fn spawn_join_task(
+        executor: &Runtime,
+        sparse_trie_result_tx: CrossbeamSender<ProofResultMessage>,
+        result: ProofWorkerResultMessage,
+    ) {
+        executor.spawn_blocking(move || {
+            let _ = sparse_trie_result_tx.send(result.finalize());
+        });
     }
 }
 

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -39,6 +39,7 @@ rayon.workspace = true
 itertools.workspace = true
 crossbeam-channel.workspace = true
 crossbeam-utils.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 
 # `metrics` feature
 reth-metrics = { workspace = true, optional = true }
@@ -61,7 +62,6 @@ reth-trie = { workspace = true, features = ["test-utils"] }
 rand.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
 default = ["metrics"]

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -38,7 +38,7 @@ use alloy_primitives::{
     B256, U256,
 };
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
-use reth_execution_errors::StateProofError;
+use reth_execution_errors::trie::StateProofError;
 use reth_primitives_traits::{dashmap::DashMap, FastInstant as Instant};
 use reth_provider::{DatabaseProviderROFactory, ProviderError, ProviderResult};
 use reth_storage_errors::db::DatabaseError;
@@ -361,7 +361,7 @@ impl ProofWorkerHandle {
                 let ProofResultContext { sender: result_tx, state, start_time: start } =
                     input.into_proof_result_sender();
 
-                let _ = result_tx.send(ProofResultMessage {
+                let _ = result_tx.send(ProofWorkerResultMessage {
                     result: Err(ParallelStateRootError::Provider(error.clone())),
                     elapsed: start.elapsed(),
                     state,
@@ -464,11 +464,10 @@ where
     }
 }
 
-/// Channel used by worker threads to deliver `ProofResultMessage` items back to
-/// `SparseTrieCacheTask`.
+/// Channel used by account worker threads to deliver proof work back to the orchestrator.
 ///
-/// Workers use this sender to deliver proof results directly to `SparseTrieCacheTask`.
-pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
+/// The account worker does not wait for storage worker receivers before sending on this channel.
+pub type ProofWorkerResultSender = CrossbeamSender<ProofWorkerResultMessage>;
 
 /// Message containing a completed proof result with metadata for direct delivery to
 /// `SparseTrieCacheTask`.
@@ -485,6 +484,63 @@ pub struct ProofResultMessage {
     pub state: HashedPostState,
 }
 
+/// Message containing account proof work from an account worker.
+///
+/// This may still contain storage proof receivers that need to be awaited by a coordinator.
+#[derive(Debug)]
+pub struct ProofWorkerResultMessage {
+    /// The account worker result.
+    pub result: Result<PartialDecodedMultiProofV2, ParallelStateRootError>,
+    /// Time elapsed from request dispatch until the account worker finished its part.
+    pub elapsed: Duration,
+    /// Original state update that triggered this proof.
+    pub state: HashedPostState,
+}
+
+impl ProofWorkerResultMessage {
+    /// Waits for any outstanding storage proof responses and converts this into the regular proof
+    /// result message expected by the sparse trie task.
+    pub fn finalize(self) -> ProofResultMessage {
+        let Self { result, elapsed, state } = self;
+        let result = result.and_then(PartialDecodedMultiProofV2::finalize);
+        ProofResultMessage { result, elapsed, state }
+    }
+}
+
+/// Account proofs plus storage proof state that may still need to be collected.
+#[derive(Debug)]
+pub struct PartialDecodedMultiProofV2 {
+    /// Account proof nodes already computed by the account worker.
+    account_proofs: Vec<ProofTrieNodeV2>,
+    /// Storage proof nodes already collected while encoding account values.
+    storage_proofs: B256Map<Vec<ProofTrieNodeV2>>,
+    /// Storage proof receivers that should be awaited outside the account worker.
+    pending_storage_proofs: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+}
+
+impl PartialDecodedMultiProofV2 {
+    /// Collects pending storage proofs and returns a complete decoded multiproof.
+    fn finalize(mut self) -> Result<DecodedMultiProofV2, ParallelStateRootError> {
+        for (hashed_address, rx) in self.pending_storage_proofs {
+            let result = rx
+                .recv()
+                .map_err(|_| {
+                    ParallelStateRootError::Other(format!(
+                        "Storage proof channel closed for {hashed_address:?}",
+                    ))
+                })?
+                .result
+                .map_err(|err| ParallelStateRootError::Other(err.to_string()))?;
+            self.storage_proofs.insert(hashed_address, result.proof);
+        }
+
+        Ok(DecodedMultiProofV2 {
+            account_proofs: self.account_proofs,
+            storage_proofs: self.storage_proofs,
+        })
+    }
+}
+
 /// Context for sending proof calculation results back to `SparseTrieCacheTask`.
 ///
 /// This struct contains all context needed to send and track proof calculation results.
@@ -492,7 +548,7 @@ pub struct ProofResultMessage {
 #[derive(Debug, Clone)]
 pub struct ProofResultContext {
     /// Channel sender for result delivery
-    pub sender: ProofResultSender,
+    pub sender: ProofWorkerResultSender,
     /// Original state update that triggered this proof
     pub state: HashedPostState,
     /// Calculation start time for measuring elapsed duration
@@ -502,7 +558,7 @@ pub struct ProofResultContext {
 impl ProofResultContext {
     /// Creates a new proof result context.
     pub const fn new(
-        sender: ProofResultSender,
+        sender: ProofWorkerResultSender,
         state: HashedPostState,
         start_time: Instant,
     ) -> Self {
@@ -963,7 +1019,7 @@ where
         v2_account_calculator: &mut V2AccountProofCalculator<'a, Provider>,
         v2_storage_calculator: Rc<RefCell<V2StorageProofCalculator<'a, Provider>>>,
         targets: MultiProofTargetsV2,
-    ) -> Result<(DecodedMultiProofV2, ValueEncoderStats), ParallelStateRootError>
+    ) -> Result<(PartialDecodedMultiProofV2, ValueEncoderStats), ParallelStateRootError>
     where
         Provider: TrieCursorFactory + HashedCursorFactory + 'a,
     {
@@ -991,9 +1047,11 @@ where
         let account_proofs =
             v2_account_calculator.proof(&mut value_encoder, &mut account_targets)?;
 
-        let (storage_proofs, value_encoder_stats) = value_encoder.finalize()?;
+        let (storage_proofs, pending_storage_proofs, value_encoder_stats) =
+            value_encoder.finish_without_waiting();
 
-        let proof = DecodedMultiProofV2 { account_proofs, storage_proofs };
+        let proof =
+            PartialDecodedMultiProofV2 { account_proofs, storage_proofs, pending_storage_proofs };
 
         Ok((proof, value_encoder_stats))
     }
@@ -1031,7 +1089,7 @@ where
         *account_proofs_processed += 1;
 
         // Send result to SparseTrieCacheTask
-        if result_tx.send(ProofResultMessage { result, elapsed: total_elapsed, state }).is_err() {
+        if result_tx.send(ProofWorkerResultMessage { result, elapsed: total_elapsed, state }).is_err() {
             trace!(
                 target: "trie::proof_task",
                 worker_id=self.worker_id,

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -58,6 +58,7 @@ use std::{
     },
     time::Duration,
 };
+use tokio::sync::{mpsc as tokio_mpsc, oneshot};
 use tracing::{debug, debug_span, error, instrument, trace};
 
 #[cfg(feature = "metrics")]
@@ -326,7 +327,7 @@ impl ProofWorkerHandle {
     pub fn dispatch_storage_proof(
         &self,
         input: StorageProofInput,
-        proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
+        proof_result_sender: oneshot::Sender<StorageProofResultMessage>,
     ) -> Result<(), ProviderError> {
         let hashed_address = input.hashed_address;
         self.storage_work_tx
@@ -467,7 +468,7 @@ where
 /// Channel used by account worker threads to deliver proof work back to the orchestrator.
 ///
 /// The account worker does not wait for storage worker receivers before sending on this channel.
-pub type ProofWorkerResultSender = CrossbeamSender<ProofWorkerResultMessage>;
+pub type ProofWorkerResultSender = tokio_mpsc::UnboundedSender<ProofWorkerResultMessage>;
 
 /// Message containing a completed proof result with metadata for direct delivery to
 /// `SparseTrieCacheTask`.
@@ -500,9 +501,12 @@ pub struct ProofWorkerResultMessage {
 impl ProofWorkerResultMessage {
     /// Waits for any outstanding storage proof responses and converts this into the regular proof
     /// result message expected by the sparse trie task.
-    pub fn finalize(self) -> ProofResultMessage {
+    pub async fn finalize(self) -> ProofResultMessage {
         let Self { result, elapsed, state } = self;
-        let result = result.and_then(PartialDecodedMultiProofV2::finalize);
+        let result = match result {
+            Ok(proof) => proof.finalize().await,
+            Err(error) => Err(error),
+        };
         ProofResultMessage { result, elapsed, state }
     }
 }
@@ -515,15 +519,15 @@ pub struct PartialDecodedMultiProofV2 {
     /// Storage proof nodes already collected while encoding account values.
     storage_proofs: B256Map<Vec<ProofTrieNodeV2>>,
     /// Storage proof receivers that should be awaited outside the account worker.
-    pending_storage_proofs: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+    pending_storage_proofs: B256Map<oneshot::Receiver<StorageProofResultMessage>>,
 }
 
 impl PartialDecodedMultiProofV2 {
     /// Collects pending storage proofs and returns a complete decoded multiproof.
-    fn finalize(mut self) -> Result<DecodedMultiProofV2, ParallelStateRootError> {
+    async fn finalize(mut self) -> Result<DecodedMultiProofV2, ParallelStateRootError> {
         for (hashed_address, rx) in self.pending_storage_proofs {
             let result = rx
-                .recv()
+                .await
                 .map_err(|_| {
                     ParallelStateRootError::Other(format!(
                         "Storage proof channel closed for {hashed_address:?}",
@@ -600,7 +604,7 @@ pub(crate) enum StorageWorkerJob {
         /// Storage proof input parameters
         input: StorageProofInput,
         /// Context for sending the proof result.
-        proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
+        proof_result_sender: oneshot::Sender<StorageProofResultMessage>,
     },
 }
 
@@ -766,7 +770,7 @@ where
         proof_tx: &ProofTaskTx<Provider>,
         v2_calculator: &mut proof_v2::StorageProofCalculator<TC, HC>,
         input: StorageProofInput,
-        proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
+        proof_result_sender: oneshot::Sender<StorageProofResultMessage>,
         storage_proofs_processed: &mut u64,
     ) where
         Provider: TrieCursorFactory + HashedCursorFactory,
@@ -1089,7 +1093,10 @@ where
         *account_proofs_processed += 1;
 
         // Send result to SparseTrieCacheTask
-        if result_tx.send(ProofWorkerResultMessage { result, elapsed: total_elapsed, state }).is_err() {
+        if result_tx
+            .send(ProofWorkerResultMessage { result, elapsed: total_elapsed, state })
+            .is_err()
+        {
             trace!(
                 target: "trie::proof_task",
                 worker_id=self.worker_id,
@@ -1121,9 +1128,9 @@ fn dispatch_v2_storage_proofs(
     storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
     account_targets: &[ProofV2Target],
     mut storage_targets: B256Map<Vec<ProofV2Target>>,
-) -> Result<B256Map<CrossbeamReceiver<StorageProofResultMessage>>, ParallelStateRootError> {
+) -> Result<B256Map<oneshot::Receiver<StorageProofResultMessage>>, ParallelStateRootError> {
     if storage_targets.is_empty() {
-        return Ok(B256Map::default())
+        return Ok(B256Map::default());
     }
 
     let mut storage_proof_receivers =
@@ -1135,8 +1142,8 @@ fn dispatch_v2_storage_proofs(
     // For storage targets with associated account proofs, ensure the first target has
     // min_len(0) so the root node is returned for storage root computation
     for (hashed_address, targets) in &mut storage_targets {
-        if account_target_addresses.contains(hashed_address) &&
-            let Some(first) = targets.first_mut()
+        if account_target_addresses.contains(hashed_address)
+            && let Some(first) = targets.first_mut()
         {
             *first = first.with_min_len(0);
         }
@@ -1151,7 +1158,7 @@ fn dispatch_v2_storage_proofs(
     // Dispatch all proofs for targeted storage slots
     for (hashed_address, targets) in sorted_storage_targets {
         // Create channel for receiving StorageProofResultMessage
-        let (result_tx, result_rx) = crossbeam_channel::unbounded();
+        let (result_tx, result_rx) = oneshot::channel();
         let input = StorageProofInput::new(hashed_address, targets);
 
         storage_work_tx

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -2,7 +2,6 @@ use crate::proof_task::StorageProofResultMessage;
 use alloy_primitives::{map::B256Map, B256};
 use alloy_rlp::Encodable;
 use core::cell::RefCell;
-use crossbeam_channel::Receiver as CrossbeamReceiver;
 use reth_execution_errors::trie::StateProofError;
 use reth_primitives_traits::{dashmap::DashMap, Account};
 use reth_storage_errors::db::DatabaseError;
@@ -17,6 +16,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use tokio::sync::oneshot;
 
 /// Stats collected by [`AsyncAccountValueEncoder`] during proof computation.
 ///
@@ -57,7 +57,7 @@ pub(crate) enum AsyncAccountDeferredValueEncoder<TC, HC> {
         /// take ownership of the receiver, preventing the `Drop` impl from trying to receive on
         /// it again.
         proof_result_rx:
-            Option<Result<CrossbeamReceiver<StorageProofResultMessage>, DatabaseError>>,
+            Option<Result<oneshot::Receiver<StorageProofResultMessage>, DatabaseError>>,
         /// Shared storage proof results.
         storage_proof_results: Rc<RefCell<B256Map<Vec<ProofTrieNodeV2>>>>,
         /// Shared stats for tracking wait time and counts.
@@ -100,7 +100,7 @@ impl<TC, HC> Drop for AsyncAccountDeferredValueEncoder<TC, HC> {
                 let rx = proof_result_rx?;
 
                 let wait_start = Instant::now();
-                let msg = rx.recv().map_err(|_| {
+                let msg = rx.blocking_recv().map_err(|_| {
                     StateProofError::Database(DatabaseError::Other(format!(
                         "Storage proof channel closed for {hashed_address:?}",
                     )))
@@ -146,7 +146,7 @@ where
                     .expect("encode called on already-consumed Dispatched encoder");
                 let wait_start = Instant::now();
                 let result = proof_result_rx?
-                    .recv()
+                    .blocking_recv()
                     .map_err(|_| {
                         StateProofError::Database(DatabaseError::Other(format!(
                             "Storage proof channel closed for {hashed_address:?}",
@@ -212,7 +212,7 @@ where
 /// multiple accounts.
 pub(crate) struct AsyncAccountValueEncoder<TC, HC> {
     /// Storage proof jobs which were dispatched ahead of time.
-    dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+    dispatched: B256Map<oneshot::Receiver<StorageProofResultMessage>>,
     /// Storage roots which have already been computed. This can be used only if a storage proof
     /// wasn't dispatched for an account, otherwise we must consume the proof result.
     cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -235,7 +235,7 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
     /// - `cached_storage_roots`: Shared cache of already-computed storage roots
     /// - `storage_calculator`: Shared storage proof calculator for synchronous computation
     pub(crate) fn new(
-        dispatched: B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+        dispatched: B256Map<oneshot::Receiver<StorageProofResultMessage>>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
         storage_calculator: Rc<RefCell<StorageProofCalculator<TC, HC>>>,
     ) -> Self {
@@ -256,7 +256,7 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
         self,
     ) -> (
         B256Map<Vec<ProofTrieNodeV2>>,
-        B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+        B256Map<oneshot::Receiver<StorageProofResultMessage>>,
         ValueEncoderStats,
     ) {
         let storage_proof_results = Rc::into_inner(self.storage_proof_results)
@@ -296,7 +296,7 @@ where
                 stats: self.stats.clone(),
                 storage_calculator: self.storage_calculator.clone(),
                 cached_storage_roots: self.cached_storage_roots.clone(),
-            }
+            };
         }
 
         // If the address didn't have a job dispatched for it then we can assume it has no targets,
@@ -305,7 +305,7 @@ where
         // If the root is already calculated then just use it directly
         if let Some(root) = self.cached_storage_roots.get(&hashed_address) {
             self.stats.borrow_mut().from_cache_count += 1;
-            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root }
+            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root };
         }
 
         // Compute storage root synchronously using the shared calculator

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -248,44 +248,26 @@ impl<TC, HC> AsyncAccountValueEncoder<TC, HC> {
         }
     }
 
-    /// Consume [`Self`] and return all collected storage proofs along with accumulated stats.
+    /// Consumes [`Self`] without waiting for remaining dispatched storage proof receivers.
     ///
-    /// This method collects any remaining dispatched proofs that weren't consumed during proof
-    /// calculation and includes their wait time in the returned stats.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if any deferred encoders produced by [`Self::deferred_encoder`] have not
-    /// been dropped.
-    pub(crate) fn finalize(
+    /// This returns any proof receivers that were not needed while constructing account proofs so
+    /// a coordinator outside the account worker can wait for them.
+    pub(crate) fn finish_without_waiting(
         self,
-    ) -> Result<(B256Map<Vec<ProofTrieNodeV2>>, ValueEncoderStats), StateProofError> {
-        let mut storage_proof_results = Rc::into_inner(self.storage_proof_results)
+    ) -> (
+        B256Map<Vec<ProofTrieNodeV2>>,
+        B256Map<CrossbeamReceiver<StorageProofResultMessage>>,
+        ValueEncoderStats,
+    ) {
+        let storage_proof_results = Rc::into_inner(self.storage_proof_results)
             .expect("no deferred encoders are still allocated")
             .into_inner();
 
-        let mut stats = Rc::into_inner(self.stats)
+        let stats = Rc::into_inner(self.stats)
             .expect("no deferred encoders are still allocated")
             .into_inner();
 
-        // Any remaining dispatched proofs need to have their results collected.
-        // These are proofs that were pre-dispatched but not consumed during proof calculation.
-        for (hashed_address, rx) in &self.dispatched {
-            let wait_start = Instant::now();
-            let result = rx
-                .recv()
-                .map_err(|_| {
-                    StateProofError::Database(DatabaseError::Other(format!(
-                        "Storage proof channel closed for {hashed_address:?}",
-                    )))
-                })?
-                .result?;
-            stats.storage_wait_time += wait_start.elapsed();
-
-            storage_proof_results.insert(*hashed_address, result.proof);
-        }
-
-        Ok((storage_proof_results, stats))
+        (storage_proof_results, self.dispatched, stats)
     }
 }
 


### PR DESCRIPTION
Reworks sparse trie proof dispatch so proof requests are sent through a single orchestrator task. The orchestrator owns proof worker dispatch, relays worker responses back to the sparse trie task, and drains in-flight responses before exiting.

Validation:
- cargo check -p reth-engine-tree

Prompted by: @klkvr