### PR TITLE
feat(bench): add chrome trace profiles

### DIFF
--- a/.github/scripts/bench-job-summary.js
+++ b/.github/scripts/bench-job-summary.js
@@ -7,6 +7,7 @@
 //   BENCH_CORES          – CPU core limit (0 = all)
 //   BENCH_WARMUP_BLOCKS  – Number of warmup blocks
 //   BENCH_SAMPLY         – 'true' if samply profiling was enabled
+//   BENCH_TRACING_CHROME – 'true' if Chrome trace recording was enabled
 //   BENCH_RUN_PAIRS      – Number of configured benchmark run pairs
 //
 // Usage from actions/github-script:
@@ -14,7 +15,15 @@
 //   await jobSummary({ core, context, chartSha, grafanaUrl, logsUrl, tracesUrl, runId });
 
 const fs = require('fs');
-const { verdict, loadSamplyUrls, blocksLabel, metricRows, waitTimeRows, fmtChange } = require('./bench-utils');
+const {
+  verdict,
+  loadSamplyUrls,
+  loadTracingChromeUrls,
+  blocksLabel,
+  metricRows,
+  waitTimeRows,
+  fmtChange,
+} = require('./bench-utils');
 
 function fmtMetricValue(v) {
   if (v === null || v === undefined || !Number.isFinite(v)) return 'n/a';
@@ -124,6 +133,13 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl,
   const samplyLinks = Object.entries(samplyUrls).map(([run, url]) => `- **${run}**: [Firefox Profiler](${url})`);
   if (samplyLinks.length > 0) {
     md += `### Samply Profiles\n\n${samplyLinks.join('\n')}\n\n`;
+  }
+
+  const tracingChromeUrls = loadTracingChromeUrls(process.env.BENCH_WORK_DIR);
+  const tracingChromeLinks = Object.entries(tracingChromeUrls)
+    .map(([run, url]) => `- **${run}**: [Perfetto](${url})`);
+  if (tracingChromeLinks.length > 0) {
+    md += `### Chrome Traces\n\n${tracingChromeLinks.join('\n')}\n\n`;
   }
 
   // Observability

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -10,6 +10,7 @@
 //   BENCH_BASELINE_ARGS    – Extra CLI args for the baseline reth node
 //   BENCH_FEATURE_ARGS     – Extra CLI args for the feature reth node
 //   BENCH_SAMPLY           – 'true' if samply profiling was enabled
+//   BENCH_TRACING_CHROME   – 'true' if Chrome trace recording was enabled
 //
 // Usage from actions/github-script:
 //   const notify = require('./.github/scripts/bench-slack-notify.js');
@@ -18,7 +19,16 @@
 
 const fs = require('fs');
 const path = require('path');
-const { fmtChange, fmtMs, verdict, isWin, loadSamplyUrls, blocksLabel, metricRows } = require('./bench-utils');
+const {
+  fmtChange,
+  fmtMs,
+  verdict,
+  isWin,
+  loadSamplyUrls,
+  loadTracingChromeUrls,
+  blocksLabel,
+  metricRows,
+} = require('./bench-utils');
 
 const SLACK_API = 'https://slack.com/api/chat.postMessage';
 
@@ -72,6 +82,16 @@ function profileLinks(samplyUrls, prefix) {
     });
 }
 
