### PR TITLE
feat(engine): add CustomBlockExecutor hook to BasicEngineValidator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,6 +3584,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-custom-block-executor"
+version = "0.0.0"
+dependencies = [
+ "alloy-genesis",
+ "alloy-network",
+ "eyre",
+ "reth-engine-tree",
+ "reth-ethereum",
+ "reth-storage-overlay",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "example-custom-dev-node"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ members = [
     "examples/bsc-p2p",
     "examples/custom-dev-node/",
     "examples/custom-state-root/",
+    "examples/custom-block-executor/",
     "examples/custom-engine-types/",
     "examples/custom-evm/",
     "examples/custom-hardforks/",

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -80,8 +80,8 @@ pub use invalid_headers::InvalidHeaderCache;
 pub use metrics::EngineApiMetrics;
 pub use payload_processor::*;
 pub use payload_validator::{
-    BasicEngineValidator, CustomBlockExecutionOutput, CustomBlockExecutor,
-    CustomBlockExecutorInput, EngineValidator, ReceiptRootReceiver, ReceiptRootSender,
+    BasicEngineValidator, CustomBlockExecutionHook, CustomBlockExecutionHookInput,
+    CustomBlockExecutionOutput, EngineValidator, ReceiptRootReceiver, ReceiptRootSender,
 };
 pub use persistence_state::PersistenceState;
 pub use reth_engine_primitives::TreeConfig;

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -79,7 +79,10 @@ pub use block_buffer::BlockBuffer;
 pub use invalid_headers::InvalidHeaderCache;
 pub use metrics::EngineApiMetrics;
 pub use payload_processor::*;
-pub use payload_validator::{BasicEngineValidator, EngineValidator};
+pub use payload_validator::{
+    BasicEngineValidator, CustomBlockExecutionOutput, CustomBlockExecutor,
+    CustomBlockExecutorInput, EngineValidator, ReceiptRootReceiver, ReceiptRootSender,
+};
 pub use persistence_state::PersistenceState;
 pub use reth_engine_primitives::TreeConfig;
 pub use reth_execution_cache::{

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -19,7 +19,10 @@
 //!    streaming state-root job can provide a sink for prewarm and execution updates.
 //! 5. Execute the block. BAL payloads use the parallel BAL execute path only when state caching and
 //!    BAL parallel execution are enabled. Otherwise the regular executor still builds and validates
-//!    the BAL before post-execution consensus uses the decoded BAL hash.
+//!    the BAL before post-execution consensus uses the decoded BAL hash. Serial execution can be
+//!    overridden via [`CustomBlockExecutor`] installed on
+//!    [`BasicEngineValidator::with_custom_block_executor`]. Returning `None` from the hook falls
+//!    back to the default execution path.
 //! 6. Stop prewarming, terminate execution caching, spawn `hash-post-state`, await
 //!    `payload-convert` and `receipt-root`, then run post-execution consensus validation.
 //! 7. Resolve the state root by finishing the prepared job. The sparse-trie job falls back to
@@ -176,9 +179,11 @@ const MAX_EXPECTED_GAS_USAGE_MULTIPLIER: u64 = 2;
 /// Worker name for deferred trie data preparation.
 const DEFERRED_TRIE_WORKER_NAME: &str = "deferred-trie";
 
-type ReceiptRootSender<N> =
+/// Sender half of the incremental receipt root computation channel.
+pub type ReceiptRootSender<N> =
     crossbeam_channel::Sender<IndexedReceipt<<N as NodePrimitives>::Receipt>>;
-type ReceiptRootReceiver = tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>;
+/// Receiver for the receipt root computed during block execution.
+pub type ReceiptRootReceiver = tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>;
 
 /// Context providing access to tree state during validation.
 ///
@@ -296,6 +301,12 @@ where
     /// None if txpool prewarming is disabled.
     #[debug(skip)]
     txpool_prewarm: Option<txpool_prewarm::Handle<Evm::Primitives, P, Evm>>,
+    /// Optional hook to override serial block execution.
+    ///
+    /// When set, the hook is invoked on the non-BAL execution path. Returning `None` falls back
+    /// to the default [`Self::execute_block`] implementation.
+    #[debug(skip)]
+    custom_block_executor: Option<CustomBlockExecutor<Evm::Primitives, Evm>>,
 }
 
 impl<N, P, Evm, V> BasicEngineValidator<P, Evm, V>
@@ -360,6 +371,7 @@ where
             overlay_manager,
             state_root_strategy: Arc::new(DefaultStateRootStrategy::default()),
             txpool_prewarm: None,
+            custom_block_executor: None,
         }
     }
 
@@ -383,6 +395,32 @@ where
             self.evm_config.clone(),
         ));
         self
+    }
+
+    /// Sets a custom block executor hook for the serial (non-BAL) execution path.
+    ///
+    /// The hook is called during [`Self::validate_block_with_state`]. If it returns `None`, the
+    /// validator falls back to the default execution path.
+    pub fn with_custom_block_executor(
+        mut self,
+        custom_block_executor: CustomBlockExecutor<N, Evm>,
+    ) -> Self {
+        self.custom_block_executor = Some(custom_block_executor);
+        self
+    }
+
+    /// Spawns a background receipt root computation task.
+    ///
+    /// Custom block executors that return [`CustomBlockExecutionOutput`] must send receipts to the
+    /// returned sender so that `receipt_root_rx` can be awaited downstream.
+    pub fn spawn_receipt_root_task(
+        &self,
+        receipts_len: usize,
+    ) -> (ReceiptRootSender<N>, ReceiptRootReceiver)
+    where
+        N: NodePrimitives,
+    {
+        self.spawn_receipt_root_task_inner(receipts_len)
     }
 
     /// Converts a [`BlockOrPayload`] to a recovered block.
