### PR TITLE
feat(engine): add skip-state-root mode

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -194,6 +194,11 @@ pub struct TreeConfig {
     /// When set, BAL storage slots are not read into the execution cache. BAL hashed-state
     /// streaming for parallel state-root computation is controlled separately.
     disable_bal_batch_io: bool,
+    /// Whether to skip trie state-root computation during engine validation.
+    ///
+    /// This trusts the block header's state root. It is intended for experiments that measure
+    /// execution without trie state-root work.
+    skip_state_root: bool,
     /// Maximum random jitter applied before each proof computation (trie-debug only).
     /// When set, each proof worker sleeps for a random duration up to this value
     /// before starting a proof calculation.
@@ -241,6 +246,7 @@ impl Default for TreeConfig {
             disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
+            skip_state_root: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -318,6 +324,7 @@ impl TreeConfig {
             disable_bal_parallel_execution: false,
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
+            skip_state_root: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
         }
@@ -745,6 +752,17 @@ impl TreeConfig {
     /// Setter for whether to disable BAL state prefetching during prewarm.
     pub const fn without_bal_batch_io(mut self, disable_bal_batch_io: bool) -> Self {
         self.disable_bal_batch_io = disable_bal_batch_io;
+        self
+    }
+
+    /// Returns whether trie state-root computation is skipped during engine validation.
+    pub const fn skip_state_root(&self) -> bool {
+        self.skip_state_root
+    }
+
+    /// Setter for whether to skip trie state-root computation during engine validation.
+    pub const fn with_skip_state_root(mut self, skip_state_root: bool) -> Self {
+        self.skip_state_root = skip_state_root;
         self
     }
 

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -11,8 +11,6 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, sync::Arc};
-
 use alloy_consensus::BlockHeader;
 use reth_errors::ConsensusError;
 use reth_payload_primitives::{
@@ -215,9 +213,9 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     }
 
     /// Verifies payload post-execution w.r.t. hashed state updates.
-    fn validate_block_post_execution_with_hashed_state(
+    fn validate_block_post_execution_with_hashed_state<'a>(
         &self,
-        _state_updates: Box<dyn FnOnce() -> Arc<HashedPostState> + Send + '_>,
+        _state_updates: &dyn FnOnce() -> &'a HashedPostState,
         _block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         // method not used by l1

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -11,6 +11,8 @@
 
 extern crate alloc;
 
+use alloc::{boxed::Box, sync::Arc};
+
 use alloy_consensus::BlockHeader;
 use reth_errors::ConsensusError;
 use reth_payload_primitives::{
@@ -215,7 +217,7 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     /// Verifies payload post-execution w.r.t. hashed state updates.
     fn validate_block_post_execution_with_hashed_state(
         &self,
-        _state_updates: &HashedPostState,
+        _state_updates: Box<dyn FnOnce() -> Arc<HashedPostState> + Send + '_>,
         _block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         // method not used by l1

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -331,8 +331,13 @@ where
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count, parallel_bal_execution);
-        let prewarm_handle =
-            self.spawn_caching_with(env, prewarm_rx, provider_builder, None, false);
+        let prewarm_handle = self.spawn_caching_with(
+            env,
+            prewarm_rx,
+            provider_builder,
+            None,
+            parallel_bal_execution,
+        );
         PayloadHandle {
             state_root_handle: None,
             install_state_hook: false,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -743,20 +743,14 @@ where
 
         // Run the hashed state validation hook but don't propagate the error yet. If the state root
         // task fails, we might need to re-run this check against a fallback state.
-        let mut hashed_state_validate_result = if strategy.is_skipped() {
-            Ok(())
-        } else {
-            debug_span!(
-                target: "engine::tree::payload_validator",
-                "validate_block_post_execution_with_hashed_state"
-            )
-            .in_scope(|| {
-                self.validator.validate_block_post_execution_with_hashed_state(
-                    Box::new(|| Arc::clone(hashed_state.get())),
-                    &block,
-                )
-            })
-        };
+        let mut hashed_state_validate_result = debug_span!(
+            target: "engine::tree::payload_validator",
+            "validate_block_post_execution_with_hashed_state"
+        )
+        .in_scope(|| {
+            self.validator
+                .validate_block_post_execution_with_hashed_state(&|| hashed_state.get(), &block)
+        });
 
         let root_time = Instant::now();
         let mut maybe_state_root = None;
@@ -861,7 +855,7 @@ where
                     });
                     hashed_state_validate_result =
                         self.validator.validate_block_post_execution_with_hashed_state(
-                            Box::new(|| Arc::clone(hashed_state.get())),
+                            &|| hashed_state.get(),
                             &block,
                         );
                 }
@@ -2162,13 +2156,6 @@ enum StateRootStrategy<N: NodePrimitives> {
     Synchronous,
     /// Custom state root computation strategy.
     Custom(#[debug(skip)] CustomStateRoot<N>),
-}
-
-impl<N: NodePrimitives> StateRootStrategy<N> {
-    /// Returns `true` if the strategy is [`Self::Skipped`].
-    const fn is_skipped(&self) -> bool {
-        matches!(self, Self::Skipped)
-    }
 }
 
 /// Type that validates the payloads processed by the engine.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -743,15 +743,20 @@ where
 
         // Run the hashed state validation hook but don't propagate the error yet. If the state root
         // task fails, we might need to re-run this check against a fallback state.
-        let mut hashed_state_validate_result = debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution_with_hashed_state").in_scope(|| {
-            // Wait for the background keccak256 hashing task to complete. This blocks until
-            // all changed addresses and storage slots have been hashed.
-            let hashed_state_ref =
-                debug_span!(target: "engine::tree::payload_validator", "wait_hashed_post_state")
-                    .in_scope(|| hashed_state.get());
-
-            self.validator.validate_block_post_execution_with_hashed_state(hashed_state_ref, &block)
-        });
+        let mut hashed_state_validate_result = if strategy.is_skipped() {
+            Ok(())
+        } else {
+            debug_span!(
+                target: "engine::tree::payload_validator",
+                "validate_block_post_execution_with_hashed_state"
+            )
+            .in_scope(|| {
+                self.validator.validate_block_post_execution_with_hashed_state(
+                    Box::new(|| Arc::clone(hashed_state.get())),
+                    &block,
+                )
+            })
+        };
 
         let root_time = Instant::now();
         let mut maybe_state_root = None;
@@ -760,6 +765,18 @@ where
         let mut trie_debug_recorders = Vec::new();
 
         match strategy {
+            StateRootStrategy::Skipped => {
+                debug!(
+                    target: "engine::tree::payload_validator",
+                    state_root = ?block.header().state_root(),
+                    "Skipping trie state-root computation"
+                );
+                maybe_state_root = Some((
+                    block.header().state_root(),
+                    Arc::new(TrieUpdates::default()),
+                    root_time.elapsed(),
+                ));
+            }
             StateRootStrategy::StateRootTask => {
                 debug!(target: "engine::tree::payload_validator", "Using sparse trie state root algorithm");
 
@@ -844,7 +861,7 @@ where
                     });
                     hashed_state_validate_result =
                         self.validator.validate_block_post_execution_with_hashed_state(
-                            hashed_state.get(),
+                            Box::new(|| Arc::clone(hashed_state.get())),
                             &block,
                         );
                 }
