### PR TITLE
perf(cli): avoid locking evm2 re-execute cache

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -25,7 +25,7 @@ use reth_provider::{
 };
 use reth_stages::stages::calculate_gas_used_from_headers;
 use reth_storage_api::{
-    ChangeSetReader, DBProvider, SharedEvm2StateProviderDatabase, StorageChangeSetReader,
+    ChangeSetReader, DBProvider, LocalEvm2StateProviderDatabase, StorageChangeSetReader,
 };
 use std::{
     collections::HashMap,
@@ -176,10 +176,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
                         let state_provider =
                             provider.history_by_block_number(block.number().saturating_sub(1))?;
-                        // SAFETY: The shared database is consumed by this synchronous execution
+                        // SAFETY: The local database is consumed by this synchronous execution
                         // call and does not outlive the state provider borrowed here.
                         let database =
-                            unsafe { SharedEvm2StateProviderDatabase::new(&*state_provider) };
+                            unsafe { LocalEvm2StateProviderDatabase::new(&*state_provider) };
                         let output = match evm_config.executor(database).execute(&block) {
                             Ok(output) => output,
                             Err(err) => {

--- a/crates/storage/storage-api/src/evm2.rs
+++ b/crates/storage/storage-api/src/evm2.rs
@@ -4,13 +4,14 @@ use crate::{
     AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
     StateProvider, StateRootProvider, StorageRootProvider,
 };
-use alloc::vec::Vec;
+use alloc::{rc::Rc, vec::Vec};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{
     map::{AddressMap, AddressSet, B256Map, U256Map},
     Address, BlockNumber, Bytes, B256, U256,
 };
 use core::{
+    cell::RefCell,
     mem,
     ops::{Deref, DerefMut},
     ptr::NonNull,
@@ -247,6 +248,76 @@ impl Database for SharedEvm2StateProviderDatabase {
 
     fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
         let mut db = self.lock()?;
+        db.get_block_hash(number).map_err(|code| Self::provider_error(&mut db, code))
+    }
+}
+
+/// A cloneable evm2 database handle that shares one cache over a borrowed Reth state provider
+/// within a single thread.
+///
+/// This avoids synchronization overhead for synchronous replay paths while still preserving cache
+/// visibility across short-lived evm2 instances.
+#[derive(Clone)]
+pub struct LocalEvm2StateProviderDatabase {
+    inner: Rc<RefCell<CacheDB<Db<BorrowedEvm2StateProviderDatabase>>>>,
+}
+
+impl LocalEvm2StateProviderDatabase {
+    /// Creates a new local shared cache over a borrowed state provider.
+    ///
+    /// # Safety
+    ///
+    /// This has the same lifetime erasure requirements as
+    /// [`BorrowedEvm2StateProviderDatabase::new`]. The returned handle and its clones must not
+    /// outlive `provider`.
+    pub unsafe fn new(provider: &dyn StateProvider) -> Self {
+        Self {
+            // SAFETY: The caller upholds the lifetime requirements for the borrowed provider.
+            inner: Rc::new(RefCell::new(CacheDB::new(Db::new(unsafe {
+                BorrowedEvm2StateProviderDatabase::new(provider)
+            })))),
+        }
+    }
+
+    /// Applies accepted state changes into the local shared cache.
+    pub fn commit_source<S: StateChangeSource>(&self, source: &S) {
+        self.inner.borrow_mut().commit_source(source);
+    }
+
+    fn provider_error(
+        db: &mut CacheDB<Db<BorrowedEvm2StateProviderDatabase>>,
+        code: DbErrorCode,
+    ) -> ProviderError {
+        SharedEvm2StateProviderDatabase::provider_error(db, code)
+    }
+}
+
+impl core::fmt::Debug for LocalEvm2StateProviderDatabase {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LocalEvm2StateProviderDatabase").finish_non_exhaustive()
+    }
+}
+
+impl Database for LocalEvm2StateProviderDatabase {
+    type Error = ProviderError;
+
+    fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let mut db = self.inner.borrow_mut();
+        db.get_account(address).map_err(|code| Self::provider_error(&mut db, code))
+    }
+
+    fn get_code_by_hash(&mut self, code_hash: &B256) -> Result<Bytecode, Self::Error> {
+        let mut db = self.inner.borrow_mut();
+        db.get_code_by_hash(code_hash).map_err(|code| Self::provider_error(&mut db, code))
+    }
+
+    fn get_storage(&mut self, address: &Address, key: &Word) -> Result<Word, Self::Error> {
+        let mut db = self.inner.borrow_mut();
+        db.get_storage(address, key).map_err(|code| Self::provider_error(&mut db, code))
+    }
+
+    fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
+        let mut db = self.inner.borrow_mut();
         db.get_block_hash(number).map_err(|code| Self::provider_error(&mut db, code))
     }
 }


### PR DESCRIPTION
## Summary
- Adds `LocalEvm2StateProviderDatabase`, a single-threaded shared evm2 cache backed by `Rc<RefCell<_>>`.
- Uses it in `reth re-execute`, where each worker executes blocks synchronously and does not need `Arc<Mutex<_>>` around every DB lookup.

## Profile
- The suspected regression is the evm2 re-execute path using `SharedEvm2StateProviderDatabase`, which locks a mutex for every account, code, storage, and block-hash lookup.
- This PR removes that lock overhead only from the synchronous CLI replay path; cross-task users continue using the existing `SharedEvm2StateProviderDatabase`.

## Verification
- `cargo test -p reth-storage-api evm2 --lib`
- `cargo check -p reth-cli-commands`
- `git diff --check`

## Benchmark status
- I could not complete the requested last-1000-block samply comparison in this sandbox: no local reth datadir or captured block corpus is mounted, no raw mainnet RPC URL is exposed by the deployment tools, and `samply` is not installed on PATH.
- The evm2 CLI workflow identified for a full run is `evm2 capture --rpc <url> --range <start>-<end> --output <fixture.json>` followed by `samply record evm2 replay <fixture.json>`.

Prompted by: @DaniPopes