### PR TITLE
perf: compute storage roots in a separate task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -1,6 +1,6 @@
 //! Sparse Trie task related functionality.
 
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 
 use crate::tree::{
     multiproof::{
@@ -16,10 +16,10 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_primitives_traits::{Account, FastInstant as Instant};
 use reth_tasks::Runtime;
 use reth_trie::{
-    updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, TrieAccount, EMPTY_ROOT_HASH,
-    TRIE_ACCOUNT_RLP_MAX_SIZE,
+    updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, ProofTrieNodeV2, ProofV2Target,
+    TrieAccount, EMPTY_ROOT_HASH, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use reth_trie_common::{MultiProofTargetsV2, ProofV2Target};
+use reth_trie_common::MultiProofTargetsV2;
 use reth_trie_parallel::{
     proof_task::{
         AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
@@ -31,7 +31,7 @@ use reth_trie_sparse::{
     ConfigurableSparseTrie, DeferredDrops, LeafUpdate, RevealableSparseTrie, SparseStateTrie,
     SparseTrie,
 };
-use revm_primitives::{hash_map::Entry, B256Map};
+use revm_primitives::{hash_map::Entry, map::B256Set, B256Map};
 use tracing::{debug, debug_span, error, instrument, trace_span};
 
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
@@ -44,6 +44,10 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     updates: CrossbeamReceiver<SparseTrieTaskMessage>,
     /// Sender half for the channel to send final hashed state to.
     final_hashed_state_tx: Option<std::sync::mpsc::Sender<HashedPostState>>,
+    /// Sender for storage roots.
+    storage_roots_tx: mpsc::Sender<Vec<(B256, RevealableSparseTrie<S>)>>,
+    /// Receiver for storage roots.
+    storage_roots_rx: CrossbeamReceiver<(B256, RevealableSparseTrie<S>)>,
     /// `SparseStateTrie` used for computing the state root.
     trie: SparseStateTrie<A, S>,
     /// The parent block's state root.
@@ -111,6 +115,11 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
     /// final [`HashedPostState`] and share it with main engine thread without requiring any extra
     /// hashing work.
     final_hashed_state: HashedPostState,
+    /// Tries that are awaiting storage root calculation.
+    pending_storage_roots: B256Set,
+    /// Storage proofs that arrived while the trie was taken for root computation.
+    /// Replayed after the trie is reinserted.
+    buffered_storage_proofs: B256Map<Vec<ProofTrieNodeV2>>,
 
     /// Metrics for the sparse trie.
     metrics: MultiProofTaskMetrics,
@@ -119,7 +128,7 @@ pub(super) struct SparseTrieCacheTask<A = ConfigurableSparseTrie, S = Configurab
 impl<A, S> SparseTrieCacheTask<A, S>
 where
     A: SparseTrie + Default,
-    S: SparseTrie + Default + Clone,
+    S: SparseTrie + Default + Clone + 'static,
 {
     /// Creates a new sparse trie, pre-populating with an existing [`SparseStateTrie`].
     #[expect(clippy::too_many_arguments)]
@@ -143,9 +152,20 @@ where
             Self::run_hashing_task(updates, hashed_state_tx, hashing_metrics)
         });
 
+        let (storage_roots_tx, storage_roots_task_rx) = mpsc::channel();
+        let (root_result_tx, storage_roots_rx) = crossbeam_channel::unbounded();
+
+        let parent_span = tracing::Span::current();
+        executor.spawn_blocking_named("trie-storage-roots", move || {
+            let _span = debug_span!(parent: parent_span, "run_storage_roots_task").entered();
+            Self::run_storage_roots_task(storage_roots_task_rx, root_result_tx)
+        });
+
         Self {
             proof_result_tx,
             proof_result_rx,
+            storage_roots_tx,
+            storage_roots_rx,
             updates: hashed_state_rx,
             proof_worker_handle,
             final_hashed_state_tx: Some(final_hashed_state_tx),
@@ -169,6 +189,8 @@ where
             pending_targets: Default::default(),
             pending_updates: Default::default(),
             final_hashed_state: Default::default(),
+            pending_storage_roots: Default::default(),
+            buffered_storage_proofs: Default::default(),
             metrics,
         }
     }
@@ -214,6 +236,30 @@ where
         }
 
         metrics.hashing_task_idle_time_seconds.record(total_idle_time.as_secs_f64());
+    }
+
+    fn run_storage_roots_task(
+        tries: mpsc::Receiver<Vec<(B256, RevealableSparseTrie<S>)>>,
+        roots_tx: CrossbeamSender<(B256, RevealableSparseTrie<S>)>,
+    ) {
+        while let Ok(tries) = tries.recv() {
+            let roots_tx = roots_tx.clone();
+            let parent_span = tracing::Span::current();
+            rayon::spawn(move || {
+                tries.into_par_iter().for_each(|(address, mut trie)| {
+                    let _enter = debug_span!(
+                        target: "engine::tree::payload_processor::sparse_trie",
+                        parent: &parent_span,
+                        "storage_root",
+                        ?address,
+                        prefix_set_len = trie.prefix_set_len()
+                    )
+                    .entered();
+                    trie.root().expect("all tries should have been revealed");
+                    roots_tx.send((address, trie)).unwrap();
+                })
+            })
+        }
     }
 
     /// Prunes and shrinks the trie for reuse in the next payload built on top of this one.
@@ -299,6 +345,15 @@ where
                     self.on_message(update);
                     self.pending_updates += 1;
                 }
