### PR TITLE
fix(net): wire max pending imports setting

### DIFF
--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -11,7 +11,9 @@ use crate::transactions::constants::{
         DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH, DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS,
         DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS_PER_PEER,
     },
-    tx_manager::DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES,
+    tx_manager::{
+        DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS, DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES,
+    },
 };
 use alloy_eips::eip2718::IsTyped2718;
 use alloy_primitives::B256;
@@ -27,6 +29,9 @@ pub struct TransactionsManagerConfig {
     pub transaction_fetcher_config: TransactionFetcherConfig,
     /// Max number of seen transactions to store for each peer.
     pub max_transactions_seen_by_peer_history: u32,
+    /// Max number of transactions allowed to be imported concurrently.
+    #[cfg_attr(feature = "serde", serde(default = "default_max_pending_pool_imports"))]
+    pub max_pending_pool_imports: usize,
     /// How new pending transactions are propagated.
     #[cfg_attr(feature = "serde", serde(default))]
     pub propagation_mode: TransactionPropagationMode,
@@ -42,6 +47,11 @@ pub struct TransactionsManagerConfig {
 }
 
 #[cfg(feature = "serde")]
+const fn default_max_pending_pool_imports() -> usize {
+    DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS
+}
+
+#[cfg(feature = "serde")]
 const fn default_tx_channel_memory_limit_bytes() -> usize {
     DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES
 }
@@ -51,6 +61,7 @@ impl Default for TransactionsManagerConfig {
         Self {
             transaction_fetcher_config: TransactionFetcherConfig::default(),
             max_transactions_seen_by_peer_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+            max_pending_pool_imports: DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS,
             propagation_mode: TransactionPropagationMode::default(),
             ingress_policy: TransactionIngressPolicy::default(),
             tx_channel_memory_limit_bytes: DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -389,7 +389,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         // over the network
         let pending = pool.pending_transactions_listener();
         let pending_pool_imports_info =
-            PendingPoolImportsInfo::new(DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS);
+            PendingPoolImportsInfo::new(transactions_manager_config.max_pending_pool_imports);
         let metrics = TransactionsManagerMetrics::default();
         metrics
             .capacity_pending_pool_imports

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -530,6 +530,7 @@ impl NetworkArgs {
                 self.max_capacity_cache_txns_pending_fetch,
             ),
             max_transactions_seen_by_peer_history: self.max_seen_tx_history,
+            max_pending_pool_imports: self.max_pending_pool_imports,
             propagation_mode: self.propagation_mode,
             ingress_policy: self.tx_ingress_policy,
             tx_channel_memory_limit_bytes: self.tx_channel_memory_limit_bytes,
@@ -1239,6 +1240,15 @@ mod tests {
 
             assert_eq!(args.dns_retries, retries);
         }
+    }
+
+    #[test]
+    fn transactions_manager_config_uses_max_pending_imports() {
+        let args = NetworkArgs { max_pending_pool_imports: 50_000, ..Default::default() };
+
+        let config = args.transactions_manager_config();
+
+        assert_eq!(config.max_pending_pool_imports, 50_000);
     }
 
     #[test]


### PR DESCRIPTION
Propagates the configured `--max-pending-imports` value into `TransactionsManagerConfig` and uses it when constructing `PendingPoolImportsInfo`.

Previously the transaction manager always used `DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS`, so CLI and programmatic overrides did not affect the actual pending pool import limit.