### PR TITLE
fix(cli): give --jit arg a unique clap id

### DIFF
--- a/crates/node/core/src/args/jit.rs
+++ b/crates/node/core/src/args/jit.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 #[command(next_help_heading = "JIT")]
 pub struct JitArgs {
     /// Enable JIT compilation of EVM bytecode.
-    #[arg(long = "jit", default_value_t = false, help_heading = "JIT")]
+    #[arg(id = "jit", long = "jit", default_value_t = false, help_heading = "JIT")]
     pub enabled: bool,
 
     /// Number of observed misses before a bytecode is promoted to JIT compilation.
@@ -88,5 +88,24 @@ impl Default for JitArgs {
             debug: false,
             blocking: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A helper type to parse Args more easily
+    #[derive(Parser)]
+    struct CommandParser<T: Args> {
+        #[command(flatten)]
+        args: T,
+    }
+
+    #[test]
+    fn jit_args_default_sanity_test() {
+        let args = CommandParser::<JitArgs>::parse_from(["reth"]).args;
+        assert_eq!(args, JitArgs::default());
     }
 }

--- a/crates/node/core/src/args/jit.rs
+++ b/crates/node/core/src/args/jit.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 #[command(next_help_heading = "JIT")]
 pub struct JitArgs {
     /// Enable JIT compilation of EVM bytecode.
-    #[arg(id = "jit", long = "jit", default_value_t = false, help_heading = "JIT")]
+    #[arg(id = "jit.enabled", long = "jit", default_value_t = false, help_heading = "JIT")]
     pub enabled: bool,
 
     /// Number of observed misses before a bytecode is promoted to JIT compilation.


### PR DESCRIPTION
## Problem
`JitArgs::enabled` uses the default clap id `enabled`. When `JitArgs` is flattened into a node command alongside another Args struct that also has an `enabled` field (e.g. a downstream node like tempo with `FaucetArgs::enabled`), clap's debug assert panics:

```
Command node: Argument names must be unique, but 'enabled' is in use by more than one argument or group
```

## Fix
Set an explicit `id = "jit"` matching the long flag, same convention as `EraArgs` (`id = "era.enable"`) and the discovery/RPC args. Adds a parse sanity test following the existing `CommandParser` pattern.

No behavior change — flag is still `--jit`.