### PR TITLE
feat(snap): add version-aware snap message helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8620,6 +8620,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
+ "test-case",
  "thiserror 2.0.18",
 ]
 
@@ -9213,6 +9214,7 @@ dependencies = [
  "reth-network-types",
  "reth-primitives-traits",
  "reth-storage-errors",
+ "test-case",
  "tokio",
  "tracing",
 ]

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -49,6 +49,7 @@ arbitrary = { workspace = true, features = ["derive"] }
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 rand.workspace = true
+test-case.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -228,6 +228,21 @@ pub enum SnapProtocolMessage {
     BlockAccessLists(BlockAccessListsMessage),
 }
 
+/// Error decoding an inbound `snap` protocol message from its framed bytes.
+#[derive(thiserror::Error, Debug)]
+pub enum SnapProtocolError {
+    /// The payload was empty and carried no message id.
+    #[error("empty snap message")]
+    Empty,
+    /// The message id is not valid for the negotiated snap version (e.g. the removed trie-node
+    /// messages `0x06`/`0x07` under snap/2).
+    #[error("message id {0:#x} is invalid for snap/{1:?}")]
+    UnsupportedMessageId(u8, SnapVersion),
+    /// Decoding the RLP message body failed.
+    #[error("RLP error: {0}")]
+    Rlp(#[from] alloy_rlp::Error),
+}
+
 impl SnapProtocolMessage {
     /// Returns the protocol message ID for this message type.
     ///
@@ -268,6 +283,21 @@ impl SnapProtocolMessage {
                 Self::ByteCodes(_) |
                 Self::BlockAccessLists(_)
         )
+    }
+
+    /// Overwrites the `request_id`, e.g. so a session can assign a connection-unique id before
+    /// sending a request.
+    pub const fn set_request_id(&mut self, request_id: u64) {
+        match self {
+            Self::GetAccountRange(m) => m.request_id = request_id,
+            Self::AccountRange(m) => m.request_id = request_id,
+            Self::GetStorageRanges(m) => m.request_id = request_id,
+            Self::StorageRanges(m) => m.request_id = request_id,
+            Self::GetByteCodes(m) => m.request_id = request_id,
+            Self::ByteCodes(m) => m.request_id = request_id,
+            Self::GetBlockAccessLists(m) => m.request_id = request_id,
+            Self::BlockAccessLists(m) => m.request_id = request_id,
+        }
     }
 
     /// Encode the message to bytes
@@ -361,6 +391,18 @@ impl SnapProtocolMessage {
         );
 
         Err(alloy_rlp::Error::Custom("Unknown message ID"))
+    }
+
+    /// Decodes a framed snap message (`[id, body..]`), validating the id against `version`.
+    ///
+    /// Empty payload, invalid id, and malformed body are reported as distinct
+    /// [`SnapProtocolError`] variants.
+    pub fn decode_versioned(version: SnapVersion, bytes: &[u8]) -> Result<Self, SnapProtocolError> {
+        let (&id, body) = bytes.split_first().ok_or(SnapProtocolError::Empty)?;
+        if !version.supports_message_id(id) {
+            return Err(SnapProtocolError::UnsupportedMessageId(id, version));
+        }
+        Self::decode(id, &mut &body[..]).map_err(SnapProtocolError::Rlp)
     }
 }
 
@@ -529,5 +571,59 @@ mod tests {
     fn request_id_and_is_response(msg: SnapProtocolMessage, expected_id: u64, is_response: bool) {
         assert_eq!(msg.request_id(), expected_id);
         assert_eq!(msg.is_response(), is_response);
+    }
+
+    #[test]
+    fn set_request_id_overwrites_the_id() {
+        let mut msg = SnapProtocolMessage::GetByteCodes(GetByteCodesMessage {
+            request_id: 1,
+            hashes: Vec::new(),
+            response_bytes: 0,
+        });
+        msg.set_request_id(42);
+        assert_eq!(msg.request_id(), 42);
+    }
+
+    #[test]
+    fn decode_versioned_round_trips_framed_message() {
+        let original = SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsMessage {
+            request_id: 7,
+            block_hashes: vec![b256_from_u64(1)],
+            response_bytes: 1024,
+        });
+        let framed = original.encode();
+        let decoded = SnapProtocolMessage::decode_versioned(SnapVersion::V2, &framed).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_versioned_rejects_empty() {
+        // An empty payload carries no message id and is distinct from an invalid id.
+        assert!(matches!(
+            SnapProtocolMessage::decode_versioned(SnapVersion::V2, &[]),
+            Err(SnapProtocolError::Empty)
+        ));
+    }
+
+    #[test]
+    fn decode_versioned_rejects_trie_node_ids_in_v2() {
+        // snap/2 (EIP-8189) removes trie nodes (`0x06`/`0x07`); decoding must reject them as an
+        // unsupported id rather than a malformed body.
+        for id in [0x06u8, 0x07] {
+            assert!(matches!(
+                SnapProtocolMessage::decode_versioned(SnapVersion::V2, &[id]),
+                Err(SnapProtocolError::UnsupportedMessageId(got, SnapVersion::V2)) if got == id
+            ));
+        }
+    }
+
+    #[test]
+    fn decode_versioned_reports_malformed_body() {
+        // A valid id (GetBlockAccessLists, 0x08) with a non-decodable body is an RLP error, not an
+        // unsupported id.
+        assert!(matches!(
+            SnapProtocolMessage::decode_versioned(SnapVersion::V2, &[0x08, 0xff]),
+            Err(SnapProtocolError::Rlp(_))
+        ));
     }
 }

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -245,6 +245,31 @@ impl SnapProtocolMessage {
         }
     }
 
