### PR TITLE
feat(revm): add CachedReads account capacity constructor

### DIFF
--- a/crates/revm/src/cached.rs
+++ b/crates/revm/src/cached.rs
@@ -41,6 +41,14 @@ pub struct CachedReads {
 // === impl CachedReads ===
 
 impl CachedReads {
+    /// Creates a new [`CachedReads`] with capacity for account entries.
+    pub fn with_account_capacity(capacity: usize) -> Self {
+        Self {
+            accounts: AddressMap::with_capacity_and_hasher(capacity, Default::default()),
+            ..Default::default()
+        }
+    }
+
     /// Gets a [`DatabaseRef`] that will cache reads from the given database.
     pub const fn as_db<DB>(&mut self, db: DB) -> CachedReadsDBRef<'_, DB> {
         self.as_db_mut(db).into_db()


### PR DESCRIPTION
Adds `CachedReads::with_account_capacity` so callers can preallocate the account cache when they know the expected number of accounts. Contracts and block hashes remain at their default capacity.
