### PR TITLE
fix(engine): store validated payload block access lists

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -29,7 +29,7 @@ use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use reth_provider::{
-    BlockExecutionOutput, BlockExecutionResult, BlockReader, ChangeSetReader,
+    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockReader, ChangeSetReader,
     DatabaseProviderFactory, HashedPostStateProvider, ProviderError, StageCheckpointReader,
     StateProviderBox, StateProviderFactory, StateReader, StorageChangeSetReader,
     StorageSettingsCache, TransactionVariant,
@@ -360,6 +360,7 @@ where
         + StateProviderFactory
         + StateReader<Receipt = N::Receipt>
         + HashedPostStateProvider
+        + BalProvider
         + Clone
         + 'static,
     P::Provider: BlockReader<Block = N::Block, Header = N::BlockHeader>
@@ -2985,8 +2986,23 @@ where
 
         let start = Instant::now();
 
-        let ValidationOutput { executed_block: executed, execution_timing_stats: timing_stats } =
-            execute(&mut self.payload_validator, input, ctx)?;
+        let ValidationOutput {
+            executed_block: executed,
+            execution_timing_stats: timing_stats,
+            raw_bal,
+        } = execute(&mut self.payload_validator, input, ctx)?;
+
+        if let Some(raw_bal) = raw_bal {
+            let num_hash = executed.recovered_block().num_hash();
+            if let Err(err) = self.provider.bal_store().insert(num_hash, raw_bal) {
+                warn!(
+                    target: "engine::tree",
+                    ?num_hash,
+                    %err,
+                    "Failed to store validated block access list"
+                );
+            }
+        }
 
         // Emit slow block event immediately after execution so it appears even when
         // persistence hasn't completed yet (e.g. blocks arriving faster than persistence).

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -491,7 +491,7 @@ where
             transaction_count: input.transaction_count(),
             gas_used: input.gas_used(),
             withdrawals: input.withdrawals().map(|w| w.to_vec()),
-            decoded_bal,
+            decoded_bal: decoded_bal.as_ref().map(Arc::clone),
         };
 
         // Plan the strategy used for state root computation.
@@ -921,7 +921,8 @@ where
             trie_output,
             changeset_provider,
         );
-        Ok(ValidationOutput::new(executed_block, timing_stats))
+        let raw_bal = decoded_bal.map(|decoded_bal| decoded_bal.as_raw_bal().clone());
+        Ok(ValidationOutput::new(executed_block, timing_stats).with_raw_bal(raw_bal))
     }
 
     /// Spawns a background task to convert a [`BlockOrPayload`] into a [`SealedBlock`] and perform

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -29,7 +29,7 @@ use reth_ethereum_engine_primitives::EthEngineTypes;
 use reth_ethereum_primitives::{Block, EthPrimitives};
 use reth_evm_ethereum::MockEvmConfig;
 use reth_primitives_traits::Block as _;
-use reth_provider::test_utils::MockEthProvider;
+use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore, RawBal};
 use reth_tasks::spawn_os_thread;
 use std::{
     collections::BTreeMap,
@@ -672,6 +672,38 @@ fn test_disconnected_block() {
             missing_ancestor: sealed.parent_num_hash()
         })
     );
+}
+
+#[test]
+fn test_validated_payload_bal_is_inserted_into_store() {
+    let mut block_builder = TestBlockBuilder::eth();
+    let parent = block_builder.get_executed_block_with_number(1, B256::ZERO);
+    let child = block_builder.get_executed_block_with_number(2, parent.recovered_block().hash());
+    let child_block = child.recovered_block().clone_sealed_block();
+    let child_num_hash = child_block.num_hash();
+    let raw_bal = Bytes::from_static(&[0xc0]);
+
+    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(vec![parent]);
+    let bal_store = BalStoreHandle::new(InMemoryBalStore::default());
+    test_harness.tree.provider.bal_store = bal_store.clone();
+
+    let outcome = test_harness
+        .tree
+        .insert_block_or_payload(
+            child_block.block_with_parent(),
+            child,
+            |_, executed, _| {
+                Ok::<_, InsertPayloadError<Block>>(
+                    ValidationOutput::new(executed, None)
+                        .with_raw_bal(Some(RawBal::from(raw_bal.clone()))),
+                )
+            },
+            |_, executed| Ok(executed.recovered_block().clone_sealed_block()),
+        )
+        .unwrap();
+
+    assert_eq!(outcome, InsertPayloadOk::Inserted(BlockStatus::Valid));
+    assert_eq!(bal_store.get_by_hash(child_num_hash.hash).unwrap(), Some(raw_bal));
 }
 
 #[tokio::test]

--- a/crates/engine/tree/src/tree/types.rs
+++ b/crates/engine/tree/src/tree/types.rs
@@ -1,6 +1,7 @@
 //! Shared types for blockchain tree validation.
 
 use crate::tree::error::InsertPayloadError;
+use alloy_eip7928::bal::RawBal;
 use reth_chain_state::{ExecutedBlock, ExecutionTimingStats};
 use reth_primitives_traits::{BlockTy, NodePrimitives};
 
@@ -18,6 +19,8 @@ pub struct ValidationOutput<N: NodePrimitives> {
     pub executed_block: ExecutedBlock<N>,
     /// Optional execution timing stats collected during validation.
     pub execution_timing_stats: Option<Box<ExecutionTimingStats>>,
+    /// Validated raw block access list carried by the payload.
+    pub raw_bal: Option<RawBal>,
 }
 
 impl<N: NodePrimitives> ValidationOutput<N> {
@@ -26,6 +29,12 @@ impl<N: NodePrimitives> ValidationOutput<N> {
         executed_block: ExecutedBlock<N>,
         execution_timing_stats: Option<Box<ExecutionTimingStats>>,
     ) -> Self {
-        Self { executed_block, execution_timing_stats }
+        Self { executed_block, execution_timing_stats, raw_bal: None }
+    }
+
+    /// Sets the validated raw block access list carried by the payload.
+    pub fn with_raw_bal(mut self, raw_bal: Option<RawBal>) -> Self {
+        self.raw_bal = raw_bal;
+        self
     }
 }


### PR DESCRIPTION
Stores raw block access list bytes from engine payloads after validation returns an executed block. This makes validated BALs available through the configured BalStore instead of dropping them after newPayload handling.

BAL store insert failures are logged as warnings so payload insertion is not rejected after validation succeeds.