### PR TITLE
feat(cli): allow overriding TraceArgs defaults

### DIFF
--- a/crates/node/core/src/args/trace.rs
+++ b/crates/node/core/src/args/trace.rs
@@ -1,6 +1,6 @@
 //! Opentelemetry tracing and logging configuration through CLI args.
 
-use clap::Parser;
+use clap::{builder::Resettable, Parser};
 use eyre::WrapErr;
 use reth_tracing::{tracing_subscriber::EnvFilter, Layers};
 use reth_tracing_otlp::OtlpProtocol;
@@ -16,13 +16,32 @@ static TRACE_DEFAULTS: OnceLock<DefaultTraceValues> = OnceLock::new();
 /// change the defaults that clap will use.
 #[derive(Debug, Clone)]
 pub struct DefaultTraceValues {
+    otlp: Option<Url>,
+    logs_otlp: Option<Url>,
+    otlp_default_endpoint: String,
+    logs_otlp_default_endpoint: String,
+    protocol: OtlpProtocol,
     service_name: String,
     service_version: Option<String>,
+    otlp_filter: String,
+    logs_otlp_filter: String,
+    sample_ratio: Option<f64>,
 }
 
 impl Default for DefaultTraceValues {
     fn default() -> Self {
-        Self { service_name: "reth".to_string(), service_version: None }
+        Self {
+            otlp: None,
+            logs_otlp: None,
+            otlp_default_endpoint: "http://localhost:4318/v1/traces".to_string(),
+            logs_otlp_default_endpoint: "http://localhost:4318/v1/logs".to_string(),
+            protocol: OtlpProtocol::Http,
+            service_name: "reth".to_string(),
+            service_version: None,
+            otlp_filter: "debug".to_string(),
+            logs_otlp_filter: "info".to_string(),
+            sample_ratio: None,
+        }
     }
 }
 
@@ -37,6 +56,36 @@ impl DefaultTraceValues {
         TRACE_DEFAULTS.get_or_init(Self::default)
     }
 
+    /// Set the default OTLP tracing endpoint.
+    pub fn with_otlp(mut self, otlp: Option<Url>) -> Self {
+        self.otlp = otlp;
+        self
+    }
+
+    /// Set the default OTLP logs endpoint.
+    pub fn with_logs_otlp(mut self, logs_otlp: Option<Url>) -> Self {
+        self.logs_otlp = logs_otlp;
+        self
+    }
+
+    /// Set the endpoint used when `--tracing-otlp` is provided without a value.
+    pub fn with_otlp_default_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.otlp_default_endpoint = endpoint.into();
+        self
+    }
+
+    /// Set the endpoint used when `--logs-otlp` is provided without a value.
+    pub fn with_logs_otlp_default_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.logs_otlp_default_endpoint = endpoint.into();
+        self
+    }
+
+    /// Set the default OTLP transport protocol.
+    pub const fn with_protocol(mut self, protocol: OtlpProtocol) -> Self {
+        self.protocol = protocol;
+        self
+    }
+
     /// Set the default service name.
     pub fn with_service_name(mut self, name: impl Into<String>) -> Self {
         self.service_name = name.into();
@@ -47,6 +96,31 @@ impl DefaultTraceValues {
     pub fn with_service_version(mut self, version: impl Into<String>) -> Self {
         self.service_version = Some(version.into());
         self
+    }
+
+    /// Set the default OTLP tracing filter.
+    pub fn with_otlp_filter(mut self, filter: impl Into<String>) -> Self {
+        self.otlp_filter = filter.into();
+        self
+    }
+
+    /// Set the default OTLP logs filter.
+    pub fn with_logs_otlp_filter(mut self, filter: impl Into<String>) -> Self {
+        self.logs_otlp_filter = filter.into();
+        self
+    }
+
+    /// Set the default OTLP trace sampling ratio.
+    pub const fn with_sample_ratio(mut self, sample_ratio: Option<f64>) -> Self {
+        self.sample_ratio = sample_ratio;
+        self
+    }
+
+    const fn protocol_as_str(&self) -> &'static str {
+        match self.protocol {
+            OtlpProtocol::Http => "http",
+            OtlpProtocol::Grpc => "grpc",
+        }
     }
 }
 
@@ -67,7 +141,8 @@ pub struct TraceArgs {
         global = true,
         value_name = "URL",
         num_args = 0..=1,
-        default_missing_value = "http://localhost:4318/v1/traces",
+        default_value = Resettable::from(DefaultTraceValues::get_global().otlp.as_ref().map(|url| url.as_str().into())),
+        default_missing_value = DefaultTraceValues::get_global().otlp_default_endpoint.as_str(),
         require_equals = true,
         value_parser = parse_otlp_endpoint,
         help_heading = "Tracing"
@@ -87,7 +162,8 @@ pub struct TraceArgs {
         global = true,
         value_name = "URL",
         num_args = 0..=1,
-        default_missing_value = "http://localhost:4318/v1/logs",
+        default_value = Resettable::from(DefaultTraceValues::get_global().logs_otlp.as_ref().map(|url| url.as_str().into())),
+        default_missing_value = DefaultTraceValues::get_global().logs_otlp_default_endpoint.as_str(),
         require_equals = true,
         value_parser = parse_otlp_endpoint,
         help_heading = "Logging"
@@ -105,7 +181,7 @@ pub struct TraceArgs {
         env = "OTEL_EXPORTER_OTLP_PROTOCOL",
         global = true,
         value_name = "PROTOCOL",
-        default_value = "http",
+        default_value = DefaultTraceValues::get_global().protocol_as_str(),
         help_heading = "Tracing"
     )]
     pub protocol: OtlpProtocol,
@@ -121,7 +197,7 @@ pub struct TraceArgs {
         long = "tracing-otlp.filter",
         global = true,
         value_name = "FILTER",
-        default_value = "debug",
+        default_value = DefaultTraceValues::get_global().otlp_filter.as_str(),
         help_heading = "Tracing"
     )]
     pub otlp_filter: EnvFilter,
