### PR TITLE
perf(net): avoid rayon dispatch overhead for incoming transaction recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8995,6 +8995,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
+ "codspeed-criterion-compat",
  "derive_more",
  "discv5",
  "enr",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -97,6 +97,7 @@ alloy-genesis.workspace = true
 # misc
 url.workspace = true
 secp256k1 = { workspace = true, features = ["rand"] }
+criterion.workspace = true
 
 [features]
 serde = [
@@ -139,3 +140,7 @@ test-utils = [
     "reth-evm-ethereum?/test-utils",
     "reth-tasks/test-utils",
 ]
+
+[[bench]]
+name = "tx_recovery"
+harness = false

--- a/crates/net/network/benches/tx_recovery.rs
+++ b/crates/net/network/benches/tx_recovery.rs
@@ -1,0 +1,102 @@
+#![allow(missing_docs)]
+
+//! Compares strategies for recovering the signers of a batch of incoming transactions, as done
+//! by the `TransactionsManager` when importing transactions received over the network.
+//!
+//! For profiling a single variant with samply:
+//!
+//! ```sh
+//! cargo bench --bench tx_recovery -- --profile-time 10 "parallel/per-item/256"
+//! samply record -p <pid>
+//! ```
+
+use alloy_consensus::transaction::SignerRecoverable;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use reth_ethereum_primitives::TransactionSigned;
+use reth_transaction_pool::test_utils::TransactionGenerator;
+
+/// Minimum work unit sizes when splitting a batch across the rayon pool.
+const MIN_SPLIT_LENS: [usize; 2] = [8, 16];
+
+fn generate_txs(count: usize) -> Vec<TransactionSigned> {
+    let mut tx_gen = TransactionGenerator::with_num_signers(rand::rng(), count.max(10));
+    (0..count).map(|_| tx_gen.gen_eip1559()).collect()
+}
+
+fn bench_recovery(c: &mut Criterion) {
+    let mut group = c.benchmark_group("batch tx recovery");
+
+    for &batch_size in &[1usize, 4, 16, 64, 256] {
+        let txs = generate_txs(batch_size);
+        group.throughput(Throughput::Elements(batch_size as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", batch_size), &txs, |b, txs| {
+            b.iter_batched(
+                || txs.clone(),
+                |txs| {
+                    txs.into_iter()
+                        .filter_map(|tx| tx.try_into_recovered().ok())
+                        .collect::<Vec<_>>()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_with_input(BenchmarkId::new("sequential/buf", batch_size), &txs, |b, txs| {
+            let mut buf = Vec::new();
+            b.iter_batched(
+                || txs.clone(),
+                |txs| {
+                    txs.into_iter()
+                        .filter_map(|tx| tx.try_into_recovered_with_buf(&mut buf).ok())
+                        .collect::<Vec<_>>()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("parallel/per-item", batch_size),
+            &txs,
+            |b, txs| {
+                b.iter_batched(
+                    || txs.clone(),
+                    |txs| {
+                        txs.into_par_iter()
+                            .filter_map(|tx| tx.try_into_recovered().ok())
+                            .collect::<Vec<_>>()
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+
+        for min_len in MIN_SPLIT_LENS {
+            group.bench_with_input(
+                BenchmarkId::new(format!("parallel/min-len-{min_len}/buf"), batch_size),
+                &txs,
+                |b, txs| {
+                    b.iter_batched(
+                        || txs.clone(),
+                        |txs| {
+                            txs.into_par_iter()
+                                .with_min_len(min_len)
+                                .map_init(Vec::new, |buf, tx| {
+                                    tx.try_into_recovered_with_buf(buf).ok()
+                                })
+                                .filter_map(|tx| tx)
+                                .collect::<Vec<_>>()
+                        },
+                        BatchSize::SmallInput,
+                    )
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_recovery);
+criterion_main!(benches);

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -62,6 +62,15 @@ pub mod tx_manager {
     /// tasks. When the budget is exhausted, new events are dropped (see metric
     /// `total_dropped_tx_events_at_full_capacity`).
     pub const DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES: usize = 1024 * 1024 * 1024;
+
+    /// Minimum number of transactions in a message for signature recovery to be dispatched to the
+    /// rayon thread pool, also used as the minimum work unit size when the batch is split across
+    /// the pool.
+    ///
+    /// Recovering a few signatures inline is cheaper than the cost of dispatching the batch to
+    /// the pool and blocking on the result, and per-item work units make rayon's join overhead
+    /// cost more CPU than the signature recovery itself.
+    pub const MIN_TX_COUNT_FOR_PARALLEL_RECOVERY: usize = 16;
 }
 
 /// Constants used by [`TransactionFetcher`](super::TransactionFetcher).

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1,7 +1,7 @@
 //! Transactions management for the p2p network.
 
-use alloy_consensus::transaction::TxHashRef;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use alloy_consensus::transaction::{SignerRecoverable, TxHashRef};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 /// Aggregation on configurable parameters for [`TransactionsManager`].
 pub mod config;
@@ -310,6 +310,9 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     pending_pool_imports_info: PendingPoolImportsInfo,
     /// Bad imports.
     bad_imports: LruCache<TxHash, FbBuildHasher<32>>,
+    /// Scratch buffer reused for the signature hash encoding when recovering incoming
+    /// transactions inline.
+    recovery_scratch_buf: Vec<u8>,
     /// All the connected peers.
     peers: HashMap<PeerId, PeerMetadata<N>>,
     /// Send half for the command channel.
@@ -403,6 +406,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             pool_imports: Default::default(),
             pending_pool_imports_info,
             bad_imports: LruCache::with_hasher(DEFAULT_MAX_COUNT_BAD_IMPORTS, Default::default()),
+            recovery_scratch_buf: Vec::new(),
             peers: Default::default(),
             command_tx,
             command_rx: UnboundedReceiverStream::new(command_rx),
@@ -1432,21 +1436,35 @@ where
 
         let txs_len = transactions.len();
 
-        let new_txs = transactions
-            .into_par_iter()
-            .filter_map(|tx| match tx.try_into_recovered() {
-                Ok(tx) => Some(Pool::Transaction::from_pooled(tx)),
-                Err(badtx) => {
-                    trace!(target: "net::tx",
-                        peer_id=format!("{peer_id:#}"),
-                        hash=%badtx.tx_hash(),
-                        client_version=%client_version,
-                        "failed ecrecovery for transaction"
-                    );
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        // recovers the transaction, reusing the given buffer for the signature hash encoding
+        let recover = |buf: &mut Vec<u8>, tx: N::PooledTransaction| match tx.recover_with_buf(buf) {
+            Ok(signer) => Some(Pool::Transaction::from_pooled(tx.with_signer(signer))),
+            Err(_) => {
+                trace!(target: "net::tx",
+                    peer_id=format!("{peer_id:#}"),
+                    hash=%tx.tx_hash(),
+                    %client_version,
+                    "failed ecrecovery for transaction"
+                );
+                None
+            }
+        };
+
+        // Only dispatch to the rayon pool for larger batches, the dispatch overhead outweighs
+        // the parallel speedup for the common case of a message with a few transactions. For
+        // larger batches, bound the split granularity for the same reason: per-item work units
+        // make rayon's join/steal overhead cost more CPU than the signature recovery itself.
+        let new_txs = if txs_len < MIN_TX_COUNT_FOR_PARALLEL_RECOVERY {
+            let buf = &mut self.recovery_scratch_buf;
+            transactions.into_iter().filter_map(|tx| recover(buf, tx)).collect::<Vec<_>>()
+        } else {
+            transactions
+                .into_par_iter()
+                .with_min_len(MIN_TX_COUNT_FOR_PARALLEL_RECOVERY)
+                .map_init(Vec::new, recover)
+                .filter_map(|tx| tx)
+                .collect::<Vec<_>>()
+        };
 
         has_bad_transactions |= new_txs.len() != txs_len;
 


### PR DESCRIPTION
Profiling a multi-node gossip setup (harness in #25084) showed rayon join/steal plumbing and spin latches consuming several times more CPU than the signature recovery itself in `import_transactions`, because batches split into per-item work units while the manager thread blocks on the bridge. Batches smaller than 16 transactions are now recovered inline, the common case for gossiped `Transactions` messages, and larger batches use `with_min_len(16)` so each work unit amortizes the dispatch cost.

Recovery encodes the signature hash into a reusable buffer via `recover_with_buf` instead of allocating per transaction: the inline path reuses a scratch buffer held by the manager, the parallel path reuses one buffer per rayon work unit via `map_init`.

Includes a benchmark comparing the recovery variants (`cargo bench -p reth-network --bench tx_recovery`), wall time per batch on an M-series laptop:

| batch | sequential | sequential/buf | parallel/per-item (before) | parallel/min-len-8/buf | parallel/min-len-16/buf (after) |
|---|---|---|---|---|---|
| 1 | 27.2µs | 25.5µs | 25.0µs | 25.7µs | 25.8µs |
| 4 | 101.8µs | 102.8µs | 67.8µs | 99.5µs | 99.1µs |
| 16 | 398µs | 398µs | 107µs | 227µs | 396µs |
| 64 | 1619µs | 1639µs | 317µs | 362µs | 485µs |
| 256 | 6650µs | 6661µs | 1046µs | 1027µs | 1132µs |

Wall time alone favors finer splitting at mid sizes because it doesn't show the CPU burned by the plumbing. Sampling the parallel variants while looping the 256-tx case for a fixed 10s window shows where the CPU goes:

| variant | secp256k1/keccak | rayon plumbing | user CPU |
|---|---|---|---|
| per-item | 49% | 44% | 84.2s |
| min-len-8 | 75% | 16% | 83.3s |
| min-len-16 | 85% | 8% | 68.4s (~19% less) |

The min-len values were also compared end-to-end with the 8-node harness: latency is statistically identical (p50 coverage ~10.3-11.0ms for both across interleaved runs), the mid-batch wall time advantage of 8 doesn't register against ms-scale propagation latencies, while 16 retains slightly lower CPU. Hence 16.

Under load the wasted CPU contends with everything else in the node: in the end-to-end harness this change reduced both CPU and propagation latency (p50 per-tx latency for small-batch gossip dropped from ~6.9ms to ~4.2ms together with #25087).