### PR TITLE
feat(revm): introduce `DatabaseStateProvider`

### DIFF
--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -102,62 +102,6 @@ impl<DB> DerefMut for StateProviderDatabase<DB> {
     }
 }
 
-/// A [`DatabaseRef`] backed account info reader.
-///
-/// This adapts account and bytecode reads from revm's database interface back into Reth's storage
-/// reader traits. It is intentionally not a full [`StateProvider`] because [`DatabaseRef`] does
-/// not expose roots or proofs.
-///
-/// Note: [`DatabaseRef::code_by_hash_ref`] returns [`Bytecode`] directly, so this adapter cannot
-/// distinguish missing bytecode from the database's default bytecode and wraps whatever the
-/// database returns in `Some`.
-#[derive(Clone)]
-pub struct DatabaseStateProvider<DB>(pub DB);
-
-impl<DB> DatabaseStateProvider<DB> {
-    /// Create a new database-backed state reader.
-    pub const fn new(db: DB) -> Self {
-        Self(db)
-    }
-
-    /// Consume self and return the inner database.
-    pub fn into_inner(self) -> DB {
-        self.0
-    }
-
-    /// Returns the inner database.
-    pub const fn inner(&self) -> &DB {
-        &self.0
-    }
-}
-
-impl<DB> core::fmt::Debug for DatabaseStateProvider<DB> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DatabaseStateProvider").finish_non_exhaustive()
-    }
-}
-
-impl<DB> AccountReader for DatabaseStateProvider<DB>
-where
-    DB: DatabaseRef<Error = ProviderError>,
-{
-    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
-        Ok(self.0.basic_ref(*address)?.map(Into::into))
-    }
-}
-
-impl<DB> BytecodeReader for DatabaseStateProvider<DB>
-where
-    DB: DatabaseRef<Error = ProviderError>,
-{
-    fn bytecode_by_hash(
-        &self,
-        code_hash: &B256,
-    ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
-        Ok(Some(reth_primitives_traits::Bytecode(self.0.code_by_hash_ref(*code_hash)?)))
-    }
-}
-
 impl<DB: EvmStateProvider> Database for StateProviderDatabase<DB> {
     type Error = ProviderError;
 
@@ -223,6 +167,62 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
         // Get the block hash or default hash with an attempt to convert U256 block number to u64
         Ok(self.0.block_hash(number)?.unwrap_or_default())
+    }
+}
+
+/// A [`DatabaseRef`] backed account info reader.
+///
+/// This adapts account and bytecode reads from revm's database interface back into Reth's storage
+/// reader traits. It is intentionally not a full [`StateProvider`] because [`DatabaseRef`] does
+/// not expose roots or proofs.
+///
+/// Note: [`DatabaseRef::code_by_hash_ref`] returns [`Bytecode`] directly, so this adapter cannot
+/// distinguish missing bytecode from the database's default bytecode and wraps whatever the
+/// database returns in `Some`.
+#[derive(Clone)]
+pub struct DatabaseStateProvider<DB>(pub DB);
+
+impl<DB> DatabaseStateProvider<DB> {
+    /// Create a new database-backed state reader.
+    pub const fn new(db: DB) -> Self {
+        Self(db)
+    }
+
+    /// Consume self and return the inner database.
+    pub fn into_inner(self) -> DB {
+        self.0
+    }
+
+    /// Returns the inner database.
+    pub const fn inner(&self) -> &DB {
+        &self.0
+    }
+}
+
+impl<DB> core::fmt::Debug for DatabaseStateProvider<DB> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DatabaseStateProvider").finish_non_exhaustive()
+    }
+}
+
+impl<DB> AccountReader for DatabaseStateProvider<DB>
+where
+    DB: DatabaseRef<Error = ProviderError>,
+{
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.0.basic_ref(*address)?.map(Into::into))
+    }
+}
+
+impl<DB> BytecodeReader for DatabaseStateProvider<DB>
+where
+    DB: DatabaseRef<Error = ProviderError>,
+{
+    fn bytecode_by_hash(
+        &self,
+        code_hash: &B256,
+    ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        Ok(Some(reth_primitives_traits::Bytecode(self.0.code_by_hash_ref(*code_hash)?)))
     }
 }
 

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -102,6 +102,62 @@ impl<DB> DerefMut for StateProviderDatabase<DB> {
     }
 }
 
