### PR TITLE
perf(engine): pad execution stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8270,7 +8270,9 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "assert_matches",
+ "codspeed-criterion-compat",
  "crossbeam-channel",
+ "crossbeam-utils",
  "derive_more",
  "eyre",
  "futures",
@@ -8722,6 +8724,7 @@ name = "reth-execution-cache"
 version = "2.3.0"
 dependencies = [
  "alloy-primitives",
+ "crossbeam-utils",
  "fixed-cache",
  "metrics",
  "parking_lot",

--- a/crates/engine/execution-cache/Cargo.toml
+++ b/crates/engine/execution-cache/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 alloy-primitives.workspace = true
+crossbeam-utils.workspace = true
 fixed-cache = { workspace = true, features = ["stats"] }
 metrics.workspace = true
 parking_lot.workspace = true

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -3,6 +3,7 @@ use alloy_primitives::{
     map::{DefaultHashBuilder, FbBuildHasher},
     Address, StorageKey, StorageValue, B256,
 };
+use crossbeam_utils::CachePadded;
 use fixed_cache::{AnyRef, CacheConfig, Stats, StatsHandler};
 use metrics::{Counter, Gauge, Histogram};
 use parking_lot::Once;
@@ -338,17 +339,17 @@ impl CachedStateMetrics {
 #[derive(Debug, Default)]
 pub struct CacheStats {
     /// Account cache hits
-    account_hits: AtomicUsize,
+    account_hits: CachePadded<AtomicUsize>,
     /// Account cache misses
-    account_misses: AtomicUsize,
+    account_misses: CachePadded<AtomicUsize>,
     /// Storage cache hits
-    storage_hits: AtomicUsize,
+    storage_hits: CachePadded<AtomicUsize>,
     /// Storage cache misses
-    storage_misses: AtomicUsize,
+    storage_misses: CachePadded<AtomicUsize>,
     /// Code cache hits
-    code_hits: AtomicUsize,
+    code_hits: CachePadded<AtomicUsize>,
     /// Code cache misses
-    code_misses: AtomicUsize,
+    code_misses: CachePadded<AtomicUsize>,
 }
 
 impl CacheStats {
@@ -429,15 +430,19 @@ impl CacheStats {
 /// Collisions (evicting a different key) don't change size since they replace an existing entry.
 #[derive(Debug)]
 pub struct CacheStatsHandler {
-    collisions: AtomicU64,
-    size: AtomicUsize,
+    collisions: CachePadded<AtomicU64>,
+    size: CachePadded<AtomicUsize>,
     capacity: usize,
 }
 
 impl CacheStatsHandler {
     /// Creates a new stats handler with all counters initialized to zero.
     pub const fn new(capacity: usize) -> Self {
-        Self { collisions: AtomicU64::new(0), size: AtomicUsize::new(0), capacity }
+        Self {
+            collisions: CachePadded::new(AtomicU64::new(0)),
+            size: CachePadded::new(AtomicUsize::new(0)),
+            capacity,
+        }
     }
 
     /// Returns the number of cache collisions.

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -68,6 +68,7 @@ tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
 crossbeam-channel.workspace = true
+crossbeam-utils.workspace = true
 
 # optional deps for test-utils
 reth-prune-types = { workspace = true, optional = true }
@@ -99,6 +100,7 @@ reth-e2e-test-utils.workspace = true
 revm-database-interface.workspace = true
 
 assert_matches.workspace = true
+criterion.workspace = true
 eyre.workspace = true
 serde_json.workspace = true
 proptest.workspace = true
@@ -145,3 +147,7 @@ trie-debug = [
 [[test]]
 name = "e2e_testsuite"
 path = "tests/e2e-testsuite/main.rs"
+
+[[bench]]
+name = "stats_false_sharing"
+harness = false

--- a/crates/engine/tree/benches/stats_false_sharing.rs
+++ b/crates/engine/tree/benches/stats_false_sharing.rs
@@ -1,0 +1,332 @@
+#![allow(missing_docs)]
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use reth_engine_tree::tree::instrumented_state::StateProviderStats;
+use reth_execution_cache::CacheStats;
+use std::{
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc, Barrier,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+const ITERATIONS_PER_THREAD: usize = 50_000;
+const MAX_THREADS: usize = 8;
+const NANOS_PER_SEC: u64 = 1_000_000_000;
+
+#[derive(Default)]
+struct UnpaddedAtomicDuration {
+    nanos: AtomicU64,
+}
+
+impl UnpaddedAtomicDuration {
+    fn duration(&self) -> Duration {
+        let nanos = self.nanos.load(Ordering::Relaxed);
+        Duration::new(nanos / NANOS_PER_SEC, (nanos % NANOS_PER_SEC) as u32)
+    }
+
+    fn add_duration(&self, duration: Duration) {
+        let nanos = duration.as_secs() * NANOS_PER_SEC + duration.subsec_nanos() as u64;
+        self.nanos.fetch_add(nanos, Ordering::Relaxed);
+    }
+}
+
+#[derive(Default)]
+struct UnpaddedStateProviderStats {
+    total_storage_fetches: AtomicUsize,
+    total_storage_fetch_latency: UnpaddedAtomicDuration,
+
+    total_code_fetches: AtomicUsize,
+    total_code_fetch_latency: UnpaddedAtomicDuration,
+    total_code_fetched_bytes: AtomicUsize,
+
+    total_account_fetches: AtomicUsize,
+    total_account_fetch_latency: UnpaddedAtomicDuration,
+}
+
+impl UnpaddedStateProviderStats {
+    fn record_storage_fetch(&self, latency: Duration) {
+        self.total_storage_fetches.fetch_add(1, Ordering::Relaxed);
+        self.total_storage_fetch_latency.add_duration(latency);
+    }
+
+    fn record_code_fetch(&self, latency: Duration, bytes: usize) {
+        self.total_code_fetches.fetch_add(1, Ordering::Relaxed);
+        self.total_code_fetch_latency.add_duration(latency);
+        self.total_code_fetched_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    fn record_account_fetch(&self, latency: Duration) {
+        self.total_account_fetches.fetch_add(1, Ordering::Relaxed);
+        self.total_account_fetch_latency.add_duration(latency);
+    }
+
+    fn checksum(&self) -> usize {
+        self.total_storage_fetches.load(Ordering::Relaxed) +
+            self.total_storage_fetch_latency.duration().as_nanos() as usize +
+            self.total_code_fetches.load(Ordering::Relaxed) +
+            self.total_code_fetch_latency.duration().as_nanos() as usize +
+            self.total_code_fetched_bytes.load(Ordering::Relaxed) +
+            self.total_account_fetches.load(Ordering::Relaxed) +
+            self.total_account_fetch_latency.duration().as_nanos() as usize
+    }
+}
+
+#[derive(Default)]
+struct UnpaddedCacheStats {
+    account_hits: AtomicUsize,
+    account_misses: AtomicUsize,
+    storage_hits: AtomicUsize,
+    storage_misses: AtomicUsize,
+    code_hits: AtomicUsize,
+    code_misses: AtomicUsize,
+}
+
+impl UnpaddedCacheStats {
+    fn record_account_hit(&self) {
+        self.account_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_account_miss(&self) {
+        self.account_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_storage_hit(&self) {
+        self.storage_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_storage_miss(&self) {
+        self.storage_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_code_hit(&self) {
+        self.code_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_code_miss(&self) {
+        self.code_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn checksum(&self) -> usize {
+        self.account_hits.load(Ordering::Relaxed) +
+            self.account_misses.load(Ordering::Relaxed) +
+            self.storage_hits.load(Ordering::Relaxed) +
+            self.storage_misses.load(Ordering::Relaxed) +
+            self.code_hits.load(Ordering::Relaxed) +
+            self.code_misses.load(Ordering::Relaxed)
+    }
+}
+
+fn worker_count() -> usize {
+    thread::available_parallelism().map_or(1, |parallelism| parallelism.get()).clamp(1, MAX_THREADS)
+}
+
+fn measure_unpadded_state_stats(workers: usize, repetitions: u64) -> Duration {
+    let stats = Arc::new(UnpaddedStateProviderStats::default());
+    let barrier = Arc::new(Barrier::new(workers + 1));
+    let latency = Duration::from_nanos(37);
+    let handles = (0..workers)
+        .map(|worker| {
+            let stats = Arc::clone(&stats);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..repetitions {
+                    for _ in 0..ITERATIONS_PER_THREAD {
+                        match worker % 3 {
+                            0 => stats.record_storage_fetch(latency),
+                            1 => stats.record_code_fetch(latency, 32),
+                            _ => stats.record_account_fetch(latency),
+                        }
+                    }
+                }
+                barrier.wait();
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let start = Instant::now();
+    barrier.wait();
+    barrier.wait();
+    let elapsed = start.elapsed();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    black_box(stats.checksum());
+    elapsed
+}
+
+fn measure_padded_state_stats(workers: usize, repetitions: u64) -> Duration {
+    let stats = Arc::new(StateProviderStats::default());
+    let barrier = Arc::new(Barrier::new(workers + 1));
+    let latency = Duration::from_nanos(37);
+    let handles = (0..workers)
+        .map(|worker| {
+            let stats = Arc::clone(&stats);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..repetitions {
+                    for _ in 0..ITERATIONS_PER_THREAD {
+                        match worker % 3 {
+                            0 => stats.record_storage_fetch(latency),
+                            1 => stats.record_code_fetch(latency, 32),
+                            _ => stats.record_account_fetch(latency),
+                        }
+                    }
+                }
+                barrier.wait();
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let start = Instant::now();
+    barrier.wait();
+    barrier.wait();
+    let elapsed = start.elapsed();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let checksum = stats.total_storage_fetches() +
+        stats.total_storage_fetch_latency().as_nanos() as usize +
+        stats.total_code_fetches() +
+        stats.total_code_fetch_latency().as_nanos() as usize +
+        stats.total_code_fetched_bytes() +
+        stats.total_account_fetches() +
+        stats.total_account_fetch_latency().as_nanos() as usize;
+    black_box(checksum);
+    elapsed
+}
+
+fn measure_unpadded_cache_stats(workers: usize, repetitions: u64) -> Duration {
+    let stats = Arc::new(UnpaddedCacheStats::default());
+    let barrier = Arc::new(Barrier::new(workers + 1));
+    let handles = (0..workers)
+        .map(|worker| {
+            let stats = Arc::clone(&stats);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..repetitions {
+                    for _ in 0..ITERATIONS_PER_THREAD {
+                        match worker % 6 {
+                            0 => stats.record_account_hit(),
+                            1 => stats.record_account_miss(),
+                            2 => stats.record_storage_hit(),
+                            3 => stats.record_storage_miss(),
+                            4 => stats.record_code_hit(),
+                            _ => stats.record_code_miss(),
+                        }
+                    }
+                }
+                barrier.wait();
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let start = Instant::now();
+    barrier.wait();
+    barrier.wait();
+    let elapsed = start.elapsed();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    black_box(stats.checksum());
+    elapsed
+}
+
+fn measure_padded_cache_stats(workers: usize, repetitions: u64) -> Duration {
+    let stats = Arc::new(CacheStats::default());
+    let barrier = Arc::new(Barrier::new(workers + 1));
+    let handles = (0..workers)
+        .map(|worker| {
+            let stats = Arc::clone(&stats);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..repetitions {
+                    for _ in 0..ITERATIONS_PER_THREAD {
+                        match worker % 6 {
+                            0 => stats.record_account_hit(),
+                            1 => stats.record_account_miss(),
+                            2 => stats.record_storage_hit(),
+                            3 => stats.record_storage_miss(),
+                            4 => stats.record_code_hit(),
+                            _ => stats.record_code_miss(),
+                        }
+                    }
+                }
+                barrier.wait();
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let start = Instant::now();
+    barrier.wait();
+    barrier.wait();
+    let elapsed = start.elapsed();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let checksum = stats.account_hits() +
+        stats.account_misses() +
+        stats.storage_hits() +
+        stats.storage_misses() +
+        stats.code_hits() +
+        stats.code_misses();
+    black_box(checksum);
+    elapsed
+}
+
+fn stats_false_sharing(c: &mut Criterion) {
+    let workers = worker_count();
+    let state_workers = workers.min(3);
+    let cache_workers = workers.min(6);
+
+    let mut group = c.benchmark_group("stats_false_sharing/state_provider");
+    group.bench_with_input(
+        BenchmarkId::new("split_fetch_fields", "unpadded"),
+        &state_workers,
+        |b, &workers| {
+            b.iter_custom(|repetitions| measure_unpadded_state_stats(workers, repetitions));
+        },
+    );
+    group.bench_with_input(
+        BenchmarkId::new("split_fetch_fields", "cache_padded"),
+        &state_workers,
+        |b, &workers| {
+            b.iter_custom(|repetitions| measure_padded_state_stats(workers, repetitions));
+        },
+    );
+    group.finish();
+
+    let mut group = c.benchmark_group("stats_false_sharing/cache_stats");
+    group.bench_with_input(
+        BenchmarkId::new("split_hit_fields", "unpadded"),
+        &cache_workers,
+        |b, &workers| {
+            b.iter_custom(|repetitions| measure_unpadded_cache_stats(workers, repetitions));
+        },
+    );
+    group.bench_with_input(
+        BenchmarkId::new("split_hit_fields", "cache_padded"),
+        &cache_workers,
+        |b, &workers| {
+            b.iter_custom(|repetitions| measure_padded_cache_stats(workers, repetitions));
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, stats_false_sharing);
+criterion_main!(benches);

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -1,5 +1,6 @@
 //! Implements a state provider that tracks latency metrics.
 use alloy_primitives::{Address, StorageKey, StorageValue, B256};
+use crossbeam_utils::CachePadded;
 use metrics::{Gauge, Histogram};
 use reth_errors::ProviderResult;
 use reth_metrics::Metrics;
@@ -141,15 +142,15 @@ impl StateProviderMetrics {
 
     /// Records accumulated fetch latency totals.
     pub(crate) fn record_totals(&self, stats: &StateProviderStats) {
-        let total_storage_fetch_latency = stats.total_storage_fetch_latency.duration();
+        let total_storage_fetch_latency = stats.total_storage_fetch_latency();
         self.total_storage_fetch_latency.record(total_storage_fetch_latency);
         self.total_storage_fetch_latency_gauge.set(total_storage_fetch_latency.as_secs_f64());
 
-        let total_code_fetch_latency = stats.total_code_fetch_latency.duration();
+        let total_code_fetch_latency = stats.total_code_fetch_latency();
         self.total_code_fetch_latency.record(total_code_fetch_latency);
         self.total_code_fetch_latency_gauge.set(total_code_fetch_latency.as_secs_f64());
 
-        let total_account_fetch_latency = stats.total_account_fetch_latency.duration();
+        let total_account_fetch_latency = stats.total_account_fetch_latency();
         self.total_account_fetch_latency.record(total_account_fetch_latency);
         self.total_account_fetch_latency_gauge.set(total_account_fetch_latency.as_secs_f64());
     }
@@ -161,8 +162,7 @@ impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {
         let res = self.state_provider.basic_account(address);
         let elapsed = start.elapsed();
         self.metrics.account_fetch_latency.record(elapsed);
-        self.stats.total_account_fetches.fetch_add(1, Ordering::Relaxed);
-        self.stats.total_account_fetch_latency.add_duration(elapsed);
+        self.stats.record_account_fetch(elapsed);
         res
     }
 }
@@ -177,8 +177,7 @@ impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {
         let res = self.state_provider.storage(account, storage_key);
         let elapsed = start.elapsed();
         self.metrics.storage_fetch_latency.record(elapsed);
-        self.stats.total_storage_fetches.fetch_add(1, Ordering::Relaxed);
-        self.stats.total_storage_fetch_latency.add_duration(elapsed);
+        self.stats.record_storage_fetch(elapsed);
         res
     }
 }
@@ -189,15 +188,12 @@ impl<S: BytecodeReader> BytecodeReader for InstrumentedStateProvider<S> {
         let res = self.state_provider.bytecode_by_hash(code_hash);
         let elapsed = start.elapsed();
         self.metrics.code_fetch_latency.record(elapsed);
-        self.stats.total_code_fetches.fetch_add(1, Ordering::Relaxed);
-        self.stats.total_code_fetch_latency.add_duration(elapsed);
-        self.stats.total_code_fetched_bytes.fetch_add(
-            res.as_ref()
-                .ok()
-                .and_then(|code| code.as_ref().map(|code| code.len()))
-                .unwrap_or_default(),
-            Ordering::Relaxed,
-        );
+        let bytes = res
+            .as_ref()
+            .ok()
+            .and_then(|code| code.as_ref().map(|code| code.len()))
+            .unwrap_or_default();
+        self.stats.record_code_fetch(elapsed, bytes);
         res
     }
 }
@@ -307,18 +303,37 @@ impl<S: HashedPostStateProvider> HashedPostStateProvider for InstrumentedStatePr
 /// Shared via `Arc` so statistics can be read after the provider is consumed.
 #[derive(Debug, Default)]
 pub struct StateProviderStats {
-    total_storage_fetches: AtomicUsize,
-    total_storage_fetch_latency: AtomicDuration,
+    total_storage_fetches: CachePadded<AtomicUsize>,
+    total_storage_fetch_latency: CachePadded<AtomicDuration>,
 
-    total_code_fetches: AtomicUsize,
-    total_code_fetch_latency: AtomicDuration,
-    total_code_fetched_bytes: AtomicUsize,
+    total_code_fetches: CachePadded<AtomicUsize>,
+    total_code_fetch_latency: CachePadded<AtomicDuration>,
+    total_code_fetched_bytes: CachePadded<AtomicUsize>,
 
-    total_account_fetches: AtomicUsize,
-    total_account_fetch_latency: AtomicDuration,
+    total_account_fetches: CachePadded<AtomicUsize>,
+    total_account_fetch_latency: CachePadded<AtomicDuration>,
 }
 
 impl StateProviderStats {
+    /// Records one storage fetch with its latency.
+    pub fn record_storage_fetch(&self, latency: Duration) {
+        self.total_storage_fetches.fetch_add(1, Ordering::Relaxed);
+        self.total_storage_fetch_latency.add_duration(latency);
+    }
+
+    /// Records one code fetch with its latency and bytecode size.
+    pub fn record_code_fetch(&self, latency: Duration, bytes: usize) {
+        self.total_code_fetches.fetch_add(1, Ordering::Relaxed);
+        self.total_code_fetch_latency.add_duration(latency);
+        self.total_code_fetched_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Records one account fetch with its latency.
+    pub fn record_account_fetch(&self, latency: Duration) {
+        self.total_account_fetches.fetch_add(1, Ordering::Relaxed);
+        self.total_account_fetch_latency.add_duration(latency);
+    }
+
     /// Returns total number of storage fetches.
     pub fn total_storage_fetches(&self) -> usize {
         self.total_storage_fetches.load(Ordering::Relaxed)


### PR DESCRIPTION
Pads block-local state provider and execution cache stats with CachePadded to avoid cache-line contention when payload processing workers update adjacent counters. Adds a focused Criterion benchmark comparing the padded production stats against local unpadded equivalents under split-field parallel updates.