### PR TITLE
perf: windowed conversion of transactions

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -26,7 +26,7 @@ use reth_provider::{
     BlockExecutionOutput, BlockReader, DatabaseProviderROFactory, StateProviderFactory, StateReader,
 };
 use reth_revm::db::BundleState;
-use reth_tasks::{utils::increase_thread_priority, ForEachOrdered, Runtime};
+use reth_tasks::{utils::increase_thread_priority, Runtime};
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, HashedPostState,
 };
@@ -455,14 +455,21 @@ where
     /// waiting for rayon scheduling.
     const PARALLEL_PREFETCH_COUNT: usize = 4;
 
+    /// Number of transactions recovered per ordered parallel window in the non-BAL path.
+    ///
+    /// Non-BAL execution must consume transactions in block order, while rayon may recover
+    /// individual transactions in any order. Windowing prioritizes the next contiguous range while
+    /// still using parallel recovery inside that range.
+    const PARALLEL_TX_WINDOW_SIZE: usize = 64;
+
     /// Spawns a task advancing transaction env iterator and streaming updates through a channel.
     ///
     /// For blocks with fewer than [`Self::SMALL_BLOCK_TX_THRESHOLD`] transactions, uses
     /// sequential iteration to avoid rayon overhead. For larger blocks, uses rayon parallel
     /// iteration to convert transactions in parallel while streaming results to execution.
     ///
-    /// When `parallel_bal_execution` is disabled, uses [`ForEachOrdered`] to preserve the
-    /// original transaction order. Otherwise, streams results as they become available.
+    /// When `parallel_bal_execution` is disabled, preserves the original transaction order.
+    /// Otherwise, streams results as they become available.
     #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     fn spawn_tx_iterator<I: ExecutableTxIterator<Evm>>(
         &self,
@@ -526,24 +533,39 @@ where
                     // start immediately without waiting for rayon work-stealing.
                     convert_serial(all.into_iter(), &convert, &prewarm_tx, &execute_tx);
 
-                    // Without BALs, we need to preserve the initial order of transactions,
-                    // so we have to use `for_each_ordered_in`.
-                    rest.into_par_iter()
-                        .enumerate()
-                        .map(|(i, tx)| {
-                            let idx = i + prefetch;
-                            let tx = convert.convert(tx);
-                            (idx, tx)
-                        })
-                        .for_each_ordered_in(executor.cpu_pool(), |(idx, tx)| {
-                            let tx = tx.map(|tx| {
-                                let tx = WithTxEnv::new(tx);
-                                let _ = prewarm_tx.send((idx, tx.clone()));
-                                tx
-                            });
-                            let _ = execute_tx.send((idx, tx));
-                            trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
-                        });
+                    // Without BALs, we need to preserve the initial order of transactions.
+                    // Process contiguous windows in order so recovery prioritizes the next
+                    // transaction range execution will request. Each window still recovers in
+                    // parallel, then drains in block order.
+                    executor.cpu_pool().install(move || {
+                        let mut rest = rest.into_iter().enumerate();
+                        loop {
+                            let chunk = rest
+                                .by_ref()
+                                .take(Self::PARALLEL_TX_WINDOW_SIZE)
+                                .collect::<Vec<_>>();
+                            if chunk.is_empty() {
+                                break;
+                            }
+
+                            let chunk = chunk
+                                .into_par_iter()
+                                .map(|(i, tx)| {
+                                    let idx = i + prefetch;
+                                    let tx = convert.convert(tx).map(WithTxEnv::new);
+                                    (idx, tx)
+                                })
+                                .collect::<Vec<_>>();
+
+                            for (idx, tx) in chunk {
+                                if let Ok(tx) = &tx {
+                                    let _ = prewarm_tx.send((idx, tx.clone()));
+                                }
+                                let _ = execute_tx.send((idx, tx));
+                                trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
+                            }
+                        }
+                    });
                 }
             });
         }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -460,7 +460,7 @@ where
     /// Non-BAL execution must consume transactions in block order, while rayon may recover
     /// individual transactions in any order. Windowing prioritizes the next contiguous range while
     /// still using parallel recovery inside that range.
-    const PARALLEL_TX_WINDOW_SIZE: usize = 64;
+    const FIRST_PARALLEL_TX_WINDOW_SIZE: usize = 64;
 
     /// Spawns a task advancing transaction env iterator and streaming updates through a channel.
     ///
@@ -534,6 +534,8 @@ where
 
                     let mut iter = iter.enumerate();
 
+                    let mut batch_size = Self::FIRST_PARALLEL_TX_WINDOW_SIZE;
+
                     // Without BALs, we need to preserve the initial order of transactions.
                     // Process contiguous windows in order so recovery prioritizes the next
                     // transaction range execution will request. Each window still recovers in