+    /// Returns the `request_id` used to correlate this message with its request/response pair.
+    pub const fn request_id(&self) -> u64 {
+        match self {
+            Self::GetAccountRange(m) => m.request_id,
+            Self::AccountRange(m) => m.request_id,
+            Self::GetStorageRanges(m) => m.request_id,
+            Self::StorageRanges(m) => m.request_id,
+            Self::GetByteCodes(m) => m.request_id,
+            Self::ByteCodes(m) => m.request_id,
+            Self::GetBlockAccessLists(m) => m.request_id,
+            Self::BlockAccessLists(m) => m.request_id,
+        }
+    }
+
+    /// Returns `true` if this is a response message (as opposed to a request).
+    pub const fn is_response(&self) -> bool {
+        matches!(
+            self,
+            Self::AccountRange(_) |
+                Self::StorageRanges(_) |
+                Self::ByteCodes(_) |
+                Self::BlockAccessLists(_)
+        )
+    }
+
     /// Encode the message to bytes
     pub fn encode(&self) -> Bytes {
         let mut buf = Vec::new();
@@ -342,6 +367,7 @@ impl SnapProtocolMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     // Helper function to create a B256 from a u64 for testing
     fn b256_from_u64(value: u64) -> B256 {
@@ -457,5 +483,51 @@ mod tests {
         assert!(v2.supports_message_id(SnapMessageId::BlockAccessLists as u8));
         assert!(!v2.supports_message_id(0x0a));
         assert!(!v2.supports_message_id(0xff));
+    }
+
+    #[test_case(
+        SnapProtocolMessage::GetAccountRange(GetAccountRangeMessage {
+            request_id: 1, root_hash: B256::ZERO, starting_hash: B256::ZERO,
+            limit_hash: B256::ZERO, response_bytes: 0,
+        }), 1, false ; "get_account_range is a request"
+    )]
+    #[test_case(
+        SnapProtocolMessage::AccountRange(AccountRangeMessage {
+            request_id: 2, accounts: vec![], proof: vec![],
+        }), 2, true ; "account_range is a response"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetStorageRanges(GetStorageRangesMessage {
+            request_id: 3, root_hash: B256::ZERO, account_hashes: vec![],
+            starting_hash: B256::ZERO, limit_hash: B256::ZERO, response_bytes: 0,
+        }), 3, false ; "get_storage_ranges is a request"
+    )]
+    #[test_case(
+        SnapProtocolMessage::StorageRanges(StorageRangesMessage {
+            request_id: 4, slots: vec![], proof: vec![],
+        }), 4, true ; "storage_ranges is a response"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetByteCodes(GetByteCodesMessage {
+            request_id: 5, hashes: vec![], response_bytes: 0,
+        }), 5, false ; "get_byte_codes is a request"
+    )]
+    #[test_case(
+        SnapProtocolMessage::ByteCodes(ByteCodesMessage { request_id: 6, codes: vec![] }),
+        6, true ; "byte_codes is a response"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsMessage {
+            request_id: 7, block_hashes: vec![], response_bytes: 0,
+        }), 7, false ; "get_block_access_lists is a request"
+    )]
+    #[test_case(
+        SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
+            request_id: 8, block_access_lists: BlockAccessLists(vec![]),
+        }), 8, true ; "block_access_lists is a response"
+    )]
+    fn request_id_and_is_response(msg: SnapProtocolMessage, expected_id: u64, is_response: bool) {
+        assert_eq!(msg.request_id(), expected_id);
+        assert_eq!(msg.is_response(), is_response);
     }
 }

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -22,7 +22,8 @@ pub enum SnapVersion {
 }
 
 impl SnapVersion {
-    /// Returns the number of messages supported by this version.
+    /// Returns the protocol message slot length for this version (not the count of valid ids; use
+    /// [`Self::supports_message_id`] to check validity).
     pub const fn message_count(self) -> u8 {
         match self {
             Self::V2 => 10,
@@ -398,11 +399,15 @@ impl SnapProtocolMessage {
     /// Empty payload, invalid id, and malformed body are reported as distinct
     /// [`SnapProtocolError`] variants.
     pub fn decode_versioned(version: SnapVersion, bytes: &[u8]) -> Result<Self, SnapProtocolError> {
-        let (&id, body) = bytes.split_first().ok_or(SnapProtocolError::Empty)?;
+        let (&id, mut body) = bytes.split_first().ok_or(SnapProtocolError::Empty)?;
         if !version.supports_message_id(id) {
             return Err(SnapProtocolError::UnsupportedMessageId(id, version));
         }
-        Self::decode(id, &mut &body[..]).map_err(SnapProtocolError::Rlp)
+        let msg = Self::decode(id, &mut body)?;
+        if !body.is_empty() {
+            return Err(SnapProtocolError::Rlp(alloy_rlp::Error::UnexpectedLength));
+        }
+        Ok(msg)
     }
 }
 

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -578,27 +578,56 @@ mod tests {
         assert_eq!(msg.is_response(), is_response);
     }
 
-    #[test]
-    fn set_request_id_overwrites_the_id() {
-        let mut msg = SnapProtocolMessage::GetByteCodes(GetByteCodesMessage {
-            request_id: 1,
-            hashes: Vec::new(),
-            response_bytes: 0,
-        });
+    #[test_case(
+        SnapProtocolMessage::GetAccountRange(GetAccountRangeMessage {
+            request_id: 1, root_hash: B256::ZERO, starting_hash: B256::ZERO,
+            limit_hash: B256::ZERO, response_bytes: 0,
+        }) ; "get_account_range"
+    )]
+    #[test_case(
+        SnapProtocolMessage::AccountRange(AccountRangeMessage {
+            request_id: 1, accounts: vec![], proof: vec![],
+        }) ; "account_range"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetStorageRanges(GetStorageRangesMessage {
+            request_id: 1, root_hash: B256::ZERO, account_hashes: vec![],
+            starting_hash: B256::ZERO, limit_hash: B256::ZERO, response_bytes: 0,
+        }) ; "get_storage_ranges"
+    )]
+    #[test_case(
+        SnapProtocolMessage::StorageRanges(StorageRangesMessage {
+            request_id: 1, slots: vec![], proof: vec![],
+        }) ; "storage_ranges"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetByteCodes(GetByteCodesMessage {
+            request_id: 1, hashes: vec![], response_bytes: 0,
+        }) ; "get_byte_codes"
+    )]
+    #[test_case(
+        SnapProtocolMessage::ByteCodes(ByteCodesMessage { request_id: 1, codes: vec![] }) ;
+        "byte_codes"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsMessage {
+            request_id: 1, block_hashes: vec![], response_bytes: 0,
+        }) ; "get_block_access_lists"
+    )]
+    #[test_case(
+        SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
+            request_id: 1, block_access_lists: BlockAccessLists(vec![]),
+        }) ; "block_access_lists"
+    )]
+    fn per_variant_request_id_and_round_trip(mut msg: SnapProtocolMessage) {
+        // set_request_id overwrites the id for every variant.
         msg.set_request_id(42);
         assert_eq!(msg.request_id(), 42);
-    }
 
