### PR TITLE
chore(release): bump version to 2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7493,7 +7493,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7543,7 +7543,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7569,7 +7569,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bb"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7617,7 +7617,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7682,7 +7682,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7771,7 +7771,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7834,7 +7834,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -7865,7 +7865,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7939,7 +7939,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7967,7 +7967,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8040,7 +8040,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8131,7 +8131,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8214,7 +8214,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8236,7 +8236,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8362,7 +8362,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8385,7 +8385,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8430,7 +8430,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8544,7 +8544,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8567,7 +8567,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8583,7 +8583,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8599,7 +8599,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8612,7 +8612,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8662,7 +8662,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8672,7 +8672,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -8697,7 +8697,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8719,7 +8719,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8737,7 +8737,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8749,7 +8749,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8815,7 +8815,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8846,7 +8846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8863,7 +8863,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8872,7 +8872,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8905,7 +8905,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytes",
  "futures",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8944,7 +8944,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "futures",
  "metrics",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8986,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9048,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9072,7 +9072,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9124,7 +9124,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9142,7 +9142,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9165,7 +9165,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9236,7 +9236,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9382,7 +9382,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9405,7 +9405,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytes",
  "eyre",
@@ -9434,7 +9434,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9445,7 +9445,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9468,7 +9468,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9479,7 +9479,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9503,7 +9503,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9512,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9554,7 +9554,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9609,7 +9609,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9641,11 +9641,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-db"
-version = "2.2.0"
+version = "2.3.0"
 
 [[package]]
 name = "reth-prune-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9665,7 +9665,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9760,7 +9760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9790,7 +9790,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api-testing-util"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9809,7 +9809,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9867,7 +9867,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9887,7 +9887,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9907,7 +9907,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9943,7 +9943,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9989,7 +9989,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10041,7 +10041,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10058,7 +10058,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10088,7 +10088,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10150,7 +10150,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10184,7 +10184,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10223,7 +10223,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10241,7 +10241,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10268,7 +10268,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10285,7 +10285,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10314,7 +10314,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10334,7 +10334,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10350,7 +10350,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10359,7 +10359,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "eyre",
@@ -10378,7 +10378,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10396,7 +10396,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10447,7 +10447,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10480,7 +10480,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10513,7 +10513,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10544,7 +10544,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "alloy-evm",
@@ -10578,7 +10578,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     { text: 'Rustdocs', link: '/docs' },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v2.2.0',
+      text: 'v2.3.0',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Bumps the workspace package version and docs nav display to 2.3.0. Refreshes Cargo.lock workspace package entries so the release metadata matches the intended tag.