@@ -137,7 +213,7 @@ pub struct TraceArgs {
         long = "logs-otlp.filter",
         global = true,
         value_name = "FILTER",
-        default_value = "info",
+        default_value = DefaultTraceValues::get_global().logs_otlp_filter.as_str(),
         help_heading = "Logging"
     )]
     pub logs_otlp_filter: EnvFilter,
@@ -168,6 +244,7 @@ pub struct TraceArgs {
         env = "OTEL_SERVICE_VERSION",
         global = true,
         value_name = "VERSION",
+        default_value = Resettable::from(DefaultTraceValues::get_global().service_version.as_ref().map(|version| version.as_str().into())),
         hide = true,
         help_heading = "Tracing"
     )]
@@ -186,6 +263,7 @@ pub struct TraceArgs {
         env = "OTEL_TRACES_SAMPLER_ARG",
         global = true,
         value_name = "RATIO",
+        default_value = Resettable::from(DefaultTraceValues::get_global().sample_ratio.map(|ratio| ratio.to_string().into())),
         help_heading = "Tracing"
     )]
     pub sample_ratio: Option<f64>,
@@ -195,12 +273,12 @@ impl Default for TraceArgs {
     fn default() -> Self {
         let defaults = DefaultTraceValues::get_global();
         Self {
-            otlp: None,
-            logs_otlp: None,
-            protocol: OtlpProtocol::Http,
-            otlp_filter: EnvFilter::from_default_env(),
-            logs_otlp_filter: EnvFilter::try_new("info").expect("valid filter"),
-            sample_ratio: None,
+            otlp: defaults.otlp.clone(),
+            logs_otlp: defaults.logs_otlp.clone(),
+            protocol: defaults.protocol,
+            otlp_filter: defaults.otlp_filter.parse().expect("valid filter"),
+            logs_otlp_filter: defaults.logs_otlp_filter.parse().expect("valid filter"),
+            sample_ratio: defaults.sample_ratio,
             service_name: defaults.service_name.clone(),
             service_version: defaults.service_version.clone(),
         }
@@ -312,4 +390,56 @@ pub enum OtlpLogsStatus {
 // Parses an OTLP endpoint url.
 fn parse_otlp_endpoint(arg: &str) -> eyre::Result<Url> {
     Url::parse(arg).wrap_err("Invalid URL for OTLP trace output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DefaultTraceValues, TraceArgs};
+    use reth_tracing_otlp::OtlpProtocol;
+
+    #[test]
+    fn default_trace_values_can_override_filters() {
+        let defaults =
+            DefaultTraceValues::default().with_otlp_filter("trace").with_logs_otlp_filter("debug");
+
+        assert_eq!(defaults.otlp_filter, "trace");
+        assert_eq!(defaults.logs_otlp_filter, "debug");
+    }
+
+    #[test]
+    fn default_trace_values_can_override_all_defaults() {
+        let otlp = "http://localhost:4318/v1/traces".parse().unwrap();
+        let logs_otlp = "http://localhost:4318/v1/logs".parse().unwrap();
+        let defaults = DefaultTraceValues::default()
+            .with_otlp(Some(otlp))
+            .with_logs_otlp(Some(logs_otlp))
+            .with_otlp_default_endpoint("http://collector:4318/v1/traces")
+            .with_logs_otlp_default_endpoint("http://collector:4318/v1/logs")
+            .with_protocol(OtlpProtocol::Grpc)
+            .with_service_name("custom")
+            .with_service_version("1.2.3")
+            .with_otlp_filter("info")
+            .with_logs_otlp_filter("debug")
+            .with_sample_ratio(Some(0.5));
+
+        let args = TraceArgs {
+            otlp: defaults.otlp.clone(),
+            logs_otlp: defaults.logs_otlp.clone(),
+            protocol: defaults.protocol,
+            otlp_filter: defaults.otlp_filter.parse().unwrap(),
+            logs_otlp_filter: defaults.logs_otlp_filter.parse().unwrap(),
+            service_name: defaults.service_name.clone(),
+            service_version: defaults.service_version.clone(),
+            sample_ratio: defaults.sample_ratio,
+        };
+
+        assert!(args.otlp.is_some());
+        assert!(args.logs_otlp.is_some());
+        assert_eq!(args.protocol, OtlpProtocol::Grpc);
+        assert_eq!(args.service_name, "custom");
+        assert_eq!(args.service_version.as_deref(), Some("1.2.3"));
+        assert_eq!(args.sample_ratio, Some(0.5));
+        assert_eq!(defaults.otlp_default_endpoint, "http://collector:4318/v1/traces");
+        assert_eq!(defaults.logs_otlp_default_endpoint, "http://collector:4318/v1/logs");
+    }
 }


### PR DESCRIPTION
## Summary
- Extend `DefaultTraceValues` to cover all `TraceArgs` defaults: OTLP endpoints, bare-flag endpoints, protocol, filters, service metadata, and sample ratio
- Wire `TraceArgs` clap defaults and `Default` through the shared defaults object
- Add focused coverage for overriding the full default surface

Prompted by: @shekhirin

## Tests
- `cargo test -p reth-node-core default_trace_values_can_override --lib`

Note: `cargo fmt --check` currently reports unrelated workspace formatting diffs outside this change.