### PR TITLE
feat(engine): add into_block_arc to built payload

### DIFF
--- a/crates/ethereum/engine-primitives/src/payload.rs
+++ b/crates/ethereum/engine-primitives/src/payload.rs
@@ -72,6 +72,11 @@ impl<N: NodePrimitives> EthBuiltPayload<N> {
         &self.block
     }
 
+    /// Consumes the payload and returns the built block with shared ownership.
+    pub fn into_block_arc(self) -> Arc<RecoveredBlock<N::Block>> {
+        self.block
+    }
+
     /// Fees of the block
     pub const fn fees(&self) -> U256 {
         self.fees


### PR DESCRIPTION
Adds a consuming accessor for `EthBuiltPayload` that returns the underlying `Arc<RecoveredBlock<_>>`.

This lets callers take shared ownership of the built block without cloning through the borrowed accessor.