### PR TITLE
feat(engine): add has blobs rpc

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -647,6 +647,13 @@ mod tests {
             Ok(vec![None; versioned_hashes.len()])
         }
 
+        fn has_versioned_hashes(
+            &self,
+            versioned_hashes: &[B256],
+        ) -> Result<Vec<bool>, BlobStoreError> {
+            Ok(vec![false; versioned_hashes.len()])
+        }
+
         fn get_cells(
             &self,
             _tx_hash: TxHash,

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -306,6 +306,10 @@ pub trait EngineApi<Engine: EngineTypes> {
     #[method(name = "exchangeCapabilities")]
     async fn exchange_capabilities(&self, capabilities: Vec<String>) -> RpcResult<Vec<String>>;
 
+    /// Report blob availability for the requested blob versioned hashes.
+    #[method(name = "hasBlobs")]
+    async fn has_blobs(&self, versioned_hashes: Vec<B256>) -> RpcResult<Vec<bool>>;
+
     /// Fetch blobs for the consensus layer from the blob store.
     #[method(name = "getBlobsV1")]
     async fn get_blobs_v1(

--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -42,6 +42,7 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getBlobsV2",
     "engine_getBlobsV3",
     "engine_getBlobsV4",
+    "engine_hasBlobs",
 ];
 
 /// Engine API capabilities set.
@@ -245,6 +246,7 @@ mod tests {
         assert!(!is_critical_method("engine_getBlobsV1"));
         assert!(!is_critical_method("engine_getBlobsV3"));
         assert!(!is_critical_method("engine_getBlobsV4"));
+        assert!(!is_critical_method("engine_hasBlobs"));
         assert!(!is_critical_method("engine_getPayloadBodiesByHashV1"));
         assert!(!is_critical_method("engine_getPayloadBodiesByRangeV1"));
         assert!(!is_critical_method("engine_getClientVersionV1"));
@@ -261,5 +263,6 @@ mod tests {
         assert!(should_warn_for_method("engine_newPayloadV4"));
 
         assert!(!should_warn_for_method("engine_getBlobsV4"));
+        assert!(!should_warn_for_method("engine_hasBlobs"));
     }
 }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -932,6 +932,25 @@ where
         &self.inner.capabilities
     }
 
+    fn has_blobs(&self, versioned_hashes: Vec<B256>) -> EngineApiResult<Vec<bool>> {
+        if versioned_hashes.len() > MAX_BLOB_LIMIT {
+            return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() })
+        }
+
+        self.inner
+            .tx_pool
+            .has_blobs_for_versioned_hashes(&versioned_hashes)
+            .map_err(|err| EngineApiError::Internal(Box::new(err)))
+    }
+
+    /// Metered version of `has_blobs`.
+    pub fn has_blobs_metered(&self, versioned_hashes: Vec<B256>) -> EngineApiResult<Vec<bool>> {
+        let start = Instant::now();
+        let res = Self::has_blobs(self, versioned_hashes);
+        self.inner.metrics.latency.has_blobs.record(start.elapsed());
+        res
+    }
+
     fn get_blobs_v1(
         &self,
         versioned_hashes: Vec<B256>,
@@ -1481,6 +1500,11 @@ where
         Ok(el_caps.list())
     }
 
