### PR TITLE
perf: reusable state storage cursor

### DIFF
--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -152,7 +152,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
                 let db_at = {
                     |block_number: u64| {
-                        StateProviderDatabase(
+                        StateProviderDatabase::new(
                             provider
                                 .history_by_block_number(block_number)
                                 .unwrap(),

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -2,7 +2,9 @@ use crate::primitives::alloy_primitives::{BlockNumber, StorageKey, StorageValue}
 use alloy_primitives::{Address, B256, U256};
 use core::ops::{Deref, DerefMut};
 use reth_primitives_traits::Account;
-use reth_storage_api::{AccountReader, BlockHashReader, BytecodeReader, StateProvider};
+use reth_storage_api::{
+    AccountReader, BlockHashReader, BytecodeReader, StateProvider, StateProviderStorageCursor,
+};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use revm::{bytecode::Bytecode, state::AccountInfo, Database, DatabaseRef};
 
@@ -31,6 +33,9 @@ pub trait EvmStateProvider {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
+
+    /// Returns a cursor for repeated storage lookups.
+    fn storage_cursor(&self) -> ProviderResult<Box<dyn StateProviderStorageCursor + '_>>;
 }
 
 // Blanket implementation of EvmStateProvider for any type that implements StateProvider.
@@ -57,22 +62,40 @@ impl<T: StateProvider> EvmStateProvider for T {
     ) -> ProviderResult<Option<StorageValue>> {
         <T as StateProvider>::storage(self, account, storage_key)
     }
+
+    fn storage_cursor(&self) -> ProviderResult<Box<dyn StateProviderStorageCursor + '_>> {
+        <T as StateProvider>::storage_cursor(self)
+    }
 }
 
 /// A [Database] and [`DatabaseRef`] implementation that uses [`EvmStateProvider`] as the underlying
 /// data source.
-#[derive(Clone)]
-pub struct StateProviderDatabase<DB>(pub DB);
+pub struct StateProviderDatabase<DB> {
+    storage_cursor: Option<Box<dyn StateProviderStorageCursor + 'static>>,
+    /// The underlying state provider.
+    pub db: DB,
+}
+
+impl<DB: Clone> Clone for StateProviderDatabase<DB> {
+    fn clone(&self) -> Self {
+        Self::new(self.db.clone())
+    }
+}
+
+// SAFETY: the cached cursor is created and used through `Database::storage`, which requires
+// `&mut self`. Execution workers do not move an active database between threads while it is being
+// accessed.
+unsafe impl<DB: Send> Send for StateProviderDatabase<DB> {}
 
 impl<DB> StateProviderDatabase<DB> {
     /// Create new State with generic `StateProvider`.
     pub const fn new(db: DB) -> Self {
-        Self(db)
+        Self { storage_cursor: None, db }
     }
 
     /// Consume State and return inner `StateProvider`.
     pub fn into_inner(self) -> DB {
-        self.0
+        self.db
     }
 }
 
@@ -92,13 +115,13 @@ impl<DB> Deref for StateProviderDatabase<DB> {
     type Target = DB;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.db
     }
 }
 
 impl<DB> DerefMut for StateProviderDatabase<DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.db
     }
 }
 
@@ -124,7 +147,25 @@ impl<DB: EvmStateProvider> Database for StateProviderDatabase<DB> {
     ///
     /// Returns `Ok` with the storage value, or the default value if not found.
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        self.storage_ref(address, index)
+        let storage_key = B256::new(index.to_be_bytes());
+        if self.storage_cursor.is_none() {
+            let cursor = self.db.storage_cursor()?;
+            // SAFETY: `storage_cursor` is declared before `db`, so it is dropped first. The cursor
+            // never outlives this `StateProviderDatabase`, and `db` is not moved while the cursor is
+            // cached because `storage` requires `&mut self`.
+            self.storage_cursor = Some(unsafe {
+                core::mem::transmute::<
+                    Box<dyn StateProviderStorageCursor + '_>,
+                    Box<dyn StateProviderStorageCursor + 'static>,
+                >(cursor)
+            });
+        }
+        Ok(self
+            .storage_cursor
+            .as_mut()
+            .expect("cursor initialized")
+            .storage(address, storage_key)?
+            .unwrap_or_default())
     }
 
     /// Retrieves the block hash for a given block number.
