### PR TITLE
feat(tasks): add worker queue metrics

### DIFF
--- a/.github/config/bench-metrics-targets.json
+++ b/.github/config/bench-metrics-targets.json
@@ -92,6 +92,30 @@
       "target": "decrease",
       "floor_pct": 2.5,
       "min_value_pct_total_latency": 1.4
+    },
+    {
+      "query": "reth_executor_named_worker_queue_wait_duration_seconds",
+      "target": "decrease",
+      "floor_pct": 10.0,
+      "min_value_pct_total_latency": 1.0
+    },
+    {
+      "query": "reth_executor_named_worker_task_duration_seconds",
+      "target": "decrease",
+      "floor_pct": 7.5,
+      "min_value_pct_total_latency": 1.0
+    },
+    {
+      "query": "reth_executor_worker_pool_job_queue_wait_duration_seconds",
+      "target": "decrease",
+      "floor_pct": 25.0,
+      "min_value_pct_total_latency": 2.5
+    },
+    {
+      "query": "reth_executor_worker_pool_job_duration_seconds",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 1.0
     }
   ]
 }

--- a/crates/tasks/src/metrics.rs
+++ b/crates/tasks/src/metrics.rs
@@ -2,7 +2,11 @@
 
 use core::fmt;
 
-use reth_metrics::{metrics::Counter, Metrics};
+use reth_metrics::{
+    metrics::{Counter, Histogram},
+    Metrics,
+};
+use std::time::Duration;
 
 /// Task Executor Metrics
 #[derive(Metrics, Clone)]
@@ -59,5 +63,61 @@ impl Drop for IncCounterOnDrop {
     /// Increment the counter when the instance is dropped.
     fn drop(&mut self) {
         self.0.increment(1);
+    }
+}
+
+/// Metrics for a named worker managed by the [`crate::worker_map::WorkerMap`].
+#[derive(Metrics, Clone)]
+#[metrics(scope = "executor.named_worker")]
+pub(crate) struct WorkerThreadMetrics {
+    /// Time spent queued before a named worker starts executing the task.
+    queue_wait_duration_seconds: Histogram,
+    /// Time spent executing a task on a named worker.
+    task_duration_seconds: Histogram,
+}
+
+impl WorkerThreadMetrics {
+    /// Create metrics for the named worker.
+    pub(crate) fn new(worker: &'static str) -> Self {
+        Self::new_with_labels(&[("worker", worker)])
+    }
+
+    /// Record how long a task waited for this worker.
+    pub(crate) fn record_queue_wait(&self, duration: Duration) {
+        self.queue_wait_duration_seconds.record(duration.as_secs_f64());
+    }
+
+    /// Record how long a task executed on this worker.
+    pub(crate) fn record_task_duration(&self, duration: Duration) {
+        self.task_duration_seconds.record(duration.as_secs_f64());
+    }
+}
+
+/// Metrics for jobs submitted through [`crate::pool::WorkerPool`] wrapper methods.
+#[cfg(feature = "rayon")]
+#[derive(Metrics, Clone)]
+#[metrics(scope = "executor.worker_pool")]
+pub(crate) struct WorkerPoolMetrics {
+    /// Time spent queued before the worker pool starts executing the outer job.
+    job_queue_wait_duration_seconds: Histogram,
+    /// Time spent executing the outer job on the worker pool.
+    job_duration_seconds: Histogram,
+}
+
+#[cfg(feature = "rayon")]
+impl WorkerPoolMetrics {
+    /// Create metrics for the worker pool.
+    pub(crate) fn new(pool: &'static str) -> Self {
+        Self::new_with_labels(&[("pool", pool)])
+    }
+
+    /// Record how long an outer job waited for this pool.
+    pub(crate) fn record_job_queue_wait(&self, duration: Duration) {
+        self.job_queue_wait_duration_seconds.record(duration.as_secs_f64());
+    }
+
+    /// Record how long an outer job executed on this pool.
+    pub(crate) fn record_job_duration(&self, duration: Duration) {
+        self.job_duration_seconds.record(duration.as_secs_f64());
     }
 }

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -1,5 +1,6 @@
 //! Additional helpers for executing tracing calls
 
