### PR TITLE
chore(deps): bump alloy crates to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,8 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44937ce84d2cbf1ee4010667bd9214bb7db134a91dd9ffa6b1b8b1d6b030449"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -148,8 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb0bdd61ddff726026676450e7e6a52c68aa39d98f2d60d05ad7caaea5b8100"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -162,8 +164,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1475c7edc6780b1759ccdb7960e28d29856ecbed47cfcf9e25be6a5f48b0cfb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -247,21 +250,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "borsh",
- "once_cell",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-eip7928"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c4584eaf235a861172e30d0d8adfa95957186f59b93f997851df90b32da7ba"
@@ -277,13 +265,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154b0f566ebbfc256b63c8d643c6a299f40a6fcd50a9d756c1d191487dd06483"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -322,8 +311,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a930a68a6f0ac19231bc2f5f0bf13fad3a26fa7df2525354890c72366c2998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -375,8 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e92108767c8c95b5e521570e039e374e65198c4179a98d200412c083d6c26d5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -389,8 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4546c9fae2861d4159ee3b25c44ab3edb90f21b849e86cf2086cacb1d56d8ac"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -414,8 +406,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2c325d5934445209c8d22fc67d27e2cf9fb79054b8154d9e522d6a4ee3a4f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -426,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f2f7dac66147d165063c670dabca7b34807428130bef4583a7976523140f8d"
+checksum = "23b1e225c8715a0aaefeec2e5f5390881b6bc11606bb81c3470ba219eb04c350"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",
@@ -480,8 +473,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4536d25780fcf51a338c26153c526c99649be1273600684ef10b397a207d4a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -523,8 +517,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9393d7f1fbe02ec0cff205943cf1b899200312bed0d150b2b99dc6c729203414"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -566,8 +561,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8d765656f02f993fa0565abeb3554ccd6a0d72ea44ce0558b983136639bd6b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -591,8 +587,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a05ef5b11fad72068e6f011c21445bc5b596ac850644c4a14c30d845ce56de8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -603,8 +600,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df4d6f40079a2e726ed433ce8d68ced771fb408f4f943fd5182fec012f7b02b"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -614,8 +612,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c1fa8062c379d4fb51d28361cd02cd6a18a49fa79831c16831449b65408aa6c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -625,8 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06bfe79149dd53de5b196aa3c96db0500b7cf0ed72dbd1a31bac7660bc7cc65"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -639,8 +639,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57af0eb1ee47312e8c92ddf2669308249015fc2cf733eb17251e7343c27b70c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -658,8 +659,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff0a296b58194c7464aa56f2bdad065c5a24b43a6de5d62b8a985ae3969ecd0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -670,8 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851167851209fac75c31833b3a4ec5d9c3efa2b14563605dc6a1d58f576e390c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -690,8 +693,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41d1a11f58b456c199e04591befc64cb236fa2574a7275a07b98b173727bd39"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -702,7 +706,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -711,8 +715,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3404fa2db0372330f451319dc000f03bd868ed5cd25b5c349d3ec16420169a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -725,8 +730,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f813a34cce29d4a340633310e5da5ac182450887333be38490c51f7776543ac2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -738,8 +744,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6149b3ef1ec411016127baeb3ff2f479290721da9f2d936b882df50d83c3133"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -749,8 +756,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf028ac8bcb161ad7c104243e710cece8e1a794f65ee6c35c4c4d693c8e80ee"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -760,8 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5f392f2f56b2417ea6b74e1e116c6f35df5ab5fce4dc422e277d72ee18ff7b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -774,8 +783,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78de3d4ed62e2c90e16be166d0ddfe41944bb5979752703199073acf976083f2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -862,8 +872,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f42ee1ef30d4d3d8b4ea5794937fccfc69e2bb1cd5bcf42d62afc57b049081"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -884,12 +895,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee68bc7d713e033eeaaecb8fd13d5d8a41af97226c4388930ad459285b8e9f70"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest",
  "serde_json",
  "tower",
