### PR TITLE
perf(revm): skip empty code hash reads

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -1,7 +1,7 @@
 //! Execution cache implementation for block processing.
 use alloy_primitives::{
     map::{DefaultHashBuilder, FbBuildHasher},
-    Address, StorageKey, StorageValue, B256,
+    Address, StorageKey, StorageValue, B256, KECCAK256_EMPTY,
 };
 use fixed_cache::{AnyRef, CacheConfig, Stats, StatsHandler};
 use metrics::{Counter, Gauge, Histogram};
@@ -507,6 +507,10 @@ impl<S: StateProvider, const PREWARM: bool> StateProvider for CachedStateProvide
 
 impl<S: BytecodeReader, const PREWARM: bool> BytecodeReader for CachedStateProvider<S, PREWARM> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        if *code_hash == KECCAK256_EMPTY {
+            return Ok(None);
+        }
+
         if PREWARM {
             match self.caches.get_or_try_insert_code_with(*code_hash, || {
                 self.state_provider.bytecode_by_hash(code_hash)
@@ -1005,6 +1009,35 @@ mod tests {
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_revm::db::{AccountStatus, BundleAccount};
     use revm_state::AccountInfo;
+
+    #[derive(Clone, Default)]
+    struct CountingBytecodeReader {
+        reads: Arc<AtomicUsize>,
+    }
+
+    impl BytecodeReader for CountingBytecodeReader {
+        fn bytecode_by_hash(&self, _code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn test_empty_code_hash_skips_provider_and_cache() {
+        let reads = Arc::new(AtomicUsize::new(0));
+        let caches = ExecutionCache::new(1000);
+        let state_provider = CachedStateProvider::new_prewarm(
+            CountingBytecodeReader { reads: Arc::clone(&reads) },
+            caches.clone(),
+            CachedStateMetrics::zeroed(CachedStateMetricsSource::Test),
+        );
+
+        let code = state_provider.bytecode_by_hash(&KECCAK256_EMPTY).unwrap();
+
+        assert!(code.is_none());
+        assert_eq!(reads.load(Ordering::Relaxed), 0);
+        assert!(caches.0.code_cache.get(&KECCAK256_EMPTY).is_none());
+    }
 
     #[test]
     fn test_empty_storage_cached_state_provider() {

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -4,7 +4,9 @@ use core::ops::{Deref, DerefMut};
 use reth_primitives_traits::Account;
 use reth_storage_api::{AccountReader, BlockHashReader, BytecodeReader, StateProvider};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
-use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
+use revm::{
+    bytecode::Bytecode, primitives::KECCAK_EMPTY, state::AccountInfo, Database, DatabaseRef,
+};
 
 /// A helper trait responsible for providing state necessary for EVM execution.
 ///
@@ -151,6 +153,10 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     ///
     /// Returns `Ok` with the bytecode if found, or the default bytecode otherwise.
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        if code_hash == KECCAK_EMPTY {
+            return Ok(Bytecode::default());
+        }
+
         Ok(self.bytecode_by_hash(&code_hash)?.unwrap_or_default().0)
     }
 
@@ -167,5 +173,55 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
         // Get the block hash or default hash with an attempt to convert U256 block number to u64
         Ok(self.0.block_hash(number)?.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[derive(Clone, Default)]
+    struct CountingEvmStateProvider {
+        reads: Arc<AtomicUsize>,
+    }
+
+    impl EvmStateProvider for CountingEvmStateProvider {
+        fn basic_account(&self, _address: &Address) -> ProviderResult<Option<Account>> {
+            Ok(None)
+        }
+
+        fn block_hash(&self, _number: BlockNumber) -> ProviderResult<Option<B256>> {
+            Ok(None)
+        }
+
+        fn bytecode_by_hash(
+            &self,
+            _code_hash: &B256,
+        ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            Ok(None)
+        }
+
+        fn storage(
+            &self,
+            _account: Address,
+            _storage_key: StorageKey,
+        ) -> ProviderResult<Option<StorageValue>> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn state_provider_database_skips_empty_code_hash_reads() {
+        let reads = Arc::new(AtomicUsize::new(0));
+        let db = StateProviderDatabase::new(CountingEvmStateProvider { reads: Arc::clone(&reads) });
+
+        let _code = db.code_by_hash_ref(KECCAK_EMPTY).unwrap();
+
+        assert_eq!(reads.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
Draft exploration for EIP-8038/BAL perf item 4.

Base: `bal-devnet-7`

Changes:
- Skips execution-cache provider/cache lookup for the canonical empty code hash.
- Skips `StateProviderDatabase::code_by_hash_ref` provider reads for the empty code hash.
- Adds focused tests for both bypasses.

Why:
- Avoids polluting code caches and touching providers for accounts known to have no bytecode.

Validation:
- `cargo +nightly fmt --all`
- `cargo test -p reth-execution-cache test_empty_code_hash_skips_provider_and_cache`
- `cargo test -p reth-revm state_provider_database_skips_empty_code_hash_reads`