### PR TITLE
fix(rpc): remove unused ipc middleware lifetimes

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -68,7 +68,7 @@ impl<HttpMiddleware, RpcMiddleware> IpcServer<HttpMiddleware, RpcMiddleware> {
 
 impl<HttpMiddleware, RpcMiddleware> IpcServer<HttpMiddleware, RpcMiddleware>
 where
-    RpcMiddleware: for<'a> Layer<RpcService, Service: RpcServiceT> + Clone + Send + 'static,
+    RpcMiddleware: Layer<RpcService, Service: RpcServiceT> + Clone + Send + 'static,
     HttpMiddleware: Layer<
             TowerServiceNoHttp<RpcMiddleware>,
             Service: Service<
@@ -371,8 +371,8 @@ pub struct TowerServiceNoHttp<L> {
 
 impl<RpcMiddleware> Service<String> for TowerServiceNoHttp<RpcMiddleware>
 where
-    RpcMiddleware: for<'a> Layer<RpcService>,
-    for<'a> <RpcMiddleware as Layer<RpcService>>::Service:
+    RpcMiddleware: Layer<RpcService>,
+    <RpcMiddleware as Layer<RpcService>>::Service:
         Send + Sync + 'static + RpcServiceT<MethodResponse = MethodResponse>,
 {
     /// The response of a handled RPC call


### PR DESCRIPTION
Removes unused higher-ranked lifetime binders from the IPC RPC middleware `Layer<RpcService>` bounds. Newer clippy reports these as `extra_unused_lifetimes`; the bounds do not depend on borrowed inputs, so the non-HRTB form preserves the same constraints.