### PR TITLE
perf(trie): floor default proof worker count at 128

### DIFF
--- a/.github/scripts/hive/build_simulators.sh
+++ b/.github/scripts/hive/build_simulators.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-fixture_variant="${1:-osaka}"
+fixture_variant="${1:-amsterdam}"
 
 case "${fixture_variant}" in
     amsterdam)
-        eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz"
-        eels_branch="devnets/bal/3"
+        eels_fixtures="https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.1.1/fixtures_bal.tar.gz"
+        eels_branch="devnets/bal/7"
         ;;
     osaka)
         eels_fixtures="https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3427,7 +3427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5109,7 +5109,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6130,7 +6130,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11004,7 +11004,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11084,7 +11084,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11689,7 +11689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11910,7 +11910,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13179,7 +13179,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7613,7 +7613,6 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
  "borsh",
  "once_cell",
  "serde",
@@ -7573,7 +7574,7 @@ name = "reth-bench"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -7852,7 +7853,7 @@ name = "reth-consensus"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -8260,7 +8261,7 @@ name = "reth-engine-tree"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -8476,7 +8477,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-genesis",
  "alloy-hardforks 0.4.7",
@@ -8669,10 +8670,10 @@ name = "reth-evm"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "derive_more",
  "futures-util",
@@ -9544,7 +9545,7 @@ name = "reth-provider"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -9935,7 +9936,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
@@ -9979,6 +9980,7 @@ name = "reth-rpc-eth-types"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928 0.4.1",
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
@@ -10527,7 +10529,7 @@ dependencies = [
 name = "reth-trie-parallel"
 version = "2.2.0"
 dependencies = [
- "alloy-eip7928 0.3.7",
+ "alloy-eip7928 0.4.1",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,10 +125,10 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -154,10 +154,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "arbitrary",
  "serde",
 ]
@@ -264,26 +264,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.8.3"
+name = "alloy-eip7928"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
 dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.8.3",
- "auto_impl",
  "borsh",
- "c-kzg",
- "derive_more",
- "either",
+ "once_cell",
  "serde",
- "serde_with",
- "sha2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -295,10 +286,10 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "arbitrary",
  "auto_impl",
  "borsh",
@@ -315,11 +306,10 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
+source = "git+https://github.com/alloy-rs/evm?rev=34d78cf9acbeb16be9b88880478a0e2acd153ffc#34d78cf9acbeb16be9b88880478a0e2acd153ffc"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -338,9 +328,9 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71ff8b55d2b8aa05259f474cae7dea0e4991724dc18936b81cb23ec492a0c2a"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "alloy-trie",
  "borsh",
  "serde",
@@ -409,13 +399,13 @@ checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -434,9 +424,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
 ]
 
@@ -501,7 +491,7 @@ checksum = "93a7c17472b55482d4734154c2f5ed13f72e03f6752cebb927f6a2d8b52e646c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -617,7 +607,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
 ]
 
@@ -641,7 +631,7 @@ checksum = "df32156f085e74eac942b6103744be49b817c302341aaa8cb0c1c88dc29228d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
 ]
 
@@ -655,7 +645,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -666,7 +656,7 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "296450f5e76bece0116c939b9437b0421a5da9c5d40031bf4cf9b38d3d94e475"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -700,10 +690,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b12366c96f4013e1aeebc96c6b56e5f33f07853c42ea2f485045c0c157a4a1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "arbitrary",
  "derive_more",
  "ethereum_ssz",
@@ -722,11 +712,11 @@ checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -743,10 +733,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7adc1243d55744a66b3a6cbbbba96436e8df5d248f2ee8186bef4238ef704ec7"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -759,7 +749,7 @@ checksum = "6184b5d14152b68b0bb8beb621339d94f0b761a37958bb365fbf7c00922125c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -773,19 +763,8 @@ checksum = "f00b631c361e7c7baaf4f1f5a9877730f3507fed2acb9d4b34841b8184b2ec28"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2855,7 +2834,7 @@ name = "custom-hardforks"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "reth-chainspec",
@@ -3301,7 +3280,7 @@ name = "ef-tests"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -3507,7 +3486,7 @@ name = "example-beacon-api-sidecar-fetcher"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-beacon",
  "clap",
