### PR TITLE
fix(engine): log an error instead of silently dropping send failures

### DIFF
--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -17,6 +17,7 @@ use std::{
     task::{ready, Context, Poll},
 };
 use tokio::sync::mpsc::UnboundedReceiver;
+use tracing::error;
 
 /// A [`ChainHandler`] that advances the chain based on incoming requests (CL engine API).
 ///
@@ -195,7 +196,9 @@ where
 
     fn on_event(&mut self, event: FromEngine<Self::Request, Self::Block>) {
         // delegate to the tree
-        let _ = self.to_tree.send(event);
+        let _ = self.to_tree.send(event).inspect_err(
+            |err| error!(target: "engine::tree", "Failed to send event to tree: {err:?}"),
+        );
     }
 
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<RequestHandlerEvent<Self::Event>> {


### PR DESCRIPTION
on_event silently dropped the SendError when to_tree channel was
closed, making it impossible to detect when Engine API events
(newPayload/forkChoiceUpdated) were lost.
