### PR TITLE
perf(net): remove redundant lookups in tx propagation

### DIFF
--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -380,10 +380,6 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     pub fn buffer_hashes(&mut self, hashes: RequestTxHashes, fallback_peer: Option<PeerId>) {
         for hash in hashes {
             // hash could have been evicted from bounded lru map
-            if self.hashes_fetch_inflight_and_pending_fetch.peek(&hash).is_none() {
-                continue
-            }
-
             let Some(TxFetchMetadata { retries, fallback_peers, .. }) =
                 self.hashes_fetch_inflight_and_pending_fetch.get(&hash)
             else {

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -997,11 +997,9 @@ where
                 return
             }
 
-            if let Some(peer) = self.peers.get_mut(&peer_id) {
-                for hash in new_pooled_hashes.iter_hashes().copied() {
-                    propagated.record(hash, PropagateKind::Hash(peer_id));
-                    peer.seen_transactions.insert(hash);
-                }
+            for hash in new_pooled_hashes.iter_hashes().copied() {
+                propagated.record(hash, PropagateKind::Hash(peer_id));
+                peer.seen_transactions.insert(hash);
             }
 
             trace!(target: "net::tx::propagation", ?peer_id, ?new_pooled_hashes, "Propagating transactions to peer");


### PR DESCRIPTION
`propagate_hashes_to` looked up the same peer twice and `TransactionFetcher::buffer_hashes` did a `peek` immediately followed by a `get` on the same map entry; the `get` already returns `None` for missing entries.