### PR TITLE
feat(trie): use account storage roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1042,7 +1042,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1907,7 +1907,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3369,7 +3369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4168,8 +4168,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4746,7 +4746,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5127,7 +5127,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6204,7 +6204,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7863,9 +7863,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312c1817d0e37c6112d30fcc9e92226d8e73cc66ea6bd640c80e0e0df956cc04"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=165879b69fd5766666f220c1752e4a7f7a15b310#165879b69fd5766666f220c1752e4a7f7a15b310"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7884,9 +7883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526ee2bfded1897b7bb43f46410f487ee48a41b7e93cf18031079660b433550d"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=165879b69fd5766666f220c1752e4a7f7a15b310#165879b69fd5766666f220c1752e4a7f7a15b310"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9585,9 +9583,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66169f2c520c1c94192a18d11c5466565f079588def7d76abb631db80d353829"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=165879b69fd5766666f220c1752e4a7f7a15b310#165879b69fd5766666f220c1752e4a7f7a15b310"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10136,9 +10133,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=165879b69fd5766666f220c1752e4a7f7a15b310#165879b69fd5766666f220c1752e4a7f7a15b310"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10666,9 +10662,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd4e89ad5d14393bde9b2b152480d4fd7f2399d0f9efe80ea29ec7c0b76bcdc"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=165879b69fd5766666f220c1752e4a7f7a15b310#165879b69fd5766666f220c1752e4a7f7a15b310"
 dependencies = [
  "zstd",
 ]
@@ -11240,7 +11235,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11320,7 +11315,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11942,7 +11937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12190,7 +12185,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13469,7 +13464,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -694,3 +694,10 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "165879b69fd5766666f220c1752e4a7f7a15b310" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "165879b69fd5766666f220c1752e4a7f7a15b310" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "165879b69fd5766666f220c1752e4a7f7a15b310" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "165879b69fd5766666f220c1752e4a7f7a15b310" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "165879b69fd5766666f220c1752e4a7f7a15b310" }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -760,6 +760,7 @@ impl BalAccountStateFields {
                     .and_then(|account| account.bytecode_hash)
                     .or(Some(alloy_consensus::constants::KECCAK_EMPTY))
             }),
+            storage_root: existing_account.and_then(|account| account.storage_root),
         }
     }
 }
@@ -835,11 +836,13 @@ mod tests {
             balance: U256::from(1),
             nonce: 3,
             bytecode_hash: Some(B256::repeat_byte(0xaa)),
+            storage_root: Some(B256::repeat_byte(0xbb)),
         }));
 
         assert_eq!(account.balance, U256::from(10));
         assert_eq!(account.nonce, 3);
         assert_eq!(account.bytecode_hash, Some(B256::repeat_byte(0xaa)));
+        assert_eq!(account.storage_root, Some(B256::repeat_byte(0xbb)));
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -737,7 +737,11 @@ where
                         // If account has pending storage updates, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
-                        let storage_root = self.trie.storage_root(addr).expect("updates are drained, storage trie should be revealed by now");
+                        let storage_root = account.and_then(|account| account.storage_root).unwrap_or_else(|| {
+                            self.trie
+                                .storage_root(addr)
+                                .expect("updates are drained, storage trie should be revealed by now")
+                        });
                         let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
                         self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
                         num_promoted += 1;
@@ -829,6 +833,8 @@ fn encode_account_leaf_value(
     storage_root: B256,
     account_rlp_buf: &mut Vec<u8>,
 ) -> Vec<u8> {
+    let storage_root = account.and_then(|account| account.storage_root).unwrap_or(storage_root);
+
     if account.is_none_or(|account| account.is_empty()) && storage_root == EMPTY_ROOT_HASH {
         return Vec::new();
     }
@@ -911,7 +917,12 @@ mod tests {
         let mut hashed_state = HashedPostState::default();
         hashed_state.accounts.insert(
             address,
-            Some(Account { balance: U256::from(100), nonce: 1, bytecode_hash: None }),
+            Some(Account {
+                balance: U256::from(100),
+                nonce: 1,
+                bytecode_hash: None,
+                storage_root: None,
+            }),
         );
         let mut storage = reth_trie::HashedStorage::new(false);
         storage.storage.insert(slot, value);
@@ -966,6 +977,7 @@ mod tests {
             nonce: 7,
             balance: U256::from(42),
             bytecode_hash: Some(B256::from([0xAA; 32])),
+            storage_root: None,
         });
         let mut account_rlp_buf = vec![0x00, 0x01];
 

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -632,7 +632,8 @@ mod tests {
         let addr4 = Address::with_last_byte(4);
         let addr5 = Address::with_last_byte(5);
 
-        let account = Account { nonce: 1, balance: U256::from(100), bytecode_hash: None };
+        let account =
+            Account { nonce: 1, balance: U256::from(100), bytecode_hash: None, storage_root: None };
 
         // Build changesets: blocks 0-4 have 1 change each, block 5 has 4 changes, block 6 has 1
         let changesets: Vec<ChangeSet> = vec![

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -539,7 +539,8 @@ mod tests {
         let addr1 = Address::with_last_byte(1);
         let addr2 = Address::with_last_byte(2);
 
-        let account = Account { nonce: 1, balance: U256::from(100), bytecode_hash: None };
+        let account =
+            Account { nonce: 1, balance: U256::from(100), bytecode_hash: None, storage_root: None };
 
         // Create storage entries
         let storage_entry = |key: u8| reth_primitives_traits::StorageEntry {

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -321,7 +321,12 @@ mod tests {
 
         assert_eq!(
             provider.basic_account(&address).unwrap(),
-            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: None })
+            Some(Account {
+                nonce: 7,
+                balance: U256::from(42),
+                bytecode_hash: None,
+                storage_root: None,
+            })
         );
     }
 
@@ -342,7 +347,12 @@ mod tests {
 
         assert_eq!(
             provider.basic_account(&address).unwrap(),
-            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: Some(code_hash) })
+            Some(Account {
+                nonce: 7,
+                balance: U256::from(42),
+                bytecode_hash: Some(code_hash),
+                storage_root: None,
+            })
         );
         assert_eq!(
             provider.bytecode_by_hash(&code_hash).unwrap(),
@@ -404,11 +414,21 @@ mod tests {
 
         assert_eq!(
             provider.basic_account(&address).unwrap(),
-            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: Some(code_hash) })
+            Some(Account {
+                nonce: 7,
+                balance: U256::from(42),
+                bytecode_hash: Some(code_hash),
+                storage_root: None,
+            })
         );
         assert_eq!(
             provider.basic_account(&address).unwrap(),
-            Some(Account { nonce: 7, balance: U256::from(42), bytecode_hash: Some(code_hash) })
+            Some(Account {
+                nonce: 7,
+                balance: U256::from(42),
+                bytecode_hash: Some(code_hash),
+                storage_root: None,
+            })
         );
         assert_eq!(account_reads.load(Ordering::Relaxed), 1);
 

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -970,13 +970,18 @@ mod tests {
         db_tx
             .put::<tables::PlainAccountState>(
                 acc1,
-                Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) },
+                Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(code_hash),
+                    storage_root: None,
+                },
             )
             .unwrap();
         db_tx
             .put::<tables::PlainAccountState>(
                 acc2,
-                Account { nonce: 0, balance, bytecode_hash: None },
+                Account { nonce: 0, balance, bytecode_hash: None, storage_root: None },
             )
             .unwrap();
         db_tx.put::<tables::Bytecodes>(code_hash, Bytecode::new_raw(code.to_vec().into())).unwrap();
