### PR TITLE
ci: ignore proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,9 @@ ignore = [
     # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
     # the fix, and no patched hickory-proto release exists
     "RUSTSEC-2026-0118",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+    # and is pulled in transitively by upstream crates with no safe upgrade available.
+    "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Adds `RUSTSEC-2026-0173` to the ignored advisory list in `deny.toml`.

The deny job started failing because `proc-macro-error2` is now reported as unmaintained and is pulled in transitively through `alloy-sol-macro v1.6.0`. `cargo-deny` reports that no safe upgrade is available for this advisory, so this mirrors the mitigation used in Alloy/Tempo while keeping the ignore documented in the deny policy.

This should unblock PRs that fail only on the new unmaintained advisory without changing dependency resolution or package code.
