### PR TITLE
chore: integrate revm glam-devnet-6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=c135e1a912074039395a4fcbc5067706e8665801#c135e1a912074039395a4fcbc5067706e8665801"
+source = "git+https://github.com/alloy-rs/evm?rev=2eba6900ba9e7113eb32693c5d52ce8b321f310b#2eba6900ba9e7113eb32693c5d52ce8b321f310b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7881,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10132,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10661,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=fed7fafab66057dff0f2516aa0982306007054f6#fed7fafab66057dff0f2516aa0982306007054f6"
 dependencies = [
  "zstd",
 ]
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "bitvec",
  "paste",
@@ -10699,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10745,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "auto_impl",
  "either",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10776,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "auto_impl",
  "either",
@@ -10793,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.41.1"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=cdcf766cba13e392791d2f9fb277284820b1b7c9#cdcf766cba13e392791d2f9fb277284820b1b7c9"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231#02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10813,7 +10813,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10861,7 +10861,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=b55020b237400aa42ce48fcaefdf5cdc255b5558#b55020b237400aa42ce48fcaefdf5cdc255b5558"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",
@@ -10874,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "eyre",
  "ruint",
@@ -10903,12 +10903,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -10923,7 +10923,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
@@ -10954,7 +10954,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glam-devnet-6#d783584a8fab078498381e4e469ef83abb8ab107"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=2eba6900ba9e7113eb32693c5d52ce8b321f310b#2eba6900ba9e7113eb32693c5d52ce8b321f310b"
+source = "git+https://github.com/alloy-rs/evm?rev=16fec5e68244f133d75d9d6f500c766388f16a90#16fec5e68244f133d75d9d6f500c766388f16a90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
+version = "0.37.1"
+source = "git+https://github.com/alloy-rs/evm?rev=c135e1a912074039395a4fcbc5067706e8665801#c135e1a912074039395a4fcbc5067706e8665801"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7861,9 +7860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312c1817d0e37c6112d30fcc9e92226d8e73cc66ea6bd640c80e0e0df956cc04"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7882,9 +7880,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526ee2bfded1897b7bb43f46410f487ee48a41b7e93cf18031079660b433550d"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9584,9 +9581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66169f2c520c1c94192a18d11c5466565f079588def7d76abb631db80d353829"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10135,9 +10131,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10665,9 +10660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd4e89ad5d14393bde9b2b152480d4fd7f2399d0f9efe80ea29ec7c0b76bcdc"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "zstd",
 ]
@@ -10675,8 +10669,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10694,8 +10687,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "bitvec",
  "paste",
@@ -10707,8 +10699,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10724,8 +10715,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10740,8 +10730,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10756,8 +10745,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "either",
@@ -10770,8 +10758,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10789,8 +10776,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "either",
@@ -10806,9 +10792,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
+version = "0.41.1"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=cdcf766cba13e392791d2f9fb277284820b1b7c9#cdcf766cba13e392791d2f9fb277284820b1b7c9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10822,13 +10807,13 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10840,8 +10825,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10867,8 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10878,8 +10861,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -709,7 +709,7 @@ revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "b55020b237
 revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
 revm-state = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "2eba6900ba9e7113eb32693c5d52ce8b321f310b" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "16fec5e68244f133d75d9d6f500c766388f16a90" }
 reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
 reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,8 +324,8 @@ reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { version = "0.5.0", default-features = false }
-reth-codecs-derive = "0.5.0"
+reth-codecs = { version = "0.5.2", default-features = false }
+reth-codecs-derive = "0.5.2"
 reth-config = { path = "crates/config", default-features = false }
 reth-consensus = { path = "crates/consensus/consensus", default-features = false }
 reth-consensus-common = { path = "crates/consensus/common", default-features = false }
@@ -393,7 +393,7 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives-traits = { version = "0.5.0", default-features = false }
+reth-primitives-traits = { version = "0.5.2", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
@@ -409,7 +409,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-rpc-traits = { version = "0.5.0", default-features = false }
+reth-rpc-traits = { version = "0.5.2", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }
@@ -428,12 +428,12 @@ reth-trie-common = { path = "crates/trie/common", default-features = false }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-zstd-compressors = { version = "0.5.0", default-features = false }
+reth-zstd-compressors = { version = "0.5.2", default-features = false }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
 revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
-revm-inspectors = "0.41.0"
+revm-inspectors = "0.41.1"
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -443,7 +443,7 @@ alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false, features = ["rlp"] }
-alloy-evm = { version = "0.37.0", default-features = false }
+alloy-evm = { version = "0.37.1", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
@@ -694,3 +694,24 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "cdcf766cba13e392791d2f9fb277284820b1b7c9" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "c135e1a912074039395a4fcbc5067706e8665801" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,7 +432,7 @@ reth-zstd-compressors = { version = "0.5.2", default-features = false }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
-revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
+revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "glam-devnet-6", default-features = false, features = ["llvm-prefer-static"] }
 revm-inspectors = "0.41.1"
 
 # eth
