### PR TITLE
refactor: use RawBal for block access lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
+checksum = "55c4584eaf235a861172e30d0d8adfa95957186f59b93f997851df90b32da7ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7968,7 +7968,7 @@ name = "reth-consensus"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8376,7 +8376,7 @@ name = "reth-engine-tree"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -8595,7 +8595,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-genesis",
  "alloy-hardforks 0.4.7",
@@ -8788,7 +8788,7 @@ name = "reth-evm"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -9191,6 +9191,7 @@ name = "reth-network-p2p"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
@@ -9673,7 +9674,7 @@ name = "reth-provider"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -10064,7 +10065,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
@@ -10110,7 +10111,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
@@ -10361,7 +10362,7 @@ name = "reth-storage-api"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10665,7 +10666,7 @@ dependencies = [
 name = "reth-trie-parallel"
 version = "2.3.0"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -10946,7 +10947,7 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "bitflags 2.11.1",
  "nonmax",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.4.0", default-features = false, features = ["rlp"] }
+alloy-eip7928 = { version = "0.4.3", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.37.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -388,15 +388,15 @@ impl Drop for ServiceGuard {
 mod tests {
     use super::*;
     use alloy_eips::NumHash;
-    use alloy_primitives::{keccak256, BlockHash, BlockNumber, Bytes, Sealed, B256, U256};
+    use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256, U256};
     use reth_chain_state::test_utils::TestBlockBuilder;
     use reth_exex_types::FinishedExExHeight;
     use reth_provider::{
         providers::{ProviderFactoryBuilder, ReadOnlyConfig},
         test_utils::{create_test_provider_factory, MockNodeTypes},
         AccountReader, BalConfig, BalNotificationStream, BalStore, BalStoreHandle,
-        ChainSpecProvider, HeaderProvider, InMemoryBalStore, ProviderError, ProviderResult,
-        SealedBal, StorageSettingsCache, TryIntoHistoricalStateProvider,
+        ChainSpecProvider, HeaderProvider, InMemoryBalStore, ProviderError, ProviderResult, RawBal,
+        StorageSettingsCache, TryIntoHistoricalStateProvider,
     };
     use reth_prune::Pruner;
     use reth_prune_types::PruneMode;
@@ -427,17 +427,9 @@ mod tests {
             BalConfig::with_in_memory_retention(PruneMode::Before(2)),
         ));
 
+        bal_store.insert(NumHash::new(1, old_hash), RawBal::new(old_bal.clone())).unwrap();
         bal_store
-            .insert(
-                NumHash::new(1, old_hash),
-                Sealed::new_unchecked(old_bal.clone(), keccak256(&old_bal)),
-            )
-            .unwrap();
-        bal_store
-            .insert(
-                NumHash::new(2, retained_hash),
-                Sealed::new_unchecked(retained_bal.clone(), keccak256(&retained_bal)),
-            )
+            .insert(NumHash::new(2, retained_hash), RawBal::new(retained_bal.clone()))
             .unwrap();
 
         let provider = create_test_provider_factory().with_bal_store(bal_store.clone());
@@ -478,7 +470,7 @@ mod tests {
     struct FailingPruneBalStore;
 
     impl BalStore for FailingPruneBalStore {
-        fn insert(&self, _num_hash: NumHash, _bal: SealedBal) -> ProviderResult<()> {
+        fn insert(&self, _num_hash: NumHash, _bal: RawBal) -> ProviderResult<()> {
             Ok(())
         }
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -427,7 +427,7 @@ mod tests {
             BalConfig::with_in_memory_retention(PruneMode::Before(2)),
         ));
 
-        bal_store.insert(NumHash::new(1, old_hash), RawBal::new(old_bal.clone())).unwrap();
+        bal_store.insert(NumHash::new(1, old_hash), RawBal::new(old_bal)).unwrap();
         bal_store
             .insert(NumHash::new(2, retained_hash), RawBal::new(retained_bal.clone()))
             .unwrap();

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -55,7 +55,10 @@ pub struct RethEvmFactory {
 impl Clone for RethEvmFactory {
     fn clone(&self) -> Self {
         Self {
+            #[cfg(feature = "jit")]
             inner: self.inner.clone(),
+            #[cfg(not(feature = "jit"))]
+            inner: self.inner,
             #[cfg(feature = "jit")]
             disabled: self.disabled.clone(),
             #[cfg(feature = "jit")]

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -3,7 +3,7 @@
 
 use alloy_consensus::Header;
 use alloy_eips::NumHash;
-use alloy_primitives::{keccak256, BlockHash, BlockNumber, Bytes, Sealed, B256};
+use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256};
 use rand::Rng;
 use reth_eth_wire::{BlockAccessLists, EthVersion, GetBlockAccessLists, HeadersDirection};
 use reth_ethereum_primitives::Block;
@@ -21,7 +21,7 @@ use reth_network_p2p::{
 };
 use reth_provider::{
     test_utils::MockEthProvider, BalNotificationStream, BalStore, BalStoreHandle, InMemoryBalStore,
-    ProviderError, ProviderResult, SealedBal,
+    ProviderError, ProviderResult, RawBal,
 };
 use reth_transaction_pool::test_utils::{TestPool, TransactionGenerator};
 use std::sync::Arc;
@@ -548,8 +548,8 @@ async fn test_eth71_get_block_access_lists() {
     let bal0 = Bytes::from_static(&[0xc1, 0x01]);
     let bal2 = Bytes::from_static(&[0xc1, 0x02]);
 
-    bal_store.insert(NumHash::new(1, hash0), sealed_bal(bal0.clone())).unwrap();
-    bal_store.insert(NumHash::new(3, hash2), sealed_bal(bal2.clone())).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(3, hash2), raw_bal(bal2.clone())).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1, hash2]).await;
     assert_eq!(response, BlockAccessLists(vec![Some(bal0), None, Some(bal2)]));
@@ -569,9 +569,9 @@ async fn test_eth71_get_block_access_lists_respects_response_soft_limit() {
     let bal2 = raw_bal_with_len(2);
     assert!(bal0.len() + bal1.len() > SOFT_RESPONSE_LIMIT);
 
-    bal_store.insert(NumHash::new(1, hash0), sealed_bal(bal0.clone())).unwrap();
-    bal_store.insert(NumHash::new(2, hash1), sealed_bal(bal1.clone())).unwrap();
-    bal_store.insert(NumHash::new(3, hash2), sealed_bal(bal2)).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(2, hash1), raw_bal(bal1.clone())).unwrap();
+    bal_store.insert(NumHash::new(3, hash2), raw_bal(bal2)).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1, hash2]).await;
 
@@ -589,8 +589,8 @@ async fn test_eth71_get_block_access_lists_returns_single_oversized_bal() {
     let bal0 = raw_bal_with_len(SOFT_RESPONSE_LIMIT + 1);
     let bal1 = raw_bal_with_len(2);
 
-    bal_store.insert(NumHash::new(1, hash0), sealed_bal(bal0.clone())).unwrap();
-    bal_store.insert(NumHash::new(2, hash1), sealed_bal(bal1)).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(2, hash1), raw_bal(bal1)).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1]).await;
 
@@ -621,7 +621,7 @@ async fn test_eth71_get_block_access_lists_caps_count() {
     // Insert one BAL so the store isn't entirely empty (not strictly needed,
     // but keeps the test path closer to real usage).
     let bal = Bytes::from_static(&[0xc1, 0x01]);
-    bal_store.insert(NumHash::new(1, hashes[0]), sealed_bal(bal)).unwrap();
+    bal_store.insert(NumHash::new(1, hashes[0]), raw_bal(bal)).unwrap();
 
     let response = request_block_access_lists(&net, hashes).await;
 
@@ -638,7 +638,7 @@ async fn test_eth71_fetch_client_get_block_access_lists() {
     let hash1 = B256::random();
     let bal0 = Bytes::from_static(&[0xc1, 0x01]);
 
-    bal_store.insert(NumHash::new(1, hash0), sealed_bal(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
 
     let fetch = net.peers()[0].network().fetch_client().await.unwrap();
     let response = fetch.get_block_access_lists(vec![hash0, hash1]).await.unwrap().into_data();
@@ -713,7 +713,7 @@ async fn spawn_bal_testnet_with_store(
 struct FailingLookupBalStore;
 
 impl BalStore for FailingLookupBalStore {
-    fn insert(&self, _num_hash: NumHash, _bal: SealedBal) -> ProviderResult<()> {
+    fn insert(&self, _num_hash: NumHash, _bal: RawBal) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -767,6 +767,6 @@ fn raw_bal_with_len(len: usize) -> Bytes {
     Bytes::from(out)
 }
 
-fn sealed_bal(bal: Bytes) -> SealedBal {
-    Sealed::new_unchecked(bal.clone(), keccak256(&bal))
+fn raw_bal(bal: Bytes) -> RawBal {
+    RawBal::new(bal)
 }

--- a/crates/net/network/tests/it/requests.rs
+++ b/crates/net/network/tests/it/requests.rs
@@ -548,8 +548,8 @@ async fn test_eth71_get_block_access_lists() {
     let bal0 = Bytes::from_static(&[0xc1, 0x01]);
     let bal2 = Bytes::from_static(&[0xc1, 0x02]);
 
-    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
-    bal_store.insert(NumHash::new(3, hash2), raw_bal(bal2.clone())).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), RawBal::from(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(3, hash2), RawBal::from(bal2.clone())).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1, hash2]).await;
     assert_eq!(response, BlockAccessLists(vec![Some(bal0), None, Some(bal2)]));
@@ -569,9 +569,9 @@ async fn test_eth71_get_block_access_lists_respects_response_soft_limit() {
     let bal2 = raw_bal_with_len(2);
     assert!(bal0.len() + bal1.len() > SOFT_RESPONSE_LIMIT);
 
-    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
-    bal_store.insert(NumHash::new(2, hash1), raw_bal(bal1.clone())).unwrap();
-    bal_store.insert(NumHash::new(3, hash2), raw_bal(bal2)).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), RawBal::from(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(2, hash1), RawBal::from(bal1.clone())).unwrap();
+    bal_store.insert(NumHash::new(3, hash2), RawBal::from(bal2)).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1, hash2]).await;
 
@@ -589,8 +589,8 @@ async fn test_eth71_get_block_access_lists_returns_single_oversized_bal() {
     let bal0 = raw_bal_with_len(SOFT_RESPONSE_LIMIT + 1);
     let bal1 = raw_bal_with_len(2);
 
-    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
-    bal_store.insert(NumHash::new(2, hash1), raw_bal(bal1)).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), RawBal::from(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(2, hash1), RawBal::from(bal1)).unwrap();
 
     let response = request_block_access_lists(&net, vec![hash0, hash1]).await;
 
@@ -621,7 +621,7 @@ async fn test_eth71_get_block_access_lists_caps_count() {
     // Insert one BAL so the store isn't entirely empty (not strictly needed,
     // but keeps the test path closer to real usage).
     let bal = Bytes::from_static(&[0xc1, 0x01]);
-    bal_store.insert(NumHash::new(1, hashes[0]), raw_bal(bal)).unwrap();
+    bal_store.insert(NumHash::new(1, hashes[0]), RawBal::from(bal)).unwrap();
 
     let response = request_block_access_lists(&net, hashes).await;
 
@@ -638,7 +638,7 @@ async fn test_eth71_fetch_client_get_block_access_lists() {
     let hash1 = B256::random();
     let bal0 = Bytes::from_static(&[0xc1, 0x01]);
 
-    bal_store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
+    bal_store.insert(NumHash::new(1, hash0), RawBal::from(bal0.clone())).unwrap();
 
     let fetch = net.peers()[0].network().fetch_client().await.unwrap();
     let response = fetch.get_block_access_lists(vec![hash0, hash1]).await.unwrap().into_data();
@@ -765,8 +765,4 @@ fn raw_bal_with_len(len: usize) -> Bytes {
     alloy_rlp::Header { list: true, payload_length }.encode(&mut out);
     out.resize(len, alloy_rlp::EMPTY_LIST_CODE);
     Bytes::from(out)
-}
-
-fn raw_bal(bal: Bytes) -> RawBal {
-    RawBal::new(bal)
 }

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -23,6 +23,7 @@ reth-storage-errors.workspace = true
 
 # ethereum
 alloy-consensus.workspace = true
+alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["rand"] }
 
@@ -50,11 +51,13 @@ test-utils = [
     "reth-network-types/test-utils",
     "reth-ethereum-primitives/test-utils",
     "reth-primitives-traits/test-utils",
+    "alloy-eip7928/std",
     "alloy-primitives/rand",
 ]
 std = [
     "reth-consensus/std",
     "reth-ethereum-primitives/std",
+    "alloy-eip7928/std",
     "alloy-eips/std",
     "alloy-primitives/std",
     "reth-primitives-traits/std",

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -1214,10 +1214,6 @@ mod tests {
     const EMPTY_LIST_CODE: u8 = 0xc0;
     use tokio::time::{timeout, Duration};
 
-    fn raw_bal(access_list: Bytes) -> RawBal {
-        RawBal::new(access_list)
-    }
-
     fn sealed_header_with_access_list_hash(access_list: &Bytes) -> SealedHeader {
         let header = Header {
             block_access_list_hash: Some(keccak256(access_list.as_ref())),
@@ -1269,7 +1265,7 @@ mod tests {
         let client = FullBlockClient::test_client(client);
 
         let received = client.get_full_block_with_access_lists(header.hash()).await;
-        let expected_access_list = raw_bal(access_list);
+        let expected_access_list = RawBal::from(access_list);
 
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert_eq!(received.data().as_ref(), Some(&expected_access_list));
@@ -1294,7 +1290,7 @@ mod tests {
             )
             .await;
 
-        let expected_access_list = raw_bal(access_list);
+        let expected_access_list = RawBal::from(access_list);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert_eq!(received.data().as_ref(), Some(&expected_access_list));
         assert_eq!(*requirement.lock(), Some(BalRequirement::Mandatory));
@@ -1318,7 +1314,7 @@ mod tests {
                 .await
                 .expect("access list request should complete");
 
-        let expected_access_list = raw_bal(access_list);
+        let expected_access_list = RawBal::from(access_list);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert_eq!(received.data().as_ref(), Some(&expected_access_list));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
@@ -1793,7 +1789,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(raw_bal(access_list))
+                    Some(RawBal::from(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1879,7 +1875,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(raw_bal(access_list))
+                    Some(RawBal::from(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1918,7 +1914,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(raw_bal(access_list))
+                    Some(RawBal::from(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -2012,7 +2008,10 @@ mod tests {
 
         assert_eq!(blocks.len(), 3);
         assert_eq!(blocks[1].block().hash(), second_hash);
-        assert_eq!(range_access_lists(&blocks), vec![Some(raw_bal(first_access_list)), None, None]);
+        assert_eq!(
+            range_access_lists(&blocks),
+            vec![Some(RawBal::from(first_access_list)), None, None]
+        );
         assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -391,9 +391,9 @@ where
                 match access_lists.0.len() {
                     0 => self.bal_request_state = BalRequestState::Ready(None),
                     1 => {
-                        let access_list = access_lists.0.into_iter().next().expect("len checked");
+                        let bal = access_lists.0.into_iter().next().expect("len checked");
                         self.bal_request_state =
-                            BalRequestState::Ready(Some(WithPeerId::new(peer, access_list)));
+                            BalRequestState::Ready(Some(WithPeerId::new(peer, bal)));
                     }
                     received => {
                         debug!(
@@ -428,18 +428,17 @@ where
     /// response from racing a still-pending BAL response and incorrectly dropping available BAL
     /// data.
     fn take_block_and_access_lists(&mut self) -> Option<SealedBlockWithAccessList<Client::Block>> {
-        let BalRequestState::Ready(access_list) = &mut self.bal_request_state else { return None };
+        let BalRequestState::Ready(bal) = &mut self.bal_request_state else { return None };
         let block = self.block_result.take()?;
-        let access_list = access_list.take().and_then(|access_list| {
-            match seal_block_access_list_for_block(&block, access_list) {
-                Ok(access_list) => access_list,
+        let raw_bal =
+            bal.take().and_then(|bal| match seal_block_access_list_for_block(&block, bal) {
+                Ok(raw_bal) => raw_bal,
                 Err(peer) => {
                     self.block.client.report_bad_message(peer);
                     None
                 }
-            }
-        });
-        Some(SealedBlockWith::new(block, access_list))
+            });
+        Some(SealedBlockWith::new(block, raw_bal))
     }
 }
 
@@ -1112,16 +1111,16 @@ impl<Net> Default for NoopFullBlockClient<Net> {
 /// reported as a bad message.
 fn seal_block_access_list_for_block<B: Block>(
     block: &SealedBlock<B>,
-    access_list: WithPeerId<Option<Bytes>>,
+    bal: WithPeerId<Option<Bytes>>,
 ) -> Result<Option<RawBal>, PeerId> {
     let Some(expected) = block.header().block_access_list_hash() else { return Ok(None) };
 
-    let (peer, access_list) = access_list.split();
-    let Some(access_list) = access_list else { return Ok(None) };
-    let access_list = RawBal::new(access_list);
-    let computed = access_list.hash();
+    let (peer, bal) = bal.split();
+    let Some(bal) = bal else { return Ok(None) };
+    let raw_bal = RawBal::new(bal);
+    let computed = raw_bal.hash();
     if computed == expected {
-        return Ok(Some(access_list))
+        return Ok(Some(raw_bal))
     }
 
     debug!(
@@ -1171,15 +1170,15 @@ where
     let mut response = Vec::with_capacity(expected);
 
     for block in blocks.by_ref() {
-        let Some(access_list) = access_lists.next() else {
+        let Some(bal) = access_lists.next() else {
             // Short BAL responses are valid; the current block and all remaining blocks are
             // returned without access-list data below.
             response.push(SealedBlockWith::from_block(block));
             break
         };
 
-        match seal_block_access_list_for_block(&block, WithPeerId::new(peer, access_list)) {
-            Ok(access_list) => response.push(SealedBlockWith::new(block, access_list)),
+        match seal_block_access_list_for_block(&block, WithPeerId::new(peer, bal)) {
+            Ok(raw_bal) => response.push(SealedBlockWith::new(block, raw_bal)),
             Err(peer) => {
                 // A hash mismatch means this BAL entry is not for the current block. Stop matching
                 // later positional entries and return the rest of the range without BAL data.
@@ -1214,11 +1213,9 @@ mod tests {
     const EMPTY_LIST_CODE: u8 = 0xc0;
     use tokio::time::{timeout, Duration};
 
-    fn sealed_header_with_access_list_hash(access_list: &Bytes) -> SealedHeader {
-        let header = Header {
-            block_access_list_hash: Some(keccak256(access_list.as_ref())),
-            ..Default::default()
-        };
+    fn sealed_header_with_access_list_hash(bal: &Bytes) -> SealedHeader {
+        let header =
+            Header { block_access_list_hash: Some(keccak256(bal.as_ref())), ..Default::default() };
         SealedHeader::seal_slow(header)
     }
 
@@ -1257,18 +1254,18 @@ mod tests {
     async fn download_single_full_block_with_access_lists() {
         let client = FullBlockWithAccessListsClient::default();
         let body = BlockBody::default();
-        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let header = sealed_header_with_access_list_hash(&access_list);
-        client.insert(header.clone(), body.clone(), access_list.clone());
+        let bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&bal);
+        client.insert(header.clone(), body.clone(), bal.clone());
 
         let request_count = Arc::clone(&client.access_list_requests);
         let client = FullBlockClient::test_client(client);
 
         let received = client.get_full_block_with_access_lists(header.hash()).await;
-        let expected_access_list = RawBal::from(access_list);
+        let expected_raw_bal = RawBal::from(bal);
 
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received.data().as_ref(), Some(&expected_access_list));
+        assert_eq!(received.data().as_ref(), Some(&expected_raw_bal));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
     }
 
@@ -1276,9 +1273,9 @@ mod tests {
     async fn download_single_full_block_with_access_lists_uses_requested_requirement() {
         let client = FullBlockWithAccessListsClient::default();
         let body = BlockBody::default();
-        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let header = sealed_header_with_access_list_hash(&access_list);
-        client.insert(header.clone(), body.clone(), access_list.clone());
+        let bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&bal);
+        client.insert(header.clone(), body.clone(), bal.clone());
 
         let requirement = Arc::clone(&client.last_access_list_requirement);
         let client = FullBlockClient::test_client(client);
@@ -1290,9 +1287,9 @@ mod tests {
             )
             .await;
 
-        let expected_access_list = RawBal::from(access_list);
+        let expected_raw_bal = RawBal::from(bal);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received.data().as_ref(), Some(&expected_access_list));
+        assert_eq!(received.data().as_ref(), Some(&expected_raw_bal));
         assert_eq!(*requirement.lock(), Some(BalRequirement::Mandatory));
     }
 
@@ -1302,9 +1299,9 @@ mod tests {
         client.set_access_list_pending_polls(1);
 
         let body = BlockBody::default();
-        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let header = sealed_header_with_access_list_hash(&access_list);
-        client.insert(header.clone(), body.clone(), access_list.clone());
+        let bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&bal);
+        client.insert(header.clone(), body.clone(), bal.clone());
 
         let request_count = Arc::clone(&client.access_list_requests);
         let client = FullBlockClient::test_client(client);
@@ -1314,9 +1311,9 @@ mod tests {
                 .await
                 .expect("access list request should complete");
 
-        let expected_access_list = RawBal::from(access_list);
+        let expected_raw_bal = RawBal::from(bal);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
-        assert_eq!(received.data().as_ref(), Some(&expected_access_list));
+        assert_eq!(received.data().as_ref(), Some(&expected_raw_bal));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
     }
 
@@ -1324,10 +1321,10 @@ mod tests {
     async fn download_single_full_block_with_access_lists_rejects_wrong_hash() {
         let client = FullBlockWithAccessListsClient::default();
         let body = BlockBody::default();
-        let expected_access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let wrong_access_list = Bytes::from_static(&[0xc1, 0x01]);
-        let header = sealed_header_with_access_list_hash(&expected_access_list);
-        client.insert(header.clone(), body.clone(), wrong_access_list);
+        let expected_bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let wrong_bal = Bytes::from_static(&[0xc1, 0x01]);
+        let header = sealed_header_with_access_list_hash(&expected_bal);
+        client.insert(header.clone(), body.clone(), wrong_bal);
 
         let bad_messages = Arc::clone(&client.bad_messages);
         let client = FullBlockClient::test_client(client);
@@ -1346,8 +1343,8 @@ mod tests {
     async fn download_single_full_block_with_access_lists_treats_none_as_unavailable() {
         let client = FullBlockWithAccessListsClient::default();
         let body = BlockBody::default();
-        let expected_access_list = Bytes::from_static(&[0xc1, 0x01]);
-        let header = sealed_header_with_access_list_hash(&expected_access_list);
+        let expected_bal = Bytes::from_static(&[0xc1, 0x01]);
+        let header = sealed_header_with_access_list_hash(&expected_bal);
         client.inner.insert(header.clone(), body.clone());
 
         let bad_messages = Arc::clone(&client.bad_messages);
@@ -1367,10 +1364,10 @@ mod tests {
     async fn download_single_full_block_with_access_lists_rejects_wrong_empty_list() {
         let client = FullBlockWithAccessListsClient::default();
         let body = BlockBody::default();
-        let expected_access_list = Bytes::from_static(&[0xc1, 0x01]);
-        let wrong_empty_access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let header = sealed_header_with_access_list_hash(&expected_access_list);
-        client.insert(header.clone(), body.clone(), wrong_empty_access_list);
+        let expected_bal = Bytes::from_static(&[0xc1, 0x01]);
+        let wrong_empty_bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&expected_bal);
+        client.insert(header.clone(), body.clone(), wrong_empty_bal);
 
         let bad_messages = Arc::clone(&client.bad_messages);
         let client = FullBlockClient::test_client(client);
@@ -1391,9 +1388,9 @@ mod tests {
         client.empty_first_response.store(true, Ordering::SeqCst);
 
         let body = BlockBody::default();
-        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let header = sealed_header_with_access_list_hash(&access_list);
-        client.insert(header.clone(), body.clone(), access_list.clone());
+        let bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&bal);
+        client.insert(header.clone(), body.clone(), bal.clone());
 
         let request_count = Arc::clone(&client.access_list_requests);
         let bad_messages = Arc::clone(&client.bad_messages);
@@ -1416,9 +1413,9 @@ mod tests {
         client.set_access_lists_unsupported(true);
 
         let body = BlockBody::default();
-        let access_list = Bytes::from_static(&[EMPTY_LIST_CODE]);
-        let header = sealed_header_with_access_list_hash(&access_list);
-        client.insert(header.clone(), body.clone(), access_list);
+        let bal = Bytes::from_static(&[EMPTY_LIST_CODE]);
+        let header = sealed_header_with_access_list_hash(&bal);
+        client.insert(header.clone(), body.clone(), bal);
 
         let request_count = Arc::clone(&client.access_list_requests);
         let requirement = Arc::clone(&client.last_access_list_requirement);
@@ -1492,9 +1489,9 @@ mod tests {
     }
 
     impl FullBlockWithAccessListsClient {
-        fn insert(&self, header: SealedHeader, body: BlockBody, access_list: Bytes) {
+        fn insert(&self, header: SealedHeader, body: BlockBody, bal: Bytes) {
             self.inner.insert(header.clone(), body);
-            self.access_lists.lock().insert(header.hash(), access_list);
+            self.access_lists.lock().insert(header.hash(), bal);
         }
 
         fn set_access_list_soft_limit(&self, limit: usize) {
@@ -1525,12 +1522,12 @@ mod tests {
             let (mut header, hash) = sealed_header.split();
             header.parent_hash = hash;
             header.number += 1;
-            let access_list = Bytes::from(vec![0xc1, block_idx as u8]);
-            header.block_access_list_hash = Some(keccak256(access_list.as_ref()));
+            let bal = Bytes::from(vec![0xc1, block_idx as u8]);
+            header.block_access_list_hash = Some(keccak256(bal.as_ref()));
 
             sealed_header = SealedHeader::seal_slow(header);
 
-            client.insert(sealed_header.clone(), body.clone(), access_list);
+            client.insert(sealed_header.clone(), body.clone(), bal);
         }
 
         (sealed_header, body)
@@ -1781,15 +1778,12 @@ mod tests {
         let blocks = response;
         assert_eq!(blocks.len(), 3);
         let expected = {
-            let access_lists = access_lists.lock();
+            let bals = access_lists.lock();
             blocks
                 .iter()
                 .map(|block| {
-                    let access_list = access_lists
-                        .get(&block.block().hash())
-                        .cloned()
-                        .expect("access list exists");
-                    Some(RawBal::from(access_list))
+                    let bal = bals.get(&block.block().hash()).cloned().expect("access list exists");
+                    Some(RawBal::from(bal))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1862,7 +1856,7 @@ mod tests {
 
         assert_eq!(blocks.len(), 5);
         let expected = {
-            let access_lists = access_lists.lock();
+            let bals = access_lists.lock();
             blocks
                 .iter()
                 .enumerate()
@@ -1871,11 +1865,8 @@ mod tests {
                         return None
                     }
 
-                    let access_list = access_lists
-                        .get(&block.block().hash())
-                        .cloned()
-                        .expect("access list exists");
-                    Some(RawBal::from(access_list))
+                    let bal = bals.get(&block.block().hash()).cloned().expect("access list exists");
+                    Some(RawBal::from(bal))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1902,7 +1893,7 @@ mod tests {
 
         assert_eq!(blocks.len(), 3);
         let expected = {
-            let access_lists = access_lists.lock();
+            let bals = access_lists.lock();
             blocks
                 .iter()
                 .map(|block| {
@@ -1910,11 +1901,8 @@ mod tests {
                         return None
                     }
 
-                    let access_list = access_lists
-                        .get(&block.block().hash())
-                        .cloned()
-                        .expect("access list exists");
-                    Some(RawBal::from(access_list))
+                    let bal = bals.get(&block.block().hash()).cloned().expect("access list exists");
+                    Some(RawBal::from(bal))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1991,7 +1979,7 @@ mod tests {
     async fn download_full_block_range_with_access_lists_preserves_valid_prefix_until_wrong_hash() {
         let client = FullBlockWithAccessListsClient::default();
         let (header, _) = insert_headers_with_access_lists_into_client(&client, 0..3);
-        let first_access_list =
+        let first_bal =
             client.access_lists.lock().get(&header.hash()).cloned().expect("access list exists");
         let second_hash = header.parent_hash;
         client.access_lists.lock().insert(second_hash, Bytes::from_static(&[0xc1, 0x7f]));
@@ -2008,10 +1996,7 @@ mod tests {
 
         assert_eq!(blocks.len(), 3);
         assert_eq!(blocks[1].block().hash(), second_hash);
-        assert_eq!(
-            range_access_lists(&blocks),
-            vec![Some(RawBal::from(first_access_list)), None, None]
-        );
+        assert_eq!(range_access_lists(&blocks), vec![Some(RawBal::from(first_bal)), None, None]);
         assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -9,7 +9,8 @@ use crate::{
     BlockClient,
 };
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{keccak256, Bytes, Sealable, Sealed, B256};
+use alloy_eip7928::bal::RawBal;
+use alloy_primitives::{Bytes, Sealable, B256};
 use core::marker::PhantomData;
 use futures::FutureExt;
 use reth_consensus::Consensus;
@@ -30,8 +31,8 @@ use std::{
 };
 use tracing::{debug, trace};
 
-/// A sealed block with optional validated block access-list data.
-pub type SealedBlockWithAccessList<B> = SealedBlockWith<B, Option<Sealed<Bytes>>>;
+/// A sealed block with optional validated raw block access-list data.
+pub type SealedBlockWithAccessList<B> = SealedBlockWith<B, Option<RawBal>>;
 
 /// A Client that can fetch full blocks from the network.
 #[derive(Debug, Clone)]
@@ -1112,14 +1113,15 @@ impl<Net> Default for NoopFullBlockClient<Net> {
 fn seal_block_access_list_for_block<B: Block>(
     block: &SealedBlock<B>,
     access_list: WithPeerId<Option<Bytes>>,
-) -> Result<Option<Sealed<Bytes>>, PeerId> {
+) -> Result<Option<RawBal>, PeerId> {
     let Some(expected) = block.header().block_access_list_hash() else { return Ok(None) };
 
     let (peer, access_list) = access_list.split();
     let Some(access_list) = access_list else { return Ok(None) };
-    let computed = keccak256(access_list.as_ref());
+    let access_list = RawBal::new(access_list);
+    let computed = access_list.hash();
     if computed == expected {
-        return Ok(Some(Sealed::new_unchecked(access_list, expected)))
+        return Ok(Some(access_list))
     }
 
     debug!(
@@ -1212,9 +1214,8 @@ mod tests {
     const EMPTY_LIST_CODE: u8 = 0xc0;
     use tokio::time::{timeout, Duration};
 
-    fn sealed_access_list(access_list: Bytes) -> Sealed<Bytes> {
-        let hash = keccak256(access_list.as_ref());
-        Sealed::new_unchecked(access_list, hash)
+    fn raw_bal(access_list: Bytes) -> RawBal {
+        RawBal::new(access_list)
     }
 
     fn sealed_header_with_access_list_hash(access_list: &Bytes) -> SealedHeader {
@@ -1227,7 +1228,7 @@ mod tests {
 
     fn range_access_lists<B: Block>(
         blocks: &[SealedBlockWithAccessList<B>],
-    ) -> Vec<Option<Sealed<Bytes>>> {
+    ) -> Vec<Option<RawBal>> {
         blocks.iter().map(|block| block.data().clone()).collect()
     }
 
@@ -1268,7 +1269,7 @@ mod tests {
         let client = FullBlockClient::test_client(client);
 
         let received = client.get_full_block_with_access_lists(header.hash()).await;
-        let expected_access_list = sealed_access_list(access_list);
+        let expected_access_list = raw_bal(access_list);
 
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert_eq!(received.data().as_ref(), Some(&expected_access_list));
@@ -1293,7 +1294,7 @@ mod tests {
             )
             .await;
 
-        let expected_access_list = sealed_access_list(access_list);
+        let expected_access_list = raw_bal(access_list);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert_eq!(received.data().as_ref(), Some(&expected_access_list));
         assert_eq!(*requirement.lock(), Some(BalRequirement::Mandatory));
@@ -1317,7 +1318,7 @@ mod tests {
                 .await
                 .expect("access list request should complete");
 
-        let expected_access_list = sealed_access_list(access_list);
+        let expected_access_list = raw_bal(access_list);
         assert_eq!(received.block(), &SealedBlock::from_sealed_parts(header, body));
         assert_eq!(received.data().as_ref(), Some(&expected_access_list));
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
@@ -1792,7 +1793,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(sealed_access_list(access_list))
+                    Some(raw_bal(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1878,7 +1879,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(sealed_access_list(access_list))
+                    Some(raw_bal(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -1917,7 +1918,7 @@ mod tests {
                         .get(&block.block().hash())
                         .cloned()
                         .expect("access list exists");
-                    Some(sealed_access_list(access_list))
+                    Some(raw_bal(access_list))
                 })
                 .collect::<Vec<_>>()
         };
@@ -2011,10 +2012,7 @@ mod tests {
 
         assert_eq!(blocks.len(), 3);
         assert_eq!(blocks[1].block().hash(), second_hash);
-        assert_eq!(
-            range_access_lists(&blocks),
-            vec![Some(sealed_access_list(first_access_list)), None, None]
-        );
+        assert_eq!(range_access_lists(&blocks), vec![Some(raw_bal(first_access_list)), None, None]);
         assert_eq!(bad_messages.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1574,7 +1574,7 @@ struct EngineApiInner<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSp
 mod tests {
     use super::*;
     use alloy_eips::{eip7685::Requests, NumHash};
-    use alloy_primitives::{keccak256, Address, Bytes, Sealed, B256};
+    use alloy_primitives::{Address, Bytes, B256};
     use alloy_rpc_types_engine::{
         ClientCode, ClientVersionV1, ExecutionPayloadV2, PayloadAttributes, PayloadStatusEnum,
     };
@@ -1588,7 +1588,7 @@ mod tests {
     };
     use reth_node_ethereum::EthereumEngineValidator;
     use reth_payload_builder::test_utils::spawn_test_payload_service;
-    use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore};
+    use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore, RawBal};
     use reth_tasks::Runtime;
     use reth_transaction_pool::noop::NoopTransactionPool;
     use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
@@ -1686,8 +1686,7 @@ mod tests {
         provider.add_block(block_without_bal_hash, block_without_bal);
 
         let raw_bal = Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]);
-        let sealed_bal = Sealed::new_unchecked(raw_bal.clone(), keccak256(&raw_bal));
-        bal_store.insert(NumHash::new(1, block_hash), sealed_bal).unwrap();
+        bal_store.insert(NumHash::new(1, block_hash), RawBal::new(raw_bal.clone())).unwrap();
 
         let missing_hash = B256::with_last_byte(3);
         let response = api
@@ -1742,8 +1741,7 @@ mod tests {
         provider.add_block(block_without_bal_hash, block_without_bal);
 
         let raw_bal = Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]);
-        let sealed_bal = Sealed::new_unchecked(raw_bal.clone(), keccak256(&raw_bal));
-        bal_store.insert(NumHash::new(1, block_hash), sealed_bal).unwrap();
+        bal_store.insert(NumHash::new(1, block_hash), RawBal::new(raw_bal.clone())).unwrap();
 
         let response = api.get_payload_bodies_by_range_v2(1, 3).await.unwrap();
 

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -1217,11 +1217,7 @@ mod tests {
     }
 
     impl BalStore for TestBalStore {
-        fn insert(
-            &self,
-            _num_hash: NumHash,
-            _bal: reth_storage_api::SealedBal,
-        ) -> ProviderResult<()> {
+        fn insert(&self, _num_hash: NumHash, _bal: reth_storage_api::RawBal) -> ProviderResult<()> {
             Ok(())
         }
 

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use parking_lot::RwLock;
 use reth_prune_types::PruneMode;
 use reth_storage_api::{
-    BalNotification, BalNotificationStream, BalStore, GetBlockAccessListLimit, SealedBal,
+    BalNotification, BalNotificationStream, BalStore, GetBlockAccessListLimit, RawBal,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_tokio_util::EventSender;
@@ -129,9 +129,9 @@ struct BalEntry {
 }
 
 impl BalStore for InMemoryBalStore {
-    fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
+    fn insert(&self, num_hash: NumHash, bal: RawBal) -> ProviderResult<()> {
         let mut inner = self.inner.write();
-        inner.insert(num_hash.hash, num_hash.number, bal.clone_inner());
+        inner.insert(num_hash.hash, num_hash.number, bal.as_raw().clone());
         if let Some(highest_block_number) = inner.highest_block_number {
             // This preserves insert-time cleanup based on the highest inserted BAL block.
             inner.prune(self.config.in_memory_retention, highest_block_number);
@@ -140,7 +140,7 @@ impl BalStore for InMemoryBalStore {
         Ok(())
     }
 
-    fn insert_many(&self, entries: Vec<(NumHash, SealedBal)>) -> ProviderResult<()> {
+    fn insert_many(&self, entries: Vec<(NumHash, RawBal)>) -> ProviderResult<()> {
         if entries.is_empty() {
             return Ok(())
         }
@@ -148,7 +148,7 @@ impl BalStore for InMemoryBalStore {
         let mut inner = self.inner.write();
         inner.entries.reserve(entries.len());
         for (num_hash, bal) in &entries {
-            inner.insert(num_hash.hash, num_hash.number, bal.clone_inner());
+            inner.insert(num_hash.hash, num_hash.number, bal.as_raw().clone());
         }
         if let Some(highest_block_number) = inner.highest_block_number {
             inner.prune(self.config.in_memory_retention, highest_block_number);
@@ -210,11 +210,11 @@ impl BalStore for InMemoryBalStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{keccak256, Sealed, B256};
+    use alloy_primitives::B256;
     use tokio_stream::StreamExt;
 
-    fn sealed_bal(bal: Bytes) -> SealedBal {
-        Sealed::new_unchecked(bal.clone(), keccak256(&bal))
+    fn raw_bal(bal: Bytes) -> RawBal {
+        RawBal::new(bal)
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
         let missing = B256::random();
         let bal = Bytes::from_static(b"bal");
 
-        store.insert(NumHash::new(1, hash), sealed_bal(bal.clone())).unwrap();
+        store.insert(NumHash::new(1, hash), raw_bal(bal.clone())).unwrap();
 
         assert_eq!(store.get_by_hashes(&[hash, missing]).unwrap(), vec![Some(bal), None]);
     }
@@ -234,8 +234,8 @@ mod tests {
         let store = InMemoryBalStore::default();
         let hash0 = B256::random();
         let hash1 = B256::random();
-        let bal0 = sealed_bal(Bytes::from_static(b"bal0"));
-        let bal1 = sealed_bal(Bytes::from_static(b"bal1"));
+        let bal0 = raw_bal(Bytes::from_static(b"bal0"));
+        let bal1 = raw_bal(Bytes::from_static(b"bal1"));
 
         store
             .insert_many(vec![
@@ -246,7 +246,7 @@ mod tests {
 
         assert_eq!(
             store.get_by_hashes(&[hash0, hash1]).unwrap(),
-            vec![Some(bal0.clone_inner()), Some(Bytes::from_static(b"bal1"))]
+            vec![Some(bal0.as_raw().clone()), Some(Bytes::from_static(b"bal1"))]
         );
     }
 
@@ -267,9 +267,9 @@ mod tests {
         let bal1 = Bytes::from_static(&[0xc1, 0x02]);
         let bal2 = Bytes::from_static(&[0xc1, 0x03]);
 
-        store.insert(NumHash::new(1, hash0), sealed_bal(bal0.clone())).unwrap();
-        store.insert(NumHash::new(2, hash1), sealed_bal(bal1.clone())).unwrap();
-        store.insert(NumHash::new(3, hash2), sealed_bal(bal2)).unwrap();
+        store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
+        store.insert(NumHash::new(2, hash1), raw_bal(bal1.clone())).unwrap();
+        store.insert(NumHash::new(3, hash2), raw_bal(bal2)).unwrap();
 
         let limited = store
             .get_by_hashes_with_limit(
@@ -291,17 +291,17 @@ mod tests {
         let retained_bal = Bytes::from_static(b"retained");
         let tip_bal = Bytes::from_static(b"tip");
 
-        store.insert(NumHash::new(1, old_hash), sealed_bal(old_bal)).unwrap();
+        store.insert(NumHash::new(1, old_hash), raw_bal(old_bal)).unwrap();
         store
             .insert(
                 NumHash::new(BAL_RETENTION_PERIOD_SLOTS, retained_hash),
-                sealed_bal(retained_bal.clone()),
+                raw_bal(retained_bal.clone()),
             )
             .unwrap();
         store
             .insert(
                 NumHash::new(BAL_RETENTION_PERIOD_SLOTS + 2, tip_hash),
-                sealed_bal(tip_bal.clone()),
+                raw_bal(tip_bal.clone()),
             )
             .unwrap();
 
@@ -320,8 +320,8 @@ mod tests {
         let old_bal = Bytes::from_static(b"old");
         let retained_bal = Bytes::from_static(b"retained");
 
-        store.insert(NumHash::new(7, old_hash), sealed_bal(old_bal)).unwrap();
-        store.insert(NumHash::new(8, retained_hash), sealed_bal(retained_bal.clone())).unwrap();
+        store.insert(NumHash::new(7, old_hash), raw_bal(old_bal)).unwrap();
+        store.insert(NumHash::new(8, retained_hash), raw_bal(retained_bal.clone())).unwrap();
 
         assert_eq!(store.prune(10).unwrap(), 1);
         assert_eq!(
@@ -340,9 +340,9 @@ mod tests {
         let high_bal = Bytes::from_static(b"high");
         let late_bal = Bytes::from_static(b"late");
 
-        store.insert(NumHash::new(7, old_hash), sealed_bal(Bytes::from_static(b"old"))).unwrap();
-        store.insert(NumHash::new(10, high_hash), sealed_bal(high_bal.clone())).unwrap();
-        store.insert(NumHash::new(8, late_hash), sealed_bal(late_bal.clone())).unwrap();
+        store.insert(NumHash::new(7, old_hash), raw_bal(Bytes::from_static(b"old"))).unwrap();
+        store.insert(NumHash::new(10, high_hash), raw_bal(high_bal.clone())).unwrap();
+        store.insert(NumHash::new(8, late_hash), raw_bal(late_bal.clone())).unwrap();
 
         assert_eq!(
             store.get_by_hashes(&[old_hash, high_hash, late_hash]).unwrap(),
@@ -358,11 +358,11 @@ mod tests {
         let old_bal = Bytes::from_static(b"old");
         let tip_bal = Bytes::from_static(b"tip");
 
-        store.insert(NumHash::new(1, old_hash), sealed_bal(old_bal.clone())).unwrap();
+        store.insert(NumHash::new(1, old_hash), raw_bal(old_bal.clone())).unwrap();
         store
             .insert(
                 NumHash::new(BAL_RETENTION_PERIOD_SLOTS + 1, tip_hash),
-                sealed_bal(tip_bal.clone()),
+                raw_bal(tip_bal.clone()),
             )
             .unwrap();
 
@@ -383,9 +383,9 @@ mod tests {
         let retained_bal = Bytes::from_static(b"retained");
         let tip_bal = Bytes::from_static(b"tip");
 
-        store.insert(NumHash::new(1, old_hash), sealed_bal(old_bal)).unwrap();
-        store.insert(NumHash::new(2, retained_hash), sealed_bal(retained_bal.clone())).unwrap();
-        store.insert(NumHash::new(4, tip_hash), sealed_bal(tip_bal.clone())).unwrap();
+        store.insert(NumHash::new(1, old_hash), raw_bal(old_bal)).unwrap();
+        store.insert(NumHash::new(2, retained_hash), raw_bal(retained_bal.clone())).unwrap();
+        store.insert(NumHash::new(4, tip_hash), raw_bal(tip_bal.clone())).unwrap();
 
         assert_eq!(
             store.get_by_hashes(&[old_hash, retained_hash, tip_hash]).unwrap(),
@@ -400,8 +400,8 @@ mod tests {
         let hash = B256::random();
         let bal = Bytes::from_static(b"bal");
 
-        store.insert(NumHash::new(1, hash), sealed_bal(Bytes::from_static(b"old"))).unwrap();
-        store.insert(NumHash::new(2, hash), sealed_bal(bal.clone())).unwrap();
+        store.insert(NumHash::new(1, hash), raw_bal(Bytes::from_static(b"old"))).unwrap();
+        store.insert(NumHash::new(2, hash), raw_bal(bal.clone())).unwrap();
 
         assert_eq!(store.get_by_hashes(&[hash]).unwrap(), vec![Some(bal)]);
     }
@@ -414,13 +414,13 @@ mod tests {
         let bal = Bytes::from_static(b"bal");
         let mut stream = store.bal_stream();
 
-        let sealed_bal = sealed_bal(bal);
+        let raw_bal = raw_bal(bal);
 
-        store.insert(NumHash::new(block_number, hash), sealed_bal.clone()).unwrap();
+        store.insert(NumHash::new(block_number, hash), raw_bal.clone()).unwrap();
 
         assert_eq!(
             stream.next().await.unwrap(),
-            BalNotification::new(NumHash::new(block_number, hash), sealed_bal)
+            BalNotification::new(NumHash::new(block_number, hash), raw_bal)
         );
     }
 
@@ -430,8 +430,8 @@ mod tests {
         let mut stream = store.bal_stream();
         let hash0 = B256::random();
         let hash1 = B256::random();
-        let bal0 = sealed_bal(Bytes::from_static(b"bal0"));
-        let bal1 = sealed_bal(Bytes::from_static(b"bal1"));
+        let bal0 = raw_bal(Bytes::from_static(b"bal0"));
+        let bal1 = raw_bal(Bytes::from_static(b"bal1"));
 
         store
             .insert_many(vec![
@@ -455,7 +455,7 @@ mod tests {
         let store = InMemoryBalStore::default();
 
         assert!(store
-            .insert(NumHash::new(1, B256::random()), sealed_bal(Bytes::from_static(b"bal")))
+            .insert(NumHash::new(1, B256::random()), raw_bal(Bytes::from_static(b"bal")))
             .is_ok());
     }
 
@@ -468,7 +468,7 @@ mod tests {
             store
                 .insert(
                     NumHash::new(number, B256::random()),
-                    sealed_bal(Bytes::from(vec![number as u8])),
+                    raw_bal(Bytes::from(vec![number as u8])),
                 )
                 .unwrap();
         }
@@ -489,13 +489,13 @@ mod tests {
         let bal = Bytes::from_static(b"bal");
         let mut stream = clone.bal_stream();
 
-        let sealed_bal = sealed_bal(bal);
+        let raw_bal = raw_bal(bal);
 
-        store.insert(NumHash::new(block_number, hash), sealed_bal.clone()).unwrap();
+        store.insert(NumHash::new(block_number, hash), raw_bal.clone()).unwrap();
 
         assert_eq!(
             stream.next().await.unwrap(),
-            BalNotification::new(NumHash::new(block_number, hash), sealed_bal)
+            BalNotification::new(NumHash::new(block_number, hash), raw_bal)
         );
     }
 }

--- a/crates/storage/provider/src/bal.rs
+++ b/crates/storage/provider/src/bal.rs
@@ -213,10 +213,6 @@ mod tests {
     use alloy_primitives::B256;
     use tokio_stream::StreamExt;
 
-    fn raw_bal(bal: Bytes) -> RawBal {
-        RawBal::new(bal)
-    }
-
     #[test]
     fn insert_and_lookup_by_hash() {
         let store = InMemoryBalStore::default();
@@ -224,7 +220,7 @@ mod tests {
         let missing = B256::random();
         let bal = Bytes::from_static(b"bal");
 
-        store.insert(NumHash::new(1, hash), raw_bal(bal.clone())).unwrap();
+        store.insert(NumHash::new(1, hash), RawBal::from(bal.clone())).unwrap();
 
         assert_eq!(store.get_by_hashes(&[hash, missing]).unwrap(), vec![Some(bal), None]);
     }
@@ -234,8 +230,8 @@ mod tests {
         let store = InMemoryBalStore::default();
         let hash0 = B256::random();
         let hash1 = B256::random();
-        let bal0 = raw_bal(Bytes::from_static(b"bal0"));
-        let bal1 = raw_bal(Bytes::from_static(b"bal1"));
+        let bal0 = RawBal::from(Bytes::from_static(b"bal0"));
+        let bal1 = RawBal::from(Bytes::from_static(b"bal1"));
 
         store
             .insert_many(vec![
@@ -267,9 +263,9 @@ mod tests {
         let bal1 = Bytes::from_static(&[0xc1, 0x02]);
         let bal2 = Bytes::from_static(&[0xc1, 0x03]);
 
-        store.insert(NumHash::new(1, hash0), raw_bal(bal0.clone())).unwrap();
-        store.insert(NumHash::new(2, hash1), raw_bal(bal1.clone())).unwrap();
-        store.insert(NumHash::new(3, hash2), raw_bal(bal2)).unwrap();
+        store.insert(NumHash::new(1, hash0), RawBal::from(bal0.clone())).unwrap();
+        store.insert(NumHash::new(2, hash1), RawBal::from(bal1.clone())).unwrap();
+        store.insert(NumHash::new(3, hash2), RawBal::from(bal2)).unwrap();
 
         let limited = store
             .get_by_hashes_with_limit(
@@ -291,17 +287,17 @@ mod tests {
         let retained_bal = Bytes::from_static(b"retained");
         let tip_bal = Bytes::from_static(b"tip");
 
-        store.insert(NumHash::new(1, old_hash), raw_bal(old_bal)).unwrap();
+        store.insert(NumHash::new(1, old_hash), RawBal::from(old_bal)).unwrap();
         store
             .insert(
                 NumHash::new(BAL_RETENTION_PERIOD_SLOTS, retained_hash),
-                raw_bal(retained_bal.clone()),
+                RawBal::from(retained_bal.clone()),
             )
             .unwrap();
         store
             .insert(
                 NumHash::new(BAL_RETENTION_PERIOD_SLOTS + 2, tip_hash),
-                raw_bal(tip_bal.clone()),
+                RawBal::from(tip_bal.clone()),
             )
             .unwrap();
 
@@ -320,8 +316,8 @@ mod tests {
         let old_bal = Bytes::from_static(b"old");
         let retained_bal = Bytes::from_static(b"retained");
 
-        store.insert(NumHash::new(7, old_hash), raw_bal(old_bal)).unwrap();
-        store.insert(NumHash::new(8, retained_hash), raw_bal(retained_bal.clone())).unwrap();
+        store.insert(NumHash::new(7, old_hash), RawBal::from(old_bal)).unwrap();
+        store.insert(NumHash::new(8, retained_hash), RawBal::from(retained_bal.clone())).unwrap();
 
         assert_eq!(store.prune(10).unwrap(), 1);
         assert_eq!(
@@ -340,9 +336,9 @@ mod tests {
         let high_bal = Bytes::from_static(b"high");
         let late_bal = Bytes::from_static(b"late");
 
-        store.insert(NumHash::new(7, old_hash), raw_bal(Bytes::from_static(b"old"))).unwrap();
-        store.insert(NumHash::new(10, high_hash), raw_bal(high_bal.clone())).unwrap();
-        store.insert(NumHash::new(8, late_hash), raw_bal(late_bal.clone())).unwrap();
+        store.insert(NumHash::new(7, old_hash), RawBal::from(Bytes::from_static(b"old"))).unwrap();
+        store.insert(NumHash::new(10, high_hash), RawBal::from(high_bal.clone())).unwrap();
+        store.insert(NumHash::new(8, late_hash), RawBal::from(late_bal.clone())).unwrap();
 
         assert_eq!(
             store.get_by_hashes(&[old_hash, high_hash, late_hash]).unwrap(),
@@ -358,11 +354,11 @@ mod tests {
         let old_bal = Bytes::from_static(b"old");
         let tip_bal = Bytes::from_static(b"tip");
 
-        store.insert(NumHash::new(1, old_hash), raw_bal(old_bal.clone())).unwrap();
+        store.insert(NumHash::new(1, old_hash), RawBal::from(old_bal.clone())).unwrap();
         store
             .insert(
                 NumHash::new(BAL_RETENTION_PERIOD_SLOTS + 1, tip_hash),
-                raw_bal(tip_bal.clone()),
+                RawBal::from(tip_bal.clone()),
             )
             .unwrap();
 
@@ -383,9 +379,9 @@ mod tests {
         let retained_bal = Bytes::from_static(b"retained");
         let tip_bal = Bytes::from_static(b"tip");
 
-        store.insert(NumHash::new(1, old_hash), raw_bal(old_bal)).unwrap();
-        store.insert(NumHash::new(2, retained_hash), raw_bal(retained_bal.clone())).unwrap();
-        store.insert(NumHash::new(4, tip_hash), raw_bal(tip_bal.clone())).unwrap();
+        store.insert(NumHash::new(1, old_hash), RawBal::from(old_bal)).unwrap();
+        store.insert(NumHash::new(2, retained_hash), RawBal::from(retained_bal.clone())).unwrap();
+        store.insert(NumHash::new(4, tip_hash), RawBal::from(tip_bal.clone())).unwrap();
 
         assert_eq!(
             store.get_by_hashes(&[old_hash, retained_hash, tip_hash]).unwrap(),
@@ -400,8 +396,8 @@ mod tests {
         let hash = B256::random();
         let bal = Bytes::from_static(b"bal");
 
-        store.insert(NumHash::new(1, hash), raw_bal(Bytes::from_static(b"old"))).unwrap();
-        store.insert(NumHash::new(2, hash), raw_bal(bal.clone())).unwrap();
+        store.insert(NumHash::new(1, hash), RawBal::from(Bytes::from_static(b"old"))).unwrap();
+        store.insert(NumHash::new(2, hash), RawBal::from(bal.clone())).unwrap();
 
         assert_eq!(store.get_by_hashes(&[hash]).unwrap(), vec![Some(bal)]);
     }
@@ -414,7 +410,7 @@ mod tests {
         let bal = Bytes::from_static(b"bal");
         let mut stream = store.bal_stream();
 
-        let raw_bal = raw_bal(bal);
+        let raw_bal = RawBal::from(bal);
 
         store.insert(NumHash::new(block_number, hash), raw_bal.clone()).unwrap();
 
@@ -430,8 +426,8 @@ mod tests {
         let mut stream = store.bal_stream();
         let hash0 = B256::random();
         let hash1 = B256::random();
-        let bal0 = raw_bal(Bytes::from_static(b"bal0"));
-        let bal1 = raw_bal(Bytes::from_static(b"bal1"));
+        let bal0 = RawBal::from(Bytes::from_static(b"bal0"));
+        let bal1 = RawBal::from(Bytes::from_static(b"bal1"));
 
         store
             .insert_many(vec![
@@ -455,7 +451,7 @@ mod tests {
         let store = InMemoryBalStore::default();
 
         assert!(store
-            .insert(NumHash::new(1, B256::random()), raw_bal(Bytes::from_static(b"bal")))
+            .insert(NumHash::new(1, B256::random()), RawBal::from(Bytes::from_static(b"bal")))
             .is_ok());
     }
 
@@ -468,7 +464,7 @@ mod tests {
             store
                 .insert(
                     NumHash::new(number, B256::random()),
-                    raw_bal(Bytes::from(vec![number as u8])),
+                    RawBal::from(Bytes::from(vec![number as u8])),
                 )
                 .unwrap();
         }
@@ -489,7 +485,7 @@ mod tests {
         let bal = Bytes::from_static(b"bal");
         let mut stream = clone.bal_stream();
 
-        let raw_bal = raw_bal(bal);
+        let raw_bal = RawBal::from(bal);
 
         store.insert(NumHash::new(block_number, hash), raw_bal.clone()).unwrap();
 

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -52,8 +52,8 @@ pub use revm_database::states::OriginalValuesKnown;
 pub use reth_static_file_types as static_file;
 pub use reth_storage_api::{
     BalNotification, BalNotificationStream, BalProvider, BalStore, BalStoreHandle,
-    GetBlockAccessListLimit, HistoryWriter, MetadataProvider, MetadataWriter, NoopBalStore,
-    SealedBal, StateWriteConfig, StatsReader, StorageSettings, StorageSettingsCache,
+    GetBlockAccessListLimit, HistoryWriter, MetadataProvider, MetadataWriter, NoopBalStore, RawBal,
+    StateWriteConfig, StatsReader, StorageSettings, StorageSettingsCache,
 };
 /// Re-export provider error.
 pub use reth_storage_errors::provider::{ProviderError, ProviderResult};

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -1,25 +1,23 @@
 use alloc::{sync::Arc, vec::Vec};
 use alloy_eip7928::bal::DecodedBal;
+pub use alloy_eip7928::bal::RawBal;
 use alloy_eips::NumHash;
-use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealed};
+use alloy_primitives::{BlockHash, BlockNumber, Bytes};
 use reth_storage_errors::provider::ProviderResult;
 use revm_database::state::bal::Bal as RevmBal;
-
-/// Raw BAL RLP bytes sealed by the BAL hash.
-pub type SealedBal = Sealed<Bytes>;
 
 /// Notification emitted when a new BAL is inserted into the store.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BalNotification {
     /// Number and hash of the block the BAL belongs to.
     pub num_hash: NumHash,
-    /// Raw BAL RLP payload sealed by the BAL hash.
-    pub bal: SealedBal,
+    /// Raw BAL RLP payload with its lazily computed hash.
+    pub bal: RawBal,
 }
 
 impl BalNotification {
     /// Creates a new [`BalNotification`].
-    pub const fn new(num_hash: NumHash, bal: SealedBal) -> Self {
+    pub const fn new(num_hash: NumHash, bal: RawBal) -> Self {
         Self { num_hash, bal }
     }
 }
@@ -46,12 +44,12 @@ pub trait BalStore: Send + Sync + 'static {
     ///
     /// Implementations may buffer inserts. Call [`Self::flush`] when pending BALs need to be made
     /// durable.
-    fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()>;
+    fn insert(&self, num_hash: NumHash, bal: RawBal) -> ProviderResult<()>;
 
     /// Insert multiple BALs.
     ///
     /// The default implementation preserves the behavior of repeated [`Self::insert`] calls.
-    fn insert_many(&self, entries: Vec<(NumHash, SealedBal)>) -> ProviderResult<()> {
+    fn insert_many(&self, entries: Vec<(NumHash, RawBal)>) -> ProviderResult<()> {
         for (num_hash, bal) in entries {
             self.insert(num_hash, bal)?;
         }
@@ -188,13 +186,13 @@ impl BalStoreHandle {
 
     /// Insert the BAL for the given block.
     #[inline]
-    pub fn insert(&self, num_hash: NumHash, bal: SealedBal) -> ProviderResult<()> {
+    pub fn insert(&self, num_hash: NumHash, bal: RawBal) -> ProviderResult<()> {
         self.inner.insert(num_hash, bal)
     }
 
     /// Insert multiple BALs.
     #[inline]
-    pub fn insert_many(&self, entries: Vec<(NumHash, SealedBal)>) -> ProviderResult<()> {
+    pub fn insert_many(&self, entries: Vec<(NumHash, RawBal)>) -> ProviderResult<()> {
         self.inner.insert_many(entries)
     }
 
@@ -291,11 +289,11 @@ pub trait BalProvider {
 pub struct NoopBalStore;
 
 impl BalStore for NoopBalStore {
-    fn insert(&self, _num_hash: NumHash, _bal: SealedBal) -> ProviderResult<()> {
+    fn insert(&self, _num_hash: NumHash, _bal: RawBal) -> ProviderResult<()> {
         Ok(())
     }
 
-    fn insert_many(&self, _entries: Vec<(NumHash, SealedBal)>) -> ProviderResult<()> {
+    fn insert_many(&self, _entries: Vec<(NumHash, RawBal)>) -> ProviderResult<()> {
         Ok(())
     }
 
@@ -423,7 +421,7 @@ mod tests {
     }
 
     impl BalStore for TestBalStore {
-        fn insert(&self, _num_hash: NumHash, _bal: SealedBal) -> ProviderResult<()> {
+        fn insert(&self, _num_hash: NumHash, _bal: RawBal) -> ProviderResult<()> {
             Ok(())
         }
 

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -11,7 +11,7 @@ use revm_database::state::bal::Bal as RevmBal;
 pub struct BalNotification {
     /// Number and hash of the block the BAL belongs to.
     pub num_hash: NumHash,
-    /// Raw BAL RLP payload with its lazily computed hash.
+    /// Raw BAL RLP payload.
     pub bal: RawBal,
 }
 


### PR DESCRIPTION
Replaces BAL `Sealed<Bytes>` plumbing with `alloy_eip7928::bal::RawBal` for full-block responses and BAL store insertion/notifications.

Bumps `alloy-eip7928` to `0.4.3` so callers can use the upstream raw BAL wrapper with cached hash access.