### PR TITLE
perf(parbal): BAL prewarming pool

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -1,0 +1,159 @@
+use alloy_primitives::{Address, StorageKey};
+use reth_execution_cache::{CachedStateProvider, ExecutionCache};
+use reth_provider::{
+    AccountReader, BytecodeReader, ProviderResult, StateProvider, StateProviderBox,
+};
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    thread::JoinHandle,
+};
+use tracing::trace;
+
+/// Builds a fresh `StateProviderBox` over the block's parent state. Type-erased so the pool is not
+/// generic over the provider factory; each worker builds its own per block.
+type BuildProviderFn = dyn Fn() -> ProviderResult<StateProviderBox> + Send + Sync;
+
+/// A single warm request: a whole account (basic account + its bytecode) or one storage slot.
+enum PrewarmTarget {
+    Account(Address),
+    Storage(Address, StorageKey),
+}
+
+/// A message in a worker's queue. The per-block lifecycle is explicit and ordered (the queue is
+/// FIFO): one `BeginBlock`, then the worker's share of `Warm`s, then one `EndBlock`.
+enum PrewarmMsg {
+    /// Open a read txn for the new block: build a provider over the parent state and hold it.
+    BeginBlock { build: Arc<BuildProviderFn>, caches: ExecutionCache },
+    /// Warm one target into the held provider's cache. Ignored if no provider is held.
+    Warm(PrewarmTarget),
+    /// Drop the held provider (and its read txn).
+    EndBlock,
+}
+
+/// Long-lived pool of blocking threads that warm the BAL read-set into the shared execution cache.
+#[derive(Debug)]
+pub(crate) struct BalPrewarmPool {
+    /// One queue per worker. `BeginBlock`/`EndBlock` are broadcast to all; `Warm`s round-robin.
+    workers: Vec<crossbeam_channel::Sender<PrewarmMsg>>,
+    /// Round-robin cursor for distributing warm requests across workers.
+    next: AtomicUsize,
+    _handles: Vec<JoinHandle<()>>,
+}
+
+impl BalPrewarmPool {
+    /// Spawns `num_threads` long-lived blocking worker threads. Owned by the
+    /// [`PayloadProcessor`](super::PayloadProcessor); the threads exit when the pool is dropped.
+    pub(crate) fn new(num_threads: usize) -> Arc<Self> {
+        let mut workers = Vec::with_capacity(num_threads);
+        let mut handles = Vec::with_capacity(num_threads);
+        for i in 0..num_threads {
+            let (tx, rx) = crossbeam_channel::unbounded::<PrewarmMsg>();
+            workers.push(tx);
+            handles.push(
+                std::thread::Builder::new()
+                    .name(format!("bal-prewarm-{i}"))
+                    .spawn(move || prewarm_loop(rx))
+                    .expect("spawn bal-prewarm thread"),
+            );
+        }
+        trace!(target: "engine::tree::bal_prewarm_pool", num_threads, "BalPrewarmPool spawned");
+        Arc::new(Self { workers, next: AtomicUsize::new(0), _handles: handles })
+    }
+
+    /// Begins a block: hands every worker the provider builder and shared cache so each opens its
+    /// own read txn over the parent state. Pair with [`end_block`](Self::end_block).
+    pub(crate) fn begin_block(&self, build: Arc<BuildProviderFn>, caches: ExecutionCache) {
+        for worker in &self.workers {
+            let _ = worker
+                .send(PrewarmMsg::BeginBlock { build: build.clone(), caches: caches.clone() });
+        }
+    }
+
+    /// Fire-and-forget: warm an account (basic account + bytecode) on some worker.
+    pub(crate) fn warm_account(&self, addr: Address) {
+        self.send_warm(PrewarmTarget::Account(addr));
+    }
+
+    /// Fire-and-forget: warm one storage slot on some worker.
+    pub(crate) fn warm_storage(&self, addr: Address, slot: StorageKey) {
+        self.send_warm(PrewarmTarget::Storage(addr, slot));
+    }
+
+    /// Ends the block: every worker drops its provider (and read txn) once it has drained the warm
+    /// requests queued ahead of this message.
+    pub(crate) fn end_block(&self) {
+        for worker in &self.workers {
+            let _ = worker.send(PrewarmMsg::EndBlock);
+        }
+    }
+
+    fn send_warm(&self, target: PrewarmTarget) {
+        let i = self.next.fetch_add(1, Ordering::Relaxed) % self.workers.len();
+        let _ = self.workers[i].send(PrewarmMsg::Warm(target));
+    }
+}
+
+/// Number of warming threads.
+///
+/// The work performed on those threads boils down mostly to MDBX reads. An MDBX read consists of
+/// a tree traversal and major page faults causing I/O.
+///
+/// In order to utilize the parallelism of `NVMe` we have to give it enough work, or equally,
+/// maintain a high queue depth. Modern `NVMe` devices require in between 64-128 requests in-flight
+/// to achieve its peak performance. Ideally we don't grow past that but it's OK to do so, it just
+/// means that a request is going to wait in the `NVMe` queue rather than in memory.
+///
+/// MDBX piggy-backs on the OS page cache for its buffers. Oftentimes, the hit rate reaches 90-99%
+/// hit rate. At that point, the workload can be classified as CPU-bound. In that case, having
+/// a high number of threads is counterproductive due to the effects of context switching, core
+/// migration, contention, etc.
+///
+/// However, that overhead is considered negligible compared to the benefits of fully utilizing
+/// `NVMe` resources. For example, with request latency of 100µs, 100k IO requests the expected
+/// time to finish is 312.5ms at QD=32 and 156.26ms at QD=64.
+///
+/// This should explain why this particular value is picked.
+pub(crate) const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
+
+fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
+    // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
+    // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
+    let mut provider: Option<CachedStateProvider<StateProviderBox>> = None;
+
+    // Blocks when idle; the channel disconnects (and the loop ends) when the pool is dropped.
+    while let Ok(msg) = rx.recv() {
+        match msg {
+            PrewarmMsg::BeginBlock { build, caches } => {
+                provider = match (build)() {
+                    Ok(inner) => Some(CachedStateProvider::new_prewarm(inner, caches)),
+                    Err(err) => {
+                        trace!(target: "engine::tree::bal_prewarm_pool", %err, "failed to build provider");
+                        None
+                    }
+                };
+            }
+            PrewarmMsg::Warm(target) => {
+                let Some(provider) = provider.as_ref() else { continue };
+                match target {
+                    PrewarmTarget::Account(addr) => {
+                        if let Ok(Some(account)) = provider.basic_account(&addr) &&
+                            let Some(code_hash) = account.bytecode_hash &&
+                            code_hash != alloy_consensus::constants::KECCAK_EMPTY
+                        {
+                            let _ = provider.bytecode_by_hash(&code_hash);
+                        }
+                    }
+                    PrewarmTarget::Storage(addr, slot) => {
+                        let _ = provider.storage(addr, slot);
+                    }
+                }
+            }
+            PrewarmMsg::EndBlock => {
+                provider = None;
+            }
+        }
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -54,7 +54,7 @@ impl BalPrewarmPool {
             workers.push(tx);
             handles.push(
                 std::thread::Builder::new()
-                    .name(format!("bal-prewarm-{i}"))
+                    .name(format!("bal-prewarm-{i:03}"))
                     .spawn(move || prewarm_loop(rx))
                     .expect("spawn bal-prewarm thread"),
             );

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -42,12 +42,13 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicUsize},
         mpsc::{self, channel},
-        Arc,
+        Arc, OnceLock,
     },
 };
 use tracing::{debug, debug_span, instrument, trace, warn, Span};
 
 pub mod bal;
