### PR TITLE
chore: integrate revm glam-devnet-6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=c135e1a912074039395a4fcbc5067706e8665801#c135e1a912074039395a4fcbc5067706e8665801"
+source = "git+https://github.com/alloy-rs/evm?rev=2eba6900ba9e7113eb32693c5d52ce8b321f310b#2eba6900ba9e7113eb32693c5d52ce8b321f310b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7881,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10661,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "zstd",
 ]
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "bitvec",
  "paste",
@@ -10699,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10745,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "auto_impl",
  "either",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10776,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "auto_impl",
  "either",
@@ -10793,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.41.1"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=cdcf766cba13e392791d2f9fb277284820b1b7c9#cdcf766cba13e392791d2f9fb277284820b1b7c9"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231#02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10813,7 +10813,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10861,7 +10861,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",
@@ -10874,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "eyre",
  "ruint",
@@ -10903,12 +10903,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -10923,7 +10923,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
@@ -10954,7 +10954,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
+version = "0.37.1"
+source = "git+https://github.com/alloy-rs/evm?rev=c135e1a912074039395a4fcbc5067706e8665801#c135e1a912074039395a4fcbc5067706e8665801"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7861,9 +7860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312c1817d0e37c6112d30fcc9e92226d8e73cc66ea6bd640c80e0e0df956cc04"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7882,9 +7880,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526ee2bfded1897b7bb43f46410f487ee48a41b7e93cf18031079660b433550d"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9584,9 +9581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66169f2c520c1c94192a18d11c5466565f079588def7d76abb631db80d353829"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10135,9 +10131,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10665,9 +10660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd4e89ad5d14393bde9b2b152480d4fd7f2399d0f9efe80ea29ec7c0b76bcdc"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "zstd",
 ]
@@ -10675,8 +10669,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10694,8 +10687,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "bitvec",
  "paste",
@@ -10707,8 +10699,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10724,8 +10715,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10740,8 +10730,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10756,8 +10745,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "either",
@@ -10770,8 +10758,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10789,8 +10776,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "either",
@@ -10806,9 +10792,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
+version = "0.41.1"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=cdcf766cba13e392791d2f9fb277284820b1b7c9#cdcf766cba13e392791d2f9fb277284820b1b7c9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10822,13 +10807,13 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10840,8 +10825,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10867,8 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10878,8 +10861,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,8 +324,8 @@ reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { version = "0.5.0", default-features = false }
-reth-codecs-derive = "0.5.0"
+reth-codecs = { version = "0.5.2", default-features = false }
+reth-codecs-derive = "0.5.2"
 reth-config = { path = "crates/config", default-features = false }
 reth-consensus = { path = "crates/consensus/consensus", default-features = false }
 reth-consensus-common = { path = "crates/consensus/common", default-features = false }
@@ -393,7 +393,7 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives-traits = { version = "0.5.0", default-features = false }
+reth-primitives-traits = { version = "0.5.2", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
@@ -409,7 +409,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-rpc-traits = { version = "0.5.0", default-features = false }
+reth-rpc-traits = { version = "0.5.2", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }
@@ -428,12 +428,12 @@ reth-trie-common = { path = "crates/trie/common", default-features = false }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-zstd-compressors = { version = "0.5.0", default-features = false }
+reth-zstd-compressors = { version = "0.5.2", default-features = false }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
 revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
-revm-inspectors = "0.41.0"
+revm-inspectors = "0.41.1"
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -443,7 +443,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false, features = ["rlp"] }
-alloy-evm = { version = "0.37.0", default-features = false }
+alloy-evm = { version = "0.37.1", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
@@ -694,3 +694,24 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "cdcf766cba13e392791d2f9fb277284820b1b7c9" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "c135e1a912074039395a4fcbc5067706e8665801" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,7 +432,7 @@ reth-zstd-compressors = { version = "0.5.2", default-features = false }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
-revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
+revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "glam-devnet-6", default-features = false, features = ["llvm-prefer-static"] }
 revm-inspectors = "0.41.1"
 
 # eth
@@ -696,22 +696,22 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "cdcf766cba13e392791d2f9fb277284820b1b7c9" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "c135e1a912074039395a4fcbc5067706e8665801" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "2eba6900ba9e7113eb32693c5d52ce8b321f310b" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -511,6 +511,7 @@ fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
         blocking: jit.blocking,
         no_dedup: default_config.no_dedup,
         no_dse: default_config.no_dse,
+        single_error: default_config.single_error,
         gas_params: default_config.gas_params,
         aot: default_config.aot,
         jit_mode: JitMode::OutOfProcess,

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1466,6 +1466,9 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
             .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
             .unwrap_or_default() as u64,
         transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
+        // EIP-2780 only activates at Amsterdam; this pre-check caps `spec_id` at PRAGUE,
+        // so the gas calculation never applies the EIP-2780 adjustment here.
+        None,
     );
 
     let gas_limit = transaction.gas_limit();


### PR DESCRIPTION
Patches `glam-devnet-6` branches of revm (`35d8fb4f`), revm-inspectors (`cdcf766`), alloy-evm (`c135e1a`), and reth-core crates (`9759d77`); workspace deps bumped to the glam versions.

Fixes the `calculate_initial_tx_gas` call for revm's new EIP-2780 argument — the tx-pool intrinsic-gas pre-check caps `spec_id` at PRAGUE, so EIP-2780 (Amsterdam) is inactive and `None` is passed.

`cargo check --workspace` is clean. The default `jit` feature (revmc → LLVM 22) was not built locally (only LLVM 20 available); validated the binary with all default features except `jit`.