### PR TITLE
fix(cli): target `reth download --force` cleanup

### DIFF
--- a/bin/reth/tests/it/main.rs
+++ b/bin/reth/tests/it/main.rs
@@ -186,19 +186,26 @@ fn download_help() {
 }
 
 #[test]
-fn download_force_overwrites_snapshot_data_but_preserves_identity_files() {
+fn download_force_removes_only_snapshot_paths() {
     let tempdir = tempfile::tempdir().expect("failed to create temp dir");
     let datadir = tempdir.path().join("datadir");
     let archive_path = tempdir.path().join("snapshot.tar.zst");
 
     fs::create_dir_all(datadir.join("db")).expect("failed to create old db dir");
+    fs::create_dir_all(datadir.join("rocksdb")).expect("failed to create old rocksdb dir");
     fs::create_dir_all(datadir.join("static_files")).expect("failed to create old static dir");
+    fs::create_dir_all(datadir.join("custom-dir")).expect("failed to create custom dir");
     fs::write(datadir.join("db/old.mdbx"), b"old db").expect("failed to write old db file");
+    fs::write(datadir.join("rocksdb/old"), b"old rocksdb").expect("failed to write old rocksdb");
     fs::write(datadir.join("static_files/old"), b"old static")
         .expect("failed to write old static file");
+    fs::write(datadir.join("reth.toml"), b"old config").expect("failed to write old config");
     fs::write(datadir.join("discovery-secret"), b"secret").expect("failed to write secret");
     fs::write(datadir.join("known-peers.json"), br#"["peer"]"#)
         .expect("failed to write known peers");
+    fs::write(datadir.join("custom-file"), b"custom").expect("failed to write custom file");
+    fs::write(datadir.join("custom-dir/file"), b"custom dir")
+        .expect("failed to write custom dir file");
     create_tar_zst_snapshot(&archive_path);
 
     let datadir_arg = datadir.to_str().expect("datadir should be utf8");
@@ -210,7 +217,9 @@ fn download_force_overwrites_snapshot_data_but_preserves_identity_files() {
         b"new snapshot data"
     );
     assert!(!datadir.join("db/old.mdbx").exists(), "old db file should be removed");
+    assert!(!datadir.join("rocksdb/old").exists(), "old rocksdb file should be removed");
     assert!(!datadir.join("static_files/old").exists(), "old static file should be removed");
+    assert!(!datadir.join("reth.toml").exists(), "old config file should be removed");
     assert_eq!(
         fs::read(datadir.join("discovery-secret")).expect("missing preserved discovery secret"),
         b"secret"
@@ -218,6 +227,11 @@ fn download_force_overwrites_snapshot_data_but_preserves_identity_files() {
     assert_eq!(
         fs::read(datadir.join("known-peers.json")).expect("missing preserved known peers"),
         br#"["peer"]"#
+    );
+    assert_eq!(fs::read(datadir.join("custom-file")).expect("missing custom file"), b"custom");
+    assert_eq!(
+        fs::read(datadir.join("custom-dir/file")).expect("missing custom dir file"),
+        b"custom dir"
     );
 }
 

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -114,7 +114,6 @@ use source::{
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    ffi::OsStr,
     path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
@@ -125,7 +124,7 @@ const RETH_SNAPSHOTS_BASE_URL: &str = "https://snapshots-r2.reth.rs";
 const RETH_SNAPSHOTS_API_URL: &str = "https://snapshots.reth.rs/api/snapshots";
 const RETH_SNAPSHOTS_SOURCE: &str = "https://snapshots.reth.rs (default)";
 const SNAPSHOT_API_PATH: &str = "/api/snapshots";
-const FORCE_PRESERVED_DATADIR_FILES: &[&str] = &["discovery-secret", "known-peers.json"];
+const FORCE_REMOVED_DATADIR_PATHS: &[&str] = &["db", "rocksdb", "static_files", "reth.toml"];
 
 /// Maximum number of simultaneous HTTP downloads across the entire snapshot job.
 const MAX_CONCURRENT_DOWNLOADS: usize = 8;
@@ -421,7 +420,7 @@ pub struct DownloadCommand<C: ChainSpecParser> {
     #[arg(long, short = 'y')]
     non_interactive: bool,
 
-    /// Overwrite existing snapshot data while preserving discovery-secret and known-peers.json.
+    /// Overwrite existing snapshot data by removing db, rocksdb, static_files, and reth.toml.
     #[arg(long, conflicts_with = "list")]
     force: bool,
 
@@ -863,26 +862,23 @@ fn selection_from_prune_mode(mode: Option<PruneMode>, snapshot_block: u64) -> Co
     }
 }
 
-/// Removes existing snapshot data while preserving files listed in
-/// [`FORCE_PRESERVED_DATADIR_FILES`].
+/// Removes existing snapshot data that is managed by `reth download`.
 fn clear_existing_datadir(target_dir: &Path) -> Result<()> {
     if !target_dir.try_exists()? {
         return Ok(());
     }
 
-    info!(target: "reth::cli", dir = ?target_dir, "Clearing existing data directory");
-    for entry in fs::read_dir(target_dir)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        if FORCE_PRESERVED_DATADIR_FILES.iter().any(|preserved| file_name == OsStr::new(preserved))
-        {
+    info!(target: "reth::cli", dir = ?target_dir, "Clearing existing snapshot data");
+    for entry in FORCE_REMOVED_DATADIR_PATHS {
+        let path = target_dir.join(entry);
+        if !path.try_exists()? {
             continue;
         }
 
-        let path = entry.path();
-        if entry.file_type()?.is_dir() {
+        let metadata = fs::metadata(&path)?;
+        if metadata.is_dir() {
             fs::remove_dir_all(&path)?;
-        } else {
+        } else if metadata.is_file() {
             fs::remove_file(&path)?;
         }
     }

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -206,7 +206,7 @@ Storage:
           Skip interactive component selection. Downloads the minimal set (state + headers + transactions + changesets) unless explicit --with-* flags narrow it
 
       --force
-          Overwrite existing snapshot data while preserving discovery-secret and known-peers.json
+          Overwrite existing snapshot data by removing db, rocksdb, static_files, and reth.toml
 
       --resumable [<RESUMABLE>]
           Enable resumable two-phase downloads (download to disk first, then extract).


### PR DESCRIPTION
Restricts `reth download --force` cleanup to `db`, `rocksdb`, `static_files`, and `reth.toml` in the target datadir. Unrelated datadir files and directories are preserved while snapshot-managed state is cleared before extraction.