### PR TITLE
feat(node): add optional latency tokio runtime for sendRaw path

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -696,7 +696,7 @@ where
                 .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
                 .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
                 .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-                .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
+                .build_with_tasks(ctx.rpc_task_executor().clone(), blob_store.clone());
 
         if validator.validator().eip4844() {
             // initializing the KZG settings can be expensive, this should be done upfront so that

--- a/crates/ethereum/node/tests/it/builder.rs
+++ b/crates/ethereum/node/tests/it/builder.rs
@@ -1,17 +1,23 @@
 //! Node builder setup tests.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use reth_db::{
     test_utils::{create_test_rw_db, TempDatabase},
     DatabaseEnv,
 };
-use reth_node_api::NodeTypesWithDBAdapter;
-use reth_node_builder::{EngineNodeLauncher, FullNodeComponents, NodeBuilder, NodeConfig};
+use reth_node_api::{FullNodeComponents, NodeTypesWithDBAdapter};
+use reth_node_builder::{EngineNodeLauncher, NodeBuilder, NodeConfig};
+use reth_node_core::{
+    args::{DatadirArgs, NetworkArgs},
+    dirs::{DataDirPath, MaybePlatformPath},
+};
 use reth_node_ethereum::node::{EthereumAddOns, EthereumNode};
 use reth_provider::providers::BlockchainProvider;
 use reth_rpc_builder::Identity;
 use reth_tasks::Runtime;
+use tempfile::tempdir;
+use tokio::sync::oneshot;
 
 #[test]
 fn test_basic_setup() {
@@ -64,12 +70,76 @@ async fn test_eth_launcher() {
             })
             .launch_with_fn(|builder| {
                 let launcher = EngineNodeLauncher::new(
-                    runtime.clone(),
+                    builder.task_executor().clone(),
                     builder.config().datadir(),
                     Default::default(),
                 );
                 builder.launch_with(launcher)
             });
+}
+
+#[test]
+fn test_eth_launcher_with_latency_runtime() {
+    let main_rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    let node_handle = main_rt.block_on(async move {
+        let runtime = Runtime::test();
+        let tempdir = tempdir().expect("temp datadir");
+        let datadir_args = DatadirArgs {
+            datadir: MaybePlatformPath::<DataDirPath>::from(tempdir.path().to_path_buf()),
+            static_files_path: Some(tempdir.path().join("static")),
+            rocksdb_path: Some(tempdir.path().join("rocksdb")),
+            pprof_dumps_path: Some(tempdir.path().join("pprof")),
+        };
+        let mut network = NetworkArgs::default();
+        network.discovery.disable_discovery = true;
+        let mut config = NodeConfig::test().with_datadir_args(datadir_args).with_network(network);
+        config.rpc.latency_worker_threads = 2;
+        let db = create_test_rw_db();
+        let (initialized_tx, initialized_rx) = oneshot::channel();
+        let builder =
+            NodeBuilder::new(config)
+                .with_database(db)
+                .with_launch_context(runtime.clone())
+                .with_types_and_provider::<EthereumNode, BlockchainProvider<
+                    NodeTypesWithDBAdapter<EthereumNode, Arc<TempDatabase<DatabaseEnv>>>,
+                >>()
+                .with_components(EthereumNode::components())
+                .with_add_ons(EthereumAddOns::default())
+                .on_component_initialized(move |_| {
+                    let _ = initialized_tx.send(());
+                    Ok(())
+                })
+                .on_node_started(|node| {
+                    let latency = node.latency_runtime.as_ref().expect("latency runtime");
+                    assert_ne!(node.task_executor.handle().id(), latency.handle().id(),);
+                    Ok(())
+                })
+                .apply(|builder| {
+                    let _ = builder.db();
+                    builder
+                });
+
+        let launcher = EngineNodeLauncher::new(
+            runtime.clone(),
+            builder.config().datadir(),
+            Default::default(),
+        );
+        let launch = builder.launch_with(launcher);
+        let node_handle = tokio::time::timeout(Duration::from_secs(30), launch)
+            .await
+            .expect("timed out waiting for node launch")
+            .expect("node launch failed");
+
+        tokio::time::timeout(Duration::from_secs(5), initialized_rx)
+            .await
+            .expect("timed out waiting for component init hook")
+            .expect("component init hook channel dropped");
+
+        node_handle
+    });
+
+    node_handle.node.task_executor.graceful_shutdown();
+    drop(node_handle);
 }
 
 #[test]
