### PR TITLE
docs(net): document recent eth wire versions

### DIFF
--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -28,10 +28,20 @@ pub enum EthVersion {
     /// The `eth` protocol version 69.
     Eth69 = 69,
     /// The `eth` protocol version 70.
+    ///
+    /// [EIP-7975](https://eips.ethereum.org/EIPS/eip-7975) adds partial block receipt
+    /// lists by extending `GetReceipts` and `Receipts` with pagination fields.
     Eth70 = 70,
     /// The `eth` protocol version 71.
+    ///
+    /// [EIP-8159](https://eips.ethereum.org/EIPS/eip-8159) adds block access list
+    /// exchange with `GetBlockAccessLists` and `BlockAccessLists`.
     Eth71 = 71,
     /// The `eth` protocol version 72.
+    ///
+    /// [EIP-8070](https://eips.ethereum.org/EIPS/eip-8070) adds sparse blobpool
+    /// support by extending `NewPooledTransactionHashes` with `cell_mask` and adding
+    /// `GetCells` and `Cells`.
     Eth72 = 72,
 }
 
@@ -88,7 +98,7 @@ impl EthVersion {
     }
 }
 
-/// RLP encodes `EthVersion` as a single byte (66-71).
+/// RLP encodes `EthVersion` as a single byte (66-72).
 impl Encodable for EthVersion {
     fn encode(&self, out: &mut dyn BufMut) {
         (*self as u8).encode(out)
@@ -100,7 +110,7 @@ impl Encodable for EthVersion {
 }
 
 /// RLP decodes a single byte into `EthVersion`.
-/// Returns error if byte is not a valid version (66-71).
+/// Returns error if byte is not a valid version (66-72).
 impl Decodable for EthVersion {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let version = u8::decode(buf)?;


### PR DESCRIPTION
Documents the eth/70 through eth/72 EthVersion variants with their corresponding EIPs and a short summary of each wire protocol change. Also updates stale RLP version range comments now that eth/72 is represented.