### PR TITLE
perf(engine): use unbounded tx iterator channels

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -427,8 +427,8 @@ where
         transaction_count: usize,
         parallel_bal_execution: bool,
     ) -> (IteratorPrewarmTxReceiver<Evm, I>, IteratorExecuteTxReceiver<Evm, I>) {
-        let (prewarm_tx, prewarm_rx) = mpsc::sync_channel(transaction_count);
-        let (execute_tx, execute_rx) = crossbeam_channel::bounded(transaction_count);
+        let (prewarm_tx, prewarm_rx) = mpsc::channel();
+        let (execute_tx, execute_rx) = crossbeam_channel::unbounded();
 
         if transaction_count == 0 {
             // Empty block — nothing to do.
@@ -781,7 +781,7 @@ where
 fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
     iter: impl Iterator<Item = RawTx>,
     convert: &C,
-    prewarm_tx: &mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>,
+    prewarm_tx: &mpsc::Sender<(usize, WithTxEnv<TxEnv, Recovered>)>,
     execute_tx: &ExecuteTxSender<TxEnv, Recovered, Err>,
 ) where
     Tx: ExecutableTxParts<TxEnv, InnerTx, Recovered = Recovered>,


### PR DESCRIPTION
previously changed to bounded #22205.

Switches the tx iterator prewarm and execute channels back to unbounded variants.

This avoids allocating and initializing `transaction_count` slots during payload processor startup while preserving the same producer/consumer flow.

<img width="1315" height="523" alt="image" src="https://github.com/user-attachments/assets/73197660-8b17-41bf-82d5-4c7911915a86" />


https://profiler.firefox.com/public/k8bynpnpmjns4t1was72jmn1c3zx043c7xv6cz0/flame-graph/?globalTrackOrder=201&thread=Bf&transforms=ff-15382~ff-20053&v=16