+use crate::metrics::WorkerPoolMetrics;
 use std::{
     any::Any,
     cell::RefCell,
@@ -12,6 +13,7 @@ use std::{
     },
     task::{ready, Context, Poll},
     thread,
+    time::Instant,
 };
 use tokio::sync::{oneshot, AcquireError, OwnedSemaphorePermit, Semaphore};
 
@@ -173,6 +175,7 @@ thread_local! {
 #[derive(Debug)]
 pub struct WorkerPool {
     pool: OnceLock<rayon::ThreadPool>,
+    metrics: OnceLock<WorkerPoolMetrics>,
     num_threads: usize,
     thread_name_prefix: &'static str,
 }
@@ -183,7 +186,7 @@ impl WorkerPool {
     /// The underlying rayon pool is not created until the first method that requires it is called.
     /// Thread names follow the pattern `"{prefix}-{index:02}"`.
     pub const fn new(num_threads: usize, thread_name_prefix: &'static str) -> Self {
-        Self { pool: OnceLock::new(), num_threads, thread_name_prefix }
+        Self { pool: OnceLock::new(), metrics: OnceLock::new(), num_threads, thread_name_prefix }
     }
 
     /// Returns a reference to the underlying rayon pool, creating it on first access.
@@ -197,6 +200,11 @@ impl WorkerPool {
             )
             .unwrap_or_else(|err| panic!("failed to build {prefix} worker pool: {err}"))
         })
+    }
+
+    /// Returns metrics for this worker pool.
+    fn metrics(&self) -> &WorkerPoolMetrics {
+        self.metrics.get_or_init(|| WorkerPoolMetrics::new(self.thread_name_prefix))
     }
 
     /// Returns `true` if the underlying rayon pool has been initialized.