@@ -1733,12 +1750,12 @@ where
     ///
     /// This method determines how to execute the block and compute its state root based on
     /// the selected strategy:
+    /// - `Skipped`: Trusts the header state root and does not compute trie state.
     /// - `StateRootTask`: Uses a dedicated task for state root computation with proof generation
     /// - `Parallel`: Computes state root in parallel with block execution
     /// - `Synchronous`: Falls back to sequential execution and state root computation
     ///
-    /// The method handles strategy fallbacks if the preferred approach fails, ensuring
-    /// block execution always completes with a valid state root.
+    /// The method handles strategy fallbacks if the preferred computed-root approach fails.
     ///
     /// # Arguments
     ///
@@ -1788,6 +1805,7 @@ where
 
                 Ok(handle)
             }
+            StateRootStrategy::Skipped |
             StateRootStrategy::Parallel |
             StateRootStrategy::Synchronous |
             StateRootStrategy::Custom(_) => {
@@ -1846,7 +1864,9 @@ where
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
     fn plan_state_root_computation(&self) -> StateRootStrategy<N> {
-        if let Some(custom_state_root) = &self.custom_state_root {
+        if self.config.skip_state_root() {
+            StateRootStrategy::Skipped
+        } else if let Some(custom_state_root) = &self.custom_state_root {
             StateRootStrategy::Custom(custom_state_root.clone())
         } else if self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
@@ -2132,6 +2152,8 @@ where
 /// Strategy describing how to compute the state root.
 #[derive(derive_more::Debug, Clone)]
 enum StateRootStrategy<N: NodePrimitives> {
+    /// Skip trie state-root computation and trust the block header root.
+    Skipped,
     /// Use the state root task (background sparse trie computation).
     StateRootTask,
     /// Run the parallel state root computation on the calling thread.
@@ -2140,6 +2162,13 @@ enum StateRootStrategy<N: NodePrimitives> {
     Synchronous,
     /// Custom state root computation strategy.
     Custom(#[debug(skip)] CustomStateRoot<N>),
+}
+
+impl<N: NodePrimitives> StateRootStrategy<N> {
+    /// Returns `true` if the strategy is [`Self::Skipped`].
+    const fn is_skipped(&self) -> bool {
+        matches!(self, Self::Skipped)
+    }
 }
 
 /// Type that validates the payloads processed by the engine.

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -719,7 +719,7 @@ where
     {
         let Self { builder, task_executor } = self;
 
-        let engine_tree_config = builder.config.engine.tree_config();
+        let engine_tree_config = builder.config.tree_config();
 
         let launcher = DebugNodeLauncher::new(EngineNodeLauncher::new(
             task_executor,
@@ -732,7 +732,7 @@ where
     /// Returns an [`EngineNodeLauncher`] that can be used to launch the node with engine API
     /// support.
     pub fn engine_api_launcher(&self) -> EngineNodeLauncher {
-        let engine_tree_config = self.builder.config.engine.tree_config();
+        let engine_tree_config = self.builder.config.tree_config();
         EngineNodeLauncher::new(
             self.task_executor.clone(),
             self.builder.config.datadir(),

--- a/crates/node/core/src/args/debug.rs
+++ b/crates/node/core/src/args/debug.rs
@@ -58,6 +58,13 @@ pub struct DebugArgs {
     #[arg(long = "debug.skip-new-payload", help_heading = "Debug")]
     pub skip_new_payload: Option<usize>,
 
+    /// Skip trie state-root computation during engine validation.
+    ///
+    /// This trusts the block header's state root and is intended for experiments that measure
+    /// execution without trie state-root work.
+    #[arg(long = "debug.skip-state-root", help_heading = "Debug", hide = true)]
+    pub skip_state_root: bool,
+
     /// If set, bypasses genesis hash validation during init.
     /// Intended for tools that direct-write the database (e.g. snapshot
     /// importers, state-actor) and want reth to trust the DB-resident
@@ -129,6 +136,7 @@ impl Default for DebugArgs {
             rpc_consensus_url: None,
             skip_fcu: None,
             skip_new_payload: None,
+            skip_state_root: false,
             skip_genesis_validation: false,
             reorg_frequency: None,
             reorg_depth: None,
@@ -365,6 +373,13 @@ mod tests {
         let default_args = DebugArgs::default();
         let args = CommandParser::<DebugArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
+    }
+
+    #[test]
+    fn test_parse_skip_state_root() {
+        let expected_args = DebugArgs { skip_state_root: true, ..Default::default() };
+        let args = CommandParser::<DebugArgs>::parse_from(["reth", "--debug.skip-state-root"]).args;
+        assert_eq!(args, expected_args);
     }
 
     #[test]

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -15,6 +15,7 @@ use eyre::eyre;
 use reth_chainspec::{ChainSpec, EthChainSpec, MAINNET};
 use reth_config::config::PruneConfig;
 use reth_engine_local::MiningMode;
+use reth_engine_primitives::TreeConfig;
 use reth_ethereum_forks::{EthereumHardforks, Head};
 use reth_network_p2p::headers::client::HeadersClient;
 use reth_primitives_traits::SealedHeader;
@@ -191,6 +192,11 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             storage: StorageArgs::default(),
             jit: JitArgs::default(),
         }
+    }
+
+    /// Creates a [`TreeConfig`] from all node arguments that affect the engine tree.
+    pub fn tree_config(&self) -> TreeConfig {
+        self.engine.tree_config().with_skip_state_root(self.debug.skip_state_root)
     }
 
     /// Sets --dev mode for the node.
@@ -630,5 +636,19 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             storage: self.storage,
             jit: self.jit.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tree_config_applies_debug_skip_state_root() {
+        let config = NodeConfig::default();
+        assert!(!config.tree_config().skip_state_root());
+
+        let config = config.with_debug(DebugArgs { skip_state_root: true, ..Default::default() });
+        assert!(config.tree_config().skip_state_root());
     }
 }


### PR DESCRIPTION
Introduces a new hidden CLI flag: --debug.skip-state-root

This flag is intended to be used for running experiments that take out the state root computation out of the picture. The state root task often is running longer than the execution, especially on the larger payloads. --debug.skip-state-root allows measuring the performance impact of changes that affect the engine performance but not necessarily decrease the overall newPayload time.

Another follow-up expected that disables state root in the payload builder.