### PR TITLE
feat: dispatch proof work by hashed account prefix

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -33,10 +33,7 @@ use crate::{
     root::ParallelStateRootError,
     value_encoder::{AsyncAccountValueEncoder, ValueEncoderStats},
 };
-use alloy_primitives::{
-    map::{B256Map, B256Set},
-    B256, U256,
-};
+use alloy_primitives::{map::B256Map, B256, U256};
 use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use reth_execution_errors::StateProofError;
 use reth_primitives_traits::{dashmap::DashMap, FastInstant as Instant};
@@ -245,7 +242,6 @@ impl ProofWorkerHandle {
         });
 
         let account_rt = runtime.clone();
-        let account_tx = storage_work_txs.clone();
         let account_avail = account_availability.clone();
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
@@ -264,7 +260,6 @@ impl ProofWorkerHandle {
                     task_ctx.clone(),
                     account_work_rx.clone(),
                     worker_id,
-                    account_tx.clone(),
                     account_avail.clone(),
                     cached_storage_roots.clone(),
                     #[cfg(feature = "metrics")]
@@ -775,8 +770,6 @@ struct AccountProofWorker<Factory> {
     work_rx: CrossbeamReceiver<AccountWorkerJob>,
     /// Unique identifier for this worker (used for tracing)
     worker_id: usize,
-    /// Channel for dispatching storage proof work (for pre-dispatched target proofs)
-    storage_work_txs: Arc<[CrossbeamSender<StorageWorkerJob>]>,
     /// Per-worker availability flags
     availability: Arc<AvailabilitySheet>,
     /// Cached storage roots
@@ -799,7 +792,6 @@ where
         task_ctx: ProofTaskCtx<Factory>,
         work_rx: CrossbeamReceiver<AccountWorkerJob>,
         worker_id: usize,
-        storage_work_txs: Arc<[CrossbeamSender<StorageWorkerJob>]>,
         availability: Arc<AvailabilitySheet>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
         #[cfg(feature = "metrics")] metrics: ProofTaskTrieMetrics,
@@ -809,7 +801,6 @@ where
             task_ctx,
             work_rx,
             worker_id,
-            storage_work_txs,
             availability,
             cached_storage_roots,
             #[cfg(feature = "metrics")]
@@ -982,19 +973,18 @@ where
 
         trace!(target: "trie::proof_task", "Processing V2 account multiproof");
 
-        let storage_proof_receivers =
-            dispatch_v2_storage_proofs(&self.storage_work_txs, &account_targets, storage_targets)?;
-
         let mut value_encoder = AsyncAccountValueEncoder::new(
-            storage_proof_receivers,
+            B256Map::default(),
             self.cached_storage_roots.clone(),
-            v2_storage_calculator,
+            v2_storage_calculator.clone(),
         );
 
         let account_proofs =
             v2_account_calculator.proof(&mut value_encoder, &mut account_targets)?;
 
-        let (storage_proofs, value_encoder_stats) = value_encoder.finalize()?;
+        let (_, value_encoder_stats) = value_encoder.finalize()?;
+        let storage_proofs =
+            compute_v2_storage_proofs(v2_storage_calculator, &account_targets, storage_targets)?;
 
         let proof = DecodedMultiProofV2 { account_proofs, storage_proofs };
 
@@ -1055,33 +1045,33 @@ where
     }
 }
 