@@ -696,22 +696,22 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "cdcf766cba13e392791d2f9fb277284820b1b7c9" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "c135e1a912074039395a4fcbc5067706e8665801" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "02dbd677e27c7817b8d2f9a7ab4dcd9c0a95f231" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "2eba6900ba9e7113eb32693c5d52ce8b321f310b" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "fed7fafab66057dff0f2516aa0982306007054f6" }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -311,11 +311,9 @@ where
 
         let span = Span::current();
 
-        let halve_workers = env.transaction_count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD;
         let state_root_handle = self.spawn_state_root(
             multiproof_provider_factory,
             env.parent_state_root,
-            halve_workers,
             config,
             pending_sparse_trie_prune,
         );
@@ -386,15 +384,11 @@ where
     ///   state root.
     ///
     /// The state hook **must** be dropped after execution to signal the end of state updates.
-    ///
-    /// When `halve_workers` is true, the proof worker pool is halved (for small blocks where
-    /// fewer transactions produce fewer state changes and most workers would be idle).
     #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     pub fn spawn_state_root<F>(
         &self,
         multiproof_provider_factory: F,
         parent_state_root: B256,
-        halve_workers: bool,
         config: &TreeConfig,
         pending_sparse_trie_prune: Option<SparseTrieRetainedPaths>,
     ) -> StateRootHandle
@@ -410,7 +404,7 @@ where
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
-        let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx, halve_workers);
+        let proof_handle = ProofWorkerHandle::new(&self.executor, task_ctx);
 
         let (state_root_tx, state_root_rx) = channel();
         let (hashed_state_tx, hashed_state_rx) = channel();
@@ -433,10 +427,6 @@ where
 
         StateRootHandle::new(parent_state_root, updates_tx, state_root_rx, hashed_state_rx)
     }
-
-    /// Transaction count threshold below which proof workers are halved, since fewer transactions
-    /// produce fewer state changes and most workers would be idle overhead.
-    const SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD: usize = 30;
 
     /// Transaction count threshold below which sequential conversion is used.
     ///

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -991,7 +991,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory));
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -2255,8 +2255,6 @@ where
         Some(self.payload_processor.spawn_state_root(
             overlay_factory,
             parent_state_root,
-            // Full proof workers — tx count unknown at FCU time (block built incrementally)
-            false,
             &self.config,
             None,
         ))

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -511,6 +511,7 @@ fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
         blocking: jit.blocking,
         no_dedup: default_config.no_dedup,
         no_dse: default_config.no_dse,
