### PR TITLE
perf(engine): reuse input BAL hash

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -10,14 +10,15 @@
 //! worker results in transaction order, tracks block gas admission, and builds the BAL that this
 //! execution actually produced.
 //!
-//! The rebuilt BAL is returned to the outer payload validator for consensus post-execution
-//! validation. This module only logs the first divergence between the received BAL and the BAL
-//! rebuilt from canonical execution.
+//! The post-execution BAL is returned to the outer payload validator for consensus validation.
+//! When canonical execution rebuilds the same decoded BAL that was received, the returned value
+//! reuses the input raw bytes and hash; otherwise this module logs the first divergence and returns
+//! the rebuilt BAL.
 
 use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError};
 use alloy_eip7928::{
     bal::{Bal as AlloyBal, DecodedBal},
-    compute_block_access_list_hash, BlockAccessList,
+    compute_block_access_list_hash,
 };
 use alloy_evm::{
     block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
@@ -51,7 +52,7 @@ pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
     txs: Receiver<(usize, Result<Tx, Err>)>,
     receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
 ) -> Result<
-    (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, BlockAccessList),
+    (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, DecodedBal),
     BalExecutionError,
 >
 where
@@ -62,6 +63,17 @@ where
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'a,
     ReceiptTy<Evm::Primitives>: Clone,
 {
+    let _ = {
+        let input_bal = Arc::clone(&input_bal);
+        runtime.spawn_blocking_named("input-bal-hash", move || {
+            let _span = tracing::debug_span!(
+                target: "engine::tree::payload_processor::bal",
+                "input_bal_hash",
+            )
+            .entered();
+            input_bal.hash()
+        })
+    };
     let worker_pool = runtime.bal_streaming_pool();
     let worker_count = worker_pool.current_num_threads().max(1).min(transaction_count);
 
@@ -94,7 +106,7 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
     receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
     worker_count: usize,
 ) -> Result<
-    (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, BlockAccessList),
+    (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, DecodedBal),
     BalExecutionError,
 >
 where
@@ -105,8 +117,7 @@ where
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
     ReceiptTy<Evm::Primitives>: Clone,
 {
-    let bal = input_bal.as_bal();
-    let input_bal_revm = convert_alloy_to_revm_bal(bal)?;
+    let input_bal_revm = convert_alloy_to_revm_bal(input_bal.as_bal())?;
 
     let block_gas_limit = evm_env.block_env.gas_limit();
     let enable_amsterdam_eip8037 = evm_env.cfg_env.enable_amsterdam_eip8037;
@@ -170,7 +181,7 @@ where
         (block_result, senders)
     };
 