+                recv(self.storage_roots_rx) -> message => {
+                    let Ok((address, trie)) = message else {
+                        return Err(ParallelStateRootError::Other("storage roots task failed".to_string()));
+                    };
+                    self.on_storage_root_result(address, trie)?;
+                    if !self.pending_storage_roots.is_empty() {
+                        continue;
+                    }
+                }
                 recv(self.proof_result_rx) -> message => {
                     let phase_end = Instant::now();
                     total_idle_time += phase_end.duration_since(idle_start);
@@ -336,12 +391,15 @@ where
                 self.dispatch_pending_targets();
                 t = Instant::now();
                 self.process_new_updates()?;
-                self.promote_pending_account_updates()?;
+                if self.promote_pending_account_updates()? {
+                    self.trie.trie_mut().update_subtrie_hashes();
+                }
                 self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
 
-                if self.finished_state_updates &&
-                    self.account_updates.is_empty() &&
-                    self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
+                if self.finished_state_updates
+                    && self.pending_storage_roots.is_empty()
+                    && self.account_updates.is_empty()
+                    && self.storage_updates.iter().all(|(_, updates)| updates.is_empty())
                 {
                     break;
                 }
@@ -461,6 +519,30 @@ where
         }
     }
 
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor::sparse_trie",
+        skip_all
+    )]
+    fn on_storage_root_result(
+        &mut self,
+        address: B256,
+        trie: RevealableSparseTrie<S>,
+    ) -> Result<(), ParallelStateRootError> {
+        self.trie.insert_storage_trie(address, trie);
+        self.pending_storage_roots.remove(&address);
+        // Replay any storage proofs that arrived while the trie was out.
+        if let Some(proofs) = self.buffered_storage_proofs.remove(&address) {
+            self.trie.reveal_storage_v2_proof_nodes(address, proofs).map_err(|e| {
+                ParallelStateRootError::Other(format!(
+                    "could not reveal buffered storage proofs: {e:?}"
+                ))
+            })?;
+        }
+
+        Ok(())
+    }
+
     /// Processes a hashed state update and encodes all state changes as trie updates.
     #[instrument(
         level = "trace",
