### PR TITLE
feat(cli): support ERE (.erae) files in import-era

### DIFF
--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -6,6 +6,7 @@ use eyre::eyre;
 use reqwest::{Client, Url};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_cli::chainspec::ChainSpecParser;
+use reth_era::common::file_ops::EraFileType;
 use reth_era_downloader::{read_dir, EraClient, EraStream, EraStreamConfig};
 use reth_era_utils as era;
 use reth_etl::Collector;
@@ -13,7 +14,10 @@ use reth_fs_util as fs;
 use reth_node_core::version::version_metadata;
 use reth_provider::StaticFileProviderFactory;
 use reth_static_file_types::StaticFileSegment;
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tracing::info;
 
 /// Syncs ERA encoded blocks from a local or remote source.
@@ -24,6 +28,13 @@ pub struct ImportEraCommand<C: ChainSpecParser> {
 
     #[clap(flatten)]
     import: ImportArgs,
+
+    /// Stop the import after this block height has been reached.
+    ///
+    /// The file containing the block is imported up to and including this height, then the
+    /// import ends. By default all available blocks are imported.
+    #[arg(long, value_name = "TO_BLOCK", verbatim_doc_comment)]
+    to_block: Option<u64>,
 }
 
 #[derive(Debug, Args)]
@@ -82,18 +93,35 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             1;
 
         if let Some(path) = self.import.path {
+            let era_type = detect_dir_era_type(&path)?;
+
+            info!(target: "reth::cli", ?era_type, path = %path.display(), to_block = ?self.to_block, "Starting ERA import");
+
             let stream = read_dir(path, next_block)?;
 
-            era::import::<era::Era1, _, _, _, _, _, _>(
-                stream,
-                &provider_factory,
-                &mut hash_collector,
-            )?;
+            match era_type {
+                EraFileType::Ere => era::import::<era::Ere, _, _, _, _, _, _>(
+                    stream,
+                    &provider_factory,
+                    &mut hash_collector,
+                    self.to_block,
+                )?,
+                _ => era::import::<era::Era1, _, _, _, _, _, _>(
+                    stream,
+                    &provider_factory,
+                    &mut hash_collector,
+                    self.to_block,
+                )?,
+            };
         } else {
             let url = match self.import.url {
                 Some(url) => url,
                 None => self.env.chain.chain().kind().try_to_url()?,
             };
+            let era_type = EraFileType::from_url(url.as_str());
+
+            info!(target: "reth::cli", ?era_type, %url, to_block = ?self.to_block, "Starting ERA import");
+
             let folder =
                 self.env.datadir.resolve_datadir(self.env.chain.chain()).data_dir().join("era");
 
@@ -103,11 +131,20 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             let client = EraClient::new(Client::new(), url, folder);
             let stream = EraStream::new(client, config);
 
-            era::import::<era::Era1, _, _, _, _, _, _>(
-                stream,
-                &provider_factory,
-                &mut hash_collector,
-            )?;
+            match era_type {
+                EraFileType::Ere => era::import::<era::Ere, _, _, _, _, _, _>(
+                    stream,
+                    &provider_factory,
+                    &mut hash_collector,
+                    self.to_block,
+                )?,
+                _ => era::import::<era::Era1, _, _, _, _, _, _>(
+                    stream,
+                    &provider_factory,
+                    &mut hash_collector,
+                    self.to_block,
+                )?,
+            };
         }
 
         Ok(())
@@ -119,4 +156,18 @@ impl<C: ChainSpecParser> ImportEraCommand<C> {
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)
     }
+}
+
+/// Detects the execution-layer ERA file type from the files in `dir`.
+fn detect_dir_era_type(dir: &Path) -> eyre::Result<EraFileType> {
+    for entry in fs::read_dir(dir)? {
+        if let Some(name) = entry?.file_name().to_str() &&
+            let Some(era_type @ (EraFileType::Era1 | EraFileType::Ere)) =
+                EraFileType::from_filename(name)
+        {
+            return Ok(era_type);
+        }
+    }
+
+    Err(eyre!("No ERA1 (.era1) or ERE (.ere, .erae) files found in {}", dir.display()))
 }

--- a/crates/cli/commands/src/import_era.rs
+++ b/crates/cli/commands/src/import_era.rs
@@ -14,10 +14,7 @@ use reth_fs_util as fs;
 use reth_node_core::version::version_metadata;
 use reth_provider::StaticFileProviderFactory;
 use reth_static_file_types::StaticFileSegment;
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 
 /// Syncs ERA encoded blocks from a local or remote source.
@@ -93,7 +90,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ImportEraC
             1;
 
         if let Some(path) = self.import.path {
-            let era_type = detect_dir_era_type(&path)?;
+            let era_type = EraFileType::from_dir(&path)?.ok_or_else(|| {
+                eyre!("No ERA1 (.era1) or ERE (.ere, .erae) files found in {}", path.display())
+            })?;
 
             info!(target: "reth::cli", ?era_type, path = %path.display(), to_block = ?self.to_block, "Starting ERA import");
 
@@ -156,18 +155,4 @@ impl<C: ChainSpecParser> ImportEraCommand<C> {
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)
     }
