### PR TITLE
ci: emit bare big-blocks bench flag

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1158,7 +1158,13 @@ jobs:
           }
 
           derek_cmd=(derek bench)
-          [ "$BENCH_BIG_BLOCKS" = "true" ] && derek_cmd+=(big-blocks="${BENCH_BIG_BLOCKS_TARGET_GAS:-true}")
+          if [ "$BENCH_BIG_BLOCKS" = "true" ]; then
+            if [ -n "$BENCH_BIG_BLOCKS_TARGET_GAS" ]; then
+              derek_cmd+=(big-blocks="$BENCH_BIG_BLOCKS_TARGET_GAS")
+            else
+              derek_cmd+=(big-blocks)
+            fi
+          fi
           [ -n "$BENCH_REORG" ] && derek_cmd+=(reorg="$BENCH_REORG")
           derek_cmd+=(
             blocks="$BENCH_BLOCKS"


### PR DESCRIPTION
Changes the benchmark workflow's Derek command reconstruction so enabled big-blocks without a target gas is emitted as `big-blocks`, matching bare boolean flags like `samply`. Targeted gas values still emit as `big-blocks=<value>`.

Validation:
- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/bench.yml')); print('yaml ok')"`
- `sed -n '1138,1192p' .github/workflows/bench.yml | sed 's/^          //' | bash -n`

Prompted by: @shekhirin