### PR TITLE
Compute auxiliary roots from full hashed state

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -212,6 +212,15 @@ impl<N: NodePrimitives> HashedPostStateProvider for MemoryOverlayStateProviderRe
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
         self.historical.hashed_post_state(bundle_state)
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        let mut state = self.historical.hashed_post_state_for_accounts(accounts)?;
+        state.extend_ref(&self.trie_input().state);
+        Ok(state)
+    }
 }
 
 impl<N: NodePrimitives> StateProvider for MemoryOverlayStateProviderRef<'_, N> {

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -255,12 +255,12 @@ struct CacheMetricSnapshot {
 
 impl CacheMetricSnapshot {
     const fn is_empty(&self) -> bool {
-        self.account_hits == 0 &&
-            self.account_misses == 0 &&
-            self.storage_hits == 0 &&
-            self.storage_misses == 0 &&
-            self.code_hits == 0 &&
-            self.code_misses == 0
+        self.account_hits == 0
+            && self.account_misses == 0
+            && self.storage_hits == 0
+            && self.storage_misses == 0
+            && self.code_hits == 0
+            && self.code_misses == 0
     }
 }
 
@@ -821,6 +821,13 @@ impl<S: HashedPostStateProvider> HashedPostStateProvider for CachedStateProvider
     fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
         self.state_provider.hashed_post_state(bundle_state)
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[alloy_primitives::Address],
+    ) -> ProviderResult<HashedPostState> {
+        self.state_provider.hashed_post_state_for_accounts(accounts)
+    }
 }
 
 /// Execution cache used during block processing.
@@ -1030,7 +1037,7 @@ impl ExecutionCache {
             // If the account was not modified, as in not changed and not destroyed, then we have
             // nothing to do w.r.t. this particular account and can move on
             if account.status.is_not_modified() {
-                continue
+                continue;
             }
 
             // If the original account had code (was a contract), we must clear the entire cache
@@ -1053,7 +1060,7 @@ impl ExecutionCache {
                         );
                     });
                     self.clear();
-                    return Ok(())
+                    return Ok(());
                 }
 
                 self.0.account_cache.remove(addr);
@@ -1065,7 +1072,7 @@ impl ExecutionCache {
             // `None` current info, should be destroyed.
             let Some(ref account_info) = account.info else {
                 trace!(target: "engine::caching", ?account, "Account with None account info found in state updates");
-                return Err(())
+                return Err(());
             };
 
             // Now we iterate over all storage and make updates to the cached storage values

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -12,7 +12,7 @@
 extern crate alloc;
 
 use alloy_consensus::BlockHeader;
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use reth_errors::ConsensusError;
 use reth_payload_primitives::{
     EngineApiMessageVersion, EngineObjectValidationError, InvalidPayloadAttributesError,
@@ -60,6 +60,11 @@ pub struct AuxiliaryStateRoot {
     pub expected_root: B256,
     /// Hashed state updates to stream into the auxiliary sparse trie task.
     pub state_updates: HashedPostState,
+    /// Accounts whose complete hashed state should be loaded before applying `state_updates`.
+    ///
+    /// If set, the engine tree computes the auxiliary root directly from the resulting full hashed
+    /// state without revealing trie nodes from a provider.
+    pub full_state_accounts: Option<Vec<Address>>,
     /// Whether the auxiliary hashed state and trie updates should become this block's retained trie
     /// data.
     ///

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -300,6 +300,13 @@ impl<S: HashedPostStateProvider> HashedPostStateProvider for InstrumentedStatePr
     fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
         self.state_provider.hashed_post_state(bundle_state)
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[alloy_primitives::Address],
+    ) -> ProviderResult<HashedPostState> {
+        self.state_provider.hashed_post_state_for_accounts(accounts)
+    }
 }
 
 /// Accumulated fetch statistics from an [`InstrumentedStateProvider`].

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -316,7 +316,8 @@ where
                           + ChangeSetReader
                           + StorageChangeSetReader
                           + BlockNumReader
-                          + StorageSettingsCache,
+                          + StorageSettingsCache
+                          + HashedPostStateProvider,
         > + BlockReader<Header = N::BlockHeader>
         + ChangeSetReader
         + BlockNumReader
@@ -1083,12 +1084,8 @@ where
             let _ = valid_block_tx.send(());
         }
 
-        let mut executed_block = self.spawn_deferred_trie_task(
-            Arc::new(block),
-            output,
-            hashed_state,
-            trie_output,
-        );
+        let mut executed_block =
+            self.spawn_deferred_trie_task(Arc::new(block), output, hashed_state, trie_output);
         if let Some(auxiliary_trie_data) = retained_auxiliary_trie_data {
             executed_block = executed_block.with_auxiliary_trie_data(auxiliary_trie_data);
         }
@@ -1527,8 +1524,9 @@ where
         auxiliary_state_root: AuxiliaryStateRoot,
     ) -> Result<StateRootComputeOutcome, ParallelStateRootError>
     where
-        F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
-            + Clone
+        F: DatabaseProviderROFactory<
+                Provider: TrieCursorFactory + HashedCursorFactory + HashedPostStateProvider,
+            > + Clone
             + Send
             + Sync
             + 'static,
@@ -1537,8 +1535,25 @@ where
             parent_root,
             expected_root: _,
             state_updates,
+            full_state_accounts,
             retain_trie_data: _,
         } = auxiliary_state_root;
