### PR TITLE
refactor(txpool): recover raw transactions as pool tx

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -24,7 +24,7 @@ use reth_primitives_traits::{
 use reth_rpc_convert::{transaction::RpcConvert, RpcTxReq, TransactionConversionError};
 use reth_rpc_eth_types::{
     block::convert_transaction_receipt,
-    utils::{binary_search, recover_raw_transaction},
+    utils::binary_search,
     EthApiError::{self, TransactionConfirmationTimeout},
     FillTransaction, SignError, TransactionSource,
 };
@@ -33,7 +33,8 @@ use reth_storage_api::{
     TransactionsProvider,
 };
 use reth_transaction_pool::{
-    AddedTransactionOutcome, PoolPooledTx, PoolTransaction, TransactionOrigin, TransactionPool,
+    AddedTransactionOutcome, PoolPooledTx, PoolTransaction, PoolTx, TransactionOrigin,
+    TransactionPool,
 };
 use std::{sync::Arc, time::Duration};
 
@@ -81,9 +82,14 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         tx: Bytes,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
         async move {
-            let recovered = recover_raw_transaction::<PoolPooledTx<Self::Pool>>(&tx)?;
-            self.send_transaction(TransactionOrigin::External, WithEncoded::new(tx, recovered))
-                .await
+            let pool_transaction =
+                <PoolTx<Self::Pool> as PoolTransaction>::recover_raw_transaction(&tx)
+                    .map_err(Self::Error::from_eth_err)?;
+            self.send_pool_transaction(
+                TransactionOrigin::External,
+                WithEncoded::new(tx, pool_transaction),
+            )
+            .await
         }
     }
 
@@ -92,6 +98,21 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         &self,
         origin: TransactionOrigin,
         tx: WithEncoded<Recovered<PoolPooledTx<Self::Pool>>>,
