### PR TITLE
ci: Add max RSS to bench reports

### DIFF
--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -85,6 +85,15 @@ def parse_combined_csv(path: str) -> list[dict]:
     return rows
 
 
+def parse_run_metadata(csv_path: str) -> dict:
+    """Read optional metadata emitted next to a run CSV."""
+    metadata_path = Path(csv_path).with_name("run-metadata.json")
+    if not metadata_path.is_file():
+        return {}
+    with open(metadata_path) as f:
+        return json.load(f)
+
+
 def stddev(values: list[float], mean: float) -> float:
     if len(values) < 2:
         return 0.0
@@ -284,6 +293,16 @@ def compute_point_stats(runs: list[list[dict]]) -> dict:
     for key in ("p50_ms", "p90_ms", "p99_ms"):
         stats[key] = _mean([run_stats[key] for run_stats in per_run_stats])
     return stats
+
+
+def add_memory_stats(stats: dict, metadata: list[dict]) -> None:
+    max_rss_values = [
+        item["max_rss_bytes"]
+        for item in metadata
+        if isinstance(item.get("max_rss_bytes"), int)
+    ]
+    if max_rss_values:
+        stats["max_rss_bytes"] = max(max_rss_values)
 
 
 def compute_wait_stats(combined: list[dict], field: str) -> dict:
@@ -517,6 +536,18 @@ def fmt_mgas(v: float) -> str:
 
 def fmt_s(v: float) -> str:
     return f"{v:.2f}s"
+
+
+def fmt_bytes(v: float) -> str:
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    value = float(v)
+    for unit in units:
+        if abs(value) < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{value:.0f}{unit}"
+            return f"{value:.2f}{unit}"
+        value /= 1024
+    return f"{value:.2f}TiB"
 
 
 def fmt_metric_value(v: float) -> str:
@@ -1712,9 +1743,16 @@ def generate_comparison_table(
         f"| P99 | {fmt_ms(run1['p99_ms'])} | {fmt_ms(run2['p99_ms'])} | {change_str(p99_pct, p99_ci_pct, p99_floor, lower_is_better=True, informational=p99_informational)} |",
         f"| Mgas/s | {fmt_mgas(run1['mean_mgas_s'])} | {fmt_mgas(run2['mean_mgas_s'])} | {change_str(gas_pct, mgas_ci_pct, mgas_floor, lower_is_better=False)} |",
         f"| Wall Clock | {fmt_s(run1['wall_clock_s'])} | {fmt_s(run2['wall_clock_s'])} | {change_str(wall_pct, wall_ci_pct, wall_floor, lower_is_better=True)} |",
+    ]
+    if run1.get("max_rss_bytes") is not None and run2.get("max_rss_bytes") is not None:
+        rss_pct = pct(run1["max_rss_bytes"], run2["max_rss_bytes"])
+        lines.append(
+            f"| Max RSS | {fmt_bytes(run1['max_rss_bytes'])} | {fmt_bytes(run2['max_rss_bytes'])} | {rss_pct:+.2f}% |"
+        )
+    lines.extend([
         f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, persist_floor, lower_is_better=True, informational=persist_informational)} |",
         "",
-    ]
+    ])
     meta_parts = [f"{n} {'big blocks' if big_blocks else 'blocks'}"]
     if warmup_blocks:
         meta_parts.append(f"{warmup_blocks} warmup")
@@ -1991,24 +2029,30 @@ def main():
 
     baseline_runs = []
     feature_runs = []
+    baseline_metadata = []
+    feature_metadata = []
     for path in args.baseline_csv:
         data = parse_combined_csv(path)
         if not data:
             print(f"No results in {path}", file=sys.stderr)
             sys.exit(1)
         baseline_runs.append(data)
+        baseline_metadata.append(parse_run_metadata(path))
     for path in args.feature_csv:
         data = parse_combined_csv(path)
         if not data:
             print(f"No results in {path}", file=sys.stderr)
             sys.exit(1)
         feature_runs.append(data)
+        feature_metadata.append(parse_run_metadata(path))
 
     all_baseline = [r for run in baseline_runs for r in run]
     all_feature = [r for run in feature_runs for r in run]
 
     baseline_stats = compute_point_stats(baseline_runs)
     feature_stats = compute_point_stats(feature_runs)
+    add_memory_stats(baseline_stats, baseline_metadata)
+    add_memory_stats(feature_stats, feature_metadata)
     ci_stats = compute_ci_stats(baseline_runs, feature_runs)
 
     if not ci_stats:

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -52,6 +52,7 @@ DATADIR="$SCHELK_MOUNT/$DATADIR_NAME"
 mkdir -p "$OUTPUT_DIR"
 LOG="${OUTPUT_DIR}/node.log"
 TARGET_METRICS_RANGE="$OUTPUT_DIR/target-metrics-range.json"
