### PR TITLE
fix(chain-state): publish deferred trie data from task

### DIFF
--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -1,4 +1,3 @@
-use parking_lot::Mutex;
 use reth_metrics::{metrics::Counter, Metrics};
 use reth_trie::{
     updates::{TrieUpdates, TrieUpdatesSorted},
@@ -8,7 +7,6 @@ use std::{
     fmt,
     sync::{Arc, LazyLock, OnceLock},
 };
-use tokio::sync::oneshot;
 use tracing::{debug_span, instrument};
 
 /// Shared handle to asynchronously populated sorted per-block trie data.
@@ -19,13 +17,13 @@ use tracing::{debug_span, instrument};
 #[derive(Clone)]
 pub struct DeferredTrieData {
     /// Shared deferred result populated by the corresponding [`DeferredTrieTask`].
-    inner: Arc<DeferredTrieDataInner>,
+    value: Arc<OnceLock<ComputedTrieData>>,
 }
 
 /// Owned task that computes and publishes sorted trie data for a [`DeferredTrieData`] handle.
 pub struct DeferredTrieTask {
-    /// Sender used to publish the computed trie data exactly once.
-    tx: oneshot::Sender<ComputedTrieData>,
+    /// Shared result initialized exactly once by this task.
+    value: Arc<OnceLock<ComputedTrieData>>,
     /// Unsorted inputs consumed by the background task.
     inputs: PendingInputs,
 }
@@ -61,14 +59,6 @@ struct DeferredTrieMetrics {
 static DEFERRED_TRIE_METRICS: LazyLock<DeferredTrieMetrics> =
     LazyLock::new(DeferredTrieMetrics::default);
 
-/// Internal state for deferred trie data shared by cloned handles.
-struct DeferredTrieDataInner {
-    /// Cached result once the publishing task completes or once this handle is created ready.
-    value: OnceLock<ComputedTrieData>,
-    /// Receiver for the publishing task. Taken by the first caller that needs to wait.
-    rx: Mutex<Option<oneshot::Receiver<ComputedTrieData>>>,
-}
-
 /// Inputs kept while a deferred trie computation is pending.
 #[derive(Clone, Debug)]
 struct PendingInputs {
@@ -81,7 +71,7 @@ struct PendingInputs {
 impl fmt::Debug for DeferredTrieData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DeferredTrieData")
-            .field("state", &if self.inner.value.get().is_some() { "ready" } else { "pending" })
+            .field("state", &if self.value.get().is_some() { "ready" } else { "pending" })
             .finish()
     }
 }
@@ -92,26 +82,16 @@ impl DeferredTrieData {
         hashed_state: Arc<HashedPostState>,
         trie_updates: Arc<TrieUpdates>,
     ) -> (Self, DeferredTrieTask) {
-        let (tx, rx) = oneshot::channel();
+        let value = Arc::new(OnceLock::new());
         (
-            Self {
-                inner: Arc::new(DeferredTrieDataInner {
-                    value: OnceLock::new(),
-                    rx: Mutex::new(Some(rx)),
-                }),
-            },
-            DeferredTrieTask { tx, inputs: PendingInputs { hashed_state, trie_updates } },
+            Self { value: Arc::clone(&value) },
+            DeferredTrieTask { value, inputs: PendingInputs { hashed_state, trie_updates } },
         )
     }
 
     /// Create a handle that is already populated with the given [`ComputedTrieData`].
     pub fn ready(bundle: ComputedTrieData) -> Self {
-        Self {
-            inner: Arc::new(DeferredTrieDataInner {
-                value: OnceLock::from(bundle),
-                rx: Mutex::new(None),
-            }),
-        }
+        Self { value: Arc::new(OnceLock::from(bundle)) }
     }
 
     /// Sorts block execution outputs.
@@ -151,22 +131,16 @@ impl DeferredTrieData {
     /// Returns trie data, waiting for the async publishing task if it has not completed.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
-        let mut initialized_from_task = false;
-        let bundle = self.inner.value.get_or_init(|| {
-            initialized_from_task = true;
-            DEFERRED_TRIE_METRICS.deferred_trie_task_wait.increment(1);
-            let rx = self
-                .inner
-                .rx
-                .lock()
-                .take()
-                .expect("deferred trie receiver already taken before data was published");
-            rx.blocking_recv().expect("deferred trie task dropped before publishing trie data")
-        });
-
-        if !initialized_from_task {
-            DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
-        }
+        let bundle = match self.value.get() {
+            Some(bundle) => {
+                DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
+                bundle
+            }
+            None => {
+                DEFERRED_TRIE_METRICS.deferred_trie_task_wait.increment(1);
+                self.value.wait()
+            }
+        };
 
         bundle.clone()
     }
@@ -175,9 +149,9 @@ impl DeferredTrieData {
 impl DeferredTrieTask {
     /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
     pub fn compute_and_publish(self) -> ComputedTrieData {
-        let Self { tx, inputs } = self;
+        let Self { value, inputs } = self;
         let computed = DeferredTrieData::sort(inputs.hashed_state, inputs.trie_updates);
-        let _ = tx.send(computed.clone());
+        let _ = value.set(computed.clone());
         computed
     }
 }

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -213,9 +213,8 @@ mod tests {
     #[test]
     fn pending_wait_blocks_until_task_publishes() {
         let (deferred, task) = empty_pending();
-        let deferred_waiter = deferred.clone();
 
-        let handle = thread::spawn(move || deferred_waiter.wait_cloned());
+        let handle = thread::spawn(move || deferred.wait_cloned());
         thread::sleep(Duration::from_millis(20));
         assert!(!handle.is_finished());
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -11,27 +11,29 @@ use tracing::{debug_span, instrument};
 
 /// Shared handle to asynchronously populated sorted per-block trie data.
 ///
-/// The corresponding [`DeferredTrieTask`] owns the unsorted inputs and publishes the sorted data
-/// when the background task completes. Callers wait for that result instead of computing it
+/// The corresponding [`DeferredTrieDataProducer`] owns the unsorted inputs and publishes the sorted
+/// data when the background task completes. Callers wait for that result instead of computing it
 /// synchronously.
 #[derive(Clone)]
 pub struct DeferredTrieData {
-    /// Shared deferred result populated by the corresponding [`DeferredTrieTask`].
+    /// Shared deferred result populated by the corresponding [`DeferredTrieDataProducer`].
     value: Arc<OnceLock<ComputedTrieData>>,
 }
 
-/// Owned task that computes and publishes sorted trie data for a [`DeferredTrieData`] handle.
-#[must_use = "DeferredTrieTask must be consumed with compute_and_publish to wake trie data waiters"]
-pub struct DeferredTrieTask {
-    /// Shared result initialized exactly once by this task.
+/// Producer consumed by a spawned task to compute sorted trie data for a [`DeferredTrieData`] handle.
+#[must_use = "DeferredTrieDataProducer must be consumed with compute_and_publish to wake trie data waiters"]
+pub struct DeferredTrieDataProducer {
+    /// Shared result initialized exactly once by this producer.
     value: Arc<OnceLock<ComputedTrieData>>,
-    /// Unsorted inputs consumed by the background task.
+    /// Unsorted inputs consumed when the producer computes trie data.
     inputs: PendingInputs,
 }
 
-impl fmt::Debug for DeferredTrieTask {
+impl fmt::Debug for DeferredTrieDataProducer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DeferredTrieTask").field("inputs", &self.inputs).finish_non_exhaustive()
+        f.debug_struct("DeferredTrieDataProducer")
+            .field("inputs", &self.inputs)
+            .finish_non_exhaustive()
     }
 }
 
@@ -77,7 +79,7 @@ impl fmt::Debug for DeferredTrieData {
     }
 }
 
-impl DeferredTrieTask {
+impl DeferredTrieDataProducer {
     /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
     pub fn compute_and_publish(self) -> ComputedTrieData {
         let Self { value, inputs } = self;
@@ -92,11 +94,11 @@ impl DeferredTrieData {
     pub fn pending(
         hashed_state: Arc<HashedPostState>,
         trie_updates: Arc<TrieUpdates>,
-    ) -> (Self, DeferredTrieTask) {
+    ) -> (Self, DeferredTrieDataProducer) {
         let value = Arc::new(OnceLock::new());
         (
             Self { value: Arc::clone(&value) },
-            DeferredTrieTask { value, inputs: PendingInputs { hashed_state, trie_updates } },
+            DeferredTrieDataProducer { value, inputs: PendingInputs { hashed_state, trie_updates } },
         )
     }
 
@@ -178,7 +180,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    fn empty_pending() -> (DeferredTrieData, DeferredTrieTask) {
+    fn empty_pending() -> (DeferredTrieData, DeferredTrieDataProducer) {
         DeferredTrieData::pending(
             Arc::new(HashedPostState::default()),
             Arc::new(TrieUpdates::default()),

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -151,24 +151,24 @@ impl DeferredTrieData {
     /// Returns trie data, waiting for the async publishing task if it has not completed.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
-        if let Some(bundle) = self.inner.value.get() {
+        let mut initialized_from_task = false;
+        let bundle = self.inner.value.get_or_init(|| {
+            initialized_from_task = true;
+            DEFERRED_TRIE_METRICS.deferred_trie_task_wait.increment(1);
+            let rx = self
+                .inner
+                .rx
+                .lock()
+                .take()
+                .expect("deferred trie receiver already taken before data was published");
+            rx.blocking_recv().expect("deferred trie task dropped before publishing trie data")
+        });
+
+        if !initialized_from_task {
             DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
-            return bundle.clone()
         }
 
-        self.inner
-            .value
-            .get_or_init(|| {
-                DEFERRED_TRIE_METRICS.deferred_trie_task_wait.increment(1);
-                let rx = self
-                    .inner
-                    .rx
-                    .lock()
-                    .take()
-                    .expect("deferred trie receiver already taken before data was published");
-                rx.blocking_recv().expect("deferred trie task dropped before publishing trie data")
-            })
-            .clone()
+        bundle.clone()
     }
 }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -77,6 +77,16 @@ impl fmt::Debug for DeferredTrieData {
     }
 }
 
+impl DeferredTrieTask {
+    /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
+    pub fn compute_and_publish(self) -> ComputedTrieData {
+        let Self { value, inputs } = self;
+        let computed = DeferredTrieData::sort(inputs.hashed_state, inputs.trie_updates);
+        let _ = value.set(computed.clone());
+        computed
+    }
+}
+
 impl DeferredTrieData {
     /// Create a new pending handle and task that will publish the computed trie data.
     pub fn pending(
@@ -144,16 +154,6 @@ impl DeferredTrieData {
         };
 
         bundle.clone()
-    }
-}
-
-impl DeferredTrieTask {
-    /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
-    pub fn compute_and_publish(self) -> ComputedTrieData {
-        let Self { value, inputs } = self;
-        let computed = DeferredTrieData::sort(inputs.hashed_state, inputs.trie_updates);
-        let _ = value.set(computed.clone());
-        computed
     }
 }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -37,6 +37,16 @@ impl fmt::Debug for DeferredTrieDataProducer {
     }
 }
 
+impl DeferredTrieDataProducer {
+    /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
+    pub fn compute_and_publish(self) -> ComputedTrieData {
+        let Self { value, inputs } = self;
+        let computed = DeferredTrieData::sort(inputs.hashed_state, inputs.trie_updates);
+        let _ = value.set(computed.clone());
+        computed
+    }
+}
+
 /// Sorted trie data computed for one executed block.
 ///
 /// Cumulative overlays are intentionally managed by
@@ -76,16 +86,6 @@ impl fmt::Debug for DeferredTrieData {
         f.debug_struct("DeferredTrieData")
             .field("state", &if self.value.get().is_some() { "ready" } else { "pending" })
             .finish()
-    }
-}
-
-impl DeferredTrieDataProducer {
-    /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
-    pub fn compute_and_publish(self) -> ComputedTrieData {
-        let Self { value, inputs } = self;
-        let computed = DeferredTrieData::sort(inputs.hashed_state, inputs.trie_updates);
-        let _ = value.set(computed.clone());
-        computed
     }
 }
 

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -21,6 +21,7 @@ pub struct DeferredTrieData {
 }
 
 /// Owned task that computes and publishes sorted trie data for a [`DeferredTrieData`] handle.
+#[must_use = "DeferredTrieTask must be consumed with compute_and_publish to wake trie data waiters"]
 pub struct DeferredTrieTask {
     /// Shared result initialized exactly once by this task.
     value: Arc<OnceLock<ComputedTrieData>>,

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -6,18 +6,34 @@ use reth_trie::{
 };
 use std::{
     fmt,
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, OnceLock},
 };
+use tokio::sync::oneshot;
 use tracing::{debug_span, instrument};
 
-/// Shared handle to asynchronously populated per-block trie data.
+/// Shared handle to asynchronously populated sorted per-block trie data.
 ///
-/// If the background task has not completed by the time trie data is needed, the caller computes
-/// the sorted data synchronously from the retained unsorted inputs and caches the result.
+/// The corresponding [`DeferredTrieTask`] owns the unsorted inputs and publishes the sorted data
+/// when the background task completes. Callers wait for that result instead of computing it
+/// synchronously.
 #[derive(Clone)]
 pub struct DeferredTrieData {
-    /// Shared deferred state holding either raw inputs (pending) or computed result (ready).
-    state: Arc<Mutex<DeferredTrieDataInner>>,
+    /// Shared deferred result populated by the corresponding [`DeferredTrieTask`].
+    inner: Arc<DeferredTrieDataInner>,
+}
+
+/// Owned task that computes and publishes sorted trie data for a [`DeferredTrieData`] handle.
+pub struct DeferredTrieTask {
+    /// Sender used to publish the computed trie data exactly once.
+    tx: oneshot::Sender<ComputedTrieData>,
+    /// Unsorted inputs consumed by the background task.
+    inputs: PendingInputs,
+}
+
+impl fmt::Debug for DeferredTrieTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeferredTrieTask").field("inputs", &self.inputs).finish_non_exhaustive()
+    }
 }
 
 /// Sorted trie data computed for one executed block.
@@ -38,21 +54,19 @@ pub struct ComputedTrieData {
 struct DeferredTrieMetrics {
     /// Number of times deferred trie data was ready (async task completed first).
     deferred_trie_async_ready: Counter,
-    /// Number of times deferred trie data required synchronous computation (fallback path).
-    deferred_trie_sync_fallback: Counter,
+    /// Number of times deferred trie data required waiting for the publishing task.
+    deferred_trie_task_wait: Counter,
 }
 
 static DEFERRED_TRIE_METRICS: LazyLock<DeferredTrieMetrics> =
     LazyLock::new(DeferredTrieMetrics::default);
 
-/// Internal state for deferred trie data.
-enum DeferredTrieDataInner {
-    /// Data is not yet available; raw inputs stored for fallback computation.
-    ///
-    /// Wrapped in `Option` to allow taking ownership during computation.
-    Pending(Option<PendingInputs>),
-    /// Data has been computed and is ready.
-    Ready(ComputedTrieData),
+/// Internal state for deferred trie data shared by cloned handles.
+struct DeferredTrieDataInner {
+    /// Cached result once the publishing task completes or once this handle is created ready.
+    value: OnceLock<ComputedTrieData>,
+    /// Receiver for the publishing task. Taken by the first caller that needs to wait.
+    rx: Mutex<Option<oneshot::Receiver<ComputedTrieData>>>,
 }
 
 /// Inputs kept while a deferred trie computation is pending.
@@ -66,32 +80,38 @@ struct PendingInputs {
 
 impl fmt::Debug for DeferredTrieData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = self.state.lock();
-        match &*state {
-            DeferredTrieDataInner::Pending(_) => {
-                f.debug_struct("DeferredTrieData").field("state", &"pending").finish()
-            }
-            DeferredTrieDataInner::Ready(_) => {
-                f.debug_struct("DeferredTrieData").field("state", &"ready").finish()
-            }
-        }
+        f.debug_struct("DeferredTrieData")
+            .field("state", &if self.inner.value.get().is_some() { "ready" } else { "pending" })
+            .finish()
     }
 }
 
 impl DeferredTrieData {
-    /// Create a new pending handle with fallback inputs for synchronous computation.
-    pub fn pending(hashed_state: Arc<HashedPostState>, trie_updates: Arc<TrieUpdates>) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(DeferredTrieDataInner::Pending(Some(PendingInputs {
-                hashed_state,
-                trie_updates,
-            })))),
-        }
+    /// Create a new pending handle and task that will publish the computed trie data.
+    pub fn pending(
+        hashed_state: Arc<HashedPostState>,
+        trie_updates: Arc<TrieUpdates>,
+    ) -> (Self, DeferredTrieTask) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self {
+                inner: Arc::new(DeferredTrieDataInner {
+                    value: OnceLock::new(),
+                    rx: Mutex::new(Some(rx)),
+                }),
+            },
+            DeferredTrieTask { tx, inputs: PendingInputs { hashed_state, trie_updates } },
+        )
     }
 
     /// Create a handle that is already populated with the given [`ComputedTrieData`].
     pub fn ready(bundle: ComputedTrieData) -> Self {
-        Self { state: Arc::new(Mutex::new(DeferredTrieDataInner::Ready(bundle))) }
+        Self {
+            inner: Arc::new(DeferredTrieDataInner {
+                value: OnceLock::from(bundle),
+                rx: Mutex::new(None),
+            }),
+        }
     }
 
     /// Sorts block execution outputs.
@@ -128,25 +148,37 @@ impl DeferredTrieData {
         ComputedTrieData::new(Arc::new(sorted_hashed_state), Arc::new(sorted_trie_updates))
     }
 
-    /// Returns trie data, computing synchronously if the async task hasn't completed.
+    /// Returns trie data, waiting for the async publishing task if it has not completed.
     #[instrument(level = "debug", target = "engine::tree::deferred_trie", skip_all)]
     pub fn wait_cloned(&self) -> ComputedTrieData {
-        let mut state = self.state.lock();
-        match &mut *state {
-            DeferredTrieDataInner::Ready(bundle) => {
-                DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
-                bundle.clone()
-            }
-            DeferredTrieDataInner::Pending(maybe_inputs) => {
-                DEFERRED_TRIE_METRICS.deferred_trie_sync_fallback.increment(1);
-
-                let inputs = maybe_inputs.take().expect("inputs must be present in Pending state");
-                let computed = Self::sort(inputs.hashed_state, inputs.trie_updates);
-                *state = DeferredTrieDataInner::Ready(computed.clone());
-
-                computed
-            }
+        if let Some(bundle) = self.inner.value.get() {
+            DEFERRED_TRIE_METRICS.deferred_trie_async_ready.increment(1);
+            return bundle.clone()
         }
+
+        self.inner
+            .value
+            .get_or_init(|| {
+                DEFERRED_TRIE_METRICS.deferred_trie_task_wait.increment(1);
+                let rx = self
+                    .inner
+                    .rx
+                    .lock()
+                    .take()
+                    .expect("deferred trie receiver already taken before data was published");
+                rx.blocking_recv().expect("deferred trie task dropped before publishing trie data")
+            })
+            .clone()
+    }
+}
+
+impl DeferredTrieTask {
+    /// Computes sorted trie data, publishes it to waiters, and returns it to the task owner.
+    pub fn compute_and_publish(self) -> ComputedTrieData {
+        let Self { tx, inputs } = self;
+        let computed = DeferredTrieData::sort(inputs.hashed_state, inputs.trie_updates);
+        let _ = tx.send(computed.clone());
+        computed
     }
 }
 
@@ -171,7 +203,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    fn empty_pending() -> DeferredTrieData {
+    fn empty_pending() -> (DeferredTrieData, DeferredTrieTask) {
         DeferredTrieData::pending(
             Arc::new(HashedPostState::default()),
             Arc::new(TrieUpdates::default()),
@@ -190,25 +222,47 @@ mod tests {
     }
 
     #[test]
-    fn pending_computes_and_caches_result() {
-        let deferred = empty_pending();
+    fn pending_waits_for_task_and_caches_result() {
+        let (deferred, task) = empty_pending();
 
+        let published = task.compute_and_publish();
         let first = deferred.wait_cloned();
         let second = deferred.wait_cloned();
 
+        assert!(Arc::ptr_eq(&published.hashed_state, &first.hashed_state));
+        assert!(Arc::ptr_eq(&published.trie_updates, &first.trie_updates));
         assert!(Arc::ptr_eq(&first.hashed_state, &second.hashed_state));
         assert!(Arc::ptr_eq(&first.trie_updates, &second.trie_updates));
     }
 
     #[test]
-    fn concurrent_waits_share_computed_result() {
-        let deferred = empty_pending();
+    fn pending_wait_blocks_until_task_publishes() {
+        let (deferred, task) = empty_pending();
+        let deferred_waiter = deferred.clone();
+
+        let handle = thread::spawn(move || deferred_waiter.wait_cloned());
+        thread::sleep(Duration::from_millis(20));
+        assert!(!handle.is_finished());
+
+        let published = task.compute_and_publish();
+        let result = handle.join().unwrap();
+
+        assert!(Arc::ptr_eq(&published.hashed_state, &result.hashed_state));
+        assert!(Arc::ptr_eq(&published.trie_updates, &result.trie_updates));
+    }
+
+    #[test]
+    fn concurrent_waits_share_published_result() {
+        let (deferred, task) = empty_pending();
         let deferred2 = deferred.clone();
 
         let handle = thread::spawn(move || deferred2.wait_cloned());
+        let published = task.compute_and_publish();
         let result1 = deferred.wait_cloned();
         let result2 = handle.join().unwrap();
 
+        assert!(Arc::ptr_eq(&published.hashed_state, &result1.hashed_state));
+        assert!(Arc::ptr_eq(&published.trie_updates, &result1.trie_updates));
         assert!(Arc::ptr_eq(&result1.hashed_state, &result2.hashed_state));
         assert!(Arc::ptr_eq(&result1.trie_updates, &result2.trie_updates));
     }
@@ -224,8 +278,9 @@ mod tests {
                 HashedStorage::from_iter(false, [(hashed_slot, U256::from(1))]),
             )]);
 
-        let deferred =
+        let (deferred, task) =
             DeferredTrieData::pending(Arc::new(hashed_state), Arc::new(TrieUpdates::default()));
+        let _ = task.compute_and_publish();
         let result = deferred.wait_cloned();
 
         assert_eq!(result.hashed_state.total_len(), 2);
@@ -238,11 +293,12 @@ mod tests {
         for i in 0..100 {
             accounts.insert(B256::with_last_byte(i), Some(Account::default()));
         }
-        let deferred = DeferredTrieData::pending(
+        let (deferred, task) = DeferredTrieData::pending(
             Arc::new(HashedPostState { accounts, storages: Default::default() }),
             Arc::new(TrieUpdates::default()),
         );
 
+        let _ = task.compute_and_publish();
         let _ = deferred.wait_cloned();
         let start = Instant::now();
         let _ = deferred.wait_cloned();

--- a/crates/chain-state/src/deferred_trie.rs
+++ b/crates/chain-state/src/deferred_trie.rs
@@ -20,7 +20,8 @@ pub struct DeferredTrieData {
     value: Arc<OnceLock<ComputedTrieData>>,
 }
 
-/// Producer consumed by a spawned task to compute sorted trie data for a [`DeferredTrieData`] handle.
+/// Producer consumed by a spawned task to compute sorted trie data for a [`DeferredTrieData`]
+/// handle.
 #[must_use = "DeferredTrieDataProducer must be consumed with compute_and_publish to wake trie data waiters"]
 pub struct DeferredTrieDataProducer {
     /// Shared result initialized exactly once by this producer.
@@ -98,7 +99,10 @@ impl DeferredTrieData {
         let value = Arc::new(OnceLock::new());
         (
             Self { value: Arc::clone(&value) },
-            DeferredTrieDataProducer { value, inputs: PendingInputs { hashed_state, trie_updates } },
+            DeferredTrieDataProducer {
+                value,
+                inputs: PendingInputs { hashed_state, trie_updates },
+            },
         )
     }
 

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -804,11 +804,11 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     /// after the block was validated.
     ///
     /// The [`DeferredTrieData`] handle allows expensive trie operations (sorting hashed state and
-    /// trie updates) to be performed outside the critical validation path. This can improve latency
-    /// for time-sensitive operations like block validation.
+    /// trie updates) to be performed outside the critical validation path by a background task.
+    /// This can improve latency for time-sensitive operations like block validation.
     ///
-    /// If the data hasn't been populated when [`Self::trie_data()`] is called, computation
-    /// occurs synchronously from stored inputs, so there is no blocking or deadlock risk.
+    /// If the data hasn't been populated when [`Self::trie_data()`] is called, the caller waits
+    /// for the background task to publish it.
     ///
     /// Use [`Self::new()`] instead when trie data is already computed and available immediately.
     pub const fn with_deferred_trie_data(
@@ -837,11 +837,11 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         &self.execution_output
     }
 
-    /// Returns the trie data, computing it synchronously if not already cached.
+    /// Returns the trie data, waiting for the background task if not already cached.
     ///
     /// Uses `OnceLock::get_or_init` internally:
     /// - If already computed: returns cached result immediately
-    /// - If not computed: first caller computes, others wait for that result
+    /// - If not computed: first caller waits for the publishing task, others wait for that result
     #[inline]
     #[tracing::instrument(level = "debug", target = "engine::tree", name = "trie_data", skip_all)]
     pub fn trie_data(&self) -> ComputedTrieData {
@@ -851,8 +851,7 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     /// Returns a clone of the deferred trie data handle.
     ///
     /// A handle is a lightweight reference that can be passed to descendants without
-    /// forcing trie data to be computed immediately. The actual work runs when
-    /// `wait_cloned()` is called by a consumer (e.g. when merging overlays).
+    /// forcing trie data to be observed immediately. The actual work runs in the background task.
     #[inline]
     pub fn trie_data_handle(&self) -> DeferredTrieData {
         self.trie_data.clone()
@@ -860,7 +859,7 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
 
     /// Returns the hashed state result of the execution outcome.
     ///
-    /// May compute trie data synchronously if the deferred task hasn't completed.
+    /// May wait for trie data if the deferred task hasn't completed.
     #[inline]
     pub fn hashed_state(&self) -> Arc<HashedPostStateSorted> {
         self.trie_data().hashed_state
@@ -868,7 +867,7 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
 
     /// Returns the trie updates resulting from the execution outcome.
     ///
-    /// May compute trie data synchronously if the deferred task hasn't completed.
+    /// May wait for trie data if the deferred task hasn't completed.
     #[inline]
     pub fn trie_updates(&self) -> Arc<TrieUpdatesSorted> {
         self.trie_data().trie_updates

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -954,10 +954,11 @@ where
         })
     }
 
-    /// Spawns a background task that creates the changeset provider used by the deferred trie task.
+    /// Spawns a background task that creates the changeset provider used by the deferred trie
+    /// producer.
     ///
     /// This is started before execution so overlay construction can run concurrently with payload
-    /// validation, then awaited before the deferred trie task is spawned.
+    /// validation, then awaited before the deferred trie producer is spawned.
     fn spawn_changeset_provider_task(
         &self,
         overlay_factory: OverlayStateProviderFactory<P, N>,
@@ -1879,7 +1880,7 @@ where
                             target: "engine::tree::changeset",
                             ?block_number,
                             ?e,
-                            "Failed to compute changesets in deferred trie task"
+                            "Failed to compute changesets for deferred trie producer"
                         );
                     }
                 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1793,17 +1793,16 @@ where
 
     /// Spawns a background task to compute and sort trie data for the executed block.
     ///
-    /// This function creates a [`DeferredTrieData`] handle with fallback inputs and spawns a
-    /// blocking task that calls `wait_cloned()` to:
+    /// This function creates a [`DeferredTrieData`] handle and spawns a blocking task that:
     /// 1. Sort the block's hashed state and trie updates
-    /// 2. Cache the result so subsequent calls return immediately
+    /// 2. Publishes the result so subsequent calls return immediately
     ///
-    /// If the background task hasn't completed when `trie_data()` is called, `wait_cloned()`
-    /// computes from the stored inputs, eliminating deadlock risk and duplicate computation.
+    /// If the background task hasn't completed when `trie_data()` is called, callers wait for the
+    /// publishing task instead of computing synchronously.
     ///
     /// The validation hot path can return immediately after state root verification,
-    /// while consumers (DB writes, overlay providers, proofs) get trie data either
-    /// from the completed task or via fallback computation.
+    /// while consumers (DB writes, overlay providers, proofs) get trie data from the completed
+    /// task.
     fn spawn_deferred_trie_task(
         &self,
         block: Arc<RecoveredBlock<N::Block>>,
@@ -1812,15 +1811,15 @@ where
         trie_output: Arc<TrieUpdates>,
         changeset_provider: impl TrieCursorFactory + Send + 'static,
     ) -> ExecutedBlock<N> {
-        // Create deferred handle with fallback inputs in case the background task hasn't completed.
+        // Create deferred handle and task that owns the unsorted inputs.
         // Resolve the lazy handle into Arc<HashedPostState>. By this point the hashed state has
         // already been computed and used for state root verification, so .get() returns instantly.
         let hashed_state = match hashed_state.try_into_inner() {
             Ok(state) => state,
             Err(handle) => handle.get().clone(),
         };
-        let deferred_trie_data = DeferredTrieData::pending(hashed_state, trie_output);
-        let deferred_handle_task = deferred_trie_data.clone();
+        let (deferred_trie_data, deferred_trie_task) =
+            DeferredTrieData::pending(hashed_state, trie_output);
         let block_validation_metrics = self.metrics.block_validation.clone();
 
         // Capture block info and cache handle for changeset computation
@@ -1832,8 +1831,8 @@ where
         // The guard ensures the pending entry is cancelled if the task panics.
         let pending_changeset_guard = self.changeset_cache.register_pending(block_hash);
 
-        // Spawn background task to compute trie data. Calling `wait_cloned` will compute from
-        // the stored inputs and cache the result, so subsequent calls return immediately.
+        // Spawn background task to compute trie data. The task publishes the sorted result before
+        // computing changesets, so trie data waiters do not block on changeset computation.
         let compute_trie_input_task = move || {
             let _span = debug_span!(
                 target: "engine::tree::payload_validator",
@@ -1844,7 +1843,7 @@ where
 
             let result = panic::catch_unwind(AssertUnwindSafe(|| {
                 let compute_start = Instant::now();
-                let computed = deferred_handle_task.wait_cloned();
+                let computed = deferred_trie_task.compute_and_publish();
                 block_validation_metrics
                     .deferred_trie_compute_duration
                     .record(compute_start.elapsed().as_secs_f64());
@@ -1889,7 +1888,7 @@ where
             if result.is_err() {
                 error!(
                     target: "engine::tree::payload_validator",
-                    "Deferred trie task panicked; fallback computation will be used when trie data is accessed"
+                    "Deferred trie task panicked"
                 );
             }
         };


### PR DESCRIPTION
Companion to #24875.

Refactors `DeferredTrieData` so pending handles are paired with a `DeferredTrieTask` that owns the unsorted inputs and publishes sorted trie data over a OnceLock. Consumers now wait for the task result instead of sorting synchronously from overlay and persistence paths.

The payload-validator task publishes trie data before computing changesets, so trie-data waiters are not blocked on changeset work.