+pub(crate) mod bal_prewarm_pool;
 pub mod multiproof;
 mod preserved_sparse_trie;
 pub mod prewarm;
@@ -153,6 +154,9 @@ where
     disable_bal_parallel_state_root: bool,
     /// Whether BAL state prefetching during prewarm is disabled.
     disable_bal_batch_io: bool,
+    /// Dedicated blocking pool for warming the BAL read-set, created lazily on the first BAL block
+    /// (see [`Self::bal_prewarm_pool`]). Its threads exit when the processor is dropped.
+    bal_prewarm_pool: OnceLock<Arc<bal_prewarm_pool::BalPrewarmPool>>,
 }
 
 impl<N, Evm> PayloadProcessor<Evm>
@@ -192,7 +196,18 @@ where
                 .then(CachedStateCacheMetrics::default),
             disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
             disable_bal_batch_io: config.disable_bal_batch_io(),
+            bal_prewarm_pool: OnceLock::new(),
         }
+    }
+
+    /// Returns the dedicated BAL read-set prewarm pool, spawning its blocking worker threads on
+    /// first use (only the BAL parallel execution path calls this).
+    fn bal_prewarm_pool(&self) -> Arc<bal_prewarm_pool::BalPrewarmPool> {
+        self.bal_prewarm_pool
+            .get_or_init(|| {
+                bal_prewarm_pool::BalPrewarmPool::new(bal_prewarm_pool::DEFAULT_BAL_PREWARM_THREADS)
+            })
+            .clone()
     }
 }
 
