### PR TITLE
chore(deps): bump revm-inspectors to 0.40.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10751,9 +10751,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
+checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -439,7 +439,7 @@ revm-state = { version = "12.0.0", default-features = false }
 revm-primitives = { version = "24.0.0", default-features = false }
 revm-interpreter = { version = "37.0.0", default-features = false }
 revm-database-interface = { version = "12.0.0", default-features = false }
-revm-inspectors = "0.40.0"
+revm-inspectors = "0.40.1"
 
 # eth
 alloy-dyn-abi = "1.6.0"


### PR DESCRIPTION
## Summary
- Bumps the workspace `revm-inspectors` dependency to `0.40.1`.
- Refreshes `Cargo.lock` for the new crate checksum.

## Impact
- Pulls in the latest `revm-inspectors` patch release for RPC/debug tracing consumers.