### PR TITLE
feat(engine): support pre-Amsterdam BAL replay

### DIFF
--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -258,6 +258,14 @@ RETH_ARGS=(
   --no-persist-peers
 )
 
+if [ "$USE_BAL" = "true" ]; then
+  if "$BINARY" node --help 2>/dev/null | grep -qF -- '--engine.allow-pre-amsterdam-bal'; then
+    RETH_ARGS+=(--engine.allow-pre-amsterdam-bal)
+  else
+    echo "BAL replay requested, but ${LABEL} binary rejected --engine.allow-pre-amsterdam-bal; continuing without it"
+  fi
+fi
+
 SYNC_STATE_IDLE=false
 if "$BINARY" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
   RETH_ARGS+=(--debug.startup-sync-state-idle)

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -50,8 +50,8 @@ pub struct EthBeaconConsensus<ChainSpec> {
     skip_blob_gas_used_check: bool,
     /// When true, skips the requests hash check in post-execution validation.
     skip_requests_hash_check: bool,
-    /// When true, allows BAL hashes before Amsterdam activation.
-    allow_bal_hashes: bool,
+    /// When true, allows BAL payloads before Amsterdam activation.
+    allow_pre_amsterdam_bal: bool,
 }
 
 impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> {
@@ -63,7 +63,7 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
             skip_gas_limit_ramp_check: false,
             skip_blob_gas_used_check: false,
             skip_requests_hash_check: false,
-            allow_bal_hashes: false,
+            allow_pre_amsterdam_bal: false,
         }
     }
 
@@ -96,9 +96,9 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBeaconConsensus<ChainSpec> 
         self
     }
 
-    /// Allows BAL hashes before Amsterdam activation.
-    pub const fn with_allow_bal_hashes(mut self, allow: bool) -> Self {
-        self.allow_bal_hashes = allow;
+    /// Allows BAL payloads before Amsterdam activation.
+    pub const fn with_allow_pre_amsterdam_bal(mut self, allow: bool) -> Self {
+        self.allow_pre_amsterdam_bal = allow;
         self
     }
 
@@ -126,7 +126,7 @@ where
             result,
             receipt_root_bloom,
             block_access_list_hash,
-            self.allow_bal_hashes,
+            self.allow_pre_amsterdam_bal,
         );
 
         if self.skip_requests_hash_check &&