@@ -899,8 +911,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d110e862e4869de0b3a6b7f7382cf035ab5a7e0668eb56df32efd7c39eb1a5da"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -918,8 +931,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc2011694071e6dcf8ad418479ee21c4ed0e9ca20906484ea9336b99f28a59f"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -956,8 +970,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.5"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2393,7 +2408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2934,7 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3420,7 +3435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4218,7 +4233,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -5168,7 +5183,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6245,7 +6260,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7115,7 +7130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7213,7 +7228,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7958,7 +7973,7 @@ name = "reth-consensus"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8366,7 +8381,7 @@ name = "reth-engine-tree"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -8585,7 +8600,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-genesis",
  "alloy-hardforks 0.4.7",
@@ -8778,7 +8793,7 @@ name = "reth-evm"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -9181,7 +9196,7 @@ name = "reth-network-p2p"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
@@ -9664,7 +9679,7 @@ name = "reth-provider"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -9792,7 +9807,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
@@ -10056,7 +10071,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
@@ -10102,7 +10117,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
@@ -10353,7 +10368,7 @@ name = "reth-storage-api"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10657,7 +10672,7 @@ dependencies = [
 name = "reth-trie-parallel"
 version = "2.3.0"
 dependencies = [
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -10938,7 +10953,7 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
- "alloy-eip7928 0.4.3",
+ "alloy-eip7928",
  "bitflags 2.13.0",
  "nonmax",
  "revm-bytecode",
@@ -11296,7 +11311,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11355,7 +11370,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11376,7 +11391,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12246,7 +12261,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13528,7 +13543,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -150,8 +149,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -165,8 +163,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -281,8 +278,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -327,8 +323,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -381,8 +376,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -396,8 +390,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -422,8 +415,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -489,8 +481,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -533,8 +524,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd85cfea1fa8ebd20d3475e961fe3a3624c0eb4659ea137715c0c83c8aeaff0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -577,8 +567,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -603,8 +592,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -616,8 +604,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef669b370940e7945a3a384cc4024038cd69ee658b71270d59c20b78dd8d20d4"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -628,8 +615,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -640,8 +626,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -655,8 +640,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -675,8 +659,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b9ad6eee93dd35a9ec0a6c1c6b180892a900ee17a6ed6500921552dd71e846"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -688,8 +671,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -709,8 +691,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -731,8 +712,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1004c1d68bfaee001712f83356f88031ab74a727b8560fb7fc738d1281ebe5"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -746,8 +726,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -760,8 +739,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -772,8 +750,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -784,8 +761,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -799,8 +775,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -888,8 +863,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -911,8 +885,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -927,8 +900,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb89df168b24773ef603af14f2449c05a7d3f27d05d3eceaea6bf96cccae168"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -947,8 +919,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e32e0b47d3b3bf5770b7c132090c614b008d307c5e1544f1925f5b7e9e9af6"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -986,8 +957,7 @@ dependencies = [
 [[package]]
 name = "alloy-tx-macros"
 version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#df681af720ae8906cbc46a84204960ff97cab338"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -701,3 +701,32 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,33 +456,33 @@ alloy-trie = { version = "0.9.4", default-features = false }
 
 alloy-hardforks = "0.4.7"
 
-alloy-consensus = { version = "2.0.5", default-features = false }
-alloy-contract = { version = "2.0.5", default-features = false }
-alloy-eips = { version = "2.0.5", default-features = false }
-alloy-genesis = { version = "2.0.5", default-features = false }
-alloy-json-rpc = { version = "2.0.5", default-features = false }
-alloy-network = { version = "2.0.5", default-features = false }
-alloy-network-primitives = { version = "2.0.5", default-features = false }
-alloy-provider = { version = "2.0.5", features = ["reqwest", "debug-api"], default-features = false }
-alloy-pubsub = { version = "2.0.5", default-features = false }
-alloy-rpc-client = { version = "2.0.5", default-features = false }
-alloy-rpc-types = { version = "2.0.5", features = ["eth"], default-features = false }
-alloy-rpc-types-admin = { version = "2.0.5", default-features = false }
-alloy-rpc-types-anvil = { version = "2.0.5", default-features = false }
-alloy-rpc-types-beacon = { version = "2.0.5", default-features = false }
-alloy-rpc-types-debug = { version = "2.0.5", default-features = false }
-alloy-rpc-types-engine = { version = "2.0.5", default-features = false }
-alloy-rpc-types-eth = { version = "2.0.5", default-features = false }
-alloy-rpc-types-mev = { version = "2.0.5", default-features = false }
-alloy-rpc-types-trace = { version = "2.0.5", default-features = false }
-alloy-rpc-types-txpool = { version = "2.0.5", default-features = false }
-alloy-serde = { version = "2.0.5", default-features = false }
-alloy-signer = { version = "2.0.5", default-features = false }
-alloy-signer-local = { version = "2.0.5", default-features = false }
-alloy-transport = { version = "2.0.5" }
-alloy-transport-http = { version = "2.0.5", features = ["reqwest-rustls-tls"], default-features = false }
-alloy-transport-ipc = { version = "2.0.5", default-features = false }
-alloy-transport-ws = { version = "2.0.5", default-features = false }
+alloy-consensus = { version = "2.1.0", default-features = false }
+alloy-contract = { version = "2.1.0", default-features = false }
+alloy-eips = { version = "2.1.0", default-features = false }
+alloy-genesis = { version = "2.1.0", default-features = false }
+alloy-json-rpc = { version = "2.1.0", default-features = false }
+alloy-network = { version = "2.1.0", default-features = false }
+alloy-network-primitives = { version = "2.1.0", default-features = false }
+alloy-provider = { version = "2.1.0", features = ["reqwest", "debug-api"], default-features = false }
+alloy-pubsub = { version = "2.1.0", default-features = false }
+alloy-rpc-client = { version = "2.1.0", default-features = false }
+alloy-rpc-types = { version = "2.1.0", features = ["eth"], default-features = false }
+alloy-rpc-types-admin = { version = "2.1.0", default-features = false }
+alloy-rpc-types-anvil = { version = "2.1.0", default-features = false }
+alloy-rpc-types-beacon = { version = "2.1.0", default-features = false }
+alloy-rpc-types-debug = { version = "2.1.0", default-features = false }
+alloy-rpc-types-engine = { version = "2.1.0", default-features = false }
+alloy-rpc-types-eth = { version = "2.1.0", default-features = false }
+alloy-rpc-types-mev = { version = "2.1.0", default-features = false }
+alloy-rpc-types-trace = { version = "2.1.0", default-features = false }
+alloy-rpc-types-txpool = { version = "2.1.0", default-features = false }
+alloy-serde = { version = "2.1.0", default-features = false }
+alloy-signer = { version = "2.1.0", default-features = false }
+alloy-signer-local = { version = "2.1.0", default-features = false }
+alloy-transport = { version = "2.1.0" }
+alloy-transport-http = { version = "2.1.0", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-transport-ipc = { version = "2.1.0", default-features = false }
+alloy-transport-ws = { version = "2.1.0", default-features = false }
 
 # misc
 either = { version = "1.16.0", default-features = false }
@@ -701,32 +701,3 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
-
-[patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "main" }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -70,7 +70,7 @@ aquamarine.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
 [dev-dependencies]
-alloy-node-bindings = "2.0.5"
+alloy-node-bindings = "2.1.0"
 alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 backon.workspace = true

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -228,6 +228,7 @@ where
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: None,
+                target_gas_limit: None,
             };
 
             env.active_node_state_mut()?
@@ -301,6 +302,7 @@ where
                     withdrawals: Some(vec![]),
                     parent_beacon_block_root: Some(B256::ZERO),
                     slot_number: None,
+                    target_gas_limit: None,
                 };
 
                 let fresh_fcu_result = EngineApiClient::<Engine>::fork_choice_updated_v3(

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -270,6 +270,7 @@ where
             withdrawals: Some(vec![]),
             parent_beacon_block_root: Some(B256::ZERO),
             slot_number: None,
+            target_gas_limit: None,
         };
 
         crate::setup_import::setup_engine_with_chain_import(
@@ -297,6 +298,7 @@ where
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: None,
+                target_gas_limit: None,
             }
             .into()
         }

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -161,6 +161,7 @@ async fn test_testsuite_assert_mine_block() -> Result<()> {
                 withdrawals: None,
                 parent_beacon_block_root: None,
                 slot_number: None,
+                target_gas_limit: None,
             },
         ));
 

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -91,6 +91,7 @@ const fn test_attributes_generator(timestamp: u64) -> PayloadAttributes {
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
+        target_gas_limit: None,
     }
 }
 

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -58,6 +58,7 @@ where
                 .is_cancun_active_at_timestamp(timestamp)
                 .then(B256::random),
             slot_number: self.chain_spec.is_amsterdam_active_at_timestamp(timestamp).then_some(0),
