### PR TITLE
fix(era): accept local file name variants

### DIFF
--- a/crates/era-downloader/src/fs.rs
+++ b/crates/era-downloader/src/fs.rs
@@ -74,7 +74,7 @@ pub fn read_era_dir(
 }
 
 /// Scans `dir` for ERA files whose type satisfies `accept`, returning them sorted by the number
-/// parsed from the `<network>-<number>-<hash>.<ext>` filename.
+/// parsed from the `<network>-<number>-...<ext>` filename.
 ///
 /// Files that don't match `accept` are passed to `on_other`, letting callers pick up sidecar files
 /// such as `checksums.txt`.
@@ -107,7 +107,7 @@ fn parse_era_entry(
     {
         let parts = name.split('-').collect::<Vec<_>>();
 
-        if parts.len() == 3 {
+        if parts.len() >= 3 {
             let number = usize::from_str(parts[1])?;
 
             return Ok(Some((number, path.into_boxed_path())));

--- a/crates/era-downloader/tests/it/fs.rs
+++ b/crates/era-downloader/tests/it/fs.rs
@@ -103,6 +103,35 @@ async fn test_streaming_from_local_directory(
     }
 }
 
+#[test_case::test_case(
+    "mainnet-00000-a6860fef-noproofs.erae";
+    "ERE profile postfix"
+)]
+#[test_case::test_case(
+    "mainnet-00000-00001-5ec1ffb8.era1";
+    "era count segment"
+)]
+#[test_case::test_case(
+    "mainnet-00000-00001-5ec1ffb8-noproofs.ere";
+    "ERE era count with profile postfix"
+)]
+#[tokio::test]
+async fn test_streaming_from_local_directory_accepts_supported_filename_variants(file_name: &str) {
+    let folder = tempfile::tempdir().unwrap();
+    let folder = folder.path().to_owned();
+
+    let checksums = sha2::Sha256::digest(CONTENTS_0).encode_hex();
+    fs::write(folder.join("checksums.txt"), checksums).await.unwrap();
+    fs::write(folder.join(file_name), CONTENTS_0).await.unwrap();
+
+    let folder = folder.into_boxed_path();
+    let mut stream = read_dir(folder.clone(), 0).unwrap();
+
+    let actual = stream.next().await.unwrap().expect("should be ok");
+    assert_eq!(actual, folder.join(file_name).into_boxed_path());
+    assert!(stream.next().await.is_none(), "no extra files should be streamed");
+}
+
 /// Consensus `.era` files are streamed in ascending era order without requiring a `checksums.txt`,
 /// and non-`.era` files in the directory are ignored.
 #[test_case::test_case(
@@ -126,6 +155,11 @@ async fn test_streaming_from_local_directory(
     &["mainnet-00000-5ec1ffb8.era1"],
     &[];
     "no era files yields an empty stream"
+)]
+#[test_case::test_case(
+    &["mainnet-00000-00001-4b363db9.era"],
+    &["mainnet-00000-00001-4b363db9.era"];
+    "accepts era count segment"
 )]
 #[tokio::test]
 async fn test_streaming_era_from_local_directory(input: &[&str], expected: &[&str]) {


### PR DESCRIPTION
Local ERA directory scans recognized supported `.era1`/`.ere`/`.erae` files by extension but ignored valid filenames with extra era-count or ERE profile segments. Accepting three or more dash-separated segments keeps sorting on the existing era number field while covering reth-generated custom export and profile names.

Validation: `cargo +nightly fmt --all --check`; `cargo nextest run -p reth-era-downloader test_streaming_from_local_directory_accepts_supported_filename_variants test_streaming_era_from_local_directory`.