### PR TITLE
chore(deps): bump revmc to 7e3536d6 (engine deadlock fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3444,7 +3444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4236,8 +4236,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4804,7 +4804,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5185,7 +5185,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6253,7 +6253,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10958,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10978,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "eyre",
  "ruint",
@@ -10987,12 +10987,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -11007,7 +11007,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -11053,7 +11053,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -11066,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#e86ab245f60e37396e7bbb66e44c877e47d58aea"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11305,7 +11305,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11364,7 +11364,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11385,7 +11385,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12228,7 +12228,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13499,7 +13499,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the `revmc` git pin `e86ab245` → `7e3536d6` (one commit: paradigmxyz/revmc#391).

## Why

`JitBackend::pause()`/`resume()` used a blocking `send` on revmc's bounded command channel (capacity 4096). With the `jit` feature compiled in but JIT never enabled (no `--jit`), the backend thread is never spawned and nothing drains the channel — but `JitPauseGuard` in `validate_block_with_state` still sends one pause + one resume per validated block. After exactly **2048 validated blocks (~6.8h at 12s slots)** the channel is full and the next `pause()` blocks the engine-tree thread forever: the engine stops answering all Engine API calls (CL sees timeouts) while P2P/RPC keep running, with no log output, no panic, and no resource spike.

Observed in production on `2.3.0 (fc2cc1e)`: node started 07:25:41 UTC, deadlocked 13:46:48 UTC inserting block 25301778 — log count of completed validations between the two: exactly 2048. The last log line was `engine::tree` "found canonical state for block in memory, creating provider builder"; the next statement is `JitPauseGuard::new`.

With revmc#391, pause/resume are skipped while the backend thread isn't started and use `try_send` (drop + `commands_dropped` stat instead of blocking) when it is.

`RuntimeStatsSnapshot` gained an additive `commands_dropped` field; reth only reads snapshot fields by reference (`RevmcMetrics::record`), so no code changes needed.