### PR TITLE
feat(era): decode execution block from consensus .era blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8486,6 +8486,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-beacon",
+ "alloy-rpc-types-engine",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "eyre",

--- a/crates/era/Cargo.toml
+++ b/crates/era/Cargo.toml
@@ -17,6 +17,8 @@ alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp = { workspace = true, features = ["derive"] }
+alloy-rpc-types-beacon = { workspace = true, features = ["ssz"] }
+alloy-rpc-types-engine = { workspace = true, features = ["ssz"] }
 
 # compression and decompression
 snap.workspace = true

--- a/crates/era/src/e2s/error.rs
+++ b/crates/era/src/e2s/error.rs
@@ -29,4 +29,8 @@ pub enum E2sError {
     /// Error during RLP encoding/decoding
     #[error("RLP error: {0}")]
     Rlp(String),
+
+    /// Error converting an execution payload into a block
+    #[error("execution payload error: {0}")]
+    ExecutionPayload(#[from] alloy_rpc_types_engine::PayloadError),
 }

--- a/crates/era/src/era/types/consensus.rs
+++ b/crates/era/src/era/types/consensus.rs
@@ -2,65 +2,44 @@
 //!
 //! # Decoding
 //!
-//! This crate only handles compression/decompression.
-//! To decode the SSZ data into concrete beacon types, use the [Lighthouse `types`](https://github.com/sigp/lighthouse/tree/stable/consensus/types)
-//! crate or another SSZ-compatible library.
+//! This crate handles compression/decompression and, for post-merge blocks, extraction of the
+//! embedded execution block via [`CompressedSignedBeaconBlock::decode_execution_block`]. The
+//! decompressed bytes are SSZ-encoded consensus types decoded with [`alloy_rpc_types_beacon`]'s
+//! fork-specific beacon block types — no external consensus client is required.
 //!
-//! # Examples
+//! [`alloy_rpc_types_beacon`]: https://docs.rs/alloy-rpc-types-beacon
 //!
-//! ## Decoding a [`CompressedBeaconState`]
+//! # Example
 //!
-//! ```ignore
-//! use types::{BeaconState, ChainSpec, MainnetEthSpec};
-//! use reth_era::era::types::consensus::CompressedBeaconState;
+//! ## Decoding the execution block from a [`CompressedSignedBeaconBlock`]
 //!
-//! fn decode_state(
-//!     compressed_state: &CompressedBeaconState,
-//! ) -> Result<(), Box<dyn std::error::Error>> {
-//!     let spec = ChainSpec::mainnet();
-//!
-//!     // Decompress to get SSZ bytes
-//!     let ssz_bytes = compressed_state.decompress()?;
-//!
-//!     // Decode with fork-aware method, chainSpec determines fork from slot in SSZ
-//!     let state = BeaconState::<MainnetEthSpec>::from_ssz_bytes(&ssz_bytes, &spec)
-//!         .map_err(|e| format!("{:?}", e))?;
-//!
-//!     println!("State slot: {}", state.slot());
-//!     println!("Fork: {:?}", state.fork_name_unchecked());
-//!     println!("Validators: {}", state.validators().len());
-//!     println!("Finalized checkpoint: {:?}", state.finalized_checkpoint());
-//!     Ok(())
-//! }
-//! ```
-//!
-//! ## Decoding a [`CompressedSignedBeaconBlock`]
-//!
-//! ```ignore
-//! use consensus_types::{ForkName, ForkVersionDecode, MainnetEthSpec, SignedBeaconBlock};
+//! ```no_run
 //! use reth_era::era::types::consensus::CompressedSignedBeaconBlock;
+//! use reth_ethereum_primitives::TransactionSigned;
 //!
-//! // Decode using fork-aware decoding, fork must be known beforehand
 //! fn decode_block(
 //!     compressed: &CompressedSignedBeaconBlock,
-//!     fork: ForkName,
 //! ) -> Result<(), Box<dyn std::error::Error>> {
-//!     // Decompress to get SSZ bytes
-//!     let ssz_bytes = compressed.decompress()?;
-//!
-//!     let block = SignedBeaconBlock::<MainnetEthSpec>::from_ssz_bytes_by_fork(&ssz_bytes, fork)
-//!         .map_err(|e| format!("{:?}", e))?;
-//!
-//!     println!("Block slot: {}", block.message().slot());
-//!     println!("Proposer index: {}", block.message().proposer_index());
-//!     println!("Parent root: {:?}", block.message().parent_root());
-//!     println!("State root: {:?}", block.message().state_root());
-//!
+//!     // Post-merge blocks carry an execution payload; pre-merge slots yield `None`.
+//!     if let Some(block) = compressed.decode_execution_block::<TransactionSigned>()? {
+//!         println!("Execution block number: {}", block.header.number);
+//!     }
 //!     Ok(())
 //! }
 //! ```
 use crate::e2s::{error::E2sError, types::Entry};
+use alloy_consensus::Block;
+use alloy_eips::eip2718::Decodable2718;
+use alloy_rpc_types_beacon::block::{
+    SignedBeaconBlockAltair, SignedBeaconBlockBellatrix, SignedBeaconBlockCapella,
+    SignedBeaconBlockDeneb, SignedBeaconBlockElectra, SignedBeaconBlockPhase0,
+};
+use alloy_rpc_types_engine::{
+    CancunPayloadFields, ExecutionPayload, ExecutionPayloadSidecar, ExecutionPayloadV1,
+    ExecutionPayloadV2, ExecutionPayloadV3, PraguePayloadFields,
+};
 use snap::{read::FrameDecoder, write::FrameEncoder};
+use ssz::Decode;
 use std::io::{Read, Write};
 
 /// Maximum allowed decompressed size for a signed beacon block SSZ payload.
@@ -134,6 +113,60 @@ impl CompressedSignedBeaconBlock {
             MAX_DECOMPRESSED_SIGNED_BEACON_BLOCK_BYTES,
             "signed beacon block",
         )
+    }
+
+    /// Decodes the execution block embedded in this beacon block, if it has one.
+    ///
+    /// Only post-merge (Bellatrix and later) blocks carry a payload; the fork is found by
+    /// trial-decoding newest to oldest. Returns `Ok(None)` for genuine pre-merge slots, confirmed
+    /// to decode as a pre-merge block. Bytes matching no known fork are an error, so malformed data
+    /// is never silently dropped.
+    pub fn decode_execution_block<T: Decodable2718>(&self) -> Result<Option<Block<T>>, E2sError> {
+        let ssz = self.decompress()?;
+
+        if let Ok(beacon) = SignedBeaconBlockElectra::<ExecutionPayloadV3>::from_ssz_bytes(&ssz) {
+            let sidecar = ExecutionPayloadSidecar::v4(
+                CancunPayloadFields {
+                    parent_beacon_block_root: beacon.message.parent_root,
+                    versioned_hashes: Vec::new(),
+                },
+                PraguePayloadFields::new(beacon.message.body.execution_requests.to_requests()),
+            );
+            let payload = ExecutionPayload::V3(beacon.message.body.execution_payload);
+            return Ok(Some(payload.try_into_block_with_sidecar(&sidecar)?));
+        }
+
+        if let Ok(beacon) = SignedBeaconBlockDeneb::<ExecutionPayloadV3>::from_ssz_bytes(&ssz) {
+            let sidecar = ExecutionPayloadSidecar::v3(CancunPayloadFields {
+                parent_beacon_block_root: beacon.message.parent_root,
+                versioned_hashes: Vec::new(),
+            });
+            let payload = ExecutionPayload::V3(beacon.message.body.execution_payload);
+            return Ok(Some(payload.try_into_block_with_sidecar(&sidecar)?));
+        }
+
+        if let Ok(beacon) = SignedBeaconBlockCapella::<ExecutionPayloadV2>::from_ssz_bytes(&ssz) {
+            let payload = ExecutionPayload::V2(beacon.message.body.execution_payload);
+            return Ok(Some(payload.try_into_block()?));
+        }
+
+        if let Ok(beacon) = SignedBeaconBlockBellatrix::<ExecutionPayloadV1>::from_ssz_bytes(&ssz) {
+            let payload = ExecutionPayload::V1(beacon.message.body.execution_payload);
+            return Ok(Some(payload.try_into_block()?));
+        }
+
+        // Pre-merge blocks carry no execution payload. Only skip a slot once it's confirmed to be a
+        // valid pre-merge block; anything else is malformed data and must error rather than skip.
+        if SignedBeaconBlockPhase0::from_ssz_bytes(&ssz).is_ok() ||
+            SignedBeaconBlockAltair::from_ssz_bytes(&ssz).is_ok()
+        {
+            return Ok(None);
+        }
+
+        Err(E2sError::Ssz(format!(
+            "consensus block ({} bytes) is not a valid SignedBeaconBlock of any known fork",
+            ssz.len()
+        )))
     }
 
     /// Convert to an [`Entry`]