+
+        if let Some(full_state_accounts) = full_state_accounts {
+            let mut full_state = multiproof_provider_factory
+                .database_provider_ro()
+                .map_err(ParallelStateRootError::Provider)?
+                .hashed_post_state_for_accounts(&full_state_accounts)
+                .map_err(ParallelStateRootError::Provider)?;
+            full_state.extend(state_updates);
+            return Ok(StateRootComputeOutcome {
+                state_root: reth_trie::root_from_full_hashed_state(full_state)
+                    .map_err(|err| ParallelStateRootError::Other(err.to_string()))?,
+                trie_updates: Arc::new(TrieUpdates::default()),
+                #[cfg(feature = "trie-debug")]
+                debug_recorders: Vec::new(),
+            });
+        }
 
         if state_updates.is_empty() {
             return Ok(StateRootComputeOutcome {
@@ -2380,7 +2395,8 @@ where
                           + ChangeSetReader
                           + StorageChangeSetReader
                           + BlockNumReader
-                          + StorageSettingsCache,
+                          + StorageSettingsCache
+                          + HashedPostStateProvider,
         > + BlockReader<Header = N::BlockHeader>
         + StateProviderFactory
         + StateReader

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -37,7 +37,9 @@ use reth_node_builder::{
 };
 use reth_node_core::args::JitArgs;
 use reth_payload_primitives::PayloadTypes;
-use reth_provider::{providers::ProviderFactoryBuilder, EthStorage};
+use reth_provider::{
+    providers::ProviderFactoryBuilder, DatabaseProviderFactory, EthStorage, HashedPostStateProvider,
+};
 use reth_rpc::{
     eth::core::{EthApiFor, EthRpcConverterFor},
     TestingApi, ValidationApi,
@@ -438,6 +440,7 @@ where
 impl<N> Node<N> for EthereumNode
 where
     N: FullNodeTypes<Types = Self>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -460,7 +463,11 @@ where
     }
 }
 
-impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for EthereumNode {
+impl<N> DebugNode<N> for EthereumNode
+where
+    N: FullNodeComponents<Types = Self>,
+    <N::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
+{
     type RpcBlock = alloy_rpc_types_eth::Block;
 
     fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> reth_ethereum_primitives::Block {

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -32,6 +32,7 @@ use reth_node_core::{
     version::{version_metadata, CLIENT_CODE},
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
+use reth_provider::{DatabaseProviderFactory, HashedPostStateProvider};
 use reth_rpc::{
     eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
     AdminApi,
@@ -1453,6 +1454,7 @@ where
             <Node::Types as NodeTypes>::Payload,
             Block = BlockTy<Node::Types>,
         > + Clone,
+    <Node::Provider as DatabaseProviderFactory>::Provider: HashedPostStateProvider,
 {
     type EngineValidator = BasicEngineValidator<Node::Provider, Node::Evm, EV::Validator>;
 

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -144,6 +144,13 @@ impl HashedPostStateProvider for StateProviderTraitObjWrapper {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> reth_trie::HashedPostState {
         self.0.hashed_post_state(bundle_state)
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> reth_errors::ProviderResult<reth_trie::HashedPostState> {
+        self.0.hashed_post_state_for_accounts(accounts)
+    }
 }
 
 impl StateProvider for StateProviderTraitObjWrapper {

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -609,8 +609,8 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
     }
 
     fn pending_state_by_hash(&self, block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
-        if let Some(pending) = self.canonical_in_memory_state.pending_state() &&
-            pending.hash() == block_hash
+        if let Some(pending) = self.canonical_in_memory_state.pending_state()
+            && pending.hash() == block_hash
         {
             return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
         }
@@ -619,16 +619,23 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
     fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
         if let Some(pending) = self.canonical_in_memory_state.pending_state() {
-            return Ok(Some(Box::new(self.block_state_provider(&pending)?)))
+            return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
         }
 
         Ok(None)
     }
 }
 
-impl<N: NodeTypesWithDB> HashedPostStateProvider for BlockchainProvider<N> {
+impl<N: ProviderNodeTypes> HashedPostStateProvider for BlockchainProvider<N> {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
         HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        self.latest()?.hashed_post_state_for_accounts(accounts)
     }
 }
 
@@ -1007,8 +1014,8 @@ mod tests {
     ) {
         let hook_provider = provider.clone();
         provider.database.db_ref().set_post_transaction_hook(Box::new(move || {
-            if let Some(state) = hook_provider.canonical_in_memory_state.head_state() &&
-                state.anchor().number + 1 == block_number
+            if let Some(state) = hook_provider.canonical_in_memory_state.head_state()
+                && state.anchor().number + 1 == block_number
             {
                 let mut lowest_memory_block =
                     state.parent_state_chain().last().expect("qed").block();

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -957,6 +957,13 @@ impl<N: ProviderNodeTypes> HashedPostStateProvider for ProviderFactory<N> {
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
         HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        self.latest()?.hashed_post_state_for_accounts(accounts)
+    }
 }
 
 impl<N: ProviderNodeTypes> MetadataProvider for ProviderFactory<N> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -60,14 +60,15 @@ use reth_prune_types::{
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
-    BlockBodyIndicesProvider, BlockBodyReader, MetadataProvider, MetadataWriter,
-    NodePrimitivesProvider, StateProvider, StateReader, StateWriteConfig, StorageChangeSetReader,
-    StoragePath, StorageSettingsCache, TryIntoHistoricalStateProvider, WriteStateInput,
+    BlockBodyIndicesProvider, BlockBodyReader, HashedPostStateProvider, MetadataProvider,
+    MetadataWriter, NodePrimitivesProvider, StateProvider, StateReader, StateWriteConfig,
+    StorageChangeSetReader, StoragePath, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    WriteStateInput,
 };
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
 use reth_trie::{
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
-    HashedPostStateSorted,
+    HashedPostState, HashedPostStateSorted, HashedStorage,
 };
 use reth_trie_db::{
     ChangesetCache, DatabaseStorageTrieCursor, ProvableTrieTableAdapter, StorageTrieEntryLike,
@@ -314,10 +315,10 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         &'a self,
         mut block_number: BlockNumber,
     ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
-        if block_number == self.best_block_number().unwrap_or_default() &&
-            block_number == self.last_block_number().unwrap_or_default()
+        if block_number == self.best_block_number().unwrap_or_default()
+            && block_number == self.last_block_number().unwrap_or_default()
         {
-            return Ok(Box::new(LatestStateProviderRef::new(self)))
+            return Ok(Box::new(LatestStateProviderRef::new(self)));
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.
@@ -540,22 +541,22 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<StaticFileWriteCtx> {
         let tip = self.last_block_number()?.max(last_block);
         Ok(StaticFileWriteCtx {
-            write_senders: EitherWriterDestination::senders(self).is_static_file() &&
-                self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
-            write_receipts: save_mode.with_state() &&
-                EitherWriter::receipts_destination(self).is_static_file(),
-            write_account_changesets: save_mode.with_state() &&
-                EitherWriterDestination::account_changesets(self).is_static_file(),
-            write_storage_changesets: save_mode.with_state() &&
-                EitherWriterDestination::storage_changesets(self).is_static_file(),
+            write_senders: EitherWriterDestination::senders(self).is_static_file()
+                && self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
+            write_receipts: save_mode.with_state()
+                && EitherWriter::receipts_destination(self).is_static_file(),
+            write_account_changesets: save_mode.with_state()
+                && EitherWriterDestination::account_changesets(self).is_static_file(),
+            write_storage_changesets: save_mode.with_state()
+                && EitherWriterDestination::storage_changesets(self).is_static_file(),
             tip,
             receipts_prune_mode: self.prune_modes.receipts,
             // Receipts are prunable if no receipts exist in SF yet and within pruning distance
             receipts_prunable: self
                 .static_file_provider
                 .get_highest_static_file_tx(StaticFileSegment::Receipts)
-                .is_none() &&
-                PruneMode::Distance(self.minimum_pruning_distance)
+                .is_none()
+                && PruneMode::Distance(self.minimum_pruning_distance)
                     .should_prune(first_block, tip),
         })
     }
@@ -586,7 +587,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<()> {
         if blocks.is_empty() {
             debug!(target: "providers::db", "Attempted to write empty block range");
-            return Ok(())
+            return Ok(());
         }
 
         let total_start = Instant::now();
@@ -661,8 +662,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let mdbx_start = Instant::now();
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
-            if !self.cached_storage_settings().storage_v2 &&
-                self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
+            if !self.cached_storage_settings().storage_v2
+                && self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
             {
                 let start = Instant::now();
                 let total_tx_count: usize =
@@ -744,12 +745,10 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }
 
-                let merged_provable_trie = TrieUpdatesSorted::merge_batch(
-                    blocks
-                        .iter()
-                        .rev()
-                        .filter_map(|block| block.auxiliary_trie_data().map(|data| data.trie_updates)),
-                );
+                let merged_provable_trie =
+                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().filter_map(|block| {
+                        block.auxiliary_trie_data().map(|data| data.trie_updates)
+                    }));
                 if !merged_provable_trie.is_empty() {
                     self.write_provable_trie_updates_sorted(&merged_provable_trie)?;
                 }
@@ -801,8 +800,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         block: &RecoveredBlock<BlockTy<N>>,
         first_tx_num: TxNumber,
     ) -> ProviderResult<StoredBlockBodyIndices> {
-        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()) &&
-            EitherWriterDestination::senders(self).is_database()
+        if self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full())
+            && EitherWriterDestination::senders(self).is_database()
         {
             let start = Instant::now();
             let tx_nums_iter = std::iter::successors(Some(first_tx_num), |n| Some(n + 1));
@@ -1015,7 +1014,7 @@ where
     while let Some((sharded_key, list)) = item {
         // If the shard does not belong to the key, break.
         if !shard_belongs_to_key(&sharded_key) {
-            break
+            break;
         }
 
         // Always delete the current shard from the database first
@@ -1030,18 +1029,18 @@ where
         // Keep it deleted (don't return anything for reinsertion)
         if first >= block_number {
             item = cursor.prev()?;
-            continue
+            continue;
         }
         // Case 2: This is a boundary shard (spans across the unwinding point)
         // The shard contains some blocks below and some at/above the unwinding point
         else if block_number <= sharded_key.as_ref().highest_block_number {
             // Return only the block numbers that are below the unwinding point
             // These will be reinserted to preserve the historical data
-            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>())
+            return Ok(list.iter().take_while(|i| *i < block_number).collect::<Vec<_>>());
         }
         // Case 3: Entire shard is below the unwinding point
         // Return all block numbers for reinsertion (preserve entire shard)
-        return Ok(list.iter().collect::<Vec<_>>())
+        return Ok(list.iter().collect::<Vec<_>>());
     }
 
     // No shards found or all processed
@@ -1120,7 +1119,10 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         let Some(block_number) = self.convert_hash_or_number(id)? else { return Ok(None) };
         let earliest_available = self.static_file_provider.earliest_history_height();
         if block_number < earliest_available {
-            return Err(ProviderError::BlockExpired { requested: block_number, earliest_available })
+            return Err(ProviderError::BlockExpired {
+                requested: block_number,
+                earliest_available,
+            });
         }
         let Some(header) = header_by_number(block_number)? else { return Ok(None) };
 
@@ -1190,7 +1192,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         F: FnMut(H, BodyTy<N>, Range<TxNumber>) -> ProviderResult<R>,
     {
         if range.is_empty() {
-            return Ok(Vec::new())
+            return Ok(Vec::new());
         }
 
         let len = range.end().saturating_sub(*range.start()) as usize + 1;
@@ -1483,6 +1485,65 @@ impl<TX: DbTx, N: NodeTypes> AccountReader for DatabaseProvider<TX, N> {
     }
 }
 
+impl<TX: DbTx, N: NodeTypes> HashedPostStateProvider for DatabaseProvider<TX, N> {
+    fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
+        HashedPostState::from_bundle_state::<reth_trie::KeccakKeyHasher>(bundle_state.state())
+    }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        let mut state = HashedPostState::with_capacity(accounts.len());
+
+        if self.cached_storage_settings().use_hashed_state() {
+            let mut account_cursor = self.tx.cursor_read::<tables::HashedAccounts>()?;
+            let mut storage_cursor = self.tx.cursor_dup_read::<tables::HashedStorages>()?;
+
+            for address in accounts {
+                let hashed_address = keccak256(address);
+                if let Some((_, account)) = account_cursor.seek_exact(hashed_address)? {
+                    state.accounts.insert(hashed_address, Some(account));
+                }
+
+                let mut storage = HashedStorage::new(false);
+                if let Some((_, entry)) = storage_cursor.seek_exact(hashed_address)? {
+                    storage.storage.insert(entry.key, entry.value);
+                    while let Some(entry) = storage_cursor.next_dup_val()? {
+                        storage.storage.insert(entry.key, entry.value);
+                    }
+                }
+                if !storage.is_empty() {
+                    state.storages.insert(hashed_address, storage);
+                }
+            }
+        } else {
+            let mut account_cursor = self.tx.cursor_read::<tables::PlainAccountState>()?;
+            let mut storage_cursor = self.tx.cursor_dup_read::<tables::PlainStorageState>()?;
+
+            for address in accounts {
+                let hashed_address = keccak256(address);
+                if let Some((_, account)) = account_cursor.seek_exact(*address)? {
+                    state.accounts.insert(hashed_address, Some(account));
+                }
+
+                let mut storage = HashedStorage::new(false);
+                if let Some((_, entry)) = storage_cursor.seek_exact(*address)? {
+                    storage.storage.insert(keccak256(entry.key), entry.value);
+                    while let Some(entry) = storage_cursor.next_dup_val()? {
+                        storage.storage.insert(keccak256(entry.key), entry.value);
+                    }
+                }
+                if !storage.is_empty() {
+                    state.storages.insert(hashed_address, storage);
+                }
+            }
+        }
+
+        Ok(state)
+    }
+}
+
 impl<TX: DbTx + 'static, N: NodeTypes> AccountExtReader for DatabaseProvider<TX, N> {
     fn changed_accounts_with_range(
         &self,
@@ -1525,8 +1586,8 @@ impl<TX: DbTx + 'static, N: NodeTypes> AccountExtReader for DatabaseProvider<TX,
             .static_file_provider
             .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
 
-        if let Some(highest) = highest_static_block &&
-            self.cached_storage_settings().storage_v2
+        if let Some(highest) = highest_static_block
+            && self.cached_storage_settings().storage_v2
         {
             let start = *range.start();
             let static_end = (*range.end()).min(highest);
@@ -1743,7 +1804,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderSyncGapProvider
             }
             Ordering::Less => {
                 // There's either missing or corrupted files.
-                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()))
+                return Err(ProviderError::HeaderNotFound(next_static_file_block_num.into()));
             }
             Ordering::Equal => {}
         }
@@ -1859,7 +1920,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
         if let Some(number) = self.convert_hash_or_number(id)? {
             let earliest_available = self.static_file_provider.earliest_history_height();
             if number < earliest_available {
-                return Err(ProviderError::BlockExpired { requested: number, earliest_available })
+                return Err(ProviderError::BlockExpired { requested: number, earliest_available });
             }
 
             let Some(header) = self.header_by_number(number)? else { return Ok(None) };
@@ -1869,7 +1930,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
             // If they exist but are not indexed, we don't have enough
             // information to return the block anyways, so we return `None`.
             let Some(transactions) = self.transactions_by_block(number.into())? else {
-                return Ok(None)
+                return Ok(None);
             };
 
             let body = self
@@ -1879,7 +1940,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> BlockReader for DatabaseProvid
                 .pop()
                 .ok_or(ProviderError::InvalidStorageOutput)?;
 
-            return Ok(Some(Self::Block::new(header, body)))
+            return Ok(Some(Self::Block::new(header, body)));
         }
 
         Ok(None)
@@ -2039,10 +2100,10 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         &self,
         tx_hash: TxHash,
     ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
-        if let Some(transaction_id) = self.transaction_id(tx_hash)? &&
-            let Some(transaction) = self.transaction_by_id_unhashed(transaction_id)? &&
-            let Some(block_number) = self.block_by_transaction_id(transaction_id)? &&
-            let Some(sealed_header) = self.sealed_header(block_number)?
+        if let Some(transaction_id) = self.transaction_id(tx_hash)?
+            && let Some(transaction) = self.transaction_by_id_unhashed(transaction_id)?
+            && let Some(block_number) = self.block_by_transaction_id(transaction_id)?
+            && let Some(sealed_header) = self.sealed_header(block_number)?
         {
             let (header, block_hash) = sealed_header.split();
             if let Some(block_body) = self.block_body_indices(block_number)? {
@@ -2062,7 +2123,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
                     timestamp: header.timestamp(),
                 };
 
-                return Ok(Some((transaction, meta)))
+                return Ok(Some((transaction, meta)));
             }
         }
 
@@ -2073,15 +2134,15 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         &self,
         id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
-        if let Some(block_number) = self.convert_hash_or_number(id)? &&
-            let Some(body) = self.block_body_indices(block_number)?
+        if let Some(block_number) = self.convert_hash_or_number(id)?
+            && let Some(body) = self.block_body_indices(block_number)?
         {
             let tx_range = body.tx_num_range();
             return if tx_range.is_empty() {
                 Ok(Some(Vec::new()))
             } else {
                 self.transactions_by_tx_range(tx_range).map(Some)
-            }
+            };
         }
         Ok(None)
     }
@@ -2156,8 +2217,8 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
         &self,
         block: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
-        if let Some(number) = self.convert_hash_or_number(block)? &&
-            let Some(body) = self.block_body_indices(number)?
+        if let Some(number) = self.convert_hash_or_number(block)?
+            && let Some(body) = self.block_body_indices(number)?
         {
             let tx_range = body.tx_num_range();
             return if tx_range.is_empty() {
@@ -2166,11 +2227,11 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> ReceiptProvider for DatabasePr
                 let receipts = self.receipts_by_tx_range(tx_range)?;
 
                 if receipts.len() != body.tx_count as usize {
-                    return Ok(None)
+                    return Ok(None);
                 }
 
                 Ok(Some(receipts))
-            }
+            };
         }
         Ok(None)
     }
@@ -2455,10 +2516,10 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
     ) -> ProviderResult<()> {
         let execution_outcome = execution_outcome.into();
 
-        if self.cached_storage_settings().use_hashed_state() &&
-            !config.write_receipts &&
-            !config.write_account_changesets &&
-            !config.write_storage_changesets
+        if self.cached_storage_settings().use_hashed_state()
+            && !config.write_receipts
+            && !config.write_account_changesets
+            && !config.write_storage_changesets
         {
             // In storage v2 with all outputs directed to static files, plain state and changesets
             // are written elsewhere. Only bytecodes need MDBX writes, so skip the expensive
@@ -2513,11 +2574,12 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         // Database, OR if receipts_in_static_files is enabled but no receipts exist in static
         // files yet. Once receipts exist in static files, we must continue writing to maintain
         // continuity and have no gaps.
-        let prunable_receipts = (EitherWriter::receipts_destination(self).is_database() ||
-            self.static_file_provider()
+        let prunable_receipts = (EitherWriter::receipts_destination(self).is_database()
+            || self
+                .static_file_provider()
                 .get_highest_static_file_tx(StaticFileSegment::Receipts)
-                .is_none()) &&
-            PruneMode::Distance(self.minimum_pruning_distance).should_prune(first_block, tip);
+                .is_none())
+            && PruneMode::Distance(self.minimum_pruning_distance).should_prune(first_block, tip);
 
         // Prepare set of addresses which logs should not be pruned.
         let mut allowed_addresses: AddressSet = AddressSet::default();
@@ -2534,12 +2596,13 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
             receipts_writer.increment_block(block_number)?;
 
             // Skip writing receipts if pruning configuration requires us to.
-            if prunable_receipts &&
-                self.prune_modes
+            if prunable_receipts
+                && self
+                    .prune_modes
                     .receipts
                     .is_some_and(|mode| mode.should_prune(block_number, tip))
             {
-                continue
+                continue;
             }
 
             // If there are new addresses to retain after this block number, track them
@@ -2551,11 +2614,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 let receipt_idx = first_tx_index + idx as u64;
                 // Skip writing receipt if log filter is active and it does not have any logs to
                 // retain
-                if prunable_receipts &&
-                    has_contract_log_filter &&
-                    !receipt.logs().iter().any(|log| allowed_addresses.contains(&log.address))
+                if prunable_receipts
+                    && has_contract_log_filter
+                    && !receipt.logs().iter().any(|log| allowed_addresses.contains(&log.address))
                 {
-                    continue
+                    continue;
                 }
 
                 receipts_writer.append_receipt(receipt_idx, receipt)?;
@@ -2686,8 +2749,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 for entry in storage {
                     tracing::trace!(?address, ?entry.key, "Updating plain state storage");
                     if let Some(db_entry) =
-                        storages_cursor.seek_by_key_subkey(address, entry.key)? &&
-                        db_entry.key == entry.key
+                        storages_cursor.seek_by_key_subkey(address, entry.key)?
+                        && db_entry.key == entry.key
                     {
                         storages_cursor.delete_current()?;
                     }
@@ -2733,8 +2796,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                 let entry = StorageEntry { key: *hashed_slot, value: *value };
 
                 if let Some(db_entry) =
-                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&
-                    db_entry.key == entry.key
+                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)?
+                    && db_entry.key == entry.key
                 {
                     hashed_storage_cursor.delete_current()?;
                 }
@@ -2918,7 +2981,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let range = block + 1..=self.last_block_number()?;
 
         if range.is_empty() {
-            return Ok(ExecutionOutcome::default())
+            return Ok(ExecutionOutcome::default());
         }
         let start_block_number = *range.start();
 
@@ -2934,8 +2997,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let storage_range = BlockNumberAddress::range(range.clone());
         let storage_changeset = if let Some(highest_block) = self
             .static_file_provider
-            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets) &&
-            self.cached_storage_settings().storage_v2
+            .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
+            && self.cached_storage_settings().storage_v2
         {
             let changesets = self.storage_changesets_range(block + 1..=highest_block)?;
             let mut changeset_writer =
@@ -2950,8 +3013,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let highest_changeset_block = self
             .static_file_provider
             .get_highest_static_file_block(StaticFileSegment::AccountChangeSets);
-        let account_changeset = if let Some(highest_block) = highest_changeset_block &&
-            self.cached_storage_settings().storage_v2
+        let account_changeset = if let Some(highest_block) = highest_changeset_block
+            && self.cached_storage_settings().storage_v2
         {
             // TODO: add a `take` method that removes and returns the items instead of doing this
             let changesets = self.account_changesets_range(block + 1..highest_block + 1)?;
@@ -3209,10 +3272,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
                 }
 
                 if let Some(node) = maybe_updated {
-                    cursor.upsert(
-                        *hashed_address,
-                        &A::StorageValue::new(nibbles, node.clone()),
-                    )?;
+                    cursor.upsert(*hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
                 }
             }
         }
@@ -3224,7 +3284,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         trie_updates: &TrieUpdatesSorted,
     ) -> ProviderResult<usize> {
         if trie_updates.is_empty() {
-            return Ok(0)
+            return Ok(0);
         }
 
         let mut num_entries = 0;
@@ -3240,7 +3300,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         let mut storage_tries = trie_updates.storage_tries_ref().iter().collect::<Vec<_>>();
         storage_tries.sort_unstable_by(|a, b| a.0.cmp(b.0));
         reth_trie_db::with_adapter!(self, |A| {
-            Self::write_provable_storage_tries::<A>(self.tx_ref(), storage_tries, &mut num_entries)?;
+            Self::write_provable_storage_tries::<A>(
+                self.tx_ref(),
+                storage_tries,
+                &mut num_entries,
+            )?;
         });
 
         Ok(num_entries)
@@ -3254,7 +3318,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
     #[instrument(level = "debug", target = "providers::db", skip_all)]
     fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize> {
         if trie_updates.is_empty() {
-            return Ok(0)
+            return Ok(0);
         }
 
         // Track the number of inserted entries.
@@ -3512,8 +3576,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> HistoryWriter for DatabaseProvi
                     StorageShardedKey::last(address, storage_key),
                     rem_index,
                     |storage_sharded_key| {
-                        storage_sharded_key.address == address &&
-                            storage_sharded_key.sharded_key.key == storage_key
+                        storage_sharded_key.address == address
+                            && storage_sharded_key.sharded_key.key == storage_key
                     },
                 )?;
 
@@ -3807,7 +3871,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
     ) -> ProviderResult<()> {
         if blocks.is_empty() {
             debug!(target: "providers::db", "Attempted to append empty block range");
-            return Ok(())
+            return Ok(());
         }
 
         // Blocks are not empty, so no need to handle the case of `blocks.first()` being
@@ -4660,10 +4724,7 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(provable_storage_entries.len(), 1);
-        assert_eq!(
-            provable_storage_entries[0].1.nibbles.0,
-            Nibbles::from_nibbles([0x3, 0x4])
-        );
+        assert_eq!(provable_storage_entries[0].1.nibbles.0, Nibbles::from_nibbles([0x3, 0x4]));
 
         provider_rw.commit().unwrap();
     }
@@ -5271,8 +5332,8 @@ mod tests {
                     ..Default::default()
                 };
 
-                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1..=
-                    slots_per_account as u64)
+                let storage: HashMap<U256, (U256, U256), FbBuildHasher<32>> = (1
+                    ..=slots_per_account as u64)
                     .map(|s| {
                         (
                             U256::from(s + acct_idx as u64 * 100),

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -1,8 +1,12 @@
 use crate::{
     AccountReader, BlockHashReader, HashedPostStateProvider, StateProvider, StateRootProvider,
 };
-use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
-use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx};
+use alloy_primitives::{keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use reth_db_api::{
+    cursor::{DbCursorRO, DbDupCursorRO},
+    tables,
+    transaction::DbTx,
+};
 use reth_primitives_traits::{Account, Bytecode};
 use reth_storage_api::{
     BytecodeReader, DBProvider, StateProofProvider, StorageRootProvider, StorageSettingsCache,
@@ -251,9 +255,64 @@ impl<Provider: DBProvider + StorageSettingsCache> StateProofProvider
     }
 }
 
-impl<Provider: DBProvider> HashedPostStateProvider for LatestStateProviderRef<'_, Provider> {
+impl<Provider: DBProvider + StorageSettingsCache> HashedPostStateProvider
+    for LatestStateProviderRef<'_, Provider>
+{
     fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
         HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
+    }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        let mut state = HashedPostState::with_capacity(accounts.len());
+
+        if self.0.cached_storage_settings().use_hashed_state() {
+            let mut account_cursor = self.tx().cursor_read::<tables::HashedAccounts>()?;
+            let mut storage_cursor = self.tx().cursor_dup_read::<tables::HashedStorages>()?;
+
+            for address in accounts {
+                let hashed_address = keccak256(address);
+                if let Some((_, account)) = account_cursor.seek_exact(hashed_address)? {
+                    state.accounts.insert(hashed_address, Some(account));
+                }
+
+                let mut storage = HashedStorage::new(false);
+                if let Some((_, entry)) = storage_cursor.seek_exact(hashed_address)? {
+                    storage.storage.insert(entry.key, entry.value);
+                    while let Some(entry) = storage_cursor.next_dup_val()? {
+                        storage.storage.insert(entry.key, entry.value);
+                    }
+                }
+                if !storage.is_empty() {
+                    state.storages.insert(hashed_address, storage);
+                }
+            }
+        } else {
+            let mut account_cursor = self.tx().cursor_read::<tables::PlainAccountState>()?;
+            let mut storage_cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
+
+            for address in accounts {
+                let hashed_address = keccak256(address);
+                if let Some((_, account)) = account_cursor.seek_exact(*address)? {
+                    state.accounts.insert(hashed_address, Some(account));
+                }
+
+                let mut storage = HashedStorage::new(false);
+                if let Some((_, entry)) = storage_cursor.seek_exact(*address)? {
+                    storage.storage.insert(keccak256(entry.key), entry.value);
+                    while let Some(entry) = storage_cursor.next_dup_val()? {
+                        storage.storage.insert(keccak256(entry.key), entry.value);
+                    }
+                }
+                if !storage.is_empty() {
+                    state.storages.insert(hashed_address, storage);
+                }
+            }
+        }
+
+        Ok(state)
     }
 }
 
@@ -273,8 +332,8 @@ impl<Provider: DBProvider + BlockHashReader + StorageSettingsCache> StateProvide
             )
         } else {
             let mut cursor = self.tx().cursor_dup_read::<tables::PlainStorageState>()?;
-            if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)? &&
-                entry.key == storage_key
+            if let Some(entry) = cursor.seek_by_key_subkey(account, storage_key)?
+                && entry.key == storage_key
             {
                 return Ok(Some(entry.value));
             }

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{BlockHash, BlockNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, B256};
 use metrics::{Counter, Histogram};
 use reth_chain_state::{EthPrimitives, StateTrieOverlayManager};
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
@@ -13,20 +13,20 @@ use reth_prune_types::PruneSegment;
 use reth_stages_types::StageId;
 use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-    DatabaseProviderROFactory, PruneCheckpointReader, StageCheckpointReader,
