### PR TITLE
chore(deps): bump revm to 41, alloy-evm 0.37, reth-core 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,12 +314,30 @@ dependencies = [
  "alloy-eips",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "revm 40.0.3",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks 0.4.7",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm",
+ "revm 41.0.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1046,7 +1064,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1057,7 +1075,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2417,7 +2435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3317,7 +3335,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3444,7 +3462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3594,7 +3612,7 @@ name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-sol-types",
  "eyre",
  "reth-ethereum",
@@ -3635,7 +3653,7 @@ dependencies = [
 name = "example-custom-evm"
 version = "0.0.0"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -3649,7 +3667,7 @@ name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "clap",
@@ -3839,7 +3857,7 @@ dependencies = [
 name = "example-precompile-cache"
 version = "0.0.0"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -4236,8 +4254,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4804,7 +4822,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5185,7 +5203,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6253,7 +6271,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7686,7 +7704,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rlp",
@@ -7722,8 +7740,8 @@ dependencies = [
  "reth-rpc-api",
  "reth-rpc-engine-api",
  "reth-storage-errors",
- "revm",
- "revm-primitives",
+ "revm 41.0.0",
+ "revm-primitives 41.0.0",
  "tokio",
  "tracing",
 ]
@@ -7753,8 +7771,8 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "revm-database 41.0.0",
+ "revm-state 41.0.0",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7768,7 +7786,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -7915,9 +7933,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98afe24504bdbdf20f746794e1708886c21cb4a59826652c9047cba7dfc716d4"
+checksum = "312c1817d0e37c6112d30fcc9e92226d8e73cc66ea6bd640c80e0e0df956cc04"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7936,9 +7954,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb02fa6170f3d13e621f1c05d0c6baa867e0b8ba9f841455114443bd2411a4e"
+checksum = "526ee2bfded1897b7bb43f46410f487ee48a41b7e93cf18031079660b433550d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8289,7 +8307,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
- "revm",
+ "revm 41.0.0",
  "serde_json",
  "tempfile",
  "tokio",
@@ -8378,7 +8396,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8433,10 +8451,10 @@ dependencies = [
  "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
- "revm",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -8748,7 +8766,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm",
+ "revm 41.0.0",
  "tracing",
 ]
 
@@ -8790,7 +8808,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -8805,7 +8823,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 41.0.0",
 ]
 
 [[package]]
@@ -8814,7 +8832,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8828,7 +8846,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-errors",
  "reth-testing-utils",
- "revm",
+ "revm 41.0.0",
  "revmc",
  "secp256k1 0.30.0",
 ]
@@ -8847,7 +8865,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-trie",
- "revm-state",
+ "revm-state 41.0.0",
  "tracing",
 ]
 
@@ -8855,7 +8873,7 @@ dependencies = [
 name = "reth-execution-errors"
 version = "2.3.0"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -8869,7 +8887,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8879,7 +8897,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_with",
 ]
@@ -9011,9 +9029,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "reth-trie",
- "revm",
- "revm-bytecode",
- "revm-database",
+ "revm 41.0.0",
+ "revm-bytecode 41.0.0",
+ "revm-database 41.0.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -9464,7 +9482,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "reth-transaction-pool",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -9637,9 +9655,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2ce8506295bfbc570855a035fe11d6beec1db922ee4d5d1a44f568e6c8b6f1"
+checksum = "66169f2c520c1c94192a18d11c5466565f079588def7d76abb631db80d353829"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9660,9 +9678,9 @@ dependencies = [
  "quanta",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
@@ -9711,9 +9729,9 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-database-interface",
- "revm-state",
+ "revm-database 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-state 41.0.0",
  "rocksdb",
  "smallvec",
  "strum",
@@ -9792,7 +9810,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm",
+ "revm 41.0.0",
 ]
 
 [[package]]
@@ -9802,7 +9820,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9862,9 +9880,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 41.0.0",
  "serde",
  "serde_json",
  "sha2",
@@ -9987,7 +10005,7 @@ name = "reth-rpc-convert"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10066,7 +10084,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10097,7 +10115,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "serde_json",
  "tokio",
@@ -10112,7 +10130,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -10144,7 +10162,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "schnellru",
  "serde",