-}
-
-/// Detects the execution-layer ERA file type from the files in `dir`.
-fn detect_dir_era_type(dir: &Path) -> eyre::Result<EraFileType> {
-    for entry in fs::read_dir(dir)? {
-        if let Some(name) = entry?.file_name().to_str() &&
-            let Some(era_type @ (EraFileType::Era1 | EraFileType::Ere)) =
-                EraFileType::from_filename(name)
-        {
-            return Ok(era_type);
-        }
-    }
-
-    Err(eyre!("No ERA1 (.era1) or ERE (.ere, .erae) files found in {}", dir.display()))
 }

--- a/crates/era-downloader/src/fs.rs
+++ b/crates/era-downloader/src/fs.rs
@@ -2,6 +2,7 @@ use crate::{EraMeta, BLOCKS_PER_FILE};
 use alloy_primitives::{hex, hex::ToHexExt, BlockNumber};
 use eyre::{eyre, OptionExt};
 use futures_util::{stream, Stream};
+use reth_era::common::file_ops::EraFileType;
 use reth_fs_util as fs;
 use sha2::{Digest, Sha256};
 use std::{fmt::Debug, io, io::BufRead, path::Path, str::FromStr};
@@ -19,11 +20,13 @@ pub fn read_dir(
             (|| {
                 let path = entry?.path();
 
-                if path.extension() == Some("era1".as_ref()) &&
-                    let Some(last) = path.components().next_back()
+                if let Some(name) = path.file_name().and_then(|name| name.to_str()) &&
+                    matches!(
+                        EraFileType::from_filename(name),
+                        Some(EraFileType::Era1 | EraFileType::Ere)
+                    )
                 {
-                    let str = last.as_os_str().to_string_lossy().to_string();
-                    let parts = str.split('-').collect::<Vec<_>>();
+                    let parts = name.split('-').collect::<Vec<_>>();
 
                     if parts.len() == 3 {
                         let number = usize::from_str(parts[1])?;

--- a/crates/era-utils/src/history.rs
+++ b/crates/era-utils/src/history.rs
@@ -12,6 +12,7 @@ use reth_era::{
     common::{decode::DecodeCompressedRlp, file_ops::StreamReader},
     e2s::error::E2sError,
     era1::{file::Era1Reader, types::execution::BlockTuple},
+    ere::file::EreReader,
 };
 use reth_era_downloader::EraMeta;
 use reth_etl::Collector;
@@ -58,6 +59,28 @@ where
     }
 }
 
+/// [`EraBlockReader`] for `.ere`/`.erae` files.
+#[derive(Debug)]
+pub struct Ere;
+
+impl<BH, BB> EraBlockReader<BH, BB> for Ere
+where
+    BH: FullBlockHeader + Value,
+    BB: FullBlockBody<OmmerHeader = BH>,
+{
+    fn blocks<M: EraMeta + ?Sized>(
+        meta: &M,
+    ) -> eyre::Result<impl Iterator<Item = eyre::Result<(BH, BB)>>> {
+        let reader: EreReader<std::fs::File> = open(meta)?;
+        Ok(reader.iter().map(|block| {
+            let block = block?;
+            let header: BH = block.header.decode()?;
+            let body: BB = block.body.decode()?;
+            Ok((header, body))
+        }))
+    }
+}
+
 /// Opens the ERA file at `meta` with the format's [`StreamReader`].
 pub fn open<Reader>(meta: &(impl EraMeta + ?Sized)) -> eyre::Result<Reader>
 where
@@ -68,11 +91,15 @@ where
 
 /// Imports blocks from `downloader`, decoding each file with the [`EraBlockReader`] `S`.
 ///
+/// When `to_block` is set, the import stops after reaching that block height; otherwise it
+/// continues until the source has no more files.
+///
 /// Returns current block height.
 pub fn import<S, Downloader, Era, PF, B, BB, BH>(
     mut downloader: Downloader,
     provider_factory: &PF,
     hash_collector: &mut Collector<BlockHash, BlockNumber>,
+    to_block: Option<BlockNumber>,
 ) -> eyre::Result<BlockNumber>
 where
     S: EraBlockReader<BH, BB>,
@@ -109,21 +136,30 @@ where
         .get_highest_static_file_block(StaticFileSegment::Headers)
         .unwrap_or_default();
 
+    let end = to_block.map_or(Bound::Unbounded, Bound::Included);
+
     while let Some(meta) = rx.recv()? {
+        let meta = meta?;
         let from = height;
         let provider = provider_factory.database_provider_rw()?;
 
         height = process::<S, _, _, _, _>(
-            &meta?,
+            &meta,
             &mut static_file_provider.latest_writer(StaticFileSegment::Headers)?,
             &provider,
             hash_collector,
-            height..,
+            (Bound::Included(height), end),
         )?;
 
         save_stage_checkpoints(&provider, from, height, height, height)?;
 
         provider.commit()?;
+
+        info!(target: "era::history::import", first = from, last = height, file = %meta.path().display(), "Imported ERA file");
+
+        if to_block.is_some_and(|to| height >= to) {
+            break;
+        }
     }
 
     let provider = provider_factory.database_provider_rw()?;
@@ -391,6 +427,27 @@ mod tests {
         fn path(&self) -> &Path {
             Path::new("test.era1")
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn import_stops_at_to_block() {
+        let pf = create_test_provider_factory();
+        init_genesis(&pf).unwrap();
+
+        let folder = tempdir().unwrap();
+        let mut hash_collector = Collector::new(4096, Some(folder.path().to_owned()));
+
+        // Each file yields blocks 1 and 2; without `to_block` the import would reach 2.
+        let stream = futures_util::stream::iter(vec![
+            Ok(TestMeta { marked: Cell::new(false) }),
+            Ok(TestMeta { marked: Cell::new(false) }),
+        ]);
+
+        let height =
+            import::<TestEra, _, _, _, Block, _, _>(stream, &pf, &mut hash_collector, Some(1))
+                .unwrap();
+
+        assert_eq!(height, 1);
     }
 
     #[test]

--- a/crates/era-utils/src/lib.rs
+++ b/crates/era-utils/src/lib.rs
@@ -10,5 +10,5 @@ pub use export::{export, ExportConfig};
 
 pub use history::{
     build_index, calculate_td_by_number, decode, import, open, process, process_iter,
-    save_stage_checkpoints, Era1, EraBlockReader,
+    save_stage_checkpoints, Era1, EraBlockReader, Ere,
 };

--- a/crates/era-utils/tests/it/history.rs
+++ b/crates/era-utils/tests/it/history.rs
@@ -39,7 +39,7 @@ async fn test_history_imports_from_fresh_state_successfully() {
 
     let expected_block_number = 8191;
     let actual_block_number =
-        import::<Era1, _, _, _, _, _, _>(stream, &pf, &mut hash_collector).unwrap();
+        import::<Era1, _, _, _, _, _, _>(stream, &pf, &mut hash_collector, None).unwrap();
 
     assert_eq!(actual_block_number, expected_block_number);
 }
@@ -69,7 +69,7 @@ async fn test_roundtrip_export_after_import() {
 
     // Import blocks from one era1 file into database
     let last_imported_block_height =
-        import::<Era1, _, _, _, _, _, _>(stream, &pf, &mut hash_collector).unwrap();
+        import::<Era1, _, _, _, _, _, _>(stream, &pf, &mut hash_collector, None).unwrap();
 
     assert_eq!(last_imported_block_height, 8191);
     let provider_ref = pf.provider_rw().unwrap().0;

--- a/crates/era/src/common/file_ops.rs
+++ b/crates/era/src/common/file_ops.rs
@@ -3,7 +3,7 @@
 use crate::e2s::{error::E2sError, types::Version};
 use std::{
     fs::File,
-    io::{Read, Seek, Write},
+    io::{self, Read, Seek, Write},
     path::Path,
 };
 
@@ -239,6 +239,22 @@ impl EraFileType {
         // Custom exports insert an `-<era-count>` segment between the era number and the hash.
         let era_count = if include_era_count { format!("-{era_count:05}") } else { String::new() };
         format!("{network_name}-{era_number:05}{era_count}-{hash}{}", self.extension())
+    }
+
+    /// Detects the execution-layer file type from the files in `dir`.
+    ///
+    /// Returns the type of the first `.era1` or `.ere`/`.erae` file found. Consensus-layer
+    /// `.era` files are ignored.
+    pub fn from_dir(dir: impl AsRef<Path>) -> io::Result<Option<Self>> {
+        for entry in std::fs::read_dir(dir)? {
+            if let Some(name) = entry?.file_name().to_str() &&
+                let Some(era_type @ (Self::Era1 | Self::Ere)) = Self::from_filename(name)
+            {
+                return Ok(Some(era_type));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Detect file type from a URL, defaulting to `Era`.

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -142,6 +142,12 @@ Storage:
           The ERA1 files are read from the remote host using HTTP GET requests parsing headers
           and bodies.
 
+      --to-block <TO_BLOCK>
+          Stop the import after this block height has been reached.
+
+          The file containing the block is imported up to and including this height, then the
+          import ends. By default all available blocks are imported.
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout


### PR DESCRIPTION
Importing from an ERE host did not work: `reth import-era --chain sepolia --url https://data.ethpandaops.io/erae/sepolia/` downloaded `.erae` files but the import pipeline decoded every file as era1. The command now detects the file type from the URL (or directory contents for `--path` imports, where `read_dir` also accepts `.erae`/`.ere` files now) and decodes ERE files with the `EreReader`.

This also adds a `--to-block` flag that ends the import once the given height has been reached, so a partial import no longer requires downloading the full file set (500GB+ for sepolia ERE).

Verified against the ethpandaops sepolia data on a fresh datadir: `--to-block 20000` imports the first three files with checksum verification and stops mid-file at exactly 20000, the imported block 20000 hash matches a public RPC, and a re-run with `--to-block 25000` resumes at 20001. era1 import from the default ithaca host still works, including the new flag.

cc @lean-apple 