@@ -1029,19 +1034,25 @@ mod tests {
 
                 // check post state
                 let account1 = address!("0x1000000000000000000000000000000000000000");
-                let account1_info =
-                    Account { balance: U256::ZERO, nonce: 0x00, bytecode_hash: Some(code_hash) };
+                let account1_info = Account {
+                    balance: U256::ZERO,
+                    nonce: 0x00,
+                    bytecode_hash: Some(code_hash),
+                    storage_root: None,
+                };
                 let account2 = address!("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba");
                 let account2_info = Account {
                     balance: U256::from(0x1bc16d674ece94bau128),
                     nonce: 0x00,
                     bytecode_hash: None,
+                    storage_root: None,
                 };
                 let account3 = address!("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
                 let account3_info = Account {
                     balance: U256::from(0x3635c9adc5de996b46u128),
                     nonce: 0x01,
                     bytecode_hash: None,
+                    storage_root: None,
                 };
 
                 // assert accounts
@@ -1114,9 +1125,14 @@ mod tests {
 
         let db_tx = provider.tx_ref();
         let acc1 = address!("0x1000000000000000000000000000000000000000");
-        let acc1_info = Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) };
+        let acc1_info = Account {
+            nonce: 0,
+            balance: U256::ZERO,
+            bytecode_hash: Some(code_hash),
+            storage_root: None,
+        };
         let acc2 = address!("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-        let acc2_info = Account { nonce: 0, balance, bytecode_hash: None };
+        let acc2_info = Account { nonce: 0, balance, bytecode_hash: None, storage_root: None };
 
         db_tx.put::<tables::PlainAccountState>(acc1, acc1_info).unwrap();
         db_tx.put::<tables::PlainAccountState>(acc2, acc2_info).unwrap();
@@ -1294,9 +1310,13 @@ mod tests {
         let code_hash = keccak256(code);
 
         // pre state
-        let caller_info = Account { nonce: 0, balance, bytecode_hash: None };
-        let destroyed_info =
-            Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) };
+        let caller_info = Account { nonce: 0, balance, bytecode_hash: None, storage_root: None };
+        let destroyed_info = Account {
+            nonce: 0,
+            balance: U256::ZERO,
+            bytecode_hash: Some(code_hash),
+            storage_root: None,
+        };
 
         // set account
         let provider = test_db.factory.provider_rw().unwrap();
@@ -1354,7 +1374,8 @@ mod tests {
                     Account {
                         nonce: 0,
                         balance: U256::from(0x1bc16d674eca30a0u64),
-                        bytecode_hash: None
+                        bytecode_hash: None,
+                        storage_root: None,
                     }
                 ),
                 (
@@ -1362,7 +1383,8 @@ mod tests {
                     Account {
                         nonce: 1,
                         balance: U256::from(0xde0b6b3a761cf60u64),
-                        bytecode_hash: None
+                        bytecode_hash: None,
+                        storage_root: None,
                     }
                 )
             ]

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -119,6 +119,7 @@ impl AccountHashingStage {
                     nonce: nonce - 1,
                     balance: balance - U256::from(1),
                     bytecode_hash: None,
+                    storage_root: None,
                 };
                 let acc_before_tx = AccountBeforeTx { address: *addr, info: Some(prev_acc) };
                 acc_changeset_cursor.append(t, &acc_before_tx)?;
@@ -464,6 +465,7 @@ mod tests {
                             nonce: nonce - 1,
                             balance: balance - U256::from(1),
                             bytecode_hash: None,
+                            storage_root: None,
                         };
                         let hashed_addr = keccak256(address);
                         if let Some((_, acc)) = hashed_acc_cursor.seek_exact(hashed_addr)? {

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -123,7 +123,12 @@ mod tests {
             .tx_ref()
             .put::<tables::PlainAccountState>(
                 address!("0x1000000000000000000000000000000000000000"),
-                Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) },
+                Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(code_hash),
+                    storage_root: None,
+                },
             )
             .unwrap();
         provider_rw
@@ -134,6 +139,7 @@ mod tests {
                     nonce: 0,
                     balance: U256::from(0x3635c9adc5dea00000u128),
                     bytecode_hash: None,
+                    storage_root: None,
                 },
             )
             .unwrap();

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -412,6 +412,7 @@ where
                     nonce: account.nonce.unwrap_or_default(),
                     balance: account.balance,
                     bytecode_hash,
+                    storage_root: None,
                 }),
                 storage,
             ),
@@ -997,6 +998,7 @@ fn write_account_to_db<TX: DbTxMut>(
         nonce: genesis_account.nonce.unwrap_or_default(),
         balance: genesis_account.balance,
         bytecode_hash,
+        storage_root: None,
     };
 
     let hashed_address = keccak256(address);
@@ -1085,6 +1087,7 @@ where
         nonce: genesis_account.nonce.unwrap_or_default(),
         balance: genesis_account.balance,
         bytecode_hash,
+        storage_root: None,
     };
 
     let hashed_address = keccak256(address);

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1419,6 +1419,7 @@ mod tests {
             nonce: 18446744073709551615,
             bytecode_hash: Some(B256::random()),
             balance: U256::MAX,
+            storage_root: None,
         };
         let key = Address::from_str("0xa2c122be93b0074270ebee7f6b7292c7deb45047")
             .expect(ERROR_ETH_ADDRESS);

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1941,6 +1941,7 @@ mod tests {
             nonce: 1,
             balance: U256::from(1000),
             bytecode_hash: None,
+            storage_root: None,
         };
         let slot = U256::from(0x42);
         let slot_b256 = B256::from(slot);
