### PR TITLE
docs: avoid propagating ExEx event send errors

### DIFF
--- a/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/3.rs
+++ b/docs/vocs/docs/snippets/sources/exex/hello-world/src/bin/3.rs
@@ -2,7 +2,7 @@ use futures_util::TryStreamExt;
 use reth::{api::FullNodeComponents, builder::NodeTypes, primitives::EthPrimitives};
 use reth_exex::{ExExContext, ExExEvent, ExExNotification};
 use reth_node_ethereum::EthereumNode;
-use reth_tracing::tracing::info;
+use reth_tracing::tracing::{info, warn};
 
 async fn my_exex<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>>(
     mut ctx: ExExContext<Node>,
@@ -21,7 +21,12 @@ async fn my_exex<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimi
         };
 
         if let Some(committed_chain) = notification.committed_chain() {
-            ctx.events.send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))?;
+            if let Err(err) =
+                ctx.events.send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))
+            {
+                warn!(%err, "ExEx event channel closed");
+                break;
+            }
         }
     }
 

--- a/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/1.rs
+++ b/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/1.rs
@@ -8,7 +8,7 @@ use futures_util::{FutureExt, TryStreamExt};
 use reth::{api::FullNodeComponents, builder::NodeTypes, primitives::EthPrimitives};
 use reth_exex::{ExExContext, ExExEvent, ExExNotification};
 use reth_node_ethereum::EthereumNode;
-use reth_tracing::tracing::info;
+use reth_tracing::tracing::{info, warn};
 
 struct MyExEx<Node: FullNodeComponents> {
     ctx: ExExContext<Node>,
@@ -36,9 +36,14 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
             };
 
             if let Some(committed_chain) = notification.committed_chain() {
-                this.ctx
+                if let Err(err) = this
+                    .ctx
                     .events
-                    .send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))?;
+                    .send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))
+                {
+                    warn!(%err, "ExEx event channel closed");
+                    return Poll::Ready(Ok(()));
+                }
             }
         }
 

--- a/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/2.rs
+++ b/docs/vocs/docs/snippets/sources/exex/tracking-state/src/bin/2.rs
@@ -13,7 +13,7 @@ use reth::{
 };
 use reth_exex::{ExExContext, ExExEvent};
 use reth_node_ethereum::EthereumNode;
-use reth_tracing::tracing::info;
+use reth_tracing::tracing::{info, warn};
 
 struct MyExEx<Node: FullNodeComponents> {
     ctx: ExExContext<Node>,
@@ -52,9 +52,14 @@ impl<Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>> Fut
                     .map(|b| b.body().transaction_count() as u64)
                     .sum::<u64>();
 
-                this.ctx
+                if let Err(err) = this
+                    .ctx
                     .events
-                    .send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))?;
+                    .send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))
+                {
+                    warn!(%err, "ExEx event channel closed");
+                    return Poll::Ready(Ok(()));
+                }
             }
 
             if let Some(first_block) = this.first_block {


### PR DESCRIPTION
## Summary
- update ExEx docs snippets to handle closed event channels explicitly
- avoid teaching examples to propagate FinishedHeight send errors with `?`

## Testing
- `cargo fmt --manifest-path docs/vocs/docs/snippets/sources/exex/hello-world/Cargo.toml`
- `cargo fmt --manifest-path docs/vocs/docs/snippets/sources/exex/tracking-state/Cargo.toml`
- `git diff --check`
- `cargo check --manifest-path docs/vocs/docs/snippets/sources/exex/hello-world/Cargo.toml` *(blocked: snippet workspace patches `reth` to missing local path `docs/vocs/docs/bin/reth`)*
- `cargo check --manifest-path docs/vocs/docs/snippets/sources/exex/tracking-state/Cargo.toml` *(blocked: snippet workspace patches `reth` to missing local path `docs/vocs/docs/bin/reth`)*

Prompted by: @klkvr