@@ -222,6 +255,13 @@ impl CompressedBeaconState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::B256;
+    use alloy_rpc_types_beacon::{
+        block::{BeaconBlock, BeaconBlockBodyPhase0, Eth1Data, SignedBeaconBlock},
+        BlsSignature,
+    };
+    use reth_ethereum_primitives::TransactionSigned;
+    use ssz::Encode;
 
     #[test]
     fn test_signed_beacon_block_compression_roundtrip() {
@@ -291,5 +331,45 @@ mod tests {
             decompress_snappy_bounded(compressed.data.as_slice(), 100, "beacon state").unwrap_err();
 
         assert!(format!("{err:?}").contains("exceeded limit"));
+    }
+
+    #[test]
+    fn decode_execution_block_skips_genuine_pre_merge() {
+        // A genuine pre-merge (phase0) beacon block carries no execution payload and yields `None`.
+        let block = SignedBeaconBlock {
+            message: BeaconBlock {
+                slot: 0,
+                proposer_index: 0,
+                parent_root: B256::ZERO,
+                state_root: B256::ZERO,
+                body: BeaconBlockBodyPhase0 {
+                    randao_reveal: BlsSignature::ZERO,
+                    eth1_data: Eth1Data {
+                        deposit_root: B256::ZERO,
+                        deposit_count: 0,
+                        block_hash: B256::ZERO,
+                    },
+                    graffiti: B256::ZERO,
+                    proposer_slashings: vec![],
+                    attester_slashings: vec![],
+                    attestations: vec![],
+                    deposits: vec![],
+                    voluntary_exits: vec![],
+                },
+            },
+            signature: BlsSignature::ZERO,
+        };
+        let compressed = CompressedSignedBeaconBlock::from_ssz(&block.as_ssz_bytes()).unwrap();
+        assert!(compressed.decode_execution_block::<TransactionSigned>().unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_execution_block_errors_on_malformed() {
+        // Bytes that decode as no known fork are malformed, not pre-merge slots, and must error
+        // instead of being silently dropped.
+        for bytes in [vec![], vec![0u8; 8]] {
+            let compressed = CompressedSignedBeaconBlock::from_ssz(&bytes).unwrap();
+            assert!(compressed.decode_execution_block::<TransactionSigned>().is_err());
+        }
     }
 }

--- a/crates/era/tests/it/era/roundtrip.rs
+++ b/crates/era/tests/it/era/roundtrip.rs
@@ -21,6 +21,7 @@ use reth_era::{
         },
     },
 };