@@ -718,7 +756,7 @@ where
         } else {
             let state_provider = make_state_provider(false);
             match state_provider {
-                Ok(state_provider) => self.execute_block(
+                Ok(state_provider) => self.execute_serial_block(
                     state_provider,
                     env,
                     &input,
@@ -975,6 +1013,55 @@ where
         }
     }
 
+    /// Executes a block on the serial path, optionally delegating to a custom executor hook.
+    #[expect(clippy::type_complexity)]
+    fn execute_serial_block<S, Err, T>(
+        &mut self,
+        state_provider: S,
+        env: ExecutionEnv<Evm>,
+        input: &BlockOrPayload<T>,
+        handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
+        state_hook: Option<Box<dyn OnStateHook + 'static>>,
+    ) -> Result<
+        (
+            BlockExecutionOutput<N::Receipt>,
+            Vec<Address>,
+            ReceiptRootReceiver,
+            Option<BlockAccessList>,
+        ),
+        InsertBlockErrorKind,
+    >
+    where
+        S: StateProvider + Send,
+        Err: core::error::Error + Send + Sync + 'static,
+        V: PayloadValidator<T, Block = N::Block>,
+        T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
+        Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
+    {
+        if let Some(custom) = &self.custom_block_executor {
+            let spawn_receipt_root = |len: usize| self.spawn_receipt_root_task_inner(len);
+            let custom_input =
+                CustomBlockExecutorInput::new(&env, &state_provider, &spawn_receipt_root);
+            let execution_start = Instant::now();
+            if let Some(result) = custom(custom_input)? {
+                let execution_duration = execution_start.elapsed();
+                self.metrics.record_block_execution(&result.output, execution_duration);
+                self.metrics.record_block_execution_gas_bucket(
+                    result.output.result.gas_used,
+                    execution_duration,
+                );
+                return Ok((
+                    result.output,
+                    result.senders,
+                    result.receipt_root_rx,
+                    result.built_bal,
+                ));
+            }
+        }
+
+        self.execute_block(state_provider, env, input, handle, state_hook)
+    }
+
     /// Executes a block with the given state provider.
     ///
     /// This method orchestrates block execution:
@@ -1050,7 +1137,7 @@ where
         }
 
         let transaction_count = input.transaction_count();
-        let (receipt_tx, result_rx) = self.spawn_receipt_root_task(transaction_count);
+        let (receipt_tx, result_rx) = self.spawn_receipt_root_task_inner(transaction_count);
         let executed_tx_index = Arc::clone(handle.executed_tx_index());
         executor.evm_mut().db_mut().set_state_hook(state_hook);
 
@@ -1146,7 +1233,7 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block via BAL path");
 
-        let (receipt_tx, result_rx) = self.spawn_receipt_root_task(env.transaction_count);
+        let (receipt_tx, result_rx) = self.spawn_receipt_root_task_inner(env.transaction_count);
         let input_bal = env.decoded_bal.ok_or_else(|| {
             InsertBlockErrorKind::Other("BAL execute path: no decoded BAL available".into())
         })?;
@@ -1183,7 +1270,7 @@ where
         Ok((output, senders, result_rx, Some(built_bal)))
     }
 
