### PR TITLE
perf: lazy BAL prewarm

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -8,7 +8,7 @@ use crate::tree::{
     ExecutionCache, PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig,
     WaitForCaches,
 };
-use alloy_eip7928::bal::DecodedBal;
+use alloy_eip7928::bal::{Bal, DecodedBal};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal};
 use alloy_primitives::B256;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
@@ -572,8 +572,8 @@ where
             PrewarmMode::BlockAccessList(
                 env.decoded_bal.clone().expect("BAL dispatch implies decoded BAL"),
             )
-        } else if self.disable_transaction_prewarming ||
-            env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
+        } else if self.disable_transaction_prewarming
+            || env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
         {
             PrewarmMode::Skipped
         } else {
@@ -1042,7 +1042,7 @@ pub struct ExecutionEnv<Evm: ConfigureEvm> {
     pub withdrawals: Option<Vec<Withdrawal>>,
     /// Optional decoded BAL for the block.
     /// Used to validate and optimize execution.
-    pub decoded_bal: Option<Arc<DecodedBal>>,
+    pub decoded_bal: Option<Arc<DecodedBal<std::sync::OnceLock<Bal>>>>,
 }
 
 impl<Evm: ConfigureEvm> ExecutionEnv<Evm>

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -42,7 +42,7 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicUsize},
         mpsc::{self, channel},
-        Arc, OnceLock,
+        Arc, LazyLock, OnceLock,
     },
 };
 use tracing::{debug, debug_span, instrument, trace, warn, Span};
@@ -60,6 +60,12 @@ use preserved_sparse_trie::{PreservedSparseTrie, SharedPreservedSparseTrie};
 /// Blocks with fewer transactions than this skip prewarming, since the fixed overhead of spawning
 /// prewarm workers exceeds the execution time saved.
 pub const SMALL_BLOCK_TX_THRESHOLD: usize = 5;
+
+/// Lazily decoded BAL carried through the execution environment.
+pub type LazyBal = LazyLock<Bal, Box<dyn FnOnce() -> Bal + Send + Sync>>;
+
+/// A decoded BAL wrapper whose BAL body is decoded on first use.
+pub type LazyDecodedBal = DecodedBal<LazyBal>;
 
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
 type IteratorTx<Evm, I> = RecoveredTx<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
@@ -1042,7 +1048,7 @@ pub struct ExecutionEnv<Evm: ConfigureEvm> {
     pub withdrawals: Option<Vec<Withdrawal>>,
     /// Optional decoded BAL for the block.
     /// Used to validate and optimize execution.
-    pub decoded_bal: Option<Arc<DecodedBal<std::sync::OnceLock<Bal>>>>,
+    pub decoded_bal: Option<Arc<LazyDecodedBal>>,
 }
 
 impl<Evm: ConfigureEvm> ExecutionEnv<Evm>

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -572,8 +572,8 @@ where
             PrewarmMode::BlockAccessList(
                 env.decoded_bal.clone().expect("BAL dispatch implies decoded BAL"),
             )
-        } else if self.disable_transaction_prewarming
-            || env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
+        } else if self.disable_transaction_prewarming ||
+            env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
         {
             PrewarmMode::Skipped
         } else {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -179,9 +179,9 @@ where
                 }
 
                 // Send withdrawal prefetch targets after all transactions dispatched
-                if let Some(to_sparse_trie_task) = to_sparse_trie_task
-                    && let Some(withdrawals) = &ctx.env.withdrawals
-                    && !withdrawals.is_empty()
+                if let Some(to_sparse_trie_task) = to_sparse_trie_task &&
+                    let Some(withdrawals) = &ctx.env.withdrawals &&
+                    !withdrawals.is_empty()
                 {
                     let targets = multiproof_targets_from_withdrawals(withdrawals);
                     let _ = to_sparse_trie_task.send(StateRootMessage::PrefetchProofs(targets));
@@ -342,8 +342,8 @@ where
         //         let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
         //     }
         //     let _ =
-        //         actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
-        //     return;
+        //         actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0
+        // });     return;
         // }
 
         let raw_bal = decoded_bal.as_raw_bal();
@@ -359,9 +359,9 @@ where
         let prefetch_bal = raw_bal.clone();
         let stream_bal = raw_bal.clone();
 
-        if let Some(saved_cache) = ctx.saved_cache.as_ref()
-            && !ctx.disable_bal_batch_io
-            && let Some(pool) = ctx.bal_prewarm_pool.as_ref()
+        if let Some(saved_cache) = ctx.saved_cache.as_ref() &&
+            !ctx.disable_bal_batch_io &&
+            let Some(pool) = ctx.bal_prewarm_pool.as_ref()
         {
             // If
             //

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -380,22 +380,16 @@ where
             let build = Arc::new(move || provider_builder.build());
 
             pool.begin_block(build, caches);
-            match peek_raw_bal_prewarm_targets(&prefetch_bal) {
-                Ok(targets) => {
-                    for target in targets {
-                        pool.warm_account(target.address);
-                        for slot in target.storage_slots {
-                            pool.warm_storage(target.address, slot.into());
-                        }
-                    }
-                }
-                Err(err) => {
-                    warn!(
-                        target: "engine::tree::payload_processor::prewarm",
-                        ?err,
-                        "Failed to peek raw BAL prewarm targets"
-                    );
-                }
+            if let Err(err) = stream_raw_bal_prewarm_targets(
+                &prefetch_bal,
+                |address| pool.warm_account(address),
+                |address, slot| pool.warm_storage(address, slot.into()),
+            ) {
+                warn!(
+                    target: "engine::tree::payload_processor::prewarm",
+                    ?err,
+                    "Failed to peek raw BAL prewarm targets"
+                );
             }
             pool.end_block();
         }
@@ -523,22 +517,17 @@ where
     }
 }
 