@@ -542,11 +544,13 @@ where
                         loop {
                             let chunk = iter
                                 .by_ref()
-                                .take(Self::PARALLEL_TX_WINDOW_SIZE)
+                                .take(batch_size)
                                 .collect::<Vec<_>>();
                             if chunk.is_empty() {
                                 break;
                             }
+
+                            batch_size = batch_size.saturating_mul(2);
 
                             let chunk = chunk
                                 .into_par_iter()

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -526,21 +526,21 @@ where
                     // few transactions are recovered sequentially and sent immediately before
                     // entering the parallel iterator for the remainder.
                     let prefetch = Self::PARALLEL_PREFETCH_COUNT.min(transaction_count);
-                    let mut all: Vec<_> = transactions.into_iter().collect();
-                    let rest = all.split_off(prefetch);
+                    let mut iter = transactions.into_iter();
 
                     // Convert the first few transactions sequentially so execution can
                     // start immediately without waiting for rayon work-stealing.
-                    convert_serial(all.into_iter(), &convert, &prewarm_tx, &execute_tx);
+                    convert_serial(iter.by_ref().take(prefetch), &convert, &prewarm_tx, &execute_tx);
+
+                    let mut iter = iter.enumerate();
 
                     // Without BALs, we need to preserve the initial order of transactions.
                     // Process contiguous windows in order so recovery prioritizes the next
                     // transaction range execution will request. Each window still recovers in
                     // parallel, then drains in block order.
                     executor.cpu_pool().install(move || {
-                        let mut rest = rest.into_iter().enumerate();
                         loop {
-                            let chunk = rest
+                            let chunk = iter
                                 .by_ref()
                                 .take(Self::PARALLEL_TX_WINDOW_SIZE)
                                 .collect::<Vec<_>>();

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -537,9 +537,7 @@ where
                     let mut batch_size = Self::FIRST_PARALLEL_TX_WINDOW_SIZE;
 
                     // Without BALs, we need to preserve the initial order of transactions.
-                    // Process contiguous windows in order so recovery prioritizes the next
-                    // transaction range execution will request. Each window still recovers in
-                    // parallel, then drains in block order.
+                    // Process exponentially increasing windows to make sure that first transactions are prioritized.
                     executor.cpu_pool().install(move || {
                         loop {
                             let chunk = iter

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -455,11 +455,7 @@ where
     /// waiting for rayon scheduling.
     const PARALLEL_PREFETCH_COUNT: usize = 4;
 
-    /// Number of transactions recovered per ordered parallel window in the non-BAL path.
-    ///
-    /// Non-BAL execution must consume transactions in block order, while rayon may recover
-    /// individual transactions in any order. Windowing prioritizes the next contiguous range while
-    /// still using parallel recovery inside that range.
+    /// Size of the first parallel tx batch in non-BAL path.
     const FIRST_PARALLEL_TX_WINDOW_SIZE: usize = 64;
 
     /// Spawns a task advancing transaction env iterator and streaming updates through a channel.

--- a/crates/evm/evm/src/engine.rs
+++ b/crates/evm/evm/src/engine.rs
@@ -83,7 +83,7 @@ pub trait ExecutableTxTuple: Send + 'static {
 
     /// Iterator over [`ExecutableTxTuple::Tx`].
     type IntoIter: IntoParallelIterator<Item = Self::RawTx, Iter: IndexedParallelIterator>
-        + IntoIterator<Item = Self::RawTx>
+        + IntoIterator<Item = Self::RawTx, IntoIter: Send>
         + Send
         + 'static;
     /// Converter that can be used to convert a [`ExecutableTxTuple::RawTx`] to a
@@ -101,7 +101,7 @@ where
     Tx: Clone + Send + Sync + 'static,
     Err: core::error::Error + Send + Sync + 'static,
     I: IntoParallelIterator<Item = RawTx, Iter: IndexedParallelIterator>
-        + IntoIterator<Item = RawTx>
+        + IntoIterator<Item = RawTx, IntoIter: Send>
         + Send
         + 'static,
     F: Fn(RawTx) -> Result<Tx, Err> + Send + Sync + 'static,


### PR DESCRIPTION
`for_each_ordered` does not work well for large number of transactions because of the way rayon schedules them, and sometime results in huge latency in between transactions
<img width="2904" height="606" alt="image" src="https://github.com/user-attachments/assets/8e61edf4-ce6b-4965-b7eb-d3e2bc7c4439" />

This PR changes the logic to recover transactions in sequential chunks of 64 transactions so that engine gets transactions as soon as possible in the right order