### PR TITLE
fix(era): omit total difficulty and accumulator for post-merge ere exports

### DIFF
--- a/crates/era-utils/src/export/ere.rs
+++ b/crates/era-utils/src/export/ere.rs
@@ -23,10 +23,6 @@ use reth_era::{
 use reth_primitives_traits::Receipt;
 use std::path::{Path, PathBuf};
 
-/// Every exported block carries header + body + receipts + total-difficulty (proofs are omitted),
-/// so the block index stores four offsets per block.
-const COMPONENT_COUNT: u64 = 4;
-
 impl EraBlockWriter for Ere {
     fn write_file<H, B, R>(
         network: &str,
@@ -39,13 +35,22 @@ impl EraBlockWriter for Ere {
         B: Encodable,
         R: Receipt,
     {
-        let tuples = blocks.iter().map(compress_block).collect::<Result<Vec<_>>>()?;
-        let accumulator = super::accumulator::<Accumulator, _, _, _>(blocks)?;
+        // Total difficulty and the accumulator are pre-merge only: post-merge blocks have zero
+        // difficulty and the accumulator is frozen at the merge. Difficulty drops to zero
+        // monotonically, so the first block decides the whole file.
+        let pre_merge = !blocks[0].header.difficulty().is_zero();
+
+        let tuples = blocks
+            .iter()
+            .map(|block| compress_block(block, pre_merge))
+            .collect::<Result<Vec<_>>>()?;
+        let accumulator =
+            pre_merge.then(|| super::accumulator::<Accumulator, _, _, _>(blocks)).transpose()?;
         let id = file_id(network, max_blocks_per_file, blocks)?;
-        let index = block_index(blocks[0].header.number(), &tuples, &accumulator);
+        let index = block_index(blocks[0].header.number(), &tuples, accumulator.as_ref());
 
         let file_path = dir.join(id.to_file_name());
-        let group = EreGroup::new(tuples, Some(accumulator), index);
+        let group = EreGroup::new(tuples, accumulator, index);
 
         EreWriter::new(std::fs::File::create(&file_path)?)
             .write_file(&EreFile::new(group, id))
@@ -55,12 +60,15 @@ impl EraBlockWriter for Ere {
     }
 }
 
-/// Compresses one block into an `ere` [`BlockTuple`] (header, body, slim receipts, cumulative total
-/// difficulty).
+/// Compresses one block into an `ere` [`BlockTuple`] (header, body, slim receipts, and, for
+/// pre-merge blocks, cumulative total difficulty).
 ///
 /// The optional ERE `Proof` (a Portal Network header-inclusion proof) is not produced here, so the
 /// file carries the [`EreProfile::NoProofs`] profile.
-fn compress_block<H, B, R>(block: &ExportBlock<H, B, R>) -> Result<BlockTuple>
+fn compress_block<H, B, R>(
+    block: &ExportBlock<H, B, R>,
+    include_total_difficulty: bool,
+) -> Result<BlockTuple>
 where
     H: BlockHeader + Encodable,
     B: Encodable,
@@ -85,9 +93,12 @@ where
     let receipts = CompressedSlimReceipts::from_receipts(&slim_receipts)
         .map_err(|e| eyre!("Failed to compress receipts: {e}"))?;
 
-    Ok(BlockTuple::new(header, body)
-        .with_receipts(receipts)
-        .with_total_difficulty(TotalDifficulty::new(block.total_difficulty)))
+    let tuple = BlockTuple::new(header, body).with_receipts(receipts);
+    Ok(if include_total_difficulty {
+        tuple.with_total_difficulty(TotalDifficulty::new(block.total_difficulty))
+    } else {
+        tuple
+    })
 }
 
 impl ChunkAccumulator for Accumulator {
@@ -121,16 +132,22 @@ fn file_id<H: BlockHeader, B, R>(
 /// Builds the [`DynamicBlockIndex`] for the file's sectioned layout.
 ///
 /// `ere` groups records by type, so the file is laid out (after the version record) as: all
-/// headers, all bodies, all receipts, all total-difficulties, the accumulator, then the index.
-/// Offsets are negative `i64`s relative to the index record, per the spec's backward-pointing
-/// convention.
+/// headers, all bodies, all receipts, all total-difficulties and the accumulator (both pre-merge
+/// only), then the index. Offsets are negative `i64`s relative to the index record, per the spec's
+/// backward-pointing convention.
 fn block_index(
     start_block: u64,
     tuples: &[BlockTuple],
-    accumulator: &Accumulator,
+    accumulator: Option<&Accumulator>,
 ) -> DynamicBlockIndex {
-    // Absolute position of each block's components, walked section by section.
-    let mut position = Header::SIZE as i64; // past the leading version record
+    // Every block carries header + body + receipts, plus total-difficulty for pre-merge files
+    // (proofs are always omitted), so the index stores three or four offsets per block.
+    let has_total_difficulty = tuples.first().is_some_and(|t| t.total_difficulty.is_some());
+    let component_count = if has_total_difficulty { 4 } else { 3 };
+
+    // Absolute position of each block's components, walked section by section, starting past the
+    // leading version record.
+    let mut position = Header::SIZE as i64;
     let mut section = |sizes: &mut dyn Iterator<Item = i64>| {
         let mut starts = Vec::with_capacity(tuples.len());
         for size in sizes {
@@ -144,25 +161,83 @@ fn block_index(
     let body_pos = section(&mut tuples.iter().map(|t| t.body.to_entry().size() as i64));
     let receipts_pos =
         section(&mut tuples.iter().map(|t| entry_size(t.receipts.as_ref().map(|r| r.to_entry()))));
-    let difficulty_pos = section(
-        &mut tuples.iter().map(|t| entry_size(t.total_difficulty.as_ref().map(|d| d.to_entry()))),
-    );
+    let difficulty_pos = has_total_difficulty.then(|| {
+        section(
+            &mut tuples
+                .iter()
+                .map(|t| entry_size(t.total_difficulty.as_ref().map(|d| d.to_entry()))),
+        )
+    });
 
-    position += accumulator.to_entry().size() as i64;
+    if let Some(accumulator) = accumulator {
+        position += accumulator.to_entry().size() as i64;
+    }
     let index_position = position;
 
-    let mut offsets = Vec::with_capacity(tuples.len() * COMPONENT_COUNT as usize);
+    let mut offsets = Vec::with_capacity(tuples.len() * component_count as usize);
     for i in 0..tuples.len() {
         offsets.push(header_pos[i] - index_position);
         offsets.push(body_pos[i] - index_position);
         offsets.push(receipts_pos[i] - index_position);
-        offsets.push(difficulty_pos[i] - index_position);
+        if let Some(difficulty_pos) = &difficulty_pos {
+            offsets.push(difficulty_pos[i] - index_position);
+        }
     }
 
-    DynamicBlockIndex::new(start_block, COMPONENT_COUNT, offsets)
+    DynamicBlockIndex::new(start_block, component_count, offsets)
 }
 
 /// Serialized size of an optional record, or `0` when absent.
 fn entry_size(entry: Option<reth_era::e2s::types::Entry>) -> i64 {
     entry.map_or(0, |e| e.size() as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use reth_era::{common::file_ops::StreamReader, ere::file::EreReader};
+    use reth_ethereum_primitives::{BlockBody, Receipt as EthReceipt};
+    use tempfile::tempdir;
+
+    /// `count` empty blocks sharing one difficulty, so the chunk is uniformly pre- or post-merge.
+    fn export_blocks(
+        count: u64,
+        difficulty: U256,
+    ) -> Vec<ExportBlock<Header, BlockBody, EthReceipt>> {
+        (0..count)
+            .map(|number| ExportBlock {
+                header: Header { number, difficulty, ..Default::default() },
+                block_hash: B256::repeat_byte(number as u8 + 1),
+                body: BlockBody::default(),
+                receipts: Vec::new(),
+                total_difficulty: U256::from(number + 1),
+            })
+            .collect()
+    }
+
+    fn write_and_read(blocks: &[ExportBlock<Header, BlockBody, EthReceipt>]) -> EreFile {
+        let dir = tempdir().unwrap();
+        let path =
+            Ere::write_file("mainnet", MAX_BLOCKS_PER_ERE as u64, blocks, dir.path()).unwrap();
+        EreReader::new(std::fs::File::open(path).unwrap()).read("mainnet".to_string()).unwrap()
+    }
+
+    #[test]
+    fn pre_merge_file_carries_total_difficulty_and_accumulator() {
+        let file = write_and_read(&export_blocks(3, U256::from(1)));
+
+        assert!(file.group.accumulator.is_some());
+        assert_eq!(file.group.index.component_count(), 4);
+        assert!(file.group.blocks.iter().all(|b| b.total_difficulty.is_some()));
+    }
+
+    #[test]
+    fn post_merge_file_omits_total_difficulty_and_accumulator() {
+        let file = write_and_read(&export_blocks(3, U256::ZERO));
+
+        assert!(file.group.accumulator.is_none());
+        assert_eq!(file.group.index.component_count(), 3);
+        assert!(file.group.blocks.iter().all(|b| b.total_difficulty.is_none()));
+    }
 }

--- a/crates/era-utils/src/export/ere.rs
+++ b/crates/era-utils/src/export/ere.rs
@@ -37,15 +37,20 @@ impl EraBlockWriter for Ere {
     {
         // Total difficulty and the accumulator are pre-merge only: post-merge blocks have zero
         // difficulty and the accumulator is frozen at the merge. Difficulty drops to zero
-        // monotonically, so the first block decides the whole file.
+        // monotonically, so the first block decides whether the file carries them at all.
         let pre_merge = !blocks[0].header.difficulty().is_zero();
+        // Post-merge blocks are not part of any epoch accumulator, so a merge-spanning file builds
+        // its accumulator from the pre-merge prefix only, while total difficulty is kept for every
+        // block.
+        let pre_merge_count = blocks.partition_point(|b| !b.header.difficulty().is_zero());
 
         let tuples = blocks
             .iter()
             .map(|block| compress_block(block, pre_merge))
             .collect::<Result<Vec<_>>>()?;
-        let accumulator =
-            pre_merge.then(|| super::accumulator::<Accumulator, _, _, _>(blocks)).transpose()?;
+        let accumulator = pre_merge
+            .then(|| super::accumulator::<Accumulator, _, _, _>(&blocks[..pre_merge_count]))
+            .transpose()?;
         let id = file_id(network, max_blocks_per_file, blocks)?;
         let index = block_index(blocks[0].header.number(), &tuples, accumulator.as_ref());
 
@@ -200,20 +205,24 @@ mod tests {
     use reth_ethereum_primitives::{BlockBody, Receipt as EthReceipt};
     use tempfile::tempdir;
 
-    /// `count` empty blocks sharing one difficulty, so the chunk is uniformly pre- or post-merge.
+    /// One empty block with the given number and difficulty (zero difficulty marks a post-merge
+    /// block).
+    fn export_block(number: u64, difficulty: U256) -> ExportBlock<Header, BlockBody, EthReceipt> {
+        ExportBlock {
+            header: Header { number, difficulty, ..Default::default() },
+            block_hash: B256::repeat_byte(number as u8 + 1),
+            body: BlockBody::default(),
+            receipts: Vec::new(),
+            total_difficulty: U256::from(number + 1),
+        }
+    }
+
+    /// `count` blocks sharing one difficulty, so the chunk is uniformly pre- or post-merge.
     fn export_blocks(
         count: u64,
         difficulty: U256,
     ) -> Vec<ExportBlock<Header, BlockBody, EthReceipt>> {
-        (0..count)
-            .map(|number| ExportBlock {
-                header: Header { number, difficulty, ..Default::default() },
-                block_hash: B256::repeat_byte(number as u8 + 1),
-                body: BlockBody::default(),
-                receipts: Vec::new(),
-                total_difficulty: U256::from(number + 1),
-            })
-            .collect()
+        (0..count).map(|number| export_block(number, difficulty)).collect()
     }
 
     fn write_and_read(blocks: &[ExportBlock<Header, BlockBody, EthReceipt>]) -> EreFile {
@@ -239,5 +248,31 @@ mod tests {
         assert!(file.group.accumulator.is_none());
         assert_eq!(file.group.index.component_count(), 3);
         assert!(file.group.blocks.iter().all(|b| b.total_difficulty.is_none()));
+    }
+
+    #[test]
+    fn merge_spanning_file_excludes_post_merge_blocks_from_accumulator() {
+        // Blocks 0-1 pre-merge (non-zero difficulty), blocks 2-3 post-merge (zero difficulty).
+        let blocks: Vec<_> = (0..4)
+            .map(|n| export_block(n, if n < 2 { U256::from(1) } else { U256::ZERO }))
+            .collect();
+        let file = write_and_read(&blocks);
+
+        // Total difficulty is kept for every block, so the component count stays at 4.
+        assert_eq!(file.group.index.component_count(), 4);
+        assert!(file.group.blocks.iter().all(|b| b.total_difficulty.is_some()));
+
+        // The accumulator must cover only the pre-merge blocks, not the whole chunk.
+        let expected = Accumulator::from_header_records(
+            &blocks[..2]
+                .iter()
+                .map(|b| HeaderRecord {
+                    block_hash: b.block_hash,
+                    total_difficulty: b.total_difficulty,
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        assert_eq!(file.group.accumulator.unwrap().root, expected.root);
     }
 }


### PR DESCRIPTION
Addresses https://github.com/paradigmxyz/reth/pull/25304#discussion_r3431240660

Total difficulty and the header accumulator are pre-merge constructs: post-merge blocks have zero difficulty (so total difficulty stops advancing) and the accumulator is frozen at the merge. 

The ere writer now emits both only for pre-merge files, dropping the per-block component count from 4 to 3 post-merge.