### PR TITLE
perf(engine): decode BALs directly into revm

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 
 use crate::tree::payload_processor::receipt_root_task::IndexedReceipt;
 
-/// Executes one block on the BAL path using the runtime's persistent BAL worker pool.
+/// Executes one block on the BAL path using the runtime's prewarming pool.
 #[expect(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
     runtime: &Runtime,
@@ -58,7 +58,9 @@ where
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'a,
     ReceiptTy<Evm::Primitives>: Clone,
 {
-    let worker_pool = runtime.bal_streaming_pool();
+    // BAL mode does not use transaction prewarming, so this keeps the BAL streaming pool dedicated
+    // to hashed-state streaming for sparse-trie/state-root progress.
+    let worker_pool = runtime.prewarming_pool();
     let worker_count = worker_pool.current_num_threads().max(1).min(transaction_count);
 
     worker_pool.in_place_scope(|scope| {

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -28,7 +28,6 @@ use reth_tasks::Runtime;
 use revm::{
     context::{result::ResultAndState, Block},
     database::{states::bundle_state::BundleRetention, State},
-    state::bal::Bal as RevmBal,
 };
 use std::sync::Arc;
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -11,14 +11,10 @@
 //! execution actually produced.
 //!
 //! The rebuilt BAL is returned to the outer payload validator for consensus post-execution
-//! validation. This module only logs the first divergence between the received BAL and the BAL
-//! rebuilt from canonical execution.
+//! validation.
 
-use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError};
-use alloy_eip7928::{
-    bal::{Bal as AlloyBal, DecodedBal},
-    compute_block_access_list_hash, BlockAccessList,
-};
+use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError, ReceivedBal};
+use alloy_eip7928::BlockAccessList;
 use alloy_evm::{
     block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
     Evm,
@@ -44,7 +40,7 @@ pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
     runtime: &Runtime,
     evm_config: &'a Evm,
     make_db: &'a MakeDb,
-    input_bal: Arc<DecodedBal>,
+    input_bal: Arc<ReceivedBal>,
     evm_env: EvmEnvFor<Evm>,
     ctx: ExecutionCtxFor<'a, Evm>,
     transaction_count: usize,
@@ -86,7 +82,7 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
     scope: &rayon::Scope<'scope>,
     evm_config: &'scope Evm,
     make_db: &'scope MakeDb,
-    input_bal: Arc<DecodedBal>,
+    input_bal: Arc<ReceivedBal>,
     evm_env: EvmEnvFor<Evm>,
     ctx: ExecutionCtxFor<'scope, Evm>,
     transaction_count: usize,
@@ -105,8 +101,7 @@ where
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
     ReceiptTy<Evm::Primitives>: Clone,
 {
-    let bal = input_bal.as_bal();
-    let input_bal_revm = convert_alloy_to_revm_bal(bal)?;
+    let input_bal_revm = input_bal.revm();
 
     let block_gas_limit = evm_env.block_env.gas_limit();
     let enable_amsterdam_eip8037 = evm_env.cfg_env.enable_amsterdam_eip8037;
@@ -170,7 +165,7 @@ where
         (block_result, senders)
     };
 
-    let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, bal);
+    let built_bal = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
     Ok((
@@ -178,53 +173,6 @@ where
         senders,
         built_bal,
     ))
-}
-
-fn convert_alloy_to_revm_bal(alloy_bal: &AlloyBal) -> Result<Arc<RevmBal>, BalExecutionError> {
-    // Convert the BAL from alloy to a BAL that can be consumed by revm, that is more amenable
-    // for state lookups.
-    //
-    // This is failable.
-    //
-    // This is due to bytecodes. A transaction can attempt to deploy illegal bytecodes, e.g. due to
-    // EIP-3541 or more specifically due to EIP-7702.
-    //
-    // During serial execution this check happens before the bytecode is deployed and if the check
-    // is triggered then the execution is reverted, and as such no actual code change event takes
-    // place. Therefore, if we do observe such a bytecode in a BAL then that means the BAL is
-    // invalid as no legal execution should've led to this bytecode deployment.
-    let received_bal_revm = RevmBal::clone_from_alloy(alloy_bal.as_vec()).map_err(|e| {
-        BalExecutionError::Consensus(reth_consensus::ConsensusError::BlockAccessListInvalid(
-            format!("{e:?}"),
-        ))
-    })?;
-    Ok(Arc::new(received_bal_revm))
-}
-
-fn take_built_bal_and_log_divergence<DB>(
-    canonical_state: &mut State<DB>,
-    received_bal: &AlloyBal,
-) -> BlockAccessList
-where
-    DB: Database,
-{
-    let built_bal = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
-    if tracing::enabled!(target: "engine::tree::payload_processor::bal", tracing::Level::DEBUG) &&
-        built_bal.as_slice() != received_bal.as_slice()
-    {
-        let rebuilt = compute_block_access_list_hash(built_bal.as_slice());
-        let expected = compute_block_access_list_hash(received_bal.as_slice());
-        let div = received_bal.diff(built_bal.as_slice());
-        tracing::debug!(
-            target: "engine::tree::payload_processor::bal",
-            %rebuilt,
-            %expected,
-            %div,
-            "first BAL divergence",
-        );
-    }
-
-    built_bal
 }
 
 /// Closes the abort channel on drop, waking scoped workers before the scope exits.
