### PR TITLE
feat: make JIT opt-in for library crates

### DIFF
--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -88,9 +88,15 @@ default = [
     "otlp-logs",
     "reth-revm/portable",
     "js-tracer",
+    "jit",
     "keccak-cache-global",
     "asm-keccak",
     "min-trace-logs",
+]
+
+jit = [
+    "reth-ethereum-cli/jit",
+    "reth-node-ethereum/jit",
 ]
 
 otlp = [

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -41,6 +41,8 @@ otlp-logs = ["reth-tracing/otlp-logs", "reth-node-core/otlp-logs"]
 
 dev = ["reth-cli-commands/arbitrary"]
 
+jit = ["reth-node-ethereum/jit"]
+
 asm-keccak = [
     "reth-node-core/asm-keccak",
     "reth-node-ethereum/asm-keccak",

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -76,7 +76,7 @@ where
 
         let components = move |spec: Arc<ChainSpec>| {
             let (evm_config, _) =
-                reth_node_ethereum::node::build_jit_evm_config(spec.clone(), &jit_args, None)
+                reth_node_ethereum::node::build_evm_config(spec.clone(), &jit_args, None)
                     .expect("failed to start revmc JIT backend");
             (evm_config, Arc::new(EthBeaconConsensus::new(spec)))
         };

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -39,7 +39,7 @@ secp256k1.workspace = true
 alloy-genesis.workspace = true
 
 [features]
-default = ["std", "jit"]
+default = ["std"]
 std = [
     "alloy-consensus/std",
     "alloy-eips/std",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -24,7 +24,7 @@ reth-provider.workspace = true
 reth-transaction-pool.workspace = true
 reth-network.workspace = true
 reth-evm.workspace = true
-reth-evm-ethereum = { workspace = true, features = ["std", "jit"] }
+reth-evm-ethereum = { workspace = true, features = ["std"] }
 reth-rpc.workspace = true
 reth-rpc-api.workspace = true
 reth-rpc-eth-api.workspace = true
@@ -93,6 +93,7 @@ reth-rpc-layer.workspace = true
 
 [features]
 default = []
+jit = ["reth-evm-ethereum/jit"]
 asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-node-core/asm-keccak",

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -13,9 +13,9 @@ use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
     eth::spec::EthExecutorSpec, ConfigureEvm, EvmFactory, EvmFactoryFor, NextBlockEnvAttributes,
 };
+use reth_evm_ethereum::factory::RethEvmFactory;
 #[cfg(feature = "jit")]
 use reth_evm_ethereum::factory::{JitBackend, JitMode, RevmcMetrics, RuntimeConfig, RuntimeTuning};
-use reth_evm_ethereum::factory::RethEvmFactory;
 use reth_network::{primitives::BasicNetworkPrimitives, NetworkHandle, PeersInfo};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, HeaderTy, NodeAddOns, NodePrimitives,
@@ -53,8 +53,6 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{error::FromEvmError, EthApiError};
 use reth_rpc_server_types::RethRpcModule;
-#[cfg(feature = "jit")]
-use reth_tracing::tracing::warn;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
     blobstore::DiskFileBlobStore, EthTransactionPool, PoolPooledTx, PoolTransaction,
@@ -527,7 +525,7 @@ fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
 /// Returns the evm config and metrics recorder if JIT starts enabled.
 #[cfg(feature = "jit")]
 #[allow(clippy::type_complexity)]
-pub fn build_jit_evm_config<C: EthereumHardforks>(
+pub fn build_evm_config<C: EthereumHardforks>(
     chain_spec: Arc<C>,
     jit: &JitArgs,
     dump_dir: Option<std::path::PathBuf>,
@@ -550,7 +548,7 @@ pub fn build_jit_evm_config<C: EthereumHardforks>(
     let jit_mode = config.jit_mode;
     let backend = JitBackend::new(config)?;
 
-    warn!(target: "reth::cli",
+    reth_tracing::tracing::warn!(target: "reth::cli",
         hot_threshold = tuning.jit_hot_threshold,
         workers = tuning.jit_worker_count,
         mode = ?jit_mode,
@@ -572,7 +570,7 @@ pub fn build_jit_evm_config<C: EthereumHardforks>(
 /// returns a plain interpreter-backed config.
 #[cfg(not(feature = "jit"))]
 #[allow(clippy::type_complexity)]
-pub fn build_jit_evm_config<C: EthereumHardforks>(
+pub fn build_evm_config<C: EthereumHardforks>(
     chain_spec: Arc<C>,
     jit: &JitArgs,
     _dump_dir: Option<std::path::PathBuf>,
@@ -607,7 +605,7 @@ where
         let jit = &ctx.config().jit;
         let dump_dir = jit.debug.then(|| ctx.config().datadir().data_dir().join("jit"));
 
-        let (evm_config, revmc_metrics) = build_jit_evm_config(ctx.chain_spec(), jit, dump_dir)?;
+        let (evm_config, revmc_metrics) = build_evm_config(ctx.chain_spec(), jit, dump_dir)?;
 
         #[cfg(not(feature = "jit"))]
         let _ = revmc_metrics;

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -62,6 +62,7 @@ use revm::context::TxEnv;
 use std::{marker::PhantomData, sync::Arc, time::SystemTime};
 
 pub use crate::{payload::EthereumPayloadBuilder, EthereumEngineValidator};
+#[cfg(feature = "jit")]
 pub use reth_evm_ethereum::factory::maybe_run_jit_helper;
 
 /// Type configuration for a regular Ethereum node.

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -13,9 +13,9 @@ use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
 use reth_evm::{
     eth::spec::EthExecutorSpec, ConfigureEvm, EvmFactory, EvmFactoryFor, NextBlockEnvAttributes,
 };
-use reth_evm_ethereum::factory::{
-    JitBackend, JitMode, RethEvmFactory, RevmcMetrics, RuntimeConfig, RuntimeTuning,
-};
+#[cfg(feature = "jit")]
+use reth_evm_ethereum::factory::{JitBackend, JitMode, RevmcMetrics, RuntimeConfig, RuntimeTuning};
+use reth_evm_ethereum::factory::RethEvmFactory;
 use reth_network::{primitives::BasicNetworkPrimitives, NetworkHandle, PeersInfo};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, HeaderTy, NodeAddOns, NodePrimitives,
@@ -53,7 +53,9 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{error::FromEvmError, EthApiError};
 use reth_rpc_server_types::RethRpcModule;
-use reth_tracing::tracing::{debug, info, warn};
+#[cfg(feature = "jit")]
+use reth_tracing::tracing::warn;
+use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
     blobstore::DiskFileBlobStore, EthTransactionPool, PoolPooledTx, PoolTransaction,
     TransactionPool, TransactionValidationTaskExecutor,
@@ -474,6 +476,7 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for EthereumNode {
 }
 
 /// Builds a [`RuntimeConfig`] from CLI [`JitArgs`].
+#[cfg(feature = "jit")]
 fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
     let default_tuning = RuntimeTuning::default();
     let tuning = RuntimeTuning {
@@ -522,6 +525,7 @@ fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
 /// This is the shared setup used by both [`EthereumExecutorBuilder`] and `reth re-execute`.
 ///
 /// Returns the evm config and metrics recorder if JIT starts enabled.
+#[cfg(feature = "jit")]
 #[allow(clippy::type_complexity)]
 pub fn build_jit_evm_config<C: EthereumHardforks>(
     chain_spec: Arc<C>,
@@ -560,6 +564,28 @@ pub fn build_jit_evm_config<C: EthereumHardforks>(
     Ok((evm_config, Some(revmc_metrics)))
 }
 
+/// Builds an [`EthEvmConfig`] from CLI [`JitArgs`].
+///
+/// This is the shared setup used by both [`EthereumExecutorBuilder`] and `reth re-execute`.
+///
+/// Compiled without the `jit` feature: errors if JIT was requested via [`JitArgs`] and otherwise
+/// returns a plain interpreter-backed config.
+#[cfg(not(feature = "jit"))]
+#[allow(clippy::type_complexity)]
+pub fn build_jit_evm_config<C: EthereumHardforks>(
+    chain_spec: Arc<C>,
+    jit: &JitArgs,
+    _dump_dir: Option<std::path::PathBuf>,
+) -> eyre::Result<(EthEvmConfig<C, RethEvmFactory>, Option<()>)> {
+    if jit.enabled {
+        eyre::bail!(
+            "JIT compilation was requested but this binary was compiled without the `jit` feature"
+        );
+    }
+    let factory = RethEvmFactory::default();
+    Ok((EthEvmConfig::new_with_evm_factory(chain_spec, factory), None))
+}
+
 /// A regular ethereum evm and executor builder.
 ///
 /// Uses [`RethEvmFactory`].
@@ -583,6 +609,10 @@ where
 
         let (evm_config, revmc_metrics) = build_jit_evm_config(ctx.chain_spec(), jit, dump_dir)?;
 
+        #[cfg(not(feature = "jit"))]
+        let _ = revmc_metrics;
+
+        #[cfg(feature = "jit")]
         if let Some(revmc_metrics) = revmc_metrics {
             let metrics_backend = evm_config.executor_factory.evm_factory().backend().clone();
             ctx.task_executor().spawn_with_graceful_shutdown_signal(|shutdown| async move {

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -164,6 +164,7 @@ jemalloc-symbols = [
     "jemalloc-prof",
     "reth-ethereum-cli?/jemalloc-symbols",
 ]
+jit = ["reth-node-ethereum?/jit"]
 js-tracer = [
     "rpc",
     "reth-rpc/js-tracer",


### PR DESCRIPTION
## Motivation

`jit` is currently a default feature of `reth-evm-ethereum` (`default = ["std", "jit"]`) and is additionally hard-enabled by `reth-node-ethereum` (`features = ["std", "jit"]`). This forces every downstream consumer of these crates to compile `revmc`/`llvm-sys`, which fails unless LLVM 22 is installed on the build host:

```
error: failed to run custom build command for revmc-llvm v0.1.0
  failed to run llvm-config: No such file or directory (os error 2)
  failed to run llvm-config-22: No such file or directory (os error 2)
```

Downstream node builders (we hit this in tempo when bumping reth) shouldn't need LLVM installed unless they opt into the JIT.

## Solution

Follow the existing `jemalloc`/`asm-keccak` pattern: heavy features are non-default in library crates and enabled via the `reth` binary's own default features, so released binaries keep JIT while library consumers opt in explicitly.

- `reth-evm-ethereum`: drop `jit` from default features (the crate already has full `cfg` fallbacks to `alloy_evm::EthEvmFactory`)
- `reth-node-ethereum`: stop hard-enabling `jit`; add a forwarding `jit` feature; `cfg`-gate the JIT setup in `node.rs` and provide a non-jit `build_jit_evm_config` with the same call shape that errors if JIT was requested at runtime (`--jit`)
- `reth-ethereum-cli`: add forwarding `jit` feature (no code changes needed — `build_jit_evm_config` keeps its signature shape)
- `reth-ethereum`: add forwarding `jit = ["reth-node-ethereum?/jit"]`
- `bin/reth`: add `jit` to default features

Behavior is unchanged for the `reth` binary (JIT remains available and runtime-gated by `--jit`/`reth_jit` as before). The `reth_jit` RPC is unaffected — it goes through the `dyn JitBackend` trait in `reth-evm` and `jit_backend()` returns `None` on non-jit builds.

Note this is a behavior change for library consumers who relied on `jit` being on by default — they now need `features = ["jit"]`.

Verified locally:
- `cargo check -p reth-evm-ethereum -p reth-node-ethereum -p reth-ethereum-cli` (no `jit`) passes
- `cargo tree -p reth-node-ethereum` contains no `revmc`/`llvm-sys`; `cargo tree -p reth` still does

Replaces #25177. PR was authored with Claude Code's help.