@@ -158,7 +199,7 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     ///
     /// Returns `Ok` with the storage value, or the default value if not found.
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        Ok(self.0.storage(address, B256::new(index.to_be_bytes()))?.unwrap_or_default())
+        Ok(self.db.storage(address, B256::new(index.to_be_bytes()))?.unwrap_or_default())
     }
 
     /// Retrieves the block hash for a given block number.
@@ -166,7 +207,7 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     /// Returns `Ok` with the block hash if found, or the default hash otherwise.
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
         // Get the block hash or default hash with an attempt to convert U256 block number to u64
-        Ok(self.0.block_hash(number)?.unwrap_or_default())
+        Ok(self.db.block_hash(number)?.unwrap_or_default())
     }
 }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -101,7 +101,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let max_simulate_blocks = self.max_simulate_blocks();
 
             self.spawn_with_state_at_block(block, move |this, db| {
-                let state_provider = db.database.0 .0;
+                let state_provider = db.database.db.0;
                 let mut db = State::builder()
                     .with_database(StateProviderDatabase::new(&state_provider))
                     .with_bundle_update()

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -553,7 +553,7 @@ where
                     .map_err(|err| EthApiError::Internal(err.into()))?;
 
                 Ok(witness_record
-                    .into_execution_witness(&db.database.0, eth_api.provider(), block_number, mode)
+                    .into_execution_witness(&db.database.db, eth_api.provider(), block_number, mode)
                     .map_err(EthApiError::from)?)
             })
             .await

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -122,7 +122,7 @@ where
         let gas_limit_override = self.gas_limit_override;
         self.eth_api
             .spawn_with_state_at_block(request.parent_block_hash, move |eth_api, state| {
-                let state = state.database.0;
+                let state = state.database.db;
                 let parent = eth_api
                     .provider()
                     .sealed_header_by_hash(request.parent_block_hash)?

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -304,7 +304,7 @@ where
 
         self.ensure_consistency(provider, input.checkpoint().block_number, None)?;
 
-        let db = StateProviderDatabase(LatestStateProviderRef::new(provider));
+        let db = StateProviderDatabase::new(LatestStateProviderRef::new(provider));
         let mut executor = self.evm_config.batch_executor(db);
 
         // Progress tracking

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -15,8 +15,8 @@ use reth_db_api::{
 use reth_primitives_traits::{Account, Bytecode, NodePrimitives};
 use reth_storage_api::{
     BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider, PruneCheckpointReader,
-    StageCheckpointReader, StateProofProvider, StorageChangeSetReader, StorageRootProvider,
-    StorageSettingsCache,
+    StageCheckpointReader, StateProofProvider, StateProviderStorageCursor, StorageChangeSetReader,
+    StorageRootProvider, StorageSettingsCache,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
@@ -52,6 +52,76 @@ type DbProof<'a, TX, A> = Proof<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
     reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
 >;
+
+enum HistoricalPlainStateStorageCursor<Hashed, Plain> {
+    Hashed(Hashed),
+    Plain(Plain),
+}
+
+struct HistoricalStorageCursor<'a, Provider, N, Hashed, Plain>
+where
+    Provider: NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+{
+    provider: &'a HistoricalStateProviderRef<'a, Provider, N>,
+    plain_state_cursor: HistoricalPlainStateStorageCursor<Hashed, Plain>,
+}
+
+impl<Provider, N, Hashed, Plain> StateProviderStorageCursor
+    for HistoricalStorageCursor<'_, Provider, N, Hashed, Plain>
+where
+    Provider: DBProvider
+        + BlockNumReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
+        + StorageSettingsCache
+        + RocksDBProviderFactory
+        + NodePrimitivesProvider<Primitives = N>,
+    N: NodePrimitives,
+    Hashed: DbDupCursorRO<tables::HashedStorages>,
+    Plain: DbDupCursorRO<tables::PlainStorageState>,
+{
+    fn storage(
+        &mut self,
+        address: Address,
+        lookup_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        match self.provider.storage_history_lookup(address, lookup_key)? {
+            HistoryInfo::NotYetWritten => Ok(None),
+            HistoryInfo::InChangeset(changeset_block_number) => self
+                .provider
+                .provider
+                .get_storage_before_block(changeset_block_number, address, lookup_key)?
+                .ok_or_else(|| ProviderError::StorageChangesetNotFound {
+                    block_number: changeset_block_number,
+                    address,
+                    storage_key: Box::new(lookup_key),
+                })
+                .map(|entry| entry.value)
+                .map(Some),
+            HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                match &mut self.plain_state_cursor {
+                    HistoricalPlainStateStorageCursor::Hashed(cursor) => {
+                        let hashed_address = alloy_primitives::keccak256(address);
+                        let hashed_slot = alloy_primitives::keccak256(lookup_key);
+                        Ok(cursor
+                            .seek_by_key_subkey(hashed_address, hashed_slot)?
+                            .filter(|entry| entry.key == hashed_slot)
+                            .map(|entry| entry.value)
+                            .or(Some(StorageValue::ZERO)))
+                    }
+                    HistoricalPlainStateStorageCursor::Plain(cursor) => Ok(cursor
+                        .seek_by_key_subkey(address, lookup_key)?
+                        .filter(|entry| entry.key == lookup_key)
+                        .map(|entry| entry.value)
+                        .or(Some(StorageValue::ZERO))),
+                }
+            }
+        }
+    }
+}
 
 /// Result of a history lookup for an account or storage slot.
 ///
@@ -669,6 +739,20 @@ where
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
         self.storage_by_lookup_key(address, storage_key)
+    }
+
+    fn storage_cursor(&self) -> ProviderResult<Box<dyn StateProviderStorageCursor + '_>> {
+        let plain_state_cursor = if self.provider.cached_storage_settings().use_hashed_state() {
+            HistoricalPlainStateStorageCursor::Hashed(
+                self.tx().cursor_dup_read::<tables::HashedStorages>()?,
+            )
+        } else {
+            HistoricalPlainStateStorageCursor::Plain(
+                self.tx().cursor_dup_read::<tables::PlainStorageState>()?,
+            )
+        };
+
+        Ok(Box::new(HistoricalStorageCursor { provider: self, plain_state_cursor }))
     }
 }
 

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -5,7 +5,8 @@ use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B2
 use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
 use reth_primitives_traits::{Account, Bytecode};
 use reth_storage_api::{
-    BytecodeReader, DBProvider, StateProofProvider, StorageRootProvider, StorageSettingsCache,
+    BytecodeReader, DBProvider, StateProofProvider, StateProviderStorageCursor,
+    StorageRootProvider, StorageSettingsCache,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::{
@@ -37,6 +38,51 @@ type DbProof<'a, TX, A> = Proof<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
     reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
 >;
+
+struct LatestHashedStorageCursor<C> {
+    cursor: C,
+}
+
+impl<C> StateProviderStorageCursor for LatestHashedStorageCursor<C>
+where
+    C: DbDupCursorRO<tables::HashedStorages>,
+{
+    fn storage(
+        &mut self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let hashed_address = alloy_primitives::keccak256(account);
+        let hashed_slot = alloy_primitives::keccak256(storage_key);
+        Ok(self
+            .cursor
+            .seek_by_key_subkey(hashed_address, hashed_slot)?
+            .filter(|entry| entry.key == hashed_slot)
+            .map(|entry| entry.value))
+    }
+}
+
+struct LatestPlainStorageCursor<C> {
+    cursor: C,
+}
+
+impl<C> StateProviderStorageCursor for LatestPlainStorageCursor<C>
+where
+    C: DbDupCursorRO<tables::PlainStorageState>,
+{
+    fn storage(
+        &mut self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        Ok(self
+            .cursor
+            .seek_by_key_subkey(account, storage_key)?
+            .filter(|entry| entry.key == storage_key)
+            .map(|entry| entry.value))
+    }
+}
+
 /// State provider over latest state that takes tx reference.
 ///
 /// Wraps a [`DBProvider`] to get access to database.
@@ -279,6 +325,18 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
                 return Ok(Some(entry.value));
             }
             Ok(None)
+        }
+    }
+
+    fn storage_cursor(&self) -> ProviderResult<Box<dyn StateProviderStorageCursor + '_>> {
+        if self.0.cached_storage_settings().use_hashed_state() {
+            Ok(Box::new(LatestHashedStorageCursor {
+                cursor: self.tx().cursor_dup_read::<tables::HashedStorages>()?,
+            }))
+        } else {
+            Ok(Box::new(LatestPlainStorageCursor {
+                cursor: self.tx().cursor_dup_read::<tables::PlainStorageState>()?,
+            }))
         }
     }
 }

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -47,6 +47,11 @@ pub trait StateProvider:
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
 
