### PR TITLE
fix: track `SavedCache` usage via `ExecutionCache`

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -910,6 +910,11 @@ impl ExecutionCache {
         }))
     }
 
+    /// Returns the number of active handles to the shared cache.
+    fn usage_count(&self) -> usize {
+        Arc::strong_count(&self.0)
+    }
+
     /// Gets code from cache, or inserts using the provided function.
     pub fn get_or_try_insert_code_with<E>(
         &self,
@@ -1117,16 +1122,12 @@ pub struct SavedCache {
 
     /// The caches used for the provider.
     caches: ExecutionCache,
-
-    /// A guard to track in-flight usage of this cache.
-    /// The cache is considered available if the strong count is 1.
-    usage_guard: Arc<()>,
 }
 
 impl SavedCache {
     /// Creates a new instance with the internals
     pub fn new(hash: B256, caches: ExecutionCache) -> Self {
-        Self { hash, caches, usage_guard: Arc::new(()) }
+        Self { hash, caches }
     }
 
     /// Returns the hash for this cache
@@ -1136,12 +1137,12 @@ impl SavedCache {
 
     /// Returns true if the cache is available for use (no other tasks are currently using it).
     pub fn is_available(&self) -> bool {
-        Arc::strong_count(&self.usage_guard) == 1
+        self.caches.usage_count() == 1
     }
 
-    /// Returns the current strong count of the usage guard.
+    /// Returns the current number of active handles to the shared cache.
     pub fn usage_count(&self) -> usize {
-        Arc::strong_count(&self.usage_guard)
+        self.caches.usage_count()
     }
 
     /// Returns the [`ExecutionCache`] belonging to the tracked hash.
@@ -1166,9 +1167,9 @@ impl SavedCache {
 
 #[cfg(any(test, feature = "test-utils"))]
 impl SavedCache {
-    /// Clones the usage guard for testing availability tracking.
-    pub fn clone_guard_for_test(&self) -> Arc<()> {
-        self.usage_guard.clone()
+    /// Clones the cache handle that acts as the availability guard.
+    pub fn clone_guard_for_test(&self) -> ExecutionCache {
+        self.caches.clone()
     }
 }
 
@@ -1258,9 +1259,9 @@ mod tests {
 
         assert!(cache.is_available(), "Cache should be available initially");
 
-        let _guard = cache.clone_guard_for_test();
+        let _cache = cache.clone_guard_for_test();
 
-        assert!(!cache.is_available(), "Cache should not be available with active guard");
+        assert!(!cache.is_available(), "Cache should not be available with active handle");
     }
 
     #[test]
@@ -1268,19 +1269,19 @@ mod tests {
         let execution_cache = ExecutionCache::new(1000);
         let cache = SavedCache::new(B256::from([2u8; 32]), execution_cache);
 
-        let guard1 = cache.clone_guard_for_test();
-        let guard2 = cache.clone_guard_for_test();
-        let guard3 = guard1.clone();
+        let cache1 = cache.clone_guard_for_test();
+        let cache2 = cache.clone_guard_for_test();
+        let cache3 = cache1.clone();
 
         assert!(!cache.is_available());
 
-        drop(guard1);
+        drop(cache1);
         assert!(!cache.is_available());
 
-        drop(guard2);
+        drop(cache2);
         assert!(!cache.is_available());
 
-        drop(guard3);
+        drop(cache3);
         assert!(cache.is_available());
     }
 

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -1126,7 +1126,7 @@ pub struct SavedCache {
 
 impl SavedCache {
     /// Creates a new instance with the internals
-    pub fn new(hash: B256, caches: ExecutionCache) -> Self {
+    pub const fn new(hash: B256, caches: ExecutionCache) -> Self {
         Self { hash, caches }
     }
 

--- a/crates/engine/execution-cache/src/lib.rs
+++ b/crates/engine/execution-cache/src/lib.rs
@@ -193,6 +193,28 @@ mod tests {
     }
 
     #[test]
+    fn raw_cache_handle_blocks_checkout_until_drop() {
+        let cache = PayloadExecutionCache::default();
+        let hash = B256::from([3u8; 32]);
+
+        cache.update_with_guard(|slot| {
+            *slot = Some(SavedCache::new(hash, ExecutionCache::new(1_000)))
+        });
+
+        let checked_out = cache.get_cache_for(hash).expect("checkout should succeed");
+        let cache_handle = checked_out.cache().clone();
+        drop(checked_out);
+
+        let blocked = cache.get_cache_for(hash);
+        assert!(blocked.is_none(), "raw ExecutionCache handle should keep slot in use");
+
+        drop(cache_handle);
+
+        let available = cache.get_cache_for(hash);
+        assert!(available.is_some(), "checkout should succeed after raw handle is dropped");
+    }
+
+    #[test]
     fn hash_mismatch_clears_and_retags() {
         let cache = PayloadExecutionCache::default();
         let hash_a = B256::from([0xAA; 32]);

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -1246,7 +1246,7 @@ mod tests {
             .execution_cache
             .update_with_guard(|slot| *slot = Some(make_saved_cache(parent_hash)));
 
-        // Checking out the cache bumps its usage_guard refcount, marking the slot as in-use.
+        // Checking out the cache bumps its `ExecutionCache` refcount, marking the slot as in-use.
         // The returned SavedCache shares the same underlying ExecutionCache Arc as the slot,
         // so any writes through the slot are observable here
         let checked_out = payload_processor
@@ -1437,7 +1437,7 @@ mod tests {
     /// 2. Fork block (parent = block 2) checks out the cache via `get_cache_for`, simulating what
     ///    `PrewarmCacheTask` does when it receives a `SavedCache`.
     /// 3. Prewarm populates the shared cache with fork-specific state.
-    /// 4. While the prewarm clone is alive, the cache is unavailable (`usage_guard` > 1).
+    /// 4. While the prewarm clone is alive, the cache is unavailable (`usage_count` > 1).
     /// 5. Prewarm drops without calling `save_cache` (fork block was invalid).
     /// 6. Canonical block 5 (parent = block 4) must get a cache with correct hash and no stale fork
     ///    data.
@@ -1463,7 +1463,7 @@ mod tests {
         let fork_key = B256::from([0xCC; 32]);
         prewarm_cache.cache().insert_storage(fork_addr, fork_key, Some(U256::from(999)));
 
-        // While prewarm holds the clone, the usage_guard count > 1 → cache is in use.
+        // While prewarm holds the clone, the cache handle count > 1 so the cache is in use.
         let during_prewarm = execution_cache.get_cache_for(block4_hash);
         assert!(
             during_prewarm.is_none(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -265,7 +265,7 @@ where
     ///
     /// Saves the warmed caches back into the shared slot after prewarming completes.
     ///
-    /// This consumes the `SavedCache` held by the task, which releases its usage guard and allows
+    /// This consumes the `SavedCache` held by the task, which releases its cache handle and allows
     /// the new, warmed cache to be inserted.
     ///
     /// This method is called from `run()` only after all execution tasks are complete.
@@ -287,8 +287,8 @@ where
         if let Some(saved_cache) = saved_cache {
             debug!(target: "engine::caching", parent_hash=?hash, "Updating execution cache");
             execution_cache.update_with_guard(|cached| {
-                // consumes the `SavedCache` held by the prewarming task, which releases its usage
-                // guard
+                // consumes the `SavedCache` held by the prewarming task, which releases its cache
+                // handle
                 let caches = saved_cache.cache().clone();
                 let new_cache = SavedCache::new(hash, caches);
 


### PR DESCRIPTION
Replaces `SavedCache::usage_guard` with just tracking refcount of `ExecutionCache` Arc so that we don't consider cache available when raw clones of `ExecutionCache` exist