+            ..Default::default()
         }
     }
 }

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -237,6 +237,7 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
+        target_gas_limit: None,
     };
 
     let request = TestingBuildBlockRequestV1 {
@@ -316,6 +317,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
+        target_gas_limit: None,
     };
 
     let envelope = node

--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -25,6 +25,7 @@ pub(crate) const fn eth_payload_attributes(timestamp: u64) -> PayloadAttributes 
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
+        target_gas_limit: None,
     }
 }
 
@@ -38,6 +39,7 @@ pub(crate) const fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAt
         withdrawals: Some(vec![]),
         parent_beacon_block_root: None,
         slot_number: None,
+        target_gas_limit: None,
     }
 }
 
@@ -55,6 +57,7 @@ pub(crate) const fn eth_payload_attributes_amsterdam(timestamp: u64) -> PayloadA
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: Some(timestamp),
+        target_gas_limit: None,
     }
 }
 

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -60,6 +60,7 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
                 withdrawals: None,
                 parent_beacon_block_root: None,
                 slot_number: None,
+                target_gas_limit: None,
             };
 
             let request = TestingBuildBlockRequestV1 {

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -138,6 +138,7 @@ async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: Some(timestamp),
+                target_gas_limit: None,
             };
 
             tokio::spawn(async move {

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -123,7 +123,7 @@ impl PayloadAttributes for EthPayloadAttributes {
     }
 
     fn target_gas_limit(&self) -> Option<u64> {
-        None
+        self.target_gas_limit
     }
 }
 
@@ -245,6 +245,7 @@ mod tests {
             withdrawals: None,
             parent_beacon_block_root: None,
             slot_number: None,
+            target_gas_limit: None,
         };
 
         // Verify that the generated payload ID matches the expected value
@@ -283,6 +284,7 @@ mod tests {
             ]),
             parent_beacon_block_root: None,
             slot_number: None,