-    fn spawn_receipt_root_task(
+    fn spawn_receipt_root_task_inner(
         &self,
         receipts_len: usize,
     ) -> (ReceiptRootSender<N>, ReceiptRootReceiver) {
@@ -2084,5 +2171,135 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
             Self::Payload(payload) => payload.gas_limit(),
             Self::Block(block) => block.gas_limit(),
         }
+    }
+}
+
+/// Output of a custom block execution hook.
+///
+/// Must match the return shape of [`BasicEngineValidator::execute_block`].
+///
+/// # Integration patterns
+///
+/// **Full cache hit** — when execution was completed earlier (e.g. via flashblocks), return the
+/// cached [`BlockExecutionOutput`] and a pre-resolved `receipt_root_rx` from a completed
+/// `tokio::sync::oneshot` channel.
+///
+/// **Incremental execution** — call [`CustomBlockExecutorInput::spawn_receipt_root_task`] and
+/// stream [`IndexedReceipt`]s to the sender while executing transactions, matching the default
+/// path in [`BasicEngineValidator::execute_block`].
+pub struct CustomBlockExecutionOutput<N: NodePrimitives> {
+    /// Block execution output.
+    pub output: BlockExecutionOutput<N::Receipt>,
+    /// Recovered transaction senders.
+    pub senders: Vec<Address>,
+    /// Receiver for the receipt root computed during execution.
+    pub receipt_root_rx: ReceiptRootReceiver,
+    /// Built block access list, if any.
+    pub built_bal: Option<BlockAccessList>,
+}
+
+impl<N: NodePrimitives> std::fmt::Debug for CustomBlockExecutionOutput<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CustomBlockExecutionOutput")
+            .field("output", &self.output)
+            .field("senders", &self.senders)
+            .field("receipt_root_rx", &"<ReceiptRootReceiver>")
+            .field("built_bal", &self.built_bal.as_ref().map(|_| "<BlockAccessList>"))
+            .finish()
+    }
+}
+
+/// Input for [`CustomBlockExecutor`].
+///
+/// Transaction bodies are not included here. Integrators that need transaction-granular reuse
+/// (e.g. flashblocks) should key external caches by [`ExecutionEnv::hash`] and validate prefixes
+/// against the payload before returning [`CustomBlockExecutionOutput`].
+pub struct CustomBlockExecutorInput<'a, Evm: ConfigureEvm, N: NodePrimitives> {
+    /// Execution environment for the block.
+    pub env: &'a ExecutionEnv<Evm>,
+    /// State provider at the parent block.
+    pub state_provider: &'a dyn StateProvider,
+    receipt_root_spawner: &'a dyn Fn(usize) -> (ReceiptRootSender<N>, ReceiptRootReceiver),
+}
+
+impl<Evm: ConfigureEvm, N: NodePrimitives> std::fmt::Debug
+    for CustomBlockExecutorInput<'_, Evm, N>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CustomBlockExecutorInput")
+            .field("env", self.env)
+            .field("state_provider", &"<dyn StateProvider>")
+            .field("receipt_root_spawner", &"<Fn>")
+            .finish()
+    }
+}
+
+impl<'a, Evm: ConfigureEvm, N: NodePrimitives> CustomBlockExecutorInput<'a, Evm, N> {
+    /// Creates a new custom block executor input.
+    pub fn new(
+        env: &'a ExecutionEnv<Evm>,
+        state_provider: &'a dyn StateProvider,
+        receipt_root_spawner: &'a dyn Fn(usize) -> (ReceiptRootSender<N>, ReceiptRootReceiver),
+    ) -> Self {
+        Self { env, state_provider, receipt_root_spawner }
+    }
+
+    /// Spawns a background receipt root computation task.
+    ///
+    /// Custom executors that run transactions incrementally should send [`IndexedReceipt`]s to the
+    /// returned sender so that `receipt_root_rx` can be awaited downstream.
+    pub fn spawn_receipt_root_task(
+        &self,
+        receipts_len: usize,
+    ) -> (ReceiptRootSender<N>, ReceiptRootReceiver) {
+        (self.receipt_root_spawner)(receipts_len)
+    }
+}
+
+/// Custom block executor hook for the serial (non-BAL) execution path.
+///
+/// Return `Ok(None)` to fall back to the default execution path.
+pub type CustomBlockExecutor<N, Evm> = Arc<
+    dyn Fn(
+            CustomBlockExecutorInput<'_, Evm, N>,
+        ) -> Result<Option<CustomBlockExecutionOutput<N>>, InsertBlockErrorKind>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+#[cfg(test)]
+mod custom_block_executor_tests {
+    use super::*;
+    use reth_ethereum_primitives::EthPrimitives;
+    use reth_evm_ethereum::MockEvmConfig;
+    use reth_revm::test_utils::StateProviderTest;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn custom_block_executor_none_falls_back() {
+        let state = StateProviderTest::default();
+        let env = ExecutionEnv::<MockEvmConfig>::test_default();
+        let spawner = |_len: usize| {
+            let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
+            let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+            drop(receipt_rx);
+            drop(result_tx);
+            (receipt_tx, result_rx)
+        };
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        let executor: CustomBlockExecutor<EthPrimitives, MockEvmConfig> = Arc::new(move |input| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(input.env.transaction_count, 0);
+            assert!(input.env.hash.is_zero());
+            let (_tx, _rx) = input.spawn_receipt_root_task(0);
+            Ok(None)
+        });
+
+        let input = CustomBlockExecutorInput::new(&env, &state, &spawner);
+        let result = executor(input);
+        assert!(result.unwrap().is_none());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -20,9 +20,9 @@
 //! 5. Execute the block. BAL payloads use the parallel BAL execute path only when state caching and
 //!    BAL parallel execution are enabled. Otherwise the regular executor still builds and validates
 //!    the BAL before post-execution consensus uses the decoded BAL hash. Serial execution can be
-//!    overridden via [`CustomBlockExecutor`] installed on
-//!    [`BasicEngineValidator::with_custom_block_executor`]. Returning `None` from the hook falls
-//!    back to the default execution path.
+//!    overridden via [`CustomBlockExecutionHook`] installed on
+//!    [`BasicEngineValidator::with_custom_block_execution_hook`]. Returning `None` from the hook
+//!    falls back to the default execution path.
 //! 6. Stop prewarming, terminate execution caching, spawn `hash-post-state`, await
 //!    `payload-convert` and `receipt-root`, then run post-execution consensus validation.
 //! 7. Resolve the state root by finishing the prepared job. The sparse-trie job falls back to
@@ -64,12 +64,16 @@
 //!         Main->>Trie: spawn proof workers and sparse trie
 //!     end
 //!     Main->>Prewarm: spawn transaction, BAL, or skipped prewarm
-//!     Main->>Receipt: spawn receipt root task
 //!     alt BAL path eligible
+//!         Main->>Receipt: spawn receipt root task
 //!         Main->>Exec: execute_block_bal
 //!         Prewarm->>Trie: BAL-derived sparse trie updates
+//!     else custom execution hook hit
+//!         Main->>Exec: CustomBlockExecutionHook
+//!         Note over Trie: no execution updates; finish may serial-recompute on mismatch
 //!     else regular execution
 //!         Tx-->>Exec: recovered transactions in block order
+//!         Main->>Receipt: spawn receipt root task
 //!         Main->>Exec: execute_block
 //!         Exec->>Receipt: stream receipts
 //!         Exec->>Trie: stream state hook updates
@@ -306,7 +310,7 @@ where
     /// When set, the hook is invoked on the non-BAL execution path. Returning `None` falls back
     /// to the default [`Self::execute_block`] implementation.
     #[debug(skip)]
-    custom_block_executor: Option<CustomBlockExecutor<Evm::Primitives, Evm>>,
+    custom_block_execution_hook: Option<CustomBlockExecutionHook<Evm::Primitives, Evm>>,
 }
 
 impl<N, P, Evm, V> BasicEngineValidator<P, Evm, V>
