### PR TITLE
feat(tasks): pin engine work to reserved cores

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -81,7 +81,7 @@ use reth_stages::{
     StageId, StageSet,
 };
 use reth_static_file::StaticFileProducer;
-use reth_tasks::TaskExecutor;
+use reth_tasks::{affinity::configure_reserved_cores, TaskExecutor};
 use reth_tracing::{
     throttle,
     tracing::{debug, error, info, warn},
@@ -231,11 +231,13 @@ impl LaunchContext {
             Err(err) => warn!(%err, "Failed to raise file descriptor limit"),
         }
 
+        configure_reserved_cores(reserved_cpu_cores);
+
         // Configure the implicit global rayon pool for `par_iter` usage.
-        // TODO: reserved_cpu_cores is currently ignored because subtracting from thread pool
-        // sizes doesn't actually reserve CPU cores for other processes.
-        let _ = reserved_cpu_cores;
-        let num_threads = available_parallelism().map_or(1, NonZeroUsize::get);
+        let num_threads = available_parallelism()
+            .map_or(1, NonZeroUsize::get)
+            .saturating_sub(reserved_cpu_cores)
+            .max(1);
         if let Err(err) = ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .thread_name(|i| format!("rayon-{i:02}"))

--- a/crates/tasks/src/affinity.rs
+++ b/crates/tasks/src/affinity.rs
@@ -1,0 +1,141 @@
+//! CPU affinity helpers for latency-sensitive engine work.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DedicatedCore {
+    Engine,
+    Prewarm,
+}
+
+#[derive(Debug, Clone)]
+struct AffinityConfig {
+    general_cores: Vec<usize>,
+    engine_core: usize,
+    prewarm_core: usize,
+}
+
+static AFFINITY_CONFIG: OnceLock<AffinityConfig> = OnceLock::new();
+
+/// Reserves the last two currently allowed CPUs for engine and prewarm work.
+pub fn configure_reserved_cores(reserved_cores: usize) {
+    if reserved_cores < 2 {
+        return
+    }
+
+    let Some(allowed_cores) = current_affinity() else {
+        return
+    };
+    if allowed_cores.len() <= reserved_cores {
+        return
+    }
+
+    let split = allowed_cores.len() - reserved_cores;
+    let general_cores = allowed_cores[..split].to_vec();
+    let engine_core = allowed_cores[split];
+    let prewarm_core = allowed_cores[split + 1];
+
+    let config = AffinityConfig { general_cores, engine_core, prewarm_core };
+    let _ = AFFINITY_CONFIG.set(config.clone());
+    apply_to_all_threads(&config.general_cores);
+}
+
+pub(crate) fn dedicated_core_for_name(name: &str) -> Option<DedicatedCore> {
+    match name {
+        "engine" | "payload-builder" => Some(DedicatedCore::Engine),
+        "builder-prewarm" => Some(DedicatedCore::Prewarm),
+        _ => None,
+    }
+}
+
+pub(crate) fn pin_current_thread(core: DedicatedCore) {
+    let Some(config) = AFFINITY_CONFIG.get() else {
+        return
+    };
+    let cpu = match core {
+        DedicatedCore::Engine => config.engine_core,
+        DedicatedCore::Prewarm => config.prewarm_core,
+    };
+    set_current_thread_affinity(&[cpu]);
+}
+
+pub(crate) fn pin_current_thread_to_general_cores() {
+    let Some(config) = AFFINITY_CONFIG.get() else {
+        return
+    };
+    set_current_thread_affinity(&config.general_cores);
+}
+
+#[cfg(target_os = "linux")]
+fn current_affinity() -> Option<Vec<usize>> {
+    let mut set = new_cpu_set();
+    let result = unsafe {
+        libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set)
+    };
+    if result != 0 {
+        return None
+    }
+
+    let cores = (0..libc::CPU_SETSIZE as usize)
+        .filter(|&cpu| unsafe { libc::CPU_ISSET(cpu, &set) })
+        .collect::<Vec<_>>();
+    (!cores.is_empty()).then_some(cores)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_affinity() -> Option<Vec<usize>> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn set_current_thread_affinity(cores: &[usize]) {
+    let mut set = new_cpu_set();
+    for &cpu in cores {
+        unsafe { libc::CPU_SET(cpu, &mut set) };
+    }
+    let result = unsafe {
+        libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set)
+    };
+    if result != 0 {
+        tracing::debug!(?cores, err = %std::io::Error::last_os_error(), "failed to set thread affinity");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_current_thread_affinity(_cores: &[usize]) {}
+
+#[cfg(target_os = "linux")]
+fn apply_to_all_threads(cores: &[usize]) {
+    let Ok(entries) = std::fs::read_dir("/proc/self/task") else {
+        set_current_thread_affinity(cores);
+        return
+    };
+
+    for entry in entries.flatten() {
+        let Some(tid) =
+            entry.file_name().to_str().and_then(|name| name.parse::<libc::pid_t>().ok())
+        else {
+            continue
+        };
+        let mut set = new_cpu_set();
+        for &cpu in cores {
+            unsafe { libc::CPU_SET(cpu, &mut set) };
+        }
+        let result = unsafe {
+            libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &set)
+        };
+        if result != 0 {
+            tracing::debug!(tid, ?cores, err = %std::io::Error::last_os_error(), "failed to set thread affinity");
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn apply_to_all_threads(cores: &[usize]) {
+    set_current_thread_affinity(cores);
+}
+
+#[cfg(target_os = "linux")]
+fn new_cpu_set() -> libc::cpu_set_t {
+    unsafe { std::mem::zeroed() }
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -35,6 +35,7 @@ pub mod metrics;
 pub mod runtime;
 pub mod shutdown;
 pub mod utils;
+pub mod affinity;
 pub(crate) mod worker_map;
 
 #[cfg(feature = "rayon")]

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -1,5 +1,8 @@
 //! Additional helpers for executing tracing calls
 
+use crate::affinity::{
+    dedicated_core_for_name, pin_current_thread, pin_current_thread_to_general_cores,
+};
 use std::{
     any::Any,
     cell::RefCell,
@@ -193,6 +196,13 @@ impl WorkerPool {
             build_pool_with_panic_handler(
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(self.num_threads)
+                    .start_handler(move |_| {
+                        if let Some(core) = dedicated_core_for_name(prefix) {
+                            pin_current_thread(core);
+                        } else {
+                            pin_current_thread_to_general_cores();
+                        }
+                    })
                     .thread_name(move |i| format!("{prefix}-{i:02}")),
             )
             .unwrap_or_else(|err| panic!("failed to build {prefix} worker pool: {err}"))

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -209,10 +209,12 @@ impl RayonConfig {
 
     /// Compute the default number of threads based on available parallelism.
     fn default_thread_count(&self) -> usize {
-        // TODO: reserved_cpu_cores is currently ignored because subtracting from thread pool
-        // sizes doesn't actually reserve CPU cores for other processes.
-        let _ = self.reserved_cpu_cores;
-        self.cpu_threads.unwrap_or_else(|| available_parallelism().map_or(1, NonZeroUsize::get))
+        self.cpu_threads.unwrap_or_else(|| {
+            available_parallelism()
+                .map_or(1, NonZeroUsize::get)
+                .saturating_sub(self.reserved_cpu_cores)
+                .max(1)
+        })
     }
 }
 

--- a/crates/tasks/src/worker_map.rs
+++ b/crates/tasks/src/worker_map.rs
@@ -4,6 +4,9 @@
 //! This is a substitute for `spawn_blocking` that reuses the same OS thread for the same
 //! named task, like a 1-thread thread pool keyed by name.
 
+use crate::affinity::{
+    dedicated_core_for_name, pin_current_thread, pin_current_thread_to_general_cores,
+};
 use dashmap::DashMap;
 use std::{
     panic::AssertUnwindSafe,
@@ -34,6 +37,11 @@ impl WorkerThread {
         let handle = thread::Builder::new()
             .name(name.to_string())
             .spawn(move || {
+                if let Some(core) = dedicated_core_for_name(name) {
+                    pin_current_thread(core);
+                } else {
+                    pin_current_thread_to_general_cores();
+                }
                 while let Some(task) = rx.blocking_recv() {
                     let _ = std::panic::catch_unwind(AssertUnwindSafe(task));
                 }


### PR DESCRIPTION
## Summary
- Reserve the last two CPUs from the current cpuset when `--engine.reserved-cpu-cores >= 2`.
- Move general process threads, named workers, and Rayon worker pools off those CPUs unless explicitly pinned.
- Pin `engine`/`payload-builder` to one reserved CPU and `builder-prewarm` to the other reserved CPU.

## Verification
- `cargo check -p reth-tasks --features rayon`

Prompted by: @shekhirin