+    async fn has_blobs(&self, versioned_hashes: Vec<B256>) -> RpcResult<Vec<bool>> {
+        trace!(target: "rpc::engine", "Serving engine_hasBlobs");
+        Ok(self.has_blobs_metered(versioned_hashes)?)
+    }
+
     async fn get_blobs_v1(
         &self,
         versioned_hashes: Vec<B256>,
@@ -1648,6 +1672,25 @@ mod tests {
         let (_, api) = setup_engine_api();
         let res = api.get_client_version_v1(client.clone());
         assert_eq!(res.unwrap(), vec![client]);
+    }
+
+    #[tokio::test]
+    async fn has_blobs_returns_ordered_availability() {
+        let (_, api) = setup_engine_api();
+
+        let res = api.has_blobs_metered(vec![B256::ZERO, B256::with_last_byte(1)]).unwrap();
+        assert_eq!(res, vec![false, false]);
+    }
+
+    #[tokio::test]
+    async fn has_blobs_rejects_large_requests() {
+        let (_, api) = setup_engine_api();
+
+        let res = api.has_blobs_metered(vec![B256::ZERO; MAX_BLOB_LIMIT + 1]);
+        assert_matches!(
+            res,
+            Err(EngineApiError::BlobRequestTooLarge { len }) if len == MAX_BLOB_LIMIT + 1
+        );
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc-engine-api/src/metrics.rs
+++ b/crates/rpc/rpc-engine-api/src/metrics.rs
@@ -60,6 +60,8 @@ pub(crate) struct EngineApiLatencyMetrics {
     pub(crate) get_blobs_v3: Histogram,
     /// Latency for `engine_getBlobsV4`
     pub(crate) get_blobs_v4: Histogram,
+    /// Latency for `engine_hasBlobs`
+    pub(crate) has_blobs: Histogram,
 }
 
 #[derive(Metrics)]

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -399,10 +399,10 @@ impl BlobStore for DiskFileBlobStore {
         {
             let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
             for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
-                if !result[idx] {
-                    if let Some(tx_hash) = versioned_to_txhashes.get(requested_hash).copied() {
-                        missing_tx_hashes.push((idx, tx_hash));
-                    }
+                if !result[idx] &&
+                    let Some(tx_hash) = versioned_to_txhashes.get(requested_hash).copied()
+                {
+                    missing_tx_hashes.push((idx, tx_hash));
                 }
             }
         }

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -379,6 +379,43 @@ impl BlobStore for DiskFileBlobStore {
         self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, indices_bitarray)
     }
 
+    fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
+        let mut result = vec![false; versioned_hashes.len()];
+        for (_tx_hash, blob_sidecar) in self.inner.blob_cache.lock().iter() {
+            for available_hash in blob_sidecar.versioned_hashes() {
+                for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
+                    if !result[idx] && *requested_hash == available_hash {
+                        result[idx] = true;
+                    }
+                }
+            }
+
+            if result.iter().all(|available| *available) {
+                return Ok(result)
+            }
+        }
+
+        let mut missing_tx_hashes = Vec::new();
+        {
+            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
+            for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
+                if !result[idx] {
+                    if let Some(tx_hash) = versioned_to_txhashes.get(requested_hash).copied() {
+                        missing_tx_hashes.push((idx, tx_hash));
+                    }
+                }
+            }
+        }
+
+        for (idx, tx_hash) in missing_tx_hashes {
+            if self.inner.contains(tx_hash)? {
+                result[idx] = true;
+            }
+        }
+
+        Ok(result)
+    }
+
     fn get_cells(
         &self,
         tx: B256,
@@ -1021,6 +1058,17 @@ mod tests {
     }
 
     #[test]
+    fn disk_has_blobs_returns_ordered_availability() {
+        let (store, _dir) = tmp_store();
+
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(TxHash::random(), sidecar).unwrap();
+
+        let request = vec![B256::ZERO, versioned_hash, versioned_hash];
+        assert_eq!(store.has_versioned_hashes(&request).unwrap(), vec![false, true, true]);
+    }
+
+    #[test]
     fn disk_get_blobs_v4_returns_requested_cells() {
         let (store, _dir) = tmp_store();
 
@@ -1051,6 +1099,32 @@ mod tests {
 
         let v3 = store.get_by_versioned_hashes_v3(&[versioned_hash]).unwrap();
         assert_eq!(v3, vec![Some(expected)]);
+    }
+
+    #[test]
+    fn disk_has_blobs_can_fallback_to_disk() {
+        let (store, _dir) = tmp_store();
+
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(TxHash::random(), sidecar).unwrap();
+        store.clear_cache();
+
+        assert_eq!(store.has_versioned_hashes(&[versioned_hash]).unwrap(), vec![true]);
+    }
+
+    #[test]
+    fn disk_has_blobs_ignores_stale_index_entries() {
+        let (store, _dir) = tmp_store();
+
+        let tx_hash = TxHash::random();
+        let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
+        store.insert(tx_hash, sidecar).unwrap();
+        store.clear_cache();
+
+        store.delete(tx_hash).unwrap();
+        store.cleanup();
+
+        assert_eq!(store.has_versioned_hashes(&[versioned_hash]).unwrap(), vec![false]);
     }
 
     #[test]

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -225,6 +225,24 @@ impl BlobStore for InMemoryBlobStore {
         self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, indices_bitarray)
     }
 
+    fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
+        let mut result = vec![false; versioned_hashes.len()];
+        for blob_sidecar in self.inner.store.read().values() {
+            for available_hash in blob_sidecar.versioned_hashes() {
+                for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
+                    if !result[idx] && *requested_hash == available_hash {
+                        result[idx] = true;
+                    }
+                }
+            }
+
+            if result.iter().all(|available| *available) {
+                break;
+            }
+        }
+        Ok(result)
+    }
+
     fn get_cells(
         &self,
         tx: B256,
@@ -276,6 +294,7 @@ fn insert_size(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::BlobTransactionSidecar;
     use alloy_eips::{
         eip4844::{kzg_to_versioned_hash, Blob, BlobAndProofV2, Bytes48},
         eip7594::{
@@ -295,6 +314,33 @@ mod tests {
         let sidecar = BlobTransactionSidecarEip7594::new(vec![blob], vec![commitment], cell_proofs);
 
         (BlobTransactionSidecarVariant::Eip7594(sidecar), versioned_hash, expected)
+    }
+
+    fn eip4844_single_blob_sidecar() -> (BlobTransactionSidecarVariant, B256) {
+        let blob = Blob::default();
+        let commitment = Bytes48::from([1u8; 48]);
+        let proof = Bytes48::default();
+        let versioned_hash = kzg_to_versioned_hash(commitment.as_slice());
+        let sidecar = BlobTransactionSidecar {
+            blobs: vec![blob],
+            commitments: vec![commitment],
+            proofs: vec![proof],
+        };
+
+        (BlobTransactionSidecarVariant::Eip4844(sidecar), versioned_hash)
+    }
+
+    #[test]
+    fn mem_has_blobs_returns_ordered_availability() {
+        let store = InMemoryBlobStore::default();
+
+        let (eip7594_sidecar, eip7594_hash, _) = eip7594_single_blob_sidecar();
+        let (eip4844_sidecar, eip4844_hash) = eip4844_single_blob_sidecar();
+        store.insert(B256::random(), eip7594_sidecar).unwrap();
+        store.insert(B256::random(), eip4844_sidecar).unwrap();
+
+        let request = vec![eip7594_hash, B256::ZERO, eip4844_hash, eip7594_hash];
+        assert_eq!(store.has_versioned_hashes(&request).unwrap(), vec![true, false, true, true]);
     }
 
     #[test]

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -120,6 +120,11 @@ pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
         indices_bitarray: B128,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError>;
 
+    /// Return whether each requested blob versioned hash is available.
+    ///
+    /// The response is always the same length and order as the request.
+    fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError>;
+
     /// Returns all requested cells for all blobs belonging to the transaction.
     ///
     /// The `indices_bitarray` is applied independently to every blob in the tx.

--- a/crates/transaction-pool/src/blobstore/noop.rs
+++ b/crates/transaction-pool/src/blobstore/noop.rs
@@ -93,6 +93,10 @@ impl BlobStore for NoopBlobStore {
         Ok(vec![None; versioned_hashes.len()])
     }
 
+    fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
+        Ok(vec![false; versioned_hashes.len()])
+    }
+
     fn get_cells(
         &self,
         tx_hash: TxHash,

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -825,6 +825,13 @@ where
         self.pool.blob_store().get_by_versioned_hashes_v4(versioned_hashes, indices_bitarray)
     }
 
+    fn has_blobs_for_versioned_hashes(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<bool>, BlobStoreError> {
+        self.pool.blob_store().has_versioned_hashes(versioned_hashes)
+    }
+
     fn blob_store(&self) -> Box<dyn BlobStore> {
         Box::new(self.pool.blob_store().clone())
     }

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -395,6 +395,13 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         Ok(vec![None; versioned_hashes.len()])
     }
 
+    fn has_blobs_for_versioned_hashes(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<bool>, BlobStoreError> {
+        Ok(vec![false; versioned_hashes.len()])
+    }
+
     fn blob_store(&self) -> Box<dyn BlobStore> {
         Box::new(NoopBlobStore)
     }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -748,6 +748,14 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         indices_bitarray: B128,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError>;
 
+    /// Return whether each requested blob versioned hash is available.
+    ///
+    /// The response is always the same length and order as the request.
+    fn has_blobs_for_versioned_hashes(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<Vec<bool>, BlobStoreError>;
+
     /// Returns the blob store used by the pool.
     fn blob_store(&self) -> Box<dyn BlobStore>;
 }


### PR DESCRIPTION
Adds engine_hasBlobs to report ordered blob availability for requested versioned hashes.

Wires the method through Engine API capabilities and blobstore availability lookup so consensus clients can check blob presence without fetching blob/proof payloads.