### PR TITLE
ci: summarize hive failure logs

### DIFF
--- a/.github/scripts/hive/print_client_logs.sh
+++ b/.github/scripts/hive/print_client_logs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shopt -s nullglob
+
+truncate_lines() {
+    cut -c 1-2000
+}
+
+for log in hivetests/workspace/logs/reth/client-*.log; do
+    lines="$(wc -l < "$log")"
+    bytes="$(wc -c < "$log")"
+
+    echo "::group::$log"
+    echo "lines=${lines} bytes=${bytes}"
+
+    echo "first 200 lines:"
+    sed -n '1,200p' "$log" | truncate_lines
+
+    echo "error context:"
+    rg -n -i -C 20 \
+        'panic|fatal|error|warn|oom|out of memory|killed|no route to host|connection refused|cannot allocate' \
+        "$log" | head -n 2000 | truncate_lines || true
+
+    echo "last 300 lines:"
+    tail -n 300 "$log" | truncate_lines
+
+    echo "::endgroup::"
+done

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -270,8 +270,7 @@ jobs:
 
       - name: Print reth client logs
         if: ${{ failure() }}
-        run: |
-          cat hivetests/workspace/logs/reth/client-*.log
+        run: .github/scripts/hive/print_client_logs.sh
 
   test-osaka:
     timeout-minutes: 120
@@ -450,8 +449,7 @@ jobs:
 
       - name: Print reth client logs
         if: ${{ failure() }}
-        run: |
-          cat hivetests/workspace/logs/reth/client-*.log
+        run: .github/scripts/hive/print_client_logs.sh
   notify-on-error:
     needs:
       - test-amsterdam


### PR DESCRIPTION
The requested failing job was `Hive-Osaka / ethereum/eels/consume-rlp - .*tests/cancun.*`. Its timeline shows `Parse hive output` failed quickly with normal unexpected Hive failures, then `Print reth client logs` started and never completed while emitting a very large client log. The downloaded partial job log is already 271 MB.

This replaces the unbounded `cat hivetests/workspace/logs/reth/client-*.log` failure handler with a bounded, more informative summary for each client log:
- line and byte counts
- first 200 lines, to capture startup/config context
- up to 2000 lines of context around common failure patterns
- last 300 lines, to capture terminal state

Validation:
- checked the exact job metadata and logs for job `80006334599`
- synthetic client log smoke test for the helper script
- `git diff --check origin/main`

Prompted by: @DaniPopes