+function chromeTraceLinks(tracingChromeUrls, prefix) {
+  return Object.entries(tracingChromeUrls)
+    .filter(([run]) => run.startsWith(`${prefix}-`))
+    .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+    .map(([run, url]) => {
+      const index = run.slice(prefix.length + 1);
+      return `<${url}|Chrome ${index}>`;
+    });
+}
+
 // Slack shortcodes for verdict (Block Kit header doesn't support unicode emoji)
 const SLACK_VERDICT = {
   '⚠️': ':warning:',
@@ -94,6 +114,7 @@ function benchConfigLine() {
   add('big-blocks-target-gas', process.env.BENCH_BIG_BLOCKS_TARGET_GAS);
   add('bal', process.env.BENCH_BAL, 'false');
   add('samply', process.env.BENCH_SAMPLY, 'false');
+  add('tracing-chrome', process.env.BENCH_TRACING_CHROME, 'false');
   add('slack', process.env.BENCH_SLACK, 'always');
   add('cores', process.env.BENCH_CORES, '0');
   add('run-pairs', process.env.BENCH_RUN_PAIRS);
@@ -106,7 +127,16 @@ function benchConfigLine() {
   return parts.length ? `*Workflow:* ${parts.join(' ')}` : '';
 }
 
-function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo, samplyUrls }) {
+function buildSuccessBlocks({
+  summary,
+  prNumber,
+  actor,
+  actorSlackId,
+  jobUrl,
+  repo,
+  samplyUrls,
+  tracingChromeUrls,
+}) {
   const { emoji, label } = verdict(summary.changes);
   const headerEmoji = SLACK_VERDICT[emoji] || emoji;
 
@@ -125,10 +155,14 @@ function buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, re
   let baselineLine = `*Baseline:* ${baselineLink}`;
   const baselineProfiles = profileLinks(samplyUrls, 'baseline');
   if (baselineProfiles.length) baselineLine += ` | ${baselineProfiles.join(' | ')}`;
+  const baselineTraces = chromeTraceLinks(tracingChromeUrls, 'baseline');
+  if (baselineTraces.length) baselineLine += ` | ${baselineTraces.join(' | ')}`;
 
   let featureLine = `*Feature:* ${featureLink}`;
   const featureProfiles = profileLinks(samplyUrls, 'feature');
   if (featureProfiles.length) featureLine += ` | ${featureProfiles.join(' | ')}`;
+  const featureTraces = chromeTraceLinks(tracingChromeUrls, 'feature');
+  if (featureTraces.length) featureLine += ` | ${featureTraces.join(' | ')}`;
 
   const countsLine = blocksLabel(summary).map(p => `*${p.key}:* ${p.value}`).join(' | ');
   const configLine = benchConfigLine();
@@ -254,11 +288,21 @@ async function success({ core, context }) {
     `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
   const samplyUrls = loadSamplyUrls(process.env.BENCH_WORK_DIR);
+  const tracingChromeUrls = loadTracingChromeUrls(process.env.BENCH_WORK_DIR);
 
   const slackUsers = loadSlackUsers(process.env.GITHUB_WORKSPACE || '.');
   const actorSlackId = slackUsers[actor];
 
-  const blocks = buildSuccessBlocks({ summary, prNumber, actor, actorSlackId, jobUrl, repo, samplyUrls });
+  const blocks = buildSuccessBlocks({
+    summary,
+    prNumber,
+    actor,
+    actorSlackId,
+    jobUrl,
+    repo,
+    samplyUrls,
+    tracingChromeUrls,
+  });
   const text = `Bench: ${summary.baseline.name} vs ${summary.feature.name}`;
 
   const slackMode = process.env.BENCH_SLACK || 'always';

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -294,10 +294,14 @@ if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
 fi
 
 if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
-  RETH_ARGS+=(
-    --log.tracing-chrome
-    --log.tracing-chrome.file "$OUTPUT_DIR/tracing-chrome-profile.json"
-  )
+  if "$BINARY" node --help 2>/dev/null | grep -qF -- '--log.tracing-chrome'; then
+    RETH_ARGS+=(
+      --log.tracing-chrome
+      --log.tracing-chrome.file "$OUTPUT_DIR/tracing-chrome-profile.json"
+    )
+  else
+    echo "Chrome trace recording requested, but ${LABEL} binary does not support --log.tracing-chrome; skipping"
+  fi
 fi
 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -294,13 +294,13 @@ if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
 fi
 
 if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
-  if "$BINARY" node --help 2>/dev/null | grep -qF -- '--log.tracing-chrome'; then
+  if "$BINARY" node --log.tracing-chrome --log.tracing-chrome.file "$OUTPUT_DIR/tracing-chrome-profile.json" --help >/dev/null 2>&1; then
     RETH_ARGS+=(
       --log.tracing-chrome
       --log.tracing-chrome.file "$OUTPUT_DIR/tracing-chrome-profile.json"
     )
   else
-    echo "Chrome trace recording requested, but ${LABEL} binary does not support --log.tracing-chrome; skipping"
+    echo "Chrome trace recording requested, but ${LABEL} binary rejected --log.tracing-chrome; skipping"
   fi
 fi
 

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -11,7 +11,8 @@
 #               BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
-#               BENCH_TRACY, BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ,
+#               BENCH_TRACING_CHROME, BENCH_TRACY,
+#               BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ,
 #               TXGEN_PAYLOADS_DIR (pre-extracted payloads; skips extraction),
 #               BENCH_TARGET_METRICS_SCRAPE_INTERVAL_MS (optional txgen override)
 set -euxo pipefail
@@ -290,6 +291,16 @@ echo "Memory limit: $(( MEM_LIMIT / 1024 / 1024 ))MB (95% of $(( TOTAL_MEM_KB / 
 
 if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   RETH_ARGS+=(--log.samply)
+fi
+
+if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+  RETH_ARGS+=(
+    --log.tracing-chrome
+    --log.tracing-chrome.file "$OUTPUT_DIR/tracing-chrome-profile.json"
+  )
+fi
+
+if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   SAMPLY="$(which samply)"
   # shellcheck disable=SC2024
   sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \

--- a/.github/scripts/bench-utils.js
+++ b/.github/scripts/bench-utils.js
@@ -42,6 +42,14 @@ function isWin(changes) {
 }
 
 function loadSamplyUrls(workDir) {
+  return loadProfileUrls(workDir, 'samply-profile-url.txt');
+}
+
+function loadTracingChromeUrls(workDir) {
+  return loadProfileUrls(workDir, 'tracing-chrome-profile-url.txt');
+}
+
+function loadProfileUrls(workDir, fileName) {
   const urls = {};
   let runs = [];
   try {
@@ -53,7 +61,7 @@ function loadSamplyUrls(workDir) {
   }
   for (const run of runs) {
     try {
-      const url = fs.readFileSync(path.join(workDir, run, 'samply-profile-url.txt'), 'utf8').trim();
+      const url = fs.readFileSync(path.join(workDir, run, fileName), 'utf8').trim();
       if (url) urls[run] = url;
     } catch {}
   }
@@ -132,6 +140,7 @@ module.exports = {
   verdict,
   isWin,
   loadSamplyUrls,
+  loadTracingChromeUrls,
   blocksLabel,
   metricRows,
   waitTimeRows,

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1436,7 +1436,8 @@ jobs:
           CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/reth-bench-charts.git"
 
           TMP_DIR=$(mktemp -d)
-          if git clone --depth 1 "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+          if git clone --depth 1 --filter=blob:none --sparse "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+            git -C "${TMP_DIR}" sparse-checkout set --no-cone "${CHART_DIR}"
             true
           else
             git init "${TMP_DIR}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,6 +66,11 @@ on:
         required: false
         default: "false"
         type: boolean
+      tracing_chrome:
+        description: "Enable Chrome trace recording"
+        required: false
+        default: "false"
+        type: boolean
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
@@ -121,6 +126,7 @@ jobs:
       baseline-name: ${{ steps.args.outputs.baseline-name }}
       feature-name: ${{ steps.args.outputs.feature-name }}
       samply: ${{ steps.args.outputs.samply }}
+      tracing-chrome: ${{ steps.args.outputs.tracing-chrome }}
       slack: ${{ steps.args.outputs.slack }}
       cores: ${{ steps.args.outputs.cores }}
       big-blocks: ${{ steps.args.outputs.big-blocks }}
@@ -180,8 +186,8 @@ jobs:
           script: |
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
-            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false|100M|2G]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [slack=always|on-win|on-error|never] [cores=N] [run-pairs=N] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
-            let pr, actor, blocks, warmup, baseline, feature, samply, cores, bigBlocks, bal;
+            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false|100M|2G]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [tracing-chrome] [slack=always|on-win|on-error|never] [cores=N] [run-pairs=N] [otlp=true|false] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
+            let pr, actor, blocks, warmup, baseline, feature, samply, tracingChrome, cores, bigBlocks, bal;
             let bigBlocksTargetGas = '';
             let explicitBlocks = false;
             let explicitWarmup = false;
@@ -214,6 +220,7 @@ jobs:
               baseline = '${{ github.event.inputs.baseline }}';
               feature = '${{ github.event.inputs.feature }}';
               samply = '${{ github.event.inputs.samply }}' === 'true' ? 'true' : 'false';
+              tracingChrome = '${{ github.event.inputs.tracing_chrome }}' === 'true' ? 'true' : 'false';
               var slack = '${{ github.event.inputs.slack }}' || 'never';
               cores = '${{ github.event.inputs.cores }}' || '0';
               const parsedBigBlocks = parseBigBlocks('${{ github.event.inputs.big_blocks }}');
@@ -251,11 +258,11 @@ jobs:
               const body = context.payload.comment.body.trim();
               const intArgs = new Set(['warmup', 'cores', 'blocks', 'run-pairs']);
               const refArgs = new Set(['baseline', 'feature']);
-              const boolArgs = new Set(['samply', 'otlp']);
+              const boolArgs = new Set(['samply', 'tracing-chrome', 'otlp']);
               const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes]]);
               const durationArgs = new Set(['wait-time']);
               const stringArgs = new Set(['baseline-args', 'feature-args']);
-              const defaults = { blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', slack: 'always', 'big-blocks': 'false', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
+              const defaults = { blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', 'tracing-chrome': 'false', slack: 'always', 'big-blocks': 'false', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -347,6 +354,7 @@ jobs:
               baseline = defaults.baseline;
               feature = defaults.feature;
               samply = defaults.samply;
+              tracingChrome = defaults['tracing-chrome'];
               var slack = defaults.slack;
               cores = defaults.cores;
               const parsedBigBlocks = parseBigBlocks(defaults['big-blocks']);
@@ -422,6 +430,7 @@ jobs:
             core.setOutput('baseline-name', baselineName);
             core.setOutput('feature-name', featureName);
             core.setOutput('samply', samply);
+            core.setOutput('tracing-chrome', tracingChrome);
             core.setOutput('slack', slack);
             core.setOutput('cores', cores);
             core.setOutput('big-blocks', bigBlocks);
@@ -491,10 +500,12 @@ jobs:
             const baseline = '${{ steps.args.outputs.baseline-name }}';
             const feature = '${{ steps.args.outputs.feature-name }}';
             const samply = '${{ steps.args.outputs.samply }}' === 'true';
+            const tracingChrome = '${{ steps.args.outputs.tracing-chrome }}' === 'true';
             const slack = '${{ steps.args.outputs.slack }}' || 'always';
             const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
             const bal = '${{ steps.args.outputs.bal }}' || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const balNote = bal !== 'false' ? `, BAL: \`${bal}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
@@ -511,7 +522,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${slackNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracingChromeNote}${slackNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -536,10 +547,12 @@ jobs:
             const baseline = '${{ steps.args.outputs.baseline-name }}';
             const feature = '${{ steps.args.outputs.feature-name }}';
             const samply = '${{ steps.args.outputs.samply }}' === 'true';
+            const tracingChrome = '${{ steps.args.outputs.tracing-chrome }}' === 'true';
             const slack = '${{ steps.args.outputs.slack }}' || 'always';
             const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
             const bal = '${{ steps.args.outputs.bal }}' || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const balNote = bal !== 'false' ? `, BAL: \`${bal}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
@@ -556,7 +569,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${slackNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracingChromeNote}${slackNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -626,6 +639,7 @@ jobs:
       BENCH_BLOCKS: ${{ needs.bench-ack.outputs.blocks }}
       BENCH_WARMUP_BLOCKS: ${{ needs.bench-ack.outputs.warmup }}
       BENCH_SAMPLY: ${{ needs.bench-ack.outputs.samply }}
+      BENCH_TRACING_CHROME: ${{ needs.bench-ack.outputs.tracing-chrome }}
       BENCH_CORES: ${{ needs.bench-ack.outputs.cores }}
       BENCH_BIG_BLOCKS: ${{ needs.bench-ack.outputs.big-blocks }}
       BENCH_BIG_BLOCKS_TARGET_GAS: ${{ needs.bench-ack.outputs.big-blocks-target-gas }}
@@ -699,10 +713,12 @@ jobs:
             const baseline = '${{ needs.bench-ack.outputs.baseline-name }}';
             const feature = '${{ needs.bench-ack.outputs.feature-name }}';
             const samply = process.env.BENCH_SAMPLY === 'true';
+            const tracingChrome = process.env.BENCH_TRACING_CHROME === 'true';
             const slack = process.env.BENCH_SLACK || 'always';
             const bigBlocks = process.env.BENCH_BIG_BLOCKS === 'true';
             const bal = process.env.BENCH_BAL || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
+            const tracingChromeNote = tracingChrome ? ', tracing-chrome: `enabled`' : '';
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const balNote = bal !== 'false' ? `, BAL: \`${bal}\`` : '';
             const cores = process.env.BENCH_CORES || '0';
@@ -719,7 +735,7 @@ jobs:
             const featureArgsVal = process.env.BENCH_FEATURE_ARGS || '';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${slackNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracingChromeNote}${slackNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -1045,6 +1061,7 @@ jobs:
             slack="$BENCH_SLACK"
           )
           [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
+          [ "$BENCH_TRACING_CHROME" = "true" ] && derek_cmd+=(tracing-chrome)
           [ -n "$BENCH_WAIT_TIME" ] && derek_cmd+=(wait-time="$BENCH_WAIT_TIME")
           [ -n "$BENCH_BASELINE_ARGS" ] && derek_cmd+=(baseline-args="$BENCH_BASELINE_ARGS")
           [ -n "$BENCH_FEATURE_ARGS" ] && derek_cmd+=(feature-args="$BENCH_FEATURE_ARGS")
@@ -1424,7 +1441,7 @@ jobs:
           name: bench-results
           path: ${{ env.BENCH_WORK_DIR }}
 
-      - name: Push charts
+      - name: Push benchmark artifacts
         id: push-charts
         if: success()
         env:
@@ -1446,30 +1463,69 @@ jobs:
 
           mkdir -p "${TMP_DIR}/${CHART_DIR}"
           cp "$BENCH_WORK_DIR"/charts/*.png "${TMP_DIR}/${CHART_DIR}/"
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            TRACE_DIR="${CHART_DIR}/tracing-chrome"
+            mkdir -p "${TMP_DIR}/${TRACE_DIR}"
+            mapfile -t RUN_DIRS < <(find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type d \( -name 'baseline-*' -o -name 'feature-*' \) -printf '%f\n' | sort -V)
+            for run_dir in "${RUN_DIRS[@]}"; do
+              TRACE="$BENCH_WORK_DIR/$run_dir/tracing-chrome-profile.json"
+              if [ ! -f "$TRACE" ]; then continue; fi
+
+              TRACE_SIZE=$(du -h "$TRACE" | cut -f1)
+              echo "Adding $run_dir Chrome trace (${TRACE_SIZE}) to benchmark artifacts..."
+              gzip -c "$TRACE" > "${TMP_DIR}/${TRACE_DIR}/${run_dir}.json.gz"
+            done
+          fi
           git -C "${TMP_DIR}" add "${CHART_DIR}"
           if git -C "${TMP_DIR}" diff --cached --quiet; then
-            echo "Charts for ${CHART_DIR} are already present, skipping push"
-            echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-            rm -rf "${TMP_DIR}"
-            exit 0
+            echo "Artifacts for ${CHART_DIR} are already present, skipping push"
+            PUSH_SHA="$(git -C "${TMP_DIR}" rev-parse HEAD)"
+          else
+            git -C "${TMP_DIR}" commit -m "bench artifacts for PR #${PR_NUMBER} run ${RUN_ID}"
+
+            for attempt in 1 2 3 4 5; do
+              if git -C "${TMP_DIR}" push origin HEAD:main; then
+                break
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                echo "::error::Failed to push benchmark artifacts after ${attempt} attempts"
+                rm -rf "${TMP_DIR}"
+                exit 1
+              fi
+              sleep "$attempt"
+              git -C "${TMP_DIR}" fetch origin main
+              git -C "${TMP_DIR}" rebase origin/main
+            done
+
+            PUSH_SHA="$(git -C "${TMP_DIR}" rev-parse HEAD)"
           fi
-          git -C "${TMP_DIR}" commit -m "bench charts for PR #${PR_NUMBER} run ${RUN_ID}"
 
-          for attempt in 1 2 3 4 5; do
-            if git -C "${TMP_DIR}" push origin HEAD:main; then
-              break
-            fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "::error::Failed to push charts after ${attempt} attempts"
-              rm -rf "${TMP_DIR}"
-              exit 1
-            fi
-            sleep "$attempt"
-            git -C "${TMP_DIR}" fetch origin main
-            git -C "${TMP_DIR}" rebase origin/main
-          done
+          if [ "${BENCH_TRACING_CHROME:-false}" = "true" ]; then
+            RAW_BASE="https://raw.githubusercontent.com/decofe/reth-bench-charts/${PUSH_SHA}/${CHART_DIR}/tracing-chrome"
+            mapfile -t RUN_DIRS < <(find "$BENCH_WORK_DIR" -mindepth 1 -maxdepth 1 -type d \( -name 'baseline-*' -o -name 'feature-*' \) -printf '%f\n' | sort -V)
+            for run_dir in "${RUN_DIRS[@]}"; do
+              if [ ! -f "${TMP_DIR}/${CHART_DIR}/tracing-chrome/${run_dir}.json.gz" ]; then continue; fi
 
-          echo "sha=$(git -C "${TMP_DIR}" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              RAW_URL="${RAW_BASE}/${run_dir}.json.gz"
+              PERFETTO_URL="$(python3 - "$RAW_URL" "${run_dir}.json.gz" <<'PY'
+          import sys
+          from urllib.parse import quote
+
+          raw_url, file_name = sys.argv[1:3]
+          print(
+              "https://ui.perfetto.dev/#!/?url="
+              + quote(raw_url, safe="")
+              + "&fileName="
+              + quote(file_name, safe="")
+          )
+          PY
+          )"
+              echo "$PERFETTO_URL" > "$BENCH_WORK_DIR/$run_dir/tracing-chrome-profile-url.txt"
+              echo "Perfetto URL for $run_dir: $PERFETTO_URL"
+            done
+          fi
+
+          echo "sha=${PUSH_SHA}" >> "$GITHUB_OUTPUT"
           rm -rf "${TMP_DIR}"
 
       - name: Compare & comment
@@ -1517,6 +1573,18 @@ jobs:
               }
               if (links.length > 0) {
                 comment += `\n\n### Samply Profiles\n\n${links.join('\n')}\n`;
+              }
+            }
+
+            if (process.env.BENCH_TRACING_CHROME === 'true') {
+              const { loadTracingChromeUrls } = require('./.github/scripts/bench-utils');
+              const tracingChromeUrls = loadTracingChromeUrls(process.env.BENCH_WORK_DIR);
+              const links = [];
+              for (const [run, url] of Object.entries(tracingChromeUrls)) {
+                links.push(`- **${run}**: [Perfetto](${url})`);
+              }
+              if (links.length > 0) {
+                comment += `\n\n### Chrome Traces\n\n${links.join('\n')}\n`;
               }
             }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10366,6 +10366,7 @@ dependencies = [
  "rolling-file",
  "tracing",
  "tracing-appender",
+ "tracing-chrome",
  "tracing-journald",
  "tracing-logfmt",
  "tracing-samply",
@@ -12501,6 +12502,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -688,6 +688,7 @@ sysinfo = { version = "0.38", default-features = false }
 tracing-journald = "0.3"
 tracing-logfmt = "0.3.7"
 tracing-samply = "0.1"
+tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3", default-features = false }
 tracing-tracy = "0.11"
 triehash = "0.8"

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -18,7 +18,7 @@ use reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNo
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::RpcModuleValidator;
 use reth_tasks::RayonConfig;
-use reth_tracing::{FileWorkerGuard, Layers};
+use reth_tracing::{Layers, TracingGuards};
 use std::{fmt, sync::Arc};
 
 /// A wrapper around a parsed CLI that handles command execution.
@@ -32,7 +32,7 @@ pub struct CliApp<
     cli: Cli<Spec, Ext, Rpc, SubCmd>,
     runner: Option<CliRunner>,
     layers: Option<Layers>,
-    guard: Option<FileWorkerGuard>,
+    guard: Option<TracingGuards>,
 }
 
 impl<C, Ext, Rpc, SubCmd> CliApp<C, Ext, Rpc, SubCmd>
@@ -141,7 +141,7 @@ where
     /// See [`Cli::init_tracing`] for more information.
     pub fn init_tracing(&mut self, runner: &CliRunner) -> Result<()> {
         if let Some(layers) = self.layers.take() {
-            self.guard = self.cli.init_tracing(runner, layers)?;
+            self.guard = Some(self.cli.init_tracing(runner, layers)?);
         }
 
         Ok(())

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -22,7 +22,7 @@ use reth_node_core::{
     version::version_metadata,
 };
 use reth_rpc_server_types::{DefaultRpcModuleValidator, RethRpcModule, RpcModuleValidator};
-use reth_tracing::{FileWorkerGuard, Layers};
+use reth_tracing::{Layers, TracingGuards};
 use std::{ffi::OsString, fmt, future::Future, marker::PhantomData, sync::Arc};
 use tracing::{info, warn};
 
@@ -210,8 +210,7 @@ impl<
 
     /// Initializes tracing with the configured options.
     ///
-    /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
-    /// that all logs are flushed to disk.
+    /// Returns tracing guards that must be kept alive to ensure outputs are flushed to disk.
     ///
     /// If an OTLP endpoint is specified, it will export traces and logs to the configured
     /// collector.
@@ -219,13 +218,13 @@ impl<
         &mut self,
         runner: &CliRunner,
         mut layers: Layers,
-    ) -> eyre::Result<Option<FileWorkerGuard>> {
+    ) -> eyre::Result<TracingGuards> {
         let otlp_status = runner.block_on(self.traces.init_otlp_tracing(&mut layers))?;
         let otlp_logs_status = runner.block_on(self.traces.init_otlp_logs(&mut layers))?;
 
         // Enable reload support if debug RPC namespace is available
         let enable_reload = self.command.debug_namespace_enabled();
-        let file_guard = self.logs.init_tracing_with_layers(layers, enable_reload)?;
+        let guards = self.logs.init_tracing_with_layers(layers, enable_reload)?;
         info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
 
         match otlp_status {
@@ -248,7 +247,7 @@ impl<
             OtlpLogsStatus::Disabled => {}
         }
 
-        Ok(file_guard)
+        Ok(guards)
     }
 }
 

--- a/crates/node/core/src/args/log.rs
+++ b/crates/node/core/src/args/log.rs
@@ -3,10 +3,10 @@
 use crate::dirs::{LogsDir, PlatformPath};
 use clap::{ArgAction, Args, ValueEnum};
 use reth_tracing::{
-    tracing_subscriber::filter::Directive, FileInfo, FileWorkerGuard, LayerInfo, Layers, LogFormat,
-    RethTracer, Tracer,
+    tracing_subscriber::filter::Directive, FileInfo, LayerInfo, Layers, LogFormat, RethTracer,
+    Tracer, TracingGuards,
 };
-use std::{fmt, fmt::Display, sync::OnceLock};
+use std::{fmt, fmt::Display, path::PathBuf, sync::OnceLock};
 use tracing::{level_filters::LevelFilter, Level};
 
 /// Constant to convert megabytes to bytes
@@ -83,6 +83,30 @@ pub struct LogArgs {
     )]
     pub samply_filter: String,
 
+    /// Emit traces to a Chrome trace JSON file. Only useful when profiling.
+    #[arg(long = "log.tracing-chrome", global = true, hide = true, default_value_t = DefaultLogArgs::get_global().tracing_chrome)]
+    pub tracing_chrome: bool,
+
+    /// The path to write Chrome trace JSON to.
+    #[arg(
+        long = "log.tracing-chrome.file",
+        value_name = "PATH",
+        global = true,
+        default_value = "trace.json",
+        hide = true
+    )]
+    pub tracing_chrome_file: PathBuf,
+
+    /// The filter to use for traces emitted to Chrome trace JSON.
+    #[arg(
+        long = "log.tracing-chrome.filter",
+        value_name = "FILTER",
+        global = true,
+        default_value_t = DefaultLogArgs::get_global().tracing_chrome_filter.clone(),
+        hide = true
+    )]
+    pub tracing_chrome_filter: String,
+
     /// Emit traces to tracy. Only useful when profiling.
     #[arg(long = "log.tracy", global = true, hide = true, default_value_t = DefaultLogArgs::get_global().tracy)]
     pub tracy: bool,
@@ -157,8 +181,8 @@ impl LogArgs {
 
     /// Initializes tracing with the configured options from cli args.
     ///
-    /// Returns the file worker guard if a file worker was configured.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
+    /// Returns guards for tracing layers that need to stay alive.
+    pub fn init_tracing(&self) -> eyre::Result<TracingGuards> {
         self.init_tracing_with_layers(Layers::new(), false)
     }
 
@@ -171,12 +195,12 @@ impl LogArgs {
     /// * `layers` - Pre-configured layers to include
     /// * `enable_reload` - If true, enables runtime log level changes
     ///
-    /// Returns the file worker guard if a file worker was configured.
+    /// Returns guards for tracing layers that need to stay alive.
     pub fn init_tracing_with_layers(
         &self,
         layers: Layers,
         enable_reload: bool,
-    ) -> eyre::Result<Option<FileWorkerGuard>> {
+    ) -> eyre::Result<TracingGuards> {
         let mut tracer = RethTracer::new();
 
         let stdout = self.layer_info(self.log_stdout_format, self.log_stdout_filter.clone(), true);
@@ -195,6 +219,12 @@ impl LogArgs {
         if self.samply {
             let config = self.layer_info(LogFormat::Terminal, self.samply_filter.clone(), false);
             tracer = tracer.with_samply(config);
+        }
+
+        if self.tracing_chrome {
+            let config =
+                self.layer_info(LogFormat::Terminal, self.tracing_chrome_filter.clone(), false);
+            tracer = tracer.with_chrome(config, self.tracing_chrome_file.clone());
         }
 
         if self.tracy {
@@ -228,6 +258,8 @@ pub struct DefaultLogArgs {
     journald_filter: String,
     samply: bool,
     samply_filter: String,
+    tracing_chrome: bool,
+    tracing_chrome_filter: String,
     tracy: bool,
     tracy_filter: String,
     color: ColorMode,
@@ -304,6 +336,18 @@ impl DefaultLogArgs {
         self
     }
 
+    /// Set whether Chrome trace JSON tracing is enabled by default.
+    pub const fn with_tracing_chrome(mut self, v: bool) -> Self {
+        self.tracing_chrome = v;
+        self
+    }
+
+    /// Set the default Chrome trace JSON filter.
+    pub fn with_tracing_chrome_filter(mut self, v: String) -> Self {
+        self.tracing_chrome_filter = v;
+        self
+    }
+
     /// Set whether tracy tracing is enabled by default.
     pub const fn with_tracy(mut self, v: bool) -> Self {
         self.tracy = v;
@@ -336,6 +380,8 @@ impl Default for DefaultLogArgs {
             journald_filter: "error".to_string(),
             samply: false,
             samply_filter: PROFILER_TRACING_FILTER.to_string(),
+            tracing_chrome: false,
+            tracing_chrome_filter: PROFILER_TRACING_FILTER.to_string(),
             tracy: false,
             tracy_filter: PROFILER_TRACING_FILTER.to_string(),
             color: ColorMode::Always,

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -19,6 +19,7 @@ reth-tracing-otlp = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "ansi", "json"], optional = true }
 tracing-appender = { workspace = true, optional = true }
+tracing-chrome = { workspace = true, optional = true }
 tracing-journald = { workspace = true, optional = true }
 tracing-logfmt = { workspace = true, optional = true }
 tracing-samply = { workspace = true, optional = true }
@@ -35,6 +36,7 @@ default = ["std", "otlp"]
 std = [
     "tracing-subscriber",
     "tracing-appender",
+    "tracing-chrome",
     "tracing-journald",
     "tracing-logfmt",
     "tracing-samply",

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -6,6 +6,7 @@ use reth_tracing_otlp::{span_layer, OtlpConfig};
 use rolling_file::{RollingConditionBasic, RollingFileAppender};
 use std::{
     fmt,
+    fs::File,
     path::{Path, PathBuf},
 };
 use tracing_appender::non_blocking::WorkerGuard;
@@ -16,6 +17,32 @@ use tracing_subscriber::{filter::Directive, reload, EnvFilter, Layer, Registry};
 ///  When a guard is dropped, all events currently in-memory are flushed to the log file this guard
 ///  belongs to.
 pub type FileWorkerGuard = tracing_appender::non_blocking::WorkerGuard;
+
+/// Guards for tracing layers that must stay alive until shutdown.
+#[derive(Default)]
+pub struct TracingGuards {
+    _file: Option<FileWorkerGuard>,
+    _chrome: Option<tracing_chrome::FlushGuard>,
+}
+
+impl fmt::Debug for TracingGuards {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TracingGuards")
+            .field("file", &self._file.is_some())
+            .field("chrome", &self._chrome.is_some())
+            .finish()
+    }
+}
+
+impl TracingGuards {
+    /// Creates tracing guards from active layer guards.
+    pub const fn new(
+        file: Option<FileWorkerGuard>,
+        chrome: Option<tracing_chrome::FlushGuard>,
+    ) -> Self {
+        Self { _file: file, _chrome: chrome }
+    }
+}
 
 ///  A boxed tracing [Layer].
 pub(crate) type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
@@ -169,6 +196,25 @@ impl Layers {
                 )?),
         );
         Ok(())
+    }
+
+    pub(crate) fn chrome(
+        &mut self,
+        config: LayerInfo,
+        file: &Path,
+    ) -> eyre::Result<tracing_chrome::FlushGuard> {
+        let writer = File::create(file)
+            .map_err(|err| eyre::eyre!("Failed to create Chrome trace file {file:?}: {err}"))?;
+        let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+            .writer(writer)
+            .include_args(true)
+            .include_locations(false)
+            .build();
+        self.add_layer(layer.with_filter(build_env_filter(
+            Some(config.default_directive.parse()?),
+            &config.filters,
+        )?));
+        Ok(guard)
     }
 
     #[cfg(feature = "tracy")]

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -57,7 +57,7 @@ tracy_client::register_demangler!();
 #[cfg(feature = "std")]
 pub use formatter::LogFormat;
 #[cfg(feature = "std")]
-pub use layers::{FileInfo, FileWorkerGuard, Layers};
+pub use layers::{FileInfo, FileWorkerGuard, Layers, TracingGuards};
 #[cfg(feature = "std")]
 pub use log_handle::{
     install_log_handle, log_handle_available, set_log_verbosity, set_log_vmodule,
@@ -86,8 +86,6 @@ mod throttle;
 #[cfg(feature = "std")]
 use tracing::level_filters::LevelFilter;
 #[cfg(feature = "std")]
-use tracing_appender::non_blocking::WorkerGuard;
-#[cfg(feature = "std")]
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 ///  Tracer for application logging.
@@ -101,6 +99,7 @@ pub struct RethTracer {
     journald: Option<String>,
     file: Option<(LayerInfo, FileInfo)>,
     samply: Option<LayerInfo>,
+    chrome: Option<(LayerInfo, std::path::PathBuf)>,
     #[cfg(feature = "tracy")]
     tracy: Option<LayerInfo>,
     /// When true, the stdout filter is wrapped in a reload layer so log levels
@@ -120,6 +119,7 @@ impl RethTracer {
             journald: None,
             file: None,
             samply: None,
+            chrome: None,
             #[cfg(feature = "tracy")]
             tracy: None,
             enable_reload: false,
@@ -157,6 +157,12 @@ impl RethTracer {
     /// Sets the samply layer configuration.
     pub fn with_samply(mut self, config: LayerInfo) -> Self {
         self.samply = Some(config);
+        self
+    }
+
+    /// Sets the Chrome trace layer configuration.
+    pub fn with_chrome(mut self, config: LayerInfo, file: std::path::PathBuf) -> Self {
+        self.chrome = Some((config, file));
         self
     }
 
@@ -245,9 +251,9 @@ pub trait Tracer: Sized {
     /// By default, this method creates a new `Layers` instance and delegates to `init_with_layers`.
     ///
     /// # Returns
-    /// An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
-    /// or an `Err` in case of an error during initialization.
-    fn init(self) -> eyre::Result<Option<WorkerGuard>> {
+    /// An `eyre::Result` with guards for layers that need to stay alive, or an `Err` in case of an
+    /// error during initialization.
+    fn init(self) -> eyre::Result<TracingGuards> {
         self.init_with_layers(Layers::new())
     }
 
@@ -259,14 +265,14 @@ pub trait Tracer: Sized {
     /// * `layers` - Pre-configured `Layers` instance to use for initialization
     ///
     /// # Returns
-    /// An `eyre::Result` which is `Ok` with an optional `WorkerGuard` if a file layer is used,
-    /// or an `Err` in case of an error during initialization.
-    fn init_with_layers(self, layers: Layers) -> eyre::Result<Option<WorkerGuard>>;
+    /// An `eyre::Result` with guards for layers that need to stay alive, or an `Err` in case of an
+    /// error during initialization.
+    fn init_with_layers(self, layers: Layers) -> eyre::Result<TracingGuards>;
 }
 
 #[cfg(feature = "std")]
 impl Tracer for RethTracer {
-    fn init_with_layers(self, mut layers: Layers) -> eyre::Result<Option<WorkerGuard>> {
+    fn init_with_layers(self, mut layers: Layers) -> eyre::Result<TracingGuards> {
         // Configure stdout layer - reloadable if requested for runtime log level changes
         if let Some(handle) = layers.stdout(
             self.stdout.format,
@@ -297,6 +303,12 @@ impl Tracer for RethTracer {
             layers.samply(config)?;
         }
 
+        let chrome_guard = if let Some((config, file)) = self.chrome {
+            Some(layers.chrome(config, &file)?)
+        } else {
+            None
+        };
+
         #[cfg(feature = "tracy")]
         if let Some(config) = self.tracy {
             layers.tracy(config)?;
@@ -306,7 +318,7 @@ impl Tracer for RethTracer {
         // so it's safe to ignore it
         let _ = tracing_subscriber::registry().with(layers.into_inner()).try_init();
 
-        Ok(file_guard)
+        Ok(TracingGuards::new(file_guard, chrome_guard))
     }
 }
 

--- a/crates/tracing/src/test_tracer.rs
+++ b/crates/tracing/src/test_tracer.rs
@@ -1,7 +1,6 @@
-use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 
-use crate::{Layers, Tracer};
+use crate::{Layers, Tracer, TracingGuards};
 
 ///  Initializes a tracing subscriber for tests.
 ///
@@ -15,11 +14,11 @@ use crate::{Layers, Tracer};
 pub struct TestTracer;
 
 impl Tracer for TestTracer {
-    fn init_with_layers(self, _layers: Layers) -> eyre::Result<Option<WorkerGuard>> {
+    fn init_with_layers(self, _layers: Layers) -> eyre::Result<TracingGuards> {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .with_writer(std::io::stderr)
             .try_init();
-        Ok(None)
+        Ok(TracingGuards::default())
     }
 }


### PR DESCRIPTION
Adds a hidden Chrome trace JSON layer and wires Derek benches to record per-run traces when `tracing-chrome` is enabled.

The bench workflow publishes gzipped traces beside chart artifacts and writes Perfetto deep links into PR comments, job summaries, and Slack notifications.
