### PR TITLE
Retain three epochs for minimal nodes

### DIFF
--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -13,11 +13,11 @@ use std::{collections::BTreeMap, path::Path};
 use tracing::info;
 
 /// Minimum blocks to keep for receipts, matching `--minimal` prune settings.
-const MINIMUM_RECEIPTS_DISTANCE: u64 = 64;
+const MINIMUM_RECEIPTS_DISTANCE: u64 = MINIMUM_HISTORY_DISTANCE;
 
 /// Minimum blocks to keep for history/bodies, matching `--minimal` prune settings
-/// (`MINIMUM_UNWIND_SAFE_DISTANCE`).
-const MINIMUM_HISTORY_DISTANCE: u64 = 10064;
+/// (three Tempo mainnet epochs at 21,600 blocks per epoch).
+const MINIMUM_HISTORY_DISTANCE: u64 = 64_800;
 
 /// Writes a [`Config`] as TOML to `<data_dir>/reth.toml`.
 ///
@@ -430,12 +430,12 @@ mod tests {
         selections.insert(SnapshotComponentType::State, ComponentSelection::All);
         selections.insert(SnapshotComponentType::Headers, ComponentSelection::All);
         selections
-            .insert(SnapshotComponentType::Transactions, ComponentSelection::Distance(10_064));
+            .insert(SnapshotComponentType::Transactions, ComponentSelection::Distance(64_800));
         selections.insert(SnapshotComponentType::Receipts, ComponentSelection::None);
         selections
-            .insert(SnapshotComponentType::AccountChangesets, ComponentSelection::Distance(10_064));
+            .insert(SnapshotComponentType::AccountChangesets, ComponentSelection::Distance(64_800));
         selections
-            .insert(SnapshotComponentType::StorageChangesets, ComponentSelection::Distance(10_064));
+            .insert(SnapshotComponentType::StorageChangesets, ComponentSelection::Distance(64_800));
         let config = config_for_selections(
             &selections,
             &empty_manifest(),
@@ -446,13 +446,13 @@ mod tests {
         assert_eq!(config.prune.segments.transaction_lookup, Some(PruneMode::Full));
         assert_eq!(config.prune.segments.sender_recovery, Some(PruneMode::Full));
         // Bodies follows tx selection
-        assert_eq!(config.prune.segments.bodies_history, Some(PruneMode::Distance(10_064)));
+        assert_eq!(config.prune.segments.bodies_history, Some(PruneMode::Distance(64_800)));
         assert_eq!(
             config.prune.segments.receipts,
             Some(PruneMode::Distance(MINIMUM_RECEIPTS_DISTANCE))
         );
-        assert_eq!(config.prune.segments.account_history, Some(PruneMode::Distance(10_064)));
-        assert_eq!(config.prune.segments.storage_history, Some(PruneMode::Distance(10_064)));
+        assert_eq!(config.prune.segments.account_history, Some(PruneMode::Distance(64_800)));
+        assert_eq!(config.prune.segments.storage_history, Some(PruneMode::Distance(64_800)));
     }
 
     #[test]
@@ -492,7 +492,7 @@ mod tests {
         selections.insert(SnapshotComponentType::Headers, ComponentSelection::All);
         selections
             .insert(SnapshotComponentType::Transactions, ComponentSelection::Distance(500_000));
-        selections.insert(SnapshotComponentType::Receipts, ComponentSelection::Distance(10_064));
+        selections.insert(SnapshotComponentType::Receipts, ComponentSelection::Distance(64_800));
 
         let chain_spec = reth_chainspec::MAINNET.clone();
         let config = config_for_selections(
@@ -504,18 +504,9 @@ mod tests {
 
         assert_eq!(config.prune.segments.sender_recovery, Some(PruneMode::Full));
         assert_eq!(config.prune.segments.transaction_lookup, None);
-        assert_eq!(
-            config.prune.segments.receipts,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
-        );
-        assert_eq!(
-            config.prune.segments.account_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
-        );
-        assert_eq!(
-            config.prune.segments.storage_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
-        );
+        assert_eq!(config.prune.segments.receipts, Some(PruneMode::Distance(10_064)));
+        assert_eq!(config.prune.segments.account_history, Some(PruneMode::Distance(10_064)));
+        assert_eq!(config.prune.segments.storage_history, Some(PruneMode::Distance(10_064)));
 
         let paris_block = chain_spec
             .ethereum_fork_activation(EthereumHardfork::Paris)
@@ -547,7 +538,7 @@ mod tests {
         selections.insert(SnapshotComponentType::State, ComponentSelection::All);
         selections.insert(SnapshotComponentType::Headers, ComponentSelection::All);
         selections
-            .insert(SnapshotComponentType::Transactions, ComponentSelection::Distance(10_064));
+            .insert(SnapshotComponentType::Transactions, ComponentSelection::Distance(64_800));
         selections.insert(SnapshotComponentType::Receipts, ComponentSelection::None);
         let config = config_for_selections(
             &selections,
@@ -558,8 +549,8 @@ mod tests {
         let desc = describe_prune_config(&config);
         assert!(desc.contains(&"sender_recovery=\"full\"".to_string()));
         // Bodies follows tx selection
-        assert!(desc.contains(&"bodies_history={ distance = 10064 }".to_string()));
-        assert!(desc.contains(&"receipts={ distance = 64 }".to_string()));
+        assert!(desc.contains(&"bodies_history={ distance = 64800 }".to_string()));
+        assert!(desc.contains(&"receipts={ distance = 64800 }".to_string()));
     }
 
     #[test]

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -234,8 +234,8 @@ impl SnapshotComponentType {
     ///
     /// Matches the `--minimal` prune configuration:
     /// - State/Headers: always All (required)
-    /// - Transactions/Changesets: Distance(10_064) (`MINIMUM_UNWIND_SAFE_DISTANCE`)
-    /// - Receipts: Distance(64) (`MINIMUM_DISTANCE`)
+    /// - Transactions/Changesets: Distance(64_800) (3 Tempo mainnet epochs)
+    /// - Receipts: Distance(64_800) (3 Tempo mainnet epochs)
     /// - TransactionSenders: None (only downloaded for archive nodes)
     /// - RocksdbIndices: None (only downloaded for archive nodes)
     ///
@@ -243,10 +243,10 @@ impl SnapshotComponentType {
     pub const fn minimal_selection(&self) -> ComponentSelection {
         match self {
             Self::State | Self::Headers => ComponentSelection::All,
-            Self::Transactions | Self::AccountChangesets | Self::StorageChangesets => {
-                ComponentSelection::Distance(10_064)
-            }
-            Self::Receipts => ComponentSelection::Distance(64),
+            Self::Transactions
+            | Self::Receipts
+            | Self::AccountChangesets
+            | Self::StorageChangesets => ComponentSelection::Distance(64_800),
             Self::TransactionSenders => ComponentSelection::None,
             Self::RocksdbIndices => ComponentSelection::None,
         }

--- a/crates/cli/commands/src/download/tui.rs
+++ b/crates/cli/commands/src/download/tui.rs
@@ -31,27 +31,25 @@ pub struct SelectorOutput {
 }
 
 /// All distance presets. Groups filter this to only valid options.
-const DISTANCE_PRESETS: [ComponentSelection; 6] = [
+const DISTANCE_PRESETS: [ComponentSelection; 5] = [
     ComponentSelection::None,
-    ComponentSelection::Distance(64),
-    ComponentSelection::Distance(10_064),
+    ComponentSelection::Distance(64_800),
     ComponentSelection::Distance(100_000),
     ComponentSelection::Distance(1_000_000),
     ComponentSelection::All,
 ];
 
-/// Presets for components that require at least 64 blocks (receipts).
-const RECEIPTS_PRESETS: [ComponentSelection; 5] = [
-    ComponentSelection::Distance(64),
-    ComponentSelection::Distance(10_064),
+/// Presets for components that require at least 64,800 blocks (receipts).
+const RECEIPTS_PRESETS: [ComponentSelection; 4] = [
+    ComponentSelection::Distance(64_800),
     ComponentSelection::Distance(100_000),
     ComponentSelection::Distance(1_000_000),
     ComponentSelection::All,
 ];
 
-/// Presets for components that require at least 10064 blocks (account/storage history).
+/// Presets for components that require at least 64,800 blocks (account/storage history).
 const HISTORY_PRESETS: [ComponentSelection; 4] = [
-    ComponentSelection::Distance(10_064),
+    ComponentSelection::Distance(64_800),
     ComponentSelection::Distance(100_000),
     ComponentSelection::Distance(1_000_000),
     ComponentSelection::All,
@@ -311,9 +309,9 @@ fn event_loop(
         let timeout =
             tick_rate.checked_sub(last_tick.elapsed()).unwrap_or_else(|| Duration::from_secs(0));
 
-        if crossterm::event::poll(timeout)? &&
-            let Event::Key(key) = event::read()? &&
-            key.kind == event::KeyEventKind::Press
+        if crossterm::event::poll(timeout)?
+            && let Event::Key(key) = event::read()?
+            && key.kind == event::KeyEventKind::Press
         {
             match key.code {
                 KeyCode::Char('q') | KeyCode::Esc => {

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -6,9 +6,14 @@ use clap::{builder::RangedU64ValueParser, Args};
 use reth_chainspec::EthereumHardforks;
 use reth_config::config::PruneConfig;
 use reth_prune_types::{
-    PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_DISTANCE, MINIMUM_UNWIND_SAFE_DISTANCE,
+    PruneMode, PruneModes, ReceiptsLogPruneConfig, MINIMUM_UNWIND_SAFE_DISTANCE,
 };
 use std::{collections::BTreeMap, ops::Not, sync::OnceLock};
+
+/// Blocks kept by `--minimal` for data needed to serve recent block sync requests.
+///
+/// This covers three Tempo mainnet epochs at 21,600 blocks per epoch.
+const MINIMAL_PEER_SYNC_DISTANCE: u64 = 64_800;
 
 /// Global static pruning defaults
 static PRUNING_DEFAULTS: OnceLock<DefaultPruningValues> = OnceLock::new();
@@ -81,10 +86,10 @@ impl Default for DefaultPruningValues {
             minimal_prune_modes: PruneModes {
                 sender_recovery: Some(PruneMode::Full),
                 transaction_lookup: Some(PruneMode::Full),
-                receipts: Some(PruneMode::Distance(MINIMUM_DISTANCE)),
-                account_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
-                storage_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
-                bodies_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
+                receipts: Some(PruneMode::Distance(MINIMAL_PEER_SYNC_DISTANCE)),
+                account_history: Some(PruneMode::Distance(MINIMAL_PEER_SYNC_DISTANCE)),
+                storage_history: Some(PruneMode::Distance(MINIMAL_PEER_SYNC_DISTANCE)),
+                bodies_history: Some(PruneMode::Distance(MINIMAL_PEER_SYNC_DISTANCE)),
                 receipts_log_filter: Default::default(),
             },
         }
@@ -121,18 +126,18 @@ impl PruneConfigKind {
         ChainSpec: EthereumHardforks,
     {
         if config.is_default() {
-            return Self::Archive
+            return Self::Archive;
         }
 
         let full_config = PruningArgs { full: true, ..Default::default() }.prune_config(chain_spec);
         if full_config.as_ref() == Some(config) {
-            return Self::Full
+            return Self::Full;
         }
 
         let minimal_config =
             PruningArgs { minimal: true, ..Default::default() }.prune_config(chain_spec);
         if minimal_config.as_ref() == Some(config) {
-            return Self::Minimal
+            return Self::Minimal;
         }
 
         Self::Custom
@@ -151,8 +156,8 @@ pub struct PruningArgs {
     /// Run minimal storage mode with maximum pruning and smaller static files.
     ///
     /// This mode configures the node to use minimal disk space by:
-    /// - Fully pruning sender recovery, transaction lookup, receipts
-    /// - Leaving 10,064 blocks for account, storage history and block bodies
+    /// - Fully pruning sender recovery and transaction lookup
+    /// - Leaving 64,800 blocks for receipts, account history, storage history and block bodies
     /// - Using 10,000 blocks per static file segment
     #[arg(long, default_value_t = false, conflicts_with = "full")]
     pub minimal: bool,

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -903,7 +903,7 @@ Pruning:
       --minimal
           Run minimal storage mode with maximum pruning and smaller static files.
 
-          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage history and block bodies - Using 10,000 blocks per static file segment
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery and transaction lookup - Leaving 64,800 blocks for receipts, account history, storage history and block bodies - Using 10,000 blocks per static file segment
 
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks

--- a/docs/vocs/docs/pages/run/storage/minimal.mdx
+++ b/docs/vocs/docs/pages/run/storage/minimal.mdx
@@ -36,10 +36,10 @@ reth node \
 | ------------ | --------------------- |
 | Sender recovery | Fully pruned |
 | Transaction lookup | Fully pruned |
-| Receipts | Retains the last 64 blocks |
-| Account history | Retains the last 10,064 blocks |
-| Storage history | Retains the last 10,064 blocks |
-| Block bodies | Retains the last 10,064 blocks |
+| Receipts | Retains the last 64,800 blocks |
+| Account history | Retains the last 64,800 blocks |
+| Storage history | Retains the last 64,800 blocks |
+| Block bodies | Retains the last 64,800 blocks |
 | Static files | Uses 10,000 blocks per file segment |
 
 ## Trade-offs

--- a/docs/vocs/docs/pages/run/storage/pruning.mdx
+++ b/docs/vocs/docs/pages/run/storage/pruning.mdx
@@ -75,10 +75,10 @@ Minimal mode configures:
 
 -   sender recovery pruning: full
 -   transaction lookup pruning: full
--   receipts pruning: retain the last 64 blocks
--   account history pruning: retain the last 10,064 blocks
--   storage history pruning: retain the last 10,064 blocks
--   bodies pruning: retain the last 10,064 blocks
+-   receipts pruning: retain the last 64,800 blocks
+-   account history pruning: retain the last 64,800 blocks
+-   storage history pruning: retain the last 64,800 blocks
+-   bodies pruning: retain the last 64,800 blocks
 -   static file segments: 10,000 blocks per file
 
 ### Custom Pruned Node


### PR DESCRIPTION
## Summary
- update `--minimal` pruning to retain 64,800 blocks for receipts, bodies, account history, and storage history
- align minimal snapshot download defaults and TUI presets with the new retention distance
- update minimal-mode docs and generated CLI docs

## Tests
- `cargo test -p reth-node-core pruning_config_kind_classifies_presets --lib`
- `cargo test -p reth-cli-commands download::config_gen::tests --lib`
- `rustfmt --edition 2024 --check crates/node/core/src/args/pruning.rs crates/cli/commands/src/download/manifest.rs crates/cli/commands/src/download/config_gen.rs crates/cli/commands/src/download/tui.rs`
- `git diff --check`

Prompted by: @SuperFluffy
