### PR TITLE
fix: send payload resolve command before returning future

### DIFF
--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -52,12 +52,12 @@ where
     ///
     /// Note: depending on the installed [`PayloadJobGenerator`], this may or may not terminate the
     /// job, See [`PayloadJob::resolve`].
-    pub async fn resolve_kind(
+    pub fn resolve_kind(
         &self,
         id: PayloadId,
         kind: PayloadKind,
-    ) -> Option<Result<T::BuiltPayload, PayloadBuilderError>> {
-        self.inner.resolve_kind(id, kind).await
+    ) -> impl Future<Output = Option<Result<T::BuiltPayload, PayloadBuilderError>>> {
+        self.inner.resolve_kind(id, kind)
     }
 
     /// Resolves the payload job and returns the best payload that has been built so far.
@@ -147,28 +147,29 @@ impl<T: PayloadTypes> PayloadBuilderHandle<T> {
     }
 
     /// Resolves the payload job and returns the best payload that has been built so far.
-    pub async fn resolve_kind(
+    ///
+    /// # Cancellation safety
+    ///
+    /// The future returned by this method is not cancellation-safe. This method sends the resolve
+    /// command before returning the future, so dropping the returned future drops the response
+    /// receiver and cancels the job identified by `id`.
+    pub fn resolve_kind(
         &self,
         id: PayloadId,
         kind: PayloadKind,
-    ) -> Option<Result<T::BuiltPayload, PayloadBuilderError>> {
+    ) -> impl Future<Output = Option<Result<T::BuiltPayload, PayloadBuilderError>>> {
         let (tx, rx) = oneshot::channel();
-        self.to_service.send(PayloadServiceCommand::Resolve(id, kind, tx)).ok()?;
-        match rx.await.transpose()? {
-            Ok(fut) => Some(fut.await),
-            Err(e) => Some(Err(e.into())),
-        }
-    }
+        let sent = self.to_service.send(PayloadServiceCommand::Resolve(id, kind, tx)).is_ok();
+        async move {
+            if !sent {
+                return None
+            }
 
-    /// Same as [`Self::resolve_kind`] but returns the underlying future.
-    pub async fn resolve_kind_fut(
-        &self,
-        id: PayloadId,
-        kind: PayloadKind,
-    ) -> Result<Option<PayloadFuture<T::BuiltPayload>>, PayloadBuilderError> {
-        let (tx, rx) = oneshot::channel();
-        self.to_service.send(PayloadServiceCommand::Resolve(id, kind, tx))?;
-        rx.await.map_err(Into::into)
+            match rx.await.transpose()? {
+                Ok(fut) => Some(fut.await),
+                Err(e) => Some(Err(e.into())),
+            }
+        }
     }
 
     /// Sends a message to the service to subscribe to payload events.

--- a/crates/payload/builder/src/traits.rs
+++ b/crates/payload/builder/src/traits.rs
@@ -66,6 +66,13 @@ pub trait PayloadJob: Future<Output = Result<(), PayloadBuilderError>> {
     /// once more. If this returns [`KeepPayloadJobAlive::No`] then the [`PayloadJob`] will be
     /// dropped after this call.
     ///
+    /// # Cancellation safety
+    ///
+    /// The returned [`ResolvePayloadFuture`](Self::ResolvePayloadFuture) is not
+    /// cancellation-safe. Dropping it cancels resolving the payload and, when the corresponding
+    /// handle resolve call has removed the payload job, cancels the job identified by that
+    /// `payload_id`.
+    ///
     /// The [`PayloadKind`] determines how the payload should be resolved in the
     /// `ResolvePayloadFuture`. [`PayloadKind::Earliest`] should return the earliest available
     /// payload (as fast as possible), e.g. racing an empty payload job against a pending job if


### PR DESCRIPTION
Updates `resolve_kind` to send the resolve command before returning its response future, so dropping the returned future drops the receiver after the command has already been sent. Removes `resolve_kind_fut` from the public handle API and documents the cancellation behavior on `resolve_kind`/`PayloadJob::resolve_kind`.

Prompted by: @SuperFluffy

Prompted by: @klkvr