### PR TITLE
perf(provider): share database provider metrics

### DIFF
--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -48,7 +48,7 @@ pub(crate) enum Action {
 /// Database provider metrics
 #[derive(Metrics)]
 #[metrics(scope = "storage.providers.database")]
-pub(crate) struct DatabaseProviderMetrics {
+pub struct DatabaseProviderMetrics {
     /// Duration of insert block
     insert_block: Histogram,
     /// Duration of insert state

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -58,6 +58,7 @@ mod builder;
 pub use builder::{ProviderFactoryBuilder, ReadOnlyConfig};
 
 mod metrics;
+pub use metrics::DatabaseProviderMetrics;
 
 mod chain;
 pub use chain::*;
@@ -96,6 +97,8 @@ pub struct ProviderFactory<N: NodeTypesWithDB> {
     runtime: reth_tasks::Runtime,
     /// Minimum distance from tip required before pruning can occur.
     minimum_pruning_distance: u64,
+    /// Database provider metrics shared by providers created from this factory.
+    database_provider_metrics: Arc<DatabaseProviderMetrics>,
     /// State for on-demand syncing of `RocksDB` secondary and static file indexes.
     ///
     /// Only set for read-only factories. Can be disabled if there is no concurrent read-write
@@ -130,6 +133,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
         //
         // Both factory and all providers it creates should share these cached settings.
         let legacy_settings = StorageSettings::v1();
+        let database_provider_metrics = Arc::new(DatabaseProviderMetrics::default());
         let storage_settings = DatabaseProvider::<_, N>::new(
             db.tx()?,
             chain_spec.clone(),
@@ -141,6 +145,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             ChangesetCache::new(),
             runtime.clone(),
             db.path(),
+            database_provider_metrics.clone(),
         )
         .storage_settings()?
         .unwrap_or(legacy_settings);
@@ -157,6 +162,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             bal_store: BalStoreHandle::new(InMemoryBalStore::default()),
             runtime,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
+            database_provider_metrics,
             read_only_sync: None,
         })
     }
@@ -390,6 +396,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             self.changeset_cache.clone(),
             self.runtime.clone(),
             self.db.path(),
+            self.database_provider_metrics.clone(),
         )
         .with_minimum_pruning_distance(self.minimum_pruning_distance))
     }
@@ -412,6 +419,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
                 self.changeset_cache.clone(),
                 self.runtime.clone(),
                 self.db.path(),
+                self.database_provider_metrics.clone(),
             )
             .with_reader_txn_tracker(self.db.clone())
             .with_minimum_pruning_distance(self.minimum_pruning_distance),
@@ -439,6 +447,7 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
             self.changeset_cache.clone(),
             self.runtime.clone(),
             self.db.path(),
+            self.database_provider_metrics.clone(),
         )
         .with_reader_txn_tracker(self.db.clone())
         .with_minimum_pruning_distance(self.minimum_pruning_distance))
@@ -973,6 +982,7 @@ where
             bal_store,
             runtime,
             minimum_pruning_distance,
+            database_provider_metrics: _,
             read_only_sync,
         } = self;
         f.debug_struct("ProviderFactory")
@@ -1009,6 +1019,7 @@ impl<N: NodeTypesWithDB> Clone for ProviderFactory<N> {
             bal_store: self.bal_store.clone(),
             runtime: self.runtime.clone(),
             minimum_pruning_distance: self.minimum_pruning_distance,
+            database_provider_metrics: self.database_provider_metrics.clone(),
             read_only_sync: self.read_only_sync.clone(),
         }
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1,7 +1,7 @@
 use crate::{
     changesets_utils::StorageRevertsIter,
     providers::{
-        database::{chain::ChainStorage, metrics},
+        database::{chain::ChainStorage, metrics, DatabaseProviderMetrics},
         rocksdb::{PendingRocksDBBatches, RocksDBProvider, RocksDBWriteCtx},
         static_file::{StaticFileWriteCtx, StaticFileWriter},
         NodeTypesForProvider, StaticFileProvider,
@@ -212,7 +212,7 @@ pub struct DatabaseProvider<TX, N: NodeTypes> {
     /// Minimum distance from tip required for pruning
     minimum_pruning_distance: u64,
     /// Database provider metrics
-    metrics: metrics::DatabaseProviderMetrics,
+    metrics: Arc<DatabaseProviderMetrics>,
     /// Database handle used to inspect active MDBX readers during unwind commits.
     reader_txn_tracker: Option<Arc<dyn ReaderTxnTracker>>,
 }
@@ -417,6 +417,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
         runtime: reth_tasks::Runtime,
         db_path: PathBuf,
         commit_order: CommitOrder,
+        metrics: Arc<DatabaseProviderMetrics>,
     ) -> Self {
         Self {
             tx,
@@ -432,7 +433,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
             pending_rocksdb_batches: Default::default(),
             commit_order,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
-            metrics: metrics::DatabaseProviderMetrics::default(),
+            metrics,
             reader_txn_tracker: None,
         }
     }
@@ -450,6 +451,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
         changeset_cache: ChangesetCache,
         runtime: reth_tasks::Runtime,
         db_path: PathBuf,
+        metrics: Arc<DatabaseProviderMetrics>,
     ) -> Self {
         Self::new_rw_inner(
             tx,
@@ -463,6 +465,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
             runtime,
             db_path,
             CommitOrder::Normal,
+            metrics,
         )
     }
 
@@ -479,6 +482,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
         changeset_cache: ChangesetCache,
         runtime: reth_tasks::Runtime,
         db_path: PathBuf,
+        metrics: Arc<DatabaseProviderMetrics>,
     ) -> Self {
         Self::new_rw_inner(
             tx,
@@ -492,6 +496,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
             runtime,
             db_path,
             CommitOrder::Unwind,
+            metrics,
         )
     }
 }
@@ -1044,6 +1049,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         changeset_cache: ChangesetCache,
         runtime: reth_tasks::Runtime,
         db_path: PathBuf,
+        metrics: Arc<DatabaseProviderMetrics>,
     ) -> Self {
         Self {
             tx,
@@ -1059,7 +1065,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             pending_rocksdb_batches: Default::default(),
             commit_order: CommitOrder::Normal,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
-            metrics: metrics::DatabaseProviderMetrics::default(),
+            metrics,
             reader_txn_tracker: None,
         }
     }


### PR DESCRIPTION
Shares `DatabaseProviderMetrics` from `ProviderFactory` and passes an `Arc` into each read-only/read-write provider it creates.

This avoids reconstructing and dropping the full metric handle set for every short-lived provider while preserving the public constructor behavior.

Profile motivating the change:

![DatabaseProvider drop profile graph](https://raw.githubusercontent.com/mattsse/reth/7875e0c0ec827806d01471d255e482066658fdc4/.github/assets/pr-25481/database-provider-drop-graph.png)