### PR TITLE
fix: remove precompile cache initial capacity

### DIFF
--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -52,7 +52,6 @@ where
     fn default() -> Self {
         Self(
             moka::sync::CacheBuilder::new(MAX_CACHE_SIZE as u64)
-                .initial_capacity(MAX_CACHE_SIZE as usize)
                 .eviction_policy(EvictionPolicy::lru())
                 .weigher(|key: &Bytes, value: &CacheEntry<S>| {
                     (key.len() + value.output.bytes.len()) as u32


### PR DESCRIPTION
Closes #24997.

Removes the `initial_capacity` hint from the precompile cache builder. The cache already uses a weighted max capacity, while `initial_capacity` preallocates entry slots rather than bytes.

Validation:
- `cargo test -p reth-engine-tree precompile_cache`
- `cargo fmt --check` attempted, but this sandbox only has stable Rust and the repository rustfmt config requires nightly-only options; it reported unrelated workspace formatting diffs.

Prompted by: @mattsse