### PR TITLE
chore(ci): replace stale AI Slack alert mention

### DIFF
--- a/.github/workflows/bench-scheduled.yml
+++ b/.github/workflows/bench-scheduled.yml
@@ -1043,7 +1043,7 @@ jobs:
               },
               {
                 type: 'section',
-                text: { type: 'mrkdwn', text: `*${modeLabel} regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>\n<@U0AAA8F0JEM> investigate this` },
+                text: { type: 'mrkdwn', text: `*${modeLabel} regression* failed while *${failedStep}*\ncc <@U09FARE0B9Q> <@U09FAL2UMLJ>\n<@U0ANX3AM5RR> investigate this` },
               },
               {
                 type: 'actions',

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -148,7 +148,7 @@ jobs:
 
             *Action required:* Re-run the workflow or investigate the build failure.
 
-            <@U0AAA8F0JEM> investigate and re-run if flaky
+            <@U0ANX3AM5RR> investigate and re-run if flaky
           SLACK_FOOTER: "paradigmxyz/reth · docker.yml"
           MSG_MINIMAL: true
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Updates scheduled bench and nightly Docker failure alerts to tag the current Centaur AI Slack user (`U0ANX3AM5RR`) instead of the stale `U0AAA8F0JEM` user.

Prompted by: @DaniPopes

Validation:
- `slack user-info U0ANX3AM5RR` resolves to `Name: ai`
- `slack user-info U0AAA8F0JEM` resolves to the stale `Name: ai`
- `rg -n "U0AAA8F0JEM|B0ANN1P4YNT" -S /home/agent/github /home/agent/branches` returned no remaining refs
- `git diff --check`