@@ -519,8 +601,20 @@ where
 
     fn on_proof_result(
         &mut self,
-        result: DecodedMultiProofV2,
+        mut result: DecodedMultiProofV2,
     ) -> Result<(), ParallelStateRootError> {
+        // Buffer storage proofs for tries currently out for root computation.
+        // They'll be replayed after the trie is reinserted.
+        if !self.pending_storage_roots.is_empty() {
+            result.storage_proofs.retain(|address, proofs| {
+                if self.pending_storage_roots.contains(address) {
+                    self.buffered_storage_proofs.entry(*address).or_default().append(proofs);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
         self.trie.reveal_decoded_multiproof_v2(result).map_err(|e| {
             ParallelStateRootError::Other(format!("could not reveal multiproof: {e:?}"))
         })
@@ -591,6 +685,10 @@ where
         let span = trace_span!("process_storage_leaf_updates").entered();
         for (address, updates) in storage_updates {
             if updates.is_empty() {
+                continue;
+            }
+            // Skip tries that are currently being processed by the storage roots task.
+            if self.pending_storage_roots.contains(address) {
                 continue;
             }
             let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
@@ -675,58 +773,44 @@ where
     /// 3. but the storage root hasn't been updated yet,
     ///
     /// we trigger state root computation on a rayon pool.
-    fn compute_drained_storage_roots(&mut self) {
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_processor::sparse_trie",
+        skip_all
+    )]
+    fn compute_drained_storage_roots(&mut self) -> bool {
         let addresses_to_compute_roots: Vec<_> = self
             .storage_updates
             .iter()
-            .filter_map(|(address, updates)| updates.is_empty().then_some(*address))
+            .filter_map(|(address, updates)| updates.is_empty().then_some(address))
             .collect();
 
-        struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);
-        // SAFETY: this wrapper only forwards the pointer across rayon; deref invariants are
-        // documented at the use site below.
-        unsafe impl<S: Send> Send for SendStorageTriePtr<S> {}
-
-        let mut tries_to_compute_roots: Vec<(B256, SendStorageTriePtr<S>)> =
-            Vec::with_capacity(addresses_to_compute_roots.len());
+        let mut tries_to_compute_roots = Vec::with_capacity(addresses_to_compute_roots.len());
+        let mut has_large_storage_trie = false;
         for address in addresses_to_compute_roots {
-            if let Some(trie) = self.trie.storage_tries_mut().get_mut(&address) &&
-                !trie.is_root_cached()
-            {
-                tries_to_compute_roots.push((address, SendStorageTriePtr(trie)));
-            }
-        }
-
-        if tries_to_compute_roots.is_empty() {
-            return;
-        }
-
-        let parent_span =
-            debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
-        tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
-            let span = if tracing::enabled!(tracing::Level::TRACE) {
-                debug_span!(
-                    target: "engine::tree::payload_processor::sparse_trie",
-                    parent: &parent_span,
-                    "storage_root",
-                    ?address
-                )
-            } else {
-                debug_span!(
-                    target: "engine::tree::payload_processor::sparse_trie",
-                    parent: &parent_span,
-                    "storage_root",
-                )
+            let Some(trie) = self.trie.storage_tries_mut().get(address) else {
+                continue;
             };
-            let _enter = span.entered();
-            // SAFETY:
-            // - pointers are created from `storage_tries_mut().get_mut(address)` above;
-            // - `addresses_to_compute_roots` comes from map iteration, so addresses are unique;
-            // - we do not insert/remove entries between pointer collection and use, so pointers
-            //   stay valid and map reallocation cannot occur;
-            // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
-            unsafe { (*trie).root().expect("updates are drained, trie should be revealed by now") };
-        });
+            if trie.is_root_cached() {
+                continue;
+            }
+
+            if trie.prefix_set_len() > 50 {
+                has_large_storage_trie = true;
+            }
+
+            tries_to_compute_roots.push((
+                *address,
+                self.trie.take_storage_trie(address).expect("trie was created above"),
+            ));
+            self.pending_storage_roots.insert(*address);
+        }
+
+        if !tries_to_compute_roots.is_empty() {
+            let _ = self.storage_roots_tx.send(tries_to_compute_roots);
+        }
+
+        has_large_storage_trie
     }
 
     /// Iterates through all storage tries for which all updates were processed, computes their
@@ -737,14 +821,14 @@ where
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
-    fn promote_pending_account_updates(&mut self) -> SparseTrieResult<()> {
+    fn promote_pending_account_updates(&mut self) -> SparseTrieResult<bool> {
         self.process_leaf_updates(false)?;
 
         if self.pending_account_updates.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
-        self.compute_drained_storage_roots();
+        let has_large_storage_trie = self.compute_drained_storage_roots();
 
         loop {
             let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
@@ -753,8 +837,8 @@ where
             let mut num_promoted = 0;
             self.pending_account_updates.retain(|addr, account| {
                 if let Some(updates) = self.storage_updates.get(addr) {
-                    if !updates.is_empty() {
-                        // If account has pending storage updates, it is still pending.
+                    if !updates.is_empty() || self.pending_storage_roots.contains(addr) {
+                        // If account has pending storage updates, or its trie root is not yet computed, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
                         let storage_root = self.trie.storage_root(addr).expect("updates are drained, storage trie should be revealed by now");
@@ -803,11 +887,11 @@ where
             // We need to keep iterating if any updates are being drained because that might
             // indicate that more pending account updates can be promoted.
             if num_promoted == 0 || !self.process_account_leaf_updates(false)? {
-                break
+                break;
             }
         }
 
-        Ok(())
+        Ok(has_large_storage_trie)
     }
 
     fn dispatch_pending_targets(&mut self) {

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1224,8 +1224,8 @@ impl ArenaParallelSparseTrie {
                                     ArenaSparseNode::Branch(ArenaSparseNodeBranch {
                                         state: ArenaSparseNodeState::Cached { rlp_node, .. },
                                         ..
-                                    }) |
-                                    ArenaSparseNode::Leaf {
+                                    })
+                                    | ArenaSparseNode::Leaf {
                                         state: ArenaSparseNodeState::Cached { rlp_node, .. },
                                         ..
                                     } => {
@@ -1316,8 +1316,8 @@ impl ArenaParallelSparseTrie {
                 ArenaSparseNode::Branch(b) => {
                     let short_key = &b.short_key;
                     let logical_end = path_offset + short_key.len();
-                    if full_path.len() <= logical_end ||
-                        full_path.slice(path_offset..logical_end) != *short_key
+                    if full_path.len() <= logical_end
+                        || full_path.slice(path_offset..logical_end) != *short_key
                     {
                         return None;
                     }
@@ -1364,14 +1364,14 @@ impl ArenaParallelSparseTrie {
                     if remaining != *key {
                         return Ok(LeafLookup::NonExistent);
                     }
-                    if let Some(expected) = expected_value &&
-                        *expected != *value
-                    {
-                        return Err(LeafLookupError::ValueMismatch {
-                            path: *full_path,
-                            expected: Some(expected.clone()),
-                            actual: value.clone(),
-                        });
+                    if let Some(expected) = expected_value {
+                        if *expected != *value {
+                            return Err(LeafLookupError::ValueMismatch {
+                                path: *full_path,
+                                expected: Some(expected.clone()),
+                                actual: value.clone(),
+                            });
+                        }
                     }
                     return Ok(LeafLookup::Exists);
                 }
@@ -1697,8 +1697,8 @@ impl ArenaParallelSparseTrie {
                     let child_nibble = head_path.last().expect("non-root leaf");
                     let parent_branch = arena[parent_idx].branch_ref();
 
-                    if parent_branch.state_mask.count_bits() == 2 &&
-                        parent_branch.sibling_child(child_nibble).is_blinded()
+                    if parent_branch.state_mask.count_bits() == 2
+                        && parent_branch.sibling_child(child_nibble).is_blinded()
                     {
                         let sibling_nibble = parent_branch
                             .state_mask
@@ -1762,8 +1762,8 @@ impl ArenaParallelSparseTrie {
                     RemoveLeafResult::Removed,
                     SubtrieCounterDeltas {
                         num_leaves_delta: -1,
-                        num_dirty_leaves_delta: (collapse_dirtied_leaf as i64) -
-                            (removed_was_dirty as i64),
+                        num_dirty_leaves_delta: (collapse_dirtied_leaf as i64)
+                            - (removed_was_dirty as i64),
                     },
                 )
             }
@@ -1881,13 +1881,13 @@ impl ArenaParallelSparseTrie {
 
         // Record the collapsed branch's logical path for trie update tracking if it
         // was previously persisted in the DB trie.
-        if let Some(trie_updates) = updates.as_mut() &&
-            !branch.branch_masks.is_empty()
-        {
-            let logical_path = cursor.head_logical_branch_path(arena);
-            if !logical_path.is_empty() {
-                trie_updates.updated_nodes.remove(&logical_path);
-                trie_updates.removed_nodes.insert(logical_path);
+        if let Some(trie_updates) = updates.as_mut() {
+            if !branch.branch_masks.is_empty() {
+                let logical_path = cursor.head_logical_branch_path(arena);
+                if !logical_path.is_empty() {
+                    trie_updates.updated_nodes.remove(&logical_path);
+                    trie_updates.removed_nodes.insert(logical_path);
+                }
             }
         }
 
@@ -2454,6 +2454,19 @@ impl SparseTrie for ArenaParallelSparseTrie {
         self.upper_arena[self.root].is_cached()
     }
 
+    fn prefix_set_len(&self) -> usize {
+        self.upper_arena
+            .iter()
+            .map(|(_, node)| {
+                if let ArenaSparseNode::Subtrie(s) = node {
+                    s.num_dirty_leaves as usize
+                } else {
+                    0
+                }
+            })
+            .sum()
+    }
+
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
     fn update_subtrie_hashes(&mut self) {
         #[cfg(feature = "trie-debug")]
@@ -2633,8 +2646,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
             .sum();
 
         // RLP buffers.
-        let buffer_size = self.buffers.rlp_buf.capacity() +
-            self.buffers.rlp_node_buf.capacity() * core::mem::size_of::<RlpNode>();
+        let buffer_size = self.buffers.rlp_buf.capacity()
+            + self.buffers.rlp_node_buf.capacity() * core::mem::size_of::<RlpNode>();
 
         upper + subtrie_size + buffer_size
     }
@@ -2669,9 +2682,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
             let result = cursor.next(&mut self.upper_arena, |_, child| {
                 matches!(
                     child,
-                    ArenaSparseNode::Branch(_) |
-                        ArenaSparseNode::Subtrie(_) |
-                        ArenaSparseNode::Leaf { .. }
+                    ArenaSparseNode::Branch(_)
+                        | ArenaSparseNode::Subtrie(_)
+                        | ArenaSparseNode::Leaf { .. }
                 )
             });
 
@@ -2839,8 +2852,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     let subtrie_root_path = subtrie_entry.path;
 
                     let subtrie_start = update_idx;
-                    while update_idx < sorted.len() &&
-                        sorted[update_idx].1.starts_with(&subtrie_root_path)
+                    while update_idx < sorted.len()
+                        && sorted[update_idx].1.starts_with(&subtrie_root_path)
                     {
                         update_idx += 1;
                     }
@@ -2921,10 +2934,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     continue;
                 }
                 // EmptyRoot, leaf, diverged branch, or empty child slot — upsert directly.
-                find_result @ (SeekResult::EmptyRoot |
-                SeekResult::RevealedLeaf |
-                SeekResult::Diverged |
-                SeekResult::NoChild { .. }) => match update {
+                find_result @ (SeekResult::EmptyRoot
+                | SeekResult::RevealedLeaf
+                | SeekResult::Diverged
+                | SeekResult::NoChild { .. }) => match update {
                     LeafUpdate::Changed(v) if !v.is_empty() => {
                         let (result, _deltas) = Self::upsert_leaf(
                             &mut self.upper_arena,

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -199,7 +199,7 @@ impl SparseTrie for ParallelSparseTrie {
 
     fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()> {
         if nodes.is_empty() {
-            return Ok(())
+            return Ok(());
         }
 
         #[cfg(feature = "trie-debug")]
@@ -222,12 +222,14 @@ impl SparseTrie for ParallelSparseTrie {
         for ProofTrieNodeV2 { path, masks, node } in nodes.iter() {
             if let Some(branch_masks) = masks {
                 // Use proper path for branch nodes by combining path and extension key.
-                let path = if let TrieNodeV2::Branch(branch) = node &&
-                    !branch.key.is_empty()
-                {
-                    let mut path = *path;
-                    path.extend(&branch.key);
-                    path
+                let path = if let TrieNodeV2::Branch(branch) = node {
+                    if branch.key.is_empty() {
+                        *path
+                    } else {
+                        let mut path = *path;
+                        path.extend(&branch.key);
+                        path
+                    }
                 } else {
                     *path
                 };
@@ -260,8 +262,8 @@ impl SparseTrie for ParallelSparseTrie {
         let hashes_from_upper = nodes
             .iter()
             .filter_map(|node| {
-                if node.path.len() != UPPER_TRIE_MAX_DEPTH ||
-                    !reachable_subtries.get(path_subtrie_index_unchecked(&node.path))
+                if node.path.len() != UPPER_TRIE_MAX_DEPTH
+                    || !reachable_subtries.get(path_subtrie_index_unchecked(&node.path))
                 {
                     return None;
                 }
@@ -293,8 +295,8 @@ impl SparseTrie for ParallelSparseTrie {
                     continue;
                 }
                 // For boundary leaves, check reachability from upper subtrie's parent branch
-                if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
-                    !Self::is_boundary_leaf_reachable(
+                if node.path.len() == UPPER_TRIE_MAX_DEPTH
+                    && !Self::is_boundary_leaf_reachable(
                         &self.upper_subtrie.nodes,
                         &node.path,
                         &node.node,
@@ -315,7 +317,7 @@ impl SparseTrie for ParallelSparseTrie {
                     hashes_from_upper.get(&node.path).copied(),
                 )?;
             }
-            return Ok(())
+            return Ok(());
         }
 
         #[cfg(not(feature = "std"))]
@@ -336,8 +338,8 @@ impl SparseTrie for ParallelSparseTrie {
             // Group the nodes by lower subtrie.
             let results = lower_nodes
                 .chunk_by(|node_a, node_b| {
-                    SparseSubtrieType::from_path(&node_a.path) ==
-                        SparseSubtrieType::from_path(&node_b.path)
+                    SparseSubtrieType::from_path(&node_a.path)
+                        == SparseSubtrieType::from_path(&node_b.path)
                 })
                 // Filter out chunks for unreachable subtries.
                 .filter_map(|nodes| {
@@ -346,8 +348,8 @@ impl SparseTrie for ParallelSparseTrie {
                         .filter(|node| {
                             // For boundary leaves, check reachability from upper subtrie's parent
                             // branch.
-                            if node.path.len() == UPPER_TRIE_MAX_DEPTH &&
-                                !Self::is_boundary_leaf_reachable(
+                            if node.path.len() == UPPER_TRIE_MAX_DEPTH
+                                && !Self::is_boundary_leaf_reachable(
                                     upper_nodes,
                                     &node.path,
                                     &node.node,
@@ -411,7 +413,7 @@ impl SparseTrie for ParallelSparseTrie {
                             hashes_from_upper.get(&node.path).copied(),
                         );
                         if res.is_err() {
-                            return (subtrie_idx, subtrie, res.map(|_| ()))
+                            return (subtrie_idx, subtrie, res.map(|_| ()));
                         }
                     }
                     (subtrie_idx, subtrie, Ok(()))
@@ -439,16 +441,17 @@ impl SparseTrie for ParallelSparseTrie {
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::Root);
 
-        if self.prefix_set.is_empty() &&
-            let Some(rlp_node) = self
+        if self.prefix_set.is_empty() {
+            if let Some(rlp_node) = self
                 .upper_subtrie
                 .nodes
                 .get(&Nibbles::default())
                 .and_then(|node| node.cached_rlp_node())
-        {
-            return rlp_node
-                .as_hash()
-                .expect("RLP-encoding of the root node cannot be less than 32 bytes")
+            {
+                return rlp_node
+                    .as_hash()
+                    .expect("RLP-encoding of the root node cannot be less than 32 bytes");
+            }
         }
 
         // Update all lower subtrie hashes
@@ -464,8 +467,9 @@ impl SparseTrie for ParallelSparseTrie {
     }
 
     fn is_root_cached(&self) -> bool {
-        self.prefix_set.is_empty() &&
-            self.upper_subtrie
+        self.prefix_set.is_empty()
+            && self
+                .upper_subtrie
                 .nodes
                 .get(&Nibbles::default())
                 .is_some_and(|node| node.cached_rlp_node().is_some())
@@ -502,7 +506,7 @@ impl SparseTrie for ParallelSparseTrie {
             }
 
             self.insert_changed_subtries(changed_subtries);
-            return
+            return;
         }
 
         #[cfg(not(feature = "std"))]
@@ -534,10 +538,10 @@ impl SparseTrie for ParallelSparseTrie {
         // we need to check if the subtrie that the key might belong to has any nodes; if not then
         // the key's portion of the trie doesn't have enough depth to reach into the subtrie, and
         // the key will be in the upper subtrie
-        if let Some(subtrie) = self.subtrie_for_path(full_path) &&
-            !subtrie.is_empty()
-        {
-            return subtrie.inner.values.get(full_path);
+        if let Some(subtrie) = self.subtrie_for_path(full_path) {
+            if !subtrie.is_empty() {
+                return subtrie.inner.values.get(full_path);
+            }
         }
 
         self.upper_subtrie.inner.values.get(full_path)
@@ -608,7 +612,7 @@ impl SparseTrie for ParallelSparseTrie {
                     path: *full_path,
                     expected: expected_value.cloned(),
                     actual: actual_value.clone(),
-                })
+                });
         }
 
         // If the value does not exist in the `values` map, then this means that the leaf either:
@@ -628,42 +632,42 @@ impl SparseTrie for ParallelSparseTrie {
                     let mut found_full_path = curr_path;
                     found_full_path.extend(key);
                     assert!(&found_full_path != full_path, "target leaf {full_path:?} found, even though value wasn't in values hashmap");
-                    return Ok(LeafLookup::NonExistent)
+                    return Ok(LeafLookup::NonExistent);
                 }
                 SparseNode::Extension { key, .. } => {
                     if full_path.len() == curr_path.len() {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                     curr_path.extend(key);
                     if !full_path.starts_with(&curr_path) {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                 }
                 SparseNode::Branch { state_mask, blinded_mask, blinded_hashes, .. } => {
                     if full_path.len() == curr_path.len() {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                     let nibble = full_path.get_unchecked(curr_path.len());
                     if !state_mask.is_bit_set(nibble) {
-                        return Ok(LeafLookup::NonExistent)
+                        return Ok(LeafLookup::NonExistent);
                     }
                     curr_path.push_unchecked(nibble);
                     if blinded_mask.is_bit_set(nibble) {
                         return Err(LeafLookupError::BlindedNode {
                             path: curr_path,
                             hash: blinded_hashes[nibble as usize],
-                        })
+                        });
                     }
                 }
             }
 
             // If we were previously looking at the upper trie, and the new path is in the
             // lower trie, we need to pull out a ref to the lower trie.
-            if curr_subtrie_is_upper &&
-                let Some(lower_subtrie) = self.lower_subtrie_for_path(&curr_path)
-            {
-                curr_subtrie = lower_subtrie;
-                curr_subtrie_is_upper = false;
+            if curr_subtrie_is_upper {
+                if let Some(lower_subtrie) = self.lower_subtrie_for_path(&curr_path) {
+                    curr_subtrie = lower_subtrie;
+                    curr_subtrie_is_upper = false;
+                }
             }
         }
     }
@@ -917,6 +921,10 @@ impl SparseTrie for ParallelSparseTrie {
         core::mem::take(&mut self.debug_recorder)
     }
 
+    fn prefix_set_len(&self) -> usize {
+        self.prefix_set.len()
+    }
+
     fn commit_updates(
         &mut self,
         updated: &HashMap<Nibbles, BranchNodeCompact>,
@@ -988,8 +996,8 @@ impl ParallelSparseTrie {
     /// occurs when `retain_updates` is enabled and an extension node's child needs revealing.
     const fn get_retriable_path(e: &SparseTrieError) -> Option<Nibbles> {
         match e.kind() {
-            SparseTrieErrorKind::BlindedNode(path) |
-            SparseTrieErrorKind::NodeNotFoundInProvider { path } => Some(*path),
+            SparseTrieErrorKind::BlindedNode(path)
+            | SparseTrieErrorKind::NodeNotFoundInProvider { path } => Some(*path),
             _ => None,
         }
     }
@@ -1056,16 +1064,16 @@ impl ParallelSparseTrie {
             self.upper_subtrie.inner.values.insert(full_path, value);
             return Ok(());
         }
-        if let Some(subtrie) = self.lower_subtrie_for_path(&full_path) &&
-            subtrie.inner.values.contains_key(&full_path)
-        {
-            self.prefix_set.insert(full_path);
-            self.lower_subtrie_for_path_mut(&full_path)
-                .expect("subtrie exists")
-                .inner
-                .values
-                .insert(full_path, value);
-            return Ok(());
+        if let Some(subtrie) = self.lower_subtrie_for_path(&full_path) {
+            if subtrie.inner.values.contains_key(&full_path) {
+                self.prefix_set.insert(full_path);
+                self.lower_subtrie_for_path_mut(&full_path)
+                    .expect("subtrie exists")
+                    .inner
+                    .values
+                    .insert(full_path, value);
+                return Ok(());
+            }
         }
 
         self.upper_subtrie.inner.values.insert(full_path, value.clone());
@@ -1229,8 +1237,8 @@ impl ParallelSparseTrie {
                     curr_path = next_path;
 
                     let next_subtrie_type = SparseSubtrieType::from_path(&curr_path);
-                    if matches!(curr_subtrie_type, SparseSubtrieType::Upper) &&
-                        matches!(next_subtrie_type, SparseSubtrieType::Lower(_))
+                    if matches!(curr_subtrie_type, SparseSubtrieType::Upper)
+                        && matches!(next_subtrie_type, SparseSubtrieType::Lower(_))
                     {
                         curr_subtrie_type = next_subtrie_type;
                     }
@@ -1563,31 +1571,31 @@ impl ParallelSparseTrie {
                 found_full_path.extend(key);
 
                 if &found_full_path == leaf_full_path {
-                    return FindNextToLeafOutcome::Found
+                    return FindNextToLeafOutcome::Found;
                 }
                 FindNextToLeafOutcome::NotFound
             }
             SparseNode::Extension { key, .. } => {
                 if leaf_full_path.len() == from_path.len() {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let mut child_path = *from_path;
                 child_path.extend(key);
 
                 if !leaf_full_path.starts_with(&child_path) {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
                 FindNextToLeafOutcome::ContinueFrom(child_path)
             }
             SparseNode::Branch { state_mask, blinded_mask, .. } => {
                 if leaf_full_path.len() == from_path.len() {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let nibble = leaf_full_path.get_unchecked(from_path.len());
                 if !state_mask.is_bit_set(nibble) {
-                    return FindNextToLeafOutcome::NotFound
+                    return FindNextToLeafOutcome::NotFound;
                 }
 
                 let mut child_path = *from_path;
@@ -1893,8 +1901,8 @@ impl ParallelSparseTrie {
 
         for (index, subtrie) in self.lower_subtries.iter_mut().enumerate() {
             if let Some(subtrie) = subtrie.take_revealed_if(|subtrie| {
-                prefix_set.contains(&subtrie.path) ||
-                    subtrie
+                prefix_set.contains(&subtrie.path)
+                    || subtrie
                         .nodes
                         .get(&subtrie.path)
                         .is_some_and(|n| n.cached_rlp_node().is_none())
@@ -1921,7 +1929,7 @@ impl ParallelSparseTrie {
                             // If we're past the subtrie path, we're done with this subtrie. Do not
                             // advance the iterator, the next key will be processed either by the
                             // next subtrie or inserted into the unchanged prefix set.
-                            break
+                            break;
                         }
                     }
                     PrefixSetMut::from(new_prefix_set)
@@ -1994,7 +2002,7 @@ impl ParallelSparseTrie {
         // Only reveal nodes that can be reached given the current state of the upper trie. If they
         // can't be reached, it means that they were removed.
         if !self.is_path_reachable_from_upper(&path) {
-            return Ok(())
+            return Ok(());
         }
 
         // Exit early if the node was already revealed before.
@@ -2007,7 +2015,7 @@ impl ParallelSparseTrie {
                 // We might still potentially need to reveal a child branch node in the lower
                 // subtrie, even if the upper subtrie already knew about the extension node.
                 if SparseSubtrieType::path_len_is_upper(path.len() + branch.key.len()) {
-                    return Ok(())
+                    return Ok(());
                 }
             } else {
                 return Ok(());
@@ -2124,13 +2132,13 @@ impl ParallelSparseTrie {
         size += self.prefix_set.len() * core::mem::size_of::<Nibbles>();
 
         // Branch node masks map
-        size += self.branch_node_masks.len() *
-            (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeMasks>());
+        size += self.branch_node_masks.len()
+            * (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeMasks>());
 
         // Updates if present
         if let Some(updates) = &self.updates {
-            size += updates.updated_nodes.len() *
-                (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeCompact>());
+            size += updates.updated_nodes.len()
+                * (core::mem::size_of::<Nibbles>() + core::mem::size_of::<BranchNodeCompact>());
             size += updates.removed_nodes.len() * core::mem::size_of::<Nibbles>();
         }
 
@@ -2150,14 +2158,14 @@ impl ParallelSparseTrie {
             match node {
                 SparseNode::Branch { state_mask, .. } => {
                     if !state_mask.is_bit_set(path.get_unchecked(current.len())) {
-                        return false
+                        return false;
                     }
 
                     current.push_unchecked(path.get_unchecked(current.len()));
                 }
                 SparseNode::Extension { key, .. } => {
                     if *key != path.slice(current.len()..current.len() + key.len()) {
-                        return false
+                        return false;
                     }
                     current.extend(key);
                 }
@@ -2180,7 +2188,7 @@ impl ParallelSparseTrie {
         debug_assert_eq!(path.len(), UPPER_TRIE_MAX_DEPTH);
 
         if !matches!(node, TrieNodeV2::Leaf(_)) {
-            return true
+            return true;
         }
 
         let parent_path = path.slice(..path.len() - 1);
@@ -2312,7 +2320,7 @@ impl SparseSubtrie {
     /// for this leaf's nibble, meaning the leaf is not reachable.
     fn is_leaf_reachable_from_parent(&self, path: &Nibbles) -> bool {
         if path.is_empty() {
-            return true
+            return true;
         }
 
         let parent_path = path.slice(..path.len() - 1);
@@ -2340,7 +2348,7 @@ impl SparseSubtrie {
         // Check if value already exists - if so, just update it (no structural changes needed)
         if let Entry::Occupied(mut e) = self.inner.values.entry(full_path) {
             e.insert(value);
-            return Ok(())
+            return Ok(());
         }
 
         // Here we are starting at the root of the subtrie, and traversing from there.
@@ -2455,7 +2463,7 @@ impl SparseSubtrie {
                         inserted_nodes.push(ext_path);
                     }
 
-                    return Ok(LeafUpdateStep::complete_with_insertions(inserted_nodes))
+                    return Ok(LeafUpdateStep::complete_with_insertions(inserted_nodes));
                 }
 
                 Ok(LeafUpdateStep::Continue)
@@ -2468,7 +2476,7 @@ impl SparseSubtrie {
                     state_mask.set_bit(nibble);
                     let new_leaf = SparseNode::new_leaf(path.slice(current.len()..));
                     self.nodes.insert(*current, new_leaf);
-                    return Ok(LeafUpdateStep::complete_with_insertions(vec![*current]))
+                    return Ok(LeafUpdateStep::complete_with_insertions(vec![*current]));
                 }
 
                 if blinded_mask.is_bit_set(nibble) {
@@ -2668,7 +2676,7 @@ impl SparseSubtrie {
                         ?path,
                         "Leaf not reachable from parent branch, skipping",
                     );
-                    return Ok(false)
+                    return Ok(false);
                 }
 
                 let mut full_key = path;
@@ -2682,7 +2690,7 @@ impl SparseSubtrie {
                             ?full_key,
                             "Leaf full key value already present, skipping",
                         );
-                        return Ok(false)
+                        return Ok(false);
                     }
                     Entry::Vacant(entry) => {
                         entry.insert(leaf.value.clone());
@@ -2967,7 +2975,7 @@ impl SparseSubtrieInner {
                         },
                         RlpNodePathStackItem { path: child_path, is_in_prefix_set: None },
                     ]);
-                    return
+                    return;
                 }
             }
             SparseNode::Branch { state_mask, state, blinded_mask, blinded_hashes } => {
@@ -2994,7 +3002,7 @@ impl SparseSubtrieInner {
                         rlp_node: rlp_node.clone(),
                         node_type,
                     });
-                    return
+                    return;
                 }
 
                 let retain_updates = update_actions.is_some() && prefix_set_contains(&path);
@@ -3054,24 +3062,24 @@ impl SparseSubtrieInner {
                                 .drain(..)
                                 .map(|path| RlpNodePathStackItem { path, is_in_prefix_set: None }),
                         );
-                        return
+                        return;
                     };
 
                     // Update the masks only if we need to retain trie updates
                     if retain_updates {
                         // Determine whether we need to set trie mask bit.
-                        let should_set_tree_mask_bit =
-                            if let Some(store_in_db_trie) = child_node_type.store_in_db_trie() {
-                                // A branch or an extension node explicitly set the
-                                // `store_in_db_trie` flag
-                                store_in_db_trie
-                            } else {
-                                // A blinded node has the tree mask bit set
-                                child_node_type.is_hash() &&
-                                    path_masks().is_some_and(|masks| {
-                                        masks.tree_mask.is_bit_set(child_nibble)
-                                    })
-                            };
+                        let should_set_tree_mask_bit = if let Some(store_in_db_trie) =
+                            child_node_type.store_in_db_trie()
+                        {
+                            // A branch or an extension node explicitly set the
+                            // `store_in_db_trie` flag
+                            store_in_db_trie
+                        } else {
+                            // A blinded node has the tree mask bit set
+                            child_node_type.is_hash()
+                                && path_masks()
+                                    .is_some_and(|masks| masks.tree_mask.is_bit_set(child_nibble))
+                        };
                         if should_set_tree_mask_bit {
                             tree_mask.set_bit(child_nibble);
                         }
@@ -3079,9 +3087,9 @@ impl SparseSubtrieInner {
                         // is a blinded node that has its hash mask bit set according to the
                         // database, set the hash mask bit and save the hash.
                         let hash = child.as_hash().filter(|_| {
-                            child_node_type.is_branch() ||
-                                (child_node_type.is_hash() &&
-                                    path_masks().is_some_and(|masks| {
+                            child_node_type.is_branch()
+                                || (child_node_type.is_hash()
+                                    && path_masks().is_some_and(|masks| {
                                         masks.hash_mask.is_bit_set(child_nibble)
                                     }))
                         });
@@ -8027,8 +8035,9 @@ mod tests {
 
         // Record state before update_leaves
         let prefix_set_len_before = trie.prefix_set.len();
-        let node_count_before = trie.upper_subtrie.nodes.len() +
-            trie.lower_subtries
+        let node_count_before = trie.upper_subtrie.nodes.len()
+            + trie
+                .lower_subtries
                 .iter()
                 .filter_map(|s| s.as_revealed_ref())
                 .map(|s| s.nodes.len())
@@ -8063,8 +8072,9 @@ mod tests {
         );
 
         // Assert: node count unchanged
-        let node_count_after = trie.upper_subtrie.nodes.len() +
-            trie.lower_subtries
+        let node_count_after = trie.upper_subtrie.nodes.len()
+            + trie
+                .lower_subtries
                 .iter()
                 .filter_map(|s| s.as_revealed_ref())
                 .map(|s| s.nodes.len())

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -375,6 +375,18 @@ where
         any_err
     }
 
+    /// Reveals V2 proof nodes for a single storage trie.
+    pub fn reveal_storage_v2_proof_nodes(
+        &mut self,
+        account: B256,
+        proof_nodes: Vec<ProofTrieNodeV2>,
+    ) -> SparseStateTrieResult<()> {
+        self.reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+            storage_proofs: B256Map::from_iter([(account, proof_nodes)]),
+            ..Default::default()
+        })
+    }
+
     /// Wipe the storage trie at the provided address.
     pub fn wipe_storage(&mut self, address: B256) -> SparseStateTrieResult<()> {
         if let Some(trie) = self.storage.tries.get_mut(&address) {

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -152,6 +152,9 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// Returns true if the root node is cached and does not need any recomputation.
     fn is_root_cached(&self) -> bool;
 
+    /// Returns the number of entries in the prefix set.
+    fn prefix_set_len(&self) -> usize;
+
     /// Recalculates and updates the RLP hashes of subtries deeper than a certain level. The level
     /// is defined in the implementation.
     ///
@@ -424,6 +427,10 @@ mod configurable_sparse_trie {
 
         fn is_root_cached(&self) -> bool {
             delegate!(self, is_root_cached)
+        }
+
+        fn prefix_set_len(&self) -> usize {
+            delegate!(self, prefix_set_len)
         }
 
         fn update_subtrie_hashes(&mut self) {

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -207,6 +207,11 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
         self.as_revealed_ref().is_some_and(|trie| trie.is_root_cached())
     }
 
+    /// Returns the number of entries in the prefix set.
+    pub fn prefix_set_len(&self) -> usize {
+        self.as_revealed_ref().map_or(0, |trie| trie.prefix_set_len())
+    }
+
     /// Returns the root hash along with any accumulated update information.
     ///
     /// This is useful for when you need both the root hash and information about
@@ -222,6 +227,13 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     pub fn root_with_updates(&mut self) -> Option<(B256, SparseTrieUpdates)> {
         let revealed = self.as_revealed_mut()?;
         Some((revealed.root(), revealed.take_updates()))
+    }
+
+    /// Updates the hashes of the subtries.
+    pub fn update_subtrie_hashes(&mut self) {
+        if let Some(trie) = self.as_revealed_mut() {
+            trie.update_subtrie_hashes();
+        }
     }
 
     /// Clears this trie, setting it to a blind state.
@@ -435,9 +447,9 @@ impl SparseNode {
     pub fn cached_rlp_node(&self) -> Option<Cow<'_, RlpNode>> {
         match &self {
             Self::Empty => None,
-            Self::Leaf { state, .. } |
-            Self::Extension { state, .. } |
-            Self::Branch { state, .. } => state.cached_rlp_node().map(Cow::Borrowed),
+            Self::Leaf { state, .. }
+            | Self::Extension { state, .. }
+            | Self::Branch { state, .. } => state.cached_rlp_node().map(Cow::Borrowed),
         }
     }
 
@@ -445,9 +457,9 @@ impl SparseNode {
     pub fn cached_hash(&self) -> Option<B256> {
         match &self {
             Self::Empty => None,
-            Self::Leaf { state, .. } |
-            Self::Extension { state, .. } |
-            Self::Branch { state, .. } => state.cached_hash(),
+            Self::Leaf { state, .. }
+            | Self::Extension { state, .. }
+            | Self::Branch { state, .. } => state.cached_hash(),
         }
     }
 
@@ -460,9 +472,9 @@ impl SparseNode {
             Self::Empty => {
                 panic!("Cannot set hash for Empty or Hash nodes")
             }
-            Self::Leaf { state, .. } |
-            Self::Extension { state, .. } |
-            Self::Branch { state, .. } => {
+            Self::Leaf { state, .. }
+            | Self::Extension { state, .. }
+            | Self::Branch { state, .. } => {
                 *state = new_state;
             }
         }


### PR DESCRIPTION
Revives #22549 on top of latest main.

Validation:
- cargo check -p reth-trie-sparse -p reth-engine-tree

Prompted by: @klkvr