### PR TITLE
fix(net): respect configured full transaction broadcast peer count

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1039,16 +1039,18 @@ where
         let max_num_full = self.config.propagation_mode.full_peer_count(self.peers.len());
 
         // Note: Assuming ~random~ order due to random state of the peers map hasher
-        for (peer_idx, (peer_id, peer)) in self.peers.iter_mut().enumerate() {
+        let mut num_full_peers = 0;
+        for (peer_id, peer) in &mut self.peers {
             if !self.policies.propagation_policy().can_propagate(peer) {
                 // skip peers we should not propagate to
                 continue
             }
             // determine whether to send full tx objects or hashes.
-            let mut builder = if peer_idx > max_num_full {
-                PropagateTransactionsBuilder::pooled(peer.version)
-            } else {
+            let mut builder = if num_full_peers < max_num_full {
+                num_full_peers += 1;
                 PropagateTransactionsBuilder::full(peer.version)
+            } else {
+                PropagateTransactionsBuilder::pooled(peer.version)
             };
 
             if propagation_mode.is_forced() {


### PR DESCRIPTION
When selecting which peers receive full transactions during propagation, the 0-based peer index was compared with `>`, so `max_num_full + 1` peers received full transactions, e.g. `TransactionPropagationMode::Max(0)` still sent full transactions to one peer. Peers skipped by the propagation policy also consumed full-broadcast slots. Count eligible peers instead.