### PR TITLE
chore: add rkrasiuk bench Slack mapping

### DIFF
--- a/.github/scripts/bench-slack-users.json
+++ b/.github/scripts/bench-slack-users.json
@@ -21,5 +21,6 @@
   "kamsz": "U0A2563UBRD",
   "zerosnacks": "U09FARPMN74",
   "samczsun": "U096R14E4H3",
-  "laibe": "U09FARE0B9Q"
+  "laibe": "U09FARE0B9Q",
+  "rkrasiuk": "U0BAWJ7RLUE"
 }


### PR DESCRIPTION
Adds rkrasiuk to the benchmark Slack user mapping.

Prompted by: @shekhirin