### PR TITLE
ci: sparse checkout benchmark chart repo

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1436,7 +1436,8 @@ jobs:
           CHARTS_REPO="https://x-access-token:${DEREK_TOKEN}@github.com/decofe/reth-bench-charts.git"
 
           TMP_DIR=$(mktemp -d)
-          if git clone --depth 1 "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+          if git clone --depth 1 --filter=blob:none --sparse "${CHARTS_REPO}" "${TMP_DIR}" 2>/dev/null; then
+            git -C "${TMP_DIR}" sparse-checkout set --no-cone "${CHART_DIR}"
             true
           else
             git init "${TMP_DIR}"


### PR DESCRIPTION
## Summary
- use a blobless sparse checkout when cloning `decofe/reth-bench-charts` for benchmark chart uploads
- limit the working tree to the target chart directory before copying PNGs

## Testing
- `git diff --check`

Prompted by: @DaniPopes