-/// Queues V2 storage proofs for all accounts in the targets and returns receivers.
-///
-/// This function queues all storage proof tasks to the worker pool but returns immediately
-/// with receivers, allowing the account trie walk to proceed in parallel with storage proof
-/// computation. This enables interleaved parallelism for better performance.
-///
-/// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
-fn dispatch_v2_storage_proofs(
-    storage_work_txs: &[CrossbeamSender<StorageWorkerJob>],
+/// Computes V2 storage proofs for all accounts in the targets using the account worker's reused
+/// storage proof calculator.
+fn compute_v2_storage_proofs<TC, HC>(
+    v2_storage_calculator: Rc<RefCell<proof_v2::StorageProofCalculator<TC, HC>>>,
     account_targets: &[ProofV2Target],
     mut storage_targets: B256Map<Vec<ProofV2Target>>,
-) -> Result<B256Map<CrossbeamReceiver<StorageProofResultMessage>>, ParallelStateRootError> {
+) -> Result<B256Map<Vec<ProofTrieNodeV2>>, StateProofError>
+where
+    TC: TrieStorageCursor,
+    HC: HashedStorageCursor<Value = U256>,
+{
     if storage_targets.is_empty() {
         return Ok(B256Map::default());
     }
 
-    let mut storage_proof_receivers =
+    let mut storage_proofs =
         B256Map::with_capacity_and_hasher(storage_targets.len(), Default::default());
 
     // Collect hashed addresses from account targets that need their storage roots computed
-    let account_target_addresses: B256Set = account_targets.iter().map(|t| t.key()).collect();
+    let account_target_addresses: std::collections::BTreeSet<_> =
+        account_targets.iter().map(|t| t.key()).collect();
 
     // For storage targets with associated account proofs, ensure the first target has
     // min_len(0) so the root node is returned for storage root computation
     for (hashed_address, targets) in &mut storage_targets {
-        if account_target_addresses.contains(hashed_address)
-            && let Some(first) = targets.first_mut()
+        if account_target_addresses.contains(hashed_address) &&
+            let Some(first) = targets.first_mut()
         {
             *first = first.with_min_len(0);
         }
@@ -1093,24 +1083,14 @@ fn dispatch_v2_storage_proofs(
     let mut sorted_storage_targets: Vec<_> = storage_targets.into_iter().collect();
     sorted_storage_targets.sort_unstable_by_key(|(addr, _)| *addr);
 
-    // Dispatch all proofs for targeted storage slots
-    for (hashed_address, targets) in sorted_storage_targets {
-        // Create channel for receiving StorageProofResultMessage
-        let (result_tx, result_rx) = crossbeam_channel::unbounded();
-        let input = StorageProofInput::new(hashed_address, targets);
-
-        storage_worker_tx(storage_work_txs, hashed_address)
-            .send(StorageWorkerJob::StorageProof { input, proof_result_sender: result_tx })
-            .map_err(|_| {
-                ParallelStateRootError::Other(format!(
-                    "Failed to queue storage proof for {hashed_address:?}: storage worker pool unavailable",
-                ))
-            })?;
-
-        storage_proof_receivers.insert(hashed_address, result_rx);
+    // Compute all proofs for targeted storage slots.
+    let mut calculator = v2_storage_calculator.borrow_mut();
+    for (hashed_address, mut targets) in sorted_storage_targets {
+        let proof = calculator.storage_proof(hashed_address, &mut targets)?;
+        storage_proofs.insert(hashed_address, proof);
     }
 
-    Ok(storage_proof_receivers)
+    Ok(storage_proofs)
 }
 
 /// Returns the worker index for a hashed account address.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -134,8 +134,8 @@ impl AvailabilitySheet {
 /// channels, and workers shut down gracefully when all handles are dropped.
 #[derive(Debug, Clone)]
 pub struct ProofWorkerHandle {
-    /// Direct sender to storage worker pool
-    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    /// Direct senders to storage workers, partitioned by hashed account prefix.
+    storage_work_txs: Arc<[CrossbeamSender<StorageWorkerJob>]>,
     /// Direct sender to account worker pool
     account_work_tx: CrossbeamSender<AccountWorkerJob>,
     /// Per-worker availability flags for storage workers. Used to determine whether to chunk
@@ -178,7 +178,6 @@ impl ProofWorkerHandle {
             + Sync
             + 'static,
     {
-        let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
         let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
@@ -191,6 +190,10 @@ impl ProofWorkerHandle {
 
         let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
         let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
+        let storage_channels: Vec<_> =
+            (0..storage_worker_count).map(|_| unbounded::<StorageWorkerJob>()).collect();
+        let storage_work_txs: Arc<[_]> =
+            storage_channels.iter().map(|(tx, _)| tx.clone()).collect::<Vec<_>>().into();
 
         debug!(
             target: "trie::proof_task",
@@ -221,7 +224,7 @@ impl ProofWorkerHandle {
 
                 let worker = StorageProofWorker::new(
                     storage_task_ctx.clone(),
-                    storage_work_rx.clone(),
+                    storage_channels[worker_id].1.clone(),
                     worker_id,
                     storage_avail.clone(),
                     storage_roots.clone(),
@@ -242,7 +245,7 @@ impl ProofWorkerHandle {
         });
 
         let account_rt = runtime.clone();
-        let account_tx = storage_work_tx.clone();
+        let account_tx = storage_work_txs.clone();
         let account_avail = account_availability.clone();
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
@@ -281,7 +284,7 @@ impl ProofWorkerHandle {
         });
 
         Self {
-            storage_work_tx,
+            storage_work_txs,
             account_work_tx,
             storage_availability,
             account_availability,
@@ -302,7 +305,7 @@ impl ProofWorkerHandle {
 
     /// Returns the number of pending storage tasks in the queue.
     pub fn pending_storage_tasks(&self) -> usize {
-        self.storage_work_tx.len()
+        self.storage_work_txs.iter().map(CrossbeamSender::len).sum()
     }
 
     /// Returns the number of pending account tasks in the queue.
@@ -329,7 +332,7 @@ impl ProofWorkerHandle {
         proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
     ) -> Result<(), ProviderError> {
         let hashed_address = input.hashed_address;
-        self.storage_work_tx
+        storage_worker_tx(&self.storage_work_txs, hashed_address)
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
             .map_err(|err| {
                 let StorageWorkerJob::StorageProof { proof_result_sender, .. } = err.0;
@@ -773,7 +776,7 @@ struct AccountProofWorker<Factory> {
     /// Unique identifier for this worker (used for tracing)
     worker_id: usize,
     /// Channel for dispatching storage proof work (for pre-dispatched target proofs)
-    storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+    storage_work_txs: Arc<[CrossbeamSender<StorageWorkerJob>]>,
     /// Per-worker availability flags
     availability: Arc<AvailabilitySheet>,
     /// Cached storage roots
@@ -796,7 +799,7 @@ where
         task_ctx: ProofTaskCtx<Factory>,
         work_rx: CrossbeamReceiver<AccountWorkerJob>,
         worker_id: usize,
-        storage_work_tx: CrossbeamSender<StorageWorkerJob>,
+        storage_work_txs: Arc<[CrossbeamSender<StorageWorkerJob>]>,
         availability: Arc<AvailabilitySheet>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
         #[cfg(feature = "metrics")] metrics: ProofTaskTrieMetrics,
@@ -806,7 +809,7 @@ where
             task_ctx,
             work_rx,
             worker_id,
-            storage_work_tx,
+            storage_work_txs,
             availability,
             cached_storage_roots,
             #[cfg(feature = "metrics")]
@@ -980,7 +983,7 @@ where
         trace!(target: "trie::proof_task", "Processing V2 account multiproof");
 
         let storage_proof_receivers =
-            dispatch_v2_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
+            dispatch_v2_storage_proofs(&self.storage_work_txs, &account_targets, storage_targets)?;
 
         let mut value_encoder = AsyncAccountValueEncoder::new(
             storage_proof_receivers,
@@ -1060,12 +1063,12 @@ where
 ///
 /// Propagates errors up if queuing fails. Receivers must be consumed by the caller.
 fn dispatch_v2_storage_proofs(
-    storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
+    storage_work_txs: &[CrossbeamSender<StorageWorkerJob>],
     account_targets: &[ProofV2Target],
     mut storage_targets: B256Map<Vec<ProofV2Target>>,
 ) -> Result<B256Map<CrossbeamReceiver<StorageProofResultMessage>>, ParallelStateRootError> {
     if storage_targets.is_empty() {
-        return Ok(B256Map::default())
+        return Ok(B256Map::default());
     }
 
     let mut storage_proof_receivers =
@@ -1077,8 +1080,8 @@ fn dispatch_v2_storage_proofs(
     // For storage targets with associated account proofs, ensure the first target has
     // min_len(0) so the root node is returned for storage root computation
     for (hashed_address, targets) in &mut storage_targets {
-        if account_target_addresses.contains(hashed_address) &&
-            let Some(first) = targets.first_mut()
+        if account_target_addresses.contains(hashed_address)
+            && let Some(first) = targets.first_mut()
         {
             *first = first.with_min_len(0);
         }
@@ -1096,7 +1099,7 @@ fn dispatch_v2_storage_proofs(
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let input = StorageProofInput::new(hashed_address, targets);
 
-        storage_work_tx
+        storage_worker_tx(storage_work_txs, hashed_address)
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender: result_tx })
             .map_err(|_| {
                 ParallelStateRootError::Other(format!(
@@ -1108,6 +1111,23 @@ fn dispatch_v2_storage_proofs(
     }
 
     Ok(storage_proof_receivers)
+}
+
+/// Returns the worker index for a hashed account address.
+///
+/// Routing by the leading byte keeps account/storage proofs for nearby hashed addresses on the same
+/// worker while spreading the full 256-prefix keyspace evenly across the configured worker count.
+fn storage_worker_index(hashed_address: B256, worker_count: usize) -> usize {
+    debug_assert!(worker_count > 0, "storage worker count must be non-zero");
+    (usize::from(hashed_address.as_slice()[0]) * worker_count) / 256
+}
+
+/// Returns the storage worker sender for the given hashed account address.
+fn storage_worker_tx(
+    storage_work_txs: &[CrossbeamSender<StorageWorkerJob>],
+    hashed_address: B256,
+) -> &CrossbeamSender<StorageWorkerJob> {
+    &storage_work_txs[storage_worker_index(hashed_address, storage_work_txs.len())]
 }
 
 /// Input parameters for storage proof computation.
@@ -1161,6 +1181,64 @@ mod tests {
 
     fn test_ctx<Factory>(factory: Factory) -> ProofTaskCtx<Factory> {
         ProofTaskCtx::new(factory)
+    }
+
+    fn hashed_address_with_prefix(prefix: u8) -> B256 {
+        let mut bytes = [0u8; 32];
+        bytes[0] = prefix;
+        B256::from(bytes)
+    }
+
+    #[test]
+    fn storage_worker_index_partitions_by_hashed_address_prefix() {
+        assert_eq!(storage_worker_index(hashed_address_with_prefix(0x00), 4), 0);
+        assert_eq!(storage_worker_index(hashed_address_with_prefix(0x3f), 4), 0);
+        assert_eq!(storage_worker_index(hashed_address_with_prefix(0x40), 4), 1);
+        assert_eq!(storage_worker_index(hashed_address_with_prefix(0x80), 4), 2);
+        assert_eq!(storage_worker_index(hashed_address_with_prefix(0xc0), 4), 3);
+        assert_eq!(storage_worker_index(hashed_address_with_prefix(0xff), 4), 3);
+    }
+
+    #[test]
+    fn storage_worker_index_is_deterministic_and_in_range() {
+        let hashed_address = hashed_address_with_prefix(0x9a);
+
+        for worker_count in 1..33 {
+            let index = storage_worker_index(hashed_address, worker_count);
+            assert_eq!(index, storage_worker_index(hashed_address, worker_count));
+            assert!(index < worker_count);
+        }
+    }
+
+    #[test]
+    fn dispatch_storage_proof_queues_to_prefix_worker() {
+        let (senders, receivers): (Vec<_>, Vec<_>) =
+            (0..4).map(|_| crossbeam_channel::unbounded::<StorageWorkerJob>()).unzip();
+        let storage_availability = Arc::new(AvailabilitySheet::new(4));
+        let account_availability = Arc::new(AvailabilitySheet::new(1));
+        let handle = ProofWorkerHandle {
+            storage_work_txs: senders.into(),
+            account_work_tx: crossbeam_channel::unbounded::<AccountWorkerJob>().0,
+            storage_availability,
+            account_availability,
+            storage_worker_count: 4,
+            account_worker_count: 1,
+        };
+
+        let hashed_address = hashed_address_with_prefix(0x80);
+        let (result_tx, _result_rx) = crossbeam_channel::unbounded();
+        handle
+            .dispatch_storage_proof(StorageProofInput::new(hashed_address, Vec::new()), result_tx)
+            .unwrap();
+
+        assert_eq!(handle.storage_work_txs[0].len(), 0);
+        assert_eq!(handle.storage_work_txs[1].len(), 0);
+        assert_eq!(handle.storage_work_txs[2].len(), 1);
+        assert_eq!(handle.storage_work_txs[3].len(), 0);
+        assert!(matches!(
+            receivers[2].try_recv(),
+            Ok(StorageWorkerJob::StorageProof { input, .. }) if input.hashed_address == hashed_address
+        ));
     }
 
     /// Ensures `ProofWorkerHandle::new` spawns workers correctly.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -37,9 +37,7 @@ use alloy_primitives::{
     map::{B256Map, B256Set},
     B256, U256,
 };
-use crossbeam_channel::{
-    unbounded, Receiver as CrossbeamReceiver, Select, Sender as CrossbeamSender, TryRecvError,
-};
+use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use reth_execution_errors::StateProofError;
 use reth_primitives_traits::{dashmap::DashMap, FastInstant as Instant};
 use reth_provider::{DatabaseProviderROFactory, ProviderError, ProviderResult};
@@ -196,8 +194,6 @@ impl ProofWorkerHandle {
             (0..storage_worker_count).map(|_| unbounded::<StorageWorkerJob>()).collect();
         let storage_work_txs: Arc<[_]> =
             storage_channels.iter().map(|(tx, _)| tx.clone()).collect::<Vec<_>>().into();
-        let storage_work_rxs: Arc<[_]> =
-            storage_channels.iter().map(|(_, rx)| rx.clone()).collect::<Vec<_>>().into();
 
         debug!(
             target: "trie::proof_task",
@@ -213,7 +209,6 @@ impl ProofWorkerHandle {
         let storage_task_ctx = task_ctx.clone();
         let storage_avail = storage_availability.clone();
         let storage_roots = cached_storage_roots.clone();
-        let storage_rx = storage_work_rxs.clone();
         let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -229,7 +224,7 @@ impl ProofWorkerHandle {
 
                 let worker = StorageProofWorker::new(
                     storage_task_ctx.clone(),
-                    storage_rx.clone(),
+                    storage_channels[worker_id].1.clone(),
                     worker_id,
                     storage_avail.clone(),
                     storage_roots.clone(),
@@ -300,7 +295,7 @@ impl ProofWorkerHandle {
 
     /// Returns `true` if more than one storage worker is currently idle.
     pub fn has_multiple_idle_storage_workers(&self) -> bool {
-        self.storage_availability.has_multiple_idle()
+        self.storage_availability.has_multiple_idle() && self.pending_storage_tasks() == 0
     }
 
     /// Returns `true` if more than one account worker is currently idle.
@@ -563,11 +558,8 @@ pub(crate) enum StorageWorkerJob {
 struct StorageProofWorker<Factory> {
     /// Shared task context with database factory and prefix sets
     task_ctx: ProofTaskCtx<Factory>,
-    /// Per-worker channels for receiving work.
-    ///
-    /// Each worker prefers its own queue for prefix locality, but can steal from other queues when
-    /// idle so a hot hashed-account prefix cannot starve the pool.
-    work_rxs: Arc<[CrossbeamReceiver<StorageWorkerJob>]>,
+    /// Dedicated channel for receiving this worker's prefix-routed work.
+    work_rx: CrossbeamReceiver<StorageWorkerJob>,
     /// Unique identifier for this worker (used for tracing)
     worker_id: usize,
     /// Per-worker availability flags
@@ -589,7 +581,7 @@ where
     /// Creates a new storage proof worker.
     const fn new(
         task_ctx: ProofTaskCtx<Factory>,
-        work_rxs: Arc<[CrossbeamReceiver<StorageWorkerJob>]>,
+        work_rx: CrossbeamReceiver<StorageWorkerJob>,
         worker_id: usize,
         availability: Arc<AvailabilitySheet>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -598,7 +590,7 @@ where
     ) -> Self {
         Self {
             task_ctx,
-            work_rxs,
+            work_rx,
             worker_id,
             availability,
             cached_storage_roots,
@@ -606,36 +598,6 @@ where
             metrics,
             #[cfg(feature = "metrics")]
             cursor_metrics,
-        }
-    }
-
-    /// Receives storage work, preferring this worker's prefix queue before stealing from others.
-    fn recv_job(&self) -> Option<StorageWorkerJob> {
-        loop {
-            let mut has_connected_rx = false;
-            for offset in 0..self.work_rxs.len() {
-                let index = (self.worker_id + offset) % self.work_rxs.len();
-                match self.work_rxs[index].try_recv() {
-                    Ok(job) => return Some(job),
-                    Err(TryRecvError::Empty) => has_connected_rx = true,
-                    Err(TryRecvError::Disconnected) => {}
-                }
-            }
-
-            if !has_connected_rx {
-                return None;
-            }
-
-            let mut select = Select::new();
-            for rx in self.work_rxs.iter() {
-                select.recv(rx);
-            }
-
-            let oper = select.select();
-            let index = oper.index();
-            if let Ok(job) = oper.recv(&self.work_rxs[index]) {
-                return Some(job);
-            }
         }
     }
 
@@ -688,7 +650,7 @@ where
         let mut total_idle_time = Duration::ZERO;
         let mut idle_start = Instant::now();
 
-        while let Some(job) = self.recv_job() {
+        while let Ok(job) = self.work_rx.recv() {
             total_idle_time += idle_start.elapsed();
 
             // Mark worker as busy.
@@ -1299,34 +1261,31 @@ mod tests {
     }
 
     #[test]
-    fn idle_storage_worker_steals_from_other_prefix_queue() {
-        let (senders, receivers): (Vec<_>, Vec<_>) =
+    fn queued_storage_work_suppresses_idle_chunking_signal() {
+        let (senders, _receivers): (Vec<_>, Vec<_>) =
             (0..2).map(|_| crossbeam_channel::unbounded::<StorageWorkerJob>()).unzip();
-        let worker = StorageProofWorker::new(
-            test_ctx(overlay_test_factory()),
-            receivers.into(),
-            0,
-            Arc::new(AvailabilitySheet::new(2)),
-            Arc::<DashMap<_, _>>::default(),
-            #[cfg(feature = "metrics")]
-            ProofTaskTrieMetrics::default(),
-            #[cfg(feature = "metrics")]
-            ProofTaskCursorMetrics::new(),
-        );
+        let storage_availability = Arc::new(AvailabilitySheet::new(2));
+        let account_availability = Arc::new(AvailabilitySheet::new(1));
+        let handle = ProofWorkerHandle {
+            storage_work_txs: senders.into(),
+            account_work_tx: crossbeam_channel::unbounded::<AccountWorkerJob>().0,
+            storage_availability: storage_availability.clone(),
+            account_availability,
+            storage_worker_count: 2,
+            account_worker_count: 1,
+        };
+        storage_availability.mark_idle(0);
+        storage_availability.mark_idle(1);
+
+        assert!(handle.has_multiple_idle_storage_workers());
 
         let hashed_address = hashed_address_with_prefix(0xff);
         let (result_tx, _result_rx) = crossbeam_channel::unbounded();
-        senders[1]
-            .send(StorageWorkerJob::StorageProof {
-                input: StorageProofInput::new(hashed_address, Vec::new()),
-                proof_result_sender: result_tx,
-            })
+        handle
+            .dispatch_storage_proof(StorageProofInput::new(hashed_address, Vec::new()), result_tx)
             .unwrap();
 
-        assert!(matches!(
-            worker.recv_job(),
-            Some(StorageWorkerJob::StorageProof { input, .. }) if input.hashed_address == hashed_address
-        ));
+        assert!(!handle.has_multiple_idle_storage_workers());
     }
 
     /// Ensures `ProofWorkerHandle::new` spawns workers correctly.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -37,7 +37,9 @@ use alloy_primitives::{
     map::{B256Map, B256Set},
     B256, U256,
 };
-use crossbeam_channel::{unbounded, Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
+use crossbeam_channel::{
+    unbounded, Receiver as CrossbeamReceiver, Select, Sender as CrossbeamSender, TryRecvError,
+};
 use reth_execution_errors::StateProofError;
 use reth_primitives_traits::{dashmap::DashMap, FastInstant as Instant};
 use reth_provider::{DatabaseProviderROFactory, ProviderError, ProviderResult};
@@ -184,9 +186,9 @@ impl ProofWorkerHandle {
 
         let divisor = if halve_workers { 2 } else { 1 };
         let storage_worker_count =
-            runtime.proof_storage_worker_pool().current_num_threads() / divisor;
+            (runtime.proof_storage_worker_pool().current_num_threads() / divisor).max(1);
         let account_worker_count =
-            runtime.proof_account_worker_pool().current_num_threads() / divisor;
+            (runtime.proof_account_worker_pool().current_num_threads() / divisor).max(1);
 
         let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
         let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
@@ -194,6 +196,8 @@ impl ProofWorkerHandle {
             (0..storage_worker_count).map(|_| unbounded::<StorageWorkerJob>()).collect();
         let storage_work_txs: Arc<[_]> =
             storage_channels.iter().map(|(tx, _)| tx.clone()).collect::<Vec<_>>().into();
+        let storage_work_rxs: Arc<[_]> =
+            storage_channels.iter().map(|(_, rx)| rx.clone()).collect::<Vec<_>>().into();
 
         debug!(
             target: "trie::proof_task",
@@ -209,6 +213,7 @@ impl ProofWorkerHandle {
         let storage_task_ctx = task_ctx.clone();
         let storage_avail = storage_availability.clone();
         let storage_roots = cached_storage_roots.clone();
+        let storage_rx = storage_work_rxs.clone();
         let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -224,7 +229,7 @@ impl ProofWorkerHandle {
 
                 let worker = StorageProofWorker::new(
                     storage_task_ctx.clone(),
-                    storage_channels[worker_id].1.clone(),
+                    storage_rx.clone(),
                     worker_id,
                     storage_avail.clone(),
                     storage_roots.clone(),
@@ -558,8 +563,11 @@ pub(crate) enum StorageWorkerJob {
 struct StorageProofWorker<Factory> {
     /// Shared task context with database factory and prefix sets
     task_ctx: ProofTaskCtx<Factory>,
-    /// Channel for receiving work
-    work_rx: CrossbeamReceiver<StorageWorkerJob>,
+    /// Per-worker channels for receiving work.
+    ///
+    /// Each worker prefers its own queue for prefix locality, but can steal from other queues when
+    /// idle so a hot hashed-account prefix cannot starve the pool.
+    work_rxs: Arc<[CrossbeamReceiver<StorageWorkerJob>]>,
     /// Unique identifier for this worker (used for tracing)
     worker_id: usize,
     /// Per-worker availability flags
@@ -581,7 +589,7 @@ where
     /// Creates a new storage proof worker.
     const fn new(
         task_ctx: ProofTaskCtx<Factory>,
-        work_rx: CrossbeamReceiver<StorageWorkerJob>,
+        work_rxs: Arc<[CrossbeamReceiver<StorageWorkerJob>]>,
         worker_id: usize,
         availability: Arc<AvailabilitySheet>,
         cached_storage_roots: Arc<DashMap<B256, B256>>,
@@ -590,7 +598,7 @@ where
     ) -> Self {
         Self {
             task_ctx,
-            work_rx,
+            work_rxs,
             worker_id,
             availability,
             cached_storage_roots,
@@ -598,6 +606,36 @@ where
             metrics,
             #[cfg(feature = "metrics")]
             cursor_metrics,
+        }
+    }
+
+    /// Receives storage work, preferring this worker's prefix queue before stealing from others.
+    fn recv_job(&self) -> Option<StorageWorkerJob> {
+        loop {
+            let mut has_connected_rx = false;
+            for offset in 0..self.work_rxs.len() {
+                let index = (self.worker_id + offset) % self.work_rxs.len();
+                match self.work_rxs[index].try_recv() {
+                    Ok(job) => return Some(job),
+                    Err(TryRecvError::Empty) => has_connected_rx = true,
+                    Err(TryRecvError::Disconnected) => {}
+                }
+            }
+
+            if !has_connected_rx {
+                return None;
+            }
+
+            let mut select = Select::new();
+            for rx in self.work_rxs.iter() {
+                select.recv(rx);
+            }
+
+            let oper = select.select();
+            let index = oper.index();
+            if let Ok(job) = oper.recv(&self.work_rxs[index]) {
+                return Some(job);
+            }
         }
     }
 
@@ -650,7 +688,7 @@ where
         let mut total_idle_time = Duration::ZERO;
         let mut idle_start = Instant::now();
 
-        while let Ok(job) = self.work_rx.recv() {
+        while let Some(job) = self.recv_job() {
             total_idle_time += idle_start.elapsed();
 
             // Mark worker as busy.
@@ -1189,6 +1227,25 @@ mod tests {
         B256::from(bytes)
     }
 
+    fn overlay_test_factory(
+    ) -> impl DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
+           + Clone
+           + Send
+           + Sync
+           + 'static {
+        let chain_spec = Arc::new(ChainSpec::default());
+        let anchor_hash = chain_spec.genesis_hash();
+        let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec);
+        let changeset_cache = reth_trie_db::ChangesetCache::new();
+        reth_provider::providers::OverlayStateProviderFactory::new(
+            provider_factory,
+            reth_provider::providers::OverlayBuilder::<reth_ethereum_primitives::EthPrimitives>::new(
+                anchor_hash,
+                changeset_cache,
+            ),
+        )
+    }
+
     #[test]
     fn storage_worker_index_partitions_by_hashed_address_prefix() {
         assert_eq!(storage_worker_index(hashed_address_with_prefix(0x00), 4), 0);
@@ -1241,21 +1298,41 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn idle_storage_worker_steals_from_other_prefix_queue() {
+        let (senders, receivers): (Vec<_>, Vec<_>) =
+            (0..2).map(|_| crossbeam_channel::unbounded::<StorageWorkerJob>()).unzip();
+        let worker = StorageProofWorker::new(
+            test_ctx(overlay_test_factory()),
+            receivers.into(),
+            0,
+            Arc::new(AvailabilitySheet::new(2)),
+            Arc::<DashMap<_, _>>::default(),
+            #[cfg(feature = "metrics")]
+            ProofTaskTrieMetrics::default(),
+            #[cfg(feature = "metrics")]
+            ProofTaskCursorMetrics::new(),
+        );
+
+        let hashed_address = hashed_address_with_prefix(0xff);
+        let (result_tx, _result_rx) = crossbeam_channel::unbounded();
+        senders[1]
+            .send(StorageWorkerJob::StorageProof {
+                input: StorageProofInput::new(hashed_address, Vec::new()),
+                proof_result_sender: result_tx,
+            })
+            .unwrap();
+
+        assert!(matches!(
+            worker.recv_job(),
+            Some(StorageWorkerJob::StorageProof { input, .. }) if input.hashed_address == hashed_address
+        ));
+    }
+
     /// Ensures `ProofWorkerHandle::new` spawns workers correctly.
     #[test]
     fn spawn_proof_workers_creates_handle() {
-        let chain_spec = Arc::new(ChainSpec::default());
-        let anchor_hash = chain_spec.genesis_hash();
-        let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec);
-        let changeset_cache = reth_trie_db::ChangesetCache::new();
-        let factory = reth_provider::providers::OverlayStateProviderFactory::new(
-            provider_factory,
-            reth_provider::providers::OverlayBuilder::<reth_ethereum_primitives::EthPrimitives>::new(
-                anchor_hash,
-                changeset_cache,
-            ),
-        );
-        let ctx = test_ctx(factory);
+        let ctx = test_ctx(overlay_test_factory());
 
         let runtime = reth_tasks::Runtime::test();
         let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false);

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -314,7 +314,7 @@ where
                 stats: self.stats.clone(),
                 storage_calculator: self.storage_calculator.clone(),
                 cached_storage_roots: self.cached_storage_roots.clone(),
-            }
+            };
         }
 
         // If the address didn't have a job dispatched for it then we can assume it has no targets,
@@ -323,7 +323,7 @@ where
         // If the root is already calculated then just use it directly
         if let Some(root) = self.cached_storage_roots.get(&hashed_address) {
             self.stats.borrow_mut().from_cache_count += 1;
-            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root }
+            return AsyncAccountDeferredValueEncoder::FromCache { account, root: *root };
         }
 
         // Compute storage root synchronously using the shared calculator


### PR DESCRIPTION
## Summary
- Split storage proof worker queues into per-worker channels and dispatch storage proof jobs deterministically by hashed account leading-byte prefix.
- Keep storage target iteration sorted by hashed address, but route each account's storage work to the worker owning that prefix range so nearby hashed accounts tend to reuse the same worker-local cursors/cache.
- Account proof workers now share the storage sender set and use the same prefix routing for pre-dispatched storage proofs.

## Profile
- Target path: `crates/trie/parallel/src/proof_task.rs` V2 storage proof pre-dispatch and direct storage proof dispatch.
- Expected locality win: repeated proof work for adjacent hashed account prefixes is assigned to the same worker instead of whichever worker wins a shared queue race.
- Benchmark workflow was not run from this sandbox; this needs the repo benchmark workflow for measured win/loss before marking ready.

## Verification
- `cargo test -p reth-trie-parallel storage_worker`
- `cargo test -p reth-trie-parallel dispatch_storage_proof_queues_to_prefix_worker`
- `cargo test -p reth-trie-parallel spawn_proof_workers_creates_handle`
- `git diff --check`