+    ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
+        async move {
+            let (encoded, recovered) = tx.split();
+            let pool_transaction =
+                <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
+
+            self.send_pool_transaction(origin, WithEncoded::new(encoded, pool_transaction)).await
+        }
+    }
+
+    /// Submits the pool transaction to the pool with the given [`TransactionOrigin`].
+    fn send_pool_transaction(
+        &self,
+        origin: TransactionOrigin,
+        tx: WithEncoded<PoolTx<Self::Pool>>,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send;
 
     /// Decodes and recovers the transaction and submits it to the pool.

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -18,7 +18,7 @@ use reth_rpc_server_types::result::{
 };
 use reth_transaction_pool::error::{
     Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
-    PoolError, PoolErrorKind, PoolTransactionError,
+    PoolError, PoolErrorKind, PoolTransactionError, RawPoolTransactionError,
 };
 use revm::{
     context_interface::result::{
@@ -567,6 +567,21 @@ where
 impl From<RecoveryError> for EthApiError {
     fn from(_: RecoveryError) -> Self {
         Self::InvalidTransactionSignature
+    }
+}
+
+impl From<RawPoolTransactionError> for EthApiError {
+    fn from(err: RawPoolTransactionError) -> Self {
+        match err {
+            RawPoolTransactionError::EmptyRawTransactionData => Self::EmptyRawTransactionData,
+            RawPoolTransactionError::FailedToDecodeSignedTransaction => {
+                Self::FailedToDecodeSignedTransaction
+            }
+            RawPoolTransactionError::InvalidTransactionSignature => {
+                Self::InvalidTransactionSignature
+            }
+            RawPoolTransactionError::Other(err) => Self::PoolError(RpcPoolError::Other(err)),
+        }
     }
 }
 

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -7,7 +7,7 @@ use alloy_consensus::BlobTransactionValidationError;
 use alloy_eips::{eip7594::BlobTransactionSidecarVariant, BlockId, Typed2718};
 use alloy_primitives::{hex, B256};
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_primitives_traits::{AlloyBlockHeader, Recovered, WithEncoded};
+use reth_primitives_traits::{AlloyBlockHeader, WithEncoded};
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},
@@ -17,7 +17,7 @@ use reth_rpc_eth_types::{error::RpcPoolError, EthApiError};
 use reth_storage_api::BlockReaderIdExt;
 use reth_transaction_pool::{
     error::Eip4844PoolTransactionError, AddedTransactionOutcome, EthBlobTransactionSidecar,
-    EthPoolTransaction, PoolPooledTx, PoolTransaction, TransactionPool,
+    EthPoolTransaction, PoolTransaction, PoolTx,
 };
 
 impl<N, Rpc> EthTransactions for EthApi<N, Rpc>
@@ -36,14 +36,12 @@ where
         self.inner.send_raw_transaction_sync_timeout()
     }
 
-    async fn send_transaction(
+    async fn send_pool_transaction(
         &self,
         origin: reth_transaction_pool::TransactionOrigin,
-        tx: WithEncoded<Recovered<PoolPooledTx<Self::Pool>>>,
+        tx: WithEncoded<PoolTx<Self::Pool>>,
     ) -> Result<B256, Self::Error> {
-        let (tx, recovered) = tx.split();
-        let mut pool_transaction =
-            <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
+        let (tx, mut pool_transaction) = tx.split();
 
         // Optionally convert legacy blob sidecars to EIP-7594 format when Osaka is active
         // This is opt-in via --rpc.force-blob-sidecar-upcasting
@@ -147,7 +145,10 @@ mod tests {
         ChainSpecProvider,
     };
     use reth_rpc_eth_api::node::RpcNodeCoreAdapter;
-    use reth_transaction_pool::test_utils::{testing_pool, TestPool};
+    use reth_transaction_pool::{
+        test_utils::{testing_pool, TestPool},
+        TransactionPool,
+    };
     use revm_primitives::Bytes;
 
     fn mock_eth_api(

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -9,6 +9,30 @@ use reth_primitives_traits::transaction::error::InvalidTransactionError;
 /// Transaction pool result type.
 pub type PoolResult<T> = Result<T, PoolError>;
 
+/// Errors that can happen while recovering a raw transaction into a pool transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum RawPoolTransactionError {
+    /// The raw transaction data is empty.
+    #[error("empty transaction data")]
+    EmptyRawTransactionData,
+    /// Decoding the signed transaction failed.
+    #[error("failed to decode signed transaction")]
+    FailedToDecodeSignedTransaction,
+    /// The transaction signature is invalid.
+    #[error("invalid transaction signature")]
+    InvalidTransactionSignature,
+    /// Any other error that occurred while recovering the raw pool transaction.
+    #[error(transparent)]
+    Other(#[from] Box<dyn core::error::Error + Send + Sync>),
+}
+
+impl RawPoolTransactionError {
+    /// Creates a new [`RawPoolTransactionError::Other`] variant.
+    pub fn other(error: impl Into<Box<dyn core::error::Error + Send + Sync>>) -> Self {
+        Self::Other(error.into())
+    }
+}
+
 /// A trait for additional errors that can be thrown by the transaction pool.
 ///
 /// For example during validation

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -288,7 +288,7 @@ pub use crate::{
         REPLACE_BLOB_PRICE_BUMP, TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
         TXPOOL_SUBPOOL_MAX_SIZE_MB_DEFAULT, TXPOOL_SUBPOOL_MAX_TXS_DEFAULT,
     },
-    error::PoolResult,
+    error::{PoolResult, RawPoolTransactionError},
     ordering::{CoinbaseTipOrdering, Priority, TransactionOrdering},
     pool::{
         blob_tx_priority, fee_delta, state::SubPool, AddedTransactionOutcome,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -52,7 +52,7 @@
 
 use crate::{
     blobstore::{BlobStore, BlobStoreError},
-    error::{InvalidPoolTransactionError, PoolError, PoolResult},
+    error::{InvalidPoolTransactionError, PoolError, PoolResult, RawPoolTransactionError},
     pool::{
         state::SubPool, BestTransactionFilter, NewTransactionEvent, TransactionEvents,
         TransactionListenerKind,
@@ -62,7 +62,7 @@ use crate::{
 };
 use alloy_consensus::{error::ValueError, transaction::TxHashRef, BlockHeader, Signed, Typed2718};
 use alloy_eips::{
-    eip2718::{Encodable2718, WithEncoded},
+    eip2718::{Decodable2718, Encodable2718, WithEncoded},
     eip2930::AccessList,
     eip4844::{
         env_settings::KzgSettings, BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1,
@@ -1358,6 +1358,24 @@ pub trait PoolTransaction:
 
     /// Define a method to convert from the `Pooled` type to `Self`
     fn from_pooled(pooled: Recovered<Self::Pooled>) -> Self;
+
+    /// Decodes and recovers a raw transaction into this pool transaction type.
+    ///
+    /// Implementations can override this to avoid constructing the pooled transaction as an
+    /// intermediate value when the raw representation can be converted directly into `Self`.
+    fn recover_raw_transaction(data: &[u8]) -> Result<Self, RawPoolTransactionError> {
+        if data.is_empty() {
+            return Err(RawPoolTransactionError::EmptyRawTransactionData)
+        }
+
+        let transaction = Self::Pooled::decode_2718_exact(data)
+            .map_err(|_| RawPoolTransactionError::FailedToDecodeSignedTransaction)?;
+
+        transaction
+            .try_into_recovered()
+            .map(Self::from_pooled)
+            .map_err(|_| RawPoolTransactionError::InvalidTransactionSignature)
+    }
 
     /// Tries to convert the `Consensus` type into the `Pooled` type.
     fn try_into_pooled(self) -> Result<Recovered<Self::Pooled>, Self::TryFromConsensusError> {


### PR DESCRIPTION
Motivated by tempoxyz/tempo#5664.

Adds a `PoolTransaction::recover_raw_transaction` hook so raw transaction submission can construct the pool transaction directly. The default implementation preserves the existing decode/recover/from_pooled flow, while `eth_sendRawTransaction` now calls the pool transaction hook before submission.