### PR TITLE
refactor(net): require BAL-capable download clients

### DIFF
--- a/crates/net/network-api/src/downloaders.rs
+++ b/crates/net/network-api/src/downloaders.rs
@@ -3,14 +3,19 @@
 use std::fmt::Debug;
 
 use futures::Future;
-use reth_network_p2p::BlockClient;
+use reth_network_p2p::{BlockAccessListsClient, BlockClient};
 use tokio::sync::oneshot;
 
 /// Provides client for downloading blocks.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BlockDownloaderProvider {
     /// The client this type can provide.
-    type Client: BlockClient<Header: Debug, Body: Debug> + Send + Sync + Clone + 'static;
+    type Client: BlockClient<Header: Debug, Body: Debug>
+        + BlockAccessListsClient
+        + Send
+        + Sync
+        + Clone
+        + 'static;
 
     /// Returns a new [`BlockClient`], used for fetching blocks from peers.
     ///

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -515,6 +515,16 @@ where
     Client: BlockClient<Header: Debug + BlockHeader + Sealable + Clone + Hash + Eq>
         + BlockAccessListsClient,
 {
+    /// Returns the block hash the requested range starts at (inclusive).
+    pub const fn start_hash(&self) -> B256 {
+        self.blocks.start_hash()
+    }
+
+    /// Returns the number of requested blocks.
+    pub const fn count(&self) -> u64 {
+        self.blocks.count()
+    }
+
     fn start_access_lists_request_if_possible(&mut self) {
         let requirement = match &self.access_lists {
             OptionalBlockAccessListsState::WaitingForBlocks { requirement } => *requirement,
@@ -1096,6 +1106,22 @@ where
     Net: NetworkPrimitives,
 {
     type Block = Net::Block;
+}
+
+impl<Net> BlockAccessListsClient for NoopFullBlockClient<Net>
+where
+    Net: NetworkPrimitives,
+{
+    type Output = futures::future::Ready<PeerRequestResult<BlockAccessLists>>;
+
+    fn get_block_access_lists_with_priority_and_requirement(
+        &self,
+        _hashes: Vec<B256>,
+        _priority: Priority,
+        _requirement: BalRequirement,
+    ) -> Self::Output {
+        futures::future::ready(Ok(WithPeerId::new(PeerId::random(), BlockAccessLists::default())))
+    }
 }
 
 impl<Net> Default for NoopFullBlockClient<Net> {

--- a/crates/net/p2p/src/test_utils/full_block.rs
+++ b/crates/net/p2p/src/test_utils/full_block.rs
@@ -1,4 +1,5 @@
 use crate::{
+    block_access_lists::client::{BalRequirement, BlockAccessListsClient},
     bodies::client::BodiesClient,
     download::DownloadClient,
     error::PeerRequestResult,
@@ -8,9 +9,9 @@ use crate::{
 };
 use alloy_consensus::Header;
 use alloy_eips::{BlockHashOrNumber, BlockNumHash};
-use alloy_primitives::{map::B256Map, B256};
+use alloy_primitives::{map::B256Map, Bytes, B256};
 use parking_lot::Mutex;
-use reth_eth_wire_types::HeadersDirection;
+use reth_eth_wire_types::{BlockAccessLists, HeadersDirection};
 use reth_ethereum_primitives::{Block, BlockBody};
 use reth_network_peers::{PeerId, WithPeerId};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
@@ -24,6 +25,7 @@ use std::{ops::RangeInclusive, sync::Arc};
 pub struct TestFullBlockClient {
     headers: Arc<Mutex<B256Map<Header>>>,
     bodies: Arc<Mutex<B256Map<BlockBody>>>,
+    access_lists: Arc<Mutex<B256Map<Bytes>>>,
     // soft response limit, max number of bodies to respond with
     soft_limit: usize,
 }
@@ -33,6 +35,7 @@ impl Default for TestFullBlockClient {
         Self {
             headers: Arc::new(Mutex::new(B256Map::default())),
             bodies: Arc::new(Mutex::new(B256Map::default())),
+            access_lists: Arc::new(Mutex::new(B256Map::default())),
             soft_limit: 20,
         }
     }
@@ -44,6 +47,11 @@ impl TestFullBlockClient {
         let hash = header.hash();
         self.headers.lock().insert(hash, header.unseal());
         self.bodies.lock().insert(hash, body);
+    }
+
+    /// Insert a raw block access list served for the given block hash.
+    pub fn insert_access_list(&self, hash: B256, access_list: Bytes) {
+        self.access_lists.lock().insert(hash, access_list);
     }
 
     /// Set the soft response limit.
@@ -169,4 +177,21 @@ impl BodiesClient for TestFullBlockClient {
 
 impl BlockClient for TestFullBlockClient {
     type Block = reth_ethereum_primitives::Block;
+}
+
+impl BlockAccessListsClient for TestFullBlockClient {
+    type Output = futures::future::Ready<PeerRequestResult<BlockAccessLists>>;
+
+    fn get_block_access_lists_with_priority_and_requirement(
+        &self,
+        hashes: Vec<B256>,
+        _priority: Priority,
+        _requirement: BalRequirement,
+    ) -> Self::Output {
+        let access_lists = self.access_lists.lock();
+        futures::future::ready(Ok(WithPeerId::new(
+            PeerId::random(),
+            BlockAccessLists(hashes.iter().map(|hash| access_lists.get(hash).cloned()).collect()),
+        )))
+    }
 }


### PR DESCRIPTION
Split from #24094.

Requires block downloader providers to return clients that can request block access lists. Updates noop/test full-block clients to satisfy that contract and exposes BAL range request metadata for downloader wrappers.