-#[derive(Debug)]
-struct RawBalPrewarmTarget {
-    address: Address,
-    storage_slots: Vec<U256>,
-}
-
-fn peek_raw_bal_prewarm_targets(
+fn stream_raw_bal_prewarm_targets(
     raw_bal: &RawBal,
-) -> Result<Vec<RawBalPrewarmTarget>, alloy_rlp::Error> {
+    mut warm_account: impl FnMut(Address),
+    mut warm_storage: impl FnMut(Address, U256),
+) -> Result<(), alloy_rlp::Error> {
     let mut buf = raw_bal.as_raw().as_ref();
     let header = alloy_rlp::Header::decode(&mut buf)?;
     if !header.list {
         return Err(alloy_rlp::Error::UnexpectedString);
     }
     let mut accounts = take_payload(&mut buf, header.payload_length)?;
-    let mut targets = Vec::new();
 
     while !accounts.is_empty() {
         let account_header = alloy_rlp::Header::decode(&mut accounts)?;
@@ -548,7 +537,7 @@ fn peek_raw_bal_prewarm_targets(
         let mut account = take_payload(&mut accounts, account_header.payload_length)?;
 
         let address = Address::decode(&mut account)?;
-        let mut storage_slots = Vec::new();
+        warm_account(address);
 
         let storage_changes_header = alloy_rlp::Header::decode(&mut account)?;
         if !storage_changes_header.list {
@@ -563,7 +552,7 @@ fn peek_raw_bal_prewarm_targets(
             }
             let mut slot_changes =
                 take_payload(&mut storage_changes, slot_changes_header.payload_length)?;
-            storage_slots.push(U256::decode(&mut slot_changes)?);
+            warm_storage(address, U256::decode(&mut slot_changes)?);
         }
 
         let storage_reads_header = alloy_rlp::Header::decode(&mut account)?;
@@ -572,13 +561,11 @@ fn peek_raw_bal_prewarm_targets(
         }
         let mut storage_reads = take_payload(&mut account, storage_reads_header.payload_length)?;
         while !storage_reads.is_empty() {
-            storage_slots.push(U256::decode(&mut storage_reads)?);
+            warm_storage(address, U256::decode(&mut storage_reads)?);
         }
-
-        targets.push(RawBalPrewarmTarget { address, storage_slots });
     }
 
-    Ok(targets)
+    Ok(())
 }
 
 fn take_payload<'a>(

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -357,7 +357,7 @@ where
         let executor = self.executor.clone();
         let parent_span = Span::current();
         let prefetch_bal = raw_bal.clone();
-        let stream_bal = raw_bal.clone();
+        let stream_bal = Arc::clone(&decoded_bal);
 
         if let Some(saved_cache) = ctx.saved_cache.as_ref() &&
             !ctx.disable_bal_batch_io &&
@@ -413,17 +413,12 @@ where
                 let parent_span = branch_span.clone();
                 let _span = branch_span.entered();
 
-                let Ok(account_changes) =
-                    DecodedBal::from_raw_bal(stream_bal).map(|decoded| decoded.split().0)
-                else {
-                    warn!(
-                        target: "engine::tree::payload_processor::prewarm",
-                        "Failed to decode BAL for hashed-state streaming"
-                    );
-                    let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
-                    let _ = stream_tx.send(());
-                    return;
-                };
+                let account_changes = stream_bal.as_bal().get_or_init(|| {
+                    DecodedBal::from_raw_bal(stream_bal.as_raw_bal().clone())
+                        .expect("validated BAL must decode")
+                        .split()
+                        .0
+                });
 
                 account_changes.par_iter().for_each(|account_changes| {
                     WorkerPool::with_worker_mut(|worker| {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -19,9 +19,10 @@ use crate::tree::{
     PayloadExecutionCache, SavedCache, StateProviderBuilder,
 };
 use alloy_consensus::transaction::TxHashRef;
-use alloy_eip7928::bal::DecodedBal;
+use alloy_eip7928::bal::{Bal, DecodedBal, RawBal};
 use alloy_eips::eip4895::Withdrawal;
-use alloy_primitives::{keccak256, B256, U256};
+use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_rlp::Decodable;
 use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
@@ -37,7 +38,7 @@ use reth_trie_common::MultiProofTargetsV2;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, channel, Receiver, Sender},
-    Arc,
+    Arc, OnceLock,
 };
 use tokio::sync::oneshot;
 use tracing::{debug, debug_span, instrument, trace, trace_span, warn, Span};
@@ -48,7 +49,7 @@ pub enum PrewarmMode<Tx> {
     /// Prewarm by executing transactions from a stream, each paired with its block index.
     Transactions(Receiver<(usize, Tx)>),
     /// Prewarm by prefetching slots from a Block Access List.
-    BlockAccessList(Arc<DecodedBal>),
+    BlockAccessList(Arc<DecodedBal<OnceLock<Bal>>>),
     /// Transaction prewarming is skipped (e.g. small blocks where the overhead exceeds the
     /// benefit). No workers are spawned.
     Skipped,
@@ -178,9 +179,9 @@ where
                 }
 
                 // Send withdrawal prefetch targets after all transactions dispatched
-                if let Some(to_sparse_trie_task) = to_sparse_trie_task &&
-                    let Some(withdrawals) = &ctx.env.withdrawals &&
-                    !withdrawals.is_empty()
+                if let Some(to_sparse_trie_task) = to_sparse_trie_task
+                    && let Some(withdrawals) = &ctx.env.withdrawals
+                    && !withdrawals.is_empty()
                 {
                     let targets = multiproof_targets_from_withdrawals(withdrawals);
                     let _ = to_sparse_trie_task.send(StateRootMessage::PrefetchProofs(targets));
@@ -332,22 +333,22 @@ where
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn run_bal_prewarm(
         &self,
-        decoded_bal: Arc<DecodedBal>,
+        decoded_bal: Arc<DecodedBal<OnceLock<Bal>>>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
     ) {
-        let bal = decoded_bal.as_bal();
-        if bal.is_empty() {
-            if let Some(to_sparse_trie_task) = self.to_sparse_trie_task.as_ref() {
-                let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
-            }
-            let _ =
-                actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
-            return;
-        }
+        // TODO: testing - restore the empty BAL fast path after raw BAL prewarm is covered.
+        // if decoded_bal.force_decode_bal().map_or(false, Bal::is_empty) {
+        //     if let Some(to_sparse_trie_task) = self.to_sparse_trie_task.as_ref() {
+        //         let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
+        //     }
+        //     let _ =
+        //         actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
+        //     return;
+        // }
 
+        let raw_bal = decoded_bal.as_raw_bal();
         trace!(
             target: "engine::tree::payload_processor::prewarm",
-            accounts = bal.len(),
             "Starting BAL prewarm"
         );
 
@@ -356,8 +357,8 @@ where
         let executor = self.executor.clone();
         let parent_span = Span::current();
         let stream_parent_span = parent_span;
-        let prefetch_bal = Arc::clone(&decoded_bal);
-        let stream_bal = Arc::clone(&decoded_bal);
+        let prefetch_bal = raw_bal.clone();
+        let stream_bal = raw_bal.clone();
         let (stream_tx, stream_rx) = oneshot::channel();
 
         if let Some(to_sparse_trie_task) = to_sparse_trie_task {
@@ -367,12 +368,23 @@ where
                     target: "engine::tree::payload_processor::prewarm",
                     parent: &stream_parent_span,
                     "bal_hashed_state_stream",
-                    bal_accounts = stream_bal.as_bal().len(),
                 );
                 let parent_span = branch_span.clone();
                 let _span = branch_span.entered();
 
-                stream_bal.as_bal().par_iter().for_each(|account_changes| {
+                let Ok(account_changes) =
+                    DecodedBal::from_raw_bal(stream_bal).map(|decoded| decoded.split().0)
+                else {
+                    warn!(
+                        target: "engine::tree::payload_processor::prewarm",
+                        "Failed to decode BAL for hashed-state streaming"
+                    );
+                    let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
+                    let _ = stream_tx.send(());
+                    return;
+                };
+
+                account_changes.par_iter().for_each(|account_changes| {
                     WorkerPool::with_worker_mut(|worker| {
                         let provider =
                             worker.get_or_init::<Option<Box<dyn AccountReader>>>(|| None);
@@ -392,9 +404,9 @@ where
             let _ = stream_tx.send(());
         }
 
-        if let Some(saved_cache) = ctx.saved_cache &&
-            !ctx.disable_bal_batch_io &&
-            let Some(pool) = ctx.bal_prewarm_pool.as_ref()
+        if let Some(saved_cache) = ctx.saved_cache
+            && !ctx.disable_bal_batch_io
+            && let Some(pool) = ctx.bal_prewarm_pool.as_ref()
         {
             // If
             //
@@ -413,13 +425,21 @@ where
             let build = Arc::new(move || provider_builder.build());
 
             pool.begin_block(build, caches);
-            for account in prefetch_bal.as_bal() {
-                pool.warm_account(account.address);
-                for change in &account.storage_changes {
-                    pool.warm_storage(account.address, change.slot.into());
+            match peek_raw_bal_prewarm_targets(&prefetch_bal) {
+                Ok(targets) => {
+                    for target in targets {
+                        pool.warm_account(target.address);
+                        for slot in target.storage_slots {
+                            pool.warm_storage(target.address, slot.into());
+                        }
+                    }
                 }
-                for &slot in &account.storage_reads {
-                    pool.warm_storage(account.address, slot.into());
+                Err(err) => {
+                    warn!(
+                        target: "engine::tree::payload_processor::prewarm",
+                        ?err,
+                        "Failed to peek raw BAL prewarm targets"
+                    );
                 }
             }
             pool.end_block();
@@ -481,7 +501,7 @@ where
 
                     if finished_execution {
                         // all tasks are done, we can exit, which will save caches and exit
-                        break
+                        break;
                     }
                 }
                 PrewarmTaskEvent::FinishedTxExecution { executed_transactions } => {
@@ -493,7 +513,7 @@ where
 
                     if final_execution_outcome.is_some() {
                         // all tasks are done, we can exit, which will save caches and exit
-                        break
+                        break;
                     }
                 }
             }
@@ -506,6 +526,76 @@ where
             self.save_cache(execution_outcome, valid_block_rx);
         }
     }
+}
+
+#[derive(Debug)]
+struct RawBalPrewarmTarget {
+    address: Address,
+    storage_slots: Vec<U256>,
+}
+
+fn peek_raw_bal_prewarm_targets(
+    raw_bal: &RawBal,
+) -> Result<Vec<RawBalPrewarmTarget>, alloy_rlp::Error> {
+    let mut buf = raw_bal.as_raw().as_ref();
+    let header = alloy_rlp::Header::decode(&mut buf)?;
+    if !header.list {
+        return Err(alloy_rlp::Error::UnexpectedString);
+    }
+    let mut accounts = take_payload(&mut buf, header.payload_length)?;
+    let mut targets = Vec::new();
+
+    while !accounts.is_empty() {
+        let account_header = alloy_rlp::Header::decode(&mut accounts)?;
+        if !account_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let mut account = take_payload(&mut accounts, account_header.payload_length)?;
+
+        let address = Address::decode(&mut account)?;
+        let mut storage_slots = Vec::new();
+
+        let storage_changes_header = alloy_rlp::Header::decode(&mut account)?;
+        if !storage_changes_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let mut storage_changes =
+            take_payload(&mut account, storage_changes_header.payload_length)?;
+        while !storage_changes.is_empty() {
+            let slot_changes_header = alloy_rlp::Header::decode(&mut storage_changes)?;
+            if !slot_changes_header.list {
+                return Err(alloy_rlp::Error::UnexpectedString);
+            }
+            let mut slot_changes =
+                take_payload(&mut storage_changes, slot_changes_header.payload_length)?;
+            storage_slots.push(U256::decode(&mut slot_changes)?);
+        }
+
+        let storage_reads_header = alloy_rlp::Header::decode(&mut account)?;
+        if !storage_reads_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let mut storage_reads = take_payload(&mut account, storage_reads_header.payload_length)?;
+        while !storage_reads.is_empty() {
+            storage_slots.push(U256::decode(&mut storage_reads)?);
+        }
+
+        targets.push(RawBalPrewarmTarget { address, storage_slots });
+    }
+
+    Ok(targets)
+}
+
+fn take_payload<'a>(
+    buf: &mut &'a [u8],
+    payload_length: usize,
+) -> Result<&'a [u8], alloy_rlp::Error> {
+    if buf.len() < payload_length {
+        return Err(alloy_rlp::Error::InputTooShort);
+    }
+    let (payload, rest) = buf.split_at(payload_length);
+    *buf = rest;
+    Ok(payload)
 }
 
 /// Context required by tx execution tasks.
@@ -572,7 +662,7 @@ where
                     %err,
                     "Failed to build state provider in prewarm thread"
                 );
-                return None
+                return None;
             }
         };
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -356,11 +356,52 @@ where
         let to_sparse_trie_task = self.to_sparse_trie_task.clone();
         let executor = self.executor.clone();
         let parent_span = Span::current();
-        let stream_parent_span = parent_span;
         let prefetch_bal = raw_bal.clone();
         let stream_bal = raw_bal.clone();
-        let (stream_tx, stream_rx) = oneshot::channel();
 
+        if let Some(saved_cache) = ctx.saved_cache.as_ref()
+            && !ctx.disable_bal_batch_io
+            && let Some(pool) = ctx.bal_prewarm_pool.as_ref()
+        {
+            // If
+            //
+            // - BAL path is enabled (and so bal_prewarm_pool is present),
+            // - dispatch_bal_batch_io is false
+            // - execution cache is not disabled
+            //
+            // we launch prewarming sequence of the BAL read set here. The BAL read-set consists
+            // of the accounts, their code if present, and declared storages (both storage_reads
+            // and storage_changes).
+            //
+            // This runs side-by-side with the parallel transaction execution reducing the time it
+            // spends blocking on the data.
+            let caches = saved_cache.cache().clone();
+            let provider_builder = ctx.provider.clone();
+            let build = Arc::new(move || provider_builder.build());
+
+            pool.begin_block(build, caches);
+            match peek_raw_bal_prewarm_targets(&prefetch_bal) {
+                Ok(targets) => {
+                    for target in targets {
+                        pool.warm_account(target.address);
+                        for slot in target.storage_slots {
+                            pool.warm_storage(target.address, slot.into());
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        target: "engine::tree::payload_processor::prewarm",
+                        ?err,
+                        "Failed to peek raw BAL prewarm targets"
+                    );
+                }
+            }
+            pool.end_block();
+        }
+
+        let stream_parent_span = parent_span;
+        let (stream_tx, stream_rx) = oneshot::channel();
         if let Some(to_sparse_trie_task) = to_sparse_trie_task {
             let ctx = ctx.clone();
             executor.bal_streaming_pool().spawn(move || {
@@ -402,47 +443,6 @@ where
             });
         } else {
             let _ = stream_tx.send(());
-        }
-
-        if let Some(saved_cache) = ctx.saved_cache
-            && !ctx.disable_bal_batch_io
-            && let Some(pool) = ctx.bal_prewarm_pool.as_ref()
-        {
-            // If
-            //
-            // - BAL path is enabled (and so bal_prewarm_pool is present),
-            // - dispatch_bal_batch_io is false
-            // - execution cache is not disabled
-            //
-            // we launch prewarming sequence of the BAL read set here. The BAL read-set consists
-            // of the accounts, their code if present, and declared storages (both storage_reads
-            // and storage_changes).
-            //
-            // This runs side-by-side with the parallel transaction execution reducing the time it
-            // spends blocking on the data.
-            let caches = saved_cache.cache().clone();
-            let provider_builder = ctx.provider.clone();
-            let build = Arc::new(move || provider_builder.build());
-
-            pool.begin_block(build, caches);
-            match peek_raw_bal_prewarm_targets(&prefetch_bal) {
-                Ok(targets) => {
-                    for target in targets {
-                        pool.warm_account(target.address);
-                        for slot in target.storage_slots {
-                            pool.warm_storage(target.address, slot.into());
-                        }
-                    }
-                }
-                Err(err) => {
-                    warn!(
-                        target: "engine::tree::payload_processor::prewarm",
-                        ?err,
-                        "Failed to peek raw BAL prewarm targets"
-                    );
-                }
-            }
-            pool.end_block();
         }
 
         stream_rx

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -359,7 +359,7 @@ where
         let prefetch_bal = raw_bal.clone();
         let stream_bal = Arc::clone(&decoded_bal);
 
-        if let Some(saved_cache) = ctx.saved_cache.as_ref() &&
+        let bal_prewarm_pool = if let Some(saved_cache) = ctx.saved_cache.as_ref() &&
             !ctx.disable_bal_batch_io &&
             let Some(pool) = ctx.bal_prewarm_pool.as_ref()
         {
@@ -391,8 +391,10 @@ where
                     "Failed to peek raw BAL prewarm targets"
                 );
             }
-            pool.end_block();
-        }
+            Some(pool)
+        } else {
+            None
+        };
 
         let stream_parent_span = parent_span;
         let (stream_tx, stream_rx) = oneshot::channel();
@@ -430,6 +432,10 @@ where
         stream_rx
             .blocking_recv()
             .expect("BAL hashed-state streaming task dropped without signaling completion");
+
+        if let Some(pool) = bal_prewarm_pool {
+            pool.end_block();
+        }
 
         // Drop the per-thread providers
         executor.bal_streaming_pool().clear();

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -15,11 +15,11 @@ use super::bal_prewarm_pool::BalPrewarmPool;
 use crate::tree::{
     payload_processor::multiproof::StateRootMessage,
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
-    CachedStateCacheMetrics, CachedStateMetrics, CachedStateProvider, ExecutionEnv,
+    CachedStateCacheMetrics, CachedStateMetrics, CachedStateProvider, ExecutionEnv, LazyDecodedBal,
     PayloadExecutionCache, SavedCache, StateProviderBuilder,
 };
 use alloy_consensus::transaction::TxHashRef;
-use alloy_eip7928::bal::{Bal, DecodedBal, RawBal};
+use alloy_eip7928::bal::RawBal;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{keccak256, Address, B256, U256};
 use alloy_rlp::Decodable;
@@ -38,7 +38,7 @@ use reth_trie_common::MultiProofTargetsV2;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, channel, Receiver, Sender},
-    Arc, OnceLock,
+    Arc,
 };
 use tokio::sync::oneshot;
 use tracing::{debug, debug_span, instrument, trace, trace_span, warn, Span};
@@ -49,7 +49,7 @@ pub enum PrewarmMode<Tx> {
     /// Prewarm by executing transactions from a stream, each paired with its block index.
     Transactions(Receiver<(usize, Tx)>),
     /// Prewarm by prefetching slots from a Block Access List.
-    BlockAccessList(Arc<DecodedBal<OnceLock<Bal>>>),
+    BlockAccessList(Arc<LazyDecodedBal>),
     /// Transaction prewarming is skipped (e.g. small blocks where the overhead exceeds the
     /// benefit). No workers are spawned.
     Skipped,
@@ -333,7 +333,7 @@ where
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn run_bal_prewarm(
         &self,
-        decoded_bal: Arc<DecodedBal<OnceLock<Bal>>>,
+        decoded_bal: Arc<LazyDecodedBal>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
     ) {
         // TODO: testing - restore the empty BAL fast path after raw BAL prewarm is covered.
@@ -407,14 +407,7 @@ where
                 let parent_span = branch_span.clone();
                 let _span = branch_span.entered();
 
-                let account_changes = stream_bal.as_bal().get_or_init(|| {
-                    DecodedBal::from_raw_bal(stream_bal.as_raw_bal().clone())
-                        .expect("validated BAL must decode")
-                        .split()
-                        .0
-                });
-
-                account_changes.par_iter().for_each(|account_changes| {
+                stream_bal.as_bal().par_iter().for_each(|account_changes| {
                     WorkerPool::with_worker_mut(|worker| {
                         let provider =
                             worker.get_or_init::<Option<Box<dyn AccountReader>>>(|| None);

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1788,10 +1788,10 @@ where
 
                 Ok(handle)
             }
-            StateRootStrategy::Skipped
-            | StateRootStrategy::Parallel
-            | StateRootStrategy::Synchronous
-            | StateRootStrategy::Custom(_) => {
+            StateRootStrategy::Skipped |
+            StateRootStrategy::Parallel |
+            StateRootStrategy::Synchronous |
+            StateRootStrategy::Custom(_) => {
                 let start = Instant::now();
                 let handle = self.payload_processor.spawn_cache_exclusive(
                     env,
@@ -2011,9 +2011,9 @@ where
             .sum();
 
         // Total time spent fetching state during execution
-        let state_read_duration = provider_stats.total_account_fetch_latency()
-            + provider_stats.total_storage_fetch_latency()
-            + provider_stats.total_code_fetch_latency();
+        let state_read_duration = provider_stats.total_account_fetch_latency() +
+            provider_stats.total_storage_fetch_latency() +
+            provider_stats.total_code_fetch_latency();
 
         // EIP-7702 delegation tracking from bytecode changes
         // Count new EIP-7702 bytecodes as delegations set

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -102,7 +102,7 @@ use crate::tree::{
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
     instrumented_state::{InstrumentedStateProvider, StateProviderMetrics, StateProviderStats},
     multiproof::{StateRootComputeOutcome, StateRootHandle},
-    payload_processor::{PayloadProcessor, PayloadProcessorSpawnOptions},
+    payload_processor::{LazyBal, LazyDecodedBal, PayloadProcessor, PayloadProcessorSpawnOptions},
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     types::{InsertPayloadResult, ValidationOutput},
     CacheWaitDurations, CachedStateProvider, EngineApiMetrics, EngineApiTreeState, ExecutionEnv,
@@ -110,7 +110,7 @@ use crate::tree::{
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::{
-    bal::{Bal, DecodedBal, RawBal},
+    bal::{DecodedBal, RawBal},
     compute_block_access_list_hash, BlockAccessList,
 };
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
@@ -2341,9 +2341,7 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     }
 
     /// Returns the decoded block access list, if present and successfully decoded.
-    pub fn try_lazy_decoded_access_list(
-        &self,
-    ) -> Result<Option<DecodedBal<std::sync::OnceLock<Bal>>>, alloy_rlp::Error> {
+    pub fn try_lazy_decoded_access_list(&self) -> Result<Option<LazyDecodedBal>, alloy_rlp::Error> {
         match self {
             Self::Payload(payload) => payload
                 .block_access_list()
@@ -2354,7 +2352,14 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
                     if !header.list || !raw.is_empty() && raw.len() != header.payload_length {
                         return Err(alloy_rlp::Error::UnexpectedString);
                     }
-                    Ok(DecodedBal::with_raw_bal(std::sync::OnceLock::new(), raw_bal))
+                    let decode_raw_bal = raw_bal.clone();
+                    let lazy_bal: LazyBal = std::sync::LazyLock::new(Box::new(move || {
+                        DecodedBal::from_raw_bal(decode_raw_bal)
+                            .expect("validated BAL must decode")
+                            .split()
+                            .0
+                    }));
+                    Ok(DecodedBal::with_raw_bal(lazy_bal, raw_bal))
                 })
                 .transpose(),
             Self::Block(_) => Ok(None),

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -109,7 +109,10 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
+use alloy_eip7928::{
+    bal::{Bal, DecodedBal, RawBal},
+    compute_block_access_list_hash, BlockAccessList,
+};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -491,7 +494,7 @@ where
                     Ok(val) => val,
                     Err(e) => {
                         let block = validated_block.try_into_inner().expect("sole handle")?;
-                        return Err(InsertBlockError::new(block, e.into()).into())
+                        return Err(InsertBlockError::new(block, e.into()).into());
                     }
                 }
             };
@@ -519,7 +522,7 @@ where
                 return Err(validated_block
                     .try_into_inner()
                     .expect("sole handle")
-                    .expect_err("Err result checked"))
+                    .expect_err("Err result checked"));
             }
         }
 
@@ -534,7 +537,7 @@ where
                 validated_block.try_into_inner().expect("sole handle")?,
                 ProviderError::HeaderNotFound(parent_hash.into()).into(),
             )
-            .into())
+            .into());
         };
         drop(_enter);
 
@@ -544,17 +547,19 @@ where
 
         // Extract the decoded BAL, if valid and available.
         let decoded_bal = ensure_ok!(input
-            .try_decoded_access_list()
+            .try_lazy_decoded_access_list()
             .map_err(|err| ConsensusError::BlockAccessListInvalid(err.to_string())))
         .map(Arc::new);
 
-        if let Some(decoded_bal) = decoded_bal.as_deref() {
-            // Reject oversized BAL sidecars before executing the block.
-            ensure_ok!(decoded_bal
-                .as_bal()
-                .validate_gas_limit(input.gas_limit())
-                .map_err(ConsensusError::from));
-        }
+        // TODO: testing - restore gas-limit validation for BAL sidecars.
+        // if let Some(decoded_bal) = decoded_bal.as_deref() {
+        //     // Reject oversized BAL sidecars before executing the block.
+        //     ensure_ok!(decoded_bal
+        //         .force_decode_bal()
+        //         .map_err(|err| ConsensusError::BlockAccessListInvalid(err.to_string()))?
+        //         .validate_gas_limit(input.gas_limit())
+        //         .map_err(ConsensusError::from));
+        // }
 
         let env = ExecutionEnv {
             evm_env,
@@ -590,7 +595,8 @@ where
         let overlay_factory =
             OverlayStateProviderFactory::new(provider_factory.clone(), overlay_builder.clone());
 
-        let parallel_bal_execution = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
+        let parallel_bal_execution =
+            ensure_ok!(self.bal_path_eligible(input.has_block_access_list_hash()));
 
         // Spawn the appropriate processor based on strategy
         let pending_sparse_trie_prune = if matches!(strategy, StateRootStrategy::StateRootTask) {
@@ -949,7 +955,7 @@ where
         if let Err(err) = hashed_state_validate_result {
             // call post-block hook
             self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
-            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
+            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into());
         }
 
         self.metrics.block_validation.record_state_root(&trie_output, root_elapsed.as_secs_f64());
@@ -978,7 +984,7 @@ where
                 )
                 .into(),
             )
-            .into())
+            .into());
         }
 
         let timing_stats = state_provider_stats.filter(|_| slow_block_enabled).map(|stats| {
@@ -1196,8 +1202,7 @@ where
     //   - Tx-count threshold (`bal_execute_path_min_tx_count`): below the parallelism break-even
     //     point, provider setup and worker scheduling overhead can exceed the gain. Tune
     //     empirically once workers are parallel; meaningless while the commit loop is sequential.
-    fn bal_path_eligible(&self, bal: Option<&DecodedBal>) -> Result<bool, InsertBlockErrorKind> {
-        let has_bal = bal.is_some();
+    fn bal_path_eligible(&self, has_bal: bool) -> Result<bool, InsertBlockErrorKind> {
         let parallel_execution = has_bal && !self.config.disable_bal_parallel_execution();
         if parallel_execution && self.config.disable_bal_parallel_state_root() {
             return Err(InsertBlockErrorKind::Other(
@@ -1249,6 +1254,10 @@ where
         let input_bal = env.decoded_bal.ok_or_else(|| {
             InsertBlockErrorKind::Other("BAL execute path: no decoded BAL available".into())
         })?;
+        let input_bal = Arc::new(
+            DecodedBal::from_raw_bal(input_bal.as_raw_bal().clone())
+                .map_err(|err| InsertBlockErrorKind::Other(Box::new(err)))?,
+        );
 
         let make_db = |fill_on_miss| {
             let provider = make_state_provider(fill_on_miss)
@@ -1702,7 +1711,7 @@ where
         ) {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
-            return Err(err.into())
+            return Err(err.into());
         }
         drop(_enter);
 
@@ -1779,10 +1788,10 @@ where
 
                 Ok(handle)
             }
-            StateRootStrategy::Skipped |
-            StateRootStrategy::Parallel |
-            StateRootStrategy::Synchronous |
-            StateRootStrategy::Custom(_) => {
+            StateRootStrategy::Skipped
+            | StateRootStrategy::Parallel
+            | StateRootStrategy::Synchronous
+            | StateRootStrategy::Custom(_) => {
                 let start = Instant::now();
                 let handle = self.payload_processor.spawn_cache_exclusive(
                     env,
@@ -1818,7 +1827,7 @@ where
                 self.provider.clone(),
                 historical,
                 Some(blocks),
-            )))
+            )));
         }
 
         // Check if the block is persisted
@@ -1826,7 +1835,7 @@ where
             debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)));
         }
 
         debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");
