### PR TITLE
feat(rpc): add admin peer ban and unban methods

### DIFF
--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -216,6 +216,12 @@ pub trait Peers: PeersInfo {
     /// Disconnect an existing connection to the given peer using the provided reason
     fn disconnect_peer_with_reason(&self, peer: PeerId, reason: DisconnectReason);
 
+    /// Bans the given peer and disconnects an active non-trusted session if one exists.
+    fn ban_peer(&self, peer: PeerId);
+
+    /// Unbans the given peer.
+    fn unban_peer(&self, peer: PeerId);
+
     /// Connect to the given peer. NOTE: if the maximum number of outbound sessions is reached,
     /// this won't do anything. See `reth_network::SessionManager::dial_outbound`.
     fn connect_peer(&self, peer: PeerId, tcp_addr: SocketAddr) {

--- a/crates/net/network-api/src/noop.rs
+++ b/crates/net/network-api/src/noop.rs
@@ -159,6 +159,10 @@ where
 
     fn disconnect_peer_with_reason(&self, _peer: PeerId, _reason: DisconnectReason) {}
 
+    fn ban_peer(&self, _peer: PeerId) {}
+
+    fn unban_peer(&self, _peer: PeerId) {}
+
     fn connect_peer_kind(
         &self,
         _peer: PeerId,

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -731,6 +731,12 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             NetworkHandleMessage::DisconnectPeer(peer_id, reason) => {
                 self.swarm.sessions_mut().disconnect(peer_id, reason);
             }
+            NetworkHandleMessage::BanPeer(peer_id) => {
+                self.swarm.peers_mut().ban_peer_by_admin(peer_id);
+            }
+            NetworkHandleMessage::UnbanPeer(peer_id) => {
+                self.swarm.peers_mut().unban_peer_by_admin(peer_id);
+            }
             NetworkHandleMessage::ConnectPeer(peer_id, kind, addr) => {
                 self.swarm.state_mut().add_and_connect(peer_id, kind, addr);
             }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -380,6 +380,17 @@ impl<N: NetworkPrimitives> Peers for NetworkHandle<N> {
         self.send_message(NetworkHandleMessage::DisconnectPeer(peer, Some(reason)))
     }
 
+    /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to ban the given peer and
+    /// disconnect an active non-trusted session if one exists.
+    fn ban_peer(&self, peer: PeerId) {
+        self.send_message(NetworkHandleMessage::BanPeer(peer))
+    }
+
+    /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to unban the given peer.
+    fn unban_peer(&self, peer: PeerId) {
+        self.send_message(NetworkHandleMessage::UnbanPeer(peer))
+    }
+
     /// Sends a message to the [`NetworkManager`](crate::NetworkManager) to connect to the given
     /// peer.
     ///
@@ -544,6 +555,10 @@ pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives
     RemovePeer(PeerId, PeerKind),
     /// Disconnects a connection to a peer if it exists, optionally providing a disconnect reason.
     DisconnectPeer(PeerId, Option<DisconnectReason>),
+    /// Bans a peer and disconnects an active non-trusted session if one exists.
+    BanPeer(PeerId),
+    /// Unbans a peer.
+    UnbanPeer(PeerId),
     /// Broadcasts an event to announce a new block to all nodes.
     AnnounceBlock(N::NewBlockPayload, B256),
     /// Sends a list of transactions to the given peer.

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -929,6 +929,26 @@ impl PeersManager {
         }
     }
 
+    /// Bans the peer indefinitely and removes it from the peer set.
+    ///
+    /// This follows [`Self::remove_peer`] and does not override trusted status. Remove trusted
+    /// peers from the trusted set before banning them.
+    pub(crate) fn ban_peer_by_admin(&mut self, peer_id: PeerId) {
+        if self.trusted_peer_ids.contains(&peer_id) ||
+            self.peers.get(&peer_id).is_some_and(Peer::is_trusted)
+        {
+            return
+        }
+
+        self.remove_peer(peer_id);
+        self.ban_list.ban_peer(peer_id);
+    }
+
+    /// Removes the peer from the ban list.
+    pub(crate) fn unban_peer_by_admin(&mut self, peer_id: PeerId) {
+        self.ban_list.unban_peer(&peer_id);
+    }
+
     /// Connect to the given peer. NOTE: if the maximum number of outbound sessions is reached,
     /// this won't do anything. See `reth_network::SessionManager::dial_outbound`.
     #[cfg_attr(not(test), expect(dead_code))]
@@ -1632,6 +1652,59 @@ mod tests {
             Poll::Ready(())
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_admin_ban_removes_peer_and_bans_indefinitely() {
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let mut peers = PeersManager::default();
+        peers.peers.insert(peer, Peer::new(PeerAddr::from_tcp(socket_addr)));
+
+        peers.ban_peer_by_admin(peer);
+
+        assert!(peers.ban_list.is_banned_peer(&peer));
+        assert!(peers.peer_by_id(peer).is_none());
+
+        match peers.queued_actions.pop_front() {
+            Some(PeerAction::PeerRemoved(peer_id)) => assert_eq!(peer_id, peer),
+            other => panic!("unexpected action: {other:?}"),
+        }
+
+        let (_, unbanned_peers) =
+            peers.ban_list.evict(std::time::Instant::now() + Duration::from_secs(1));
+        assert!(unbanned_peers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_admin_ban_does_not_override_trusted_peer() {
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let mut peers = PeersManager::default();
+        peers.peers.insert(peer, Peer::trusted(PeerAddr::from_tcp(socket_addr)));
+
+        peers.ban_peer_by_admin(peer);
+
+        assert!(!peers.ban_list.is_banned_peer(&peer));
+        assert!(peers.peer_by_id(peer).is_some());
+        assert!(peers.queued_actions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_admin_unban_only_removes_banlist_entry() {
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let mut peers = PeersManager::default();
+        let mut peer_info = Peer::new(PeerAddr::from_tcp(socket_addr));
+        peer_info.reputation = i32::MIN;
+        peers.peers.insert(peer, peer_info);
+        peers.ban_list.ban_peer(peer);
+        assert!(peers.peers.get(&peer).is_some_and(Peer::is_banned));
+
+        peers.unban_peer_by_admin(peer);
+
+        assert!(!peers.ban_list.is_banned_peer(&peer));
+        assert!(peers.peers.get(&peer).is_some_and(Peer::is_banned));
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -27,6 +27,14 @@ pub trait AdminApi {
     #[method(name = "removeTrustedPeer")]
     fn remove_trusted_peer(&self, record: AnyNode) -> RpcResult<bool>;
 
+    /// Bans a remote node and disconnects an active non-trusted session if one exists.
+    #[method(name = "banPeer")]
+    fn ban_peer(&self, record: AnyNode) -> RpcResult<bool>;
+
+    /// Unbans a remote node.
+    #[method(name = "unbanPeer")]
+    fn unban_peer(&self, record: AnyNode) -> RpcResult<bool>;
+
     /// The peers administrative property can be queried for all the information known about the
     /// connected remote nodes at the networking granularity. These include general information
     /// about the nodes themselves as participants of the devp2p P2P overlay protocol, as well as

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -145,6 +145,8 @@ where
     AdminApiClient::remove_peer(client, node.into()).await.unwrap();
     AdminApiClient::add_trusted_peer(client, node.into()).await.unwrap();
     AdminApiClient::remove_trusted_peer(client, node.into()).await.unwrap();
+    AdminApiClient::ban_peer(client, node.into()).await.unwrap();
+    AdminApiClient::unban_peer(client, node.into()).await.unwrap();
     AdminApiClient::node_info(client).await.unwrap();
 }
 

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -77,6 +77,18 @@ where
         Ok(true)
     }
 
+    /// Handler for `admin_banPeer`
+    fn ban_peer(&self, record: AnyNode) -> RpcResult<bool> {
+        self.network.ban_peer(record.peer_id());
+        Ok(true)
+    }
+
+    /// Handler for `admin_unbanPeer`
+    fn unban_peer(&self, record: AnyNode) -> RpcResult<bool> {
+        self.network.unban_peer(record.peer_id());
+        Ok(true)
+    }
+
     /// Handler for `admin_peers`
     async fn peers(&self) -> RpcResult<Vec<PeerInfo>> {
         let peers = self.network.get_all_peers().await.to_rpc_result()?;

--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -75,6 +75,42 @@ Returns true if the peer was successfully removed.
 {"jsonrpc":"2.0","id":1,"result":true}
 ```
 
+## `admin_banPeer`
+
+Bans a remote peer from future connections.
+
+For non-trusted peers, this also removes the peer from the peer set and disconnects any active session. Trusted peers must be removed from the trusted set before they can be banned.
+
+Returns `true` once the request has been accepted.
+
+| Client | Method invocation                                |
+| ------ | ------------------------------------------------ |
+| RPC    | `{"method": "admin_banPeer", "params": [url]}`   |
+
+### Example
+
+```js
+// > {"jsonrpc":"2.0","id":1,"method":"admin_banPeer","params":["enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303"]}
+{"jsonrpc":"2.0","id":1,"result":true}
+```
+
+## `admin_unbanPeer`
+
+Removes a remote peer from the ban list.
+
+Returns `true` once the request has been accepted.
+
+| Client | Method invocation                                  |
+| ------ | -------------------------------------------------- |
+| RPC    | `{"method": "admin_unbanPeer", "params": [url]}`   |
+
+### Example
+
+```js
+// > {"jsonrpc":"2.0","id":1,"method":"admin_unbanPeer","params":["enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303"]}
+{"jsonrpc":"2.0","id":1,"result":true}
+```
+
 ## `admin_nodeInfo`
 
 Returns all information known about the running node.


### PR DESCRIPTION
Adds `admin_banPeer` and `admin_unbanPeer` to the admin namespace.

`admin_banPeer` reuses the existing peer-manager remove behavior for non-trusted peers, disconnecting an active session if one exists, and adds an indefinite peer `BanList` entry. Trusted peers are left unchanged and must be removed from the trusted set before they can be banned. `admin_unbanPeer` only removes the peer from the `BanList`, leaving reputation state unchanged.