### PR TITLE
perf(rpc): arc chain change cache data

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -427,9 +427,8 @@ where
     fn on_reorg_block(
         &mut self,
         block_hash: B256,
-        res: ProviderResult<Option<RecoveredBlock<Provider::Block>>>,
+        res: ProviderResult<Option<Arc<RecoveredBlock<Provider::Block>>>>,
     ) {
-        let res = res.map(|b| b.map(Arc::new));
         if let Some(queued) = self.full_block_cache.remove(&block_hash) {
             // send the response to queued senders
             for tx in queued {
@@ -659,13 +658,13 @@ where
                             for block in chain_change.blocks {
                                 // Index transactions before caching the block
                                 this.index_block_transactions(&block);
-                                this.on_new_block(block.hash(), Ok(Some(Arc::new(block))));
+                                this.on_new_block(block.hash(), Ok(Some(block)));
                             }
 
                             for block_receipts in chain_change.receipts {
                                 this.on_new_receipts(
                                     block_receipts.block_hash,
-                                    Ok(Some(Arc::new(block_receipts.receipts))),
+                                    Ok(Some(block_receipts.receipts)),
                                 );
                             }
                         }
@@ -683,7 +682,7 @@ where
                             for block_receipts in chain_change.receipts {
                                 this.on_reorg_receipts(
                                     block_receipts.block_hash,
-                                    Ok(Some(Arc::new(block_receipts.receipts))),
+                                    Ok(Some(block_receipts.receipts)),
                                 );
                             }
                         }
@@ -790,12 +789,12 @@ enum CacheAction<B: Block, R> {
 
 struct BlockReceipts<R> {
     block_hash: B256,
-    receipts: Vec<R>,
+    receipts: Arc<Vec<R>>,
 }
 
 /// A change of the canonical chain
 struct ChainChange<B: Block, R> {
-    blocks: Vec<RecoveredBlock<B>>,
+    blocks: Vec<Arc<RecoveredBlock<B>>>,
     receipts: Vec<BlockReceipts<R>>,
 }
 
@@ -807,9 +806,11 @@ impl<B: Block, R: Clone> ChainChange<B, R> {
         let (blocks, receipts): (Vec<_>, Vec<_>) = chain
             .blocks_and_receipts()
             .map(|(block, receipts)| {
-                let block_receipts =
-                    BlockReceipts { block_hash: block.hash(), receipts: receipts.clone() };
-                (block.clone(), block_receipts)
+                let block_receipts = BlockReceipts {
+                    block_hash: block.hash(),
+                    receipts: Arc::new(receipts.clone()),
+                };
+                (Arc::new(block.clone()), block_receipts)
             })
             .unzip();
         Self { blocks, receipts }


### PR DESCRIPTION
Wrap canonical chain cache notifications in `Arc` before sending them to the cache service. This avoids allocating the block and receipt Arcs while processing new canonical and reorg cache actions.