### PR TITLE
fix(trie): avoid sparse arena HashSet warning

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -10,11 +10,7 @@ use nodes::{
 
 use crate::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdates};
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
-use alloy_primitives::{
-    keccak256,
-    map::{B256Map, HashSet},
-    B256,
-};
+use alloy_primitives::{keccak256, map::B256Map, B256};
 use alloy_trie::TrieMask;
 use core::{cmp::Reverse, mem};
 use reth_execution_errors::SparseTrieResult;
@@ -2138,7 +2134,11 @@ impl ArenaParallelSparseTrie {
     }
 
     #[cfg(debug_assertions)]
-    fn collect_reachable_nodes(arena: &NodeArena, idx: Index, reachable: &mut HashSet<Index>) {
+    fn collect_reachable_nodes(
+        arena: &NodeArena,
+        idx: Index,
+        reachable: &mut alloy_primitives::map::HashSet<Index>,
+    ) {
         if !reachable.insert(idx) {
             return;
         }
@@ -2153,9 +2153,10 @@ impl ArenaParallelSparseTrie {
 
     #[cfg(debug_assertions)]
     fn assert_no_orphaned_nodes(arena: &NodeArena, root: Index, label: &str) {
-        let mut reachable = HashSet::default();
+        let mut reachable = alloy_primitives::map::HashSet::default();
         Self::collect_reachable_nodes(arena, root, &mut reachable);
-        let all_indices: HashSet<Index> = arena.iter().map(|(idx, _)| idx).collect();
+        let all_indices: alloy_primitives::map::HashSet<Index> =
+            arena.iter().map(|(idx, _)| idx).collect();
         let orphaned: Vec<_> = all_indices.difference(&reachable).collect();
         debug_assert!(
             orphaned.is_empty(),


### PR DESCRIPTION
Fixes the unused import warning seen in https://github.com/paradigmxyz/reth/actions/runs/27894689788/job/82544358748 by gating the `HashSet` import with `debug_assertions`.

The type is only used by debug assertion helpers, so release-style benchmark builds no longer import it.