### PR TITLE
Fix snapshot streaming download progress

### DIFF
--- a/crates/cli/commands/src/download/extract.rs
+++ b/crates/cli/commands/src/download/extract.rs
@@ -308,7 +308,7 @@ pub(crate) fn streaming_download_and_extract(
         }
 
         let result = if let Some(progress) = shared {
-            let reader = SharedProgressReader { inner: response, progress: Arc::clone(progress) };
+            let reader = SharedProgressReader::new(response, Arc::clone(progress));
             extract_archive_raw(reader, format, target_dir, None)
         } else {
             let total_size = response.content_length().unwrap_or(0);

--- a/crates/cli/commands/src/download/progress.rs
+++ b/crates/cli/commands/src/download/progress.rs
@@ -676,6 +676,15 @@ pub(crate) struct SharedProgressReader<R> {
     pub(crate) inner: R,
     /// Shared counters updated as bytes are read.
     pub(crate) progress: Arc<SharedProgress>,
+    /// Logical compressed bytes read by this streaming attempt.
+    downloaded: u64,
+}
+
+impl<R> SharedProgressReader<R> {
+    /// Wraps a reader with shared progress accounting for one streaming attempt.
+    pub(crate) fn new(inner: R, progress: Arc<SharedProgress>) -> Self {
+        Self { inner, progress, downloaded: 0 }
+    }
 }
 
 impl<R: Read> Read for SharedProgressReader<R> {
@@ -686,7 +695,15 @@ impl<R: Read> Read for SharedProgressReader<R> {
         }
         let n = self.inner.read(buf)?;
         self.progress.record_session_fetched_bytes(n as u64);
+        self.progress.add_active_download_bytes(n as u64);
+        self.downloaded += n as u64;
         Ok(n)
+    }
+}
+
+impl<R> Drop for SharedProgressReader<R> {
+    fn drop(&mut self) {
+        self.progress.sub_active_download_bytes(self.downloaded);
     }
 }
 
@@ -774,6 +791,7 @@ pub(crate) fn spawn_progress_display(progress: Arc<SharedProgress>) -> tokio::ta
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
     use std::sync::atomic::Ordering;
 
     #[test]
@@ -803,6 +821,22 @@ mod tests {
 
         assert_eq!(progress.logical_downloaded_bytes(), 0);
         assert_eq!(progress.active_downloads.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn shared_progress_reader_tracks_active_download_bytes() {
+        let progress = SharedProgress::new(10, 20, 1, CancellationToken::new());
+
+        {
+            let mut reader =
+                SharedProgressReader::new(Cursor::new([0u8; 4]), Arc::clone(&progress));
+            let mut buf = [0u8; 8];
+            assert_eq!(reader.read(&mut buf).unwrap(), 4);
+            assert_eq!(progress.session_fetched_bytes.load(Ordering::Relaxed), 4);
+            assert_eq!(progress.logical_downloaded_bytes(), 4);
+        }
+
+        assert_eq!(progress.logical_downloaded_bytes(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make the shared streaming download reader update active logical download bytes
- roll back active bytes when a streaming attempt ends
- add a focused unit test for the aggregate progress counters

Prompted by: @SuperFluffy

## Test
- cargo test -p reth-cli-commands download::progress::tests::shared_progress_reader_tracks_active_download_bytes