### PR TITLE
fix(docs): preserve rustdocs navigation

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -50,6 +50,10 @@ jobs:
           test -f docs/dist/public/sdk/index.html
           test -f docs/dist/public/logo.png
           test -f docs/dist/public/reth-prod.png
+          test -f docs/dist/public/docs/index.html
+          test -f docs/dist/public/docs/reth/index.html
+          test -d docs/dist/public/docs/static.files
+          grep -q 'content="rustdoc"' docs/dist/public/docs/index.html
           echo "Vocs Build Complete"
 
       - name: Setup Pages

--- a/docs/vocs/package.json
+++ b/docs/vocs/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vocs dev",
-    "build": "bash scripts/build-cargo-docs.sh && vocs build && bun scripts/generate-redirects.ts && bun scripts/inject-cargo-docs.ts && bun scripts/fix-search-index.ts",
+    "build": "bash scripts/build-cargo-docs.sh && vocs build && bun scripts/fix-rustdocs-navigation.ts && bun scripts/generate-redirects.ts && bun scripts/inject-cargo-docs.ts && bun scripts/fix-search-index.ts",
     "preview": "vocs preview",
     "check-links": "bun scripts/check-links.ts",
     "generate-redirects": "bun scripts/generate-redirects.ts",
     "build-cargo-docs": "bash scripts/build-cargo-docs.sh",
-    "inject-cargo-docs": "bun scripts/inject-cargo-docs.ts"
+    "inject-cargo-docs": "bun scripts/inject-cargo-docs.ts",
+    "fix-rustdocs-navigation": "bun scripts/fix-rustdocs-navigation.ts"
   },
   "dependencies": {
     "mermaid": "^11",

--- a/docs/vocs/scripts/fix-rustdocs-navigation.ts
+++ b/docs/vocs/scripts/fix-rustdocs-navigation.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+import { readdir, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+const ASSETS_DIR = './docs/dist/public/assets'
+const LINK_MARKER = 'c=Yd(!!i);if(Hd(e.to))'
+const RUSTDOCS_NAVIGATION_GUARD =
+  'c=Yd(!!i);if(t==="/docs"||t?.startsWith("/docs/"))return(0,v.jsx)(`a`,{...o,href:t});if(Hd(e.to))'
+
+async function fixRustdocsNavigation() {
+  const files = await readdir(ASSETS_DIR)
+  let patchedFiles = 0
+
+  for (const file of files) {
+    if (!file.endsWith('.js')) continue
+
+    const path = join(ASSETS_DIR, file)
+    const code = await readFile(path, 'utf-8')
+
+    if (code.includes(RUSTDOCS_NAVIGATION_GUARD)) {
+      patchedFiles++
+      continue
+    }
+
+    if (!code.includes(LINK_MARKER)) continue
+
+    await writeFile(path, code.replace(LINK_MARKER, RUSTDOCS_NAVIGATION_GUARD))
+    patchedFiles++
+    console.log(`Patched Rustdocs navigation in ${path}`)
+  }
+
+  if (patchedFiles !== 1) {
+    console.error(`Expected to patch one Vocs client navigation bundle, patched ${patchedFiles}`)
+    process.exit(1)
+  }
+}
+
+fixRustdocsNavigation().catch((error) => {
+  console.error('Error fixing Rustdocs navigation:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
Fixes Rustdocs navigation from Vocs pages after the Vocs 2 migration. The Vocs client router was intercepting /docs clicks and rendering its 404 even though the Rustdoc static artifact existed.

Adds a post-build patch so /docs links load as normal document navigations, and verifies the Pages artifact includes the injected Rustdoc output before upload.