-    StorageChangeSetReader, StorageSettingsCache,
+    DatabaseProviderROFactory, HashedPostStateProvider, PruneCheckpointReader,
+    StageCheckpointReader, StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
     updates::TrieUpdatesSorted,
-    HashedPostStateSorted,
+    HashedPostState, HashedPostStateSorted,
 };
 use reth_trie_db::{
     ChangesetCache, DatabaseAccountTrieCursor, DatabaseHashedCursorFactory,
-    DatabaseProvableAccountTrieCursor, DatabaseProvableStorageTrieCursor, DatabaseStorageTrieCursor,
-    LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter, PackedProvableAccountsTrie,
-    PackedProvableStoragesTrie, PackedStoragesTrie,
+    DatabaseProvableAccountTrieCursor, DatabaseProvableStorageTrieCursor,
+    DatabaseStorageTrieCursor, LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter,
+    PackedProvableAccountsTrie, PackedProvableStoragesTrie, PackedStoragesTrie,
 };
 use std::{
     ops::RangeInclusive,
@@ -210,7 +210,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     return Err(ProviderError::other(std::io::Error::other(format!(
                         "anchor_hash {anchor_hash} doesn't match OverlayBuilder's configured parent ({})",
                         self.parent_hash
-                    ))))
+                    ))));
                 }
                 Ok((Arc::clone(trie), Arc::clone(state)))
             }
