### PR TITLE
ci: tolerate missing llvm helper in bench workflows

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -373,7 +373,22 @@ jobs:
           fi
 
           # llvm
-          .github/scripts/install_llvm.sh ubuntu
+          if [ -x .github/scripts/install_llvm.sh ]; then
+            .github/scripts/install_llvm.sh ubuntu
+          else
+            sudo apt-get install -y --no-install-recommends \
+              lsb-release wget gnupg ca-certificates software-properties-common
+            llvm_sh="$(mktemp)"
+            wget -qO "$llvm_sh" https://apt.llvm.org/llvm.sh
+            chmod +x "$llvm_sh"
+            sudo "$llvm_sh" 22 all
+            rm -f "$llvm_sh"
+            for bin in clang llvm-config lld ld.lld FileCheck; do
+              if command -v "$bin-22" &>/dev/null; then
+                sudo ln -fs "$(command -v "$bin-22")" "/usr/bin/$bin"
+              fi
+            done
+          fi
 
           # uv (Python package manager)
           if ! command -v uv &>/dev/null; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -800,7 +800,22 @@ jobs:
           fi
 
           # llvm
-          .github/scripts/install_llvm.sh ubuntu
+          if [ -x .github/scripts/install_llvm.sh ]; then
+            .github/scripts/install_llvm.sh ubuntu
+          else
+            sudo apt-get install -y --no-install-recommends \
+              lsb-release wget gnupg ca-certificates software-properties-common
+            llvm_sh="$(mktemp)"
+            wget -qO "$llvm_sh" https://apt.llvm.org/llvm.sh
+            chmod +x "$llvm_sh"
+            sudo "$llvm_sh" 22 all
+            rm -f "$llvm_sh"
+            for bin in clang llvm-config lld ld.lld FileCheck; do
+              if command -v "$bin-22" &>/dev/null; then
+                sudo ln -fs "$(command -v "$bin-22")" "/usr/bin/$bin"
+              fi
+            done
+          fi
 
           # uv (Python package manager)
           if ! command -v uv &>/dev/null; then


### PR DESCRIPTION
Fixes bench runs that checkout older PR branches without `.github/scripts/install_llvm.sh` while using the current bench workflow. The dependency step now uses the helper when it exists and falls back to the same LLVM 22 apt.llvm.org install flow inline when it does not.

Validation:
- `uv run python` YAML parse for `.github/workflows/bench.yml` and `.github/workflows/bench-scheduled.yml`
- `git diff --check`

Prompted by: @gakonst