### PR TITLE
fix: gate reth jit helper call

### DIFF
--- a/bin/reth/src/main.rs
+++ b/bin/reth/src/main.rs
@@ -18,12 +18,15 @@ use reth_node_ethereum::EthereumNode;
 use tracing::info;
 
 fn main() {
-    match reth_node_ethereum::node::maybe_run_jit_helper() {
-        Ok(std::ops::ControlFlow::Break(())) => return,
-        Ok(std::ops::ControlFlow::Continue(())) => {}
-        Err(err) => {
-            eprintln!("Error: {err:?}");
-            std::process::exit(1);
+    #[cfg(feature = "jit")]
+    {
+        match reth_node_ethereum::node::maybe_run_jit_helper() {
+            Ok(std::ops::ControlFlow::Break(())) => return,
+            Ok(std::ops::ControlFlow::Continue(())) => {}
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                std::process::exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
The `reth` binary unconditionally called `maybe_run_jit_helper()`, but that helper is only exported by `reth-node-ethereum` when the `jit` feature is enabled. This breaks builds that use the default feature set except `jit`.

This gates the helper dispatch behind `#[cfg(feature = "jit")]`, allowing non-JIT builds to proceed directly to normal CLI startup.

Verification:
- `cargo build --bin reth --no-default-features --features 'jemalloc,otlp,otlp-logs,reth-revm/portable,js-tracer,keccak-cache-global,asm-keccak,min-trace-logs'`

Prompted by: @DaniPopes