### PR TITLE
fix(reth-bb): adjust block gas limit

### DIFF
--- a/bin/reth-bb/src/main.rs
+++ b/bin/reth-bb/src/main.rs
@@ -101,6 +101,7 @@ impl PayloadValidator<BbPayloadTypes> for BbEngineValidator {
 
         // Update block's gas usage to make sure metrics are correct
         block.header.gas_used += blocks.iter().map(|b| b.gas_used).sum::<u64>();
+        block.header.gas_limit += blocks.iter().map(|b| b.gas_limit).sum::<u64>();
 
         // Prepend transactions from previous blocks to make sure that persistence indices are
         // correct.


### PR DESCRIPTION
Right now block's gas limit of the resulting block in reth-bb is set to value of the last regular block, which ends up triggering this check for every block
https://github.com/paradigmxyz/reth/blob/dea1c20a858a7bc55a6faf2040e0257361a5d523/crates/engine/tree/src/tree/payload_validator.rs#L515-L526

This PR fixes gas limit to match the total value of all included blocks which should prevent it