### PR TITLE
perf(engine): skip unnecessary BAL hashed account reads

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -21,13 +21,13 @@ use crate::tree::{
 use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::eip4895::Withdrawal;
-use alloy_primitives::keccak256;
+use alloy_primitives::{keccak256, B256, U256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx, SpecFor};
 use reth_metrics::Metrics;
-use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
+use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     AccountReader, BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader,
 };
@@ -634,8 +634,9 @@ where
 
     /// Hashes and streams a single BAL account's state to the sparse trie task.
     ///
-    /// For each account, storage slots are hashed and sent immediately, then the account is read
-    /// from the database and sent as a separate update.
+    /// For each changed account, storage slots are hashed and sent immediately, then the account
+    /// is sent as a separate update. The parent account is read only when the BAL did not provide
+    /// all account leaf fields needed by the sparse trie.
     ///
     /// The `provider` is lazily initialized on first call and reused across accounts on the same
     /// thread.
@@ -651,6 +652,11 @@ where
         }
         let address = account_changes.address;
         let mut hashed_address = None;
+        let account_fields = BalAccountStateFields::from_changes(account_changes);
+
+        if !bal_account_changes_state_root(account_changes, account_fields) {
+            return;
+        }
 
         if !account_changes.storage_changes.is_empty() {
             let hashed_address = *hashed_address.get_or_insert_with(|| keccak256(address));
@@ -668,75 +674,44 @@ where
             let _ = to_sparse_trie_task.send(StateRootMessage::HashedStateUpdate(hashed_state));
         }
 
