### PR TITLE
perf(tx-pool): reuse state provider across batch validation

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -299,7 +299,7 @@ pub use crate::{
     validate::{
         EthTransactionValidator, StatefulValidationFn, StatelessValidationFn,
         TransactionValidationOutcome, TransactionValidationTaskExecutor, TransactionValidator,
-        ValidPoolTransaction,
+        TransactionValidatorWithState, ValidPoolTransaction,
     },
 };
 use crate::{identifier::TransactionId, pool::PoolInner};

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -413,11 +413,26 @@ impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T>
     type Transaction = T;
     type Block = reth_ethereum_primitives::Block;
 
-    async fn validate_transaction(
+    fn validate_stateless(
+        &self,
+        _origin: TransactionOrigin,
+        _transaction: &Self::Transaction,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        if self.return_invalid {
+            return Err(InvalidPoolTransactionError::Underpriced);
+        }
+        Ok(())
+    }
+
+    fn validate_stateful<S>(
         &self,
         origin: TransactionOrigin,
         mut transaction: Self::Transaction,
-    ) -> TransactionValidationOutcome<Self::Transaction> {
+        _state: &S,
+    ) -> TransactionValidationOutcome<Self::Transaction>
+    where
+        S: reth_storage_api::AccountReader + reth_storage_api::BytecodeReader + ?Sized,
+    {
         if self.return_invalid {
             return TransactionValidationOutcome::Invalid(
                 transaction,
@@ -439,6 +454,27 @@ impl<T: EthPoolTransaction> TransactionValidator for MockTransactionValidator<T>
             },
             authorities: None,
         }
+    }
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        match self.validate_stateless(origin, &transaction) {
+            Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+            Ok(()) => {
+                self.validate_stateful(origin, transaction, &crate::validate::NOOP_ACCOUNT_READER)
+            }
+        }
+    }
+
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        self.validate_transactions_with_state(transactions, &crate::validate::NOOP_ACCOUNT_READER)
     }
 }
 

--- a/crates/transaction-pool/src/test_utils/okvalidator.rs
+++ b/crates/transaction-pool/src/test_utils/okvalidator.rs
@@ -1,8 +1,10 @@
 use std::marker::PhantomData;
 
 use crate::{
-    validate::ValidTransaction, EthPooledTransaction, PoolTransaction, TransactionOrigin,
-    TransactionValidationOutcome, TransactionValidator,
+    error::InvalidPoolTransactionError,
+    validate::{ValidTransaction, NOOP_ACCOUNT_READER},
+    EthPooledTransaction, PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
+    TransactionValidator,
 };
 use reth_ethereum_primitives::Block;
 
@@ -21,6 +23,23 @@ impl<T> OkValidator<T> {
         self.propagate = propagate;
         self
     }
+
+    fn valid_outcome(&self, transaction: T) -> TransactionValidationOutcome<T>
+    where
+        T: PoolTransaction,
+    {
+        let authorities = transaction.authorization_list().map(|auths| {
+            auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>()
+        });
+        TransactionValidationOutcome::Valid {
+            balance: *transaction.cost(),
+            state_nonce: transaction.nonce(),
+            bytecode_hash: None,
+            transaction: ValidTransaction::Valid(transaction),
+            propagate: self.propagate,
+            authorities,
+        }
+    }
 }
 
 impl<T> Default for OkValidator<T> {
@@ -36,22 +55,42 @@ where
     type Transaction = T;
     type Block = Block;
 
-    async fn validate_transaction(
+    fn validate_stateless(
+        &self,
+        _origin: TransactionOrigin,
+        _transaction: &Self::Transaction,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        Ok(())
+    }
+
+    fn validate_stateful<S>(
         &self,
         _origin: TransactionOrigin,
         transaction: Self::Transaction,
+        _state: &S,
+    ) -> TransactionValidationOutcome<Self::Transaction>
+    where
+        S: reth_storage_api::AccountReader + reth_storage_api::BytecodeReader + ?Sized,
+    {
+        self.valid_outcome(transaction)
+    }
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
-        // Always return valid
-        let authorities = transaction.authorization_list().map(|auths| {
-            auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>()
-        });
-        TransactionValidationOutcome::Valid {
-            balance: *transaction.cost(),
-            state_nonce: transaction.nonce(),
-            bytecode_hash: None,
-            transaction: ValidTransaction::Valid(transaction),
-            propagate: self.propagate,
-            authorities,
+        match self.validate_stateless(origin, &transaction) {
+            Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+            Ok(()) => self.validate_stateful(origin, transaction, &NOOP_ACCOUNT_READER),
         }
+    }
+
+    async fn validate_transactions(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+            + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        self.validate_transactions_with_state(transactions, &NOOP_ACCOUNT_READER)
     }
 }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     metrics::TxPoolValidationMetrics,
     traits::TransactionOrigin,
-    validate::ValidTransaction,
+    validate::{TransactionValidatorWithState, ValidTransaction},
     Address, BlobTransactionSidecarVariant, EthBlobTransactionSidecar, EthPoolTransaction,
     LocalTransactionConfig, TransactionValidationOutcome, TransactionValidationTaskExecutor,
     TransactionValidator,
@@ -31,7 +31,9 @@ use reth_primitives_traits::{
     transaction::error::InvalidTransactionError, Account, BlockTy, GotExpected, HeaderTy,
     SealedBlock,
 };
-use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, BytecodeReader, StateProviderFactory};
+use reth_storage_api::{
+    AccountInfoReader, AccountReader, BlockReaderIdExt, BytecodeReader, StateProviderFactory,
+};
 use reth_tasks::Runtime;
 use revm::context_interface::Cfg;
 use revm_primitives::U256;