@@ -315,11 +263,11 @@ mod tests {
     };
     use std::convert::Infallible;
 
-    /// Wraps a `BlockAccessList` into an `Arc<DecodedBal>` by RLP-encoding the BAL.
-    fn to_arc_decoded(bal: BlockAccessList) -> Arc<DecodedBal> {
+    /// Wraps a `BlockAccessList` into a received BAL by RLP-encoding the BAL.
+    fn to_received_bal(bal: BlockAccessList) -> Arc<ReceivedBal> {
         let alloy_bal: AlloyBal = bal.into();
         let raw = alloy_rlp::encode(&alloy_bal).into();
-        Arc::new(DecodedBal::new(alloy_bal, raw))
+        Arc::new(ReceivedBal::from_rlp_bytes(raw).expect("valid BAL"))
     }
 
     /// Builds an in-memory canonical DB pre-populated with the post-Cancun system contracts
@@ -437,7 +385,7 @@ mod tests {
             &Runtime::test(),
             evm_config,
             db_factory(system_contracts_db()),
-            to_arc_decoded(input_bal),
+            to_received_bal(input_bal),
             &block,
             Vec::<Recovered<TransactionSigned>>::new(),
         );
@@ -468,7 +416,7 @@ mod tests {
         runtime: &Runtime,
         evm_config: EthEvmConfig,
         make_db: MakeDb,
-        input_bal: Arc<DecodedBal>,
+        input_bal: Arc<ReceivedBal>,
         block: &SealedBlock<Block>,
         txs: Vec<Tx>,
     ) -> Result<BlockExecutionOutput<Receipt>, BalExecutionError>
@@ -485,7 +433,7 @@ mod tests {
         runtime: &Runtime,
         evm_config: EthEvmConfig,
         make_db: MakeDb,
-        input_bal: Arc<DecodedBal>,
+        input_bal: Arc<ReceivedBal>,
         block: &SealedBlock<Block>,
         txs: Vec<Tx>,
     ) -> Result<(BlockExecutionOutput<Receipt>, BlockAccessList), BalExecutionError>
@@ -658,7 +606,7 @@ mod tests {
             &Runtime::test(),
             evm_config,
             db_factory(pre_block_db),
-            to_arc_decoded(reference_bal),
+            to_received_bal(reference_bal),
             &block,
             vec![recovered1, recovered2],
         );
@@ -754,7 +702,7 @@ mod tests {
             &Runtime::test(),
             evm_config,
             db_factory(canonical_db_template),
-            to_arc_decoded(reference_bal),
+            to_received_bal(reference_bal),
             &block,
             txs,
         )
@@ -900,7 +848,7 @@ mod tests {
             &Runtime::test(),
             evm_config,
             db_factory(pre_block_db),
-            to_arc_decoded(reference_bal),
+            to_received_bal(reference_bal),
             &low_gas_block,
             vec![tx1, tx2],
         );
@@ -1056,7 +1004,7 @@ mod tests {
 
         let received = {
             let raw = alloy_rlp::encode(&tampered_bal).into();
-            Arc::new(DecodedBal::new(tampered_bal, raw))
+            Arc::new(ReceivedBal::from_rlp_bytes(raw).expect("valid tampered BAL"))
         };
 
         let result = run_execute_block_full(
@@ -1092,7 +1040,7 @@ mod tests {
             &Runtime::test(),
             evm_config,
             failing_make_db,
-            to_arc_decoded(BlockAccessList::default()),
+            to_received_bal(BlockAccessList::default()),
             &block,
             Vec::<Recovered<TransactionSigned>>::new(),
         );
@@ -1128,7 +1076,7 @@ mod tests {
             &Runtime::test(),
             &evm_config,
             &make_db,
-            to_arc_decoded(BlockAccessList::default()),
+            to_received_bal(BlockAccessList::default()),
             evm_env,
             execution_ctx,
             1, // transaction_count = 1 → exactly one worker spawned

--- a/crates/engine/tree/src/tree/payload_processor/bal/input.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/input.rs
@@ -1,0 +1,213 @@
+use alloy_eip7928::{bal::RawBal, BlockAccessIndex, BlockAccessListGasError};
+use alloy_primitives::Bytes;
+use alloy_rlp::{Decodable, Error as RlpError, Header};
+use reth_consensus::ConsensusError;
+use revm_state::{
+    bal::{AccountBal, AccountInfoBal, Bal as RevmBal, BalWrites, StorageBal},
+    primitives::{Address, AddressIndexMap, B256, U256},
+    Bytecode,
+};
+use std::sync::Arc;
+
+/// Received block access list decoded into the form used by BAL execution.
+#[derive(Debug)]
+pub struct ReceivedBal {
+    raw: RawBal,
+    revm: Arc<RevmBal>,
+}
+
+impl ReceivedBal {
+    /// Decodes a received raw EIP-7928 BAL directly into revm's representation.
+    pub fn from_rlp_bytes(raw: Bytes) -> Result<Self, ConsensusError> {
+        let raw = RawBal::new(raw);
+        let mut slice = raw.as_raw().as_ref();
+        let revm = decode_revm_bal(&mut slice).map_err(|err| {
+            ConsensusError::BlockAccessListInvalid(format!("failed to decode BAL: {err}"))
+        })?;
+        if !slice.is_empty() {
+            return Err(ConsensusError::BlockAccessListInvalid(
+                "failed to decode BAL: trailing bytes".into(),
+            ));
+        }
+
+        Ok(Self { raw, revm: Arc::new(revm) })
+    }
+
+    /// Returns true if the received BAL contains no accounts.
+    pub fn is_empty(&self) -> bool {
+        self.revm.accounts.is_empty()
+    }
+
+    /// Returns the number of accounts in the received BAL.
+    pub fn len(&self) -> usize {
+        self.revm.accounts.len()
+    }
+
+    /// Returns the revm BAL used by speculative workers.
+    pub fn revm(&self) -> Arc<RevmBal> {
+        Arc::clone(&self.revm)
+    }
+
+    /// Returns the revm BAL by reference.
+    pub fn revm_ref(&self) -> &RevmBal {
+        &self.revm
+    }
+
+    /// Returns the original raw BAL bytes.
+    pub const fn as_raw_bal(&self) -> &RawBal {
+        &self.raw
+    }
+
+    /// Validates the BAL item-cost bound against the block gas limit.
+    pub fn validate_gas_limit(&self, gas_limit: u64) -> Result<(), ConsensusError> {
+        let items = self.total_bal_items();
+        if items > gas_limit / alloy_eip7928::constants::ITEM_COST as u64 {
+            return Err(BlockAccessListGasError::new(items, gas_limit).into())
+        }
+        Ok(())
+    }
+
+    fn total_bal_items(&self) -> u64 {
+        self.revm.accounts.values().map(|account| 1 + account.storage.storage.len() as u64).sum()
+    }
+}
+
+fn decode_revm_bal(buf: &mut &[u8]) -> Result<RevmBal, RlpError> {
+    let mut payload = Header::decode_bytes(buf, true)?;
+    let mut accounts = Vec::new();
+    while !payload.is_empty() {
+        accounts.push(decode_account(&mut payload)?);
+    }
+    Ok(RevmBal { accounts: AddressIndexMap::from_iter(accounts) })
+}
+
+fn decode_account(buf: &mut &[u8]) -> Result<(Address, AccountBal), RlpError> {
+    let mut payload = Header::decode_bytes(buf, true)?;
+    let address = Address::decode(&mut payload)?;
+    let storage_changes = Header::decode_bytes(&mut payload, true)?;
+    let storage_reads = Header::decode_bytes(&mut payload, true)?;
+    let balance_changes = Header::decode_bytes(&mut payload, true)?;
+    let nonce_changes = Header::decode_bytes(&mut payload, true)?;
+    let code_changes = Header::decode_bytes(&mut payload, true)?;
+    require_empty(payload)?;
+
+    Ok((
+        address,
+        AccountBal {
+            account_info: AccountInfoBal {
+                nonce: BalWrites { writes: decode_nonce_writes(nonce_changes)? },
+                balance: BalWrites { writes: decode_u256_writes(balance_changes)? },
+                code: BalWrites { writes: decode_code_writes(code_changes)? },
+            },
+            storage: decode_storage(storage_changes, storage_reads)?,
+        },
+    ))
+}
+
+fn decode_storage(
+    mut storage_changes: &[u8],
+    mut storage_reads: &[u8],
+) -> Result<StorageBal, RlpError> {
+    let mut storage = StorageBal::default();
+
+    while !storage_changes.is_empty() {
+        let mut payload = Header::decode_bytes(&mut storage_changes, true)?;
+        let slot = U256::decode(&mut payload)?;
+        let changes = Header::decode_bytes(&mut payload, true)?;
+        require_empty(payload)?;
+        storage.storage.insert(slot, BalWrites { writes: decode_u256_writes(changes)? });
+    }
+
+    while !storage_reads.is_empty() {
+        let slot = U256::decode(&mut storage_reads)?;
+        storage.storage.insert(slot, BalWrites::default());
+    }
+
+    Ok(storage)
+}
+
+fn decode_u256_writes(mut payload: &[u8]) -> Result<Vec<(BlockAccessIndex, U256)>, RlpError> {
+    let mut writes = Vec::new();
+    while !payload.is_empty() {
+        let mut change = Header::decode_bytes(&mut payload, true)?;
+        let index = BlockAccessIndex::decode(&mut change)?;
+        let value = U256::decode(&mut change)?;
+        require_empty(change)?;
+        writes.push((index, value));
+    }
+    Ok(writes)
+}
+
+fn decode_nonce_writes(mut payload: &[u8]) -> Result<Vec<(BlockAccessIndex, u64)>, RlpError> {
+    let mut writes = Vec::new();
+    while !payload.is_empty() {
+        let mut change = Header::decode_bytes(&mut payload, true)?;
+        let index = BlockAccessIndex::decode(&mut change)?;
+        let value = u64::decode(&mut change)?;
+        require_empty(change)?;
+        writes.push((index, value));
+    }
+    Ok(writes)
+}
+
+fn decode_code_writes(
+    mut payload: &[u8],
+) -> Result<Vec<(BlockAccessIndex, (B256, Bytecode))>, RlpError> {
+    let mut writes = Vec::new();
+    while !payload.is_empty() {
+        let mut change = Header::decode_bytes(&mut payload, true)?;
+        let index = BlockAccessIndex::decode(&mut change)?;
+        let raw = Bytes::decode(&mut change)?;
+        require_empty(change)?;
+
+        let bytecode =
+            Bytecode::new_raw_checked(raw).map_err(|_| RlpError::Custom("invalid bytecode"))?;
+        writes.push((index, (bytecode.hash_slow(), bytecode)));
+    }
+    Ok(writes)
+}
+
+fn require_empty(payload: &[u8]) -> Result<(), RlpError> {
+    if payload.is_empty() {
+        Ok(())
+    } else {
+        Err(RlpError::UnexpectedLength)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eip7928::{
+        AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
+    };
+
+    #[test]
+    fn direct_decode_matches_revm_clone_from_alloy() {
+        let account = AccountChanges::new(Address::from([0x11; 20]))
+            .with_storage_change(SlotChanges::new(
+                U256::from(1),
+                vec![
+                    StorageChange::new(BlockAccessIndex::new(0), U256::from(0x10)),
+                    StorageChange::new(BlockAccessIndex::new(2), U256::from(0x20)),
+                ],
+            ))
+            .with_storage_read(U256::from(2))
+            .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(1000)))
+            .with_nonce_change(NonceChange::new(BlockAccessIndex::new(2), 7))
+            .with_code_change(CodeChange::new(
+                BlockAccessIndex::new(3),
+                Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xf3]),
+            ));
+        let read_only_account =
+            AccountChanges::new(Address::from([0x22; 20])).with_storage_read(U256::from(3));
+        let block_access_list = vec![account, read_only_account];
+        let alloy_bal = alloy_eip7928::bal::Bal::new(block_access_list.clone());
+        let raw = alloy_rlp::encode(&alloy_bal).into();
+
+        let expected = RevmBal::clone_from_alloy(&block_access_list).expect("valid alloy BAL");
+        let received = ReceivedBal::from_rlp_bytes(raw).expect("valid raw BAL");
+
+        assert_eq!(received.revm_ref(), &expected);
+    }
+}

--- a/crates/engine/tree/src/tree/payload_processor/bal/input.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/input.rs
@@ -2,12 +2,14 @@ use alloy_eip7928::{bal::RawBal, BlockAccessIndex, BlockAccessListGasError};
 use alloy_primitives::Bytes;
 use alloy_rlp::{Decodable, Error as RlpError, Header};
 use reth_consensus::ConsensusError;
-use revm_state::{
+use revm::state::{
     bal::{AccountBal, AccountInfoBal, Bal as RevmBal, BalWrites, StorageBal},
     primitives::{Address, AddressIndexMap, B256, U256},
     Bytecode,
 };
 use std::sync::Arc;
+
+type CodeWrite = (BlockAccessIndex, (B256, Bytecode));
 
 /// Received block access list decoded into the form used by BAL execution.
 #[derive(Debug)]
@@ -150,9 +152,7 @@ fn decode_nonce_writes(mut payload: &[u8]) -> Result<Vec<(BlockAccessIndex, u64)
     Ok(writes)
 }
 
-fn decode_code_writes(
-    mut payload: &[u8],
-) -> Result<Vec<(BlockAccessIndex, (B256, Bytecode))>, RlpError> {
+fn decode_code_writes(mut payload: &[u8]) -> Result<Vec<CodeWrite>, RlpError> {
     let mut writes = Vec::new();
     while !payload.is_empty() {
         let mut change = Header::decode_bytes(&mut payload, true)?;
@@ -167,7 +167,7 @@ fn decode_code_writes(
     Ok(writes)
 }
 
-fn require_empty(payload: &[u8]) -> Result<(), RlpError> {
+const fn require_empty(payload: &[u8]) -> Result<(), RlpError> {
     if payload.is_empty() {
         Ok(())
     } else {

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -8,6 +8,7 @@
 //! the rebuilt block-level BAL hash after post-execution. It does not yet run per-transaction
 //! fragment checks. It does not yet report rich undeclared-access diagnostics.
 
+mod input;
 mod ordered_outputs;
 mod worker;
 
@@ -16,3 +17,4 @@ pub mod execute;
 
 pub use error::BalExecutionError;
 pub use execute::execute_block;
+pub use input::ReceivedBal;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -2,13 +2,15 @@
 
 use super::precompile_cache::PrecompileCacheMap;
 use crate::tree::{
-    payload_processor::prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
+    payload_processor::{
+        bal::ReceivedBal,
+        prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
+    },
     sparse_trie::SparseTrieCacheTask,
     CacheWaitDurations, CachedStateCacheMetrics, CachedStateMetrics, CachedStateMetricsSource,
     ExecutionCache, PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig,
     WaitForCaches,
 };
-use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal};
 use alloy_primitives::B256;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
@@ -583,7 +585,7 @@ where
     {
         let mode = if parallel_bal_execution {
             PrewarmMode::BlockAccessList(
-                env.decoded_bal.clone().expect("BAL dispatch implies decoded BAL"),
+                env.received_bal.clone().expect("BAL dispatch implies received BAL"),
             )
         } else if self.disable_transaction_prewarming ||
             env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
@@ -1054,9 +1056,9 @@ pub struct ExecutionEnv<Evm: ConfigureEvm> {
     /// Withdrawals included in the block.
     /// Used to generate prefetch targets for withdrawal addresses.
     pub withdrawals: Option<Vec<Withdrawal>>,
-    /// Optional decoded BAL for the block.
+    /// Optional received BAL for the block.
     /// Used to validate and optimize execution.
-    pub decoded_bal: Option<Arc<DecodedBal>>,
+    pub received_bal: Option<Arc<ReceivedBal>>,
 }
 
 impl<Evm: ConfigureEvm> ExecutionEnv<Evm>
@@ -1074,7 +1076,7 @@ where
             transaction_count: 0,
             gas_used: 0,
             withdrawals: None,
-            decoded_bal: None,
+            received_bal: None,
         }
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -33,7 +33,7 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_tasks::{pool::WorkerPool, Runtime};
 use reth_trie_common::MultiProofTargetsV2;
-use revm_state::bal::AccountBal as RevmAccountBal;
+use revm::state::bal::AccountBal as RevmAccountBal;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, channel, Receiver, Sender},
@@ -789,7 +789,7 @@ mod tests {
     use super::*;
     use alloy_eip7928::BlockAccessIndex;
     use alloy_primitives::bytes;
-    use revm_state::{bal::BalWrites, Bytecode};
+    use revm::state::{bal::BalWrites, Bytecode};
 
     fn account_with_storage_read(slot: U256) -> RevmAccountBal {
         let mut account = RevmAccountBal::default();

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -429,7 +429,6 @@ where
 
         // Drop the per-thread providers
         executor.bal_streaming_pool().clear();
-        executor.prewarming_pool().clear();
 
         let _ = actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
     }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -11,7 +11,7 @@
 //! 2. Prewarming tasks execute transactions in parallel using shared caches
 //! 3. When actual block execution happens, it benefits from the warmed cache
 
-use super::bal_prewarm_pool::BalPrewarmPool;
+use super::{bal::ReceivedBal, bal_prewarm_pool::BalPrewarmPool};
 use crate::tree::{
     payload_processor::multiproof::StateRootMessage,
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
@@ -19,9 +19,8 @@ use crate::tree::{
     PayloadExecutionCache, SavedCache, StateProviderBuilder,
 };
 use alloy_consensus::transaction::TxHashRef;
-use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::eip4895::Withdrawal;
-use alloy_primitives::{keccak256, B256, U256};
+use alloy_primitives::{keccak256, Address, B256, U256};
 use crossbeam_channel::Sender as CrossbeamSender;
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
@@ -34,6 +33,7 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_tasks::{pool::WorkerPool, Runtime};
 use reth_trie_common::MultiProofTargetsV2;
+use revm_state::bal::AccountBal as RevmAccountBal;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, channel, Receiver, Sender},
@@ -48,7 +48,7 @@ pub enum PrewarmMode<Tx> {
     /// Prewarm by executing transactions from a stream, each paired with its block index.
     Transactions(Receiver<(usize, Tx)>),
     /// Prewarm by prefetching slots from a Block Access List.
-    BlockAccessList(Arc<DecodedBal>),
+    BlockAccessList(Arc<ReceivedBal>),
     /// Transaction prewarming is skipped (e.g. small blocks where the overhead exceeds the
     /// benefit). No workers are spawned.
     Skipped,
@@ -332,11 +332,10 @@ where
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn run_bal_prewarm(
         &self,
-        decoded_bal: Arc<DecodedBal>,
+        received_bal: Arc<ReceivedBal>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
     ) {
-        let bal = decoded_bal.as_bal();
-        if bal.is_empty() {
+        if received_bal.is_empty() {
             if let Some(to_sparse_trie_task) = self.to_sparse_trie_task.as_ref() {
                 let _ = to_sparse_trie_task.send(StateRootMessage::FinishedStateUpdates);
             }
@@ -347,7 +346,7 @@ where
 
         trace!(
             target: "engine::tree::payload_processor::prewarm",
-            accounts = bal.len(),
+            accounts = received_bal.len(),
             "Starting BAL prewarm"
         );
 
@@ -356,8 +355,8 @@ where
         let executor = self.executor.clone();
         let parent_span = Span::current();
         let stream_parent_span = parent_span;
-        let prefetch_bal = Arc::clone(&decoded_bal);
-        let stream_bal = Arc::clone(&decoded_bal);
+        let prefetch_bal = Arc::clone(&received_bal);
+        let stream_bal = Arc::clone(&received_bal);
         let (stream_tx, stream_rx) = oneshot::channel();
 
         if let Some(to_sparse_trie_task) = to_sparse_trie_task {
@@ -367,18 +366,20 @@ where
                     target: "engine::tree::payload_processor::prewarm",
                     parent: &stream_parent_span,
                     "bal_hashed_state_stream",
-                    bal_accounts = stream_bal.as_bal().len(),
+                    bal_accounts = stream_bal.len(),
                 );
                 let parent_span = branch_span.clone();
                 let _span = branch_span.entered();
 
-                stream_bal.as_bal().par_iter().for_each(|account_changes| {
+                let accounts = stream_bal.revm_ref().accounts.iter().collect::<Vec<_>>();
+                accounts.into_par_iter().for_each(|(address, account_changes)| {
                     WorkerPool::with_worker_mut(|worker| {
                         let provider =
                             worker.get_or_init::<Option<Box<dyn AccountReader>>>(|| None);
                         ctx.send_bal_hashed_state(
                             &parent_span,
                             provider,
+                            *address,
                             account_changes,
                             &to_sparse_trie_task,
                         );
@@ -413,13 +414,10 @@ where
             let build = Arc::new(move || provider_builder.build());
 
             pool.begin_block(build, caches);
-            for account in prefetch_bal.as_bal() {
-                pool.warm_account(account.address);
-                for change in &account.storage_changes {
-                    pool.warm_storage(account.address, change.slot.into());
-                }
-                for &slot in &account.storage_reads {
-                    pool.warm_storage(account.address, slot.into());
+            for (address, account) in &prefetch_bal.revm_ref().accounts {
+                pool.warm_account(*address);
+                for slot in account.storage.storage.keys() {
+                    pool.warm_storage(*address, (*slot).into());
                 }
             }
             pool.end_block();
@@ -637,13 +635,13 @@ where
         &self,
         parent_span: &Span,
         provider: &mut Option<Box<dyn AccountReader>>,
-        account_changes: &alloy_eip7928::AccountChanges,
+        address: Address,
+        account_changes: &RevmAccountBal,
         to_sparse_trie_task: &CrossbeamSender<StateRootMessage>,
     ) {
         if self.disable_bal_parallel_state_root {
             return;
         }
-        let address = account_changes.address;
         let mut hashed_address = None;
         let account_fields = BalAccountStateFields::from_changes(account_changes);
 
@@ -651,17 +649,17 @@ where
             return;
         }
 
-        if !account_changes.storage_changes.is_empty() {
-            let hashed_address = *hashed_address.get_or_insert_with(|| keccak256(address));
-            let mut storage_map = reth_trie::HashedStorage::new(false);
-
-            for slot_changes in &account_changes.storage_changes {
-                let hashed_slot = keccak256(slot_changes.slot.to_be_bytes::<32>());
-                if let Some(last_change) = slot_changes.changes.last() {
-                    storage_map.storage.insert(hashed_slot, last_change.new_value);
-                }
+        let mut storage_map = reth_trie::HashedStorage::new(false);
+        for (slot, writes) in &account_changes.storage.storage {
+            if let Some((_, value)) = writes.writes.last() {
+                let hashed_slot = keccak256(slot.to_be_bytes::<32>());
+                storage_map.storage.insert(hashed_slot, *value);
             }
+        }
 
+        let has_storage_writes = !storage_map.storage.is_empty();
+        if has_storage_writes {
+            let hashed_address = *hashed_address.get_or_insert_with(|| keccak256(address));
             let mut hashed_state = reth_trie::HashedPostState::default();
             hashed_state.storages.insert(hashed_address, storage_map);
             let _ = to_sparse_trie_task.send(StateRootMessage::HashedStateUpdate(hashed_state));
@@ -722,17 +720,21 @@ struct BalAccountStateFields {
 }
 
 impl BalAccountStateFields {
-    fn from_changes(account_changes: &alloy_eip7928::AccountChanges) -> Self {
+    fn from_changes(account_changes: &RevmAccountBal) -> Self {
         Self {
-            balance: account_changes.balance_changes.last().map(|change| change.post_balance),
-            nonce: account_changes.nonce_changes.last().map(|change| change.new_nonce),
-            code_hash: account_changes.code_changes.last().map(|code_change| {
-                if code_change.new_code.is_empty() {
-                    alloy_consensus::constants::KECCAK_EMPTY
-                } else {
-                    keccak256(&code_change.new_code)
-                }
-            }),
+            balance: account_changes
+                .account_info
+                .balance
+                .writes
+                .last()
+                .map(|(_, balance)| *balance),
+            nonce: account_changes.account_info.nonce.writes.last().map(|(_, nonce)| *nonce),
+            code_hash: account_changes
+                .account_info
+                .code
+                .writes
+                .last()
+                .map(|(_, (code_hash, _))| *code_hash),
         }
     }
 
@@ -764,11 +766,12 @@ impl BalAccountStateFields {
     }
 }
 
-const fn bal_account_changes_state_root(
-    account_changes: &alloy_eip7928::AccountChanges,
+fn bal_account_changes_state_root(
+    account_changes: &RevmAccountBal,
     account_fields: BalAccountStateFields,
 ) -> bool {
-    !account_fields.is_empty() || !account_changes.storage_changes.is_empty()
+    !account_fields.is_empty() ||
+        account_changes.storage.storage.values().any(|writes| !writes.writes.is_empty())
 }
 
 /// Returns [`MultiProofTargetsV2`] for withdrawal addresses.
@@ -785,16 +788,28 @@ fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProof
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eip7928::{
-        AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
-        StorageChange,
-    };
-    use alloy_primitives::{address, bytes};
+    use alloy_eip7928::BlockAccessIndex;
+    use alloy_primitives::bytes;
+    use revm_state::{bal::BalWrites, Bytecode};
+
+    fn account_with_storage_read(slot: U256) -> RevmAccountBal {
+        let mut account = RevmAccountBal::default();
+        account.storage.storage.insert(slot, BalWrites::default());
+        account
+    }
+
+    fn account_with_storage_write(slot: U256, value: U256) -> RevmAccountBal {
+        let mut account = RevmAccountBal::default();
+        account
+            .storage
+            .storage
+            .insert(slot, BalWrites { writes: vec![(BlockAccessIndex::new(1), value)] });
+        account
+    }
 
     #[test]
     fn bal_read_only_account_does_not_change_state_root() {
-        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
-            .with_storage_read(U256::from(1));
+        let changes = account_with_storage_read(U256::from(1));
         let fields = BalAccountStateFields::from_changes(&changes);
 
         assert!(fields.is_empty());
@@ -803,10 +818,15 @@ mod tests {
 
     #[test]
     fn bal_account_with_all_leaf_fields_does_not_need_parent_account() {
-        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
-            .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(10)))
-            .with_nonce_change(NonceChange::new(BlockAccessIndex::new(1), 7))
-            .with_code_change(CodeChange::new(BlockAccessIndex::new(1), bytes!("6001600155")));
+        let mut changes = RevmAccountBal::default();
+        changes.account_info.balance.writes.push((BlockAccessIndex::new(1), U256::from(10)));
+        changes.account_info.nonce.writes.push((BlockAccessIndex::new(1), 7));
+        let bytecode = Bytecode::new_raw(bytes!("6001600155"));
+        changes
+            .account_info
+            .code
+            .writes
+            .push((BlockAccessIndex::new(1), (bytecode.hash_slow(), bytecode)));
         let fields = BalAccountStateFields::from_changes(&changes);
 
         assert!(bal_account_changes_state_root(&changes, fields));
@@ -815,11 +835,7 @@ mod tests {
 
     #[test]
     fn bal_storage_change_needs_parent_account_when_leaf_fields_missing() {
-        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
-            .with_storage_change(SlotChanges::new(
-                U256::from(1),
-                vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(2))],
-            ));
+        let changes = account_with_storage_write(U256::from(1), U256::from(2));
         let fields = BalAccountStateFields::from_changes(&changes);
 
         assert!(bal_account_changes_state_root(&changes, fields));
@@ -828,8 +844,8 @@ mod tests {
 
     #[test]
     fn bal_account_uses_existing_fields_only_when_missing() {
-        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
-            .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(10)));
+        let mut changes = RevmAccountBal::default();
+        changes.account_info.balance.writes.push((BlockAccessIndex::new(1), U256::from(10)));
         let fields = BalAccountStateFields::from_changes(&changes);
         let account = fields.into_account(Some(Account {
             balance: U256::from(1),

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -102,14 +102,14 @@ use crate::tree::{
     error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
     instrumented_state::{InstrumentedStateProvider, StateProviderMetrics, StateProviderStats},
     multiproof::{StateRootComputeOutcome, StateRootHandle},
-    payload_processor::{PayloadProcessor, PayloadProcessorSpawnOptions},
+    payload_processor::{bal::ReceivedBal, PayloadProcessor, PayloadProcessorSpawnOptions},
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
     types::{InsertPayloadResult, ValidationOutput},
     CacheWaitDurations, CachedStateProvider, EngineApiMetrics, EngineApiTreeState, ExecutionEnv,
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
+use alloy_eip7928::{compute_block_access_list_hash, BlockAccessList};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{map::B256Set, B256};
@@ -546,18 +546,11 @@ where
             .in_scope(|| self.evm_env_for(&input))
             .map_err(NewPayloadError::other)?;
 
-        // Extract the decoded BAL, if valid and available.
-        let decoded_bal = ensure_ok!(input
-            .try_decoded_access_list()
-            .map_err(|err| ConsensusError::BlockAccessListInvalid(err.to_string())))
-        .map(Arc::new);
+        // Extract the received BAL, if valid and available.
+        let received_bal = ensure_ok!(input.try_received_access_list()).map(Arc::new);
 
-        if let Some(decoded_bal) = decoded_bal.as_deref() {
-            // Reject oversized BAL sidecars before executing the block.
-            ensure_ok!(decoded_bal
-                .as_bal()
-                .validate_gas_limit(input.gas_limit())
-                .map_err(ConsensusError::from));
+        if let Some(received_bal) = received_bal.as_deref() {
+            ensure_ok!(received_bal.validate_gas_limit(input.gas_limit()));
         }
 
         let env = ExecutionEnv {
@@ -568,7 +561,7 @@ where
             transaction_count: input.transaction_count(),
             gas_used: input.gas_used(),
             withdrawals: input.withdrawals().map(|w| w.to_vec()),
-            decoded_bal: decoded_bal.as_ref().map(Arc::clone),
+            received_bal: received_bal.as_ref().map(Arc::clone),
         };
 
         // Plan the strategy used for state root computation.
@@ -594,7 +587,8 @@ where
         let overlay_factory =
             OverlayStateProviderFactory::new(provider_factory.clone(), overlay_builder.clone());
 
-        let parallel_bal_execution = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
+        let parallel_bal_execution =
+            ensure_ok!(self.bal_path_eligible(env.received_bal.as_deref()));
 
         // Spawn the appropriate processor based on strategy
         let pending_sparse_trie_prune = if matches!(strategy, StateRootStrategy::StateRootTask) {
@@ -1002,7 +996,7 @@ where
 
         let executed_block =
             self.spawn_deferred_trie_task(Arc::new(block), output, hashed_state, trie_output);
-        let raw_bal = decoded_bal.map(|decoded_bal| decoded_bal.as_raw_bal().clone());
+        let raw_bal = received_bal.map(|received_bal| received_bal.as_raw_bal().clone());
         Ok(ValidationOutput::new(executed_block, timing_stats).with_raw_bal(raw_bal))
     }
 
@@ -1110,7 +1104,7 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        let has_bal = env.decoded_bal.is_some();
+        let has_bal = env.received_bal.is_some();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
@@ -1200,7 +1194,7 @@ where
     //   - Tx-count threshold (`bal_execute_path_min_tx_count`): below the parallelism break-even
     //     point, provider setup and worker scheduling overhead can exceed the gain. Tune
     //     empirically once workers are parallel; meaningless while the commit loop is sequential.
-    fn bal_path_eligible(&self, bal: Option<&DecodedBal>) -> Result<bool, InsertBlockErrorKind> {
+    fn bal_path_eligible(&self, bal: Option<&ReceivedBal>) -> Result<bool, InsertBlockErrorKind> {
         let has_bal = bal.is_some();
         let parallel_execution = has_bal && !self.config.disable_bal_parallel_execution();
         if parallel_execution && self.config.disable_bal_parallel_state_root() {
@@ -1250,8 +1244,8 @@ where
         debug!(target: "engine::tree::payload_validator", "Executing block via BAL path");
 
         let (receipt_tx, result_rx) = self.spawn_receipt_root_task(env.transaction_count);
-        let input_bal = env.decoded_bal.ok_or_else(|| {
-            InsertBlockErrorKind::Other("BAL execute path: no decoded BAL available".into())
+        let input_bal = env.received_bal.ok_or_else(|| {
+            InsertBlockErrorKind::Other("BAL execute path: no received BAL available".into())
         })?;
 
         let make_db = |fill_on_miss| {
@@ -2335,12 +2329,12 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
         matches!(self, Self::Block(_))
     }
 
-    /// Returns the decoded block access list, if present and successfully decoded.
-    pub fn try_decoded_access_list(&self) -> Result<Option<DecodedBal>, alloy_rlp::Error> {
+    /// Returns the received block access list, if present and successfully decoded.
+    pub fn try_received_access_list(&self) -> Result<Option<ReceivedBal>, ConsensusError> {
         match self {
             Self::Payload(payload) => payload
                 .block_access_list()
-                .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
+                .map(|block_access_list| ReceivedBal::from_rlp_bytes(block_access_list.clone()))
                 .transpose(),
             Self::Block(_) => Ok(None),
         }


### PR DESCRIPTION
The BAL path currently decodes the raw EIP-7928 sidecar into alloy BAL types, then immediately converts that into revm's BAL layout for execution.

This PR makes received BALs decode directly into `revm_state::bal::Bal` and keeps the original raw bytes around for output/storage.

What changed:

- add `ReceivedBal`, which owns the raw BAL bytes and an `Arc<revm_state::bal::Bal>`
- remove the per-block alloy -> revm conversion from BAL execution
- make BAL gas validation and prewarm iterate the revm-native layout
- add a parity test against `RevmBal::clone_from_alloy`

Benchmarked on an i9-9900K with `RAYON_NUM_THREADS=16`, using 16 recent raw BALs from `https://ethereum.reth.rs/rpc` after rebasing on current `main` and updating the harness to `alloy-eip7928` `0.4.5`.

| case | current decode+clone | direct RLP -> revm | owned alloy -> revm | alloy + rayon clone |
|---|---:|---:|---:|---:|
| 16 real BALs, median | `440.0 us` | `326.4 us` (`1.36x`) | `379.1 us` (`1.17x`) | `561.6 us` (`0.76x`) |
| 16 real BALs, speedup range | baseline | `1.05x - 1.65x` | `1.07x - 1.31x` | `0.51x - 0.86x` |

The rayon rows are exploratory only; this PR always uses direct decode. Rayon is not a good default for current-size BALs, but starts to help on much larger synthetic inputs:

| scaled case | direct RLP -> revm vs current | alloy + rayon clone vs current | rayon conversion-only vs sequential |
|---|---:|---:|---:|
| account-heavy `8x` | `1.49x` | `1.17x` | `1.47x` |
| account-heavy `64x` | `1.56x` | `1.32x` | `1.50x` |
| code-heavy `8x` | `1.02x` | `1.13x` | `1.49x` |
| code-heavy `64x` | `1.12x` | `1.29x` | `1.58x` |

Conclusion: direct decode is the right default for this PR. Rayon probably only belongs behind a large-BAL threshold if we add it later.
