### PR TITLE
fix(static-file): respect prune checkpoints in consistency check

### DIFF
--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -67,10 +67,10 @@ mod tests {
         providers::{StaticFileProvider, StaticFileWriter},
         test_utils::MockNodeTypesWithDB,
         AccountExtReader, BlockBodyIndicesProvider, BlockWriter, DatabaseProviderFactory,
-        ProviderFactory, ProviderResult, ReceiptProvider, StageCheckpointWriter,
-        StaticFileProviderFactory, StorageReader,
+        ProviderFactory, ProviderResult, PruneCheckpointWriter, ReceiptProvider,
+        StageCheckpointWriter, StaticFileProviderFactory, StorageReader,
     };
-    use reth_prune_types::{PruneMode, PruneModes};
+    use reth_prune_types::{PruneCheckpoint, PruneMode, PruneModes, PruneSegment};
     use reth_stages_api::{
         ExecInput, ExecutionStageThresholds, PipelineTarget, Stage, StageCheckpoint, StageId,
     };
@@ -533,5 +533,131 @@ mod tests {
 
         // Fill the gap, and ensure no unwind is necessary.
         update_db_and_check::<tables::Receipts>(&db, current + 1, None);
+    }
+
+    #[test]
+    fn test_consistency_senders_distance_prune_checkpoint() {
+        use reth_db_api::models::StorageSettings;
+        use reth_storage_api::StorageSettingsCache;
+
+        let db = seed_data(90).unwrap();
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+        let static_file_provider = db.factory.static_file_provider();
+
+        // No senders (or changesets) static files exist while the stage checkpoints are at
+        // the tip, like a node restarted after a distance-pruned snapshot import. Without
+        // prune checkpoints this is indistinguishable from data loss, so an unwind to 0 is
+        // requested.
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(Some(PipelineTarget::Unwind(0)))
+        ));
+
+        // With `Distance` prune checkpoints at the tip the missing data is intentional and
+        // no unwind should be requested.
+        // See <https://github.com/paradigmxyz/reth/issues/23463>
+        let provider_rw = db.factory.provider_rw().unwrap();
+        for segment in [
+            PruneSegment::SenderRecovery,
+            PruneSegment::AccountHistory,
+            PruneSegment::StorageHistory,
+        ] {
+            provider_rw
+                .save_prune_checkpoint(
+                    segment,
+                    PruneCheckpoint {
+                        block_number: Some(89),
+                        tx_number: None,
+                        prune_mode: PruneMode::Distance(2_000_000),
+                    },
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(None)
+        ));
+    }
+
+    #[test]
+    fn test_consistency_unwind_bounded_by_prune_checkpoint() {
+        use reth_db_api::models::StorageSettings;
+        use reth_storage_api::StorageSettingsCache;
+
+        let db = seed_data(90).unwrap();
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+        let static_file_provider = db.factory.static_file_provider();
+
+        // Senders are only pruned up to block 50 while the stage checkpoint is at the tip:
+        // blocks 51..=89 did lose data, so an unwind is still required, but bounded by the
+        // prune checkpoint instead of going all the way to 0.
+        let provider_rw = db.factory.provider_rw().unwrap();
+        provider_rw
+            .save_prune_checkpoint(
+                PruneSegment::SenderRecovery,
+                PruneCheckpoint {
+                    block_number: Some(50),
+                    tx_number: None,
+                    prune_mode: PruneMode::Distance(39),
+                },
+            )
+            .unwrap();
+        for segment in [PruneSegment::AccountHistory, PruneSegment::StorageHistory] {
+            provider_rw
+                .save_prune_checkpoint(
+                    segment,
+                    PruneCheckpoint {
+                        block_number: Some(89),
+                        tx_number: None,
+                        prune_mode: PruneMode::Distance(2_000_000),
+                    },
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(Some(PipelineTarget::Unwind(50)))
+        ));
+    }
+
+    #[test]
+    fn test_consistency_receipts_distance_prune_checkpoint() {
+        let db = seed_data(90).unwrap();
+        let static_file_provider = db.factory.static_file_provider();
+
+        // Remove all receipts static files, like a node whose receipts have been
+        // distance-pruned away.
+        while let Some(block) =
+            static_file_provider.get_highest_static_file_block(StaticFileSegment::Receipts)
+        {
+            static_file_provider.delete_jar(StaticFileSegment::Receipts, block).unwrap();
+        }
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(Some(PipelineTarget::Unwind(0)))
+        ));
+
+        let provider_rw = db.factory.provider_rw().unwrap();
+        provider_rw
+            .save_prune_checkpoint(
+                PruneSegment::Receipts,
+                PruneCheckpoint {
+                    block_number: Some(89),
+                    tx_number: None,
+                    prune_mode: PruneMode::Distance(2_000_000),
+                },
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(None)
+        ));
     }
 }

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -582,6 +582,48 @@ mod tests {
     }
 
     #[test]