@@ -264,7 +272,16 @@ impl WorkerPool {
     /// Each thread can access its own [`Worker`] via the provided reference or through additional
     /// [`WorkerPool::with_worker`] calls.
     pub fn install<R: Send>(&self, f: impl FnOnce(&Worker) -> R + Send) -> R {
-        self.pool().install(|| WORKER.with_borrow(|worker| f(worker)))
+        let pool = self.pool();
+        let metrics = self.metrics().clone();
+        let queued_at = Instant::now();
+
+        pool.install(move || {
+            let started_at = Instant::now();
+            metrics.record_job_queue_wait(started_at.saturating_duration_since(queued_at));
+            let _record_job_duration = RecordWorkerPoolJobDurationOnDrop::new(metrics, started_at);
+            WORKER.with_borrow(|worker| f(worker))
+        })
     }
 
     /// Runs a closure on the pool without worker state access.
@@ -272,12 +289,30 @@ impl WorkerPool {
     /// Like [`install`](Self::install) but for closures that don't need per-thread [`Worker`]
     /// state.
     pub fn install_fn<R: Send>(&self, f: impl FnOnce() -> R + Send) -> R {
-        self.pool().install(f)
+        let pool = self.pool();
+        let metrics = self.metrics().clone();
+        let queued_at = Instant::now();
+
+        pool.install(move || {
+            let started_at = Instant::now();
+            metrics.record_job_queue_wait(started_at.saturating_duration_since(queued_at));
+            let _record_job_duration = RecordWorkerPoolJobDurationOnDrop::new(metrics, started_at);
+            f()
+        })
     }
 
     /// Spawns a closure on the pool.
     pub fn spawn(&self, f: impl FnOnce() + Send + 'static) {
-        self.pool().spawn(f);
+        let pool = self.pool();
+        let metrics = self.metrics().clone();
+        let queued_at = Instant::now();
+
+        pool.spawn(move || {
+            let started_at = Instant::now();
+            metrics.record_job_queue_wait(started_at.saturating_duration_since(queued_at));
+            let _record_job_duration = RecordWorkerPoolJobDurationOnDrop::new(metrics, started_at);
+            f();
+        });
     }
 
     /// Executes `f` on this pool using [`rayon::in_place_scope`], which converts the calling
@@ -298,6 +333,24 @@ impl WorkerPool {
     /// Mutably access the current thread's [`Worker`] from within a pool closure.
     pub fn with_worker_mut<R>(f: impl FnOnce(&mut Worker) -> R) -> R {
         WORKER.with_borrow_mut(|worker| f(worker))
+    }
+}
+
+/// Records a worker pool job's run time when the job finishes or unwinds.
+struct RecordWorkerPoolJobDurationOnDrop {
+    metrics: WorkerPoolMetrics,
+    started_at: Instant,
+}
+
+impl RecordWorkerPoolJobDurationOnDrop {
+    const fn new(metrics: WorkerPoolMetrics, started_at: Instant) -> Self {
+        Self { metrics, started_at }
+    }
+}
+
+impl Drop for RecordWorkerPoolJobDurationOnDrop {
+    fn drop(&mut self) {
+        self.metrics.record_job_duration(self.started_at.elapsed());
     }
 }
 

--- a/crates/tasks/src/worker_map.rs
+++ b/crates/tasks/src/worker_map.rs
@@ -4,6 +4,7 @@
 //! This is a substitute for `spawn_blocking` that reuses the same OS thread for the same
 //! named task, like a 1-thread thread pool keyed by name.
 
+use crate::metrics::WorkerThreadMetrics;
 use dashmap::DashMap;
 use std::{
     panic::AssertUnwindSafe,
@@ -12,6 +13,7 @@ use std::{
         Arc,
     },
     thread,
+    time::Instant,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -21,6 +23,8 @@ type BoxedTask = Box<dyn FnOnce() + Send + 'static>;
 struct WorkerThread {
     /// Sender to submit work to this worker's thread.
     tx: mpsc::UnboundedSender<BoxedTask>,
+    /// Metrics labeled with this worker's name.
+    metrics: WorkerThreadMetrics,
     /// Number of tasks currently running or queued on this worker.
     pending: Arc<AtomicUsize>,
     /// The OS thread handle. Taken during shutdown to join.
@@ -40,7 +44,12 @@ impl WorkerThread {
             })
             .unwrap_or_else(|e| panic!("failed to spawn worker thread {name:?}: {e}"));
 
-        Self { tx, pending: Arc::new(AtomicUsize::new(0)), handle: Some(handle) }
+        Self {
+            tx,
+            metrics: WorkerThreadMetrics::new(name),
+            pending: Arc::new(AtomicUsize::new(0)),
+            handle: Some(handle),
+        }
     }
 
     /// Spawns a closure on this worker.
@@ -53,9 +62,14 @@ impl WorkerThread {
 
         let (result_tx, result_rx) = oneshot::channel();
         let pending = self.pending.clone();
+        let metrics = self.metrics.clone();
+        let queued_at = Instant::now();
 
         let task: BoxedTask = Box::new(move || {
+            let started_at = Instant::now();
+            metrics.record_queue_wait(started_at.saturating_duration_since(queued_at));
             let _decrement_pending = DecrementPendingOnDrop(pending);
+            let _record_task_duration = RecordTaskDurationOnDrop::new(metrics, started_at);
             let _ = result_tx.send(f());
         });
 
@@ -76,9 +90,14 @@ impl WorkerThread {
 
         let (result_tx, result_rx) = oneshot::channel();
         let pending = self.pending.clone();
+        let metrics = self.metrics.clone();
+        let queued_at = Instant::now();
 
         let task: BoxedTask = Box::new(move || {
+            let started_at = Instant::now();
+            metrics.record_queue_wait(started_at.saturating_duration_since(queued_at));
             let _decrement_pending = DecrementPendingOnDrop(pending);
+            let _record_task_duration = RecordTaskDurationOnDrop::new(metrics, started_at);
             let _ = result_tx.send(f());
         });
 
@@ -97,6 +116,24 @@ struct DecrementPendingOnDrop(Arc<AtomicUsize>);
 impl Drop for DecrementPendingOnDrop {
     fn drop(&mut self) {
         self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Records a worker task's run time when the task finishes or unwinds.
+struct RecordTaskDurationOnDrop {
+    metrics: WorkerThreadMetrics,
+    started_at: Instant,
+}
+
+impl RecordTaskDurationOnDrop {
+    const fn new(metrics: WorkerThreadMetrics, started_at: Instant) -> Self {
+        Self { metrics, started_at }
+    }
+}
+
+impl Drop for RecordTaskDurationOnDrop {
+    fn drop(&mut self) {
+        self.metrics.record_task_duration(self.started_at.elapsed());
     }
 }
 


### PR DESCRIPTION
Adds scheduler-level queue wait and execution duration histograms for named blocking workers and worker pool outer jobs. Metrics are labeled by worker or pool name so callers like deferred trie and state overlay can be inspected separately.