@@ -2026,6 +2027,7 @@ mod tests {
             nonce: 1,
             balance: U256::from(1000),
             bytecode_hash: None,
+            storage_root: None,
         };
         let slot = U256::from(0x42);
 
@@ -2125,6 +2127,7 @@ mod tests {
             nonce: 1,
             balance: U256::from(1000),
             bytecode_hash: None,
+            storage_root: None,
         };
         let slot = U256::from(0x42);
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4720,7 +4720,15 @@ mod tests {
                 .tx
                 .cursor_write::<tables::PlainAccountState>()
                 .unwrap()
-                .upsert(address, &Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None })
+                .upsert(
+                    address,
+                    &Account {
+                        nonce: 0,
+                        balance: U256::ZERO,
+                        bytecode_hash: None,
+                        storage_root: None,
+                    },
+                )
                 .unwrap();
             provider_rw.commit().unwrap();
         }
@@ -4733,8 +4741,18 @@ mod tests {
         state_init.insert(
             address,
             (
-                Some(Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None }),
-                Some(Account { nonce: 1, balance: U256::ZERO, bytecode_hash: None }),
+                Some(Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: None,
+                    storage_root: None,
+                }),
+                Some(Account {
+                    nonce: 1,
+                    balance: U256::ZERO,
+                    bytecode_hash: None,
+                    storage_root: None,
+                }),
                 storage_map,
             ),
         );
@@ -4744,7 +4762,12 @@ mod tests {
         block_reverts.insert(
             address,
             (
-                Some(Some(Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None })),
+                Some(Some(Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: None,
+                    storage_root: None,
+                })),
                 vec![StorageEntry { key: slot_key, value: U256::ZERO }],
             ),
         );
@@ -5343,7 +5366,12 @@ mod tests {
                 .unwrap()
                 .upsert(
                     hashed_address,
-                    &Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None },
+                    &Account {
+                        nonce: 0,
+                        balance: U256::ZERO,
+                        bytecode_hash: None,
+                        storage_root: None,
+                    },
                 )
                 .unwrap();
             provider_rw.commit().unwrap();

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -936,13 +936,19 @@ mod tests {
         )
         .unwrap();
 
-        let acc_plain = Account { nonce: 100, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at15 = Account { nonce: 15, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at10 = Account { nonce: 10, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at7 = Account { nonce: 7, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at3 = Account { nonce: 3, balance: U256::ZERO, bytecode_hash: None };
+        let acc_plain =
+            Account { nonce: 100, balance: U256::ZERO, bytecode_hash: None, storage_root: None };
+        let acc_at15 =
+            Account { nonce: 15, balance: U256::ZERO, bytecode_hash: None, storage_root: None };
+        let acc_at10 =
+            Account { nonce: 10, balance: U256::ZERO, bytecode_hash: None, storage_root: None };
+        let acc_at7 =
+            Account { nonce: 7, balance: U256::ZERO, bytecode_hash: None, storage_root: None };
+        let acc_at3 =
+            Account { nonce: 3, balance: U256::ZERO, bytecode_hash: None, storage_root: None };
 
-        let higher_acc_plain = Account { nonce: 4, balance: U256::ZERO, bytecode_hash: None };
+        let higher_acc_plain =
+            Account { nonce: 4, balance: U256::ZERO, bytecode_hash: None, storage_root: None };
 
         // setup
         tx.put::<tables::AccountChangeSets>(1, AccountBeforeTx { address: ADDRESS, info: None })
@@ -1320,10 +1326,20 @@ mod tests {
         factory.set_storage_settings_cache(StorageSettings::v2());
 
         let slot = U256::from_be_bytes(*STORAGE);
-        let account: revm::state::AccountInfo =
-            Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None }.into();
-        let higher_account: revm::state::AccountInfo =
-            Account { nonce: 1, balance: U256::from(2000), bytecode_hash: None }.into();
+        let account: revm::state::AccountInfo = Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: None,
+            storage_root: None,
+        }
+        .into();
+        let higher_account: revm::state::AccountInfo = Account {
+            nonce: 1,
+            balance: U256::from(2000),
+            bytecode_hash: None,
+            storage_root: None,
+        }
+        .into();
 
         let mut rng = generators::rng();
         let blocks = random_block_range(
@@ -1390,14 +1406,24 @@ mod tests {
             .tx_ref()
             .put::<tables::HashedAccounts>(
                 hashed_address,
-                Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None },
+                Account {
+                    nonce: 1,
+                    balance: U256::from(1000),
+                    bytecode_hash: None,
+                    storage_root: None,
+                },
             )
             .unwrap();
         provider_rw
             .tx_ref()
             .put::<tables::HashedAccounts>(
                 hashed_higher_address,
-                Account { nonce: 1, balance: U256::from(2000), bytecode_hash: None },
+                Account {
+                    nonce: 1,
+                    balance: U256::from(2000),
+                    bytecode_hash: None,
+                    storage_root: None,
+                },
             )
             .unwrap();
         provider_rw.commit().unwrap();

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -728,6 +728,7 @@ mod tests {
                         nonce: block_num,
                         balance: U256::from(block_num * 1000),
                         bytecode_hash: None,
+                        storage_root: None,
                     }),
                 })
                 .collect()
@@ -814,7 +815,12 @@ mod tests {
                 .append_account_changeset(
                     vec![AccountBeforeTx {
                         address: other_address,
-                        info: Some(Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None }),
+                        info: Some(Account {
+                            nonce: 0,
+                            balance: U256::ZERO,
+                            bytecode_hash: None,
+                            storage_root: None,
+                        }),
                     }],
                     1,
                 )
@@ -829,6 +835,7 @@ mod tests {
                             nonce: 1,
                             balance: U256::from(1000),
                             bytecode_hash: None,
+                            storage_root: None,
                         }),
                     }],
                     2,
@@ -911,6 +918,7 @@ mod tests {
                             nonce: block_num,
                             balance: U256::from(block_num * 1000 + i as u64),
                             bytecode_hash: None,
+                            storage_root: None,
                         }),
                     });
                 }