@@ -528,6 +543,7 @@ where
             evm_config: self.evm_config.clone(),
             saved_cache: saved_cache.clone(),
             provider: provider_builder,
+            bal_prewarm_pool: parallel_bal_execution.then(|| self.bal_prewarm_pool()),
             metrics: PrewarmMetrics::default(),
             cache_metrics: self.cache_metrics.clone(),
             cache_state_metrics: self.cache_state_metrics.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -20,7 +20,7 @@ use crate::tree::{
 use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::eip4895::Withdrawal;
-use alloy_primitives::{keccak256, StorageKey, B256};
+use alloy_primitives::{keccak256, B256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
@@ -28,8 +28,7 @@ use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx,
 use reth_metrics::Metrics;
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
-    AccountReader, BlockExecutionOutput, BlockReader, StateProvider, StateProviderBox,
-    StateProviderFactory, StateReader,
+    AccountReader, BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader,
 };
 use reth_revm::{database::StateProviderDatabase, state::EvmState};
 use reth_tasks::{pool::WorkerPool, Runtime};
@@ -41,6 +40,8 @@ use std::sync::{
 };
 use tokio::sync::oneshot;
 use tracing::{debug, debug_span, instrument, trace, trace_span, warn, Span};
+
+use super::bal_prewarm_pool::BalPrewarmPool;
 
 /// Determines the prewarming mode: transaction-based, BAL-based, or skipped.
 #[derive(Debug)]
@@ -355,7 +356,6 @@ where
         let to_sparse_trie_task = self.to_sparse_trie_task.clone();
         let executor = self.executor.clone();
         let parent_span = Span::current();
-        let prefetch_parent_span = parent_span.clone();
         let stream_parent_span = parent_span;
         let prefetch_bal = Arc::clone(&decoded_bal);
         let stream_bal = Arc::clone(&decoded_bal);
@@ -394,30 +394,38 @@ where
             let _ = stream_tx.send(());
         }
 
