### PR TITLE
chore: raise max RLP block size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10545,7 +10545,6 @@ name = "reth-trie-parallel"
 version = "2.2.0"
 dependencies = [
  "alloy-eip7928 0.4.1",
- "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -10,12 +10,8 @@ use reth_primitives_traits::{
     Block, BlockBody, BlockHeader, GotExpected, SealedBlock, SealedHeader,
 };
 
-/// The maximum RLP length of a block, defined in [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934).
-///
-/// Calculated as `MAX_BLOCK_SIZE` - `SAFETY_MARGIN` where
-/// `MAX_BLOCK_SIZE` = `10_485_760`
-/// `SAFETY_MARGIN` = `2_097_152`
-pub const MAX_RLP_BLOCK_SIZE: usize = 8_388_608;
+/// Maximum allowed RLP-encoded block size.
+pub const MAX_RLP_BLOCK_SIZE: usize = 16_777_216;
 
 /// Gas used needs to be less than gas limit. Gas used is going to be checked after execution.
 #[inline]

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -67,8 +67,11 @@ use reth_engine_primitives::{
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
-    block::BlockExecutor, execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
-    OnStateHook, SpecFor,
+    block::BlockExecutor,
+    execute::{
+        convert_alloy_block_execution_error, convert_alloy_block_execution_result, ExecutableTxFor,
+    },
+    ConfigureEvm, EvmEnvFor, ExecutionCtxFor, OnStateHook, SpecFor, StateHookExt,
 };
 use reth_execution_cache::{CacheFillMode, CacheStats, SavedCache};
 use reth_payload_primitives::{
@@ -1075,7 +1078,7 @@ where
         let transaction_count = input.transaction_count();
         let (receipt_tx, result_rx) = self.spawn_receipt_root_task(transaction_count);
         let executed_tx_index = Arc::clone(handle.executed_tx_index());
-        executor.evm_mut().db_mut().set_state_hook(
+        executor.evm_mut().db_mut().set_reth_state_hook(
             handle.state_hook().map(|hook| Box::new(hook) as Box<dyn OnStateHook + 'static>),
         );
 

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -23,7 +23,7 @@ use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
     block::TxResult,
     execute::{BlockBuilder, BlockBuilderOutcome},
-    ConfigureEvm, Evm, NextBlockEnvAttributes,
+    ConfigureEvm, Evm, NextBlockEnvAttributes, StateHookExt,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_execution_cache::{CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider};
@@ -222,7 +222,7 @@ where
     // If we have a sparse trie handle, wire a state hook that streams per-tx state diffs
     // to the background trie pipeline for incremental state root computation.
     if let Some(ref handle) = trie_handle {
-        builder.evm_mut().db_mut().set_state_hook(Some(Box::new(handle.state_hook())));
+        builder.evm_mut().db_mut().set_reth_state_hook(Some(Box::new(handle.state_hook())));
     }
 
     builder.apply_pre_execution_changes().map_err(|err| {
@@ -453,7 +453,7 @@ where
     {
         // Drop the state hook, which drops the StateHookSender and triggers
         // FinishedStateUpdates via its Drop impl, signaling the trie task to finalize.
-        builder.evm_mut().db_mut().set_state_hook(None);
+        builder.evm_mut().db_mut().set_reth_state_hook(None);
 
         // The sparse trie has been computing incrementally alongside tx execution.
         // This recv() waits for the final root hash — most work is already done.

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -1,6 +1,6 @@
 //! Traits for execution.
 
-use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
+use crate::{ConfigureEvm, Database, OnStateHook, StateHookExt, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessList};
@@ -638,11 +638,11 @@ where
             .executor_for_block(&mut self.db, block)
             .map_err(BlockExecutionError::other)?;
 
-        executor.evm_mut().db_mut().set_state_hook(Some(Box::new(state_hook)));
+        executor.evm_mut().db_mut().set_reth_state_hook(Some(Box::new(state_hook)));
 
         let result = executor.execute_block(block.transactions_recovered());
 
-        self.db.set_state_hook(None);
+        self.db.set_reth_state_hook(None);
         self.db.merge_transitions(BundleRetention::Reverts);
 
         result

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -48,12 +48,14 @@ pub use engine::{ConfigureEngineEvm, ConvertTx, ExecutableTxIterator, Executable
 #[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod noop;
+mod state_hook;
+pub use state_hook::{OnStateHook, StateHookExt};
 #[cfg(any(test, feature = "test-utils"))]
 /// test helpers for mocking executor
 pub mod test_utils;
 
 pub use alloy_evm::{
-    block::{state_changes, system_calls, OnStateHook},
+    block::{state_changes, system_calls},
     *,
 };
 

--- a/crates/evm/evm/src/state_hook.rs
+++ b/crates/evm/evm/src/state_hook.rs
@@ -1,0 +1,38 @@
+use revm::{database::State, state::EvmState};
+
+/// A hook that is called when state changes are committed.
+pub trait OnStateHook: Send + 'static {
+    /// Invoked with the state being committed.
+    fn on_state(&mut self, state: &EvmState);
+}
+
+impl<F> OnStateHook for F
+where
+    F: FnMut(&EvmState) + Send + 'static,
+{
+    fn on_state(&mut self, state: &EvmState) {
+        self(state)
+    }
+}
+
+/// Extension trait for installing reth state hooks on the database state.
+pub trait StateHookExt {
+    /// Sets the state hook.
+    fn set_reth_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>);
+}
+
+impl<DB: revm::Database> StateHookExt for State<DB> {
+    fn set_reth_state_hook(&mut self, hook: Option<Box<dyn OnStateHook>>) {
+        self.set_state_hook(
+            hook.map(|hook| Box::new(RevmStateHook(hook)) as Box<dyn revm::OnStateHook>),
+        );
+    }
+}
+
+struct RevmStateHook(Box<dyn OnStateHook>);
+
+impl revm::OnStateHook for RevmStateHook {
+    fn on_state(&mut self, state: &EvmState) {
+        self.0.on_state(state);
+    }
+}

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -22,7 +22,6 @@ reth-trie.workspace = true
 
 # alloy
 alloy-eip7928.workspace = true
-alloy-evm.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -95,7 +95,7 @@ impl StateRootHandle {
     /// Returns a state hook that streams state updates to the background state root task.
     ///
     /// The hook must be dropped after execution completes to signal the end of state updates.
-    pub fn state_hook(&self) -> impl alloy_evm::block::OnStateHook {
+    pub fn state_hook(&self) -> impl FnMut(&EvmState) + Send + 'static {
         let sender = StateHookSender::new(self.updates_tx.clone());
 
         move |state: &EvmState| {


### PR DESCRIPTION
Raises the maximum RLP-encoded block size to 16MiB.