@@ -257,7 +257,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     {
         // If the anchor is the DB tip then there won't be any reverts necessary.
         if db_tip_block.hash == anchor_hash {
-            return Ok(None)
+            return Ok(None);
         }
 
         let anchor_number = provider
@@ -619,26 +619,26 @@ where
         let tx = self.provider.tx_ref();
         let trie_updates = self.trie_updates.as_ref();
         let cursor: Box<dyn TrieCursor + Send> = match (self.trie_table_kind, self.is_v2) {
-            (TrieTableKind::Canonical, true) => Box::new(
-                DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
+            (TrieTableKind::Canonical, true) => {
+                Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
                     tx.cursor_read::<PackedAccountsTrie>()?,
-                ),
-            ),
-            (TrieTableKind::Canonical, false) => Box::new(
-                DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+                ))
+            }
+            (TrieTableKind::Canonical, false) => {
+                Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
                     tx.cursor_read::<tables::AccountsTrie>()?,
-                ),
-            ),
-            (TrieTableKind::Provable, true) => Box::new(
-                DatabaseProvableAccountTrieCursor::<_, PackedKeyAdapter>::new(
+                ))
+            }
+            (TrieTableKind::Provable, true) => {
+                Box::new(DatabaseProvableAccountTrieCursor::<_, PackedKeyAdapter>::new(
                     tx.cursor_read::<PackedProvableAccountsTrie>()?,
-                ),
-            ),
-            (TrieTableKind::Provable, false) => Box::new(
-                DatabaseProvableAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+                ))
+            }
+            (TrieTableKind::Provable, false) => {
+                Box::new(DatabaseProvableAccountTrieCursor::<_, LegacyKeyAdapter>::new(
                     tx.cursor_read::<tables::ProvableAccountsTrie>()?,
-                ),
-            ),
+                ))
+            }
         };
         Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
     }
