### PR TITLE
fix(docker): include LICENSES in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,8 @@
 
 # include licenses
 !LICENSE-*
+!/LICENSES
+!/LICENSES/**
 
 # include example files
 !/examples

--- a/docs/repo/ci.md
+++ b/docs/repo/ci.md
@@ -21,6 +21,25 @@ The CI runs a couple of workflows:
 - **[stale]**: Marks issues as stale if there has been no activity
 - **[docker]**: Publishes the Docker image.
 
+#### Docker workflow changes
+
+Docker changes usually affect more than one workflow. Before merging changes to Dockerfiles,
+Docker build inputs, or files copied into images:
+
+- Check all Dockerfiles and bake targets that share the repository build context:
+  `Dockerfile`, `Dockerfile.depot`, `.github/scripts/hive/Dockerfile`, and `docker-bake.hcl`.
+- Keep `.dockerignore` in sync with every file or directory copied from the repository context.
+  A file that exists in git can still be missing from Docker builds if it is not allowlisted there.
+- Check the workflow users of those targets: `docker.yml`, reusable `docker-test.yml`, and callers
+  such as `hive.yml` and `kurtosis.yml`.
+- Run local syntax checks before opening or merging the PR when BuildKit/buildx is available, for
+  example `docker build --check -f Dockerfile .`, `docker build --check -f Dockerfile.depot .`,
+  and `docker buildx bake --print -f docker-bake.hcl`.
+- Run at least one GitHub Actions dry run for the affected workflow. For the publishing workflow,
+  use `docker.yml` with `workflow_dispatch`, `build_type=git-sha`, and `dry_run=true`.
+- When updating shared image contents, look at recent Docker-related PRs and existing workflow
+  history to identify when failures started and whether sibling workflows are affected.
+
 ### Integration Testing
 
 - **[kurtosis]**: Spins up a Kurtosis testnet and runs Assertoor tests on Reth pairs.


### PR DESCRIPTION
## Summary
- include the tracked `LICENSES` directory in the Docker build context
- fix nightly Depot builds failing at `COPY LICENSES ./LICENSES` with `"/LICENSES": not found`

## Investigation
- Failing scheduled run: https://github.com/paradigmxyz/reth/actions/runs/28308006982
- Failed step: `Build and push images`
- Error: `COPY LICENSES ./LICENSES` could not find `/LICENSES` in the Docker context
- Cause: `.dockerignore` excludes everything, then re-includes `LICENSE-*` but not the tracked `LICENSES/` directory

## Verification
- `git diff --check`
- Could not run a local Docker context build because the sandbox has no Docker daemon socket at `/var/run/docker.sock`.

Prompted by: @DaniPopes