-    #[test]
-    fn decode_versioned_round_trips_framed_message() {
-        let original = SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsMessage {
-            request_id: 7,
-            block_hashes: vec![b256_from_u64(1)],
-            response_bytes: 1024,
-        });
-        let framed = original.encode();
-        let decoded = SnapProtocolMessage::decode_versioned(SnapVersion::V2, &framed).unwrap();
-        assert_eq!(decoded, original);
+        // decode_versioned round-trips every valid snap/2 id.
+        let decoded =
+            SnapProtocolMessage::decode_versioned(SnapVersion::V2, &msg.encode()).unwrap();
+        assert_eq!(decoded, msg);
     }
 
     #[test]
@@ -629,6 +658,23 @@ mod tests {
         assert!(matches!(
             SnapProtocolMessage::decode_versioned(SnapVersion::V2, &[0x08, 0xff]),
             Err(SnapProtocolError::Rlp(_))
+        ));
+    }
+
+    #[test]
+    fn decode_versioned_rejects_trailing_bytes() {
+        // A valid framed message with junk appended after the RLP body must be rejected rather
+        // than silently decoded.
+        let original = SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsMessage {
+            request_id: 7,
+            block_hashes: vec![b256_from_u64(1)],
+            response_bytes: 1024,
+        });
+        let mut framed = original.encode().to_vec();
+        framed.push(0xff);
+        assert!(matches!(
+            SnapProtocolMessage::decode_versioned(SnapVersion::V2, &framed),
+            Err(SnapProtocolError::Rlp(alloy_rlp::Error::UnexpectedLength))
         ));
     }
 }

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -41,6 +41,7 @@ parking_lot = { workspace = true, optional = true }
 reth-consensus = { workspace = true, features = ["test-utils"] }
 
 parking_lot.workspace = true