@@ -650,30 +650,30 @@ where
         let tx = self.provider.tx_ref();
         let trie_updates = self.trie_updates.as_ref();
         let cursor: Box<dyn TrieStorageCursor + Send> = match (self.trie_table_kind, self.is_v2) {
-            (TrieTableKind::Canonical, true) => Box::new(
-                DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
+            (TrieTableKind::Canonical, true) => {
+                Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
                     tx.cursor_dup_read::<PackedStoragesTrie>()?,
                     hashed_address,
-                ),
-            ),
-            (TrieTableKind::Canonical, false) => Box::new(
-                DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+                ))
+            }
+            (TrieTableKind::Canonical, false) => {
+                Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
                     tx.cursor_dup_read::<tables::StoragesTrie>()?,
                     hashed_address,
-                ),
-            ),
-            (TrieTableKind::Provable, true) => Box::new(
-                DatabaseProvableStorageTrieCursor::<_, PackedKeyAdapter>::new(
+                ))
+            }
+            (TrieTableKind::Provable, true) => {
+                Box::new(DatabaseProvableStorageTrieCursor::<_, PackedKeyAdapter>::new(
                     tx.cursor_dup_read::<PackedProvableStoragesTrie>()?,
                     hashed_address,
-                ),
-            ),
-            (TrieTableKind::Provable, false) => Box::new(
-                DatabaseProvableStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+                ))
+            }
+            (TrieTableKind::Provable, false) => {
+                Box::new(DatabaseProvableStorageTrieCursor::<_, LegacyKeyAdapter>::new(
                     tx.cursor_dup_read::<tables::ProvableStoragesTrie>()?,
                     hashed_address,
-                ),
-            ),
+                ))
+            }
         };
         Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
     }