+RUN_METADATA="$OUTPUT_DIR/run-metadata.json"
 
 RETH_SCOPE="${RETH_SCOPE:-reth-bench.scope}"
 BENCH_TARGET_METRICS_SCRAPE_INTERVAL_MS="${BENCH_TARGET_METRICS_SCRAPE_INTERVAL_MS:-}"
@@ -87,6 +88,28 @@ with open(output_path, "w") as f:
         f,
         indent=2,
     )
+    f.write("\n")
+PY
+}
+
+record_run_metadata() {
+  local max_rss_bytes=""
+  max_rss_bytes="$(systemctl show "$RETH_SCOPE" -p MemoryPeak --value 2>/dev/null || true)"
+  if ! [[ "$max_rss_bytes" =~ ^[0-9]+$ ]] || [ "$max_rss_bytes" -le 0 ]; then
+    max_rss_bytes=""
+  fi
+
+  python3 - "$RUN_METADATA" "$max_rss_bytes" <<'PY'
+import json
+import sys
+
+output_path, max_rss_bytes = sys.argv[1:3]
+metadata = {}
+if max_rss_bytes:
+    metadata["max_rss_bytes"] = int(max_rss_bytes)
+
+with open(output_path, "w") as f:
+    json.dump(metadata, f, indent=2)
     f.write("\n")
 PY
 }
@@ -582,6 +605,8 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   -m "bal-mode=${BENCH_BAL:-false}" \
   -m "bal-enabled=$USE_BAL" \
   "${PROMETHEUS_METADATA[@]}" 2>&1 | sed -u "s/^/[bench] /"
+
+record_run_metadata
 
 if [ -n "$TARGET_METRICS_START_MS" ]; then
   TARGET_METRICS_END_MS="$(capture_unix_time_ms)"

--- a/.github/scripts/bench-utils.js
+++ b/.github/scripts/bench-utils.js
@@ -10,6 +10,21 @@ const SIG_EMOJI = { good: '✅', bad: '❌', neutral: '⚪' };
 function fmtMs(v) { return v.toFixed(2) + 'ms'; }
 function fmtMgas(v) { return v.toFixed(2); }
 function fmtS(v) { return v.toFixed(2) + 's'; }
+function fmtBytes(v) {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = Number(v || 0);
+  for (const unit of units) {
+    if (Math.abs(value) < 1024 || unit === units[units.length - 1]) {
+      return unit === 'B' ? value.toFixed(0) + unit : value.toFixed(2) + unit;
+    }
+    value /= 1024;
+  }
+  return value.toFixed(2) + 'TiB';
+}
+
+function pctChange(base, feature) {
+  return base > 0 ? (feature - base) / base * 100 : 0;
+}
 
 function fmtChange(ch) {
   if (!ch || (!ch.pct && !ch.ci_pct)) return '';
@@ -116,6 +131,12 @@ function metricRows(summary) {
     { label: 'P99',        baseline: fmtMs(b.p99_ms),        feature: fmtMs(f.p99_ms),        change: fmtChange(c.p99) },
     { label: 'Mgas/s',     baseline: fmtMgas(b.mean_mgas_s), feature: fmtMgas(f.mean_mgas_s), change: fmtChange(c.mgas_s) },
     { label: 'Wall Clock', baseline: fmtS(b.wall_clock_s),   feature: fmtS(f.wall_clock_s),   change: fmtChange(c.wall_clock) },
+    ...(b.max_rss_bytes != null && f.max_rss_bytes != null ? [{
+      label: 'Max RSS',
+      baseline: fmtBytes(b.max_rss_bytes),
+      feature: fmtBytes(f.max_rss_bytes),
+      change: `${pctChange(b.max_rss_bytes, f.max_rss_bytes) >= 0 ? '+' : ''}${pctChange(b.max_rss_bytes, f.max_rss_bytes).toFixed(2)}%`,
+    }] : []),
     { label: 'Persist Wait', baseline: fmtMs(b.mean_persist_ms || 0), feature: fmtMs(f.mean_persist_ms || 0), change: fmtChange(c.persist_wait) },
   ];
 }


### PR DESCRIPTION
## Summary
- record systemd MemoryPeak for each txgen benchmark run
- include Max RSS in benchmark markdown, job summary, and Slack metric rows when available

## Testing
- uv run python -m py_compile .github/scripts/bench-reth-summary.py
- bash -n .github/scripts/bench-txgen-run.sh
- node -c .github/scripts/bench-utils.js
- synthetic bench-reth-summary.py run verifying Max RSS in summary.json and comment.md

Prompted by: @pepyakin