### PR TITLE
perf: store `Arc`'d blocks in `Chain`

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -934,7 +934,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
             [first, rest @ ..] => {
                 let trie_data_handle = first.trie_data_handle();
                 let mut chain = Chain::from_block(
-                    first.recovered_block().clone(),
+                    Arc::clone(&first.recovered_block),
                     ExecutionOutcome::from((
                         first.execution_outcome().clone(),
                         first.block_number(),
@@ -950,7 +950,7 @@ impl<N: NodePrimitives<SignedTx: SignedTransaction>> NewCanonicalChain<N> {
                 for exec in rest {
                     let trie_data_handle = exec.trie_data_handle();
                     chain.append_block(
-                        exec.recovered_block().clone(),
+                        Arc::clone(&exec.recovered_block),
                         ExecutionOutcome::from((
                             exec.execution_outcome().clone(),
                             exec.block_number(),

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -1,7 +1,7 @@
 //! Contains [Chain], a chain of blocks and their final state.
 
 use crate::ExecutionOutcome;
-use alloc::{borrow::Cow, collections::BTreeMap, vec::Vec};
+use alloc::{borrow::Cow, collections::BTreeMap, sync::Arc, vec::Vec};
 use alloy_consensus::{
     transaction::{Recovered, TxHashRef},
     BlockHeader, TxReceipt,
@@ -29,7 +29,7 @@ use reth_trie_common::LazyTrieData;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Chain<N: NodePrimitives = reth_ethereum_primitives::EthPrimitives> {
     /// All blocks in this chain.
-    blocks: BTreeMap<BlockNumber, RecoveredBlock<N::Block>>,
+    blocks: BTreeMap<BlockNumber, Arc<RecoveredBlock<N::Block>>>,
     /// The outcome of block execution for this chain.
     ///
     /// This field contains the state of all accounts after the execution of all blocks in this
@@ -67,12 +67,17 @@ impl<N: NodePrimitives> Chain<N> {
     ///
     /// A chain of blocks should not be empty.
     pub fn new(
-        blocks: impl IntoIterator<Item = RecoveredBlock<N::Block>>,
+        blocks: impl IntoIterator<Item: Into<Arc<RecoveredBlock<N::Block>>>>,
         execution_outcome: ExecutionOutcome<N::Receipt>,
         trie_data: BTreeMap<BlockNumber, LazyTrieData>,
     ) -> Self {
-        let blocks =
-            blocks.into_iter().map(|b| (b.header().number(), b)).collect::<BTreeMap<_, _>>();
+        let blocks = blocks
+            .into_iter()
+            .map(|b| {
+                let block = b.into();
+                (block.header().number(), block)
+            })
+            .collect::<BTreeMap<_, _>>();
         debug_assert!(!blocks.is_empty(), "Chain should have at least one block");
 
         Self { blocks, execution_outcome, trie_data }
@@ -80,21 +85,22 @@ impl<N: NodePrimitives> Chain<N> {
 
     /// Create new Chain from a single block and its state.
     pub fn from_block(
-        block: RecoveredBlock<N::Block>,
+        block: impl Into<Arc<RecoveredBlock<N::Block>>>,
         execution_outcome: ExecutionOutcome<N::Receipt>,
         trie_data: LazyTrieData,
     ) -> Self {
+        let block = block.into();
         let block_number = block.header().number();
         Self::new([block], execution_outcome, BTreeMap::from([(block_number, trie_data)]))
     }
 
     /// Get the blocks in this chain.
-    pub const fn blocks(&self) -> &BTreeMap<BlockNumber, RecoveredBlock<N::Block>> {
+    pub const fn blocks(&self) -> &BTreeMap<BlockNumber, Arc<RecoveredBlock<N::Block>>> {
         &self.blocks
     }
 
     /// Consumes the type and only returns the blocks in this chain.
-    pub fn into_blocks(self) -> BTreeMap<BlockNumber, RecoveredBlock<N::Block>> {
+    pub fn into_blocks(self) -> BTreeMap<BlockNumber, Arc<RecoveredBlock<N::Block>>> {
         self.blocks
     }
 
@@ -140,7 +146,9 @@ impl<N: NodePrimitives> Chain<N> {
 
     /// Returns the block with matching hash.
     pub fn recovered_block(&self, block_hash: BlockHash) -> Option<&RecoveredBlock<N::Block>> {
-        self.blocks.iter().find_map(|(_num, block)| (block.hash() == block_hash).then_some(block))
+        self.blocks
+            .iter()
+            .find_map(|(_num, block)| (block.hash() == block_hash).then_some(block.as_ref()))
     }
 
     /// Return execution outcome at the `block_number` or None if block is not known
@@ -202,7 +210,7 @@ impl<N: NodePrimitives> Chain<N> {
 
     /// Returns an iterator over all blocks in the chain with increasing block number.
     pub fn blocks_iter(&self) -> impl Iterator<Item = &RecoveredBlock<N::Block>> + '_ {
-        self.blocks().iter().map(|block| block.1)
+        self.blocks().iter().map(|block| block.1.as_ref())
     }
 
     /// Returns an iterator over all transactions in the chain.
@@ -327,10 +335,11 @@ impl<N: NodePrimitives> Chain<N> {
     /// This method assumes that blocks attachment to the chain has already been validated.
     pub fn append_block(
         &mut self,
-        block: RecoveredBlock<N::Block>,
+        block: impl Into<Arc<RecoveredBlock<N::Block>>>,
         execution_outcome: ExecutionOutcome<N::Receipt>,
         trie_data: LazyTrieData,
     ) {
+        let block = block.into();
         let block_number = block.header().number();
         self.blocks.insert(block_number, block);
         self.execution_outcome.extend(execution_outcome);
@@ -362,7 +371,7 @@ impl<N: NodePrimitives> Chain<N> {
 /// Wrapper type for `blocks` display in `Chain`
 #[derive(Debug)]
 pub struct DisplayBlocksChain<'a, B: reth_primitives_traits::Block>(
-    pub &'a BTreeMap<BlockNumber, RecoveredBlock<B>>,
+    pub &'a BTreeMap<BlockNumber, Arc<RecoveredBlock<B>>>,
 );
 
 impl<B: reth_primitives_traits::Block> fmt::Display for DisplayBlocksChain<'_, B> {
@@ -383,7 +392,7 @@ impl<B: reth_primitives_traits::Block> fmt::Display for DisplayBlocksChain<'_, B
 /// All blocks in the chain
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ChainBlocks<'a, B: Block> {
-    blocks: Cow<'a, BTreeMap<BlockNumber, RecoveredBlock<B>>>,
+    blocks: Cow<'a, BTreeMap<BlockNumber, Arc<RecoveredBlock<B>>>>,
 }
 
 impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, B> {
@@ -391,14 +400,14 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
     ///
     /// Note: this always yields at least one block.
     #[inline]
-    pub fn into_blocks(self) -> impl Iterator<Item = RecoveredBlock<B>> {
+    pub fn into_blocks(self) -> impl Iterator<Item = Arc<RecoveredBlock<B>>> {
         self.blocks.into_owned().into_values()
     }
 
     /// Creates an iterator over all blocks in the chain with increasing block number.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = (&BlockNumber, &RecoveredBlock<B>)> {
-        self.blocks.iter()
+        self.blocks.iter().map(|(number, block)| (number, block.as_ref()))
     }
 
     /// Get the tip of the chain.
@@ -408,7 +417,7 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
     /// Chains always have at least one block.
     #[inline]
     pub fn tip(&self) -> &RecoveredBlock<B> {
-        self.blocks.last_key_value().expect("Chain should have at least one block").1
+        self.blocks.last_key_value().expect("Chain should have at least one block").1.as_ref()
     }
 
     /// Get the _first_ block of the chain.
@@ -418,7 +427,7 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
     /// Chains always have at least one block.
     #[inline]
     pub fn first(&self) -> &RecoveredBlock<B> {
-        self.blocks.first_key_value().expect("Chain should have at least one block").1
+        self.blocks.first_key_value().expect("Chain should have at least one block").1.as_ref()
     }
 
     /// Returns an iterator over all transactions in the chain.
@@ -475,8 +484,8 @@ impl<B: Block<Body: BlockBody<Transaction: SignedTransaction>>> ChainBlocks<'_, 
 }
 
 impl<B: Block> IntoIterator for ChainBlocks<'_, B> {
-    type Item = (BlockNumber, RecoveredBlock<B>);
-    type IntoIter = alloc::collections::btree_map::IntoIter<BlockNumber, RecoveredBlock<B>>;
+    type Item = (BlockNumber, Arc<RecoveredBlock<B>>);
+    type IntoIter = alloc::collections::btree_map::IntoIter<BlockNumber, Arc<RecoveredBlock<B>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.blocks.into_owned().into_iter()
@@ -608,7 +617,7 @@ pub(super) mod serde_bincode_compat {
                     let block = N::Block::decode(&mut repr.rlp.as_ref())
                         .expect("invalid RLP for block in serde_bincode_compat");
                     let sealed = SealedBlock::new_unhashed(block);
-                    (num, RecoveredBlock::new_sealed(sealed, repr.senders))
+                    (num, Arc::new(RecoveredBlock::new_sealed(sealed, repr.senders)))
                 })
                 .collect();
 
@@ -706,11 +715,15 @@ mod tests {
 
         block3.set_parent_hash(block2_hash);
 
-        let mut chain1: Chain =
-            Chain { blocks: BTreeMap::from([(1, block1), (2, block2)]), ..Default::default() };
+        let mut chain1: Chain = Chain {
+            blocks: BTreeMap::from([(1, Arc::new(block1)), (2, Arc::new(block2))]),
+            ..Default::default()
+        };
 
-        let chain2 =
-            Chain { blocks: BTreeMap::from([(3, block3), (4, block4)]), ..Default::default() };
+        let chain2 = Chain {
+            blocks: BTreeMap::from([(3, Arc::new(block3)), (4, Arc::new(block4))]),
+            ..Default::default()
+        };
 
         assert!(chain1.append_chain(chain2.clone()).is_ok());
 
@@ -827,7 +840,7 @@ mod tests {
         // Create a Chain object with a BTreeMap of blocks mapped to their block numbers,
         // including block1_hash and block2_hash, and the execution_outcome
         let chain: Chain = Chain {
-            blocks: BTreeMap::from([(10, block1), (11, block2)]),
+            blocks: BTreeMap::from([(10, Arc::new(block1)), (11, Arc::new(block2))]),
             execution_outcome: execution_outcome.clone(),
             ..Default::default()
         };

--- a/crates/exex/exex/src/backfill/job.rs
+++ b/crates/exex/exex/src/backfill/job.rs
@@ -287,7 +287,8 @@ mod tests {
         assert_eq!(chains.len(), 1);
         let mut chain = chains.into_iter().next().unwrap();
         chain.execution_outcome_mut().bundle.reverts.sort();
-        assert_eq!(chain.blocks(), &[(1, block.clone())].into());
+        assert_eq!(chain.blocks().len(), 1);
+        assert_eq!(chain.blocks().get(&1).map(|block| block.as_ref()), Some(block));
         assert_eq!(chain.execution_outcome(), &execution_outcome);
 
         Ok(())
@@ -437,7 +438,11 @@ mod tests {
         for (i, (pipeline_block, pipeline_output)) in pipeline_results.iter().enumerate() {
             let block_number = pipeline_block.number();
             let chain_block = chain.blocks().get(&block_number).expect("block should be in chain");
-            assert_eq!(chain_block, pipeline_block, "block {i}: block mismatch in batch backfill");
+            assert_eq!(
+                chain_block.as_ref(),
+                pipeline_block,
+                "block {i}: block mismatch in batch backfill"
+            );
 
             let chain_receipts = &chain.execution_outcome().receipts[i];
             assert_eq!(
@@ -482,12 +487,14 @@ mod tests {
 
         let mut chain1 = chains[0].clone();
         chain1.execution_outcome_mut().bundle.reverts.sort();
-        assert_eq!(chain1.blocks(), &[(1, block1)].into());
+        assert_eq!(chain1.blocks().len(), 1);
+        assert_eq!(chain1.blocks().get(&1).map(|block| block.as_ref()), Some(&block1));
         assert_eq!(chain1.execution_outcome(), &to_execution_outcome(1, &output1));
 
         let mut chain2 = chains[1].clone();
         chain2.execution_outcome_mut().bundle.reverts.sort();
-        assert_eq!(chain2.blocks(), &[(2, block2)].into());
+        assert_eq!(chain2.blocks().len(), 1);
+        assert_eq!(chain2.blocks().get(&2).map(|block| block.as_ref()), Some(&block2));
         assert_eq!(chain2.execution_outcome(), &to_execution_outcome(2, &output2));
 
         Ok(())

--- a/crates/exex/exex/src/manager.rs
+++ b/crates/exex/exex/src/manager.rs
@@ -1078,7 +1078,7 @@ mod tests {
         // Setup a notification
         let notification = ExExNotification::ChainCommitted {
             new: Arc::new(Chain::new(
-                vec![Default::default()],
+                vec![RecoveredBlock::default()],
                 Default::default(),
                 Default::default(),
             )),
@@ -1148,7 +1148,7 @@ mod tests {
         // Setup a notification
         let notification = ExExNotification::ChainCommitted {
             new: Arc::new(Chain::new(
-                vec![Default::default()],
+                vec![RecoveredBlock::default()],
                 Default::default(),
                 Default::default(),
             )),


### PR DESCRIPTION
Changes `Chain` and `blocks_to_chain` to store `Arc<RecoveredBlock>` in `Chain` and avoid clonning entire blocks on FCU