+        single_error: default_config.single_error,
         gas_params: default_config.gas_params,
         aot: default_config.aot,
         jit_mode: JitMode::OutOfProcess,

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -47,10 +47,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth71;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -424,12 +424,12 @@ pub struct EngineArgs {
     pub allow_unwind_canonical_header: bool,
 
     /// Configure the number of storage proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to 2x available parallelism.
+    /// If not specified, defaults to 2x available parallelism, with a minimum of 128.
     #[arg(long = "engine.storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_count.map(|v| v.to_string().into())))]
     pub storage_worker_count: Option<usize>,
 
     /// Configure the number of account proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to the same count as storage workers.
+    /// If not specified, defaults to 2x available parallelism, with a minimum of 128.
     #[arg(long = "engine.account-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().account_worker_count.map(|v| v.to_string().into())))]
     pub account_worker_count: Option<usize>,
 

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -48,6 +48,15 @@ pub const DEFAULT_STATE_TRIE_OVERLAY_WORKER_THREADS: usize = 4;
 /// Default maximum number of concurrent blocking tasks (for RPC tracing guard).
 pub const DEFAULT_MAX_BLOCKING_TASKS: usize = 512;
 
+/// Minimum default size of the proof worker pools.
+///
+/// Proof workers spend most of their time blocked on database reads, so the pool
+/// size acts as an I/O queue depth, not a CPU budget. Deriving it only from
+/// available parallelism starves the disk on small CPU allocations (e.g. the
+/// 6-core EIP-7870 profile yields 12 workers, leaving multiproof computation
+/// dominated by serialized read latency).
+pub const DEFAULT_MIN_PROOF_WORKERS: usize = 128;
+
 /// Configuration for the tokio runtime.
 #[derive(Debug, Clone)]
 pub enum TokioConfig {
@@ -108,10 +117,12 @@ pub struct RayonConfig {
     /// Maximum number of concurrent blocking tasks for the RPC guard semaphore.
     pub max_blocking_tasks: usize,
     /// Number of threads for the proof storage worker pool (trie storage proof workers).
-    /// If `None`, derived from available parallelism.
+    /// If `None`, twice the available parallelism, with a floor of
+    /// [`DEFAULT_MIN_PROOF_WORKERS`].
     pub proof_storage_worker_threads: Option<usize>,
     /// Number of threads for the proof account worker pool (trie account proof workers).
-    /// If `None`, derived from available parallelism.
+    /// If `None`, twice the available parallelism, with a floor of
+    /// [`DEFAULT_MIN_PROOF_WORKERS`].
     pub proof_account_worker_threads: Option<usize>,
     /// Number of threads for the prewarming pool (execution prewarming workers).
     /// If `None`, derived from available parallelism.
@@ -922,13 +933,17 @@ impl RuntimeBuilder {
 
             let blocking_guard = BlockingTaskGuard::new(config.rayon.max_blocking_tasks);
 
-            let proof_storage_worker_threads =
-                config.rayon.proof_storage_worker_threads.unwrap_or(default_threads * 2);
+            let proof_storage_worker_threads = config
+                .rayon
+                .proof_storage_worker_threads
+                .unwrap_or_else(|| (default_threads * 2).max(DEFAULT_MIN_PROOF_WORKERS));
             let proof_storage_worker_pool =
                 WorkerPool::new(proof_storage_worker_threads, "proof-strg");
 
-            let proof_account_worker_threads =
-                config.rayon.proof_account_worker_threads.unwrap_or(default_threads * 2);
+            let proof_account_worker_threads = config
+                .rayon
+                .proof_account_worker_threads
+                .unwrap_or_else(|| (default_threads * 2).max(DEFAULT_MIN_PROOF_WORKERS));
             let proof_account_worker_pool =
                 WorkerPool::new(proof_account_worker_threads, "proof-acct");
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1466,6 +1466,9 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
             .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
             .unwrap_or_default() as u64,
         transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
+        // EIP-2780 only activates at Amsterdam; this pre-check caps `spec_id` at PRAGUE,
+        // so the gas calculation never applies the EIP-2780 adjustment here.
+        None,
     );
 
     let gas_limit = transaction.gas_limit();

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -159,18 +159,13 @@ impl ProofWorkerHandle {
     /// # Parameters
     /// - `runtime`: The centralized runtime used to spawn blocking worker tasks
     /// - `task_ctx`: Shared context with database view and prefix sets
-    /// - `halve_workers`: Whether to halve the worker pool size (for small blocks)
     #[instrument(
         name = "ProofWorkerHandle::new",
         level = "debug",
         target = "trie::proof_task",
         skip_all
     )]
-    pub fn new<Factory>(
-        runtime: &Runtime,
-        task_ctx: ProofTaskCtx<Factory>,
-        halve_workers: bool,
-    ) -> Self
+    pub fn new<Factory>(runtime: &Runtime, task_ctx: ProofTaskCtx<Factory>) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
@@ -183,11 +178,8 @@ impl ProofWorkerHandle {
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
-        let divisor = if halve_workers { 2 } else { 1 };
-        let storage_worker_count =
-            runtime.proof_storage_worker_pool().current_num_threads() / divisor;
-        let account_worker_count =
-            runtime.proof_account_worker_pool().current_num_threads() / divisor;
+        let storage_worker_count = runtime.proof_storage_worker_pool().current_num_threads();
+        let account_worker_count = runtime.proof_account_worker_pool().current_num_threads();
 
         let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
         let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
@@ -196,7 +188,6 @@ impl ProofWorkerHandle {
             target: "trie::proof_task",
             storage_worker_count,
             account_worker_count,
-            halve_workers,
             "Spawning proof worker pools"
         );
 
@@ -1180,7 +1171,7 @@ mod tests {
         let ctx = test_ctx(factory);
 
         let runtime = reth_tasks::Runtime::test();
-        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false);
+        let proof_handle = ProofWorkerHandle::new(&runtime, ctx);
 
         // Verify handle can be cloned
         let _cloned_handle = proof_handle.clone();

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1046,10 +1046,10 @@ Engine:
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
-          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
+          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, with a minimum of 128
 
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
-          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers
+          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, with a minimum of 128
 
       --engine.prewarming-threads <PREWARMING_THREADS>
           Configure the number of prewarming threads. If not specified, defaults to available parallelism


### PR DESCRIPTION
Integrates the `glam-devnet-6` branches of the revm dependency chain into reth.

Workspace git pins:
- revm → `b55020b2`
- revm-inspectors → `02dbd677`
- alloy-evm → `2eba6900`
- reth-core crates → `fed7faf`
- revmc → `glam-devnet-6` branch (`d783584a`)

Sets the new `single_error` field on revmc's `RuntimeConfig` (added upstream in the JIT single-error-mode change), defaulting it from `RuntimeConfig::default()` like the other unset fields.

Replaces #25923 (same diff, re-based on the `glamsterdam-devnet-6` branch).