### PR TITLE
feat(bootnode): advertise NAT addresses in discv5 and support dual-stack

### DIFF
--- a/crates/cli/commands/src/p2p/bootnode.rs
+++ b/crates/cli/commands/src/p2p/bootnode.rs
@@ -3,11 +3,17 @@
 use clap::Parser;
 use reth_cli_util::{get_secret_key, load_secret_key::rng_secret_key};
 use reth_discv4::{DiscoveryUpdate, Discv4, Discv4Config};
-use reth_discv5::{discv5::Event, Config, Discv5};
+use reth_discv5::{
+    discv5::{self, Event, ListenConfig},
+    Config, Discv5, DEFAULT_DISCOVERY_V5_PORT,
+};
 use reth_net_nat::NatResolver;
 use reth_network_peers::NodeRecord;
 use secp256k1::SecretKey;
-use std::{net::SocketAddr, path::PathBuf};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    path::PathBuf,
+};
 use tokio::select;
 use tokio_stream::StreamExt;
 use tracing::info;
@@ -21,16 +27,19 @@ pub struct Command {
 
     /// Secret key to use for the bootnode.
     ///
-    /// This will also deterministically set the peer ID.  
-    /// If a path is provided but no key exists at that path,  
-    /// a new random secret will be generated and stored there.  
+    /// This will also deterministically set the peer ID.
+    /// If a path is provided but no key exists at that path,
+    /// a new random secret will be generated and stored there.
     /// If no path is specified, a new ephemeral random secret will be used.
     #[arg(long, value_name = "PATH")]
     pub p2p_secret_key: Option<PathBuf>,
 
-    /// NAT resolution method (any|none|upnp|publicip|extip:\<IP\>)
+    /// NAT resolution method (any|none|upnp|publicip|extip:\<IP\>).
+    ///
+    /// Can be repeated with one IPv4 and one IPv6 `extip:<IP>` to advertise a dual-stack discv5
+    /// ENR (discv4 binds a single socket and always advertises only the `--addr` family).
     #[arg(long, default_value = "any")]
-    pub nat: NatResolver,
+    pub nat: Vec<NatResolver>,
 
     /// Run a v5 topic discovery bootnode.
     #[arg(long)]
@@ -44,8 +53,9 @@ impl Command {
 
         let sk = self.network_secret()?;
         let local_enr = NodeRecord::from_secret_key(self.addr, &sk);
+        let nat = self.resolved_nat()?;
 
-        let config = Discv4Config::builder().external_ip_resolver(Some(self.nat)).build();
+        let config = self.discv4_config(&nat);
 
         let (_discv4, mut discv4_service) = Discv4::bind(self.addr, local_enr, sk, config).await?;
 
@@ -56,11 +66,15 @@ impl Command {
 
         // Optional discv5 update event listener if v5 is enabled
         let mut discv5_updates = None;
+        // Keep the discv5 service alive for the event loop lifetime.
+        let mut _discv5 = None;
 
         if self.v5 {
             info!("Starting discv5");
-            let config = Config::builder(self.addr).build();
-            let (_discv5, updates) = Discv5::start(&sk, config).await?;
+            let config = self.discv5_config(&nat);
+            let (discv5, updates) = Discv5::start(&sk, config).await?;
+            log_discv5_enr(&discv5);
+            _discv5 = Some(discv5);
             discv5_updates = Some(updates);
         };
 
@@ -93,7 +107,7 @@ impl Command {
                     }
                 } => {
                     if let Some(update) = update {
-                     if let Event::SessionEstablished(enr, _) = update {
+                        if let Event::SessionEstablished(enr, _) = update {
                             info!("(Discv5) new peer added, peer_id={:?}", enr.id());
                         }
                     } else {
@@ -112,5 +126,227 @@ impl Command {
             Some(path) => Ok(get_secret_key(path)?),
             None => Ok(rng_secret_key()),
         }
+    }
+
+    /// Resolves the configured `--nat` values into the addresses to advertise.
+    ///
+    /// A single value behaves like the rest of the node: the resolver drives discv4's external IP
+    /// resolution, and any fixed IP is also advertised in the discv5 ENR. Two `extip:<IP>` values
+    /// (one per family) advertise a dual-stack discv5 record; discv4 advertises only the family
+    /// matching `--addr`, since it binds a single socket.
+    fn resolved_nat(&self) -> eyre::Result<BootnodeNat> {
+        match self.nat.as_slice() {
+            [] => Ok(BootnodeNat::single(NatResolver::Any, self.addr.port())),
+            [nat] => Ok(BootnodeNat::single(nat.clone(), self.addr.port())),
+            [first, second] => {
+                let first_ip = fixed_external_ip(first)?;
+                let second_ip = fixed_external_ip(second)?;
+
+                if first_ip.is_ipv4() == second_ip.is_ipv4() {
+                    eyre::bail!("repeated --nat requires one IPv4 and one IPv6 extip:<IP> value");
+                }
+
+                // discv4 binds a single socket, so its resolver must use the `--addr` family.
+                let primary_ip =
+                    if first_ip.is_ipv4() == self.addr.is_ipv4() { first_ip } else { second_ip };
+
+                Ok(BootnodeNat {
+                    resolver: NatResolver::ExternalIp(primary_ip),
+                    advertised_ips: vec![first_ip, second_ip],
+                })
+            }
+            _ => eyre::bail!("--nat can be provided at most twice"),
+        }
+    }
+
+    fn discv4_config(&self, nat: &BootnodeNat) -> Discv4Config {
+        Discv4Config::builder().external_ip_resolver(Some(nat.resolver.clone())).build()
+    }
+
+    fn discv5_config(&self, nat: &BootnodeNat) -> Config {
+        let mut builder = Config::builder(self.addr);
+
+        // Bind every family we advertise (plus the `--addr` family). Without a listen socket of a
+        // given family, `build_local_enr` drops that family's advertised IP even though setting it
+        // disables `enr_update` — which would leave discv5 with no usable record.
+        let bind_ipv4 = self.addr.is_ipv4() || nat.advertised_ips.iter().any(IpAddr::is_ipv4);
+        let bind_ipv6 = self.addr.is_ipv6() || nat.advertised_ips.iter().any(IpAddr::is_ipv6);
+        if bind_ipv4 && bind_ipv6 {
+            let listen = ListenConfig::DualStack {
+                ipv4: Ipv4Addr::UNSPECIFIED,
+                ipv4_port: DEFAULT_DISCOVERY_V5_PORT,
+                ipv6: Ipv6Addr::UNSPECIFIED,
+                ipv6_port: DEFAULT_DISCOVERY_V5_PORT,
+            };
+            builder = builder.discv5_config(discv5::ConfigBuilder::new(listen).build());
+        }
+
+        for ip in &nat.advertised_ips {
+            builder = builder.advertised_ip(*ip);
+        }
+
+        builder.build()
+    }
+}
+
+/// Resolved `--nat` configuration for the bootnode.
+#[derive(Debug)]
+struct BootnodeNat {
+    /// Resolver driving discv4's external IP resolution.
+    resolver: NatResolver,
+    /// Fixed IPs to advertise in the discv5 ENR (one per family).
+    advertised_ips: Vec<IpAddr>,
+}
+
+impl BootnodeNat {
+    fn single(resolver: NatResolver, port: u16) -> Self {
+        let advertised_ips = resolver.clone().as_external_ip(port).into_iter().collect();
+        Self { resolver, advertised_ips }
+    }
+}
+
+fn fixed_external_ip(nat: &NatResolver) -> eyre::Result<IpAddr> {
+    match nat {
+        NatResolver::ExternalIp(ip) => Ok(*ip),
+        _ => eyre::bail!("--nat can only be repeated with extip:<IP> values"),
+    }
+}
+
+fn log_discv5_enr(discv5: &Discv5) {
+    let enr = discv5.local_enr();
+    info!(
+        id = ?enr.node_id(),
+        ip4 = ?enr.ip4(),
+        ip6 = ?enr.ip6(),
+        udp4 = ?enr.udp4(),
+        udp6 = ?enr.udp6(),
+        tcp4 = ?enr.tcp4(),
+        tcp6 = ?enr.tcp6(),
+        "(Discv5) advertised endpoints",
+    );
+    info!("(Discv5) enr: {enr}");
+    if let Some(record) = discv5.node_record() {
+        info!("(Discv5) enode: {record}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_discv5::build_local_enr;
+
+    #[test]
+    fn repeated_nat_uses_matching_addr_family_as_primary() {
+        let command = Command::parse_from([
+            "reth",
+            "--addr",
+            "[::]:30303",
+            "--nat",
+            "extip:1.2.3.4",
+            "--nat",
+            "extip:2001:db8::1",
+        ]);
+
+        let nat = command.resolved_nat().unwrap();
+
+        // discv4 binds the `--addr` (IPv6) family, so its resolver uses the IPv6 extip; both
+        // families are still advertised by discv5.
+        assert_eq!(nat.resolver, NatResolver::ExternalIp("2001:db8::1".parse().unwrap()));
+        assert_eq!(nat.advertised_ips.len(), 2);
+    }
+
+    #[test]
+    fn repeated_nat_requires_extip_values() {
+        let command = Command::parse_from(["reth", "--nat", "any", "--nat", "extip:2001:db8::1"]);
+
+        assert!(command.resolved_nat().is_err());
+    }
+
+    #[test]
+    fn repeated_nat_requires_distinct_ip_families() {
+        let command =
+            Command::parse_from(["reth", "--nat", "extip:1.2.3.4", "--nat", "extip:5.6.7.8"]);
+
+        assert!(command.resolved_nat().is_err());
+    }
+
+    #[test]
+    fn single_extip_is_advertised() {
+        let command =
+            Command::parse_from(["reth", "--addr", "0.0.0.0:30301", "--nat", "extip:1.2.3.4"]);
+
+        let nat = command.resolved_nat().unwrap();
+
+        assert_eq!(nat.advertised_ips, vec!["1.2.3.4".parse::<IpAddr>().unwrap()]);
+    }
+
+    #[test]
+    fn discv5_advertises_single_extip_of_other_family_than_addr() {
+        // A v6 extip under a v4 `--addr` must still be bound and advertised, not silently dropped.
+        let command = Command::parse_from([
+            "reth",
+            "--addr",
+            "0.0.0.0:30301",
+            "--v5",
+            "--nat",
+            "extip:2001:db8::1",
+        ]);
+        let nat = command.resolved_nat().unwrap();
+        let config = command.discv5_config(&nat);
+        let sk = SecretKey::from_byte_array(&[1u8; 32]).unwrap();
+
+        let (enr, _, _, _) = build_local_enr(&sk, &config);
+
+        assert_eq!(enr.ip6(), Some("2001:db8::1".parse().unwrap()));
+        assert_eq!(enr.udp6(), Some(DEFAULT_DISCOVERY_V5_PORT));
+    }
+
+    #[test]
+    fn discv4_config_advertises_only_the_addr_family() {
+        // discv4 binds a single socket, so it must not advertise the secondary (IPv6) family it
+        // cannot serve; the IPv4 resolver drives discv4 and only discv5 carries both families.
+        let command = Command::parse_from([
+            "reth",
+            "--addr",
+            "0.0.0.0:30303",
+            "--nat",
+            "extip:1.2.3.4",
+            "--nat",
+            "extip:2001:db8::1",
+        ]);
+        let nat = command.resolved_nat().unwrap();
+        let config = command.discv4_config(&nat);
+
+        assert_eq!(nat.resolver, NatResolver::ExternalIp("1.2.3.4".parse().unwrap()));
+        assert!(config.additional_eip868_rlp_pairs.is_empty());
+    }
+
+    #[test]
+    fn discv5_config_advertises_dual_stack_nat_endpoints() {
+        let command = Command::parse_from([
+            "reth",
+            "--addr",
+            "0.0.0.0:30301",
+            "--v5",
+            "--nat",
+            "extip:1.2.3.4",
+            "--nat",
+            "extip:2001:db8::1",
+        ]);
+        let nat = command.resolved_nat().unwrap();
+        let config = command.discv5_config(&nat);
+        let sk = SecretKey::from_byte_array(&[1u8; 32]).unwrap();
+
+        let (enr, _, _, _) = build_local_enr(&sk, &config);
+
+        assert_eq!(enr.ip4(), Some("1.2.3.4".parse().unwrap()));
+        assert_eq!(enr.ip6(), Some("2001:db8::1".parse().unwrap()));
+        assert_eq!(enr.udp4(), Some(DEFAULT_DISCOVERY_V5_PORT));
+        assert_eq!(enr.udp6(), Some(DEFAULT_DISCOVERY_V5_PORT));
+        // Discovery runs over UDP, advertised for both families above. The ENR's TCP hint is the
+        // single rlpx/`--addr` port and is emitted only for that family (there is no second-family
+        // TCP socket to point at); a discovery-only bootnode never serves rlpx regardless.
+        assert_eq!(enr.tcp4(), Some(30301));
+        assert_eq!(enr.tcp6(), None);
     }
 }

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -72,12 +72,15 @@ pub struct ConfigBuilder {
     /// NOTE: IP address of `RLPx` socket overwrites IP address of same IP version in
     /// [`discv5::ListenConfig`].
     tcp_socket: SocketAddr,
-    /// IP address to advertise in the local ENR instead of the listen socket address.
+    /// IPv4 address to advertise in the local ENR instead of the listen socket address.
     ///
     /// This is separate from [`discv5::ListenConfig`] because the listen address describes where
     /// discv5 binds its UDP socket. Nodes commonly bind to an unspecified address like `0.0.0.0`
     /// while advertising an externally reachable address from NAT configuration.
-    advertised_ip: Option<IpAddr>,
+    advertised_ipv4: Option<Ipv4Addr>,
+    /// IPv6 address to advertise in the local ENR instead of the listen socket address. See
+    /// [`Self::advertised_ipv4`].
+    advertised_ipv6: Option<Ipv6Addr>,
     /// List of `(key, rlp-encoded-value)` tuples that should be advertised in local node record
     /// (in addition to tcp port, udp port and fork).
     other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -101,7 +104,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
-            advertised_ip,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -114,7 +118,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork: fork.map(|(key, fork_id)| (key, fork_id.fork_id)),
             tcp_socket,
-            advertised_ip,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval: Some(lookup_interval),
             bootstrap_lookup_interval: Some(bootstrap_lookup_interval),
@@ -187,8 +192,14 @@ impl ConfigBuilder {
 
     /// Sets the IP address to advertise in the local [`Enr`](discv5::enr::Enr), without changing
     /// the discv5 listen socket.
+    ///
+    /// Routed to the matching address family, so calling this once per family yields a dual-stack
+    /// advertisement.
     pub const fn advertised_ip(mut self, ip: IpAddr) -> Self {
-        self.advertised_ip = Some(ip);
+        match ip {
+            IpAddr::V4(ip) => self.advertised_ipv4 = Some(ip),
+            IpAddr::V6(ip) => self.advertised_ipv6 = Some(ip),
+        }
         self
     }
 
@@ -236,7 +247,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
-            advertised_ip,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -250,7 +262,7 @@ impl ConfigBuilder {
 
         discv5_config.listen_config =
             amend_listen_config_wrt_rlpx(&discv5_config.listen_config, tcp_socket.ip());
-        if advertised_ip.is_some() {
+        if advertised_ipv4.is_some() || advertised_ipv6.is_some() {
             // The upstream discv5 service can update local ENR IP fields from peer-observed
             // socket addresses. When the operator configured a NAT address, that address is
             // intentional advertisement state and must not be replaced by peer observations.
@@ -273,7 +285,8 @@ impl ConfigBuilder {
             bootstrap_nodes,
             fork,
             tcp_socket,
-            advertised_ip,
+            advertised_ipv4,
+            advertised_ipv6,
             other_enr_kv_pairs,
             lookup_interval,
             bootstrap_lookup_interval,
@@ -299,8 +312,10 @@ pub struct Config {
     /// NOTE: IP address of `RLPx` socket overwrites IP address of same IP version in
     /// [`discv5::ListenConfig`].
     pub(super) tcp_socket: SocketAddr,
-    /// IP address to advertise in the local ENR instead of the listen socket address.
-    pub(super) advertised_ip: Option<IpAddr>,
+    /// IPv4 address to advertise in the local ENR instead of the listen socket address.
+    pub(super) advertised_ipv4: Option<Ipv4Addr>,
+    /// IPv6 address to advertise in the local ENR instead of the listen socket address.
+    pub(super) advertised_ipv6: Option<Ipv6Addr>,
     /// Additional kv-pairs (besides tcp port, udp port and fork) that should be advertised to
     /// peers by including in local node record.
     pub(super) other_enr_kv_pairs: Vec<(&'static [u8], Bytes)>,
@@ -325,7 +340,8 @@ impl Config {
             bootstrap_nodes: HashSet::default(),
             fork: None,
             tcp_socket: rlpx_tcp_socket,
-            advertised_ip: None,
+            advertised_ipv4: None,
+            advertised_ipv6: None,
             other_enr_kv_pairs: Vec::new(),
             lookup_interval: None,
             bootstrap_lookup_interval: None,

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -471,7 +471,15 @@ pub fn build_local_enr(
 ) -> (Enr<SecretKey>, NodeRecord, Option<&'static [u8]>, IpMode) {
     let mut builder = discv5::enr::Enr::builder();
 
-    let Config { discv5_config, fork, tcp_socket, advertised_ip, other_enr_kv_pairs, .. } = config;
+    let Config {
+        discv5_config,
+        fork,
+        tcp_socket,
+        advertised_ipv4,
+        advertised_ipv6,
+        other_enr_kv_pairs,
+        ..
+    } = config;
 
     let socket = {
         let v4 = crate::config::ipv4(&discv5_config.listen_config);
@@ -480,7 +488,7 @@ pub fn build_local_enr(
         // Prefer an explicit advertised IP for ENR IP fields. Listen sockets still supply UDP
         // ports and determine which address-family fields are emitted.
         if let Some(addr) = v4 {
-            if let Some(IpAddr::V4(ip)) = advertised_ip {
+            if let Some(ip) = advertised_ipv4 {
                 builder.ip4(*ip);
             } else if *addr.ip() != Ipv4Addr::UNSPECIFIED {
                 builder.ip4(*addr.ip());
@@ -488,7 +496,7 @@ pub fn build_local_enr(
             builder.udp4(addr.port());
         }
         if let Some(addr) = v6 {
-            if let Some(IpAddr::V6(ip)) = advertised_ip {
+            if let Some(ip) = advertised_ipv6 {
                 builder.ip6(*ip);
             } else if *addr.ip() != Ipv6Addr::UNSPECIFIED {
                 builder.ip6(*addr.ip());

--- a/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/bootnode.mdx
@@ -20,7 +20,9 @@ Options:
           This will also deterministically set the peer ID. If a path is provided but no key exists at that path, a new random secret will be generated and stored there. If no path is specified, a new ephemeral random secret will be used.
 
       --nat <NAT>
-          NAT resolution method (any|none|upnp|publicip|extip:\<IP\>)
+          NAT resolution method (any|none|upnp|publicip|extip:\<IP\>).
+
+          Can be repeated with one IPv4 and one IPv6 `extip:<IP>` to advertise a dual-stack discv5 ENR (discv4 binds a single socket and always advertises only the `--addr` family).
 
           [default: any]
 


### PR DESCRIPTION
## Summary

The `reth p2p bootnode` command previously **ignored `--nat` for discv5** (`Config::builder(self.addr).build()`), so a bootnode behind NAT advertised its bind address in its discv5 ENR. This wires the operator-provided NAT address into the discv5 ENR via the existing `advertised_ip` mechanism, and adds optional dual-stack (IPv4 + IPv6) advertisement.

## Changes

- **discv5 NAT advertisement**: a fixed `--nat extip:<IP>` is now advertised in the discv5 ENR via `advertised_ip` (which disables `enr_update`, so the operator-configured address isn't overwritten by peer observations).
- **Dual-stack**: `--nat` is now repeatable. Given one IPv4 and one IPv6 `extip:<IP>`, the bootnode binds discv5 on both families and advertises both in the discv5 ENR. discv4 binds a single socket, so it advertises only the `--addr` family.
- **Generalize discv5 `advertised_ip` to one address per family** (`advertised_ipv4` / `advertised_ipv6`) in `reth-discv5`. The public `advertised_ip(IpAddr)` setter is kept and now routes by family, so existing single-IP callers are unaffected; calling it once per family yields a dual-stack advertisement.
- **Bug fix**: the discv5 service handle was previously bound inside the `if self.v5` block and dropped at the end of it, tearing the service down immediately. It is now held for the event-loop lifetime.
- **Startup logging**: logs the discv5 ENR (base64), the `enode://` URL, and a decoded `ip4/ip6/udp/tcp` summary so operators can verify what is advertised.
- Regenerated `bootnode.mdx` CLI reference (`make update-book-cli`).

## Testing

- `cargo test -p reth-cli-commands p2p::bootnode` — 7 tests, incl. dual-stack advertisement and a cross-family regression (a single `extip` of a family other than `--addr` must still bind + advertise that family rather than be silently dropped while `enr_update` is disabled).
- `cargo test -p reth-discv5` — 13 tests (incl. `build_local_enr`).
- `cargo +nightly fmt --all --check` and clippy clean on touched crates.