@@ -1028,6 +1036,7 @@ mod tests {
                         nonce: 1,
                         balance: U256::from(1000),
                         bytecode_hash: None,
+                        storage_root: None,
                     }),
                 })
                 .collect();

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -47,6 +47,7 @@ mod tests {
                         nonce: block_num,
                         balance: U256::from(block_num * 1000 + i as u64),
                         bytecode_hash: None,
+                        storage_root: None,
                     }),
                 }
             })

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -235,7 +235,7 @@ impl ExtendedAccount {
     /// Create new instance of extended account
     pub fn new(nonce: u64, balance: U256) -> Self {
         Self {
-            account: Account { nonce, balance, bytecode_hash: None },
+            account: Account { nonce, balance, bytecode_hash: None, storage_root: None },
             bytecode: None,
             storage: Default::default(),
         }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -887,7 +887,12 @@ mod tests {
         type PreState = BTreeMap<Address, (Account, BTreeMap<B256, U256>)>;
         let mut prestate: PreState = (0..10)
             .map(|key| {
-                let account = Account { nonce: 1, balance: U256::from(key), bytecode_hash: None };
+                let account = Account {
+                    nonce: 1,
+                    balance: U256::from(key),
+                    bytecode_hash: None,
+                    storage_root: None,
+                };
                 let storage =
                     (1..11).map(|key| (B256::with_last_byte(key), U256::from(key))).collect();
                 (Address::with_last_byte(key), (account, storage))
@@ -1038,8 +1043,12 @@ mod tests {
         assert_state_root(&state, &prestate, "changed nonce");
 
         // recreate account 1
-        let account1_new =
-            Account { nonce: 56, balance: U256::from(123), bytecode_hash: Some(B256::random()) };
+        let account1_new = Account {
+            nonce: 56,
+            balance: U256::from(123),
+            bytecode_hash: Some(B256::random()),
+            storage_root: None,
+        };
         prestate.insert(address1, (account1_new, BTreeMap::default()));
         state.commit(HashMap::from_iter([(
             address1,

--- a/crates/trie/common/src/account.rs
+++ b/crates/trie/common/src/account.rs
@@ -63,7 +63,8 @@ mod tests {
             Account {
                 nonce: 10,
                 balance: U256::from(1000),
-                bytecode_hash: Some(keccak256([0x60, 0x61]))
+                bytecode_hash: Some(keccak256([0x60, 0x61])),
+                storage_root: None,
             }
             .into_trie_account(expected_storage_root),
             trie_account

--- a/crates/trie/common/src/added_removed_keys.rs
+++ b/crates/trie/common/src/added_removed_keys.rs
@@ -194,7 +194,12 @@ mod tests {
         let addr = B256::random();
 
         // Add account with non-empty state (has balance)
-        let account = Account { balance: U256::from(1000), nonce: 0, bytecode_hash: None };
+        let account = Account {
+            balance: U256::from(1000),
+            nonce: 0,
+            bytecode_hash: None,
+            storage_root: None,
+        };
         update.accounts.insert(addr, Some(account));
 
         // Add empty storage

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -1650,7 +1650,15 @@ mod tests {
 
         let state = HashedPostState {
             accounts: B256Map::from_iter([
-                (addr1, Some(Account { nonce: 1, balance: U256::from(100), bytecode_hash: None })),
+                (
+                    addr1,
+                    Some(Account {
+                        nonce: 1,
+                        balance: U256::from(100),
+                        bytecode_hash: None,
+                        storage_root: None,
+                    }),
+                ),
                 (addr2, None),
                 (addr3, Some(Account::default())),
             ]),

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -248,6 +248,7 @@ impl MultiProof {
                     balance: account.balance,
                     nonce: account.nonce,
                     bytecode_hash: (account.code_hash != KECCAK_EMPTY).then_some(account.code_hash),
+                    storage_root: Some(account.storage_root),
                 })
             }
             None
@@ -377,6 +378,7 @@ impl DecodedMultiProof {
                     balance: account.balance,
                     nonce: account.nonce,
                     bytecode_hash: (account.code_hash != KECCAK_EMPTY).then_some(account.code_hash),
+                    storage_root: Some(account.storage_root),
                 })
             }
             None
@@ -827,7 +829,15 @@ impl AccountProof {
             // See: https://github.com/ethereum/go-ethereum/issues/28441
             (EMPTY_ROOT_HASH, None)
         } else {
-            (storage_hash, Some(Account { nonce, balance, bytecode_hash: code_hash.into() }))
+            (
+                storage_hash,
+                Some(Account {
+                    nonce,
+                    balance,
+                    bytecode_hash: code_hash.into(),
+                    storage_root: Some(storage_hash),
+                }),
+            )
         };
 
         Self { address, info, proof: account_proof, storage_root, storage_proofs }
@@ -1245,7 +1255,12 @@ mod tests {
             address: Address::random(),
             info: Some(
                 // non-empty account
-                Account { nonce: 100, balance: U256::ZERO, bytecode_hash: Some(KECCAK_EMPTY) },
+                Account {
+                    nonce: 100,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(KECCAK_EMPTY),
+                    storage_root: None,
+                },
             ),
             proof: vec![],
             storage_root: B256::ZERO,
@@ -1340,6 +1355,7 @@ mod tests {
                 nonce: 42,
                 balance: U256::from(100),
                 bytecode_hash: Some(KECCAK_EMPTY),
+                storage_root: None,
             }),
             proof: vec![],
             storage_root: B256::random(),

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -388,7 +388,12 @@ mod tests {
         let mut hashed_state = HashedPostState::default();
         hashed_state.accounts.insert(
             B256::from(U256::from(1)),
-            Some(Account { nonce: 1, balance: U256::from(10), bytecode_hash: None }),
+            Some(Account {
+                nonce: 1,
+                balance: U256::from(10),
+                bytecode_hash: None,
+                storage_root: None,
+            }),
         );
         hashed_state.accounts.insert(B256::from(U256::from(2)), None);
         hashed_state.storages.insert(

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -244,7 +244,10 @@ fn holesky_deposit_contract_proof() {
         info: Some(Account {
             balance: U256::ZERO,
             nonce: 0,
-            bytecode_hash: Some(b256!("0x2034f79e0e33b0ae6bef948532021baceb116adf2616478703bec6b17329f1cc"))
+            bytecode_hash: Some(b256!(
+                "0x2034f79e0e33b0ae6bef948532021baceb116adf2616478703bec6b17329f1cc"
+            )),
+            storage_root: None,
         }),
         storage_root: b256!("0x556a482068355939c95a3412bdb21213a301483edb1b64402fb66ac9f3583599"),
         proof: convert_to_proof([

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -158,14 +158,24 @@ fn test_empty_account() {
         (
             Address::random(),
             (
-                Account { nonce: 0, balance: U256::from(0), bytecode_hash: None },
+                Account {
+                    nonce: 0,
+                    balance: U256::from(0),
+                    bytecode_hash: None,
+                    storage_root: None,
+                },
                 BTreeMap::from([(B256::with_last_byte(0x4), U256::from(12))]),
             ),
         ),
         (
             Address::random(),
             (
-                Account { nonce: 0, balance: U256::from(0), bytecode_hash: None },
+                Account {
+                    nonce: 0,
+                    balance: U256::from(0),
+                    bytecode_hash: None,
+                    storage_root: None,
+                },
                 BTreeMap::default(),
             ),
         ),
@@ -176,6 +186,7 @@ fn test_empty_account() {
                     nonce: 155,
                     balance: U256::from(414241124u32),
                     bytecode_hash: Some(keccak256("test")),
+                    storage_root: None,
                 },
                 BTreeMap::from([
                     (B256::ZERO, U256::from(3)),
@@ -199,6 +210,7 @@ fn test_empty_storage_root() {
         nonce: 155,
         balance: U256::from(414241124u32),
         bytecode_hash: Some(keccak256(code)),
+        storage_root: None,
     };
     insert_account(tx.tx_ref(), address, account, &Default::default());
     tx.commit().unwrap();
@@ -225,6 +237,7 @@ fn test_storage_root() {
         nonce: 155,
         balance: U256::from(414241124u32),
         bytecode_hash: Some(keccak256(code)),
+        storage_root: None,
     };
 
     insert_account(tx.tx_ref(), address, account, &storage);
@@ -312,7 +325,8 @@ fn test_state_root_with_state(state: State) {
 }
 
 fn encode_account(account: Account, storage_root: Option<B256>) -> Vec<u8> {
-    let account = account.into_trie_account(storage_root.unwrap_or(EMPTY_ROOT_HASH));
+    let account =
+        account.into_trie_account(storage_root.or(account.storage_root).unwrap_or(EMPTY_ROOT_HASH));
     let mut account_rlp = Vec::with_capacity(account.length());
     account.encode(&mut account_rlp);
     account_rlp
@@ -378,7 +392,12 @@ fn account_and_storage_trie() {
 
     // Insert first account
     let key1 = b256!("0xb000000000000000000000000000000000000000000000000000000000000000");
-    let account1 = Account { nonce: 0, balance: U256::from(3).mul(ether), bytecode_hash: None };
+    let account1 = Account {
+        nonce: 0,
+        balance: U256::from(3).mul(ether),
+        bytecode_hash: None,
+        storage_root: None,
+    };
     hashed_account_cursor.upsert(key1, &account1).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key1), &encode_account(account1, None));
 
@@ -397,8 +416,12 @@ fn account_and_storage_trie() {
     assert_eq!(key3[0], 0xB0);
     assert_eq!(key3[1], 0x41);
     let code_hash = b256!("0x5be74cad16203c4905c068b012a2e9fb6d19d036c410f16fd177f337541440dd");
-    let account3 =
-        Account { nonce: 0, balance: U256::from(2).mul(ether), bytecode_hash: Some(code_hash) };
+    let account3 = Account {
+        nonce: 0,
+        balance: U256::from(2).mul(ether),
+        bytecode_hash: Some(code_hash),
+        storage_root: None,
+    };
     hashed_account_cursor.upsert(key3, &account3).unwrap();
     for (hashed_slot, value) in storage {
         if hashed_storage_cursor
@@ -481,7 +504,12 @@ fn account_and_storage_trie() {
     let address4b = address!("0x4f61f2d5ebd991b85aa1677db97307caf5215c91");
     let key4b = keccak256(address4b);
     assert_eq!(key4b.0[0], key4a.0[0]);
-    let account4b = Account { nonce: 0, balance: U256::from(5).mul(ether), bytecode_hash: None };
+    let account4b = Account {
+        nonce: 0,
+        balance: U256::from(5).mul(ether),
+        bytecode_hash: None,
+        storage_root: None,
+    };
     hashed_account_cursor.upsert(key4b, &account4b).unwrap();
 
     let mut prefix_set = PrefixSetMut::default();
@@ -767,7 +795,12 @@ fn extension_node_storage_trie<N: ProviderNodeTypes>(
 fn extension_node_trie<N: ProviderNodeTypes>(
     tx: &DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>, N>,
 ) -> B256 {
-    let a = Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(B256::random()) };
+    let a = Account {
+        nonce: 0,
+        balance: U256::from(1u64),
+        bytecode_hash: Some(B256::random()),
+        storage_root: None,
+    };
     let val = encode_account(a, None);
 
     let mut hashed_accounts = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -9,7 +9,7 @@ use reth_provider::{DatabaseProviderROFactory, ProviderError};
 use reth_storage_errors::db::DatabaseError;
 use reth_tasks::Runtime;
 use reth_trie::{
-    hashed_cursor::HashedCursorFactory,
+    hashed_cursor::{HashedCursor, HashedCursorFactory},
     node_iter::{TrieElement, TrieNodeIter},
     prefix_set::TriePrefixSets,
     trie_cursor::TrieCursorFactory,
@@ -91,16 +91,31 @@ where
             self.prefix_sets.storage_prefix_sets,
         );
 
+        let provider = self.factory.database_provider_ro()?;
+
         // Pre-calculate storage roots in parallel for accounts which were changed.
-        tracker.set_precomputed_storage_roots(storage_root_targets.len() as u64);
-        debug!(target: "trie::parallel_state_root", len = storage_root_targets.len(), "pre-calculating storage roots");
+        let storage_root_targets_len = storage_root_targets.len();
+        debug!(target: "trie::parallel_state_root", len = storage_root_targets_len, "pre-calculating storage roots");
         let mut storage_roots = HashMap::with_capacity(storage_root_targets.len());
+        let mut precomputed_storage_roots = 0;
 
         let handle = self.runtime.handle().clone();
+        let mut hashed_account_cursor =
+            provider.hashed_account_cursor().map_err(ProviderError::Database)?;
 
         for (hashed_address, prefix_set) in
             storage_root_targets.into_iter().sorted_unstable_by_key(|(address, _)| *address)
         {
+            if hashed_account_cursor
+                .seek(hashed_address)
+                .map_err(ProviderError::Database)?
+                .is_some_and(|(address, account)| {
+                    address == hashed_address && account.storage_root.is_some()
+                })
+            {
+                continue;
+            }
+
             let factory = self.factory.clone();
             #[cfg(feature = "metrics")]
             let metrics = self.metrics.storage_trie.clone();
@@ -124,12 +139,13 @@ where
                 let _ = tx.send(result);
             }));
             storage_roots.insert(hashed_address, rx);
+            precomputed_storage_roots += 1;
         }
+        tracker.set_precomputed_storage_roots(precomputed_storage_roots);
+        drop(hashed_account_cursor);
 
         trace!(target: "trie::parallel_state_root", "calculating state root");
         let mut trie_updates = TrieUpdates::default();
-
-        let provider = self.factory.database_provider_ro()?;
 
         let walker = TrieWalker::<_>::state_trie(
             provider.account_trie_cursor().map_err(ProviderError::Database)?,
@@ -149,42 +165,51 @@ where
                     hash_builder.add_branch(node.key, node.value, node.children_are_in_trie);
                 }
                 TrieElement::Leaf(hashed_address, account) => {
-                    let storage_root_result = match storage_roots.remove(&hashed_address) {
-                        Some(rx) => rx.recv().map_err(|_| {
-                            ParallelStateRootError::StorageRoot(StorageRootError::Database(
-                                DatabaseError::Other(format!(
-                                    "channel closed for {hashed_address}"
-                                )),
-                            ))
-                        })??,
-                        // Since we do not store all intermediate nodes in the database, there might
-                        // be a possibility of re-adding a non-modified leaf to the hash builder.
-                        None => {
-                            tracker.inc_missed_leaves();
-                            StorageRoot::new_hashed(
-                                &provider,
-                                &provider,
-                                hashed_address,
-                                Default::default(),
-                                #[cfg(feature = "metrics")]
-                                self.metrics.storage_trie.clone(),
-                            )
-                            .calculate(retain_updates)?
-                        }
-                    };
-
-                    let (storage_root, _, updates) = match storage_root_result {
-                        reth_trie::StorageRootProgress::Complete(root, _, updates) => (root, (), updates),
-                        reth_trie::StorageRootProgress::Progress(..) => {
-                            return Err(ParallelStateRootError::StorageRoot(
-                                StorageRootError::Database(DatabaseError::Other(
-                                    "StorageRoot returned Progress variant in parallel trie calculation".to_string()
+                    let (storage_root, updates) = if let Some(storage_root) = account.storage_root {
+                        (storage_root, None)
+                    } else {
+                        let storage_root_result = match storage_roots.remove(&hashed_address) {
+                            Some(rx) => rx.recv().map_err(|_| {
+                                ParallelStateRootError::StorageRoot(StorageRootError::Database(
+                                    DatabaseError::Other(format!(
+                                        "channel closed for {hashed_address}"
+                                    )),
                                 ))
-                            ))
-                        }
+                            })??,
+                            // Since we do not store all intermediate nodes in the database, there
+                            // might be a possibility of re-adding a non-modified leaf to the hash
+                            // builder.
+                            None => {
+                                tracker.inc_missed_leaves();
+                                StorageRoot::new_hashed(
+                                    &provider,
+                                    &provider,
+                                    hashed_address,
+                                    Default::default(),
+                                    #[cfg(feature = "metrics")]
+                                    self.metrics.storage_trie.clone(),
+                                )
+                                .calculate(retain_updates)?
+                            }
+                        };
+
+                        let (storage_root, _, updates) = match storage_root_result {
+                            reth_trie::StorageRootProgress::Complete(root, _, updates) => {
+                                (root, (), updates)
+                            }
+                            reth_trie::StorageRootProgress::Progress(..) => {
+                                return Err(ParallelStateRootError::StorageRoot(
+                                    StorageRootError::Database(DatabaseError::Other(
+                                        "StorageRoot returned Progress variant in parallel trie calculation".to_string()
+                                    ))
+                                ))
+                            }
+                        };
+
+                        (storage_root, Some(updates))
                     };
 
-                    if retain_updates {
+                    if retain_updates && let Some(updates) = updates {
                         trie_updates.insert_storage_updates(hashed_address, updates);
                     }
 

--- a/crates/trie/parallel/src/value_encoder.rs
+++ b/crates/trie/parallel/src/value_encoder.rs
@@ -159,6 +159,7 @@ where
 
                 let root = match result.root {
                     Some(root) => root,
+                    None if let Some(storage_root) = account.storage_root => storage_root,
                     None => {
                         // In `compute_v2_account_multiproof` we ensure that all dispatched storage
                         // proofs computations for which there is also an account proof will return
@@ -185,13 +186,19 @@ where
             Self::Sync { storage_calculator, hashed_address, account, cached_storage_roots } => {
                 let hashed_address = *hashed_address;
                 let account = *account;
-                let mut calculator = storage_calculator.borrow_mut();
-                let root_node = calculator.storage_root_node(hashed_address)?;
-                let storage_root = calculator
-                    .compute_root_hash(&[root_node])?
-                    .expect("storage_root_node returns a node at empty path");
+                let storage_root = if let Some(storage_root) = account.storage_root {
+                    storage_root
+                } else {
+                    let mut calculator = storage_calculator.borrow_mut();
+                    let root_node = calculator.storage_root_node(hashed_address)?;
+                    let storage_root = calculator
+                        .compute_root_hash(&[root_node])?
+                        .expect("storage_root_node returns a node at empty path");
 
-                cached_storage_roots.insert(hashed_address, storage_root);
+                    cached_storage_roots.insert(hashed_address, storage_root);
+                    storage_root
+                };
+
                 (account, storage_root)
             }
         };
@@ -319,6 +326,11 @@ where
 
         // If the address didn't have a job dispatched for it then we can assume it has no targets,
         // and we only need its root.
+
+        if let Some(root) = account.storage_root {
+            self.stats.borrow_mut().from_cache_count += 1;
+            return AsyncAccountDeferredValueEncoder::FromCache { account, root }
+        }
 
         // If the root is already calculated then just use it directly
         if let Some(root) = self.cached_storage_roots.get(&hashed_address) {

--- a/crates/trie/trie/src/progress.rs
+++ b/crates/trie/trie/src/progress.rs
@@ -61,6 +61,7 @@ impl From<MerkleCheckpoint> for IntermediateStateRootState {
                         nonce: checkpoint.account_nonce,
                         balance: checkpoint.account_balance,
                         bytecode_hash: Some(checkpoint.account_bytecode_hash),
+                        storage_root: None,
                     },
                 }
             }),

--- a/crates/trie/trie/src/proof/mod.rs
+++ b/crates/trie/trie/src/proof/mod.rs
@@ -227,32 +227,41 @@ where
                     let leaf_is_proof_target = proof_targets.is_some();
                     let collect_storage_masks =
                         self.collect_branch_node_masks && leaf_is_proof_target;
-                    let storage_prefix_set = self
-                        .prefix_sets
-                        .storage_prefix_sets
-                        .remove(&hashed_address)
-                        .unwrap_or_default();
-                    let storage_multiproof = StorageProof::new_hashed(
-                        self.trie_cursor_factory.clone(),
-                        self.hashed_cursor_factory.clone(),
-                        hashed_address,
-                    )
-                    .with_prefix_set_mut(storage_prefix_set)
-                    .with_branch_node_masks(collect_storage_masks)
-                    .storage_multiproof(proof_targets.unwrap_or_default())?;
+                    let storage_root =
+                        if !leaf_is_proof_target && let Some(storage_root) = account.storage_root {
+                            storage_root
+                        } else {
+                            let storage_prefix_set = self
+                                .prefix_sets
+                                .storage_prefix_sets
+                                .remove(&hashed_address)
+                                .unwrap_or_default();
+                            let storage_multiproof = StorageProof::new_hashed(
+                                self.trie_cursor_factory.clone(),
+                                self.hashed_cursor_factory.clone(),
+                                hashed_address,
+                            )
+                            .with_prefix_set_mut(storage_prefix_set)
+                            .with_branch_node_masks(collect_storage_masks)
+                            .storage_multiproof(proof_targets.unwrap_or_default())?;
+
+                            let storage_root = storage_multiproof.root;
+
+                            // We might be adding leaves that are not necessarily our proof targets.
+                            if leaf_is_proof_target {
+                                // Overwrite storage multiproof.
+                                storages.insert(hashed_address, storage_multiproof);
+                            }
+
+                            storage_root
+                        };
 
                     // Encode account
                     account_rlp.clear();
-                    let account = account.into_trie_account(storage_multiproof.root);
+                    let account = account.into_trie_account(storage_root);
                     account.encode(&mut account_rlp as &mut dyn BufMut);
 
                     hash_builder.add_leaf(Nibbles::unpack(hashed_address), &account_rlp);
-
-                    // We might be adding leaves that are not necessarily our proof targets.
-                    if leaf_is_proof_target {
-                        // Overwrite storage multiproof.
-                        storages.insert(hashed_address, storage_multiproof);
-                    }
                 }
             }
         }

--- a/crates/trie/trie/src/proof_v2/value.rs
+++ b/crates/trie/trie/src/proof_v2/value.rs
@@ -123,18 +123,24 @@ where
     H: HashedCursorFactory,
 {
     fn encode(self, buf: &mut Vec<u8>) -> Result<(), StateProofError> {
-        let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(self.hashed_address)?;
-        let hashed_cursor =
-            self.hashed_cursor_factory.hashed_storage_cursor(self.hashed_address)?;
+        let storage_root = if let Some(storage_root) = self.account.storage_root {
+            storage_root
+        } else {
+            let trie_cursor = self.trie_cursor_factory.storage_trie_cursor(self.hashed_address)?;
+            let hashed_cursor =
+                self.hashed_cursor_factory.hashed_storage_cursor(self.hashed_address)?;
 
-        let mut storage_proof_calculator = ProofCalculator::new_storage(trie_cursor, hashed_cursor);
-        if let Some(prefix_set) = self.storage_prefix_sets.get(&self.hashed_address) {
-            storage_proof_calculator = storage_proof_calculator.with_prefix_set(prefix_set.clone());
-        }
-        let root_node = storage_proof_calculator.storage_root_node(self.hashed_address)?;
-        let storage_root = storage_proof_calculator
-            .compute_root_hash(&[root_node])?
-            .expect("storage_root_node returns a node at empty path");
+            let mut storage_proof_calculator =
+                ProofCalculator::new_storage(trie_cursor, hashed_cursor);
+            if let Some(prefix_set) = self.storage_prefix_sets.get(&self.hashed_address) {
+                storage_proof_calculator =
+                    storage_proof_calculator.with_prefix_set(prefix_set.clone());
+            }
+            let root_node = storage_proof_calculator.storage_root_node(self.hashed_address)?;
+            storage_proof_calculator
+                .compute_root_hash(&[root_node])?
+                .expect("storage_root_node returns a node at empty path")
+        };
 
         let trie_account = self.account.into_trie_account(storage_root);
         trie_account.encode(buf);

--- a/crates/trie/trie/src/test_utils.rs
+++ b/crates/trie/trie/src/test_utils.rs
@@ -13,7 +13,7 @@ where
     S: IntoIterator<Item = (B256, U256)>,
 {
     let encoded_accounts = accounts.into_iter().map(|(address, (account, storage))| {
-        let storage_root = storage_root(storage);
+        let storage_root = account.storage_root.unwrap_or_else(|| storage_root(storage));
         let account = account.into_trie_account(storage_root);
         (address, alloy_rlp::encode(account))
     });
@@ -34,7 +34,7 @@ where
     S: IntoIterator<Item = (B256, U256)>,
 {
     let encoded_accounts = accounts.into_iter().map(|(address, (account, storage))| {
-        let storage_root = storage_root_prehashed(storage);
+        let storage_root = account.storage_root.unwrap_or_else(|| storage_root_prehashed(storage));
         let account = account.into_trie_account(storage_root);
         (address, alloy_rlp::encode(account))
     });

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -269,55 +269,67 @@ where
                     tracker.inc_leaf();
                     storage_ctx.hashed_entries_walked += 1;
 
-                    // calculate storage root, calculating the remaining threshold so we have
-                    // bounded memory usage even while in the middle of storage root calculation
-                    let remaining_threshold = self.threshold.saturating_sub(
-                        storage_ctx.total_updates_len(&account_node_iter, &hash_builder),
-                    );
-
-                    if hashed_storage_cursor.is_none() {
-                        hashed_storage_cursor =
-                            Some(self.hashed_cursor_factory.hashed_storage_cursor(hashed_address)?);
-                    }
-                    if storage_trie_cursor.is_none() {
-                        storage_trie_cursor =
-                            Some(self.trie_cursor_factory.storage_trie_cursor(hashed_address)?);
-                    }
-
-                    let storage_result = StorageRoot::<T, H>::calculate_with_cursors(
-                        StorageRootCalculation {
+                    if let Some(storage_root) = account.storage_root {
+                        storage_ctx.add_account_leaf(
                             hashed_address,
-                            prefix_set: self
-                                .prefix_sets
-                                .storage_prefix_sets
-                                .get(&hashed_address)
-                                .cloned()
-                                .unwrap_or_default(),
-                            previous_state: None,
-                            threshold: remaining_threshold,
+                            account,
+                            storage_root,
+                            &mut hash_builder,
+                        );
+                    } else {
+                        // calculate storage root, calculating the remaining threshold so we have
+                        // bounded memory usage even while in the middle of storage root calculation
+                        let remaining_threshold = self.threshold.saturating_sub(
+                            storage_ctx.total_updates_len(&account_node_iter, &hash_builder),
+                        );
+
+                        if hashed_storage_cursor.is_none() {
+                            hashed_storage_cursor = Some(
+                                self.hashed_cursor_factory.hashed_storage_cursor(hashed_address)?,
+                            );
+                        }
+                        if storage_trie_cursor.is_none() {
+                            storage_trie_cursor =
+                                Some(self.trie_cursor_factory.storage_trie_cursor(hashed_address)?);
+                        }
+
+                        let storage_result = StorageRoot::<T, H>::calculate_with_cursors(
+                            StorageRootCalculation {
+                                hashed_address,
+                                prefix_set: self
+                                    .prefix_sets
+                                    .storage_prefix_sets
+                                    .get(&hashed_address)
+                                    .cloned()
+                                    .unwrap_or_default(),
+                                previous_state: None,
+                                threshold: remaining_threshold,
+                                retain_updates,
+                            },
+                            storage_trie_cursor
+                                .as_mut()
+                                .expect("storage trie cursor is initialized"),
+                            hashed_storage_cursor
+                                .as_mut()
+                                .expect("hashed storage cursor is initialized"),
+                            #[cfg(feature = "metrics")]
+                            &self.metrics.storage_trie,
+                        )?;
+                        if let Some(storage_state) = storage_ctx.process_storage_root_result(
+                            storage_result,
+                            hashed_address,
+                            account,
+                            &mut hash_builder,
                             retain_updates,
-                        },
-                        storage_trie_cursor.as_mut().expect("storage trie cursor is initialized"),
-                        hashed_storage_cursor
-                            .as_mut()
-                            .expect("hashed storage cursor is initialized"),
-                        #[cfg(feature = "metrics")]
-                        &self.metrics.storage_trie,
-                    )?;
-                    if let Some(storage_state) = storage_ctx.process_storage_root_result(
-                        storage_result,
-                        hashed_address,
-                        account,
-                        &mut hash_builder,
-                        retain_updates,
-                    )? {
-                        // storage root hit threshold, need to pause
-                        return Ok(storage_ctx.create_progress_state(
-                            account_node_iter,
-                            hash_builder,
-                            hashed_address,
-                            Some(storage_state),
-                        ))
+                        )? {
+                            // storage root hit threshold, need to pause
+                            return Ok(storage_ctx.create_progress_state(
+                                account_node_iter,
+                                hash_builder,
+                                hashed_address,
+                                Some(storage_state),
+                            ))
+                        }
                     }
 
                     // decide if we need to return intermediate progress
@@ -455,10 +467,7 @@ impl StateRootContext {
                 }
 
                 // Encode the account with the computed storage root
-                self.account_rlp.clear();
-                let trie_account = account.into_trie_account(storage_root);
-                trie_account.encode(&mut self.account_rlp as &mut dyn BufMut);
-                hash_builder.add_leaf(Nibbles::unpack(hashed_address), &self.account_rlp);
+                self.add_account_leaf(hashed_address, account, storage_root, hash_builder);
                 Ok(None)
             }
             StorageRootProgress::Progress(state, storage_slots_walked, updates) => {
@@ -480,6 +489,19 @@ impl StateRootContext {
                 Ok(Some(IntermediateStorageRootState { state: *state, account }))
             }
         }
+    }
+
+    fn add_account_leaf(
+        &mut self,
+        hashed_address: B256,
+        account: Account,
+        storage_root: B256,
+        hash_builder: &mut HashBuilder,
+    ) {
+        self.account_rlp.clear();
+        let trie_account = account.into_trie_account(storage_root);
+        trie_account.encode(&mut self.account_rlp as &mut dyn BufMut);
+        hash_builder.add_leaf(Nibbles::unpack(hashed_address), &self.account_rlp);
     }
 }
 

--- a/crates/trie/trie/src/verify.rs
+++ b/crates/trie/trie/src/verify.rs
@@ -544,6 +544,7 @@ mod tests {
                 nonce: 1,
                 balance: U256::from(1000),
                 bytecode_hash: Some(keccak256(b"code1")),
+                storage_root: None,
             },
         );
 
@@ -613,6 +614,7 @@ mod tests {
                     nonce: i as u64,
                     balance: U256::from(i as u64 * 1000),
                     bytecode_hash: (i == 2).then(|| keccak256([i])),
+                    storage_root: None,
                 },
             );
 

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -249,17 +249,18 @@ where
                 .ok_or(TrieWitnessError::MissingAccount(hashed_address))?
                 .unwrap_or_default();
 
-            let storage_root =
-                if let Some(storage_trie) = sparse_trie.storage_trie_mut(&hashed_address) {
-                    storage_trie.root()
-                } else {
-                    let record_root_node = !self.mode.is_canonical() ||
-                        state
-                            .storages
-                            .get(&hashed_address)
-                            .is_some_and(|storage| !storage.storage.is_empty());
-                    self.account_storage_root(hashed_address, record_root_node)?
-                };
+            let storage_root = if let Some(storage_root) = account.storage_root {
+                storage_root
+            } else if let Some(storage_trie) = sparse_trie.storage_trie_mut(&hashed_address) {
+                storage_trie.root()
+            } else {
+                let record_root_node = !self.mode.is_canonical() ||
+                    state
+                        .storages
+                        .get(&hashed_address)
+                        .is_some_and(|storage| !storage.storage.is_empty());
+                self.account_storage_root(hashed_address, record_root_node)?
+            };
 
             if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
                 account_removals.insert(hashed_address, LeafUpdate::Changed(vec![]));

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -421,7 +421,7 @@ pub fn random_eoa_account<R: Rng>(rng: &mut R) -> (Address, Account) {
     let balance = U256::from(rng.random::<u32>());
     let addr = Address::random();
 
-    (addr, Account { nonce, balance, bytecode_hash: None })
+    (addr, Account { nonce, balance, bytecode_hash: None, storage_root: None })
 }
 
 /// Generate random Externally Owned Accounts


### PR DESCRIPTION
Pins reth-core to paradigmxyz/reth-core@165879b69fd5766666f220c1752e4a7f7a15b310 and uses Account.storage_root when available while encoding trie accounts. Falls back to the existing storage-root calculation when the optional field is unset.