+/// A [`DatabaseRef`] backed account info reader.
+///
+/// This adapts account and bytecode reads from revm's database interface back into Reth's storage
+/// reader traits. It is intentionally not a full [`StateProvider`] because [`DatabaseRef`] does
+/// not expose roots or proofs.
+///
+/// Note: [`DatabaseRef::code_by_hash_ref`] returns [`Bytecode`] directly, so this adapter cannot
+/// distinguish missing bytecode from the database's default bytecode and wraps whatever the
+/// database returns in `Some`.
+#[derive(Clone)]
+pub struct DatabaseStateProvider<DB>(pub DB);
+
+impl<DB> DatabaseStateProvider<DB> {
+    /// Create a new database-backed state reader.
+    pub const fn new(db: DB) -> Self {
+        Self(db)
+    }
+
+    /// Consume self and return the inner database.
+    pub fn into_inner(self) -> DB {
+        self.0
+    }
+
+    /// Returns the inner database.
+    pub const fn inner(&self) -> &DB {
+        &self.0
+    }
+}
+
+impl<DB> core::fmt::Debug for DatabaseStateProvider<DB> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DatabaseStateProvider").finish_non_exhaustive()
+    }
+}
+
+impl<DB> AccountReader for DatabaseStateProvider<DB>
+where
+    DB: DatabaseRef<Error = ProviderError>,
+{
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(self.0.basic_ref(*address)?.map(Into::into))
+    }
+}
+
+impl<DB> BytecodeReader for DatabaseStateProvider<DB>
+where
+    DB: DatabaseRef<Error = ProviderError>,
+{
+    fn bytecode_by_hash(
+        &self,
+        code_hash: &B256,
+    ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        Ok(Some(reth_primitives_traits::Bytecode(self.0.code_by_hash_ref(*code_hash)?)))
+    }
+}
+
 impl<DB: EvmStateProvider> Database for StateProviderDatabase<DB> {
     type Error = ProviderError;
 
@@ -167,5 +223,203 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
         // Get the block hash or default hash with an attempt to convert U256 block number to u64
         Ok(self.0.block_hash(number)?.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cached::CachedReads;
+    use alloy_consensus::constants::KECCAK_EMPTY;
+    use alloy_primitives::Bytes;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct CountingDatabaseRef {
+        address: Address,
+        code_hash: B256,
+        account: Option<AccountInfo>,
+        bytecode: Bytecode,
+        account_reads: Arc<AtomicUsize>,
+        bytecode_reads: Arc<AtomicUsize>,
+        fail_account_reads: bool,
+        fail_bytecode_reads: bool,
+    }
+
+    impl CountingDatabaseRef {
+        fn new(address: Address, account: Option<AccountInfo>, bytecode: Bytecode) -> Self {
+            let code_hash = account.as_ref().map(|account| account.code_hash).unwrap_or_default();
+            Self {
+                address,
+                code_hash,
+                account,
+                bytecode,
+                account_reads: Arc::default(),
+                bytecode_reads: Arc::default(),
+                fail_account_reads: false,
+                fail_bytecode_reads: false,
+            }
+        }
+    }
+
+    impl DatabaseRef for CountingDatabaseRef {
+        type Error = ProviderError;
+
+        fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            if self.fail_account_reads {
+                return Err(ProviderError::UnsupportedProvider)
+            }
+
+            self.account_reads.fetch_add(1, Ordering::Relaxed);
+            Ok((address == self.address).then(|| self.account.clone()).flatten())
+        }
+
+        fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+            if self.fail_bytecode_reads {
+                return Err(ProviderError::UnsupportedProvider)
+            }
+
+            self.bytecode_reads.fetch_add(1, Ordering::Relaxed);
+            Ok(if code_hash == self.code_hash {
+                self.bytecode.clone()
+            } else {
+                Bytecode::default()
+            })
+        }
+
+        fn storage_ref(&self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+            Ok(U256::ZERO)
+        }
+
+        fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[test]
+    fn database_state_provider_maps_missing_account() {
+        let address = Address::repeat_byte(0x01);
+        let db = CountingDatabaseRef::new(address, None, Bytecode::default());
+        let provider = DatabaseStateProvider::new(db);
+
+        assert_eq!(provider.basic_account(&address).unwrap(), None);
+    }
+
+    #[test]
+    fn database_state_provider_maps_empty_code_hash() {
+        let address = Address::repeat_byte(0x01);
+        let account = AccountInfo {
+            nonce: 7,
+            balance: U256::from(42),
+            code_hash: KECCAK_EMPTY,
+            code: None,
+            account_id: None,
+        };
+        let db = CountingDatabaseRef::new(address, Some(account), Bytecode::default());
+        let provider = DatabaseStateProvider::new(db);
+
+        assert_eq!(
+            provider.basic_account(&address).unwrap(),
+            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: None })
+        );
+    }
+
+    #[test]
+    fn database_state_provider_maps_code_hash_and_bytecode() {
+        let address = Address::repeat_byte(0x01);
+        let code_hash = B256::repeat_byte(0x42);
+        let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]));
+        let account = AccountInfo {
+            nonce: 7,
+            balance: U256::from(42),
+            code_hash,
+            code: Some(bytecode.clone()),
+            account_id: None,
+        };
+        let db = CountingDatabaseRef::new(address, Some(account), bytecode.clone());
+        let provider = DatabaseStateProvider::new(db);
+
+        assert_eq!(
+            provider.basic_account(&address).unwrap(),
+            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: Some(code_hash) })
+        );
+        assert_eq!(
+            provider.bytecode_by_hash(&code_hash).unwrap(),
+            Some(reth_primitives_traits::Bytecode(bytecode))
+        );
+    }
+
+    #[test]
+    fn database_state_provider_wraps_default_bytecode_for_unknown_hash() {
+        let address = Address::repeat_byte(0x01);
+        let unknown_hash = B256::repeat_byte(0x42);
+        let db = CountingDatabaseRef::new(address, None, Bytecode::default());
+        let provider = DatabaseStateProvider::new(db);
+
+        assert_eq!(
+            provider.bytecode_by_hash(&unknown_hash).unwrap(),
+            Some(reth_primitives_traits::Bytecode(Bytecode::default()))
+        );
+    }
+
+    #[test]
+    fn database_state_provider_propagates_database_errors() {
+        let address = Address::repeat_byte(0x01);
+        let code_hash = B256::repeat_byte(0x42);
+        let db = CountingDatabaseRef {
+            fail_account_reads: true,
+            fail_bytecode_reads: true,
+            ..CountingDatabaseRef::new(address, None, Bytecode::default())
+        };
+        let provider = DatabaseStateProvider::new(db);
+
+        assert!(matches!(
+            provider.basic_account(&address),
+            Err(ProviderError::UnsupportedProvider)
+        ));
+        assert!(matches!(
+            provider.bytecode_by_hash(&code_hash),
+            Err(ProviderError::UnsupportedProvider)
+        ));
+    }
+
+    #[test]
+    fn database_state_provider_uses_cached_reads() {
+        let address = Address::repeat_byte(0x01);
+        let code_hash = B256::repeat_byte(0x42);
+        let bytecode = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]));
+        let account = AccountInfo {
+            nonce: 7,
+            balance: U256::from(42),
+            code_hash,
+            code: Some(bytecode.clone()),
+            account_id: None,
+        };
+        let db = CountingDatabaseRef::new(address, Some(account), bytecode.clone());
+        let account_reads = db.account_reads.clone();
+        let bytecode_reads = db.bytecode_reads.clone();
+        let mut cached_reads = CachedReads::default();
+        let provider = DatabaseStateProvider::new(cached_reads.as_db(db));
+
+        assert_eq!(
+            provider.basic_account(&address).unwrap(),
+            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: Some(code_hash) })
+        );
+        assert_eq!(
+            provider.basic_account(&address).unwrap(),
+            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: Some(code_hash) })
+        );
+        assert_eq!(account_reads.load(Ordering::Relaxed), 1);
+
+        assert_eq!(
+            provider.bytecode_by_hash(&code_hash).unwrap(),
+            Some(reth_primitives_traits::Bytecode(bytecode.clone()))
+        );
+        assert_eq!(
+            provider.bytecode_by_hash(&code_hash).unwrap(),
+            Some(reth_primitives_traits::Bytecode(bytecode))
+        );
+        assert_eq!(bytecode_reads.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
Adds a minimal account-info reader backed by a revm `DatabaseRef`, mirroring `StateProviderDatabase` in the reverse direction.

This lets callers reuse cached revm account and bytecode reads through Reth's storage reader traits without pretending the adapter is a full `StateProvider`.