@@ -714,6 +714,24 @@ where
         let hashed_cursor_factory =
             HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
         hashed_cursor_factory.hashed_storage_cursor(hashed_address)
+    }
+}
+
+impl<Provider> HashedPostStateProvider for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider + HashedPostStateProvider,
+{
+    fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> HashedPostState {
+        self.provider.hashed_post_state(bundle_state)
+    }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        let mut state = self.provider.hashed_post_state_for_accounts(accounts)?;
+        state.extend_from_sorted(&self.hashed_post_state);
+        Ok(state)
     }
 }
 

--- a/crates/storage/storage-api/src/macros.rs
+++ b/crates/storage/storage-api/src/macros.rs
@@ -63,6 +63,7 @@ macro_rules! delegate_provider_impls {
             }
             HashedPostStateProvider $(where [$($generics)*])? {
                 fn hashed_post_state(&self, bundle_state: &revm_database::BundleState) -> reth_trie::HashedPostState;
+                fn hashed_post_state_for_accounts(&self, accounts: &[alloy_primitives::Address]) -> reth_storage_api::errors::provider::ProviderResult<reth_trie::HashedPostState>;
             }
         );
     }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -530,6 +530,13 @@ impl<C: Send + Sync, N: NodePrimitives> HashedPostStateProvider for NoopProvider
     fn hashed_post_state(&self, _bundle_state: &revm_database::BundleState) -> HashedPostState {
         HashedPostState::default()
     }