@@ -1862,7 +1871,7 @@ where
     ) {
         if state.invalid_headers.get(&block.hash()).is_some() {
             // we already marked this block as invalid
-            return
+            return;
         }
         self.invalid_block_hook.on_invalid_block(parent_header, block, output, trie_updates);
     }
@@ -2002,9 +2011,9 @@ where
             .sum();
 
         // Total time spent fetching state during execution
-        let state_read_duration = provider_stats.total_account_fetch_latency() +
-            provider_stats.total_storage_fetch_latency() +
-            provider_stats.total_code_fetch_latency();
+        let state_read_duration = provider_stats.total_account_fetch_latency()
+            + provider_stats.total_storage_fetch_latency()
+            + provider_stats.total_code_fetch_latency();
 
         // EIP-7702 delegation tracking from bytecode changes
         // Count new EIP-7702 bytecodes as delegations set
@@ -2332,13 +2341,31 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
     }
 
     /// Returns the decoded block access list, if present and successfully decoded.
-    pub fn try_decoded_access_list(&self) -> Result<Option<DecodedBal>, alloy_rlp::Error> {
+    pub fn try_lazy_decoded_access_list(
+        &self,
+    ) -> Result<Option<DecodedBal<std::sync::OnceLock<Bal>>>, alloy_rlp::Error> {
         match self {
             Self::Payload(payload) => payload
                 .block_access_list()
-                .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
+                .map(|block_access_list| {
+                    let raw_bal = RawBal::new(block_access_list.clone());
+                    let mut raw = raw_bal.as_raw().as_ref();
+                    let header = alloy_rlp::Header::decode(&mut raw)?;
+                    if !header.list || !raw.is_empty() && raw.len() != header.payload_length {
+                        return Err(alloy_rlp::Error::UnexpectedString);
+                    }
+                    Ok(DecodedBal::with_raw_bal(std::sync::OnceLock::new(), raw_bal))
+                })
                 .transpose(),
             Self::Block(_) => Ok(None),
+        }
+    }
+
+    /// Returns true if the block header commits to a block access list.
+    pub fn has_block_access_list_hash(&self) -> bool {
+        match self {
+            Self::Payload(payload) => payload.block_access_list().is_some(),
+            Self::Block(block) => block.header().block_access_list_hash().is_some(),
         }
     }
 


### PR DESCRIPTION
Adds lazy BAL plumbing for engine-tree BAL validation/prewarm.

- Add BlockOrPayload::try_lazy_decoded_access_list returning LazyDecodedBal.
- Carry lazy decoded BAL in ExecutionEnv.
- Gate BAL path from BAL presence on the input/header and keep BAL execution decoding explicit.
- Stream raw BAL RLP prewarm targets directly into the prewarm pool.
- Temporarily comment out BAL gas-limit and empty-BAL prewarm checks with TODOs for testing.

Prompted by: @rkrasiuk