@@ -101,7 +171,7 @@ fn test_eth_launcher_with_tokio_runtime() {
                 })
                 .launch_with_fn(|builder| {
                     let launcher = EngineNodeLauncher::new(
-                        runtime.clone(),
+                        builder.task_executor().clone(),
                         builder.config().datadir(),
                         Default::default(),
                     );

--- a/crates/node/api/src/node.rs
+++ b/crates/node/api/src/node.rs
@@ -109,6 +109,8 @@ pub struct AddOnsContext<'a, N: FullNodeComponents> {
     pub node: N,
     /// Node configuration.
     pub config: &'a NodeConfig<<N::Types as NodeTypes>::ChainSpec>,
+    /// RPC/latency task executor when a dedicated runtime is configured.
+    pub rpc_task_executor: TaskExecutor,
     /// Handle to the beacon consensus engine.
     pub beacon_engine_handle: ConsensusEngineHandle<<N::Types as NodeTypes>::Payload>,
     /// Notification channel for engine API events

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -808,6 +808,14 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         self.sender_recovery_cache.as_ref()
     }
 
+    /// Returns the RPC/latency executor of the node.
+    ///
+    /// When a latency runtime is configured, this is the dedicated tokio runtime for the
+    /// sendRaw path. Otherwise, this is the same as [`Self::task_executor`].
+    pub fn rpc_task_executor(&self) -> TaskExecutor {
+        self.config_container.latency_runtime.clone().unwrap_or_else(|| self.executor.clone())
+    }
+
     /// Returns the chain spec of the node.
     pub fn chain_spec(&self) -> Arc<<Node::Types as NodeTypes>::ChainSpec> {
         self.provider().chain_spec()

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -82,7 +82,7 @@ impl<T: FullNodeTypes> fmt::Debug for NodeTypesAdapter<T> {
 pub struct NodeAdapter<T: FullNodeTypes, C: NodeComponents<T> = ComponentsFor<T>> {
     /// The components of the node.
     pub components: C,
-    /// The task executor for the node.
+    /// The main task executor for the node.
     pub task_executor: TaskExecutor,
     /// The provider of the node.
     pub provider: T::Provider,

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -86,7 +86,7 @@ use reth_stages::{
 };
 use reth_static_file::{blocks_per_file_for_prune_distance, StaticFileProducer, StaticFileSegment};
 use reth_storage_overlay::OverlayManager;
-use reth_tasks::TaskExecutor;
+use reth_tasks::{Runtime, TaskExecutor, TokioConfig};
 use reth_tracing::{
     throttle,
     tracing::{debug, error, info, warn},
@@ -151,7 +151,7 @@ impl LaunchContext {
         ChainSpec: EthChainSpec + reth_chainspec::EthereumHardforks,
     {
         let toml_config = self.load_toml_config(&config)?;
-        Ok(self.with(WithConfigs { config, toml_config }))
+        Ok(self.with(WithConfigs { config, toml_config, latency_runtime: None }))
     }
 
     /// Loads the reth config with the configured `data_dir` and overrides settings according to the
@@ -373,6 +373,29 @@ impl<R, ChainSpec: EthChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpe
     pub fn with_adjusted_instance_ports(mut self) -> Self {
         self.node_config_mut().adjust_instance_ports();
         self
+    }
+
+    /// Builds the optional latency-sensitive tokio runtime from CLI args if not already set.
+    pub fn ensure_latency_runtime(&mut self) -> eyre::Result<()> {
+        let threads = self.node_config().rpc.latency_worker_threads;
+        if threads == 0 {
+            return Ok(());
+        }
+        if self.configs().latency_runtime.is_some() {
+            return Ok(());
+        }
+        let rt = self
+            .task_executor()
+            .build_attached_tokio(TokioConfig::latency_runtime(threads))
+            .map_err(|err| eyre::eyre!("failed to build latency tokio runtime: {err}"))?;
+        self.left_mut().latency_runtime = Some(rt);
+        info!(target: "reth::cli", threads, "Latency RPC tokio runtime enabled");
+        Ok(())
+    }
+
+    /// Returns the RPC/latency executor when configured, otherwise the main executor.
+    pub fn rpc_task_executor(&self) -> TaskExecutor {
+        self.configs().latency_runtime.clone().unwrap_or_else(|| self.task_executor().clone())
     }
 
     /// Returns the container for all config types
@@ -1335,11 +1358,17 @@ pub struct WithConfigs<ChainSpec> {
     pub config: NodeConfig<ChainSpec>,
     /// The loaded reth.toml config.
     pub toml_config: reth_config::Config,
+    /// Optional latency-sensitive tokio runtime, built at launch from CLI args.
+    pub latency_runtime: Option<Runtime>,
 }
 
 impl<ChainSpec> Clone for WithConfigs<ChainSpec> {
     fn clone(&self) -> Self {
-        Self { config: self.config.clone(), toml_config: self.toml_config.clone() }
+        Self {
+            config: self.config.clone(),
+            toml_config: self.toml_config.clone(),
+            latency_runtime: self.latency_runtime.clone(),
+        }
     }
 }
 
@@ -1459,12 +1488,13 @@ fn delete_partial_trie_unwind_marker(provider: &impl MetadataWriter) -> Provider
 
 #[cfg(test)]
 mod tests {
-    use super::{get_partial_trie_unwind_marker, LaunchContext, NodeConfig};
+    use super::{get_partial_trie_unwind_marker, LaunchContext, NodeConfig, WithConfigs};
     use reth_config::Config;
     use reth_db_api::models::PartialStateTrieUnwindMarker;
     use reth_node_core::args::PruningArgs;
     use reth_provider::{MetadataProvider, ProviderResult, StageCheckpointReader};
     use reth_stages::{FinishCheckpoint, StageCheckpoint, StageId};
+    use reth_tasks::Runtime;
 
     const EXTENSION: &str = "toml";
 
@@ -1491,6 +1521,22 @@ mod tests {
         }
     }
 
+    #[test]
+    fn ensure_latency_runtime_creates_second_handle() {
+        let runtime = Runtime::test();
+        let datadir = NodeConfig::test().datadir();
+        let mut config = NodeConfig::test();
+        config.rpc.latency_worker_threads = 2;
+
+        let mut ctx = LaunchContext::new(runtime.clone(), datadir)
+            .with(WithConfigs { config, toml_config: Config::default(), latency_runtime: None })
+            .attach(());
+
+        ctx.ensure_latency_runtime().unwrap();
+        assert!(ctx.configs().latency_runtime.is_some());
+        assert_ne!(runtime.handle().id(), ctx.rpc_task_executor().handle().id());
+    }
+
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
         let temp_dir = tempfile::tempdir().unwrap();
         let config_path = temp_dir.path().join(filename).with_extension(EXTENSION);
@@ -1502,7 +1548,7 @@ mod tests {
     fn test_save_prune_config() {
         with_tempdir("prune-store-test", |config_path| {
             let mut reth_config = Config::default();
-            let node_config = NodeConfig {
+            let node_config = super::NodeConfig {
                 pruning: PruningArgs {
                     full: true,
                     minimal: false,
@@ -1529,7 +1575,7 @@ mod tests {
                     bodies_before: None,
                     minimum_distance: None,
                 },
-                ..NodeConfig::test()
+                ..super::NodeConfig::test()
             };
             LaunchContext::save_pruning_config(&mut reth_config, &node_config, config_path)
                 .unwrap();

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -99,7 +99,7 @@ impl EngineNodeLauncher {
         let disabled_stages = N::disabled_stages();
 
         // setup the launch context
-        let ctx = ctx
+        let mut ctx = ctx
             .with_configured_globals(engine_tree_config.reserved_cpu_cores())
             // load the toml config
             .with_loaded_toml_config(config)?
@@ -136,8 +136,11 @@ impl EngineNodeLauncher {
             // later the components.
             .with_blockchain_db::<T, _>(move |provider_factory| {
                 Ok(BlockchainProvider::new(provider_factory)?)
-            })?
-            .with_components(components_builder, on_component_initialized).await?;
+            })?;
+
+        ctx.ensure_latency_runtime()?;
+
+        let ctx = ctx.with_components(components_builder, on_component_initialized).await?;
 
         // spawn exexs if any
         let maybe_exex_manager_handle = ctx.launch_exex(installed_exex).await?;
@@ -200,6 +203,7 @@ impl EngineNodeLauncher {
         let add_ons_ctx = AddOnsContext {
             node: ctx.node_adapter().clone(),
             config: ctx.node_config(),
+            rpc_task_executor: ctx.rpc_task_executor(),
             beacon_engine_handle: beacon_engine_handle.clone(),
             jwt_secret,
             engine_events: event_sender.clone(),
@@ -421,6 +425,7 @@ impl EngineNodeLauncher {
             task_executor: ctx.task_executor().clone(),
             config: ctx.node_config().clone(),
             data_dir: ctx.data_dir().clone(),
+            latency_runtime: ctx.configs().latency_runtime.clone(),
             add_ons_handle: RpcHandle {
                 rpc_server_handles,
                 rpc_registry,

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -15,7 +15,7 @@ use reth_payload_builder::PayloadBuilderHandle;
 use reth_provider::ChainSpecProvider;
 use reth_rpc_api::EngineApiClient;
 use reth_rpc_builder::{auth::AuthServerHandle, RpcServerHandle};
-use reth_tasks::TaskExecutor;
+use reth_tasks::{Runtime, TaskExecutor};
 use std::{
     fmt::Debug,
     marker::PhantomData,
@@ -128,6 +128,8 @@ pub struct FullNode<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub data_dir: ChainPath<DataDirPath>,
     /// The handle to launched add-ons
     pub add_ons_handle: AddOns::Handle,
+    /// Keeps the optional latency-sensitive tokio runtime alive for the node's lifetime.
+    pub latency_runtime: Option<Runtime>,
 }
 
 impl<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> Clone for FullNode<Node, AddOns> {
@@ -142,6 +144,7 @@ impl<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> Clone for FullNode<Node
             config: self.config.clone(),
             data_dir: self.data_dir.clone(),
             add_ons_handle: self.add_ons_handle.clone(),
+            latency_runtime: self.latency_runtime.clone(),
         }
     }
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -44,6 +44,7 @@ use reth_rpc_builder::{
 };
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_rpc_eth_types::{cache::cache_new_blocks_task, EthConfig, EthStateCache};
+use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
 use reth_tracing::tracing::{debug, info};
 use std::{
@@ -957,7 +958,8 @@ where
         F: FnOnce(RpcModuleContainer<'_, N, EthB::EthApi>) -> eyre::Result<()>,
     {
         let rpc_middleware = self.rpc_middleware.clone();
-        let tokio_runtime = self.tokio_runtime.clone();
+        let explicit_tokio_runtime = self.tokio_runtime.clone();
+        let rpc_task_executor = ctx.rpc_task_executor.clone();
         let setup_ctx = self.setup_rpc_components(ctx, ext).await?;
         let RpcSetupContext {
             node,
@@ -970,6 +972,9 @@ where
             engine_events,
             engine_handle,
         } = setup_ctx;
+
+        let tokio_runtime =
+            resolve_tokio_runtime(explicit_tokio_runtime, config, &rpc_task_executor);
 
         let server_config = config
             .rpc
@@ -1029,7 +1034,8 @@ where
     {
         let rpc_middleware = self.rpc_middleware.clone();
         let auth_http_middleware = self.auth_http_middleware.clone();
-        let tokio_runtime = self.tokio_runtime.clone();
+        let explicit_tokio_runtime = self.tokio_runtime.clone();
+        let rpc_task_executor = ctx.rpc_task_executor.clone();
         let setup_ctx = self.setup_rpc_components(ctx, ext).await?;
         let RpcSetupContext {
             node,
@@ -1042,6 +1048,9 @@ where
             engine_events,
             engine_handle,
         } = setup_ctx;
+
+        let tokio_runtime =
+            resolve_tokio_runtime(explicit_tokio_runtime, config, &rpc_task_executor);
 
         let server_config = config
             .rpc
@@ -1099,7 +1108,9 @@ where
         let Self { eth_api_builder, engine_api_builder, hooks, .. } = self;
 
         let engine_api = engine_api_builder.build_engine_api(&ctx).await?;
-        let AddOnsContext { node, config, beacon_engine_handle, jwt_secret, engine_events } = ctx;
+        let rpc_task_spawner = ctx.rpc_task_executor.clone();
+        let AddOnsContext { node, config, beacon_engine_handle, jwt_secret, engine_events, .. } =
+            ctx;
 
         info!(target: "reth::cli", "Engine API handler initialized");
 
@@ -1121,6 +1132,7 @@ where
             config: eth_config,
             cache,
             engine_handle: beacon_engine_handle.clone(),
+            rpc_task_spawner,
         };
         let eth_api = eth_api_builder.build_eth_api(ctx).await?;
 
@@ -1281,6 +1293,19 @@ where
     }
 }
 
+/// Resolves the tokio runtime handle for jsonrpsee.
+///
+/// An explicit handle from [`RpcAddOns::with_tokio_runtime`] takes precedence. Otherwise, when
+/// latency worker threads are configured, the RPC executor handle is used automatically.
+fn resolve_tokio_runtime<ChainSpec>(
+    explicit: Option<tokio::runtime::Handle>,
+    config: &NodeConfig<ChainSpec>,
+    rpc_executor: &TaskExecutor,
+) -> Option<tokio::runtime::Handle> {
+    explicit
+        .or_else(|| (config.rpc.latency_worker_threads > 0).then(|| rpc_executor.handle().clone()))
+}
+
 /// `EthApiCtx` struct
 /// This struct is used to pass the necessary context to the `EthApiBuilder` to build the `EthApi`.
 #[derive(Debug)]
@@ -1293,6 +1318,8 @@ pub struct EthApiCtx<'a, N: FullNodeTypes> {
     pub cache: EthStateCache<PrimitivesTy<N::Types>>,
     /// Handle to the beacon consensus engine
     pub engine_handle: ConsensusEngineHandle<<N::Types as NodeTypes>::Payload>,
+    /// RPC/latency task spawner for sendRaw-sensitive work.
+    pub rpc_task_spawner: TaskExecutor,
 }
 
 impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumHardforks>>>
@@ -1303,6 +1330,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
         reth_rpc::EthApiBuilder::new_with_components(self.components.clone())
             .eth_cache(self.cache)
             .task_spawner(self.components.task_executor().clone())
+            .rpc_task_spawner(self.rpc_task_spawner.clone())
             .gas_cap(self.config.rpc_gas_cap.into())
             .max_simulate_blocks(self.config.rpc_max_simulate_blocks)
             .compute_state_root_for_eth_simulate(self.config.compute_state_root_for_eth_simulate)

--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -78,6 +78,7 @@ pub struct DefaultRpcServerArgs {
     rpc_max_connections: MaxU32,
     rpc_max_tracing_requests: usize,
     rpc_max_blocking_io_requests: usize,
+    latency_worker_threads: usize,
     rpc_max_trace_filter_blocks: u64,
     rpc_max_blocks_per_filter: ZeroAsNoneU64,
     rpc_max_logs_per_response: ZeroAsNoneU64,
@@ -275,6 +276,14 @@ impl DefaultRpcServerArgs {
         self
     }
 
+    /// Set the default number of worker threads for the latency-sensitive RPC runtime.
+    ///
+    /// `0` disables the dedicated runtime.
+    pub const fn with_latency_worker_threads(mut self, v: usize) -> Self {
+        self.latency_worker_threads = v;
+        self
+    }
+
     /// Set the default max trace filter blocks
     pub const fn with_rpc_max_trace_filter_blocks(mut self, v: u64) -> Self {
         self.rpc_max_trace_filter_blocks = v;
@@ -403,6 +412,7 @@ impl Default for DefaultRpcServerArgs {
             rpc_max_connections: RPC_DEFAULT_MAX_CONNECTIONS.into(),
             rpc_max_tracing_requests: constants::default_max_tracing_requests(),
             rpc_max_blocking_io_requests: constants::DEFAULT_MAX_BLOCKING_IO_REQUEST,
+            latency_worker_threads: 0,
             rpc_max_trace_filter_blocks: constants::DEFAULT_MAX_TRACE_FILTER_BLOCKS,
             rpc_max_blocks_per_filter: constants::DEFAULT_MAX_BLOCKS_PER_FILTER.into(),
             rpc_max_logs_per_response: (constants::DEFAULT_MAX_LOGS_PER_RESPONSE as u64).into(),
@@ -563,6 +573,14 @@ pub struct RpcServerArgs {
     /// runtime.
     #[arg(long = "rpc.max-blocking-io-requests", alias = "rpc-max-blocking-io-requests", value_name = "COUNT", default_value_t = DefaultRpcServerArgs::get_global().rpc_max_blocking_io_requests)]
     pub rpc_max_blocking_io_requests: usize,
+
+    /// Number of worker threads for the latency-sensitive RPC tokio runtime.
+    ///
+    /// When set to a value greater than 0, the public RPC server (HTTP/WS/IPC) and the sendRaw
+    /// transaction backend (tx-batcher and pool validation) run on a dedicated tokio runtime
+    /// isolated from sync, P2P, and engine work. Defaults to 0 (disabled).
+    #[arg(long = "rpc.latency-worker-threads", default_value_t = DefaultRpcServerArgs::get_global().latency_worker_threads)]
+    pub latency_worker_threads: usize,
 
     /// Maximum number of blocks for `trace_filter` requests.
     #[arg(long = "rpc.max-trace-filter-blocks", alias = "rpc-max-trace-filter-blocks", value_name = "COUNT", default_value_t = DefaultRpcServerArgs::get_global().rpc_max_trace_filter_blocks)]
@@ -863,6 +881,7 @@ impl Default for RpcServerArgs {
             rpc_max_connections,
             rpc_max_tracing_requests,
             rpc_max_blocking_io_requests,
+            latency_worker_threads,
             rpc_max_trace_filter_blocks,
             rpc_max_blocks_per_filter,
             rpc_max_logs_per_response,
@@ -909,6 +928,7 @@ impl Default for RpcServerArgs {
             rpc_max_connections,
             rpc_max_tracing_requests,
             rpc_max_blocking_io_requests,
+            latency_worker_threads,
             rpc_max_trace_filter_blocks,
             rpc_max_blocks_per_filter,
             rpc_max_logs_per_response,
@@ -1052,6 +1072,20 @@ mod tests {
     }
 
     #[test]
+    fn test_rpc_latency_worker_threads_parse() {
+        let args = CommandParser::<RpcServerArgs>::parse_from([
+            "reth",
+            "--rpc.latency-worker-threads",
+            "4",
+        ])
+        .args;
+        assert_eq!(args.latency_worker_threads, 4);
+
+        let default_args = CommandParser::<RpcServerArgs>::parse_from(["reth"]).args;
+        assert_eq!(default_args.latency_worker_threads, 0);
+    }
+
+    #[test]
     fn test_rpc_server_args() {
         let args = RpcServerArgs {
             http: true,
@@ -1087,6 +1121,7 @@ mod tests {
             rpc_max_connections: 500u32.into(),
             rpc_max_tracing_requests: 16,
             rpc_max_blocking_io_requests: 256,
+            latency_worker_threads: 0,
             rpc_max_trace_filter_blocks: 4000,
             rpc_max_blocks_per_filter: 1000u64.into(),
             rpc_max_logs_per_response: 10000u64.into(),

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -41,6 +41,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     gas_oracle: Option<GasPriceOracle<N::Provider>>,
     blocking_task_pool: Option<BlockingTaskPool>,
     task_spawner: Runtime,
+    rpc_task_spawner: Option<Runtime>,
     next_env: NextEnv,
     max_batch_size: usize,
     max_blocking_io_requests: usize,
@@ -95,6 +96,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             gas_oracle,
             blocking_task_pool,
             task_spawner,
+            rpc_task_spawner,
             next_env,
             max_batch_size,
             max_blocking_io_requests,
@@ -119,6 +121,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             gas_oracle,
             blocking_task_pool,
             task_spawner,
+            rpc_task_spawner,
             next_env,
             max_batch_size,
             max_blocking_io_requests,
@@ -152,6 +155,7 @@ where
             fee_history_cache_config: FeeHistoryCacheConfig::default(),
             proof_permits: DEFAULT_PROOF_PERMITS,
             task_spawner: Runtime::test(),
+            rpc_task_spawner: None,
             gas_oracle_config: Default::default(),
             eth_state_cache_config: Default::default(),
             next_env: Default::default(),
@@ -176,6 +180,12 @@ where
         self
     }
 
+    /// Configures the task spawner used for latency-sensitive RPC work (e.g. tx-batcher).
+    pub fn rpc_task_spawner(mut self, spawner: Runtime) -> Self {
+        self.rpc_task_spawner = Some(spawner);
+        self
+    }
+
     /// Changes the configured converter.
     pub fn with_rpc_converter<RpcNew>(
         self,
@@ -195,6 +205,7 @@ where
             gas_oracle,
             blocking_task_pool,
             task_spawner,
+            rpc_task_spawner,
             gas_oracle_config,
             next_env,
             max_batch_size,
@@ -219,6 +230,7 @@ where
             gas_oracle,
             blocking_task_pool,
             task_spawner,
+            rpc_task_spawner,
             gas_oracle_config,
             next_env,
             max_batch_size,
@@ -250,6 +262,7 @@ where
             gas_oracle,
             blocking_task_pool,
             task_spawner,
+            rpc_task_spawner,
             gas_oracle_config,
             next_env: _,
             max_batch_size,
@@ -274,6 +287,7 @@ where
             gas_oracle,
             blocking_task_pool,
             task_spawner,
+            rpc_task_spawner,
             gas_oracle_config,
             next_env,
             max_batch_size,
@@ -523,6 +537,7 @@ where
             fee_history_cache_config,
             proof_permits,
             task_spawner,
+            rpc_task_spawner,
             next_env,
             max_batch_size,
             max_blocking_io_requests,
@@ -532,6 +547,8 @@ where
             evm_memory_limit,
             force_blob_sidecar_upcasting,
         } = self;
+
+        let batcher_spawner = rpc_task_spawner.unwrap_or_else(|| task_spawner.clone());
 
         let provider = components.provider().clone();
 
@@ -574,6 +591,7 @@ where
             }),
             fee_history_cache,
             task_spawner,
+            batcher_spawner,
             proof_permits,
             rpc_converter,
             next_env,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -307,6 +307,7 @@ where
         blocking_task_pool: BlockingTaskPool,
         fee_history_cache: FeeHistoryCache<ProviderHeader<N::Provider>>,
         task_spawner: Runtime,
+        batcher_spawner: Runtime,
         proof_permits: usize,
         converter: Rpc,
         next_env: impl PendingEnvBuilder<N::Evm>,
@@ -333,9 +334,12 @@ where
         let (raw_tx_sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
 
         // Create tx pool insertion batcher
-        let (processor, tx_batch_sender) =
-            BatchTxProcessor::new(components.pool().clone(), max_batch_size);
-        task_spawner.spawn_critical_task("tx-batcher", processor);
+        let (processor, tx_batch_sender) = BatchTxProcessor::new(
+            components.pool().clone(),
+            max_batch_size,
+            batcher_spawner.handle().clone(),
+        );
+        batcher_spawner.spawn_critical_task("tx-batcher", processor);
 
         Self {
             components,

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -48,6 +48,9 @@ pub const DEFAULT_STATE_TRIE_OVERLAY_WORKER_THREADS: usize = 4;
 /// Default maximum number of concurrent blocking tasks (for RPC tracing guard).
 pub const DEFAULT_MAX_BLOCKING_TASKS: usize = 512;
 
+/// Default thread name prefix for the latency-sensitive tokio runtime.
+pub const DEFAULT_LATENCY_THREAD_NAME: &str = "tokio-latency";
+
 /// Configuration for the tokio runtime.
 #[derive(Debug, Clone)]
 pub enum TokioConfig {
@@ -88,6 +91,47 @@ impl TokioConfig {
             thread_name: "tokio-rt",
         }
     }
+
+    /// Create a config for an owned latency-sensitive tokio runtime.
+    pub const fn latency_runtime(worker_threads: usize) -> Self {
+        Self::Owned {
+            worker_threads: Some(worker_threads),
+            thread_keep_alive: DEFAULT_THREAD_KEEP_ALIVE,
+            thread_name: DEFAULT_LATENCY_THREAD_NAME,
+        }
+    }
+}
+
+/// Builds an owned tokio runtime from the given configuration.
+fn build_owned_tokio(
+    config: &TokioConfig,
+) -> Result<(Option<TokioRuntime>, Handle), RuntimeBuildError> {
+    match config {
+        TokioConfig::Owned { worker_threads, thread_keep_alive, thread_name } => {
+            let mut builder = tokio::runtime::Builder::new_multi_thread();
+            builder.enable_all().thread_keep_alive(*thread_keep_alive).thread_name(*thread_name);
+
+            if let Some(threads) = worker_threads {
+                builder.worker_threads(*threads);
+            }
+
+            let runtime = builder.build()?;
+            let handle = runtime.handle().clone();
+            Ok((Some(runtime), handle))
+        }
+        TokioConfig::ExistingHandle(handle) => Ok((None, handle.clone())),
+    }
+}
+
+#[cfg(feature = "rayon")]
+fn build_minimal_rayon_pool(name_prefix: &str) -> Result<rayon::ThreadPool, RuntimeBuildError> {
+    let name_prefix = name_prefix.to_string();
+    build_pool_with_panic_handler(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .thread_name(move |i| format!("{name_prefix}-{i:02}")),
+    )
+    .map_err(RuntimeBuildError::from)
 }
 
 /// Configuration for the rayon thread pools.
@@ -298,6 +342,11 @@ struct RuntimeInner {
     /// Named single-thread worker map. Each unique name gets a dedicated OS thread
     /// that is reused across all tasks submitted under that name.
     worker_map: WorkerMap,
+    /// When set, rayon pools and worker pools are borrowed from the parent runtime.
+    ///
+    /// Used by attached latency runtimes to avoid duplicating rayon thread pools.
+    #[cfg(feature = "rayon")]
+    pool_parent: Option<Arc<Self>>,
     /// Handle to the spawned [`TaskManager`] background task.
     /// The task monitors critical tasks for panics and fires the shutdown signal.
     /// Can be taken via [`Runtime::take_task_manager_handle`] to poll for panic errors.
@@ -341,6 +390,9 @@ impl Runtime {
     /// Get the general-purpose rayon CPU thread pool.
     #[cfg(feature = "rayon")]
     pub fn cpu_pool(&self) -> &rayon::ThreadPool {
+        if let Some(parent) = &self.0.pool_parent {
+            return &parent.cpu_pool;
+        }
         &self.0.cpu_pool
     }
 
@@ -353,6 +405,9 @@ impl Runtime {
     /// Get the storage I/O pool.
     #[cfg(feature = "rayon")]
     pub fn storage_pool(&self) -> &rayon::ThreadPool {
+        if let Some(parent) = &self.0.pool_parent {
+            return &parent.storage_pool;
+        }
         &self.0.storage_pool
     }
 
@@ -365,24 +420,36 @@ impl Runtime {
     /// Get the proof storage worker pool.
     #[cfg(feature = "rayon")]
     pub fn proof_storage_worker_pool(&self) -> &WorkerPool {
+        if let Some(parent) = &self.0.pool_parent {
+            return &parent.proof_storage_worker_pool;
+        }
         &self.0.proof_storage_worker_pool
     }
 
     /// Get the proof account worker pool.
     #[cfg(feature = "rayon")]
     pub fn proof_account_worker_pool(&self) -> &WorkerPool {
+        if let Some(parent) = &self.0.pool_parent {
+            return &parent.proof_account_worker_pool;
+        }
         &self.0.proof_account_worker_pool
     }
 
     /// Get the prewarming pool.
     #[cfg(feature = "rayon")]
     pub fn prewarming_pool(&self) -> &WorkerPool {
+        if let Some(parent) = &self.0.pool_parent {
+            return &parent.prewarming_pool;
+        }
         &self.0.prewarming_pool
     }
 
     /// Get the BAL streaming pool.
     #[cfg(feature = "rayon")]
     pub fn bal_streaming_pool(&self) -> &WorkerPool {
+        if let Some(parent) = &self.0.pool_parent {
+            return &parent.bal_streaming_pool;
+        }
         &self.0.bal_streaming_pool
     }
 
@@ -390,6 +457,80 @@ impl Runtime {
     #[cfg(feature = "rayon")]
     pub fn state_trie_overlay_worker_pool(&self) -> Arc<WorkerPool> {
         Arc::clone(&self.0.state_trie_overlay_worker_pool)
+    }
+
+    /// Builds an attached tokio runtime that shares shutdown and panic reporting with `self`.
+    ///
+    /// The returned [`Runtime`] spawns tasks on a dedicated tokio handle while reusing the
+    /// parent's shutdown signal, task event channel, graceful shutdown counter, metrics, and
+    /// rayon pools (when the `rayon` feature is enabled).
+    ///
+    /// Only the main runtime should own a [`TaskManager`] handle. Attached runtimes must not
+    /// call [`Self::take_task_manager_handle`].
+    pub fn build_attached_tokio(&self, config: TokioConfig) -> Result<Self, RuntimeBuildError> {
+        let (owned_runtime, handle) = build_owned_tokio(&config)?;
+        let parent = Arc::clone(&self.0);
+
+        #[cfg(feature = "rayon")]
+        let (
+            cpu_pool,
+            rpc_pool,
+            storage_pool,
+            blocking_guard,
+            proof_storage_worker_pool,
+            proof_account_worker_pool,
+            prewarming_pool,
+            bal_streaming_pool,
+            state_trie_overlay_worker_pool,
+        ) = {
+            // Placeholder pools are never used while `pool_parent` is set.
+            let cpu_pool = build_minimal_rayon_pool("cpu")?;
+            let storage_pool = build_minimal_rayon_pool("storage")?;
+            (
+                cpu_pool,
+                parent.rpc_pool.clone(),
+                storage_pool,
+                parent.blocking_guard.clone(),
+                WorkerPool::new(1, "proof-strg"),
+                WorkerPool::new(1, "proof-acct"),
+                WorkerPool::new(1, "prewarm"),
+                WorkerPool::new(1, "bal-stream"),
+                Arc::clone(&parent.state_trie_overlay_worker_pool),
+            )
+        };
+
+        let inner = RuntimeInner {
+            _tokio_runtime: owned_runtime,
+            handle,
+            on_shutdown: parent.on_shutdown.clone(),
+            task_events_tx: parent.task_events_tx.clone(),
+            metrics: parent.metrics.clone(),
+            graceful_tasks: Arc::clone(&parent.graceful_tasks),
+            #[cfg(feature = "rayon")]
+            cpu_pool,
+            #[cfg(feature = "rayon")]
+            rpc_pool,
+            #[cfg(feature = "rayon")]
+            storage_pool,
+            #[cfg(feature = "rayon")]
+            blocking_guard,
+            #[cfg(feature = "rayon")]
+            proof_storage_worker_pool,
+            #[cfg(feature = "rayon")]
+            proof_account_worker_pool,
+            #[cfg(feature = "rayon")]
+            prewarming_pool,
+            #[cfg(feature = "rayon")]
+            bal_streaming_pool,
+            #[cfg(feature = "rayon")]
+            state_trie_overlay_worker_pool,
+            worker_map: WorkerMap::new(),
+            #[cfg(feature = "rayon")]
+            pool_parent: Some(parent),
+            task_manager_handle: Mutex::new(None),
+        };
+
+        Ok(Self(Arc::new(inner)))
     }
 }
 
@@ -862,24 +1003,7 @@ impl RuntimeBuilder {
         debug!(?self.config, "Building runtime");
         let config = self.config;
 
-        let (owned_runtime, handle) = match &config.tokio {
-            TokioConfig::Owned { worker_threads, thread_keep_alive, thread_name } => {
-                let mut builder = tokio::runtime::Builder::new_multi_thread();
-                builder
-                    .enable_all()
-                    .thread_keep_alive(*thread_keep_alive)
-                    .thread_name(*thread_name);
-
-                if let Some(threads) = worker_threads {
-                    builder.worker_threads(*threads);
-                }
-
-                let runtime = builder.build()?;
-                let h = runtime.handle().clone();
-                (Some(runtime), h)
-            }
-            TokioConfig::ExistingHandle(h) => (None, h.clone()),
-        };
+        let (owned_runtime, handle) = build_owned_tokio(&config.tokio)?;
 
         let (task_manager, on_shutdown, task_events_tx, graceful_tasks) =
             TaskManager::new_parts(handle.clone());
@@ -1006,6 +1130,8 @@ impl RuntimeBuilder {
             #[cfg(feature = "rayon")]
             state_trie_overlay_worker_pool,
             worker_map: WorkerMap::new(),
+            #[cfg(feature = "rayon")]
+            pool_parent: None,
             task_manager_handle: Mutex::new(Some(task_manager_handle)),
         };
 
@@ -1103,5 +1229,84 @@ mod tests {
         assert_eq!(runtime.proof_account_worker_pool().current_num_threads(), 2);
         assert_eq!(runtime.prewarming_pool().current_num_threads(), 2);
         assert_eq!(runtime.state_trie_overlay_worker_pool().current_num_threads(), 2);
+    }
+
+    #[test]
+    fn test_tokio_config_latency_runtime() {
+        let config = TokioConfig::latency_runtime(4);
+        assert!(matches!(
+            config,
+            TokioConfig::Owned {
+                worker_threads: Some(4),
+                thread_name: DEFAULT_LATENCY_THREAD_NAME,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn attached_runtime_uses_different_handle() {
+        let main = Runtime::test();
+        let attached = main.build_attached_tokio(TokioConfig::latency_runtime(2)).unwrap();
+
+        assert_ne!(main.handle().id(), attached.handle().id());
+        assert!(attached.take_task_manager_handle().is_none());
+    }
+
+    #[test]
+    fn attached_critical_task_panic_reaches_parent_task_manager() {
+        let main = Runtime::test();
+        let attached = main.build_attached_tokio(TokioConfig::latency_runtime(2)).unwrap();
+        let manager_handle = main.take_task_manager_handle().unwrap();
+
+        attached.spawn_critical_task("attached critical panic", async {
+            panic!("attached panic");
+        });
+
+        main.handle().block_on(async move {
+            let err_result = manager_handle.await.unwrap();
+            assert!(err_result.is_err());
+            let panicked_err = err_result.unwrap_err();
+            assert_eq!(panicked_err.task_name, "attached critical panic");
+            assert_eq!(panicked_err.error, Some("attached panic".to_string()));
+        });
+    }
+
+    #[test]
+    fn attached_task_respects_shutdown() {
+        use crate::shutdown::signal;
+
+        let main = Runtime::test();
+        let attached = main.build_attached_tokio(TokioConfig::latency_runtime(2)).unwrap();
+
+        let (signal, shutdown) = signal();
+        attached.spawn_task(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            drop(signal);
+        });
+
+        main.graceful_shutdown();
+        main.handle().block_on(shutdown);
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn attached_runtime_shares_rayon_pools_with_parent() {
+        let main = Runtime::test();
+        let attached = main.build_attached_tokio(TokioConfig::latency_runtime(2)).unwrap();
+
+        assert_eq!(main.cpu_pool() as *const rayon::ThreadPool, attached.cpu_pool() as *const _);
+        assert_eq!(
+            main.storage_pool() as *const rayon::ThreadPool,
+            attached.storage_pool() as *const _
+        );
+        assert_eq!(
+            main.bal_streaming_pool() as *const WorkerPool,
+            attached.bal_streaming_pool() as *const WorkerPool
+        );
+        assert!(Arc::ptr_eq(
+            &main.0.state_trie_overlay_worker_pool,
+            &attached.0.state_trie_overlay_worker_pool,
+        ));
     }
 }

--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -12,7 +12,10 @@ use std::{
     pin::Pin,
     task::{ready, Context, Poll},
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    runtime::Handle,
+    sync::{mpsc, oneshot},
+};
 
 /// A single batch transaction request
 #[derive(Debug)]
@@ -45,6 +48,7 @@ where
 pub struct BatchTxProcessor<Pool: TransactionPool> {
     pool: Pool,
     max_batch_size: usize,
+    spawn_handle: Handle,
     buf: Vec<BatchTxRequest<Pool::Transaction>>,
     #[pin]
     request_rx: mpsc::UnboundedReceiver<BatchTxRequest<Pool::Transaction>>,
@@ -58,10 +62,12 @@ where
     pub fn new(
         pool: Pool,
         max_batch_size: usize,
+        spawn_handle: Handle,
     ) -> (Self, mpsc::UnboundedSender<BatchTxRequest<Pool::Transaction>>) {
         let (request_tx, request_rx) = mpsc::unbounded_channel();
 
-        let processor = Self { pool, max_batch_size, buf: Vec::with_capacity(1), request_rx };
+        let processor =
+            Self { pool, max_batch_size, spawn_handle, buf: Vec::with_capacity(1), request_rx };
 
         (processor, request_tx)
     }
@@ -121,7 +127,8 @@ where
             if !this.buf.is_empty() {
                 let batch = std::mem::take(this.buf);
                 let pool = this.pool.clone();
-                tokio::spawn(async move {
+                let spawn_handle = this.spawn_handle.clone();
+                spawn_handle.spawn(async move {
                     Self::process_batch(&pool, batch).await;
                 });
                 this.buf.reserve(1);
@@ -202,7 +209,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_processor() {
         let pool = testing_pool();
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000, Handle::current());
 
         // Spawn the processor
         let handle = tokio::spawn(processor);
@@ -236,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn test_add_transaction() {
         let pool = testing_pool();
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000);
+        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), 1000, Handle::current());
 
         // Spawn the processor
         let handle = tokio::spawn(processor);
@@ -264,7 +271,8 @@ mod tests {
     async fn test_max_batch_size() {
         let pool = testing_pool();
         let max_batch_size = 10;
-        let (processor, request_tx) = BatchTxProcessor::new(pool.clone(), max_batch_size);
+        let (processor, request_tx) =
+            BatchTxProcessor::new(pool.clone(), max_batch_size, Handle::current());
 
         // Spawn batch processor with threshold
         let handle = tokio::spawn(processor);

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -447,6 +447,13 @@ RPC:
 
           [default: 256]
 
+      --rpc.latency-worker-threads <LATENCY_WORKER_THREADS>
+          Number of worker threads for the latency-sensitive RPC tokio runtime.
+
+          When set to a value greater than 0, the public RPC server (HTTP/WS/IPC) and the sendRaw transaction backend (tx-batcher and pool validation) run on a dedicated tokio runtime isolated from sync, P2P, and engine work. Defaults to 0 (disabled).
+
+          [default: 0]
+
       --rpc.max-trace-filter-blocks <COUNT>
           Maximum number of blocks for `trace_filter` requests
 

--- a/examples/custom-node-components/src/main.rs
+++ b/examples/custom-node-components/src/main.rs
@@ -68,7 +68,7 @@ where
             TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone(), evm_config)
                 .kzg_settings(ctx.kzg_settings()?)
                 .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-                .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
+                .build_with_tasks(ctx.rpc_task_executor().clone(), blob_store.clone());
 
         let transaction_pool =
             Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, self.pool_config);


### PR DESCRIPTION
Closes #17604

Adds `--rpc.latency-worker-threads` (default `0`). When non-zero, node launch builds a second Tokio runtime and routes public RPC + sendRaw backend work through it. Default off; no behavior change when unset.

---

### Motivation

#17604 describes `eth_sendRawTransaction` tail jitter under node load: p50 stays low while p99 spikes. That is scheduling contention on the shared main Tokio runtime (sync, P2P, engine, RPC background tasks), not median throughput.

This PR adds an opt-in runtime boundary so operators can isolate that path. It is a first step — not full per-method RPC routing.

---

### Runtime split when the flag is on

| Workload | Runtime |
|----------|---------|
| jsonrpsee HTTP/WS/IPC dispatch (all public RPC, including sendRaw) | Latency |
| tx-batcher + batch `process_batch` spawns | Latency |
| Pool validation tasks (local + P2P) | Latency |
| `EthStateCache` + canonical block cache task | Main |
| `EthFilter` / `EthPubSub` background tasks | Main |
| `EthApi` blocking IO (`getLogs`, traces, proofs) | Main |
| Fee-history background task | Main |
| Sync, P2P networking, engine, ExEx, engine auth server | Main |

jsonrpsee dispatches **all** incoming public RPC on the latency pool when enabled — not sendRaw-only. Blocking IO for reads still offloads to main via `task_spawner`. Pool validation is shared (local sendRaw and P2P inserts).

Explicit `RpcAddOns::with_tokio_runtime` still takes precedence over the auto-resolved latency handle.

---

### Implementation

Build happens once in engine launch via `ensure_latency_runtime()` on `WithConfigs` (before `with_components`). No `LaunchExecutors` / CLI pre-wiring.

- **`reth-tasks`**: `Runtime::build_attached_tokio` — dedicated Tokio handle (`tokio-latency-*`), shared shutdown/metrics/rayon pools with parent via `pool_parent`
- **`WithConfigs.latency_runtime`**: stores the attached runtime; `rpc_task_executor()` falls back to main when unset
- **`FullNode.latency_runtime`**: keeps the attached runtime alive for the node lifetime (jsonrpsee only holds a `Handle`)
- **Wiring**: `BuilderContext` / `AddOnsContext` → pool validation, tx-batcher (`rpc_task_spawner`), jsonrpsee (`resolve_tokio_runtime`)
- **`BatchTxProcessor`**: takes an explicit `tokio::runtime::Handle` for batch spawns
- **CLI**: `--rpc.latency-worker-threads`, default `0`

---

### Observations from testing

Manual harness (not in-repo): dev node, 50 `eth_sendRawTransaction`/s, `--rpc.latency-worker-threads 4`, 3 runs per scenario (medians). Not production TPS.

**Tail spread** = p99 − p50.

#### getLogs background (10/s), chain primed ~181 blocks

| Config | p50 | p99 | tail spread | max |
|--------|-----|-----|-------------|-----|
| off | 1.76 ms | 9.19 ms | 7.4 ms | 126.6 ms |
| on | 1.69 ms | 4.60 ms | 2.9 ms | 50.3 ms |

p50 flat. p99 lower in all 3 runs (−50% median).

#### Other backgrounds

| Background | off p99 | on p99 | Notes |
|------------|---------|--------|-------|
| getLogs + getBlock 40/s (`rpc-read`) | 6.05 ms | 5.60 ms | sendRaw p99 ~flat; read-RPC p95 +17% |
| filter-poll 20/s | 8.03 ms | 9.40 ms | p99 +17% |
| getLogs 30/s (`getlogs-heavy`) | 5.47 ms | 7.22 ms | p99 +32% |

At high public-RPC rates, read handlers compete with sendRaw on the shared latency pool (expected for this design). Thread count was not swept (4 only).

---

### Test plan

- [x] `cargo nextest run -p reth-tasks`
- [x] `cargo nextest run -p reth-node-core test_rpc_latency_worker_threads_parse`
- [x] `cargo nextest run -p reth-node-builder ensure_latency_runtime_creates_second_handle`
- [x] `cargo nextest run -p reth-node-ethereum --test it test_eth_launcher_with_latency_runtime`