@@ -3586,7 +3565,7 @@ dependencies = [
 name = "example-custom-beacon-withdrawals"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-sol-types",
  "eyre",
@@ -3641,7 +3620,7 @@ dependencies = [
 name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -3663,7 +3642,7 @@ dependencies = [
 name = "example-custom-payload-builder"
 version = "0.0.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "eyre",
  "futures-util",
  "reth-basic-payload-builder",
@@ -6101,6 +6080,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7511,7 +7499,7 @@ name = "reth-basic-payload-builder"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -7537,7 +7525,7 @@ name = "reth-bb"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
@@ -7585,8 +7573,8 @@ name = "reth-bench"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.4",
+ "alloy-eip7928 0.3.7",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -7633,7 +7621,7 @@ name = "reth-chain-state"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -7666,7 +7654,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -7698,7 +7686,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -7794,7 +7782,7 @@ dependencies = [
 name = "reth-cli-util"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -7815,11 +7803,10 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -7836,8 +7823,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7867,7 +7853,7 @@ name = "reth-consensus"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -7880,7 +7866,7 @@ name = "reth-consensus-common"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "rand 0.9.4",
  "reth-chainspec",
@@ -7894,7 +7880,7 @@ name = "reth-consensus-debug-client"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -8012,7 +7998,7 @@ dependencies = [
 name = "reth-db-models"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8108,7 +8094,7 @@ name = "reth-downloaders"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
@@ -8146,7 +8132,7 @@ name = "reth-e2e-test-utils"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -8251,7 +8237,7 @@ name = "reth-engine-primitives"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8275,8 +8261,8 @@ name = "reth-engine-tree"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.4",
+ "alloy-eip7928 0.3.7",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8375,7 +8361,7 @@ name = "reth-era"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -8453,7 +8439,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8491,8 +8477,8 @@ version = "2.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.4",
+ "alloy-eip7928 0.3.7",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
@@ -8579,7 +8565,7 @@ name = "reth-ethereum-consensus"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -8594,7 +8580,7 @@ dependencies = [
 name = "reth-ethereum-engine-primitives"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -8624,7 +8610,7 @@ name = "reth-ethereum-payload-builder"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8653,7 +8639,7 @@ name = "reth-ethereum-primitives"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
@@ -8684,9 +8670,10 @@ name = "reth-evm"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "derive_more",
  "futures-util",
@@ -8708,7 +8695,7 @@ name = "reth-evm-ethereum"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -8760,7 +8747,7 @@ name = "reth-execution-types"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -8781,7 +8768,7 @@ name = "reth-exex"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "eyre",
@@ -8825,7 +8812,7 @@ dependencies = [
 name = "reth-exex-test-utils"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "eyre",
  "futures-util",
  "reth-chainspec",
@@ -8856,7 +8843,7 @@ dependencies = [
 name = "reth-exex-types"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "bincode",
@@ -8883,7 +8870,7 @@ name = "reth-invalid-block-hooks"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -8997,7 +8984,7 @@ name = "reth-network"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9083,7 +9070,7 @@ name = "reth-network-p2p"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9176,7 +9163,7 @@ name = "reth-node-builder"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -9247,7 +9234,7 @@ name = "reth-node-core"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -9304,7 +9291,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
@@ -9387,7 +9374,7 @@ name = "reth-node-events"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -9484,7 +9471,7 @@ name = "reth-payload-primitives"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9524,11 +9511,10 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -9559,8 +9545,8 @@ name = "reth-provider"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips 2.0.4",
+ "alloy-eip7928 0.3.7",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9613,7 +9599,7 @@ name = "reth-prune"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "assert_matches",
  "itertools 0.14.0",
@@ -9687,7 +9673,7 @@ version = "2.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -9703,7 +9689,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -9765,7 +9751,7 @@ dependencies = [
 name = "reth-rpc-api"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -9779,7 +9765,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -9795,7 +9781,7 @@ dependencies = [
 name = "reth-rpc-api-testing-util"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -9814,7 +9800,7 @@ dependencies = [
 name = "reth-rpc-builder"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -9912,7 +9898,7 @@ dependencies = [
 name = "reth-rpc-engine-api"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9950,8 +9936,8 @@ version = "2.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928",
- "alloy-eips 2.0.4",
+ "alloy-eip7928 0.3.7",
+ "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -9959,7 +9945,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -9994,7 +9980,7 @@ name = "reth-rpc-eth-types"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -10059,7 +10045,7 @@ dependencies = [
 name = "reth-rpc-server-types"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -10073,8 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10090,7 +10075,7 @@ name = "reth-stages"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10151,7 +10136,7 @@ dependencies = [
 name = "reth-stages-api"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "aquamarine",
  "assert_matches",
@@ -10243,8 +10228,10 @@ name = "reth-storage-api"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eip7928 0.4.1",
+ "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -10268,7 +10255,7 @@ dependencies = [
 name = "reth-storage-errors"
 version = "2.2.0"
 dependencies = [
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -10286,7 +10273,7 @@ name = "reth-storage-rpc-provider"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -10335,7 +10322,7 @@ name = "reth-testing-utils"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -10395,7 +10382,7 @@ name = "reth-transaction-pool"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -10446,7 +10433,7 @@ name = "reth-trie"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10483,7 +10470,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.4",
+ "alloy-serde",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -10541,7 +10528,7 @@ dependencies = [
 name = "reth-trie-parallel"
 version = "2.2.0"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -10607,8 +10594,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
 dependencies = [
  "zstd",
 ]
@@ -10616,8 +10602,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10635,8 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "bitvec",
  "phf",
@@ -10647,8 +10631,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10664,8 +10647,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10680,10 +10662,9 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
- "alloy-eips 1.8.3",
+ "alloy-eips",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -10694,8 +10675,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "auto_impl",
  "either",
@@ -10708,8 +10688,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10727,8 +10706,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "auto_impl",
  "either",
@@ -10745,8 +10723,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=388421d0ca7be4c4c75262320f4cf20b88bd62bd#388421d0ca7be4c4c75262320f4cf20b88bd62bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10765,8 +10742,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10778,8 +10754,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10804,11 +10779,9 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
  "alloy-primitives",
- "num_enum",
  "once_cell",
  "serde",
 ]
@@ -10816,11 +10789,11 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
+source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
+ "nonmax",
  "revm-bytecode",
  "revm-primitives",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.34.0"
-source = "git+https://github.com/alloy-rs/evm?rev=34d78cf9acbeb16be9b88880478a0e2acd153ffc#34d78cf9acbeb16be9b88880478a0e2acd153ffc"
+source = "git+https://github.com/alloy-rs/evm?rev=5b511acf021fd6f6bd6d52a1e98007af3bf07dd6#5b511acf021fd6f6bd6d52a1e98007af3bf07dd6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3427,7 +3427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4192,8 +4192,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4742,7 +4742,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5109,7 +5109,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.3.1"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=032288088069e7e6378f8d4bbac0124db98a77f1#032288088069e7e6378f8d4bbac0124db98a77f1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.3.1"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=032288088069e7e6378f8d4bbac0124db98a77f1#032288088069e7e6378f8d4bbac0124db98a77f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.3.1"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=032288088069e7e6378f8d4bbac0124db98a77f1#032288088069e7e6378f8d4bbac0124db98a77f1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.3.1"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=032288088069e7e6378f8d4bbac0124db98a77f1#032288088069e7e6378f8d4bbac0124db98a77f1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10594,7 +10594,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.3.1"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=d3173732af1daf19a641c6197f5cdece39fbe18d#d3173732af1daf19a641c6197f5cdece39fbe18d"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=032288088069e7e6378f8d4bbac0124db98a77f1#032288088069e7e6378f8d4bbac0124db98a77f1"
 dependencies = [
  "zstd",
 ]
@@ -10602,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10620,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "bitvec",
  "phf",
@@ -10631,7 +10631,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10662,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10675,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "auto_impl",
  "either",
@@ -10688,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "auto_impl",
  "either",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.39.0"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=388421d0ca7be4c4c75262320f4cf20b88bd62bd#388421d0ca7be4c4c75262320f4cf20b88bd62bd"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=3bc4974d969f1df05b0db887ee0ad096b60cd838#3bc4974d969f1df05b0db887ee0ad096b60cd838"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10742,7 +10742,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10779,7 +10779,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/bluealloy/revm?rev=191c163a23569a94097c4f9a7291158183fce256#191c163a23569a94097c4f9a7291158183fce256"
+source = "git+https://github.com/bluealloy/revm?rev=9ccf9e5800e7308f0a591c0493ae8e0de35317f8#9ccf9e5800e7308f0a591c0493ae8e0de35317f8"
 dependencies = [
  "alloy-eip7928 0.4.1",
  "bitflags 2.11.1",
@@ -11004,7 +11004,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11084,7 +11084,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11910,7 +11910,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13179,7 +13179,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -700,3 +700,24 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "388421d0ca7be4c4c75262320f4cf20b88bd62bd" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "34d78cf9acbeb16be9b88880478a0e2acd153ffc" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -702,22 +702,22 @@ vergen-git2 = "9.1.0"
 ipnet = "2.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "388421d0ca7be4c4c75262320f4cf20b88bd62bd" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "34d78cf9acbeb16be9b88880478a0e2acd153ffc" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
-reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "d3173732af1daf19a641c6197f5cdece39fbe18d" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "3bc4974d969f1df05b0db887ee0ad096b60cd838" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "5b511acf021fd6f6bd6d52a1e98007af3bf07dd6" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "032288088069e7e6378f8d4bbac0124db98a77f1" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "032288088069e7e6378f8d4bbac0124db98a77f1" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "032288088069e7e6378f8d4bbac0124db98a77f1" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "032288088069e7e6378f8d4bbac0124db98a77f1" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "032288088069e7e6378f8d4bbac0124db98a77f1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-sol-types = { version = "1.5.6", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.3.7", default-features = false }
+alloy-eip7928 = { version = "0.4.1", default-features = false }
 alloy-evm = { version = "0.34.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }

--- a/bin/reth-bb/src/evm_config.rs
+++ b/bin/reth-bb/src/evm_config.rs
@@ -108,7 +108,7 @@ fn seed_state_block_hashes<DB>(state: &mut &mut revm::database::State<DB>, hashe
 /// Used as a [`BalIndexReader`] callback so the
 /// generic [`BbBlockExecutor`](crate::evm::BbBlockExecutor) can pick its
 /// starting segment without a trait bound on `DB`.
-fn read_bal_index<DB>(state: &&mut revm::database::State<DB>) -> u64 {
+const fn read_bal_index<DB>(state: &&mut revm::database::State<DB>) -> u64 {
     state.bal_state.bal_index().get()
 }
 
@@ -119,7 +119,7 @@ fn read_bal_index<DB>(state: &&mut revm::database::State<DB>) -> u64 {
 /// `bal_index` between sub-events of a segment boundary (post-N's `finish()`
 /// and pre-N+1's `apply_pre_execution_changes()`) without a trait bound on
 /// `DB`.
-fn bump_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>) {
+const fn bump_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>) {
     state.bump_bal_index();
 }
 
@@ -129,7 +129,7 @@ fn bump_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>
 /// [`BbBlockExecutor::initialize`](crate::evm::BbBlockExecutor) can renumber
 /// a worker's incoming `bal_index = i + 1` into the boundary-padded space
 /// `i + 1 + 2*k` (where `k` is the worker's segment index).
-fn set_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>, index: u64) {
+const fn set_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>, index: u64) {
     state.set_bal_index(revm::state::bal::BlockAccessIndex::new(index));
 }
 

--- a/bin/reth-bb/src/evm_config.rs
+++ b/bin/reth-bb/src/evm_config.rs
@@ -109,7 +109,7 @@ fn seed_state_block_hashes<DB>(state: &mut &mut revm::database::State<DB>, hashe
 /// generic [`BbBlockExecutor`](crate::evm::BbBlockExecutor) can pick its
 /// starting segment without a trait bound on `DB`.
 fn read_bal_index<DB>(state: &&mut revm::database::State<DB>) -> u64 {
-    state.bal_state.bal_index()
+    state.bal_state.bal_index().get()
 }
 
 /// Bumps the BAL index on a `&mut State<DB>`.
@@ -130,7 +130,7 @@ fn bump_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>
 /// a worker's incoming `bal_index = i + 1` into the boundary-padded space
 /// `i + 1 + 2*k` (where `k` is the worker's segment index).
 fn set_bal_index<DB: revm::Database>(state: &mut &mut revm::database::State<DB>, index: u64) {
-    state.set_bal_index(index);
+    state.set_bal_index(revm::state::bal::BlockAccessIndex::new(index));
 }
 
 // ---------------------------------------------------------------------------

--- a/bin/reth-bench/Cargo.toml
+++ b/bin/reth-bench/Cargo.toml
@@ -58,9 +58,6 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-# url parsing
-url.workspace = true
-
 # async
 async-trait.workspace = true
 futures.workspace = true

--- a/bin/reth-bench/src/bench/generate_big_block.rs
+++ b/bin/reth-bench/src/bench/generate_big_block.rs
@@ -6,10 +6,8 @@
 //! [`ExecutionData`] and environment switches at each block boundary.
 
 use alloy_consensus::TxEnvelope;
-use alloy_eips::{
-    eip7928::{AccountChanges, BlockAccessList, SlotChanges},
-    Typed2718,
-};
+use alloy_eip7928::{AccountChanges, BlockAccessList, SlotChanges};
+use alloy_eips::Typed2718;
 use alloy_primitives::{Bytes, B256};
 use alloy_provider::{
     network::{AnyNetwork, AnyRpcBlock},
@@ -532,6 +530,16 @@ async fn fetch_one_block(
         return Ok(None);
     };
 
+    // `alloy-provider` returns `alloy_eips::eip7928::BlockAccessList` (alloy_eip7928 0.3);
+    // re-encode through the shared wire format into the 0.4 type used by the rest of
+    // reth-bench.
+    let block_access_list = block_access_list
+        .map(|bal| {
+            let raw = alloy_rlp::encode(&bal);
+            <BlockAccessList as alloy_rlp::Decodable>::decode(&mut raw.as_slice())
+        })
+        .transpose()?;
+
     Ok(Some((rpc_block, block_access_list)))
 }
 
@@ -579,17 +587,17 @@ fn shift_account_changes(
     let shift = tx_index_offset + 2 * segment_idx;
     for slot_changes in &mut account_changes.storage_changes {
         for change in &mut slot_changes.changes {
-            change.block_access_index += shift;
+            change.block_access_index.0 += shift;
         }
     }
     for change in &mut account_changes.balance_changes {
-        change.block_access_index += shift;
+        change.block_access_index.0 += shift;
     }
     for change in &mut account_changes.nonce_changes {
-        change.block_access_index += shift;
+        change.block_access_index.0 += shift;
     }
     for change in &mut account_changes.code_changes {
-        change.block_access_index += shift;
+        change.block_access_index.0 += shift;
     }
 }
 
@@ -643,8 +651,12 @@ pub fn compute_payload_block_hash(data: &ExecutionData) -> eyre::Result<B256> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eips::eip7928::{BalanceChange, CodeChange, NonceChange, StorageChange};
+    use alloy_eip7928::{BalanceChange, BlockAccessIndex, CodeChange, NonceChange, StorageChange};
     use alloy_primitives::{Address, U256};
+
+    fn bai(value: u64) -> BlockAccessIndex {
+        BlockAccessIndex::new(value)
+    }
 
     #[test]
     fn merge_block_access_list_offsets_and_merges_accounts() {
@@ -655,11 +667,11 @@ mod tests {
             address: shared,
             storage_changes: vec![SlotChanges::new(
                 U256::from(1),
-                vec![StorageChange::new(0, U256::from(10))],
+                vec![StorageChange::new(bai(0), U256::from(10))],
             )],
             storage_reads: vec![U256::from(3)],
-            balance_changes: vec![BalanceChange::new(1, U256::from(100))],
-            nonce_changes: vec![NonceChange::new(2, 7)],
+            balance_changes: vec![BalanceChange::new(bai(1), U256::from(100))],
+            nonce_changes: vec![NonceChange::new(bai(2), 7)],
             code_changes: vec![],
         }];
 
@@ -667,19 +679,25 @@ mod tests {
             AccountChanges {
                 address: shared,
                 storage_changes: vec![
-                    SlotChanges::new(U256::from(1), vec![StorageChange::new(1, U256::from(20))]),
-                    SlotChanges::new(U256::from(2), vec![StorageChange::new(2, U256::from(30))]),
+                    SlotChanges::new(
+                        U256::from(1),
+                        vec![StorageChange::new(bai(1), U256::from(20))],
+                    ),
+                    SlotChanges::new(
+                        U256::from(2),
+                        vec![StorageChange::new(bai(2), U256::from(30))],
+                    ),
                 ],
                 storage_reads: vec![U256::from(4)],
-                balance_changes: vec![BalanceChange::new(0, U256::from(150))],
-                nonce_changes: vec![NonceChange::new(2, 8)],
-                code_changes: vec![CodeChange::new(1, Bytes::from_static(&[0xaa]))],
+                balance_changes: vec![BalanceChange::new(bai(0), U256::from(150))],
+                nonce_changes: vec![NonceChange::new(bai(2), 8)],
+                code_changes: vec![CodeChange::new(bai(1), Bytes::from_static(&[0xaa]))],
             },
             AccountChanges {
                 address: other,
                 storage_changes: vec![SlotChanges::new(
                     U256::from(9),
-                    vec![StorageChange::new(0, U256::from(90))],
+                    vec![StorageChange::new(bai(0), U256::from(90))],
                 )],
                 storage_reads: vec![],
                 balance_changes: vec![],
@@ -700,13 +718,13 @@ mod tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![1, 3]
+            vec![bai(1), bai(3)]
         );
         assert_eq!(
             shared.nonce_changes.iter().map(|change| change.block_access_index).collect::<Vec<_>>(),
-            vec![2, 5]
+            vec![bai(2), bai(5)]
         );
-        assert_eq!(shared.code_changes[0].block_access_index, 4);
+        assert_eq!(shared.code_changes[0].block_access_index, bai(4));
 
         let slot_one = shared
             .storage_changes
@@ -715,7 +733,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             slot_one.changes.iter().map(|change| change.block_access_index).collect::<Vec<_>>(),
-            vec![0, 4]
+            vec![bai(0), bai(4)]
         );
 
         let slot_two = shared
@@ -723,11 +741,11 @@ mod tests {
             .iter()
             .find(|slot_changes| slot_changes.slot == U256::from(2))
             .unwrap();
-        assert_eq!(slot_two.changes[0].block_access_index, 5);
+        assert_eq!(slot_two.changes[0].block_access_index, bai(5));
 
         let other = &merged[1];
         assert_eq!(other.address, Address::repeat_byte(0x22));
-        assert_eq!(other.storage_changes[0].changes[0].block_access_index, 3);
+        assert_eq!(other.storage_changes[0].changes[0].block_access_index, bai(3));
     }
 
     #[test]
@@ -743,7 +761,10 @@ mod tests {
         // these per-block BAL entries are merged for a standalone big block.
         let mut existing = AccountChanges {
             address,
-            storage_changes: vec![SlotChanges::new(A, vec![StorageChange::new(0, U256::from(10))])],
+            storage_changes: vec![SlotChanges::new(
+                A,
+                vec![StorageChange::new(bai(0), U256::from(10))],
+            )],
             storage_reads: vec![B, C],
             balance_changes: vec![],
             nonce_changes: vec![],
@@ -755,7 +776,10 @@ mod tests {
         // merge should also dedupe it. D remains read-only.
         let incoming = AccountChanges {
             address,
-            storage_changes: vec![SlotChanges::new(B, vec![StorageChange::new(1, U256::from(20))])],
+            storage_changes: vec![SlotChanges::new(
+                B,
+                vec![StorageChange::new(bai(1), U256::from(20))],
+            )],
             storage_reads: vec![A, C, D],
             balance_changes: vec![],
             nonce_changes: vec![],

--- a/bin/reth-bench/src/bench/helpers.rs
+++ b/bin/reth-bench/src/bench/helpers.rs
@@ -1,6 +1,7 @@
 //! Common helpers for reth-bench commands.
 
-use alloy_eips::{eip7928::BlockAccessList, BlockNumberOrTag};
+use alloy_eip7928::BlockAccessList;
+use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{network::AnyNetwork, Provider, RootProvider};
 use eyre::Result;
 use std::{

--- a/bin/reth-bench/src/bench/new_payload_only.rs
+++ b/bin/reth-bench/src/bench/new_payload_only.rs
@@ -89,6 +89,7 @@ impl Command {
                     }
                 };
 
+                #[allow(clippy::if_then_some_else_none)]
                 let rlp = if rlp_blocks {
                     let Ok(rlp) = block_provider.debug_get_raw_block(next_block.into()).await
                     else {

--- a/bin/reth-bench/src/valid_payload.rs
+++ b/bin/reth-bench/src/valid_payload.rs
@@ -3,7 +3,7 @@
 //! before sending additional calls.
 
 use alloy_consensus::TxEnvelope;
-use alloy_eips::eip7928::BlockAccessList;
+use alloy_eip7928::BlockAccessList;
 use alloy_primitives::Bytes;
 use alloy_provider::{ext::EngineApi, network::AnyRpcBlock, Network, Provider};
 use alloy_rpc_types_engine::{

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -34,8 +34,23 @@ use revm::{
     database::{states::bundle_state::BundleRetention, State},
     primitives::{eip7825::TX_GAS_LIMIT_CAP, hardfork::SpecId},
 };
-use revm_state::bal::Bal as RevmBal;
+use revm_state::bal::{alloy::AlloyBal as RevmAlloyBal, Bal as RevmBal};
 use std::sync::Arc;
+
+/// Re-encode reth's 0.3 [`AlloyBal`] as revm's 0.4 [`RevmAlloyBal`] via RLP.
+/// The wire format is identical across versions.
+fn alloy_bal_v3_to_v4(bal: &AlloyBal) -> Result<RevmAlloyBal, alloy_rlp::Error> {
+    let mut buf = Vec::new();
+    alloy_rlp::Encodable::encode(bal, &mut buf);
+    <RevmAlloyBal as alloy_rlp::Decodable>::decode(&mut buf.as_slice())
+}
+
+/// Re-encode revm's 0.4 [`RevmAlloyBal`] as reth's 0.3 [`AlloyBal`] via RLP.
+fn alloy_bal_v4_to_v3(bal: &RevmAlloyBal) -> Result<AlloyBal, alloy_rlp::Error> {
+    let mut buf = Vec::new();
+    alloy_rlp::Encodable::encode(bal, &mut buf);
+    <AlloyBal as alloy_rlp::Decodable>::decode(&mut buf.as_slice())
+}
 
 use crate::tree::payload_processor::receipt_root_task::IndexedReceipt;
 
@@ -101,8 +116,10 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let bal = input_bal.as_bal();
+    let bal_v4 = alloy_bal_v3_to_v4(bal)
+        .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?;
     let input_bal_revm: Arc<RevmBal> = Arc::new(
-        RevmBal::try_from(Vec::<_>::from(bal.clone()))
+        RevmBal::try_from(bal_v4)
             .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?,
     );
 
@@ -213,9 +230,11 @@ pub(crate) fn validate_bal<DB>(
 where
     DB: Database,
 {
-    let composed_alloy = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+    let composed_v4 = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+    let composed_alloy = alloy_bal_v4_to_v3(&composed_v4)
+        .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?;
     let input_bal_entries = input_bal.as_bal();
-    if composed_alloy == input_bal_entries.as_slice() {
+    if composed_alloy.as_slice() == input_bal_entries.as_slice() {
         return Ok(());
     }
     let rebuilt = compute_block_access_list_hash(&composed_alloy);

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -116,8 +116,8 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let bal = input_bal.as_bal();
-    let bal_v4 = alloy_bal_v3_to_v4(bal)
-        .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?;
+    let bal_v4 =
+        alloy_bal_v3_to_v4(bal).map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?;
     let input_bal_revm: Arc<RevmBal> = Arc::new(
         RevmBal::try_from(bal_v4)
             .map_err(|e| BalExecutionError::BalConversion(format!("{e:?}")))?,
@@ -306,7 +306,7 @@ impl BlockGasTracker {
         Ok(())
     }
 
-    fn record_result<H>(&mut self, result: &ResultAndState<H>) {
+    const fn record_result<H>(&mut self, result: &ResultAndState<H>) {
         let gas = result.result.gas();
         self.cumulative_tx_gas_used = self.cumulative_tx_gas_used.saturating_add(gas.tx_gas_used());
         self.block_regular_gas_used =
@@ -435,7 +435,8 @@ mod tests {
             executor.evm_mut().db_mut().bump_bal_index();
             executor.apply_post_execution_changes().expect("post-exec");
         }
-        state.take_built_alloy_bal().expect("with_bal_builder was set")
+        let bal_v4 = state.take_built_alloy_bal().expect("with_bal_builder was set");
+        alloy_bal_v4_to_v3(&bal_v4).expect("v4 -> v3 RLP round-trip").into()
     }
 
     #[test]
@@ -556,7 +557,8 @@ mod tests {
             executor.evm_mut().db_mut().bump_bal_index();
             executor.apply_post_execution_changes().expect("post-exec");
         }
-        state.take_built_alloy_bal().expect("with_bal_builder was set")
+        let bal_v4 = state.take_built_alloy_bal().expect("with_bal_builder was set");
+        alloy_bal_v4_to_v3(&bal_v4).expect("v4 -> v3 RLP round-trip").into()
     }
 
     #[test]
@@ -722,7 +724,9 @@ mod tests {
             executor.apply_post_execution_changes().expect("serial post-exec")
         };
 
-        let bal = state.take_built_alloy_bal().expect("with_bal_builder was set");
+        let bal_v4 = state.take_built_alloy_bal().expect("with_bal_builder was set");
+        let bal: BlockAccessList =
+            alloy_bal_v4_to_v3(&bal_v4).expect("v4 -> v3 RLP round-trip").into();
         state.merge_transitions(BundleRetention::Reverts);
         let bundle_state = state.take_bundle();
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -8,7 +8,7 @@ use alloy_primitives::Address;
 use crossbeam_channel::{Receiver, Sender};
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database, EvmEnvFor, ExecutionCtxFor};
 use revm::database::State;
-use revm_state::bal::Bal as RevmBal;
+use revm_state::bal::{Bal as RevmBal, BlockAccessIndex};
 use std::sync::Arc;
 
 pub(super) struct BalWorkerOutput<R> {
@@ -64,7 +64,10 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
-                executor.evm_mut().db_mut().set_bal_index(index as u64 + 1);
+                executor
+                    .evm_mut()
+                    .db_mut()
+                    .set_bal_index(BlockAccessIndex::new(index as u64 + 1));
                 let result = executor
                     .execute_transaction_without_commit(tx)
                     .map_err(BalExecutionError::Evm)?;

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -64,10 +64,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
-                executor
-                    .evm_mut()
-                    .db_mut()
-                    .set_bal_index(BlockAccessIndex::new(index as u64 + 1));
+                executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
                 let result = executor
                     .execute_transaction_without_commit(tx)
                     .map_err(BalExecutionError::Evm)?;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1021,7 +1021,7 @@ mod tests {
     use reth_trie::{test_utils::state_root, HashedPostState};
     use reth_trie_db::ChangesetCache;
     use revm_primitives::{Address, HashMap, B256, KECCAK_EMPTY, U256};
-    use revm_state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot};
+    use revm_state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot, TransactionId};
     use std::sync::Arc;
 
     fn make_saved_cache(hash: B256) -> SavedCache {
@@ -1190,25 +1190,23 @@ mod tests {
                             EvmStorageSlot::new_changed(
                                 U256::ZERO,
                                 U256::from(rng.random::<u64>()),
-                                0,
+                                TransactionId::ZERO,
                             ),
                         );
                     }
                 }
 
-                let account = revm_state::Account {
-                    info: AccountInfo {
-                        balance: U256::from(rng.random::<u64>()),
-                        nonce: rng.random::<u64>(),
-                        code_hash: KECCAK_EMPTY,
-                        code: Some(Default::default()),
-                        account_id: None,
-                    },
-                    original_info: Box::new(AccountInfo::default()),
-                    storage,
-                    status: AccountStatus::Touched,
-                    transaction_id: 0,
+                let mut account = revm_state::Account::default();
+                account.info = AccountInfo {
+                    balance: U256::from(rng.random::<u64>()),
+                    nonce: rng.random::<u64>(),
+                    code_hash: KECCAK_EMPTY,
+                    code: Some(Default::default()),
+                    account_id: None,
                 };
+                account.storage = storage;
+                account.status = AccountStatus::Touched;
+                account.transaction_id = TransactionId::ZERO;
 
                 state_update.insert(address, account);
             }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -284,13 +284,8 @@ where
 
         let span = Span::current();
 
-        let halve_workers = env.transaction_count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD;
-        let state_root_handle = self.spawn_state_root(
-            multiproof_provider_factory,
-            env.parent_state_root,
-            halve_workers,
-            config,
-        );
+        let state_root_handle =
+            self.spawn_state_root(multiproof_provider_factory, env.parent_state_root, config);
         // BAL blocks only bypass the normal execution state hook when the parallel BAL executor
         // consumes the BAL. If parallel BAL execution is disabled, or if state caching is
         // disabled so the BAL executor cannot use a shared cache, treat the BAL as absent here so
@@ -355,15 +350,11 @@ where
     ///   state root.
     ///
     /// The state hook **must** be dropped after execution to signal the end of state updates.
-    ///
-    /// When `halve_workers` is true, the proof worker pool is halved (for small blocks where
-    /// fewer transactions produce fewer state changes and most workers would be idle).
     #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     pub fn spawn_state_root<F>(
         &self,
         multiproof_provider_factory: F,
         parent_state_root: B256,
-        halve_workers: bool,
         config: &TreeConfig,
     ) -> StateRootHandle
     where
@@ -378,7 +369,7 @@ where
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
-        let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
+        let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx);
 
         let (state_root_tx, state_root_rx) = channel();
 
@@ -392,10 +383,6 @@ where
 
         StateRootHandle::new(parent_state_root, updates_tx, state_root_rx)
     }
-
-    /// Transaction count threshold below which proof workers are halved, since fewer transactions
-    /// produce fewer state changes and most workers would be idle overhead.
-    const SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD: usize = 30;
 
     /// Transaction count threshold below which sequential conversion is used.
     ///

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -994,7 +994,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory));
 
         let default_trie = RevealableSparseTrie::blind_from(ConfigurableSparseTrie::Arena(
             ArenaParallelSparseTrie::default(),

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -2237,8 +2237,6 @@ where
         Some(self.payload_processor.spawn_state_root(
             overlay_factory,
             parent_state_root,
-            // Full proof workers — tx count unknown at FCU time (block built incrementally)
-            false,
             &self.config,
         ))
     }

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -269,6 +269,7 @@ mod tests {
                 state_gas_used: 0,
                 reservoir: 0,
                 gas_refunded: 0,
+                refill_amount: 0,
                 bytes: Bytes::default(),
             })
         })
@@ -283,6 +284,7 @@ mod tests {
             state_gas_used: 0,
             reservoir: 0,
             gas_refunded: 0,
+            refill_amount: 0,
             bytes: alloy_primitives::Bytes::copy_from_slice(b"cached_result"),
         };
 
@@ -317,6 +319,7 @@ mod tests {
                     state_gas_used: 0,
                     reservoir: 0,
                     gas_refunded: 0,
+                    refill_amount: 0,
                     bytes: alloy_primitives::Bytes::copy_from_slice(b"output_from_precompile_1"),
                 })
             }
@@ -334,6 +337,7 @@ mod tests {
                     state_gas_used: 0,
                     reservoir: 0,
                     gas_refunded: 0,
+                    refill_amount: 0,
                     bytes: alloy_primitives::Bytes::copy_from_slice(b"output_from_precompile_2"),
                 })
             }

--- a/crates/errors/src/error.rs
+++ b/crates/errors/src/error.rs
@@ -61,9 +61,9 @@ mod size_asserts {
         };
     }
 
-    static_assert_size!(RethError, 56);
+    static_assert_size!(RethError, 64);
     static_assert_size!(BlockExecutionError, 56);
     static_assert_size!(ConsensusError, 48);
     static_assert_size!(DatabaseError, 32);
-    static_assert_size!(ProviderError, 48);
+    static_assert_size!(ProviderError, 56);
 }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -416,14 +416,14 @@ mod tests {
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let evm_env = EvmEnv {
-            cfg_env: CfgEnv::new().with_spec_and_mainnet_gas_params(SpecId::CONSTANTINOPLE),
+            cfg_env: CfgEnv::new().with_spec_and_mainnet_gas_params(SpecId::PETERSBURG),
             ..Default::default()
         };
 
         let evm = evm_config.evm_with_env(db, evm_env);
 
         // Check that the spec ID is setup properly
-        assert_eq!(evm.cfg.spec, SpecId::CONSTANTINOPLE);
+        assert_eq!(evm.cfg.spec, SpecId::PETERSBURG);
     }
 
     #[test]
@@ -483,7 +483,7 @@ mod tests {
         let db = CacheDB::<EmptyDBTyped<ProviderError>>::default();
 
         let evm_env = EvmEnv {
-            cfg_env: CfgEnv::new().with_spec_and_mainnet_gas_params(SpecId::CONSTANTINOPLE),
+            cfg_env: CfgEnv::new().with_spec_and_mainnet_gas_params(SpecId::PETERSBURG),
             ..Default::default()
         };
 

--- a/crates/ethereum/node/tests/e2e/prestate.rs
+++ b/crates/ethereum/node/tests/e2e/prestate.rs
@@ -103,6 +103,19 @@ async fn debug_trace_call_matches_geth_prestate_snapshot() -> Result<()> {
         )
         .await?;
 
+    // NOTE: this currently fails on the bal-devnet-7 revm bump.
+    //
+    // Reth's `prepare_call_env` sets `cfg_env.disable_fee_charge = true` (added for L2 operator
+    // fees in `eth_call`, see <https://github.com/paradigmxyz/reth/issues/18470>). Older revm
+    // still touched the coinbase in `reward_beneficiary` regardless, so the prestate tracer
+    // picked it up and matched geth's snapshot. Newer revm (bluealloy/revm#3559, commit
+    // `28826aed`) early-returns from `reward_beneficiary` when fee charge is disabled, so the
+    // beneficiary is no longer loaded into the journal and the coinbase entry disappears from
+    // reth's `debug_traceCall` prestate output — while geth's snapshot still has it.
+    //
+    // Fixing this requires either re-enabling fee charge in the trace path (re-introducing
+    // operator-fee charges on L2 sims) or having revm-inspectors explicitly include the
+    // beneficiary. Leaving the assertion in place so the regression stays visible.
     similar_asserts::assert_eq!(trace, expected_frame);
 
     Ok(())

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -27,6 +27,7 @@ alloy-primitives.workspace = true
 alloy-eips.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
+alloy-rlp.workspace = true
 
 auto_impl.workspace = true
 derive_more.workspace = true

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -24,10 +24,10 @@ revm.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
+alloy-eip7928 = { workspace = true, features = ["rlp"] }
 alloy-eips.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
-alloy-rlp.workspace = true
 
 auto_impl.workspace = true
 derive_more.workspace = true
@@ -43,9 +43,9 @@ default = ["std"]
 std = [
     "dep:rayon",
     "reth-primitives-traits/std",
+    "alloy-eip7928/std",
     "alloy-eips/std",
     "alloy-primitives/std",
-    "alloy-rlp/std",
     "alloy-consensus/std",
     "revm/std",
     "alloy-evm/std",

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -45,6 +45,7 @@ std = [
     "reth-primitives-traits/std",
     "alloy-eips/std",
     "alloy-primitives/std",
+    "alloy-rlp/std",
     "alloy-consensus/std",
     "revm/std",
     "alloy-evm/std",

--- a/crates/evm/evm/src/either.rs
+++ b/crates/evm/evm/src/either.rs
@@ -80,7 +80,7 @@ where
         }
     }
 
-    fn take_bal(&mut self) -> Option<alloy_eips::eip7928::BlockAccessList> {
+    fn take_bal(&mut self) -> Option<alloy_eip7928::BlockAccessList> {
         match self {
             Self::Left(a) => a.take_bal(),
             Self::Right(b) => b.take_bal(),

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -29,8 +29,8 @@ use revm::{
     state::bal::{alloy::AlloyBal, Bal},
 };
 
-/// Convert revm's [`AlloyBal`] (alloy_eip7928 0.4) into reth's [`BlockAccessList`]
-/// (alloy_eip7928 0.3) by round-tripping through RLP. The wire format is identical
+/// Convert revm's [`AlloyBal`] (`alloy_eip7928` 0.4) into reth's [`BlockAccessList`]
+/// (`alloy_eip7928` 0.3) by round-tripping through RLP. The wire format is identical
 /// across versions; only the Rust types differ.
 fn alloy_bal_to_block_access_list(bal: AlloyBal) -> Option<BlockAccessList> {
     let mut buf = Vec::new();

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,10 +3,8 @@
 use crate::{ConfigureEvm, Database, OnStateHook, TxEnvFor};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::{
-    eip2718::WithEncoded,
-    eip7928::{compute_block_access_list_hash, BlockAccessList},
-};
+use alloy_eip7928::{compute_block_access_list_hash, BlockAccessList};
+use alloy_eips::eip2718::WithEncoded;
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory, GasOutput};
 use alloy_evm::{
     block::{CommitChanges, ExecutableTxParts},
@@ -26,17 +24,8 @@ pub use reth_storage_errors::provider::ProviderError;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 use revm::{
     database::{states::bundle_state::BundleRetention, BundleState, State},
-    state::bal::{alloy::AlloyBal, Bal},
+    state::bal::Bal,
 };
-
-/// Convert revm's [`AlloyBal`] (`alloy_eip7928` 0.4) into reth's [`BlockAccessList`]
-/// (`alloy_eip7928` 0.3) by round-tripping through RLP. The wire format is identical
-/// across versions; only the Rust types differ.
-fn alloy_bal_to_block_access_list(bal: AlloyBal) -> Option<BlockAccessList> {
-    let mut buf = Vec::new();
-    alloy_rlp::Encodable::encode(&bal, &mut buf);
-    <BlockAccessList as alloy_rlp::Decodable>::decode(&mut buf.as_slice()).ok()
-}
 
 /// A type that knows how to execute a block. It is assumed to operate on a
 /// [`crate::Evm`] internally and use [`State`] as database.
@@ -513,7 +502,7 @@ where
         // merge all transitions into bundle state
         db.merge_transitions(BundleRetention::Reverts);
 
-        let block_access_list = db.take_built_alloy_bal().and_then(alloy_bal_to_block_access_list);
+        let block_access_list = db.take_built_alloy_bal();
         let block_access_list_hash =
             block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal));
 
@@ -657,7 +646,7 @@ where
     }
 
     fn take_bal(&mut self) -> Option<BlockAccessList> {
-        self.db.take_built_alloy_bal().and_then(alloy_bal_to_block_access_list)
+        self.db.take_built_alloy_bal()
     }
 }
 

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -26,8 +26,17 @@ pub use reth_storage_errors::provider::ProviderError;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 use revm::{
     database::{states::bundle_state::BundleRetention, BundleState, State},
-    state::bal::Bal,
+    state::bal::{alloy::AlloyBal, Bal},
 };
+
+/// Convert revm's [`AlloyBal`] (alloy_eip7928 0.4) into reth's [`BlockAccessList`]
+/// (alloy_eip7928 0.3) by round-tripping through RLP. The wire format is identical
+/// across versions; only the Rust types differ.
+fn alloy_bal_to_block_access_list(bal: AlloyBal) -> Option<BlockAccessList> {
+    let mut buf = Vec::new();
+    alloy_rlp::Encodable::encode(&bal, &mut buf);
+    <BlockAccessList as alloy_rlp::Decodable>::decode(&mut buf.as_slice()).ok()
+}
 
 /// A type that knows how to execute a block. It is assumed to operate on a
 /// [`crate::Evm`] internally and use [`State`] as database.
@@ -504,7 +513,7 @@ where
         // merge all transitions into bundle state
         db.merge_transitions(BundleRetention::Reverts);
 
-        let block_access_list = db.take_built_alloy_bal();
+        let block_access_list = db.take_built_alloy_bal().and_then(alloy_bal_to_block_access_list);
         let block_access_list_hash =
             block_access_list.as_ref().map(|bal| compute_block_access_list_hash(bal));
 
@@ -648,7 +657,7 @@ where
     }
 
     fn take_bal(&mut self) -> Option<BlockAccessList> {
-        self.db.take_built_alloy_bal()
+        self.db.take_built_alloy_bal().and_then(alloy_bal_to_block_access_list)
     }
 }
 

--- a/crates/net/eth-wire-types/src/block_access_lists.rs
+++ b/crates/net/eth-wire-types/src/block_access_lists.rs
@@ -89,20 +89,22 @@ impl<'a> arbitrary::Arbitrary<'a> for BlockAccessLists {
 mod tests {
     use super::*;
     use alloy_eip7928::{
-        AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
+        AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
+        StorageChange,
     };
     use alloy_primitives::{Address, U256};
     use alloy_rlp::EMPTY_LIST_CODE;
 
     fn elaborate_account_changes(seed: u8) -> Vec<AccountChanges> {
+        let bai = BlockAccessIndex::new;
         vec![
             AccountChanges {
                 address: Address::from([seed; 20]),
                 storage_changes: vec![SlotChanges::new(
                     U256::from_be_bytes([seed.wrapping_add(1); 32]),
                     vec![
-                        StorageChange::new(1, U256::from_be_bytes([seed.wrapping_add(2); 32])),
-                        StorageChange::new(2, U256::from_be_bytes([seed.wrapping_add(3); 32])),
+                        StorageChange::new(bai(1), U256::from_be_bytes([seed.wrapping_add(2); 32])),
+                        StorageChange::new(bai(2), U256::from_be_bytes([seed.wrapping_add(3); 32])),
                     ],
                 )],
                 storage_reads: vec![
@@ -110,15 +112,15 @@ mod tests {
                     U256::from_be_bytes([seed.wrapping_add(5); 32]),
                 ],
                 balance_changes: vec![
-                    BalanceChange::new(1, U256::from(1_000 + seed as u64)),
-                    BalanceChange::new(2, U256::from(2_000 + seed as u64)),
+                    BalanceChange::new(bai(1), U256::from(1_000 + seed as u64)),
+                    BalanceChange::new(bai(2), U256::from(2_000 + seed as u64)),
                 ],
                 nonce_changes: vec![
-                    NonceChange::new(1, seed as u64),
-                    NonceChange::new(2, seed as u64 + 1),
+                    NonceChange::new(bai(1), seed as u64),
+                    NonceChange::new(bai(2), seed as u64 + 1),
                 ],
                 code_changes: vec![CodeChange::new(
-                    1,
+                    bai(1),
                     Bytes::from(vec![0x60, seed, 0x61, seed.wrapping_add(1), 0x56]),
                 )],
             },
@@ -126,9 +128,9 @@ mod tests {
                 address: Address::from([seed.wrapping_add(9); 20]),
                 storage_changes: Vec::new(),
                 storage_reads: vec![U256::from_be_bytes([seed.wrapping_add(10); 32])],
-                balance_changes: vec![BalanceChange::new(3, U256::from(3_000 + seed as u64))],
-                nonce_changes: vec![NonceChange::new(3, seed as u64 + 2)],
-                code_changes: vec![CodeChange::new(2, Bytes::from(vec![0x5f, 0x5f, 0xf3]))],
+                balance_changes: vec![BalanceChange::new(bai(3), U256::from(3_000 + seed as u64))],
+                nonce_changes: vec![NonceChange::new(bai(3), seed as u64 + 2)],
+                code_changes: vec![CodeChange::new(bai(2), Bytes::from(vec![0x5f, 0x5f, 0xf3]))],
             },
         ]
     }

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -37,10 +37,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth71;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -412,12 +412,12 @@ pub struct EngineArgs {
     pub allow_unwind_canonical_header: bool,
 
     /// Configure the number of storage proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to 2x available parallelism.
+    /// If not specified, defaults to 2x available parallelism, with a minimum of 128.
     #[arg(long = "engine.storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_count.map(|v| v.to_string().into())))]
     pub storage_worker_count: Option<usize>,
 
     /// Configure the number of account proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to the same count as storage workers.
+    /// If not specified, defaults to 2x available parallelism, with a minimum of 128.
     #[arg(long = "engine.account-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().account_worker_count.map(|v| v.to_string().into())))]
     pub account_worker_count: Option<usize>,
 

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -9,11 +9,21 @@ use reth_rpc_eth_types::{
     cache::db::StateProviderTraitObjWrapper, error::FromEthApiError, EthApiError,
 };
 use reth_storage_api::StateProviderFactory;
+use revm::state::bal::alloy::AlloyBal;
 
 use crate::{
     helpers::{Call, LoadBlock, Trace},
     RpcNodeCore,
 };
+
+/// Convert revm's [`AlloyBal`] (alloy_eip7928 0.4) into reth's [`BlockAccessList`]
+/// (alloy_eip7928 0.3) by round-tripping through RLP. The wire format is identical
+/// across versions; only the Rust types differ.
+fn alloy_bal_to_block_access_list(bal: AlloyBal) -> Option<BlockAccessList> {
+    let mut buf = Vec::new();
+    alloy_rlp::Encodable::encode(&bal, &mut buf);
+    <BlockAccessList as alloy_rlp::Decodable>::decode(&mut buf.as_slice()).ok()
+}
 
 /// Helper trait for `eth_blockAccessList` RPC method.
 pub trait GetBlockAccessList: Trace + Call + LoadBlock {
@@ -58,7 +68,7 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock {
                     .apply_post_execution_changes()
                     .map_err(|err| EthApiError::Internal(err.into()))?;
 
-                let bal = db.take_built_alloy_bal();
+                let bal = db.take_built_alloy_bal().and_then(alloy_bal_to_block_access_list);
                 Ok(bal)
             })
             .await

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -16,8 +16,8 @@ use crate::{
     RpcNodeCore,
 };
 
-/// Convert revm's [`AlloyBal`] (alloy_eip7928 0.4) into reth's [`BlockAccessList`]
-/// (alloy_eip7928 0.3) by round-tripping through RLP. The wire format is identical
+/// Convert revm's [`AlloyBal`] (`alloy_eip7928` 0.4) into reth's [`BlockAccessList`]
+/// (`alloy_eip7928` 0.3) by round-tripping through RLP. The wire format is identical
 /// across versions; only the Rust types differ.
 fn alloy_bal_to_block_access_list(bal: AlloyBal) -> Option<BlockAccessList> {
     let mut buf = Vec::new();

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -1,6 +1,6 @@
 //! Helpers for `eth_blockAccessList` RPC method.
 use alloy_consensus::BlockHeader;
-use alloy_eips::eip7928::BlockAccessList;
+use alloy_eip7928::BlockAccessList;
 use alloy_rpc_types_eth::BlockId;
 use reth_errors::RethError;
 use reth_evm::{block::BlockExecutor, ConfigureEvm, Evm};
@@ -9,21 +9,11 @@ use reth_rpc_eth_types::{
     cache::db::StateProviderTraitObjWrapper, error::FromEthApiError, EthApiError,
 };
 use reth_storage_api::StateProviderFactory;
-use revm::state::bal::alloy::AlloyBal;
 
 use crate::{
     helpers::{Call, LoadBlock, Trace},
     RpcNodeCore,
 };
-
-/// Convert revm's [`AlloyBal`] (`alloy_eip7928` 0.4) into reth's [`BlockAccessList`]
-/// (`alloy_eip7928` 0.3) by round-tripping through RLP. The wire format is identical
-/// across versions; only the Rust types differ.
-fn alloy_bal_to_block_access_list(bal: AlloyBal) -> Option<BlockAccessList> {
-    let mut buf = Vec::new();
-    alloy_rlp::Encodable::encode(&bal, &mut buf);
-    <BlockAccessList as alloy_rlp::Decodable>::decode(&mut buf.as_slice()).ok()
-}
 
 /// Helper trait for `eth_blockAccessList` RPC method.
 pub trait GetBlockAccessList: Trace + Call + LoadBlock {
@@ -68,7 +58,7 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock {
                     .apply_post_execution_changes()
                     .map_err(|err| EthApiError::Internal(err.into()))?;
 
-                let bal = db.take_built_alloy_bal().and_then(alloy_bal_to_block_access_list);
+                let bal = db.take_built_alloy_bal();
                 Ok(bal)
             })
             .await

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -29,6 +29,7 @@ reth-transaction-pool.workspace = true
 reth-trie.workspace = true
 
 # ethereum
+alloy-eip7928 = { workspace = true, features = ["rlp"] }
 alloy-eips.workspace = true
 alloy-evm = { workspace = true, features = ["overrides", "call-util"] }
 alloy-primitives.workspace = true

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -995,6 +995,7 @@ mod tests {
         Block, BlockBody, EthPrimitives, Receipt, Transaction, TransactionSigned,
     };
     use reth_primitives_traits::{RecoveredBlock, SealedHeader};
+    use reth_revm::state::bal::BlockAccessIndex;
     use reth_storage_api::{
         noop::NoopProvider, BalProvider, BalStore, BalStoreHandle, BlockBodyIndicesProvider,
         BlockHashReader, BlockNumReader, BlockReader, BlockSource, HeaderProvider, ReceiptProvider,
@@ -1115,15 +1116,19 @@ mod tests {
     #[test]
     fn cached_revm_bal_size_accounts_for_nested_allocations() {
         let mut account = RevmAccountBal::default();
-        account.account_info.nonce.writes.push((1, 1));
-        account.account_info.balance.writes.push((2, StorageValue::from(1u64)));
+        account.account_info.nonce.writes.push((BlockAccessIndex::new(1), 1));
+        account
+            .account_info
+            .balance
+            .writes
+            .push((BlockAccessIndex::new(2), StorageValue::from(1u64)));
         account.account_info.code.writes.push((
-            3,
+            BlockAccessIndex::new(3),
             (B256::repeat_byte(0xaa), Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]))),
         ));
         account.storage.storage.insert(
             StorageKey::from(1u64),
-            RevmBalWrites::new(vec![(4, StorageValue::from(2u64))]),
+            RevmBalWrites::new(vec![(BlockAccessIndex::new(4), StorageValue::from(2u64))]),
         );
 
         let mut bal = RevmBal::default();

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -3,7 +3,8 @@
 use super::{EthStateCacheConfig, MultiConsumerLruCache};
 use crate::block::CachedTransaction;
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
-use alloy_eips::{eip7928::bal::DecodedBal, BlockHashOrNumber};
+use alloy_eip7928::bal::DecodedBal;
+use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, TxHash, B256};
 use futures::{stream::FuturesOrdered, Stream, StreamExt};
 use reth_chain_state::CanonStateNotification;

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -27,7 +27,7 @@ reth-ethereum-primitives.workspace = true
 
 # ethereum
 alloy-eips.workspace = true
-alloy-eip7928 = { version = "0.4", default-features = false, features = ["rlp"] }
+alloy-eip7928 = { workspace = true, features = ["rlp"] }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -47,8 +47,10 @@ default = ["std"]
 std = [
     "reth-chainspec/std",
     "alloy-consensus/std",
+    "alloy-eip7928/std",
     "alloy-eips/std",
     "alloy-primitives/std",
+    "alloy-rlp/std",
     "alloy-rpc-types-engine/std",
     "reth-primitives-traits/std",
     "reth-stages-types/std",
@@ -77,6 +79,7 @@ serde = [
     "reth-stages-types/serde",
     "reth-trie-common/serde",
     "revm-database/serde",
+    "alloy-eip7928/serde",
     "alloy-eips/serde",
     "alloy-primitives/serde",
     "alloy-consensus/serde",

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -27,8 +27,10 @@ reth-ethereum-primitives.workspace = true
 
 # ethereum
 alloy-eips.workspace = true
+alloy-eip7928 = { version = "0.4", default-features = false, features = ["rlp"] }
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
+alloy-rlp.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 auto_impl.workspace = true

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -2,7 +2,7 @@ use alloc::{sync::Arc, vec::Vec};
 use alloy_eips::{eip7928::bal::DecodedBal, NumHash};
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealed};
 use reth_storage_errors::provider::ProviderResult;
-use revm_database::state::bal::Bal as RevmBal;
+use revm_database::state::bal::{alloy::AlloyBal, Bal as RevmBal};
 
 /// Raw BAL RLP bytes sealed by the BAL hash.
 pub type SealedBal = Sealed<Bytes>;
@@ -92,14 +92,15 @@ pub trait BalStore: Send + Sync + 'static {
         &self,
         block_hash: BlockHash,
     ) -> ProviderResult<Option<DecodedBal<RevmBal>>> {
-        self.get_decoded_by_hash(block_hash)?
-            .map(|decoded| {
-                decoded.try_map(|bal| {
-                    RevmBal::try_from(Vec::from(bal))
-                        .map_err(reth_storage_errors::provider::ProviderError::other)
-                })
-            })
-            .transpose()
+        let Some(raw) = self.get_by_hash(block_hash)? else { return Ok(None) };
+        // revm-state's `Bal` is built from `alloy_eip7928 0.4`, while reth's `DecodedBal` is
+        // generic over `alloy_eip7928 0.3`. Re-decode the wire-format RLP into the revm-side
+        // `AlloyBal` and convert.
+        let alloy_bal = <AlloyBal as alloy_rlp::Decodable>::decode(&mut raw.as_ref())
+            .map_err(reth_storage_errors::provider::ProviderError::other)?;
+        let revm_bal = RevmBal::try_from(alloy_bal)
+            .map_err(reth_storage_errors::provider::ProviderError::other)?;
+        Ok(Some(DecodedBal::new(revm_bal, raw)))
     }
 
     /// Fetch BAL response entries for the given block hashes, stopping after the soft limit is

--- a/crates/storage/storage-api/src/bal.rs
+++ b/crates/storage/storage-api/src/bal.rs
@@ -1,8 +1,9 @@
 use alloc::{sync::Arc, vec::Vec};
-use alloy_eips::{eip7928::bal::DecodedBal, NumHash};
+use alloy_eip7928::bal::DecodedBal;
+use alloy_eips::NumHash;
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealed};
 use reth_storage_errors::provider::ProviderResult;
-use revm_database::state::bal::{alloy::AlloyBal, Bal as RevmBal};
+use revm_database::state::bal::Bal as RevmBal;
 
 /// Raw BAL RLP bytes sealed by the BAL hash.
 pub type SealedBal = Sealed<Bytes>;
@@ -93,11 +94,9 @@ pub trait BalStore: Send + Sync + 'static {
         block_hash: BlockHash,
     ) -> ProviderResult<Option<DecodedBal<RevmBal>>> {
         let Some(raw) = self.get_by_hash(block_hash)? else { return Ok(None) };
-        // revm-state's `Bal` is built from `alloy_eip7928 0.4`, while reth's `DecodedBal` is
-        // generic over `alloy_eip7928 0.3`. Re-decode the wire-format RLP into the revm-side
-        // `AlloyBal` and convert.
-        let alloy_bal = <AlloyBal as alloy_rlp::Decodable>::decode(&mut raw.as_ref())
-            .map_err(reth_storage_errors::provider::ProviderError::other)?;
+        let alloy_bal =
+            <alloy_eip7928::BlockAccessList as alloy_rlp::Decodable>::decode(&mut raw.as_ref())
+                .map_err(reth_storage_errors::provider::ProviderError::other)?;
         let revm_bal = RevmBal::try_from(alloy_bal)
             .map_err(reth_storage_errors::provider::ProviderError::other)?;
         Ok(Some(DecodedBal::new(revm_bal, raw)))

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -11,6 +11,10 @@
 
 extern crate alloc;
 
+// Pulled in to activate the `rlp` feature on alloy-eip7928 0.4, the version used by
+// revm-state. The crate is not referenced directly from this file.
+use alloy_eip7928 as _;
+
 // Re-export used error types.
 pub use reth_storage_errors as errors;
 mod bal;

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -11,10 +11,6 @@
 
 extern crate alloc;
 
-// Pulled in to activate the `rlp` feature on alloy-eip7928 0.4, the version used by
-// revm-state. The crate is not referenced directly from this file.
-use alloy_eip7928 as _;
-
 // Re-export used error types.
 pub use reth_storage_errors as errors;
 mod bal;

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -44,6 +44,15 @@ pub const DEFAULT_STORAGE_POOL_THREADS: usize = 16;
 /// Default maximum number of concurrent blocking tasks (for RPC tracing guard).
 pub const DEFAULT_MAX_BLOCKING_TASKS: usize = 512;
 
+/// Minimum default size of the proof worker pools.
+///
+/// Proof workers spend most of their time blocked on database reads, so the pool
+/// size acts as an I/O queue depth, not a CPU budget. Deriving it only from
+/// available parallelism starves the disk on small CPU allocations (e.g. the
+/// 6-core EIP-7870 profile yields 12 workers, leaving multiproof computation
+/// dominated by serialized read latency).
+pub const DEFAULT_MIN_PROOF_WORKERS: usize = 128;
+
 /// Configuration for the tokio runtime.
 #[derive(Debug, Clone)]
 pub enum TokioConfig {
@@ -104,10 +113,12 @@ pub struct RayonConfig {
     /// Maximum number of concurrent blocking tasks for the RPC guard semaphore.
     pub max_blocking_tasks: usize,
     /// Number of threads for the proof storage worker pool (trie storage proof workers).
-    /// If `None`, derived from available parallelism.
+    /// If `None`, twice the available parallelism, with a floor of
+    /// [`DEFAULT_MIN_PROOF_WORKERS`].
     pub proof_storage_worker_threads: Option<usize>,
     /// Number of threads for the proof account worker pool (trie account proof workers).
-    /// If `None`, derived from available parallelism.
+    /// If `None`, twice the available parallelism, with a floor of
+    /// [`DEFAULT_MIN_PROOF_WORKERS`].
     pub proof_account_worker_threads: Option<usize>,
     /// Number of threads for the prewarming pool (execution prewarming workers).
     /// If `None`, derived from available parallelism.
@@ -850,13 +861,17 @@ impl RuntimeBuilder {
 
             let blocking_guard = BlockingTaskGuard::new(config.rayon.max_blocking_tasks);
 
-            let proof_storage_worker_threads =
-                config.rayon.proof_storage_worker_threads.unwrap_or(default_threads * 2);
+            let proof_storage_worker_threads = config
+                .rayon
+                .proof_storage_worker_threads
+                .unwrap_or_else(|| (default_threads * 2).max(DEFAULT_MIN_PROOF_WORKERS));
             let proof_storage_worker_pool =
                 WorkerPool::new(proof_storage_worker_threads, "proof-strg");
 
-            let proof_account_worker_threads =
-                config.rayon.proof_account_worker_threads.unwrap_or(default_threads * 2);
+            let proof_account_worker_threads = config
+                .rayon
+                .proof_account_worker_threads
+                .unwrap_or_else(|| (default_threads * 2).max(DEFAULT_MIN_PROOF_WORKERS));
             let proof_account_worker_pool =
                 WorkerPool::new(proof_account_worker_threads, "proof-acct");
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1414,6 +1414,8 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
         SpecId::MERGE
     };
 
+    // Cap intrinsic gas check at pre-Amsterdam specs; EIP-8037 `cpsb` does not apply here.
+    let cpsb = 0;
     let gas = revm_interpreter::gas::calculate_initial_tx_gas(
         spec_id,
         transaction.input(),
@@ -1424,10 +1426,11 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
             .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
             .unwrap_or_default() as u64,
         transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
+        cpsb,
     );
 
     let gas_limit = transaction.gas_limit();
-    if gas_limit < gas.initial_total_gas || gas_limit < gas.floor_gas {
+    if gas_limit < gas.initial_total_gas() || gas_limit < gas.floor_gas {
         Err(InvalidPoolTransactionError::IntrinsicGasTooLow)
     } else {
         Ok(())

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -159,18 +159,13 @@ impl ProofWorkerHandle {
     /// # Parameters
     /// - `runtime`: The centralized runtime used to spawn blocking worker tasks
     /// - `task_ctx`: Shared context with database view and prefix sets
-    /// - `halve_workers`: Whether to halve the worker pool size (for small blocks)
     #[instrument(
         name = "ProofWorkerHandle::new",
         level = "debug",
         target = "trie::proof_task",
         skip_all
     )]
-    pub fn new<Factory>(
-        runtime: &Runtime,
-        task_ctx: ProofTaskCtx<Factory>,
-        halve_workers: bool,
-    ) -> Self
+    pub fn new<Factory>(runtime: &Runtime, task_ctx: ProofTaskCtx<Factory>) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
@@ -183,11 +178,8 @@ impl ProofWorkerHandle {
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
-        let divisor = if halve_workers { 2 } else { 1 };
-        let storage_worker_count =
-            runtime.proof_storage_worker_pool().current_num_threads() / divisor;
-        let account_worker_count =
-            runtime.proof_account_worker_pool().current_num_threads() / divisor;
+        let storage_worker_count = runtime.proof_storage_worker_pool().current_num_threads();
+        let account_worker_count = runtime.proof_account_worker_pool().current_num_threads();
 
         let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
         let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
@@ -196,7 +188,6 @@ impl ProofWorkerHandle {
             target: "trie::proof_task",
             storage_worker_count,
             account_worker_count,
-            halve_workers,
             "Spawning proof worker pools"
         );
 
@@ -1176,7 +1167,7 @@ mod tests {
         let ctx = test_ctx(factory);
 
         let runtime = reth_tasks::Runtime::test();
-        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false);
+        let proof_handle = ProofWorkerHandle::new(&runtime, ctx);
 
         // Verify handle can be cloned
         let _cloned_handle = proof_handle.clone();

--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,7 @@ allow-git = [
     "https://github.com/foundry-rs/block-explorers",
     "https://github.com/bluealloy/revm",
     "https://github.com/paradigmxyz/revm-inspectors",
+    "https://github.com/paradigmxyz/reth-core",
     "https://github.com/alloy-rs/evm",
     "https://github.com/alloy-rs/hardforks",
     "https://github.com/paradigmxyz/jsonrpsee",

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1033,10 +1033,10 @@ Engine:
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
-          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
+          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, with a minimum of 128
 
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
-          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers
+          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, with a minimum of 128
 
       --engine.prewarming-threads <PREWARMING_THREADS>
           Configure the number of prewarming threads. If not specified, defaults to available parallelism


### PR DESCRIPTION
Proof workers spend most of their time blocked on database reads, so the pool size acts as an I/O queue depth rather than a CPU budget. Deriving it from available parallelism alone starves the disk on small CPU allocations: under the 6-core EIP-7870 profile the default yields 12 workers (6 after small-block halving) and multiproof computation serializes on read latency.

Measured on the jochemnet gas-benchmark suite (1.5 TB state, 6-CPU pin, NVMe): the worst storage-write payload (100M gas, ~20k cold slot writes to one contract) improves from 2.5 s to 0.9 s, and value-transfer payloads hide the state-root tail behind execution entirely. Machines whose derived default already exceeds 128 are unaffected; explicit `--engine.storage-worker-count` / `--engine.account-worker-count` still override.

The second commit removes the tx-count-based small-block halving: transaction count is a poor proxy for state-change volume, and with the floor in place the halving shows no measurable benefit (64 vs 128 workers is within noise on NVMe).