+    fn test_consistency_senders_before_prune_checkpoint() {
+        use reth_db_api::models::StorageSettings;
+        use reth_storage_api::StorageSettingsCache;
+
+        let db = seed_data(90).unwrap();
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+        let static_file_provider = db.factory.static_file_provider();
+
+        // Same scenario as the `Distance` case, but pruned with a `Before` mode. The check is
+        // bounded by the prune checkpoint block regardless of the prune mode, so a node that
+        // pruned senders with `Before` must not be told to unwind to 0 either.
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(Some(PipelineTarget::Unwind(0)))
+        ));
+
+        let provider_rw = db.factory.provider_rw().unwrap();
+        for segment in [
+            PruneSegment::SenderRecovery,
+            PruneSegment::AccountHistory,
+            PruneSegment::StorageHistory,
+        ] {
+            provider_rw
+                .save_prune_checkpoint(
+                    segment,
+                    PruneCheckpoint {
+                        block_number: Some(89),
+                        tx_number: None,
+                        prune_mode: PruneMode::Before(90),
+                    },
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+
+        assert!(matches!(
+            static_file_provider.check_consistency(&db.factory.database_provider_ro().unwrap()),
+            Ok(None)
+        ));
+    }
+
+    #[test]
     fn test_consistency_unwind_bounded_by_prune_checkpoint() {
         use reth_db_api::models::StorageSettings;
         use reth_storage_api::StorageSettingsCache;

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1573,7 +1573,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         highest_block: Option<BlockNumber>,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
         N: NodePrimitives<Receipt: Value, BlockHeader: Value, SignedTx: Value>,
     {
         match segment {
@@ -1645,7 +1645,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         highest_static_file_block: Option<BlockNumber>,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
     {
         debug!(target: "reth::providers::static_file", "Ensuring invariants");
         let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
@@ -1691,15 +1691,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
         debug!(target: "reth::providers::static_file", ?stage_id, checkpoint_block_number, "Retrieved stage checkpoint");
 
+        let effective_available_block =
+            Self::effective_available_block(provider, segment, highest_static_file_block)?;
+
         // If the checkpoint is ahead, then we lost static file data. May be data corruption.
-        if checkpoint_block_number > highest_static_file_block {
+        if checkpoint_block_number > effective_available_block {
             info!(
                 target: "reth::providers::static_file",
                 checkpoint_block_number,
-                unwind_target = highest_static_file_block,
+                unwind_target = effective_available_block,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block));
+            return Ok(Some(effective_available_block));
         }
 
         // If the checkpoint is ahead, or matches, then nothing to do.
@@ -1779,7 +1782,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         block_from_key: F,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
         T: Table,
         F: Fn(&T::Key) -> BlockNumber,
     {
@@ -1828,15 +1831,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let checkpoint_block_number =
             provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
 
-        if checkpoint_block_number > highest_static_file_block {
+        let effective_available_block =
+            Self::effective_available_block(provider, segment, highest_static_file_block)?;
+
+        if checkpoint_block_number > effective_available_block {
             info!(
                 target: "reth::providers::static_file",
                 checkpoint_block_number,
-                unwind_target = highest_static_file_block,
+                unwind_target = effective_available_block,
                 ?segment,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block))
+            return Ok(Some(effective_available_block))
         }
 
         if checkpoint_block_number < highest_static_file_block {
@@ -1861,6 +1867,46 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         }
 
         Ok(None)
+    }
+
+    /// Returns the highest block for which data for this segment is expected to be
+    /// available, taking prune checkpoints into account.
+    ///
+    /// Data below a segment's prune checkpoint has been intentionally deleted, so its
+    /// absence from static files is not an inconsistency. Without this, a pruned segment
+    /// whose stage checkpoint is ahead of its (empty) static files is treated as data
+    /// corruption and triggers an unwind to block 0, which aborts the node on startup.
+    /// See <https://github.com/paradigmxyz/reth/issues/23463>.
+    fn effective_available_block<Provider>(
+        provider: &Provider,
+        segment: StaticFileSegment,
+        highest_static_file_block: BlockNumber,
+    ) -> ProviderResult<BlockNumber>
+    where
+        Provider: PruneCheckpointReader,
+    {
+        let Some(prune_segment) = Self::prune_segment_for_static_file(segment) else {
+            return Ok(highest_static_file_block)
+        };
+
+        let prune_checkpoint_block = provider
+            .get_prune_checkpoint(prune_segment)?
+            .and_then(|checkpoint| checkpoint.block_number)
+            .unwrap_or_default();
+
+        Ok(highest_static_file_block.max(prune_checkpoint_block))
+    }
+
+    /// Returns the prune segment that governs data availability for a static file segment,
+    /// or `None` if the segment is never pruned.
+    const fn prune_segment_for_static_file(segment: StaticFileSegment) -> Option<PruneSegment> {
+        match segment {
+            StaticFileSegment::Receipts => Some(PruneSegment::Receipts),
+            StaticFileSegment::TransactionSenders => Some(PruneSegment::SenderRecovery),
+            StaticFileSegment::AccountChangeSets => Some(PruneSegment::AccountHistory),
+            StaticFileSegment::StorageChangeSets => Some(PruneSegment::StorageHistory),
+            StaticFileSegment::Headers | StaticFileSegment::Transactions => None,
+        }
     }
 
     /// Returns the earliest available block number that has not been expired and is still

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -748,8 +748,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         let current_block = if let Some(current_block_number) = self.current_block_number() {
             current_block_number
         } else {
-            self.increment_block(0)?;
-            0
+            // A fresh file does not necessarily start at block 0: a writer opened for a
+            // pruned segment may be positioned on a later fixed range, in which case its
+            // first block is the expected start of that range.
+            let first_block = self.writer.user_header().expected_block_start();
+            self.increment_block(first_block)?;
+            first_block
         };
 
         match current_block.cmp(&advance_to) {

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -883,4 +883,28 @@ mod tests {
 
         drop(writer);
     }
+
+    /// `ensure_at_block` on a fresh file that does not start at block 0 (e.g. created for a
+    /// distance-pruned segment) must initialize the writer at the file's expected block
+    /// start instead of erroring out.
+    ///
+    /// See <https://github.com/paradigmxyz/reth/issues/23463>.
+    #[test]
+    fn test_ensure_at_block_on_empty_non_genesis_file() {
+        let static_dir = tempfile::tempdir().unwrap();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // A writer for block 250 opens a fresh empty file covering blocks 200..=299.
+        let mut writer = provider.get_writer(250, StaticFileSegment::TransactionSenders).unwrap();
+        assert_eq!(writer.current_block_number(), None);
+
+        writer.ensure_at_block(250).unwrap();
+        assert_eq!(writer.current_block_number(), Some(250));
+        writer.commit().unwrap();
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::TransactionSenders),
+            Some(250)
+        );
+    }
 }


### PR DESCRIPTION
Closes #23463

## Problem

Running with senders in static files and `--prune.sender-recovery.distance N` aborts the node ~25 min after a snapshot import, in a permanent crash loop:

```
assertion `left != right` failed: A static file inconsistency was found that would trigger an unwind to block 0
```

Two things break:

1. The consistency check only treats a segment as intentionally empty when its prune checkpoint mode is `Full` (`is_segment_fully_pruned`). With `Distance(N)` the check compares the stage checkpoint against the highest static file block, finds e.g. `24850381 > 0`, and requests an unwind to block 0, which trips the `assert_ne!` at startup. #21647 added the `Full` skip and #21918 fixed the stage side, but the `Distance` path was left out.
2. Even when the check passes, resuming a distance-pruned segment can fail in `ensure_at_block`: a fresh static file does not necessarily start at block 0, but the writer initializes empty files with `increment_block(0)`. This is the second failure mode reported in the issue comments:

```
trying to append data to TransactionSenders as block #0 but expected block #24500000
```

## Solution

* `ensure_invariants` now compares the stage checkpoint against `max(highest_static_file_block, prune_checkpoint_block)`. Data below the prune checkpoint is intentionally absent, not corrupted. A real data loss above the prune checkpoint is still detected, and the resulting unwind is bounded by the prune checkpoint instead of going to 0. Applies to both invariant paths (tx-based segments and changesets), and incidentally also covers `PruneMode::Before`, which has the same problem as `Distance`.
* `ensure_at_block` initializes an empty file at its `expected_block_start()` instead of a hardcoded 0. No behavior change for genesis files, where `expected_block_start() == 0`.

This follows the approach of #21636 and #24062, which were both closed for inactivity without ever getting a review (credits to @gakonst and @ametel01), and was requested in https://github.com/paradigmxyz/reth/issues/23463#issuecomment-4262248180. Happy to split the `ensure_at_block` fix into its own PR if preferred.

## Testing

All four tests fail before the fix and pass after:

* `test_consistency_senders_distance_prune_checkpoint` reproduces the issue state: senders expected in static files, none present, stage checkpoint at the tip, `Distance` prune checkpoint. Returns `Unwind(0)` before the fix, no unwind after.
* `test_consistency_unwind_bounded_by_prune_checkpoint` checks that a real data loss above the prune checkpoint still triggers an unwind, bounded by the prune checkpoint.
* `test_consistency_receipts_distance_prune_checkpoint` covers the same scenario for receipts.
* `test_ensure_at_block_on_empty_non_genesis_file` reproduces the append failure on a fresh non-genesis file.
