### PR TITLE
fix(chain-state): avoid engine deadlock from locks held across the trie compute

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -50,12 +50,18 @@ enum DeferredTrieDataInner {
     /// Data is not yet available; raw inputs stored for fallback computation.
     ///
     /// Wrapped in `Option` to allow taking ownership during computation.
+    // jnt-v2 fix: PATCH 2 makes `pending` store Ready, so this variant is no longer
+    // constructed (still matched by wait_cloned/Debug). Kept intentionally.
+    #[allow(dead_code)]
     Pending(Option<PendingInputs>),
     /// Data has been computed and is ready.
     Ready(ComputedTrieData),
 }
 
 /// Inputs kept while a deferred trie computation is pending.
+// jnt-v2 fix: PATCH 2 makes `pending` store Ready, so these fields are no longer
+// constructed/read on any live path. Kept intentionally (matched by wait_cloned).
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 struct PendingInputs {
     /// Unsorted hashed post-state from execution.
@@ -81,12 +87,11 @@ impl fmt::Debug for DeferredTrieData {
 impl DeferredTrieData {
     /// Create a new pending handle with fallback inputs for synchronous computation.
     pub fn pending(hashed_state: Arc<HashedPostState>, trie_updates: Arc<TrieUpdates>) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(DeferredTrieDataInner::Pending(Some(PendingInputs {
-                hashed_state,
-                trie_updates,
-            })))),
-        }
+        // FIX (jnt-v2 engine wedge): compute eagerly and store Ready. The lazy variant computed
+        // inside wait_cloned WHILE HOLDING the Mutex (Self::sort runs a rayon::join), which
+        // deadlocked the overlay/engine machinery. Computing up-front means wait_cloned always
+        // finds Ready and never holds the lock across a compute (no deadlock, no busy-wait).
+        Self::ready(Self::sort(hashed_state, trie_updates))
     }
 
     /// Create a handle that is already populated with the given [`ComputedTrieData`].

--- a/crates/chain-state/src/state_trie_overlay.rs
+++ b/crates/chain-state/src/state_trie_overlay.rs
@@ -289,38 +289,38 @@ impl<N: NodePrimitives> StateTrieOverlayManager<N> {
             None => ComputeOverlayInput::MergeBlocks(blocks),
         };
 
-        // The vacant entry is the cache-fill gate: racing callers block instead of recomputing.
+        // FIX (jnt-v2 engine wedge): do not hold an `overlays` DashMap entry (shard write) guard
+        // across the blocking overlay compute. Compute first, then recheck-and-insert.
+        self.metrics.overlay_cache_fills.increment(1);
+        let computed = {
+            #[cfg(feature = "rayon")]
+            {
+                if let Some(worker_pool) = &self.worker_pool {
+                    let compute_span = span.clone();
+                    let metrics = self.metrics.clone();
+                    Arc::new(worker_pool.install_fn(move || {
+                        let _guard = compute_span.enter();
+                        compute_overlay(compute_input, anchor_hash, &metrics)
+                    }))
+                } else {
+                    Arc::new(compute_overlay(compute_input, anchor_hash, &self.metrics))
+                }
+            }
+
+            #[cfg(not(feature = "rayon"))]
+            {
+                Arc::new(compute_overlay(compute_input, anchor_hash, &self.metrics))
+            }
+        };
         let input = match self.overlays.entry(key) {
             Entry::Occupied(entry) => {
                 self.metrics.overlay_cache_reuses.increment(1);
                 span.record("cache_reused", true);
-                return Ok(Arc::clone(entry.get()))
+                Arc::clone(entry.get())
             }
             Entry::Vacant(entry) => {
-                self.metrics.overlay_cache_fills.increment(1);
-                let input = {
-                    #[cfg(feature = "rayon")]
-                    {
-                        if let Some(worker_pool) = &self.worker_pool {
-                            let compute_span = span;
-                            let metrics = self.metrics.clone();
-                            Arc::new(worker_pool.install_fn(move || {
-                                let _guard = compute_span.enter();
-                                compute_overlay(compute_input, anchor_hash, &metrics)
-                            }))
-                        } else {
-                            Arc::new(compute_overlay(compute_input, anchor_hash, &self.metrics))
-                        }
-                    }
-
-                    #[cfg(not(feature = "rayon"))]
-                    {
-                        Arc::new(compute_overlay(compute_input, anchor_hash, &self.metrics))
-                    }
-                };
-
-                entry.insert(Arc::clone(&input));
-                input
+                entry.insert(Arc::clone(&computed));
+                computed
             }
         };
 


### PR DESCRIPTION
Fixes a cyclic deadlock in `StateTrieOverlayManager` / `DeferredTrieData` that wedges the engine under sustained Engine-API block import (observed via op-node / op-supernode CL-sync). The process stays up but the Engine API stops making progress: `Block added to canonical chain N` with no following `Canonical chain committed N`, `forkchoiceUpdated` times out, and libmdbx logs `Long-lived read transaction has been timed out open_duration=300.000s`; all threads park.

Two places hold a lock across a blocking `rayon` compute:

- `get_overlay` holds a `self.overlays` `DashMap` entry (shard-write) guard across `compute_overlay`. The post-persistence cleanup `remove_blocks` → `self.overlays.len()` / `.retain(...)` locks every shard and then blocks on that held shard.
- `DeferredTrieData::wait_cloned` holds the `state` `Mutex` across `Self::sort` (a `rayon::join`). Reached from a state-trie-overlay worker, the worker blocks in the join and rayon work-steals a `get_overlay` job that re-enters `wait_cloned` — a single-thread self-deadlock.

Fix — don't hold a lock across the compute:
- `get_overlay` computes the overlay *before* taking the map entry, then rechecks-and-inserts.
- `DeferredTrieData` computes the sort eagerly in `pending()` so `wait_cloned` always finds a ready value (never sorts on, or parks, a worker on the hot path).

Reported downstream as ethereum-optimism/optimism#21076.

Validation: an unpatched `maxperf` build wedges within minutes of a fresh from-genesis CL-sync; with this change it ran a 6-hour continuous soak and repeated from-genesis resyncs (two chains, ~11 days of backlog caught up to the live tip) with zero wedges. I also have a deterministic, timeout-guarded regression test that deadlocks on `main` and passes with this fix — happy to add it to this PR.

Draft for maintainer feedback on the approach. A laziness-preserving alternative (keep the deferral but make `Self::sort` sequential, which removes the work-steal re-entrancy) passes the same tests; I can take that route instead if you'd rather keep the async sort.
