### PR TITLE
refactor(rpc): store decoded revm BALs behind Arc

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -1,6 +1,6 @@
 //! Helpers for `eth_blockAccessList` RPC method.
 use alloy_consensus::BlockHeader;
-use alloy_eip7928::BlockAccessList;
+use alloy_eip7928::{bal::DecodedBal, BlockAccessList};
 use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::BlockId;
 use reth_errors::RethError;
@@ -32,7 +32,11 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
             if let Some(cached_bal) =
                 self.cache().get_bal(block.hash()).await.map_err(Self::Error::from_eth_err)?
             {
-                return Ok(Some(cached_bal.as_bal().clone().into_alloy_bal()))
+                let (bal, _) = DecodedBal::from_rlp_bytes(cached_bal.as_raw().clone())
+                    .map_err(RethError::other)
+                    .map_err(Self::Error::from_eth_err)?
+                    .split();
+                return Ok(Some(Vec::from(bal)))
             }
 
             self.spawn_blocking_io(move |eth_api| {

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -280,7 +280,7 @@ impl<N: NodePrimitives> EthStateCache<N> {
     pub async fn get_bal(
         &self,
         block_hash: B256,
-    ) -> ProviderResult<Option<Arc<DecodedBal<RevmBal>>>> {
+    ) -> ProviderResult<Option<Arc<DecodedBal<Arc<RevmBal>>>>> {
         let (response_tx, rx) = oneshot::channel();
         let _ = self.to_service.send(CacheAction::GetBal { block_hash, response_tx });
         rx.await
@@ -925,12 +925,12 @@ pub async fn cache_new_blocks_task<St, N: NodePrimitives>(
 
 /// Cached decoded revm BAL.
 #[derive(Clone, Debug)]
-pub(crate) struct CachedRevmBal(Arc<DecodedBal<RevmBal>>);
+pub(crate) struct CachedRevmBal(Arc<DecodedBal<Arc<RevmBal>>>);
 
 impl CachedRevmBal {
     /// Creates a cached revm BAL from an owned decoded BAL.
     #[inline]
-    fn new(bal: DecodedBal<RevmBal>) -> Self {
+    fn new(bal: DecodedBal<Arc<RevmBal>>) -> Self {
         Self(Arc::new(bal))
     }
 }
@@ -941,11 +941,13 @@ impl InMemorySize for CachedRevmBal {
     }
 }
 
-fn decoded_revm_bal_size(bal: &DecodedBal<RevmBal>) -> usize {
-    core::mem::size_of::<DecodedBal<RevmBal>>() + bal.as_raw().len() + revm_bal_size(bal.as_bal())
+fn decoded_revm_bal_size(bal: &DecodedBal<Arc<RevmBal>>) -> usize {
+    core::mem::size_of::<DecodedBal<Arc<RevmBal>>>() +
+        bal.as_raw().len() +
+        revm_bal_size(bal.as_bal())
 }
 
-fn revm_bal_size(bal: &RevmBal) -> usize {
+fn revm_bal_size(bal: &Arc<RevmBal>) -> usize {
     core::mem::size_of::<RevmBal>() +
         bal.accounts.capacity() * core::mem::size_of::<(Address, RevmAccountBal)>() +
         bal.accounts.values().map(revm_account_bal_heap_size).sum::<usize>()
@@ -1020,8 +1022,8 @@ mod tests {
         service
     }
 
-    fn test_decoded_revm_bal() -> DecodedBal<RevmBal> {
-        DecodedBal::new(RevmBal::default(), Bytes::from_static(&[0xc0]))
+    fn test_decoded_revm_bal() -> DecodedBal<Arc<RevmBal>> {
+        DecodedBal::new(Arc::new(RevmBal::default()), Bytes::from_static(&[0xc0]))
     }
 
     fn test_block() -> RecoveredBlock<Block> {
@@ -1137,10 +1139,10 @@ mod tests {
 
         let raw = Bytes::from_static(&[0xc0, 0x01, 0x02]);
         let previous_estimate = core::mem::size_of::<CachedRevmBal>() +
-            core::mem::size_of::<DecodedBal<RevmBal>>() +
+            core::mem::size_of::<DecodedBal<Arc<RevmBal>>>() +
             raw.len() +
             core::mem::size_of::<RevmBal>();
-        assert!(CachedRevmBal::new(DecodedBal::new(bal, raw)).size() > previous_estimate);
+        assert!(CachedRevmBal::new(DecodedBal::new(Arc::new(bal), raw)).size() > previous_estimate);
     }
 
     #[tokio::test]
@@ -1234,7 +1236,7 @@ mod tests {
         fn revm_bal_by_hash(
             &self,
             _block_hash: BlockHash,
-        ) -> ProviderResult<Option<DecodedBal<RevmBal>>> {
+        ) -> ProviderResult<Option<DecodedBal<Arc<RevmBal>>>> {
             self.fetches.fetch_add(1, Ordering::SeqCst);
             Ok(Some(test_decoded_revm_bal()))
         }

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -92,11 +92,12 @@ pub trait BalStore: Send + Sync + 'static {
     fn revm_bal_by_hash(
         &self,
         block_hash: BlockHash,
-    ) -> ProviderResult<Option<DecodedBal<RevmBal>>> {
+    ) -> ProviderResult<Option<DecodedBal<Arc<RevmBal>>>> {
         self.get_decoded_by_hash(block_hash)?
             .map(|decoded| {
                 decoded.try_map(|bal| {
                     RevmBal::try_from(Vec::from(bal))
+                        .map(Arc::new)
                         .map_err(reth_storage_errors::provider::ProviderError::other)
                 })
             })
@@ -232,7 +233,7 @@ impl BalStoreHandle {
     pub fn revm_bal_by_hash(
         &self,
         block_hash: BlockHash,
-    ) -> ProviderResult<Option<DecodedBal<RevmBal>>> {
+    ) -> ProviderResult<Option<DecodedBal<Arc<RevmBal>>>> {
         self.inner.revm_bal_by_hash(block_hash)
     }
 


### PR DESCRIPTION
Stores decoded revm BALs as `DecodedBal<Arc<RevmBal>>` in the BAL store/cache so callers that need a shared revm BAL can clone the `Arc` instead of cloning the full BAL.

For `eth_blockAccessList` cache hits, decodes the retained raw BAL bytes instead of cloning the revm BAL back into alloy form.