### PR TITLE
perf(engine): avoid receipt root task for empty blocks

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -52,7 +52,7 @@ use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
-use alloy_primitives::{map::B256Set, B256};
+use alloy_primitives::{map::B256Set, Bloom, B256};
 use reth_tasks::LazyHandle;
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
@@ -88,6 +88,7 @@ use reth_provider::{
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
 use reth_trie::{trie_cursor::TrieCursorFactory, updates::TrieUpdates, HashedPostState};
+use reth_trie_common::EMPTY_ROOT_HASH;
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::{Address, KECCAK_EMPTY};
@@ -118,7 +119,7 @@ const DEFERRED_TRIE_WORKER_NAME: &str = "deferred-trie";
 
 type ReceiptRootSender<N> =
     crossbeam_channel::Sender<IndexedReceipt<<N as NodePrimitives>::Receipt>>;
-type ReceiptRootReceiver = tokio::sync::oneshot::Receiver<(B256, alloy_primitives::Bloom)>;
+type ReceiptRootReceiver = tokio::sync::oneshot::Receiver<(B256, Bloom)>;
 
 /// Context providing access to tree state during validation.
 ///
@@ -1243,6 +1244,12 @@ where
         // Unbounded channel is used since tx count bounds capacity anyway.
         let (receipt_tx, receipt_rx) = crossbeam_channel::unbounded();
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        if receipts_len == 0 {
+            let _ = result_tx.send((EMPTY_ROOT_HASH, Bloom::ZERO));
+            return (receipt_tx, result_rx)
+        }
+
         let task_handle = ReceiptRootTaskHandle::new(receipt_rx, result_tx);
         self.payload_processor
             .executor()


### PR DESCRIPTION
## Summary

- Return the known empty receipts root and zero logs bloom without spawning the receipt-root task when a block has no transactions.
- Keep the existing receipt channel shape for the execution path while avoiding the per-empty-block blocking task dispatch.

## Testing

- rustfmt +nightly --check crates/engine/tree/src/tree/payload_validator.rs
- cargo +1.95.0 test -p reth-engine-tree receipt_root_task --lib
- cargo +1.95.0 test -p reth-engine-tree --lib