@@ -371,7 +373,7 @@ where
         origin: TransactionOrigin,
         transaction: Tx,
     ) -> TransactionValidationOutcome<Tx> {
-        self.validate_one_with_provider(origin, transaction, &mut None)
+        TransactionValidatorWithState::validate_transaction_sync(self, origin, transaction)
     }
 
     /// Validates a single transaction with the provided state provider.
@@ -418,7 +420,7 @@ where
 
                 let state = maybe_state.as_deref().expect("provider is set");
 
-                self.validate_stateful(origin, transaction, state)
+                self.run_stateful_checks(origin, transaction, state)
             }
             Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
         }
@@ -435,7 +437,7 @@ where
         if let Err(err) = self.validate_stateless(origin, &transaction) {
             return TransactionValidationOutcome::Invalid(transaction, err);
         }
-        self.validate_stateful(origin, transaction, state)
+        self.run_stateful_checks(origin, transaction, &state)
     }
 
     /// Validates a single transaction without requiring any state access (stateless checks only).
@@ -443,6 +445,15 @@ where
     /// Checks tx type support, nonce bounds, size limits, gas limits, fee constraints, chain ID,
     /// intrinsic gas, and blob tx pre-checks.
     pub fn validate_stateless(
+        &self,
+        origin: TransactionOrigin,
+        transaction: &Tx,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        self.run_stateless_checks(origin, transaction)
+    }
+
+    /// Shared stateless validation used by the public API and [`TransactionValidator`].
+    fn run_stateless_checks(
         &self,
         origin: TransactionOrigin,
         transaction: &Tx,
@@ -639,11 +650,24 @@ where
     pub fn validate_stateful<P>(
         &self,
         origin: TransactionOrigin,
-        mut transaction: Tx,
+        transaction: Tx,
         state: P,
     ) -> TransactionValidationOutcome<Tx>
     where
         P: AccountInfoReader,
+    {
+        self.run_stateful_checks(origin, transaction, &state)
+    }
+
+    /// Shared stateful validation used by the public API and [`TransactionValidator`].
+    fn run_stateful_checks<S>(
+        &self,
+        origin: TransactionOrigin,
+        mut transaction: Tx,
+        state: &S,
+    ) -> TransactionValidationOutcome<Tx>
+    where
+        S: AccountReader + BytecodeReader + ?Sized,
     {
         // Use provider to get account info
         let account = match state.basic_account(transaction.sender_ref()) {
@@ -654,7 +678,7 @@ where
         };
 
         // check for bytecode
-        match self.validate_sender_bytecode(&transaction, &account, &state) {
+        match self.validate_sender_bytecode(&transaction, &account, state) {
             Err(outcome) => return outcome,
             Ok(Err(err)) => return TransactionValidationOutcome::Invalid(transaction, err),
             _ => {}
@@ -852,31 +876,6 @@ where
             .map(|auths| auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>())
     }
 
-    /// Validates all given transactions.
-    fn validate_batch(
-        &self,
-        transactions: impl IntoIterator<Item = (TransactionOrigin, Tx)>,
-    ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut provider = None;
-        transactions
-            .into_iter()
-            .map(|(origin, tx)| self.validate_one_with_provider(origin, tx, &mut provider))
-            .collect()
-    }
-
-    /// Validates all given transactions with origin.
-    fn validate_batch_with_origin(
-        &self,
-        origin: TransactionOrigin,
-        transactions: impl IntoIterator<Item = Tx> + Send,
-    ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut provider = None;
-        transactions
-            .into_iter()
-            .map(|tx| self.validate_one_with_provider(origin, tx, &mut provider))
-            .collect()
-    }
-
     fn on_new_head_block(&self, new_tip_block: &HeaderTy<Evm::Primitives>) {
         // update all forks
         if self.chain_spec().is_shanghai_active_at_timestamp(new_tip_block.timestamp()) {
@@ -963,12 +962,32 @@ where
     type Transaction = Tx;
     type Block = BlockTy<Evm::Primitives>;
 
+    fn validate_stateless(
+        &self,
+        origin: TransactionOrigin,
+        transaction: &Self::Transaction,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        self.run_stateless_checks(origin, transaction)
+    }
+
+    fn validate_stateful<S>(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+        state: &S,
+    ) -> TransactionValidationOutcome<Self::Transaction>
+    where
+        S: AccountReader + BytecodeReader + ?Sized,
+    {
+        self.run_stateful_checks(origin, transaction, state)
+    }
+
     async fn validate_transaction(
         &self,
         origin: TransactionOrigin,
         transaction: Self::Transaction,
     ) -> TransactionValidationOutcome<Self::Transaction> {
-        self.validate_one(origin, transaction)
+        TransactionValidatorWithState::validate_transaction_sync(self, origin, transaction)
     }
 
     async fn validate_transactions(
@@ -976,7 +995,7 @@ where
         transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
             + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
-        self.validate_batch(transactions)
+        TransactionValidatorWithState::validate_transactions_sync(self, transactions)
     }
 
     async fn validate_transactions_with_origin(
@@ -984,11 +1003,29 @@ where
         origin: TransactionOrigin,
         transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
     ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
-        self.validate_batch_with_origin(origin, transactions)
+        TransactionValidatorWithState::validate_transactions_with_origin_sync(
+            self,
+            origin,
+            transactions,
+        )
     }
 
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
         Self::on_new_head_block(self, new_tip_block.header())
+    }
+}
+
+impl<Client, Tx, Evm> TransactionValidatorWithState for EthTransactionValidator<Client, Tx, Evm>
+where
+    Client: ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks> + StateProviderFactory,
+    Tx: EthPoolTransaction,
+    Evm: ConfigureEvm,
+{
+    fn latest_state(
+        &self,
+    ) -> Result<reth_storage_api::StateProviderBox, reth_storage_api::errors::provider::ProviderError>
+    {
+        self.client.latest()
     }
 }
 
@@ -1943,5 +1980,154 @@ mod tests {
 
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         assert!(outcome.is_valid()); // Should be valid because balance check is disabled
+    }
+
+    /// Wraps [`EthTransactionValidator`] and counts [`TransactionValidatorWithState::latest_state`]
+    /// calls.
+    #[derive(Debug)]
+    struct CountingValidator {
+        inner: EthTransactionValidator<MockEthProvider, EthPooledTransaction, EthEvmConfig>,
+        latest_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl CountingValidator {
+        fn new(
+            inner: EthTransactionValidator<MockEthProvider, EthPooledTransaction, EthEvmConfig>,
+        ) -> Self {
+            Self {
+                inner,
+                latest_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        fn latest_calls(&self) -> usize {
+            self.latest_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl TransactionValidator for CountingValidator {
+        type Transaction = EthPooledTransaction;
+        type Block = reth_ethereum_primitives::Block;
+
+        fn validate_stateless(
+            &self,
+            origin: TransactionOrigin,
+            transaction: &Self::Transaction,
+        ) -> Result<(), InvalidPoolTransactionError> {
+            self.inner.validate_stateless(origin, transaction)
+        }
+
+        fn validate_stateful<S>(
+            &self,
+            origin: TransactionOrigin,
+            transaction: Self::Transaction,
+            state: &S,
+        ) -> TransactionValidationOutcome<Self::Transaction>
+        where
+            S: reth_storage_api::AccountReader + reth_storage_api::BytecodeReader + ?Sized,
+        {
+            self.inner.validate_stateful(origin, transaction, state)
+        }
+
+        async fn validate_transaction(
+            &self,
+            origin: TransactionOrigin,
+            transaction: Self::Transaction,
+        ) -> TransactionValidationOutcome<Self::Transaction> {
+            TransactionValidatorWithState::validate_transaction_sync(self, origin, transaction)
+        }
+
+        async fn validate_transactions(
+            &self,
+            transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+                + Send,
+        ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+            TransactionValidatorWithState::validate_transactions_sync(self, transactions)
+        }
+    }
+
+    impl TransactionValidatorWithState for CountingValidator {
+        fn latest_state(
+            &self,
+        ) -> Result<
+            reth_storage_api::StateProviderBox,
+            reth_storage_api::errors::provider::ProviderError,
+        > {
+            self.latest_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.latest_state()
+        }
+    }
+
+    fn funded_validator(
+        provider: MockEthProvider,
+    ) -> EthTransactionValidator<MockEthProvider, EthPooledTransaction, EthEvmConfig> {
+        EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .build(InMemoryBlobStore::default())
+    }
+
+    #[test]
+    fn batch_reuses_single_state_provider() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let validator = CountingValidator::new(funded_validator(provider));
+        let batch =
+            (0..5).map(|_| (TransactionOrigin::External, transaction.clone())).collect::<Vec<_>>();
+
+        let outcomes = TransactionValidatorWithState::validate_transactions_sync(&validator, batch);
+        assert_eq!(outcomes.len(), 5);
+        assert!(outcomes.iter().all(|outcome| outcome.is_valid()));
+        assert_eq!(validator.latest_calls(), 1);
+    }
+
+    #[test]
+    fn batch_skips_state_when_all_fail_stateless() {
+        let transaction = get_transaction();
+        let provider = MockEthProvider::default().with_genesis_block();
+        provider.add_account(
+            transaction.sender(),
+            ExtendedAccount::new(transaction.nonce(), U256::MAX),
+        );
+
+        let validator = CountingValidator::new(
+            EthTransactionValidatorBuilder::new(provider, test_evm_config())
+                .set_block_gas_limit(1_000_000)
+                .build(InMemoryBlobStore::default()),
+        );
+
+        let batch =
+            (0..3).map(|_| (TransactionOrigin::External, transaction.clone())).collect::<Vec<_>>();
+
+        let outcomes = TransactionValidatorWithState::validate_transactions_sync(&validator, batch);
+        assert_eq!(outcomes.len(), 3);
+        assert!(outcomes.iter().all(|outcome| outcome.is_invalid()));
+        assert_eq!(validator.latest_calls(), 0);
+    }
+
+    #[test]
+    fn batch_preserves_result_order() {
+        let (transaction, provider) = setup_priority_fee_test();
+        let minimum_priority_fee =
+            transaction.max_priority_fee_per_gas().expect("priority fee is expected") * 2;
+
+        let validator =
+            create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
+
+        let batch = vec![
+            (TransactionOrigin::External, transaction.clone()),
+            (TransactionOrigin::Local, transaction.clone()),
+            (TransactionOrigin::External, transaction.clone()),
+            (TransactionOrigin::Local, transaction),
+        ];
+
+        let outcomes = TransactionValidatorWithState::validate_transactions_sync(&validator, batch);
+        assert!(outcomes[0].is_invalid());
+        assert!(outcomes[1].is_valid());
+        assert!(outcomes[2].is_invalid());
+        assert!(outcomes[3].is_valid());
     }
 }

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -10,15 +10,21 @@ use alloy_eips::{eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthoriz
 use alloy_primitives::{Address, TxHash, B256, U256};
 use futures_util::future::Either;
 use reth_primitives_traits::{Block, Recovered, SealedBlock};
+use reth_storage_api::{
+    errors::provider::ProviderError, AccountReader, BytecodeReader, StateProviderBox,
+};
 use std::{fmt, fmt::Debug, future::Future, time::Instant};
 
 mod constants;
 mod eth;
+mod noop_reader;
 mod task;
 
 pub use eth::*;
 
 pub use task::{TransactionValidationTaskExecutor, ValidationTask};
+
+pub(crate) use noop_reader::NOOP_ACCOUNT_READER;
 
 /// Validation constants.
 pub use constants::{DEFAULT_MAX_TX_INPUT_BYTES, TX_SLOT_BYTE_SIZE};
@@ -166,6 +172,66 @@ impl<T: PoolTransaction> ValidTransaction<T> {
     }
 }
 
+// Two-phase batch validation: run stateless checks first, then stateful checks against a
+// shared provider. Results are stored by input index so the returned vec matches batch order.
+type StatelessBatchResults<T> = Vec<Option<TransactionValidationOutcome<T>>>;
+type StatelessBatchPending<T> = Vec<(usize, TransactionOrigin, T)>;
+
+/// Performs validations not requiring chain state access.
+///
+/// Must not access the database or any chain state.
+fn validate_stateless_batch<T: PoolTransaction, V: TransactionValidator<Transaction = T>>(
+    validator: &V,
+    transactions: Vec<(TransactionOrigin, T)>,
+) -> (StatelessBatchResults<T>, StatelessBatchPending<T>) {
+    let len = transactions.len();
+    let mut results: StatelessBatchResults<T> = (0..len).map(|_| None).collect();
+    let mut pending = Vec::new();
+
+    for (index, (origin, transaction)) in transactions.into_iter().enumerate() {
+        match validator.validate_stateless(origin, &transaction) {
+            Ok(()) => pending.push((index, origin, transaction)),
+            Err(err) => {
+                results[index] = Some(TransactionValidationOutcome::Invalid(transaction, err))
+            }
+        }
+    }
+
+    (results, pending)
+}
+
+/// Completes batch validation using a shared state provider for transactions that passed
+/// stateless checks.
+fn validate_stateful_batch<T: PoolTransaction, V: TransactionValidator<Transaction = T>, S>(
+    validator: &V,
+    mut results: StatelessBatchResults<T>,
+    pending: StatelessBatchPending<T>,
+    state: &S,
+) -> Vec<TransactionValidationOutcome<T>>
+where
+    S: AccountReader + BytecodeReader + ?Sized,
+{
+    for (index, origin, transaction) in pending {
+        results[index] = Some(validator.validate_stateful(origin, transaction, state));
+    }
+
+    results.into_iter().map(|result| result.expect("batch result filled")).collect()
+}
+
+/// Maps state-fetch failures to error outcomes for all pending transactions.
+fn state_fetch_error_outcomes<T: PoolTransaction>(
+    mut results: StatelessBatchResults<T>,
+    pending: StatelessBatchPending<T>,
+    err: ProviderError,
+) -> Vec<TransactionValidationOutcome<T>> {
+    for (index, _, transaction) in pending {
+        results[index] =
+            Some(TransactionValidationOutcome::Error(*transaction.hash(), Box::new(err.clone())));
+    }
+
+    results.into_iter().map(|result| result.expect("batch result filled")).collect()
+}
+
 /// Provides support for validating transaction at any given state of the chain
 pub trait TransactionValidator: Debug + Send + Sync {
     /// The transaction type to validate.
@@ -173,6 +239,51 @@ pub trait TransactionValidator: Debug + Send + Sync {
 
     /// The block type used for new head block notifications.
     type Block: Block;
+
+    /// Performs validations not requiring chain state.
+    ///
+    /// Must not access the database or any chain state.
+    fn validate_stateless(
+        &self,
+        origin: TransactionOrigin,
+        transaction: &Self::Transaction,
+    ) -> Result<(), InvalidPoolTransactionError>;
+
+    /// Validates a transaction against the given chain state.
+    ///
+    /// The transaction must have already passed [`Self::validate_stateless`].
+    ///
+    /// Uses [`AccountReader`] + [`BytecodeReader`] instead of
+    /// [`AccountInfoReader`](reth_storage_api::AccountInfoReader) so callers can pass a
+    /// [`StateProviderBox`] directly.
+    fn validate_stateful<S>(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+        state: &S,
+    ) -> TransactionValidationOutcome<Self::Transaction>
+    where
+        S: AccountReader + BytecodeReader + ?Sized;
+
+    /// Validates a batch of transactions using a shared state provider.
+    ///
+    /// The provider must be supplied by the caller; this method does not fetch state.
+    fn validate_transactions_with_state<S>(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction)>,
+        state: &S,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>>
+    where
+        S: AccountReader + BytecodeReader + ?Sized,
+    {
+        transactions
+            .into_iter()
+            .map(|(origin, transaction)| match self.validate_stateless(origin, &transaction) {
+                Ok(()) => self.validate_stateful(origin, transaction, state),
+                Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+            })
+            .collect()
+    }
 
     /// Validates the transaction and returns a [`TransactionValidationOutcome`] describing the
     /// validity of the given transaction.
@@ -198,6 +309,9 @@ pub trait TransactionValidator: Debug + Send + Sync {
     /// example nonce or balance changes. Hence, any validation checks must be applied in this
     /// function.
     ///
+    /// Validators backed by chain state should implement [`TransactionValidatorWithState`] to
+    /// obtain optimized batch validation.
+    ///
     /// See [`TransactionValidationTaskExecutor`] for a reference implementation.
     fn validate_transaction(
         &self,
@@ -208,6 +322,10 @@ pub trait TransactionValidator: Debug + Send + Sync {
     /// Validates a batch of transactions.
     ///
     /// Must return all outcomes for the given transactions in the same order.
+    ///
+    /// The default implementation validates each transaction independently, which may fetch
+    /// chain state multiple times. Validators with a state provider should override this and
+    /// use [`TransactionValidatorWithState::validate_transactions_sync`].
     ///
     /// See also [`Self::validate_transaction`].
     fn validate_transactions(
@@ -239,6 +357,57 @@ pub trait TransactionValidator: Debug + Send + Sync {
     fn on_new_head_block(&self, _new_tip_block: &SealedBlock<Self::Block>) {}
 }
 
+/// Validators that can read latest chain state (production nodes).
+///
+/// Async methods on [`TransactionValidator`] should delegate to the sync helpers here so batch
+/// validation fetches state at most once.
+pub trait TransactionValidatorWithState: TransactionValidator + Sized {
+    /// Returns a state provider for the latest chain state.
+    fn latest_state(&self) -> Result<StateProviderBox, ProviderError>;
+
+    /// Validates a single transaction synchronously.
+    fn validate_transaction_sync(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        match self.validate_stateless(origin, &transaction) {
+            Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+            Ok(()) => match self.latest_state() {
+                Ok(state) => self.validate_stateful(origin, transaction, state.as_ref()),
+                Err(err) => TransactionValidationOutcome::Error(*transaction.hash(), Box::new(err)),
+            },
+        }
+    }
+
+    /// Validates a batch of transactions synchronously, reusing a single state provider.
+    fn validate_transactions_sync(
+        &self,
+        transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction)>,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let transactions: Vec<_> = transactions.into_iter().collect();
+        let (results, pending) = validate_stateless_batch(self, transactions);
+
+        if pending.is_empty() {
+            return results.into_iter().map(|result| result.expect("batch result filled")).collect();
+        }
+
+        match self.latest_state() {
+            Ok(state) => validate_stateful_batch(self, results, pending, state.as_ref()),
+            Err(err) => state_fetch_error_outcomes(results, pending, err),
+        }
+    }
+
+    /// Validates a batch of transactions with the same origin synchronously.
+    fn validate_transactions_with_origin_sync(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction>,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        self.validate_transactions_sync(transactions.into_iter().map(move |tx| (origin, tx)))
+    }
+}
+
 impl<A, B> TransactionValidator for Either<A, B>
 where
     A: TransactionValidator,
@@ -246,6 +415,32 @@ where
 {
     type Transaction = A::Transaction;
     type Block = A::Block;
+
+    fn validate_stateless(
+        &self,
+        origin: TransactionOrigin,
+        transaction: &Self::Transaction,
+    ) -> Result<(), InvalidPoolTransactionError> {
+        match self {
+            Self::Left(v) => v.validate_stateless(origin, transaction),
+            Self::Right(v) => v.validate_stateless(origin, transaction),
+        }
+    }
+
+    fn validate_stateful<S>(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+        state: &S,
+    ) -> TransactionValidationOutcome<Self::Transaction>
+    where
+        S: AccountReader + BytecodeReader + ?Sized,
+    {
+        match self {
+            Self::Left(v) => v.validate_stateful(origin, transaction, state),
+            Self::Right(v) => v.validate_stateful(origin, transaction, state),
+        }
+    }
 
     async fn validate_transaction(
         &self,

--- a/crates/transaction-pool/src/validate/noop_reader.rs
+++ b/crates/transaction-pool/src/validate/noop_reader.rs
@@ -1,0 +1,23 @@
+use alloy_primitives::{Address, B256};
+use reth_primitives_traits::{Account, Bytecode};
+use reth_storage_api::{errors::provider::ProviderResult, AccountReader, BytecodeReader};
+
+/// Stand-in state provider for test/mock validators that don't have a database.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct NoopAccountInfoReader;
+
+impl AccountReader for NoopAccountInfoReader {
+    fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
+        Ok(Some(Account::default()))
+    }
+}
+
+impl BytecodeReader for NoopAccountInfoReader {
+    fn bytecode_by_hash(&self, _code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        Ok(None)
+    }
+}
+
+/// Used by mock validators to satisfy [`TransactionValidator::validate_stateful`] without calling
+/// `latest_state()`.
+pub(crate) static NOOP_ACCOUNT_READER: NoopAccountInfoReader = NoopAccountInfoReader;

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -236,6 +236,26 @@ where
     type Transaction = <V as TransactionValidator>::Transaction;
     type Block = V::Block;
 
+    fn validate_stateless(
+        &self,
+        origin: TransactionOrigin,
+        transaction: &Self::Transaction,
+    ) -> Result<(), crate::error::InvalidPoolTransactionError> {
+        self.validator.validate_stateless(origin, transaction)
+    }
+
+    fn validate_stateful<S>(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+        state: &S,
+    ) -> TransactionValidationOutcome<Self::Transaction>
+    where
+        S: reth_storage_api::AccountReader + reth_storage_api::BytecodeReader + ?Sized,
+    {
+        self.validator.validate_stateful(origin, transaction, state)
+    }
+
     async fn validate_transaction(
         &self,
         origin: TransactionOrigin,
@@ -326,7 +346,7 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::MockTransaction,
-        validate::{TransactionValidationOutcome, ValidTransaction},
+        validate::{TransactionValidationOutcome, ValidTransaction, NOOP_ACCOUNT_READER},
         TransactionOrigin,
     };
     use alloy_primitives::{Address, U256};
@@ -338,11 +358,23 @@ mod tests {
         type Transaction = MockTransaction;
         type Block = reth_ethereum_primitives::Block;
 
-        async fn validate_transaction(
+        fn validate_stateless(
+            &self,
+            _origin: TransactionOrigin,
+            _transaction: &Self::Transaction,
+        ) -> Result<(), crate::error::InvalidPoolTransactionError> {
+            Ok(())
+        }
+
+        fn validate_stateful<S>(
             &self,
             _origin: TransactionOrigin,
             transaction: Self::Transaction,
-        ) -> TransactionValidationOutcome<Self::Transaction> {
+            _state: &S,
+        ) -> TransactionValidationOutcome<Self::Transaction>
+        where
+            S: reth_storage_api::AccountReader + reth_storage_api::BytecodeReader + ?Sized,
+        {
             TransactionValidationOutcome::Valid {
                 balance: U256::ZERO,
                 state_nonce: 0,
@@ -351,6 +383,25 @@ mod tests {
                 propagate: false,
                 authorities: Some(Vec::<Address>::new()),
             }
+        }
+
+        async fn validate_transaction(
+            &self,
+            origin: TransactionOrigin,
+            transaction: Self::Transaction,
+        ) -> TransactionValidationOutcome<Self::Transaction> {
+            match self.validate_stateless(origin, &transaction) {
+                Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+                Ok(()) => self.validate_stateful(origin, transaction, &NOOP_ACCOUNT_READER),
+            }
+        }
+
+        async fn validate_transactions(
+            &self,
+            transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction), IntoIter: Send>
+                + Send,
+        ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+            self.validate_transactions_with_state(transactions, &NOOP_ACCOUNT_READER)
         }
     }
 


### PR DESCRIPTION
Closes #18527

Splits transaction validation into stateless and stateful phases on `TransactionValidator` and adds `TransactionValidatorWithState` with sync batch helpers that run stateless checks first, fetch latest state once, then run stateful checks on survivors.

`EthTransactionValidator` now routes single and batch validation through this path instead of its private `validate_batch`, so batch validation reuses one state provider. Mock validators use `NOOP_ACCOUNT_READER` where they don't need real chain state.

**Breaking:** custom `TransactionValidator` impls must implement `validate_stateless` and `validate_stateful`.