@@ -253,7 +253,7 @@ where
                 return Err(ConsensusError::SlotNumberMissing)
             }
         } else {
-            if header.block_access_list_hash().is_some() && !self.allow_bal_hashes {
+            if header.block_access_list_hash().is_some() && !self.allow_pre_amsterdam_bal {
                 return Err(ConsensusError::BlockAccessListHashUnexpected)
             }
             if header.slot_number().is_some() {
@@ -433,7 +433,7 @@ mod tests {
         header.block_access_list_hash = Some(B256::ZERO);
 
         assert!(EthBeaconConsensus::new(chain_spec)
-            .with_allow_bal_hashes(true)
+            .with_allow_pre_amsterdam_bal(true)
             .validate_header(&SealedHeader::seal_slow(header,))
             .is_ok());
     }
@@ -453,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn prague_header_rejects_slot_number_with_allowed_bal_hashes_before_amsterdam() {
+    fn prague_header_rejects_slot_number_with_allowed_pre_amsterdam_bal() {
         let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
         let mut header = valid_prague_header();
         header.block_access_list_hash = Some(B256::ZERO);
@@ -461,7 +461,7 @@ mod tests {
 
         assert!(matches!(
             EthBeaconConsensus::new(chain_spec)
-                .with_allow_bal_hashes(true)
+                .with_allow_pre_amsterdam_bal(true)
                 .validate_header(&SealedHeader::seal_slow(header,))
                 .unwrap_err(),
             ConsensusError::SlotNumberUnexpected
@@ -474,7 +474,7 @@ mod tests {
         let expected_hash = B256::repeat_byte(0x42);
         let block = prague_recovered_block_with_bal_hash(expected_hash);
         let result = BlockExecutionResult::<Receipt>::default();
-        let consensus = EthBeaconConsensus::new(chain_spec).with_allow_bal_hashes(true);
+        let consensus = EthBeaconConsensus::new(chain_spec).with_allow_pre_amsterdam_bal(true);
 
         assert!(FullConsensus::<EthPrimitives>::validate_block_post_execution(
             &consensus,

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -46,7 +46,7 @@ pub(crate) fn validate_block_post_execution_with_bal_hashes<B, R, ChainSpec>(
     result: &BlockExecutionResult<R>,
     receipt_root_bloom: Option<(B256, Bloom)>,
     block_access_list_hash: Option<B256>,
-    allow_bal_hashes: bool,
+    allow_pre_amsterdam_bal: bool,
 ) -> Result<(), ConsensusError>
 where
     B: Block,
@@ -106,7 +106,7 @@ where
     }
 
     // Validate that the header block access list hash matches the calculated block access list hash
-    let is_allowed_pre_amsterdam_bal_hash = allow_bal_hashes &&
+    let is_allowed_pre_amsterdam_bal_hash = allow_pre_amsterdam_bal &&
         !chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
         block.header().block_access_list_hash().is_some();
 

--- a/crates/ethereum/node/src/engine.rs
+++ b/crates/ethereum/node/src/engine.rs
@@ -29,6 +29,12 @@ impl<ChainSpec> EthereumEngineValidator<ChainSpec> {
         Self { inner: EthereumExecutionPayloadValidator::new(chain_spec) }
     }
 
+    /// Allow pre-Amsterdam BAL payloads.
+    pub fn with_allow_pre_amsterdam_bal(mut self, allow: bool) -> Self {
+        self.inner = self.inner.with_allow_pre_amsterdam_bal(allow);
+        self
+    }
+
     /// Returns the chain spec used by the validator.
     #[inline]
     fn chain_spec(&self) -> &ChainSpec {

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -335,7 +335,10 @@ where
             ctx.node.evm_config().clone(),
             ctx.config.rpc.flashbots_config(),
             ctx.node.task_executor().clone(),
-            Arc::new(EthereumEngineValidator::new(ctx.config.chain.clone())),
+            Arc::new(
+                EthereumEngineValidator::new(ctx.config.chain.clone())
+                    .with_allow_pre_amsterdam_bal(ctx.config.engine.allow_pre_amsterdam_bal),
+            ),
         );
 
         let eth_config =
@@ -759,7 +762,10 @@ where
     type Consensus = Arc<EthBeaconConsensus<<Node::Types as NodeTypes>::ChainSpec>>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
-        Ok(Arc::new(EthBeaconConsensus::new(ctx.chain_spec())))
+        Ok(Arc::new(
+            EthBeaconConsensus::new(ctx.chain_spec())
+                .with_allow_pre_amsterdam_bal(ctx.config().engine.allow_pre_amsterdam_bal),
+        ))
     }
 }
 
@@ -781,6 +787,7 @@ where
     type Validator = EthereumEngineValidator<Types::ChainSpec>;
 
     async fn build(self, ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
-        Ok(EthereumEngineValidator::new(ctx.config.chain.clone()))
+        Ok(EthereumEngineValidator::new(ctx.config.chain.clone())
+            .with_allow_pre_amsterdam_bal(ctx.config.engine.allow_pre_amsterdam_bal))
     }
 }

--- a/crates/ethereum/payload/src/validator.rs
+++ b/crates/ethereum/payload/src/validator.rs
@@ -12,12 +12,20 @@ use std::sync::Arc;
 pub struct EthereumExecutionPayloadValidator<ChainSpec> {
     /// Chain spec to validate against.
     chain_spec: Arc<ChainSpec>,
+    /// Whether to allow pre-Amsterdam BAL payloads.
+    allow_pre_amsterdam_bal: bool,
 }
 
 impl<ChainSpec> EthereumExecutionPayloadValidator<ChainSpec> {
     /// Create a new validator.
     pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
-        Self { chain_spec }
+        Self { chain_spec, allow_pre_amsterdam_bal: false }
+    }
+
+    /// Allow pre-Amsterdam BAL payloads.
+    pub const fn with_allow_pre_amsterdam_bal(mut self, allow: bool) -> Self {
+        self.allow_pre_amsterdam_bal = allow;
+        self
     }
 
     /// Returns the chain spec used by the validator.
@@ -36,7 +44,7 @@ impl<ChainSpec: EthereumHardforks> EthereumExecutionPayloadValidator<ChainSpec> 
         &self,
         payload: ExecutionData,
     ) -> Result<SealedBlock<Block<T>>, PayloadError> {
-        ensure_well_formed_payload(&self.chain_spec, payload)
+        ensure_well_formed_payload_inner(&self.chain_spec, payload, self.allow_pre_amsterdam_bal)
     }
 }
 
@@ -71,14 +79,34 @@ where
     ChainSpec: EthereumHardforks,
     T: SignedTransaction,
 {
+    ensure_well_formed_payload_inner(chain_spec, payload, false)
+}
+
+fn ensure_well_formed_payload_inner<ChainSpec, T>(
+    chain_spec: ChainSpec,
+    payload: ExecutionData,
+    allow_pre_amsterdam_bal: bool,
+) -> Result<SealedBlock<Block<T>>, PayloadError>
+where
+    ChainSpec: EthereumHardforks,
+    T: SignedTransaction,
+{
     let ExecutionData { payload, sidecar } = payload;
 
     let expected_hash = payload.block_hash();
+    let should_ignore_pre_amsterdam_bal = allow_pre_amsterdam_bal &&
+        payload.block_access_list().is_some() &&
+        !chain_spec.is_amsterdam_active_at_timestamp(payload.timestamp());
 
-    // First parse the block
-    let sealed_block = payload.try_into_block_with_sidecar(&sidecar)?.seal_slow();
+    let mut block = payload.try_into_block_with_sidecar(&sidecar)?;
 
-    // Ensure the hash included in the payload matches the block hash
+    if should_ignore_pre_amsterdam_bal {
+        block.header.block_access_list_hash = None;
+        block.header.slot_number = None;
+    }
+
+    let sealed_block = block.seal_slow();
+
     if expected_hash != sealed_block.hash() {
         return Err(PayloadError::BlockHash {
             execution: sealed_block.hash(),
@@ -104,4 +132,61 @@ where
     )?;
 
     Ok(sealed_block)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
+    use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
+    use alloy_primitives::{Bytes, B256};
+    use alloy_rpc_types_engine::{ExecutionPayload, ExecutionPayloadSidecar, ExecutionPayloadV4};
+    use reth_chainspec::ChainSpecBuilder;
+    use reth_ethereum_primitives::{Block as EthBlock, TransactionSigned};
+
+    #[test]
+    fn pre_amsterdam_bal_payload_is_opt_in() {
+        let block = empty_prague_block();
+        let original_hash = block.clone().seal_slow().hash();
+        let raw_bal = Bytes::from_static(&[0xc0]);
+        let payload = ExecutionPayload::V4(ExecutionPayloadV4::from_block_unchecked_with_bal(
+            original_hash,
+            &block,
+            raw_bal,
+        ));
+        let execution_data =
+            ExecutionData { payload, sidecar: ExecutionPayloadSidecar::from_block(&block) };
+
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().prague_activated().build());
+        assert!(matches!(
+            EthereumExecutionPayloadValidator::new(chain_spec.clone())
+                .ensure_well_formed_payload::<TransactionSigned>(execution_data.clone())
+                .unwrap_err(),
+            PayloadError::BlockHash { .. }
+        ));
+
+        let sealed = EthereumExecutionPayloadValidator::new(chain_spec)
+            .with_allow_pre_amsterdam_bal(true)
+            .ensure_well_formed_payload::<TransactionSigned>(execution_data)
+            .unwrap();
+
+        assert_eq!(sealed.hash(), original_hash);
+        assert!(sealed.header().block_access_list_hash.is_none());
+        assert!(sealed.header().slot_number.is_none());
+    }
+
+    fn empty_prague_block() -> EthBlock {
+        let mut block = EthBlock::default();
+        block.header.ommers_hash = EMPTY_OMMER_ROOT_HASH;
+        block.header.transactions_root = EMPTY_ROOT_HASH;
+        block.header.receipts_root = EMPTY_ROOT_HASH;
+        block.header.withdrawals_root = Some(EMPTY_ROOT_HASH);
+        block.header.base_fee_per_gas = Some(0);
+        block.header.parent_beacon_block_root = Some(B256::ZERO);
+        block.header.blob_gas_used = Some(0);
+        block.header.excess_blob_gas = Some(0);
+        block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+        block.body.withdrawals = Some(Default::default());
+        block
+    }
 }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -55,6 +55,7 @@ pub struct DefaultEngineValues {
     share_execution_cache_with_payload_builder: bool,
     share_sparse_trie_with_payload_builder: bool,
     suppress_persistence_during_build: bool,
+    allow_pre_amsterdam_bal: bool,
     bal_parallel_execution_disabled: bool,
     bal_parallel_state_root_disabled: bool,
 }
@@ -247,6 +248,12 @@ impl DefaultEngineValues {
         self
     }
 
+    /// Set whether to allow BAL payloads before Amsterdam activation by default.
+    pub const fn with_allow_pre_amsterdam_bal(mut self, v: bool) -> Self {
+        self.allow_pre_amsterdam_bal = v;
+        self
+    }
+
     /// Set whether to disable BAL-based parallel execution by default
     pub const fn with_bal_parallel_execution_disabled(mut self, v: bool) -> Self {
         self.bal_parallel_execution_disabled = v;
@@ -292,6 +299,7 @@ impl Default for DefaultEngineValues {
             share_execution_cache_with_payload_builder: false,
             share_sparse_trie_with_payload_builder: false,
             suppress_persistence_during_build: false,
+            allow_pre_amsterdam_bal: false,
             bal_parallel_execution_disabled: false,
             bal_parallel_state_root_disabled: false,
         }
@@ -523,6 +531,11 @@ pub struct EngineArgs {
     )]
     pub suppress_persistence_during_build: bool,
 
+    /// Allow block access lists before Amsterdam activation. This is only intended for
+    /// benchmarking pre-Amsterdam BAL replay.
+    #[arg(long = "engine.allow-pre-amsterdam-bal", default_value_t = DefaultEngineValues::get_global().allow_pre_amsterdam_bal)]
+    pub allow_pre_amsterdam_bal: bool,
+
     /// Disable BAL (Block Access List, EIP-7928) based parallel execution.
     #[arg(long = "engine.disable-bal-parallel-execution", default_value_t = DefaultEngineValues::get_global().bal_parallel_execution_disabled)]
     pub bal_parallel_execution_disabled: bool,
@@ -584,6 +597,7 @@ impl Default for EngineArgs {
             share_execution_cache_with_payload_builder,
             share_sparse_trie_with_payload_builder,
             suppress_persistence_during_build,
+            allow_pre_amsterdam_bal,
             bal_parallel_execution_disabled,
             bal_parallel_state_root_disabled,
         } = DefaultEngineValues::get_global().clone();
@@ -623,6 +637,7 @@ impl Default for EngineArgs {
             share_execution_cache_with_payload_builder,
             share_sparse_trie_with_payload_builder,
             suppress_persistence_during_build,
+            allow_pre_amsterdam_bal,
             bal_parallel_execution_disabled,
             bal_parallel_state_root_disabled,
             disable_bal_batch_io: false,
@@ -809,6 +824,7 @@ mod tests {
             share_execution_cache_with_payload_builder: false,
             share_sparse_trie_with_payload_builder: false,
             suppress_persistence_during_build: false,
+            allow_pre_amsterdam_bal: true,
             bal_parallel_execution_disabled: true,
             bal_parallel_state_root_disabled: true,
             disable_bal_batch_io: true,
@@ -856,6 +872,7 @@ mod tests {
             "--engine.disable-sparse-trie-cache-pruning",
             "--engine.state-root-task-timeout",
             "2s",
+            "--engine.allow-pre-amsterdam-bal",
             "--engine.disable-bal-parallel-execution",
             "--engine.disable-bal-parallel-state-root",
             "--engine.disable-bal-batch-io",

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1109,6 +1109,9 @@ Engine:
 
           When enabled, persistence cycles are deferred from the moment an FCU with payload attributes arrives until the next FCU clears the build. Useful on chains with short block times where persistence I/O can interfere with block building latency.
 
+      --engine.allow-pre-amsterdam-bal
+          Allow block access lists before Amsterdam activation. This is only intended for benchmarking pre-Amsterdam BAL replay
+
       --engine.disable-bal-parallel-execution
           Disable BAL (Block Access List, EIP-7928) based parallel execution
 


### PR DESCRIPTION
Allows Derek BAL replay before Amsterdam through an opt-in engine setting. When enabled, payload validation ignores BAL-only header fields for the block-hash check before Amsterdam, and consensus accepts the corresponding pre-Amsterdam BAL hash.

Companion txgen PR: https://github.com/tempoxyz/txgen/pull/136