+use reth_ethereum_primitives::TransactionSigned;
 use std::io::Cursor;
 
 use crate::{EraTestDownloader, HOODI, MAINNET};
@@ -121,6 +122,16 @@ async fn test_era_file_roundtrip(
         assert_eq!(
             original_block_data, recompressed_block_data,
             "Block {block_idx} should be identical after re-compression cycle"
+        );
+
+        // The embedded execution block must decode on real data (post-merge slots yield `Some`,
+        // pre-merge slots `None`) and be identical across the re-compression cycle.
+        let original_exec = original_block.decode_execution_block::<TransactionSigned>()?;
+        let recompressed_exec = recompressed_block.decode_execution_block::<TransactionSigned>()?;
+
+        assert_eq!(
+            original_exec, recompressed_exec,
+            "Block {block_idx} execution block should be identical after re-compression cycle"
         );
     }
 


### PR DESCRIPTION
Adds `CompressedSignedBeaconBlock::decode_execution_block`, which extracts the execution block embedded in a post-merge consensus `.era` beacon block, trial-decoding the fork newest to oldest. Pre-merge slots return `None`; bytes matching no known fork error instead of being silently dropped.

To verify expensive test that are ignores in regular CI : 

```
  cargo nextest run --release -p reth-era --run-ignored all -j1 \
    -E 'test(era::roundtrip::test_roundtrip_compression_encoding)'
```