### PR TITLE
fix(rpc): treat eth_sendRawTransaction as local path

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -86,7 +86,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 <PoolTx<Self::Pool> as PoolTransaction>::recover_raw_transaction(&tx)
                     .map_err(Self::Error::from_eth_err)?;
             self.send_pool_transaction(
-                TransactionOrigin::External,
+                TransactionOrigin::Local,
                 WithEncoded::new(tx, pool_transaction),
             )
             .await

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -147,7 +147,7 @@ mod tests {
     use reth_rpc_eth_api::node::RpcNodeCoreAdapter;
     use reth_transaction_pool::{
         test_utils::{testing_pool, TestPool},
-        TransactionPool,
+        TransactionOrigin, TransactionPool,
     };
     use revm_primitives::Bytes;
 
@@ -213,6 +213,8 @@ mod tests {
 
         assert!(pool.get(&tx_1_result).is_some(), "tx1 not found in the pool");
         assert!(pool.get(&tx_2_result).is_some(), "tx2 not found in the pool");
+        assert_eq!(pool.get(&tx_1_result).unwrap().origin, TransactionOrigin::Local);
+        assert_eq!(pool.get(&tx_2_result).unwrap().origin, TransactionOrigin::Local);
     }
 
     #[tokio::test]


### PR DESCRIPTION
> The issue me met in prod

We run a reth node, we found some txs we sent over `eth_sendRawTransaction` JSON-RPC got evicted after a while, and the txpool showed the number of queued txs is 30000+. But we never had this issue in geth before, seems the txpool has different evict policy in geth vs reth. 



Aligns `eth_sendRawTransaction` with the documented RPC transaction flow by submitting decoded raw transactions to the pool with `TransactionOrigin::Local`.

https://github.com/paradigmxyz/reth/blob/771d57e0c0cdcbd0bc29d713d966f98293d5cb78/crates/transaction-pool/src/lib.rs#L46-L53

And this matches Geth-style local submission semantics and keeps RPC-submitted transactions eligible for local transaction handling.