-    let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, bal);
+    let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, &input_bal);
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
     Ok((
@@ -201,20 +212,34 @@ fn convert_alloy_to_revm_bal(alloy_bal: &AlloyBal) -> Result<Arc<RevmBal>, BalEx
     Ok(Arc::new(received_bal_revm))
 }
 
+/// Takes the BAL rebuilt from canonical execution and returns the post-execution BAL commitment
+/// input.
+///
+/// If canonical execution rebuilt exactly the same decoded BAL that was received, this reuses the
+/// received raw RLP bytes and cached hash. Otherwise it logs the first divergence at debug level
+/// and returns a freshly encoded rebuilt BAL so post-execution consensus validation still compares
+/// the header commitment against execution output.
 fn take_built_bal_and_log_divergence<DB>(
     canonical_state: &mut State<DB>,
-    received_bal: &AlloyBal,
-) -> BlockAccessList
+    input_bal: &DecodedBal,
+) -> DecodedBal
 where
     DB: Database,
 {
     let built_bal = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
-    if tracing::enabled!(target: "engine::tree::payload_processor::bal", tracing::Level::DEBUG) &&
-        built_bal.as_slice() != received_bal.as_slice()
-    {
+    let input_alloy_bal = input_bal.as_bal();
+    if built_bal.as_slice() == input_alloy_bal.as_slice() {
+        return DecodedBal::new_unchecked(
+            AlloyBal::from(built_bal),
+            input_bal.as_raw().clone(),
+            input_bal.hash(),
+        )
+    }
+
+    if tracing::enabled!(target: "engine::tree::payload_processor::bal", tracing::Level::DEBUG) {
         let rebuilt = compute_block_access_list_hash(built_bal.as_slice());
-        let expected = compute_block_access_list_hash(received_bal.as_slice());
-        let div = received_bal.diff(built_bal.as_slice());
+        let expected = input_bal.hash();
+        let div = input_alloy_bal.diff(built_bal.as_slice());
         tracing::debug!(
             target: "engine::tree::payload_processor::bal",
             %rebuilt,
@@ -224,7 +249,9 @@ where
         );
     }
 
-    built_bal
+    let built_bal = AlloyBal::from(built_bal);
+    let raw = alloy_rlp::encode(&built_bal).into();
+    DecodedBal::new(built_bal, raw)
 }
 
 /// Closes the abort channel on drop, waking scoped workers before the scope exits.
@@ -433,18 +460,21 @@ mod tests {
 
         let block = empty_amsterdam_block(bal_hash);
 
-        let result = run_execute_block(
+        let input_bal = to_arc_decoded(input_bal);
+        let input_raw = input_bal.as_raw().clone();
+        let result = run_execute_block_full(
             &Runtime::test(),
             evm_config,
             db_factory(system_contracts_db()),
-            to_arc_decoded(input_bal),
+            input_bal,
             &block,
             Vec::<Recovered<TransactionSigned>>::new(),
         );
 
         match result {
-            Ok(output) => {
+            Ok((output, built_bal)) => {
                 assert!(output.receipts.is_empty(), "empty block → no receipts");
+                assert_eq!(built_bal.as_raw(), &input_raw, "matching BALs should reuse input raw");
             }
             Err(e) => panic!("expected success, got {e:?}"),
         }
@@ -488,7 +518,7 @@ mod tests {
         input_bal: Arc<DecodedBal>,
         block: &SealedBlock<Block>,
         txs: Vec<Tx>,
-    ) -> Result<(BlockExecutionOutput<Receipt>, BlockAccessList), BalExecutionError>
+    ) -> Result<(BlockExecutionOutput<Receipt>, DecodedBal), BalExecutionError>
     where
         Tx: ExecutableTxFor<EthEvmConfig> + Send,
         DB: Database + Send,
@@ -1072,7 +1102,7 @@ mod tests {
 
         match result {
             Ok((_, built_bal)) => {
-                let rebuilt = alloy_eip7928::compute_block_access_list_hash(&built_bal);
+                let rebuilt = built_bal.hash();
                 assert_ne!(rebuilt, tampered_hash, "rebuilt and header hashes must differ");
             }
             Err(e) => panic!("expected success with rebuilt BAL, got {e:?}"),
@@ -1126,11 +1156,13 @@ mod tests {
         let make_db = db_factory(system_contracts_db());
         let make_db = |_: bool| make_db();
 
+        let input_bal = to_arc_decoded(BlockAccessList::default());
+        let runtime = Runtime::test();
         let result = execute_block(
-            &Runtime::test(),
+            &runtime,
             &evm_config,
             &make_db,
-            to_arc_decoded(BlockAccessList::default()),
+            input_bal,
             evm_env,
             execution_ctx,
             1, // transaction_count = 1 → exactly one worker spawned

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -109,7 +109,10 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
+use alloy_eip7928::{
+    bal::{Bal as AlloyBal, DecodedBal},
+    BlockAccessList,
+};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -1131,12 +1134,7 @@ where
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err, N::Receipt>,
     ) -> Result<
-        (
-            BlockExecutionOutput<N::Receipt>,
-            Vec<Address>,
-            ReceiptRootReceiver,
-            Option<BlockAccessList>,
-        ),
+        (BlockExecutionOutput<N::Receipt>, Vec<Address>, ReceiptRootReceiver, Option<DecodedBal>),
         InsertBlockErrorKind,
     >
     where
@@ -1148,7 +1146,8 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        let has_bal = env.decoded_bal.is_some();
+        let input_bal = env.decoded_bal.clone();
+        let has_bal = input_bal.is_some();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
@@ -1219,7 +1218,12 @@ where
         debug_span!(target: "engine::tree", "merge_transitions")
             .in_scope(|| db.merge_transitions(BundleRetention::Reverts));
 
-        let built_bal = if has_bal { db.take_built_alloy_bal() } else { None };
+        let built_bal = if has_bal {
+            db.take_built_alloy_bal()
+                .map(|built_bal| post_execution_bal(built_bal, input_bal.as_deref()))
+        } else {
+            None
+        };
         let output = BlockExecutionOutput { result, state: db.take_bundle() };
 
         let execution_duration = execution_start.elapsed();
@@ -1259,7 +1263,7 @@ where
     /// 2. Relies on BAL prewarm to stream sparse-trie updates and optional state prefetches.
     /// 3. Spawns the receipt-root task.
     /// 4. Calls [`crate::tree::payload_processor::bal::execute_block`].
-    /// 5. Returns the rebuilt BAL for post-execution consensus validation.
+    /// 5. Returns the post-execution BAL for consensus validation.
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     #[expect(clippy::type_complexity)]
     fn execute_block_bal<Tx, Err, MakeStateProvider, T>(
@@ -1269,12 +1273,7 @@ where
         handle: &PayloadHandle<Tx, Err, N::Receipt>,
         make_state_provider: &MakeStateProvider,
     ) -> Result<
-        (
-            BlockExecutionOutput<N::Receipt>,
-            Vec<Address>,
-            ReceiptRootReceiver,
-            Option<BlockAccessList>,
-        ),
+        (BlockExecutionOutput<N::Receipt>, Vec<Address>, ReceiptRootReceiver, Option<DecodedBal>),
         InsertBlockErrorKind,
     >
     where
@@ -1720,7 +1719,7 @@ where
         output: &BlockExecutionOutput<N::Receipt>,
         ctx: &mut TreeCtx<'_, N>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
-        built_bal: Option<BlockAccessList>,
+        built_bal: Option<DecodedBal>,
     ) -> Result<(), InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1733,8 +1732,7 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
-        let block_access_list_hash =
-            built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal));
+        let block_access_list_hash = built_bal.as_ref().map(|bal| bal.hash());
 
         if let Err(err) = self.consensus.validate_block_post_execution(
             block,
@@ -2507,3 +2505,24 @@ pub type CustomStateRoot<N> = Arc<
         + Sync
         + 'static,
 >;
+
+/// Builds the BAL used for post-execution consensus validation.
+///
+/// If the rebuilt BAL is exactly equal to the received decoded BAL, the returned value reuses the
+/// received raw RLP bytes and cached hash. Otherwise the rebuilt BAL is encoded so the consensus
+/// check still compares the header commitment against the canonical execution output.
+fn post_execution_bal(built_bal: BlockAccessList, input_bal: Option<&DecodedBal>) -> DecodedBal {
+    if let Some(input_bal) = input_bal &&
+        built_bal.as_slice() == input_bal.as_bal().as_slice()
+    {
+        return DecodedBal::new_unchecked(
+            AlloyBal::from(built_bal),
+            input_bal.as_raw().clone(),
+            input_bal.hash(),
+        )
+    }
+
+    let built_bal = AlloyBal::from(built_bal);
+    let raw = alloy_rlp::encode(&built_bal).into();
+    DecodedBal::new(built_bal, raw)
+}


### PR DESCRIPTION
Returns post-execution BAL data as `DecodedBal` so matching rebuilt BALs can reuse the input raw bytes and cached hash instead of re-encoding the rebuilt list.

The BAL execution path now starts input BAL hash computation in parallel with execution. Divergent BALs still fall back to hashing the rebuilt BAL for the consensus comparison.