+
+    fn hashed_post_state_for_accounts(
+        &self,
+        _accounts: &[alloy_primitives::Address],
+    ) -> ProviderResult<HashedPostState> {
+        Ok(HashedPostState::default())
+    }
 }
 
 impl<C: Send + Sync, N: NodePrimitives> StateReader for NoopProvider<C, N> {

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, StorageKey, StorageValue
 use auto_impl::auto_impl;
 use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::Bytecode;
-use reth_storage_errors::provider::ProviderResult;
+use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie_common::HashedPostState;
 use revm_database::BundleState;
 
@@ -60,10 +60,10 @@ pub trait StateProvider:
 
         if let Some(code_hash) = acc.bytecode_hash {
             if code_hash == KECCAK_EMPTY {
-                return Ok(None)
+                return Ok(None);
             }
             // Get the code from the code hash
-            return self.bytecode_by_hash(&code_hash)
+            return self.bytecode_by_hash(&code_hash);
         }
 
         // Return `None` if no code hash is set
@@ -99,6 +99,14 @@ impl<T: AccountReader + BytecodeReader> AccountInfoReader for T {}
 pub trait HashedPostStateProvider {
     /// Returns the `HashedPostState` of the provided [`BundleState`].
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState;
+
+    /// Returns the complete hashed state for the provided account addresses.
+    fn hashed_post_state_for_accounts(
+        &self,
+        _accounts: &[Address],
+    ) -> ProviderResult<HashedPostState> {
+        Err(ProviderError::UnsupportedProvider)
+    }
 }
 
 /// Trait for reading bytecode associated with a given code hash.

--- a/crates/trie/trie/src/lib.rs
+++ b/crates/trie/trie/src/lib.rs
@@ -45,6 +45,27 @@ pub mod changesets;
 mod trie;
 pub use trie::{StateRoot, StorageRoot, TrieType};
 
+use crate::{
+    hashed_cursor::{noop::NoopHashedCursorFactory, HashedPostStateCursorFactory},
+    trie_cursor::noop::NoopTrieCursorFactory,
+};
+use reth_execution_errors::StateRootError;
+
+/// Computes a state root from a complete in-memory hashed state without reading trie or hashed
+/// state cursors.
+pub fn root_from_full_hashed_state(
+    state: reth_trie_common::HashedPostState,
+) -> Result<alloy_primitives::B256, StateRootError> {
+    let sorted = state.into_sorted();
+    let prefix_sets = sorted.construct_prefix_sets().freeze();
+    StateRoot::new(
+        NoopTrieCursorFactory,
+        HashedPostStateCursorFactory::new(NoopHashedCursorFactory, &sorted),
+    )
+    .with_prefix_sets(prefix_sets)
+    .root()
+}
+
 /// Utilities for state root checkpoint progress.
 mod progress;
 pub use progress::{


### PR DESCRIPTION
## Summary
- add provider support for materializing complete hashed state for selected accounts
- add an in-memory full-hashed-state root helper that uses no trie or hashed-state DB cursors
- allow auxiliary roots to opt into full whitelisted-account state materialization before overlaying updates
- propagate the provider bound through the generic engine/node builder surfaces

## Validation
- cargo check -p reth-trie -p reth-storage-api -p reth-provider -p reth-engine-primitives -p reth-engine-tree
- cargo check -p reth-engine-tree -p reth-node-builder -p reth-node-ethereum

Prompted by: @rkrasiuk