-        if provider.is_none() {
-            let _span = debug_span!(
-                target: "engine::tree::payload_processor::prewarm",
-                parent: parent_span,
-                "bal_hashed_state_provider_init",
-                has_saved_cache = !self.disable_bal_batch_io && self.saved_cache.is_some(),
-            )
-            .entered();
+        let existing_account = if account_fields.needs_parent_account() {
+            if provider.is_none() {
+                let _span = debug_span!(
+                    target: "engine::tree::payload_processor::prewarm",
+                    parent: parent_span,
+                    "bal_hashed_state_provider_init",
+                    has_saved_cache = !self.disable_bal_batch_io && self.saved_cache.is_some(),
+                )
+                .entered();
 
-            let inner = match self.provider.build() {
-                Ok(p) => p,
-                Err(err) => {
-                    warn!(
-                        target: "engine::tree::payload_processor::prewarm",
-                        ?err,
-                        "Failed to build provider for BAL account reads"
-                    );
-                    return;
-                }
-            };
-            let boxed: Box<dyn AccountReader> = match (self.disable_bal_batch_io, &self.saved_cache)
-            {
-                (false, Some(saved)) => {
-                    let caches = saved.cache().clone();
-                    Box::new(CachedStateProvider::new_prewarm(inner, caches))
-                }
-                _ => Box::new(inner),
-            };
-            *provider = Some(boxed);
-        }
-        let account_reader = provider.as_ref().expect("provider just initialized");
-
-        let existing_account = account_reader.basic_account(&address).ok().flatten();
-
-        let balance = account_changes.balance_changes.last().map(|change| change.post_balance);
-        let nonce = account_changes.nonce_changes.last().map(|change| change.new_nonce);
-        let code_hash = account_changes.code_changes.last().map(|code_change| {
-            if code_change.new_code.is_empty() {
-                alloy_consensus::constants::KECCAK_EMPTY
-            } else {
-                keccak256(&code_change.new_code)
+                let inner = match self.provider.build() {
+                    Ok(p) => p,
+                    Err(err) => {
+                        warn!(
+                            target: "engine::tree::payload_processor::prewarm",
+                            ?err,
+                            "Failed to build provider for BAL account reads"
+                        );
+                        return;
+                    }
+                };
+                let boxed: Box<dyn AccountReader> =
+                    match (self.disable_bal_batch_io, &self.saved_cache) {
+                        (false, Some(saved)) => {
+                            let caches = saved.cache().clone();
+                            Box::new(CachedStateProvider::new_prewarm(inner, caches))
+                        }
+                        _ => Box::new(inner),
+                    };
+                *provider = Some(boxed);
             }
-        });
-
-        if balance.is_none() &&
-            nonce.is_none() &&
-            code_hash.is_none() &&
-            account_changes.storage_changes.is_empty()
-        {
-            return;
-        }
-
-        let account = reth_primitives_traits::Account {
-            balance: balance.unwrap_or_else(|| {
-                existing_account
-                    .as_ref()
-                    .map(|account| account.balance)
-                    .unwrap_or(alloy_primitives::U256::ZERO)
-            }),
-            nonce: nonce.unwrap_or_else(|| {
-                existing_account.as_ref().map(|account| account.nonce).unwrap_or(0)
-            }),
-            bytecode_hash: code_hash.or_else(|| {
-                existing_account
-                    .as_ref()
-                    .and_then(|account| account.bytecode_hash)
-                    .or(Some(alloy_consensus::constants::KECCAK_EMPTY))
-            }),
+            let account_reader = provider.as_ref().expect("provider just initialized");
+            account_reader.basic_account(&address).ok().flatten()
+        } else {
+            None
         };
+
+        let account = account_fields.into_account(existing_account);
 
         let hashed_address = hashed_address.unwrap_or_else(|| keccak256(address));
         let mut hashed_state = reth_trie::HashedPostState::default();
@@ -744,6 +719,63 @@ where
 
         let _ = to_sparse_trie_task.send(StateRootMessage::HashedStateUpdate(hashed_state));
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct BalAccountStateFields {
+    balance: Option<U256>,
+    nonce: Option<u64>,
+    code_hash: Option<B256>,
+}
+
+impl BalAccountStateFields {
+    fn from_changes(account_changes: &alloy_eip7928::AccountChanges) -> Self {
+        Self {
+            balance: account_changes.balance_changes.last().map(|change| change.post_balance),
+            nonce: account_changes.nonce_changes.last().map(|change| change.new_nonce),
+            code_hash: account_changes.code_changes.last().map(|code_change| {
+                if code_change.new_code.is_empty() {
+                    alloy_consensus::constants::KECCAK_EMPTY
+                } else {
+                    keccak256(&code_change.new_code)
+                }
+            }),
+        }
+    }
+
+    const fn is_empty(self) -> bool {
+        self.balance.is_none() && self.nonce.is_none() && self.code_hash.is_none()
+    }
+
+    const fn needs_parent_account(self) -> bool {
+        self.balance.is_none() || self.nonce.is_none() || self.code_hash.is_none()
+    }
+
+    fn into_account(self, existing_account: Option<Account>) -> Account {
+        let existing_account = existing_account.as_ref();
+        Account {
+            balance: self.balance.unwrap_or_else(|| {
+                existing_account
+                    .map(|account| account.balance)
+                    .unwrap_or(alloy_primitives::U256::ZERO)
+            }),
+            nonce: self
+                .nonce
+                .unwrap_or_else(|| existing_account.map(|account| account.nonce).unwrap_or(0)),
+            bytecode_hash: self.code_hash.or_else(|| {
+                existing_account
+                    .and_then(|account| account.bytecode_hash)
+                    .or(Some(alloy_consensus::constants::KECCAK_EMPTY))
+            }),
+        }
+    }
+}
+
+const fn bal_account_changes_state_root(
+    account_changes: &alloy_eip7928::AccountChanges,
+    account_fields: BalAccountStateFields,
+) -> bool {
+    !account_fields.is_empty() || !account_changes.storage_changes.is_empty()
 }
 
 /// Returns [`MultiProofTargetsV2`] for withdrawal addresses.
@@ -754,6 +786,67 @@ fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProof
     MultiProofTargetsV2 {
         account_targets: withdrawals.iter().map(|w| keccak256(w.address).into()).collect(),
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eip7928::{
+        AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
+        StorageChange,
+    };
+    use alloy_primitives::{address, bytes};
+
+    #[test]
+    fn bal_read_only_account_does_not_change_state_root() {
+        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
+            .with_storage_read(U256::from(1));
+        let fields = BalAccountStateFields::from_changes(&changes);
+
+        assert!(fields.is_empty());
+        assert!(!bal_account_changes_state_root(&changes, fields));
+    }
+
+    #[test]
+    fn bal_account_with_all_leaf_fields_does_not_need_parent_account() {
+        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
+            .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(10)))
+            .with_nonce_change(NonceChange::new(BlockAccessIndex::new(1), 7))
+            .with_code_change(CodeChange::new(BlockAccessIndex::new(1), bytes!("6001600155")));
+        let fields = BalAccountStateFields::from_changes(&changes);
+
+        assert!(bal_account_changes_state_root(&changes, fields));
+        assert!(!fields.needs_parent_account());
+    }
+
+    #[test]
+    fn bal_storage_change_needs_parent_account_when_leaf_fields_missing() {
+        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
+            .with_storage_change(SlotChanges::new(
+                U256::from(1),
+                vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(2))],
+            ));
+        let fields = BalAccountStateFields::from_changes(&changes);
+
+        assert!(bal_account_changes_state_root(&changes, fields));
+        assert!(fields.needs_parent_account());
+    }
+
+    #[test]
+    fn bal_account_uses_existing_fields_only_when_missing() {
+        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
+            .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(10)));
+        let fields = BalAccountStateFields::from_changes(&changes);
+        let account = fields.into_account(Some(Account {
+            balance: U256::from(1),
+            nonce: 3,
+            bytecode_hash: Some(B256::repeat_byte(0xaa)),
+        }));
+
+        assert_eq!(account.balance, U256::from(10));
+        assert_eq!(account.nonce, 3);
+        assert_eq!(account.bytecode_hash, Some(B256::repeat_byte(0xaa)));
     }
 }
 


### PR DESCRIPTION
## Summary

- Skip BAL hashed-state account emission for read-only account entries that do not affect the state root.
- Avoid reading the parent account when BAL already provides the account leaf fields needed by the sparse trie: balance, nonce, and code hash.
- Add focused unit coverage for read-only entries, complete leaf fields, storage-change fallback, and partial-field fallback.

## Why

BAL hashed-state streaming was still doing parent account lookups for accounts that either did not need to be written into the trie, or already had all required leaf fields in BAL. This removes those unnecessary hashed account reads from the state-root path without adding an executor/provider overlay.

## Bench

Two-run average on the account-heavy CODE benchmark:

| row | HashedAccounts get | avg elapsed |
|---|---:|---:|
| EXTCODEHASH existing | -2.35% | +2.45% |
| EXTCODEHASH non-existing | -9.20% | -6.29% |
| EXTCODESIZE existing | -2.15% | -2.26% |
| EXTCODESIZE non-existing | -8.84% | -7.15% |

The clearest win is on non-existing CODE rows; `EXTCODEHASH existing` is noisy in this sample.

## Validation

- `cargo +nightly fmt --all --check`
- `cargo +nightly check -p reth-engine-tree`
- `cargo +nightly test -p reth-engine-tree --lib bal_`
- `cargo +nightly clippy -p reth-engine-tree --lib --no-deps -- -D warnings`