@@ -371,7 +375,7 @@ where
             overlay_manager,
             state_root_strategy: Arc::new(DefaultStateRootStrategy::default()),
             txpool_prewarm: None,
-            custom_block_executor: None,
+            custom_block_execution_hook: None,
         }
     }
 
@@ -397,30 +401,16 @@ where
         self
     }
 
-    /// Sets a custom block executor hook for the serial (non-BAL) execution path.
+    /// Sets a custom block execution hook for the serial (non-BAL) execution path.
     ///
     /// The hook is called during [`Self::validate_block_with_state`]. If it returns `None`, the
     /// validator falls back to the default execution path.
-    pub fn with_custom_block_executor(
+    pub fn with_custom_block_execution_hook(
         mut self,
-        custom_block_executor: CustomBlockExecutor<N, Evm>,
+        custom_block_execution_hook: CustomBlockExecutionHook<N, Evm>,
     ) -> Self {
-        self.custom_block_executor = Some(custom_block_executor);
+        self.custom_block_execution_hook = Some(custom_block_execution_hook);
         self
-    }
-
-    /// Spawns a background receipt root computation task.
-    ///
-    /// Custom block executors that return [`CustomBlockExecutionOutput`] must send receipts to the
-    /// returned sender so that `receipt_root_rx` can be awaited downstream.
-    pub fn spawn_receipt_root_task(
-        &self,
-        receipts_len: usize,
-    ) -> (ReceiptRootSender<N>, ReceiptRootReceiver)
-    where
-        N: NodePrimitives,
-    {
-        self.spawn_receipt_root_task_inner(receipts_len)
     }
 
     /// Converts a [`BlockOrPayload`] to a recovered block.
@@ -1013,7 +1003,14 @@ where
         }
     }
 
-    /// Executes a block on the serial path, optionally delegating to a custom executor hook.
+    /// Executes a block on the serial path, optionally delegating to a custom execution hook.
+    ///
+    /// On a custom cache hit the streaming [`OnStateHook`] from the state-root job is unused:
+    /// there is no live EVM to feed incremental trie updates. Dropping the hook finishes the
+    /// sparse-trie update stream with no execution updates; [`PreparedStateRootJob::finish`]
+    /// accepts that task root only if it matches the block header, otherwise it recomputes
+    /// serially. Integrators that need streaming state-root latency on cache hits should also
+    /// install a custom [`StateRootStrategy`].
     #[expect(clippy::type_complexity)]
     fn execute_serial_block<S, Err, T>(
         &mut self,
@@ -1038,12 +1035,15 @@ where
         T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
-        if let Some(custom) = &self.custom_block_executor {
+        if let Some(custom) = &self.custom_block_execution_hook {
             let spawn_receipt_root = |len: usize| self.spawn_receipt_root_task_inner(len);
             let custom_input =
-                CustomBlockExecutorInput::new(&env, &state_provider, &spawn_receipt_root);
+                CustomBlockExecutionHookInput::new(&env, &state_provider, &spawn_receipt_root);
             let execution_start = Instant::now();
             if let Some(result) = custom(custom_input)? {
+                // Leave `state_hook` unused: Drop finishes the sparse-trie stream with no
+                // execution updates. finish() then keeps the task root only if it matches the
+                // header; otherwise it recomputes serially from the cached BundleState.
                 let execution_duration = execution_start.elapsed();
                 self.metrics.record_block_execution(&result.output, execution_duration);
                 self.metrics.record_block_execution_gas_bucket(
@@ -2174,19 +2174,26 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     }
 }
 
-/// Output of a custom block execution hook.
+/// Output of a [`CustomBlockExecutionHook`].
 ///
-/// Must match the return shape of [`BasicEngineValidator::execute_block`].
+/// Must match the return shape of the default serial execution path.
 ///
-/// # Integration patterns
+/// # Integration
 ///
-/// **Full cache hit** — when execution was completed earlier (e.g. via flashblocks), return the
-/// cached [`BlockExecutionOutput`] and a pre-resolved `receipt_root_rx` from a completed
-/// `tokio::sync::oneshot` channel.
+/// **Full-block cache hit** — when execution was completed earlier (e.g. via flashblocks), return
+/// the cached [`BlockExecutionOutput`] and a pre-resolved `receipt_root_rx` from a completed
+/// `tokio::sync::oneshot` channel. Key the external cache by [`ExecutionEnv::hash`].
 ///
-/// **Incremental execution** — call [`CustomBlockExecutorInput::spawn_receipt_root_task`] and
-/// stream [`IndexedReceipt`]s to the sender while executing transactions, matching the default
-/// path in [`BasicEngineValidator::execute_block`].
+/// The streaming state-root [`OnStateHook`] is not passed into the hook and is unused on a hit.
+/// Dropping it finishes the sparse-trie update stream with no execution updates;
+/// [`PreparedStateRootJob::finish`] keeps that task root only if it matches the header, otherwise
+/// it recomputes serially. For streaming state-root latency on cache hits, also install a custom
+/// [`StateRootStrategy`].
+///
+/// **Receipt roots from hook-run execution** — if the hook executes transactions itself, call
+/// [`CustomBlockExecutionHookInput::spawn_receipt_root_task`] and stream [`IndexedReceipt`]s on the
+/// returned [`ReceiptRootSender`]. The hook still does not receive the state-root [`OnStateHook`],
+/// so sparse-trie streaming remains unavailable on this path.
 pub struct CustomBlockExecutionOutput<N: NodePrimitives> {
     /// Block execution output.
     pub output: BlockExecutionOutput<N::Receipt>,
@@ -2209,12 +2216,13 @@ impl<N: NodePrimitives> std::fmt::Debug for CustomBlockExecutionOutput<N> {
     }
 }
 
-/// Input for [`CustomBlockExecutor`].
+/// Input for [`CustomBlockExecutionHook`].
 ///
-/// Transaction bodies are not included here. Integrators that need transaction-granular reuse
-/// (e.g. flashblocks) should key external caches by [`ExecutionEnv::hash`] and validate prefixes
-/// against the payload before returning [`CustomBlockExecutionOutput`].
-pub struct CustomBlockExecutorInput<'a, Evm: ConfigureEvm, N: NodePrimitives> {
+/// Transaction bodies are not included. Full-block reuse should key an external cache by
+/// [`ExecutionEnv::hash`]. Transaction-granular (prefix) reuse is the integrator's responsibility
+/// outside this hook; validate any reused prefix against the payload before returning
+/// [`CustomBlockExecutionOutput`].
+pub struct CustomBlockExecutionHookInput<'a, Evm: ConfigureEvm, N: NodePrimitives> {
     /// Execution environment for the block.
     pub env: &'a ExecutionEnv<Evm>,
     /// State provider at the parent block.
@@ -2223,10 +2231,10 @@ pub struct CustomBlockExecutorInput<'a, Evm: ConfigureEvm, N: NodePrimitives> {
 }
 
 impl<Evm: ConfigureEvm, N: NodePrimitives> std::fmt::Debug
-    for CustomBlockExecutorInput<'_, Evm, N>
+    for CustomBlockExecutionHookInput<'_, Evm, N>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CustomBlockExecutorInput")
+        f.debug_struct("CustomBlockExecutionHookInput")
             .field("env", self.env)
             .field("state_provider", &"<dyn StateProvider>")
             .field("receipt_root_spawner", &"<Fn>")
@@ -2234,8 +2242,8 @@ impl<Evm: ConfigureEvm, N: NodePrimitives> std::fmt::Debug
     }
 }
 
