### PR TITLE
feat(debug): add clear txpool rpc

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -40,6 +40,10 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[method(name = "getBadBlocks")]
     async fn bad_blocks(&self) -> RpcResult<Vec<serde_json::Value>>;
 
+    /// Clears all transactions from the transaction pool.
+    #[method(name = "clearTxpool")]
+    async fn debug_clear_txpool(&self) -> RpcResult<()>;
+
     /// Returns the structured logs created during the execution of EVM between two blocks
     /// (excluding start) as a JSON object.
     #[method(name = "traceChain")]

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -449,6 +449,7 @@ where
     DebugApiClient::<TransactionRequest>::raw_transaction(client, B256::default()).await.unwrap();
     DebugApiClient::<TransactionRequest>::raw_receipts(client, block_id).await.unwrap_err();
     DebugApiClient::<TransactionRequest>::bad_blocks(client).await.unwrap();
+    DebugApiClient::<TransactionRequest>::debug_clear_txpool(client).await.unwrap();
     DebugApiClient::<TransactionRequest>::debug_account_at(
         client,
         block_id,

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -38,6 +38,7 @@ use reth_storage_api::{
     TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
+use reth_transaction_pool::TransactionPool;
 use reth_trie_common::{
     updates::TrieUpdates, ExecutionWitnessMode, HashedPostState, HashedStorage,
 };
@@ -846,6 +847,14 @@ where
         }
 
         Ok(bad_blocks)
+    }
+
+    /// Handler for `debug_clearTxpool`
+    async fn debug_clear_txpool(&self) -> RpcResult<()> {
+        let pool = self.eth_api().pool();
+        let all_hashes = pool.all_transaction_hashes();
+        let _ = pool.remove_transactions(all_hashes);
+        Ok(())
     }
 
     /// Handler for `debug_traceChain`


### PR DESCRIPTION
Adds `debug_clearTxpool` to clear pending and queued transactions from the transaction pool for geth-compatible testing/debug workflows.

The debug method reuses the existing pool removal path and returns an empty success result instead of the `admin_clearTxpool` count to match geth's response shape.