### PR TITLE
feat(tree): defer BAL input drop

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -67,6 +67,7 @@ where
 
     worker_pool.in_place_scope(|scope| {
         execute_block_inner(
+            runtime,
             scope,
             evm_config,
             make_db,
@@ -83,6 +84,7 @@ where
 
 #[expect(clippy::too_many_arguments, clippy::type_complexity)]
 fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
+    runtime: &Runtime,
     scope: &rayon::Scope<'scope>,
     evm_config: &'scope Evm,
     make_db: &'scope MakeDb,
@@ -173,6 +175,11 @@ where
     let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, bal);
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
+
+    // BAL consists of lots of small objects and may be expensive to drop. Defer dropping to the
+    // background.
+    runtime.spawn_drop(input_bal_revm);
+
     Ok((
         BlockExecutionOutput { state: canonical_state.take_bundle(), result: block_result },
         senders,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1009,7 +1009,22 @@ where
             trie_output,
             changeset_provider,
         );
-        let raw_bal = decoded_bal.map(|decoded_bal| decoded_bal.as_raw_bal().clone());
+
+        // Here we need to provide the original raw BAL into the validation output if it was
+        // provided to us in the first place.
+        //
+        // This is also a place where decoded BAL becomes no longer needed. It's a big structure
+        // consisting of lots of small allocations. Dropping it takes a significant amount of time.
+        // Therefore, we drop it in background task to avoid blocking block return.
+        let raw_bal = match decoded_bal {
+            None => None,
+            Some(decoded_bal) => {
+                let raw_bal = decoded_bal.as_raw_bal().clone();
+                self.runtime.spawn_drop(decoded_bal);
+                Some(raw_bal)
+            }
+        };
+
         Ok(ValidationOutput::new(executed_block, timing_stats).with_raw_bal(raw_bal))
     }
 


### PR DESCRIPTION
Dropping the BAL takes a considerable amount of time. Here we defer it to a separate thread to perform deallocation.