+test-case.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [features]

--- a/crates/net/p2p/src/snap/client.rs
+++ b/crates/net/p2p/src/snap/client.rs
@@ -2,7 +2,8 @@ use crate::{download::DownloadClient, error::PeerRequestResult, priority::Priori
 use futures::Future;
 use reth_eth_wire_types::snap::{
     AccountRangeMessage, BlockAccessListsMessage, ByteCodesMessage, GetAccountRangeMessage,
-    GetBlockAccessListsMessage, GetByteCodesMessage, GetStorageRangesMessage, StorageRangesMessage,
+    GetBlockAccessListsMessage, GetByteCodesMessage, GetStorageRangesMessage, SnapProtocolMessage,
+    StorageRangesMessage,
 };
 
 /// Response types for snap sync requests
@@ -18,6 +19,21 @@ pub enum SnapResponse {
     ///
     /// Only valid for `snap/2` (EIP-8189).
     BlockAccessLists(BlockAccessListsMessage),
+}
+
+impl TryFrom<SnapProtocolMessage> for SnapResponse {
+    /// The original message, returned unchanged when it is a request rather than a response.
+    type Error = SnapProtocolMessage;
+
+    fn try_from(msg: SnapProtocolMessage) -> Result<Self, Self::Error> {
+        match msg {
+            SnapProtocolMessage::AccountRange(m) => Ok(Self::AccountRange(m)),
+            SnapProtocolMessage::StorageRanges(m) => Ok(Self::StorageRanges(m)),
+            SnapProtocolMessage::ByteCodes(m) => Ok(Self::ByteCodes(m)),
+            SnapProtocolMessage::BlockAccessLists(m) => Ok(Self::BlockAccessLists(m)),
+            request => Err(request),
+        }
+    }
 }
 
 /// The snap sync downloader client
@@ -81,4 +97,48 @@ pub trait SnapClient: DownloadClient {
         request: GetBlockAccessListsMessage,
         priority: Priority,
     ) -> Self::Output;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_eth_wire_types::BlockAccessLists;
+    use test_case::test_case;
+
+    #[test_case(
+        SnapProtocolMessage::GetAccountRange(GetAccountRangeMessage {
+            request_id: 1, root_hash: Default::default(), starting_hash: Default::default(),
+            limit_hash: Default::default(), response_bytes: 0,
+        }), false ; "account range request is not a response"
+    )]
+    #[test_case(
+        SnapProtocolMessage::GetBlockAccessLists(GetBlockAccessListsMessage {
+            request_id: 1, block_hashes: vec![], response_bytes: 0,
+        }), false ; "block access lists request is not a response"
+    )]
+    #[test_case(
+        SnapProtocolMessage::AccountRange(AccountRangeMessage {
+            request_id: 1, accounts: vec![], proof: vec![],
+        }), true ; "account range response converts"
+    )]
+    #[test_case(
+        SnapProtocolMessage::ByteCodes(ByteCodesMessage { request_id: 1, codes: vec![] }),
+        true ; "byte codes response converts"
+    )]
+    #[test_case(
+        SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
+            request_id: 1, block_access_lists: BlockAccessLists(vec![]),
+        }), true ; "block access lists response converts"
+    )]
+    fn try_from_snap_message(msg: SnapProtocolMessage, is_response: bool) {
+        let original = msg.clone();
+        match SnapResponse::try_from(msg) {
+            Ok(_) => assert!(is_response),
+            // requests are returned unchanged
+            Err(returned) => {
+                assert!(!is_response);
+                assert_eq!(returned, original);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Message-level helpers for the snap/2 (EIP-8189) client, no networking wiring.

- `SnapProtocolMessage::request_id` / `set_request_id` — correlate and assign connection-unique request ids.
- `SnapProtocolMessage::is_response` and `TryFrom<SnapProtocolMessage> for SnapResponse` — split request vs response without cloning.
- `SnapProtocolMessage::decode_versioned` — decode a framed message and validate its id against the negotiated `SnapVersion`, with `SnapProtocolError` distinguishing empty payload, invalid id (e.g. the removed trie-node `0x06`/`0x07`), and malformed RLP.

These are the building blocks the snap/2 client needs for request/response tracking and version-aware decoding.