### PR TITLE
refactor(engine): inline received BAL gas validation

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -550,7 +550,11 @@ where
         .map(Arc::new);
 
         if let Some(decoded_bal) = decoded_bal.as_deref() {
-            ensure_ok!(Self::validate_received_bal_gas(decoded_bal, input.gas_limit()));
+            // Reject oversized BAL sidecars before executing the block.
+            ensure_ok!(decoded_bal
+                .as_bal()
+                .validate_gas_limit(input.gas_limit())
+                .map_err(ConsensusError::from));
         }
 
         let env = ExecutionEnv {
@@ -1106,13 +1110,6 @@ where
         } else {
             self.provider.sealed_header_by_hash(hash)
         }
-    }
-
-    fn validate_received_bal_gas(
-        decoded_bal: &DecodedBal,
-        gas_limit: u64,
-    ) -> Result<(), ConsensusError> {
-        decoded_bal.as_bal().validate_gas_limit(gas_limit).map_err(ConsensusError::from)
     }
 
     /// Executes a block with the given state provider.


### PR DESCRIPTION
Inlines the single received BAL gas-limit validation call in the payload validator and removes the private helper.

The early check stays next to BAL decoding so oversized BAL sidecars are rejected before block execution work begins.