### PR TITLE
chore(deps): bump alloy-eip7928 to 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17201e6cbb4efbb1e510b0746839cd743a5cec3fcfb4673ea2342bd657341c93"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,7 +449,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.4.4", default-features = false, features = ["rlp"] }
+alloy-eip7928 = { version = "0.4.5", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.37.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }


### PR DESCRIPTION
Updates the workspace `alloy-eip7928` dependency from 0.4.4 to 0.4.5 and refreshes `Cargo.lock`.