### PR TITLE
feat(rpc): support sendRawTransactionSync timeout arg

### DIFF
--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -65,6 +65,14 @@ where
     };
 }
 
+async fn assert_empty_raw_transaction_sync_error(client: &HttpClient, params: ArrayParams) {
+    let err = client
+        .request::<Value, _>("eth_sendRawTransactionSync", params)
+        .await
+        .expect_err("empty raw transaction should fail after RPC parameter decoding");
+    assert!(err.to_string().contains("empty transaction data"), "{err:?}");
+}
+
 /// Represents a builder for creating JSON-RPC requests.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RawRpcParamsBuilder {
@@ -670,6 +678,28 @@ async fn test_call_eth_functions_http() {
     let handle = launch_http(vec![RethRpcModule::Eth]).await;
     let client = handle.http_client().unwrap();
     test_basic_eth_calls(&client).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_send_raw_transaction_sync_accepts_optional_timeout_arg() {
+    reth_tracing::init_test_tracing();
+
+    let handle = launch_http(vec![RethRpcModule::Eth]).await;
+    let client = handle.http_client().unwrap();
+
+    let mut one_arg = ArrayParams::new();
+    one_arg.insert(Bytes::default()).unwrap();
+    assert_empty_raw_transaction_sync_error(&client, one_arg).await;
+
+    let mut null_timeout = ArrayParams::new();
+    null_timeout.insert(Bytes::default()).unwrap();
+    null_timeout.insert(Value::Null).unwrap();
+    assert_empty_raw_transaction_sync_error(&client, null_timeout).await;
+
+    let mut two_args = ArrayParams::new();
+    two_args.insert(Bytes::default()).unwrap();
+    two_args.insert(1u64).unwrap();
+    assert_empty_raw_transaction_sync_error(&client, two_args).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -385,7 +385,11 @@ pub trait EthApi<
     ///
     /// This will return a timeout error if the transaction isn't included within some time period.
     #[method(name = "sendRawTransactionSync")]
-    async fn send_raw_transaction_sync(&self, bytes: Bytes) -> RpcResult<R>;
+    async fn send_raw_transaction_sync(
+        &self,
+        bytes: Bytes,
+        timeout_ms: Option<u64>,
+    ) -> RpcResult<R>;
 
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
     /// + len(message) + message))).
@@ -912,9 +916,13 @@ where
     }
 
     /// Handler for: `eth_sendRawTransactionSync`
-    async fn send_raw_transaction_sync(&self, tx: Bytes) -> RpcResult<RpcReceipt<T::NetworkTypes>> {
-        trace!(target: "rpc::eth", ?tx, "Serving eth_sendRawTransactionSync");
-        Ok(EthTransactions::send_raw_transaction_sync(self, tx).await?)
+    async fn send_raw_transaction_sync(
+        &self,
+        tx: Bytes,
+        timeout_ms: Option<u64>,
+    ) -> RpcResult<RpcReceipt<T::NetworkTypes>> {
+        trace!(target: "rpc::eth", ?tx, ?timeout_ms, "Serving eth_sendRawTransactionSync");
+        Ok(EthTransactions::send_raw_transaction_sync(self, tx, timeout_ms).await?)
     }
 
     /// Handler for: `eth_sign`

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -121,12 +121,18 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn send_raw_transaction_sync(
         &self,
         tx: Bytes,
+        timeout_ms: Option<u64>,
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send
     where
         Self: LoadReceipt + 'static,
     {
         let this = self.clone();
-        let timeout_duration = self.send_raw_transaction_sync_timeout();
+        let configured_timeout = self.send_raw_transaction_sync_timeout();
+        let timeout_duration = timeout_ms
+            .filter(|timeout_ms| *timeout_ms > 0)
+            .map(Duration::from_millis)
+            .map(|timeout| timeout.min(configured_timeout))
+            .unwrap_or(configured_timeout);
         async move {
             let mut stream = this.provider().canonical_state_stream();
             let hash = EthTransactions::send_raw_transaction(&this, tx).await?;

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -157,6 +157,16 @@ mod tests {
         RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig>,
         EthRpcConverter<ChainSpec>,
     > {
+        mock_eth_api_with_sync_timeout(accounts, Duration::from_secs(30))
+    }
+
+    fn mock_eth_api_with_sync_timeout(
+        accounts: AddressMap<ExtendedAccount>,
+        send_raw_transaction_sync_timeout: Duration,
+    ) -> EthApi<
+        RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, EthEvmConfig>,
+        EthRpcConverter<ChainSpec>,
+    > {
         let mock_provider = MockEthProvider::default()
             .with_chain_spec(ChainSpecBuilder::mainnet().cancun_activated().build());
         mock_provider.extend_accounts(accounts);
@@ -177,7 +187,16 @@ mod tests {
         let genesis_hash = B256::ZERO;
         mock_provider.add_block(genesis_hash, Block::new(genesis_header, Default::default()));
 
-        EthApi::builder(mock_provider, pool, NoopNetwork::default(), evm_config).build()
+        EthApi::builder(mock_provider, pool, NoopNetwork::default(), evm_config)
+            .send_raw_transaction_sync_timeout(send_raw_transaction_sync_timeout)
+            .build()
+    }
+
+    fn raw_transfer_tx() -> Bytes {
+        // https://etherscan.io/tx/0xa694b71e6c128a2ed8e2e0f6770bddbe52e3bb8f10e8472f9a79ab81497a8b5d
+        Bytes::from(hex!(
+            "02f871018303579880850555633d1b82520894eee27662c2b8eba3cd936a23f039f3189633e4c887ad591c62bdaeb180c080a07ea72c68abfb8fca1bd964f0f99132ed9280261bdca3e549546c0205e800f7d0a05b4ef3039e9c9b9babc179a1878fb825b5aaf5aed2fa8744854150157b08d6f3"
+        ))
     }
 
     #[tokio::test]
@@ -185,10 +204,7 @@ mod tests {
         let eth_api = mock_eth_api(Default::default());
         let pool = eth_api.pool();
 
-        // https://etherscan.io/tx/0xa694b71e6c128a2ed8e2e0f6770bddbe52e3bb8f10e8472f9a79ab81497a8b5d
-        let tx_1 = Bytes::from(hex!(
-            "02f871018303579880850555633d1b82520894eee27662c2b8eba3cd936a23f039f3189633e4c887ad591c62bdaeb180c080a07ea72c68abfb8fca1bd964f0f99132ed9280261bdca3e549546c0205e800f7d0a05b4ef3039e9c9b9babc179a1878fb825b5aaf5aed2fa8744854150157b08d6f3"
-        ));
+        let tx_1 = raw_transfer_tx();
 
         let tx_1_result = eth_api.send_raw_transaction(tx_1).await.unwrap();
         assert_eq!(
@@ -215,6 +231,62 @@ mod tests {
         assert!(pool.get(&tx_2_result).is_some(), "tx2 not found in the pool");
         assert_eq!(pool.get(&tx_1_result).unwrap().origin, TransactionOrigin::Local);
         assert_eq!(pool.get(&tx_2_result).unwrap().origin, TransactionOrigin::Local);
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_sync_uses_request_timeout() {
+        let eth_api = mock_eth_api(Default::default());
+
+        let err = eth_api.send_raw_transaction_sync(raw_transfer_tx(), Some(1)).await.unwrap_err();
+
+        assert!(matches!(
+            err,
+            EthApiError::TransactionConfirmationTimeout { duration, .. }
+                if duration == Duration::from_millis(1)
+        ));
+        assert_eq!(eth_api.pool().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_sync_uses_configured_timeout_when_omitted() {
+        let eth_api = mock_eth_api_with_sync_timeout(Default::default(), Duration::from_millis(1));
+
+        let err = eth_api.send_raw_transaction_sync(raw_transfer_tx(), None).await.unwrap_err();
+
+        assert!(matches!(
+            err,
+            EthApiError::TransactionConfirmationTimeout { duration, .. }
+                if duration == Duration::from_millis(1)
+        ));
+        assert_eq!(eth_api.pool().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_sync_uses_configured_timeout_when_zero() {
+        let eth_api = mock_eth_api_with_sync_timeout(Default::default(), Duration::from_millis(1));
+
+        let err = eth_api.send_raw_transaction_sync(raw_transfer_tx(), Some(0)).await.unwrap_err();
+
+        assert!(matches!(
+            err,
+            EthApiError::TransactionConfirmationTimeout { duration, .. }
+                if duration == Duration::from_millis(1)
+        ));
+        assert_eq!(eth_api.pool().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_sync_caps_request_timeout() {
+        let eth_api = mock_eth_api_with_sync_timeout(Default::default(), Duration::from_millis(1));
+
+        let err = eth_api.send_raw_transaction_sync(raw_transfer_tx(), Some(50)).await.unwrap_err();
+
+        assert!(matches!(
+            err,
+            EthApiError::TransactionConfirmationTimeout { duration, .. }
+                if duration == Duration::from_millis(1)
+        ));
+        assert_eq!(eth_api.pool().len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds the optional `timeoutMs` parameter to `eth_sendRawTransactionSync` and applies it to the receipt wait while preserving the configured sync timeout as the default and cap.

This aligns the method shape with EIP-7966 and other client behavior for omitted, `null`, and `0` timeout values.