+            target_gas_limit: None,
         };
 
         // Verify that the generated payload ID matches the expected value
@@ -316,6 +318,7 @@ mod tests {
                 .unwrap(),
             ),
             slot_number: None,
+            target_gas_limit: None,
         };
 
         // Verify that the generated payload ID matches the expected value

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -2044,6 +2044,7 @@ mod tests {
             withdrawals: Some(vec![]),
             parent_beacon_block_root: None,
             slot_number: None,
+            target_gas_limit: None,
         };
         let custody_columns = B128::from(0b1010u128);
 
@@ -2099,6 +2100,7 @@ mod tests {
             // Invalid for V3/Cancun, but should be ignored if forkchoice is SYNCING.
             parent_beacon_block_root: None,
             slot_number: None,
+            target_gas_limit: None,
         };
 
         let api_task = tokio::spawn(async move {
@@ -2147,6 +2149,7 @@ mod tests {
             withdrawals: Some(vec![]),
             parent_beacon_block_root: None,
             slot_number: None,
+            target_gas_limit: None,
         };
 
         let api_task = tokio::spawn(async move {


### PR DESCRIPTION
Updates the Alloy `2.0.5` crate set to the released `2.1.0` crates and removes the temporary `alloy-rs/alloy` `main` patches.

Keeps the `target_gas_limit` payload attributes wiring required by the new API.