### PR TITLE
feat(cli): explicitly reject `.era` export

### DIFF
--- a/crates/cli/commands/src/export_era.rs
+++ b/crates/cli/commands/src/export_era.rs
@@ -42,24 +42,40 @@ pub struct ExportArgs {
     path: Option<PathBuf>,
 }
 
-/// Execution-layer ERA formats that can be produced from the database.
+/// ERA formats accepted by `--file-type`.
 ///
-/// Consensus-layer `.era` files cannot be exported, so they are not representable here.
+/// Only `era1`/`ere` are exportable; `era` is listed but rejected at runtime.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum ExportFileType {
     /// Execution blocks written in the `.era1` format.
     Era1,
     /// Execution blocks written in the `.ere` format.
     Ere,
+    /// Consensus-layer `.era` format. Not exportable from an execution client; selecting it is an
+    /// error.
+    Era,
 }
 
 impl ExportFileType {
-    /// The format name (`era1` / `ere`), used for log lines and the default directory name.
+    /// The format name (`era1` / `ere` / `era`), used for log lines and the default directory name.
     const fn format(&self) -> &'static str {
         match self {
             Self::Era1 => "era1",
             Self::Ere => "ere",
+            Self::Era => "era",
         }
+    }
+
+    /// Rejects consensus-layer `.era`, which can't be produced from the execution database.
+    fn ensure_exportable(self) -> eyre::Result<()> {
+        if matches!(self, Self::Era) {
+            eyre::bail!(
+                "Consensus-layer ERA (.era) files cannot be exported: they require beacon blocks \
+                 and state that the execution database does not store. Export `era1` or `ere` \
+                 instead."
+            );
+        }
+        Ok(())
     }
 }
 
@@ -72,6 +88,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraC
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
 
         let file_type = self.export.file_type;
+        file_type.ensure_exportable()?;
         let format = file_type.format();
 
         // Either the specified path or default to `<data-dir>/<chain>/<format>-export/`.
@@ -115,6 +132,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraC
         let exported_files = match file_type {
             ExportFileType::Era1 => era::export::<era::Era1, _>(&provider, &export_config)?,
             ExportFileType::Ere => era::export::<era::Ere, _>(&provider, &export_config)?,
+            // Guarded above by `ensure_exportable`.
+            ExportFileType::Era => unreachable!("`.era` export is rejected before this point"),
         };
 
         info!(

--- a/crates/cli/commands/src/export_era.rs
+++ b/crates/cli/commands/src/export_era.rs
@@ -69,14 +69,19 @@ impl ExportFileType {
     /// Rejects consensus-layer `.era`, which can't be produced from the execution database.
     fn ensure_exportable(self) -> eyre::Result<()> {
         if matches!(self, Self::Era) {
-            eyre::bail!(
-                "Consensus-layer ERA (.era) files cannot be exported: they require beacon blocks \
-                 and state that the execution database does not store. Export `era1` or `ere` \
-                 instead."
-            );
+            return Err(era_not_exportable());
         }
         Ok(())
     }
+}
+
+/// Error returned when a consensus-layer `.era` export is requested. Such files require beacon
+/// blocks and state that the execution database does not store.
+fn era_not_exportable() -> eyre::Report {
+    eyre::eyre!(
+        "Consensus-layer ERA (.era) files cannot be exported: they require beacon blocks and \
+         state that the execution database does not store. Export `era1` or `ere` instead."
+    )
 }
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraCommand<C> {
@@ -85,11 +90,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraC
     where
         N: CliNodeTypes<ChainSpec = C::ChainSpec>,
     {
-        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
-
         let file_type = self.export.file_type;
         file_type.ensure_exportable()?;
         let format = file_type.format();
+
+        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO, runtime)?;
 
         // Either the specified path or default to `<data-dir>/<chain>/<format>-export/`.
         let data_dir = match &self.export.path {
@@ -132,8 +137,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> ExportEraC
         let exported_files = match file_type {
             ExportFileType::Era1 => era::export::<era::Era1, _>(&provider, &export_config)?,
             ExportFileType::Ere => era::export::<era::Ere, _>(&provider, &export_config)?,
-            // Guarded above by `ensure_exportable`.
-            ExportFileType::Era => unreachable!("`.era` export is rejected before this point"),
+            // Rejected above by `ensure_exportable`.
+            ExportFileType::Era => return Err(era_not_exportable()),
         };
 
         info!(

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -137,6 +137,7 @@ Storage:
           Possible values:
           - era1: Execution blocks written in the `.era1` format
           - ere:  Execution blocks written in the `.ere` format
+          - era:  Consensus-layer `.era` format. Not exportable from an execution client; selecting it is an error
 
           [default: era1]
 


### PR DESCRIPTION
`export-era` can't produce consensus-layer `.era` files from the execution DB. Surface `era` as a `--file-type` value and reject it before env init with a clear error, instead of failing later on unrelated datadir/db errors.