### PR TITLE
chore: fix cargo deny advisory check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/deny.toml
+++ b/deny.toml
@@ -4,26 +4,13 @@
 [advisories]
 yanked = "warn"
 ignore = [
-    # https://rustsec.org/advisories/RUSTSEC-2024-0384 used by sse example
-    "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
     # https://rustsec.org/advisories/RUSTSEC-2023-0089 atomic-polyfill is unmaintained, transitive dep via test-fuzz
     "RUSTSEC-2023-0089",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru upgrade requires a discv5 bump first
-    "RUSTSEC-2026-0002",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
-    "RUSTSEC-2026-0097",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
-    "RUSTSEC-2026-0173",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
-    # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
-    # the fix, and no patched hickory-proto release exists
-    "RUSTSEC-2026-0118",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
-    # and is pulled in transitively by upstream crates with no safe upgrade available.
     "RUSTSEC-2026-0173",
 ]
 


### PR DESCRIPTION
Updates `anyhow` to 1.0.103 to resolve RUSTSEC-2026-0190.

Also removes stale cargo-deny advisory ignores that no longer match the dependency graph, which caused the deny job to fail with `advisory-not-detected`.