### PR TITLE
fix(rpc): use effective tx gas cap for estimates

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -94,15 +94,13 @@ pub trait EstimateCall: Call {
         }
 
         // the gas limit of the corresponding block
-        let max_gas_limit = evm_env
-            .cfg_env
-            .tx_gas_limit_cap
-            // If EIP-8037 is enabled, the transaction gas limit cap is not applicable
-            .filter(|_| !evm_env.cfg_env.is_amsterdam_eip8037_enabled())
-            .map_or_else(
-                || evm_env.block_env.gas_limit(),
-                |cap| cap.min(evm_env.block_env.gas_limit()),
-            );
+        let block_gas_limit = evm_env.block_env.gas_limit();
+        // If EIP-8037 is enabled, the transaction gas limit cap is not applicable
+        let max_gas_limit = if evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+            block_gas_limit
+        } else {
+            evm_env.cfg_env.tx_gas_limit_cap().min(block_gas_limit)
+        };
 
         // Determine the highest possible gas limit, considering both the request's specified limit
         // and the block's limit.


### PR DESCRIPTION
Closes #25469 by using revm's effective transaction gas cap when bounding eth_estimateGas.

```rust
    fn tx_gas_limit_cap(&self) -> u64 {
        self.tx_gas_limit_cap
            .unwrap_or(if self.spec.clone().into().is_enabled_in(SpecId::OSAKA) {
                eip7825::TX_GAS_LIMIT_CAP
            } else {
                u64::MAX
            })
    }
```

just using `tx_gas_limit_cap` directly can lead to the reported bug if the config doesnt properly configure a tx_gas_limit_cap post fusaka