+    /// Returns a cursor for repeated storage lookups.
+    fn storage_cursor(&self) -> ProviderResult<Box<dyn StateProviderStorageCursor + '_>> {
+        Ok(Box::new(FallbackStateProviderStorageCursor(self)))
+    }
+
     /// Get account code by its address.
     ///
     /// Returns `None` if the account doesn't exist or account is not a contract
@@ -87,6 +92,30 @@ pub trait StateProvider:
         // Get basic account information
         // Returns None if acc doesn't exist
         self.basic_account(addr)?.map_or_else(|| Ok(None), |acc| Ok(Some(acc.nonce)))
+    }
+}
+
+/// Cursor for repeated storage lookups against a [`StateProvider`].
+pub trait StateProviderStorageCursor {
+    /// Get storage of given account.
+    fn storage(
+        &mut self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>>;
+}
+
+struct FallbackStateProviderStorageCursor<'a, P: ?Sized>(&'a P);
+
+impl<P: StateProvider + ?Sized> StateProviderStorageCursor
+    for FallbackStateProviderStorageCursor<'_, P>
+{
+    fn storage(
+        &mut self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        self.0.storage(account, storage_key)
     }
 }
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -244,7 +244,7 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
 
         // Execute the block
         let state_provider = provider.latest();
-        let state_db = StateProviderDatabase(&state_provider);
+        let state_db = StateProviderDatabase::new(&state_provider);
         let executor = executor_provider.batch_executor(state_db);
 
         let output = executor


### PR DESCRIPTION
Adds reusable storage cursors for StateProvider-backed EVM execution so validation and builder storage reads do not reopen MDBX dup cursors on every slot lookup.

- Adds StateProviderStorageCursor with a default fallback to StateProvider::storage.
- Makes StateProviderDatabase lazily create and reuse one storage cursor for Database::storage calls.
- Overrides storage_cursor for latest and historical DB-backed providers with HashedStorages/PlainStorageState dup cursors.
- Updates existing StateProviderDatabase construction/access sites after switching it away from a tuple struct.
- Leaves DatabaseRef::storage_ref on the existing fallback path.

Validation:
- cargo check -p reth-storage-api -p reth-provider -p reth-revm -p reth-engine-tree -p reth-ethereum-payload-builder -p ef-tests -p reth-cli-commands -p reth-stages -p reth-rpc-eth-api -p reth-rpc

Prompted by: @rkrasiuk