@@ -10190,9 +10208,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947a4e5cec5166505ea078c9164f06bf691fd83d3850e72851b58a9f1900cb6d"
+checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10377,7 +10395,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database",
+ "revm-database 41.0.0",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -10395,8 +10413,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
- "revm-state",
+ "revm-database-interface 41.0.0",
+ "revm-state 41.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -10424,7 +10442,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-trie",
- "revm",
+ "revm 41.0.0",
  "tokio",
  "tracing",
 ]
@@ -10549,9 +10567,9 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "revm",
- "revm-interpreter",
- "revm-primitives",
+ "revm 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-primitives 41.0.0",
  "rustc-hash",
  "schnellru",
  "serde",
@@ -10591,8 +10609,8 @@ dependencies = [
  "reth-tracing",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
- "revm-state",
+ "revm-database 41.0.0",
+ "revm-state 41.0.0",
  "tracing",
  "triehash",
 ]
@@ -10623,8 +10641,8 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
- "revm-state",
+ "revm-database 41.0.0",
+ "revm-state 41.0.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -10653,8 +10671,8 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm",
- "revm-database",
+ "revm 41.0.0",
+ "revm-database 41.0.0",
  "serde_json",
  "similar-asserts",
  "tracing",
@@ -10666,7 +10684,7 @@ name = "reth-trie-parallel"
 version = "2.3.0"
 dependencies = [
  "alloy-eip7928 0.4.1",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
@@ -10689,7 +10707,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "reth-trie-sparse",
- "revm-state",
+ "revm-state 41.0.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10731,9 +10749,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395b92a7cf863f70bd109e35f70a2fe36033187de06f6840e0ccf61c8008375d"
+checksum = "bdd4e89ad5d14393bde9b2b152480d4fd7f2399d0f9efe80ea29ec7c0b76bcdc"
 dependencies = [
  "zstd",
 ]
@@ -10744,17 +10762,36 @@ version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 11.0.1",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database 15.0.2",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-precompile 36.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+]
+
+[[package]]
+name = "revm"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+dependencies = [
+ "revm-bytecode 41.0.0",
+ "revm-context 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-handler 41.0.0",
+ "revm-inspector 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-precompile 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
 ]
 
 [[package]]
@@ -10766,7 +10803,19 @@ dependencies = [
  "bitvec",
  "paste",
  "phf",
- "revm-primitives",
+ "revm-primitives 24.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives 41.0.0",
  "serde",
 ]
 