-        if ctx.saved_cache.is_some() && !ctx.disable_bal_batch_io {
-            executor.prewarming_pool().spawn(move || {
-                let branch_span = debug_span!(
-                    target: "engine::tree::payload_processor::prewarm",
-                    parent: &prefetch_parent_span,
-                    "bal_prefetch_storage",
-                    bal_accounts = prefetch_bal.as_bal().len(),
-                );
-                let parent_span = branch_span.clone();
-                let _span = branch_span.entered();
+        if let Some(saved_cache) = ctx.saved_cache &&
+            !ctx.disable_bal_batch_io &&
+            let Some(pool) = ctx.bal_prewarm_pool.as_ref()
+        {
+            // If
+            //
+            // - BAL path is enabled (and so bal_prewarm_pool is present),
+            // - dispatch_bal_batch_io is false
+            // - execution cache is not disabled
+            //
+            // we launch prewarming sequence of the BAL read set here. The BAL read-set consists
+            // of the accounts, their code if present, and declared storages (both storage_reads
+            // and storage_changes).
+            //
+            // This runs side-by-side with the parallel transaction execution reducing the time it
+            // spends blocking on the data.
+            let caches = saved_cache.cache().clone();
+            let provider_builder = ctx.provider.clone();
+            let build = Arc::new(move || provider_builder.build());
 
-                prefetch_bal.as_bal().par_iter().for_each(|account| {
-                    if ctx.should_stop() {
-                        return;
-                    }
-                    WorkerPool::with_worker_mut(|worker| {
-                        let provider = worker
-                            .get_or_init::<Option<CachedStateProvider<StateProviderBox>>>(|| None);
-                        ctx.prefetch_bal_storage(&parent_span, provider, account);
-                    });
-                });
-
-                let _ = prefetch_tx.send(());
-            });
+            pool.begin_block(build, caches);
+            for account in prefetch_bal.as_bal() {
+                pool.warm_account(account.address);
+                for change in &account.storage_changes {
+                    pool.warm_storage(account.address, change.slot.into());
+                }
+                for &slot in &account.storage_reads {
+                    pool.warm_storage(account.address, slot.into());
+                }
+            }
+            pool.end_block();
+            let _ = prefetch_tx.send(());
         } else {
             let _ = prefetch_tx.send(());
         }
@@ -523,6 +531,9 @@ where
     pub saved_cache: Option<SavedCache>,
     /// Provider to obtain the state
     pub provider: StateProviderBuilder<N, P>,
+    /// Dedicated blocking pool for warming the BAL read-set. `Some` only on the BAL parallel
+    /// execution path; the pool is owned by the [`PayloadProcessor`](super::PayloadProcessor).
+    pub(crate) bal_prewarm_pool: Option<Arc<BalPrewarmPool>>,
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
     /// Metrics for the execution cache.
@@ -733,66 +744,6 @@ where
         hashed_state.accounts.insert(hashed_address, Some(account));
 
         let _ = to_sparse_trie_task.send(StateRootMessage::HashedStateUpdate(hashed_state));
-    }
-
-    /// Prefetches storage slots for a single BAL account into the cache.
-    ///
-    /// Account reads are handled separately by [`Self::send_bal_hashed_state`], so this method
-    /// only
-    /// warms storage.
-    ///
-    /// The `provider` is lazily initialized on first call and reused across accounts on the same
-    /// thread.
-    fn prefetch_bal_storage(
-        &self,
-        parent_span: &Span,
-        provider: &mut Option<CachedStateProvider<reth_provider::StateProviderBox>>,
-        account: &alloy_eip7928::AccountChanges,
-    ) {
-        if self.disable_bal_batch_io ||
-            (account.storage_changes.is_empty() && account.storage_reads.is_empty())
-        {
-            return;
-        }
-
-        let state_provider = match provider {
-            Some(p) => p,
-            slot @ None => {
-                let _span = debug_span!(
-                    target: "engine::tree::payload_processor::prewarm",
-                    parent: parent_span,
-                    "bal_prefetch_provider_init",
-                )
-                .entered();
-
-                let built = match self.provider.build() {
-                    Ok(p) => p,
-                    Err(err) => {
-                        trace!(
-                            target: "engine::tree::payload_processor::prewarm",
-                            %err,
-                            "Failed to build state provider in BAL prewarm thread"
-                        );
-                        return;
-                    }
-                };
-                let saved_cache =
-                    self.saved_cache.as_ref().expect("BAL prewarm should only run with cache");
-                let caches = saved_cache.cache().clone();
-                slot.insert(CachedStateProvider::new_prewarm(built, caches))
-            }
-        };
-
-        let start = Instant::now();
-
-        for slot in &account.storage_changes {
-            let _ = state_provider.storage(account.address, StorageKey::from(slot.slot));
-        }
-        for &slot in &account.storage_reads {
-            let _ = state_provider.storage(account.address, StorageKey::from(slot));
-        }
-
-        self.metrics.bal_slot_iteration_duration.record(start.elapsed().as_secs_f64());
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -40,7 +40,6 @@ use std::sync::{
 };
 use tokio::sync::oneshot;
 use tracing::{debug, debug_span, instrument, trace, trace_span, warn, Span};
-
 use super::bal_prewarm_pool::BalPrewarmPool;
 
 /// Determines the prewarming mode: transaction-based, BAL-based, or skipped.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -11,6 +11,7 @@
 //! 2. Prewarming tasks execute transactions in parallel using shared caches
 //! 3. When actual block execution happens, it benefits from the warmed cache
 
+use super::bal_prewarm_pool::BalPrewarmPool;
 use crate::tree::{
     payload_processor::multiproof::StateRootMessage,
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
@@ -40,7 +41,6 @@ use std::sync::{
 };
 use tokio::sync::oneshot;
 use tracing::{debug, debug_span, instrument, trace, trace_span, warn, Span};
-use super::bal_prewarm_pool::BalPrewarmPool;
 
 /// Determines the prewarming mode: transaction-based, BAL-based, or skipped.
 #[derive(Debug)]


### PR DESCRIPTION
Async revm line of experiments coincidentally revealed the issue with having BAL prewarming on rayon thread. It manifested as increased CPU usage esp. in sched_yield dicated by the work-stealing mechanisms in rayon.

Apart from that, this change affects:

- a) coverage: pre-request the bytecode optimistically 
- b) granularity: instead of requesting an account and then
   its storage items we request everything in parallel. This
   reduces the problem of having one really long account
   blocking prewarming for too long.

All those changes independently affect performance in different ways. However, there is no performance improvement to be seen as of yet because we are bottlenecked on await_storage_root. The experiments disabling storage roots show 30% improvement in GGas/s throughput.