-impl<'a, Evm: ConfigureEvm, N: NodePrimitives> CustomBlockExecutorInput<'a, Evm, N> {
-    /// Creates a new custom block executor input.
+impl<'a, Evm: ConfigureEvm, N: NodePrimitives> CustomBlockExecutionHookInput<'a, Evm, N> {
+    /// Creates a new custom block execution hook input.
     pub fn new(
         env: &'a ExecutionEnv<Evm>,
         state_provider: &'a dyn StateProvider,
@@ -2246,8 +2254,8 @@ impl<'a, Evm: ConfigureEvm, N: NodePrimitives> CustomBlockExecutorInput<'a, Evm,
 
     /// Spawns a background receipt root computation task.
     ///
-    /// Custom executors that run transactions incrementally should send [`IndexedReceipt`]s to the
-    /// returned sender so that `receipt_root_rx` can be awaited downstream.
+    /// This is the supported way to spawn the task from a hook. Stream [`IndexedReceipt`]s on the
+    /// returned [`ReceiptRootSender`] so `receipt_root_rx` can be awaited downstream.
     pub fn spawn_receipt_root_task(
         &self,
         receipts_len: usize,
@@ -2256,12 +2264,18 @@ impl<'a, Evm: ConfigureEvm, N: NodePrimitives> CustomBlockExecutorInput<'a, Evm,
     }
 }
 
-/// Custom block executor hook for the serial (non-BAL) execution path.
+/// Custom block execution hook for the serial (non-BAL) execution path.
 ///
 /// Return `Ok(None)` to fall back to the default execution path.
-pub type CustomBlockExecutor<N, Evm> = Arc<
+///
+/// On `Ok(Some(_))`, the streaming state-root [`OnStateHook`] is unused; see
+/// [`CustomBlockExecutionOutput`] for the state-root implications.
+///
+/// Named to avoid colliding with `BlockExecutor` implementations such as the
+/// `CustomBlockExecutor` type in `examples/custom-beacon-withdrawals`.
+pub type CustomBlockExecutionHook<N, Evm> = Arc<
     dyn Fn(
-            CustomBlockExecutorInput<'_, Evm, N>,
+            CustomBlockExecutionHookInput<'_, Evm, N>,
         ) -> Result<Option<CustomBlockExecutionOutput<N>>, InsertBlockErrorKind>
         + Send
         + Sync
@@ -2269,27 +2283,33 @@ pub type CustomBlockExecutor<N, Evm> = Arc<
 >;
 
 #[cfg(test)]
-mod custom_block_executor_tests {
+mod custom_block_execution_hook_tests {
     use super::*;
+    use alloy_primitives::Bloom;
     use reth_ethereum_primitives::EthPrimitives;
     use reth_evm_ethereum::MockEvmConfig;
     use reth_revm::test_utils::StateProviderTest;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    fn test_receipt_root_spawner(
+        _len: usize,
+    ) -> (ReceiptRootSender<EthPrimitives>, ReceiptRootReceiver) {
+        let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        drop(receipt_rx);
+        drop(result_tx);
+        (receipt_tx, result_rx)
+    }
+
+    /// Contract test: `Ok(None)` is the documented fallback signal. Does not exercise
+    /// `execute_serial_block` dispatch.
     #[test]
-    fn custom_block_executor_none_falls_back() {
+    fn hook_none_is_fallback_signal() {
         let state = StateProviderTest::default();
         let env = ExecutionEnv::<MockEvmConfig>::test_default();
-        let spawner = |_len: usize| {
-            let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
-            let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-            drop(receipt_rx);
-            drop(result_tx);
-            (receipt_tx, result_rx)
-        };
         let calls = Arc::new(AtomicUsize::new(0));
         let calls_clone = Arc::clone(&calls);
-        let executor: CustomBlockExecutor<EthPrimitives, MockEvmConfig> = Arc::new(move |input| {
+        let hook: CustomBlockExecutionHook<EthPrimitives, MockEvmConfig> = Arc::new(move |input| {
             calls_clone.fetch_add(1, Ordering::SeqCst);
             assert_eq!(input.env.transaction_count, 0);
             assert!(input.env.hash.is_zero());
@@ -2297,9 +2317,42 @@ mod custom_block_executor_tests {
             Ok(None)
         });
 
-        let input = CustomBlockExecutorInput::new(&env, &state, &spawner);
-        let result = executor(input);
+        let input = CustomBlockExecutionHookInput::new(&env, &state, &test_receipt_root_spawner);
+        let result = hook(input);
         assert!(result.unwrap().is_none());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Contract test: `Ok(Some(_))` carries the cached output shape, including a pre-resolved
+    /// receipt root. Does not exercise `execute_serial_block` dispatch.
+    #[test]
+    fn hook_some_returns_cached_output_shape() {
+        let state = StateProviderTest::default();
+        let env = ExecutionEnv::<MockEvmConfig>::test_default();
+        let expected_root = B256::repeat_byte(0xab);
+        let expected_bloom = Bloom::repeat_byte(0xcd);
+
+        let hook: CustomBlockExecutionHook<EthPrimitives, MockEvmConfig> =
+            Arc::new(move |_input| {
+                let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+                result_tx.send((expected_root, expected_bloom)).unwrap();
+                Ok(Some(CustomBlockExecutionOutput {
+                    output: BlockExecutionOutput {
+                        result: Default::default(),
+                        state: Default::default(),
+                    },
+                    senders: vec![Address::repeat_byte(0x11)],
+                    receipt_root_rx: result_rx,
+                    built_bal: None,
+                }))
+            });
+
+        let input = CustomBlockExecutionHookInput::new(&env, &state, &test_receipt_root_spawner);
+        let result = hook(input).unwrap().expect("cache hit");
+        assert_eq!(result.senders, vec![Address::repeat_byte(0x11)]);
+        assert!(result.built_bal.is_none());
+        let (root, bloom) = result.receipt_root_rx.blocking_recv().unwrap();
+        assert_eq!(root, expected_root);
+        assert_eq!(bloom, expected_bloom);
     }
 }

--- a/examples/custom-block-executor/Cargo.toml
+++ b/examples/custom-block-executor/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-custom-block-executor"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+reth-ethereum = { workspace = true, features = ["node", "test-utils"] }
+reth-engine-tree.workspace = true
+reth-storage-overlay.workspace = true
+
+eyre.workspace = true
+tokio.workspace = true
+serde_json.workspace = true
+
+alloy-genesis.workspace = true
+alloy-network.workspace = true

--- a/examples/custom-block-executor/src/main.rs
+++ b/examples/custom-block-executor/src/main.rs
@@ -1,16 +1,15 @@
 //! Example: Running a reth node with a custom block execution hook.
 //!
-//! This demonstrates how to use the [`CustomBlockExecutor`] hook on the serial (non-BAL)
+//! This demonstrates how to install a [`CustomBlockExecutionHook`] on the serial (non-BAL)
 //! execution path. The example always returns `Ok(None)` so the validator falls back to the
-//! default execution path.
+//! default execution path — it only shows builder wiring.
 //!
 //! The key integration point is wrapping [`BasicEngineValidatorBuilder`] to call
-//! [`BasicEngineValidator::with_custom_block_executor`] on the resulting validator.
+//! [`BasicEngineValidator::with_custom_block_execution_hook`] on the resulting validator.
 //!
-//! For a full cache hit (e.g. reusing flashblock execution), return
-//! [`CustomBlockExecutionOutput`] with a pre-resolved `receipt_root_rx`. For incremental
-//! execution inside the hook, call [`CustomBlockExecutorInput::spawn_receipt_root_task`] and
-//! stream receipts to the sender.
+//! For a full-block cache hit (e.g. reusing flashblock execution keyed by `input.env.hash`),
+//! return [`CustomBlockExecutionOutput`] with a pre-resolved `receipt_root_rx`. See the type
+//! docs for state-root implications on that path.
 //!
 //! # Usage
 //!
@@ -24,7 +23,7 @@ use std::sync::Arc;
 
 use alloy_genesis::Genesis;
 use reth_engine_tree::tree::{
-    payload_validator::CustomBlockExecutor, BasicEngineValidator, TreeConfig,
+    payload_validator::CustomBlockExecutionHook, BasicEngineValidator, TreeConfig,
 };
 use reth_ethereum::{
     chainspec::ChainSpec,
@@ -53,22 +52,22 @@ type ExampleEvmConfig = EthEvmConfig<ChainSpec, RethEvmFactory>;
 // ---------------------------------------------------------------------------
 
 /// An [`EngineValidatorBuilder`] that wraps [`BasicEngineValidatorBuilder`] and
-/// installs a [`CustomBlockExecutor`] on the resulting [`BasicEngineValidator`].
+/// installs a [`CustomBlockExecutionHook`] on the resulting [`BasicEngineValidator`].
 #[derive(Clone)]
-struct PassthroughBlockExecutorValidatorBuilder {
+struct PassthroughBlockExecutionHookValidatorBuilder {
     inner: BasicEngineValidatorBuilder<EthereumEngineValidatorBuilder>,
-    custom_block_executor: CustomBlockExecutor<EthPrimitives, ExampleEvmConfig>,
+    custom_block_execution_hook: CustomBlockExecutionHook<EthPrimitives, ExampleEvmConfig>,
 }
 
-impl std::fmt::Debug for PassthroughBlockExecutorValidatorBuilder {
+impl std::fmt::Debug for PassthroughBlockExecutionHookValidatorBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PassthroughBlockExecutorValidatorBuilder")
+        f.debug_struct("PassthroughBlockExecutionHookValidatorBuilder")
             .field("inner", &self.inner)
             .finish_non_exhaustive()
     }
 }
 
-impl<N> EngineValidatorBuilder<N> for PassthroughBlockExecutorValidatorBuilder
+impl<N> EngineValidatorBuilder<N> for PassthroughBlockExecutionHookValidatorBuilder
 where
     N: FullNodeComponents<Types = EthereumNode, Evm = ExampleEvmConfig>,
 {
@@ -84,9 +83,8 @@ where
         tree_config: TreeConfig,
         overlay_manager: OverlayManager<EthPrimitives>,
     ) -> eyre::Result<Self::EngineValidator> {
-        let validator =
-            self.inner.build_tree_validator(ctx, tree_config, overlay_manager).await?;
-        Ok(validator.with_custom_block_executor(self.custom_block_executor))
+        let validator = self.inner.build_tree_validator(ctx, tree_config, overlay_manager).await?;
+        Ok(validator.with_custom_block_execution_hook(self.custom_block_execution_hook))
     }
 }
 
@@ -98,9 +96,9 @@ where
 async fn main() -> eyre::Result<()> {
     let runtime = Runtime::test();
 
-    // A custom block executor that always falls back to the default path.
-    // Replace with cache lookup keyed by `input.env.hash` to reuse prior execution.
-    let passthrough_executor: CustomBlockExecutor<EthPrimitives, ExampleEvmConfig> =
+    // Always fall back to the default path. Replace with a cache lookup keyed by
+    // `input.env.hash` to reuse prior full-block execution.
+    let passthrough_hook: CustomBlockExecutionHook<EthPrimitives, ExampleEvmConfig> =
         Arc::new(|input| {
             let _block_hash = input.env.hash;
             Ok(None)
@@ -111,14 +109,14 @@ async fn main() -> eyre::Result<()> {
         .with_rpc(RpcServerArgs::default().with_http())
         .with_chain(custom_chain());
 
-    let add_ons: EthereumAddOns<_, _, _, _, PassthroughBlockExecutorValidatorBuilder> =
+    let add_ons: EthereumAddOns<_, _, _, _, PassthroughBlockExecutionHookValidatorBuilder> =
         EthereumAddOns::new(RpcAddOns::new(
             EthereumEthApiBuilder::<alloy_network::Ethereum>::default(),
             EthereumEngineValidatorBuilder::default(),
             BasicEngineApiBuilder::<EthereumEngineValidatorBuilder>::default(),
-            PassthroughBlockExecutorValidatorBuilder {
+            PassthroughBlockExecutionHookValidatorBuilder {
                 inner: BasicEngineValidatorBuilder::default(),
-                custom_block_executor: passthrough_executor,
+                custom_block_execution_hook: passthrough_hook,
             },
             Default::default(),
             Identity::new(),
@@ -132,7 +130,7 @@ async fn main() -> eyre::Result<()> {
         .launch_with_debug_capabilities()
         .await?;
 
-    println!("Node running with custom block executor hook — press Ctrl+C to exit");
+    println!("Node running with custom block execution hook — press Ctrl+C to exit");
 
     node_exit_future.await
 }

--- a/examples/custom-block-executor/src/main.rs
+++ b/examples/custom-block-executor/src/main.rs
@@ -1,0 +1,179 @@
+//! Example: Running a reth node with a custom block execution hook.
+//!
+//! This demonstrates how to use the [`CustomBlockExecutor`] hook on the serial (non-BAL)
+//! execution path. The example always returns `Ok(None)` so the validator falls back to the
+//! default execution path.
+//!
+//! The key integration point is wrapping [`BasicEngineValidatorBuilder`] to call
+//! [`BasicEngineValidator::with_custom_block_executor`] on the resulting validator.
+//!
+//! For a full cache hit (e.g. reusing flashblock execution), return
+//! [`CustomBlockExecutionOutput`] with a pre-resolved `receipt_root_rx`. For incremental
+//! execution inside the hook, call [`CustomBlockExecutorInput::spawn_receipt_root_task`] and
+//! stream receipts to the sender.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run -p example-custom-block-executor -- node --dev --http
+//! ```
+
+#![warn(unused_crate_dependencies)]
+
+use std::sync::Arc;
+
+use alloy_genesis::Genesis;
+use reth_engine_tree::tree::{
+    payload_validator::CustomBlockExecutor, BasicEngineValidator, TreeConfig,
+};
+use reth_ethereum::{
+    chainspec::ChainSpec,
+    evm::factory::RethEvmFactory,
+    node::{
+        builder::{
+            rpc::{
+                BasicEngineApiBuilder, BasicEngineValidatorBuilder, EngineValidatorBuilder,
+                Identity, RpcAddOns,
+            },
+            FullNodeComponents, NodeBuilder, NodeHandle,
+        },
+        core::{args::RpcServerArgs, node_config::NodeConfig},
+        EthEvmConfig, EthereumAddOns, EthereumEngineValidatorBuilder, EthereumEthApiBuilder,
+        EthereumNode,
+    },
+    tasks::Runtime,
+    EthPrimitives,
+};
+use reth_storage_overlay::OverlayManager;
+
+type ExampleEvmConfig = EthEvmConfig<ChainSpec, RethEvmFactory>;
+
+// ---------------------------------------------------------------------------
+// Custom Engine Validator Builder
+// ---------------------------------------------------------------------------
+
+/// An [`EngineValidatorBuilder`] that wraps [`BasicEngineValidatorBuilder`] and
+/// installs a [`CustomBlockExecutor`] on the resulting [`BasicEngineValidator`].
+#[derive(Clone)]
+struct PassthroughBlockExecutorValidatorBuilder {
+    inner: BasicEngineValidatorBuilder<EthereumEngineValidatorBuilder>,
+    custom_block_executor: CustomBlockExecutor<EthPrimitives, ExampleEvmConfig>,
+}
+
+impl std::fmt::Debug for PassthroughBlockExecutorValidatorBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PassthroughBlockExecutorValidatorBuilder")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<N> EngineValidatorBuilder<N> for PassthroughBlockExecutorValidatorBuilder
+where
+    N: FullNodeComponents<Types = EthereumNode, Evm = ExampleEvmConfig>,
+{
+    type EngineValidator = BasicEngineValidator<
+        N::Provider,
+        N::Evm,
+        <EthereumEngineValidatorBuilder as reth_ethereum::node::builder::rpc::PayloadValidatorBuilder<N>>::Validator,
+    >;
+
+    async fn build_tree_validator(
+        self,
+        ctx: &reth_ethereum::node::builder::AddOnsContext<'_, N>,
+        tree_config: TreeConfig,
+        overlay_manager: OverlayManager<EthPrimitives>,
+    ) -> eyre::Result<Self::EngineValidator> {
+        let validator =
+            self.inner.build_tree_validator(ctx, tree_config, overlay_manager).await?;
+        Ok(validator.with_custom_block_executor(self.custom_block_executor))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let runtime = Runtime::test();
+
+    // A custom block executor that always falls back to the default path.
+    // Replace with cache lookup keyed by `input.env.hash` to reuse prior execution.
+    let passthrough_executor: CustomBlockExecutor<EthPrimitives, ExampleEvmConfig> =
+        Arc::new(|input| {
+            let _block_hash = input.env.hash;
+            Ok(None)
+        });
+
+    let node_config = NodeConfig::test()
+        .dev()
+        .with_rpc(RpcServerArgs::default().with_http())
+        .with_chain(custom_chain());
+
+    let add_ons: EthereumAddOns<_, _, _, _, PassthroughBlockExecutorValidatorBuilder> =
+        EthereumAddOns::new(RpcAddOns::new(
+            EthereumEthApiBuilder::<alloy_network::Ethereum>::default(),
+            EthereumEngineValidatorBuilder::default(),
+            BasicEngineApiBuilder::<EthereumEngineValidatorBuilder>::default(),
+            PassthroughBlockExecutorValidatorBuilder {
+                inner: BasicEngineValidatorBuilder::default(),
+                custom_block_executor: passthrough_executor,
+            },
+            Default::default(),
+            Identity::new(),
+        ));
+
+    let NodeHandle { node: _node, node_exit_future } = NodeBuilder::new(node_config)
+        .testing_node(runtime)
+        .with_types::<EthereumNode>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(add_ons)
+        .launch_with_debug_capabilities()
+        .await?;
+
+    println!("Node running with custom block executor hook — press Ctrl+C to exit");
+
+    node_exit_future.await
+}
+
+fn custom_chain() -> Arc<ChainSpec> {
+    let custom_genesis = r#"
+{
+    "nonce": "0x42",
+    "timestamp": "0x0",
+    "extraData": "0x5343",
+    "gasLimit": "0x1c9c380",
+    "difficulty": "0x0",
+    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "coinbase": "0x0000000000000000000000000000000000000000",
+    "alloc": {
+        "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b": {
+            "balance": "0x4a47e3c12448f4ad000000"
+        }
+    },
+    "number": "0x0",
+    "gasUsed": "0x0",
+    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "config": {
+        "ethash": {},
+        "chainId": 2600,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 0,
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
+        "shanghaiTime": 0
+    }
+}
+"#;
+    let genesis: Genesis = serde_json::from_str(custom_genesis).unwrap();
+    Arc::new(genesis.into())
+}


### PR DESCRIPTION
Closes #21280

Adds a `CustomBlockExecutionHook` on `BasicEngineValidator` so downstream nodes can override serial block execution during `engine_newPayload`.

The idea is pretty simple: if you've already executed the full block earlier (flashblocks), you can return that cached result when the full block shows up. If you can't reuse anything, return `Ok(None)` and fall back to the normal execution path.

This follows the same extension style as `with_state_root_strategy` — small optional hook, default behavior unchanged when it isn't set.

A few details:

- serial path only; BAL is untouched
- post-exec validation + state root checks still run after the hook
- hook input has `env` + parent state provider; tx bodies aren't passed in, so external caches should key off `ExecutionEnv::hash`
- on a cache hit the streaming state-root `OnStateHook` is unused (no live EVM to feed). The sparse-trie stream finishes empty; `finish` keeps that root only if it matches the header, otherwise it recomputes serially. Streaming state-root latency on hits needs a custom `StateRootStrategy` too
- payload processor / prewarm still run before the hook
- added `examples/custom-block-executor` to show the `EngineValidatorBuilder` wiring

Base follow-up is implementing the actual cached executor on their side. Transaction-granular (prefix) reuse stays with the integrator for now.