@@ -10779,11 +10828,28 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 11.0.1",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10797,9 +10863,25 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 12.1.1",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10809,12 +10891,26 @@ version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
+ "derive_more",
+ "revm-bytecode 11.0.1",
+ "revm-database-interface 12.1.1",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+]
+
+[[package]]
+name = "revm-database"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+dependencies = [
  "alloy-eips",
  "derive_more",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "either",
+ "revm-bytecode 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10826,8 +10922,22 @@ checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -10840,14 +10950,33 @@ checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 11.0.1",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-interpreter 37.0.3",
+ "revm-precompile 36.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 41.0.0",
+ "revm-context 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-precompile 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10859,21 +10988,39 @@ checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-context 18.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-handler 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
+checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10883,7 +11030,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10895,10 +11042,23 @@ version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 11.0.1",
+ "revm-context-interface 19.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+dependencies = [
+ "revm-bytecode 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10915,14 +11075,38 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface 19.0.3",
+ "revm-primitives 24.0.1",
+ "ripemd",
+ "secp256k1 0.31.1",
+ "sha2",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
  "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface",
- "revm-primitives",
+ "revm-context-interface 41.0.0",
+ "revm-primitives 41.0.0",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
@@ -10940,6 +11124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-primitives"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "revm-state"
 version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10948,8 +11143,22 @@ dependencies = [
  "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
  "nonmax",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 11.0.1",
+ "revm-primitives 24.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+dependencies = [
+ "alloy-eip7928 0.4.1",
+ "bitflags 2.11.1",
+ "nonmax",
+ "revm-bytecode 41.0.0",
+ "revm-primitives 41.0.0",
  "serde",
 ]
 
@@ -10958,12 +11167,12 @@ name = "revmc"
 version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
+ "revm-bytecode 11.0.1",
+ "revm-context-interface 19.0.3",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-primitives 24.0.1",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -10993,10 +11202,10 @@ version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
 dependencies = [
  "paste",
- "revm-bytecode",
- "revm-context-interface",
- "revm-interpreter",
- "revm-primitives",
+ "revm-bytecode 11.0.1",
+ "revm-context-interface 19.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-primitives 24.0.1",
  "revmc-backend",
  "revmc-context",
  "tracing",
@@ -11014,15 +11223,15 @@ dependencies = [
  "either",
  "indexmap 2.14.0",
  "oxc_index",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 11.0.1",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -11038,13 +11247,13 @@ name = "revmc-context"
 version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
 dependencies = [
- "revm-context",
- "revm-context-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
  "ruint",
 ]
 
@@ -11066,7 +11275,7 @@ name = "revmc-runtime"
 version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -11077,16 +11286,16 @@ dependencies = [
  "libloading 0.9.0",
  "quanta",
  "rayon",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 11.0.1",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database 15.0.2",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-primitives 24.0.1",
+ "revm-state 12.0.1",
  "revmc-backend",
  "revmc-builtins",
  "revmc-codegen",
@@ -11303,7 +11512,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11362,7 +11571,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11383,7 +11592,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11999,7 +12208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12226,7 +12435,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13497,7 +13706,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,24 +306,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks 0.4.7",
- "alloy-primitives",
- "alloy-sol-types",
- "auto_impl",
- "derive_more",
- "revm 40.0.3",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "alloy-evm"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
@@ -337,7 +319,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm 41.0.0",
+ "revm",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1064,7 +1046,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1075,7 +1057,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3335,7 +3317,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3462,7 +3444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3612,7 +3594,7 @@ name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-sol-types",
  "eyre",
  "reth-ethereum",
@@ -3653,7 +3635,7 @@ dependencies = [
 name = "example-custom-evm"
 version = "0.0.0"
 dependencies = [
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -3667,7 +3649,7 @@ name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "clap",
@@ -3857,7 +3839,7 @@ dependencies = [
 name = "example-precompile-cache"
 version = "0.0.0"
 dependencies = [
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -4254,8 +4236,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4822,7 +4804,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5203,7 +5185,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6271,7 +6253,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7704,7 +7686,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rlp",
@@ -7740,8 +7722,8 @@ dependencies = [
  "reth-rpc-api",
  "reth-rpc-engine-api",
  "reth-storage-errors",
- "revm 41.0.0",
- "revm-primitives 41.0.0",
+ "revm",
+ "revm-primitives",
  "tokio",
  "tracing",
 ]
@@ -7771,8 +7753,8 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "reth-trie",
- "revm-database 41.0.0",
- "revm-state 41.0.0",
+ "revm-database",
+ "revm-state",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7786,7 +7768,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -8307,7 +8289,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
- "revm 41.0.0",
+ "revm",
  "serde_json",
  "tempfile",
  "tokio",
@@ -8396,7 +8378,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8451,10 +8433,10 @@ dependencies = [
  "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
- "revm 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -8766,7 +8748,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm 41.0.0",
+ "revm",
  "tracing",
 ]
 
@@ -8808,7 +8790,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -8823,7 +8805,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 41.0.0",
+ "revm",
 ]
 
 [[package]]
@@ -8832,7 +8814,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8846,7 +8828,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-errors",
  "reth-testing-utils",
- "revm 41.0.0",
+ "revm",
  "revmc",
  "secp256k1 0.30.0",
 ]
@@ -8865,7 +8847,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-trie",
- "revm-state 41.0.0",
+ "revm-state",
  "tracing",
 ]
 
@@ -8873,7 +8855,7 @@ dependencies = [
 name = "reth-execution-errors"
 version = "2.3.0"
 dependencies = [
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -8887,7 +8869,7 @@ version = "2.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8897,7 +8879,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -9029,9 +9011,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "reth-trie",
- "revm 41.0.0",
- "revm-bytecode 41.0.0",
- "revm-database 41.0.0",
+ "revm",
+ "revm-bytecode",
+ "revm-database",
  "serde",
  "serde_json",
  "tempfile",
@@ -9482,7 +9464,7 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -9678,9 +9660,9 @@ dependencies = [
  "quanta",
  "rayon",
  "reth-codecs",
- "revm-bytecode 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
@@ -9729,9 +9711,9 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
- "revm-database 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-state 41.0.0",
+ "revm-database",
+ "revm-database-interface",
+ "revm-state",
  "rocksdb",
  "smallvec",
  "strum",
@@ -9810,7 +9792,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm 41.0.0",
+ "revm",
 ]
 
 [[package]]
@@ -9820,7 +9802,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9880,9 +9862,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
- "revm-primitives 41.0.0",
+ "revm-primitives",
  "serde",
  "serde_json",
  "sha2",
@@ -10005,7 +9987,7 @@ name = "reth-rpc-convert"
 version = "2.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10084,7 +10066,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10115,7 +10097,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "serde_json",
  "tokio",
@@ -10130,7 +10112,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -10162,7 +10144,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "schnellru",
  "serde",
@@ -10395,7 +10377,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database 41.0.0",
+ "revm-database",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -10413,8 +10395,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface 41.0.0",
- "revm-state 41.0.0",
+ "revm-database-interface",
+ "revm-state",
  "thiserror 2.0.18",
 ]
 
@@ -10442,7 +10424,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-trie",
- "revm 41.0.0",
+ "revm",
  "tokio",
  "tracing",
 ]
@@ -10567,9 +10549,9 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "revm 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-primitives 41.0.0",
+ "revm",
+ "revm-interpreter",
+ "revm-primitives",
  "rustc-hash",
  "schnellru",
  "serde",
@@ -10609,8 +10591,8 @@ dependencies = [
  "reth-tracing",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database 41.0.0",
- "revm-state 41.0.0",
+ "revm-database",
+ "revm-state",
  "tracing",
  "triehash",
 ]
@@ -10641,8 +10623,8 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database 41.0.0",
- "revm-state 41.0.0",
+ "revm-database",
+ "revm-state",
  "serde",
  "serde_json",
  "serde_with",
@@ -10671,8 +10653,8 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm 41.0.0",
- "revm-database 41.0.0",
+ "revm",
+ "revm-database",
  "serde_json",
  "similar-asserts",
  "tracing",
@@ -10684,7 +10666,7 @@ name = "reth-trie-parallel"
 version = "2.3.0"
 dependencies = [
  "alloy-eip7928 0.4.1",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
@@ -10707,7 +10689,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "reth-trie-sparse",
- "revm-state 41.0.0",
+ "revm-state",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10758,53 +10740,21 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "40.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
-dependencies = [
- "revm-bytecode 11.0.1",
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-database 15.0.2",
- "revm-database-interface 12.1.1",
- "revm-handler 20.0.3",
- "revm-inspector 21.0.3",
- "revm-interpreter 37.0.3",
- "revm-precompile 36.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
-]
-
-[[package]]
-name = "revm"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
- "revm-bytecode 41.0.0",
- "revm-context 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-handler 41.0.0",
- "revm-inspector 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-precompile 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
-]
-
-[[package]]
-name = "revm-bytecode"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
-dependencies = [
- "bitvec",
- "paste",
- "phf",
- "revm-primitives 24.0.1",
- "serde",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
 ]
 
 [[package]]
@@ -10814,25 +10764,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
 dependencies = [
  "bitvec",
+ "paste",
  "phf",
- "revm-primitives 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-context"
-version = "18.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
-dependencies = [
- "bitvec",
- "cfg-if",
- "derive-where",
- "revm-bytecode 11.0.1",
- "revm-context-interface 19.0.3",
- "revm-database-interface 12.1.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
+ "revm-primitives",
  "serde",
 ]
 
@@ -10845,27 +10779,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-context-interface"
-version = "19.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "auto_impl",
- "either",
- "revm-database-interface 12.1.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
@@ -10879,23 +10797,10 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
-]
-
-[[package]]
-name = "revm-database"
-version = "15.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
-dependencies = [
- "derive_more",
- "revm-bytecode 11.0.1",
- "revm-database-interface 12.1.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
 ]
 
 [[package]]
@@ -10907,25 +10812,11 @@ dependencies = [
  "alloy-eips",
  "derive_more",
  "either",
- "revm-bytecode 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
-]
-
-[[package]]
-name = "revm-database-interface"
-version = "12.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
-dependencies = [
- "auto_impl",
- "either",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10936,29 +10827,10 @@ checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "revm-handler"
-version = "20.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
-dependencies = [
- "auto_impl",
- "derive-where",
- "revm-bytecode 11.0.1",
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-database-interface 12.1.1",
- "revm-interpreter 37.0.3",
- "revm-precompile 36.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
 ]
 
 [[package]]
@@ -10969,33 +10841,15 @@ checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 41.0.0",
- "revm-context 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-precompile 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
  "serde",
-]
-
-[[package]]
-name = "revm-inspector"
-version = "21.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
-dependencies = [
- "auto_impl",
- "either",
- "revm-context 18.0.3",
- "revm-database-interface 12.1.1",
- "revm-handler 20.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -11006,12 +10860,12 @@ checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-handler 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "serde",
  "serde_json",
 ]
@@ -11030,23 +10884,10 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "37.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
-dependencies = [
- "revm-bytecode 11.0.1",
- "revm-context-interface 19.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
 ]
 
 [[package]]
@@ -11055,35 +10896,11 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
- "revm-bytecode 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "revm-state",
  "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "36.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "arrayref",
- "aurora-engine-modexp",
- "c-kzg",
- "cfg-if",
- "k256",
- "p256",
- "revm-context-interface 19.0.3",
- "revm-primitives 24.0.1",
- "ripemd",
- "secp256k1 0.31.1",
- "sha2",
 ]
 
 [[package]]
@@ -11105,22 +10922,11 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface 41.0.0",
- "revm-primitives 41.0.0",
+ "revm-context-interface",
+ "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
-dependencies = [
- "alloy-primitives",
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -11136,20 +10942,6 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
-dependencies = [
- "alloy-eip7928 0.4.1",
- "bitflags 2.11.1",
- "nonmax",
- "revm-bytecode 11.0.1",
- "revm-primitives 24.0.1",
- "serde",
-]
-
-[[package]]
-name = "revm-state"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
@@ -11157,22 +10949,22 @@ dependencies = [
  "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
  "nonmax",
- "revm-bytecode 41.0.0",
- "revm-primitives 41.0.0",
+ "revm-bytecode",
+ "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
- "revm-bytecode 11.0.1",
- "revm-context-interface 19.0.3",
- "revm-handler 20.0.3",
- "revm-inspector 21.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-primitives",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -11185,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
  "eyre",
  "ruint",
@@ -11194,18 +10986,18 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
  "paste",
- "revm-bytecode 11.0.1",
- "revm-context-interface 19.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-interpreter",
+ "revm-primitives",
  "revmc-backend",
  "revmc-context",
  "tracing",
@@ -11214,7 +11006,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
@@ -11223,15 +11015,15 @@ dependencies = [
  "either",
  "indexmap 2.14.0",
  "oxc_index",
- "revm-bytecode 11.0.1",
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-database-interface 12.1.1",
- "revm-handler 20.0.3",
- "revm-inspector 21.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "revmc-backend",
  "revmc-build",
  "revmc-builtins",
@@ -11245,22 +11037,22 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-handler 20.0.3",
- "revm-inspector 21.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
+ "revm-context",
+ "revm-context-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "ruint",
 ]
 
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -11273,9 +11065,9 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#5ca04c3896c0be9447430853355ab11c0e9c6c24"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
 dependencies = [
- "alloy-evm 0.36.0",
+ "alloy-evm",
  "alloy-primitives",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -11286,16 +11078,16 @@ dependencies = [
  "libloading 0.9.0",
  "quanta",
  "rayon",
- "revm-bytecode 11.0.1",
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-database 15.0.2",
- "revm-database-interface 12.1.1",
- "revm-handler 20.0.3",
- "revm-inspector 21.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
  "revmc-backend",
  "revmc-builtins",
  "revmc-codegen",
@@ -11512,7 +11304,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11592,7 +11384,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12208,7 +12000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12435,7 +12227,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13706,7 +13498,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,7 +3444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4236,8 +4236,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4804,7 +4804,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5185,7 +5185,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11304,7 +11304,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11384,7 +11384,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12227,7 +12227,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13498,7 +13498,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,8 +325,8 @@ reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { version = "0.4.1", default-features = false }
-reth-codecs-derive = "0.4.1"
+reth-codecs = { version = "0.5.0", default-features = false }
+reth-codecs-derive = "0.5.0"
 reth-config = { path = "crates/config", default-features = false }
 reth-consensus = { path = "crates/consensus/consensus", default-features = false }
 reth-consensus-common = { path = "crates/consensus/common", default-features = false }
@@ -394,7 +394,7 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives-traits = { version = "0.4.1", default-features = false }
+reth-primitives-traits = { version = "0.5.0", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
@@ -410,7 +410,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-rpc-traits = { version = "0.4.1", default-features = false }
+reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }
@@ -429,18 +429,18 @@ reth-trie-common = { path = "crates/trie/common", default-features = false }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-zstd-compressors = { version = "0.4.1", default-features = false }
+reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # revm
-revm = { version = "40.0.3", default-features = false }
-revm-bytecode = { version = "11.0.0", default-features = false }
-revm-database = { version = "15.0.0", default-features = false }
-revm-state = { version = "12.0.0", default-features = false }
-revm-primitives = { version = "24.0.0", default-features = false }
-revm-interpreter = { version = "37.0.0", default-features = false }
-revm-database-interface = { version = "12.0.0", default-features = false }
+revm = { version = "41.0.0", default-features = false }
+revm-bytecode = { version = "41.0.0", default-features = false }
+revm-database = { version = "41.0.0", default-features = false }
+revm-state = { version = "41.0.0", default-features = false }
+revm-primitives = { version = "41.0.0", default-features = false }
+revm-interpreter = { version = "41.0.0", default-features = false }
+revm-database-interface = { version = "41.0.0", default-features = false }
 revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
-revm-inspectors = "0.40.1"
+revm-inspectors = "0.41.0"
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -450,7 +450,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.0", default-features = false, features = ["rlp"] }
-alloy-evm = { version = "0.36.0", default-features = false }
+alloy-evm = { version = "0.37.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1392,7 +1392,7 @@ mod tests {
         let mut state_hook = handle.state_hook().expect("state hook is None");
 
         for update in state_updates {
-            state_hook.on_state(&update);
+            state_hook.on_state(update);
         }
         drop(state_hook);
 

--- a/crates/ethereum/evm/tests/execute.rs
+++ b/crates/ethereum/evm/tests/execute.rs
@@ -811,7 +811,7 @@ fn test_balance_increment_not_duplicated() {
     let tx_clone = tx.clone();
 
     let _output = executor
-        .execute_with_state_hook(block, move |state: &EvmState| {
+        .execute_with_state_hook(block, move |state: EvmState| {
             if let Some(account) = state.get(&withdrawal_recipient) {
                 let _ = tx_clone.send(account.info.balance);
             }

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -98,8 +98,8 @@ impl StateRootHandle {
     pub fn state_hook(&self) -> impl alloy_evm::block::OnStateHook {
         let sender = StateHookSender::new(self.updates_tx.clone());
 
-        move |state: &EvmState| {
-            let _ = sender.send(StateRootMessage::StateUpdate(state.clone()));
+        move |state: EvmState| {
+            let _ = sender.send(StateRootMessage::StateUpdate(state));
         }
     }
 

--- a/examples/precompile-cache/src/main.rs
+++ b/examples/precompile-cache/src/main.rs
@@ -103,7 +103,6 @@ impl EvmFactory for MyEvmFactory {
 }
 
 /// A custom precompile that contains the cache and precompile it wraps.
-#[derive(Clone)]
 pub struct WrappedPrecompile {
     /// The precompile to wrap.
     precompile: DynPrecompile,


### PR DESCRIPTION
Bumps the revm crates to the unified 41.0.0 release, alloy-evm to 0.37.0, revm-inspectors to 0.41.0, and the reth-core crates (reth-codecs, reth-codecs-derive, reth-primitives-traits, reth-rpc-traits, reth-zstd-compressors) to 0.5.0.

The only code change required is in the state hook plumbing: alloy-evm 0.37 changed `OnStateHook` to take `EvmState` by value instead of by reference, which lets the state root task hand the state to the channel without cloning.

Note on the `jit` feature: revmc main still pins the revm 40-era crates and alloy-evm 0.36, so the jit build (default feature of reth-evm-ethereum) does not typecheck against revm 41 until revmc is bumped. Once revmc main is updated, a `cargo update revmc` on this branch picks it up and removes the duplicated revm/alloy-evm versions from the lockfile. Everything outside the jit path compiles with all targets.