### PR TITLE
Filter auxiliary full-state overlay by account

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -1,6 +1,8 @@
 use super::ExecutedBlock;
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use alloy_primitives::{
+    map::hash_map, keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256,
+};
 use reth_errors::ProviderResult;
 use reth_primitives_traits::{Account, Bytecode, NodePrimitives};
 use reth_storage_api::{
@@ -218,7 +220,23 @@ impl<N: NodePrimitives> HashedPostStateProvider for MemoryOverlayStateProviderRe
         accounts: &[Address],
     ) -> ProviderResult<HashedPostState> {
         let mut state = self.historical.hashed_post_state_for_accounts(accounts)?;
-        state.extend_ref(&self.trie_input().state);
+        let overlay = &self.trie_input().state;
+        for address in accounts {
+            let hashed_address = keccak256(address);
+            if let Some(account) = overlay.accounts.get(&hashed_address) {
+                state.accounts.insert(hashed_address, *account);
+            }
+            if let Some(storage) = overlay.storages.get(&hashed_address) {
+                match state.storages.entry(hashed_address) {
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(storage.clone());
+                    }
+                    hash_map::Entry::Occupied(mut entry) => {
+                        entry.get_mut().extend(storage);
+                    }
+                }
+            }
+        }
         Ok(state)
     }
 }

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{keccak256, Address, BlockHash, BlockNumber, B256};
+use alloy_primitives::{map::hash_map, keccak256, Address, BlockHash, BlockNumber, B256};
 use metrics::{Counter, Histogram};
 use reth_chain_state::{EthPrimitives, StateTrieOverlayManager};
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
@@ -740,7 +740,14 @@ where
                 state.accounts.insert(hashed_address, account);
             }
             if let Some(storage) = self.hashed_post_state.storages.get(&hashed_address) {
-                state.storages.insert(hashed_address, storage.clone().into());
+                match state.storages.entry(hashed_address) {
+                    hash_map::Entry::Vacant(entry) => {
+                        entry.insert(storage.clone().into());
+                    }
+                    hash_map::Entry::Occupied(mut entry) => {
+                        entry.get_mut().extend_from_sorted(storage);
+                    }
+                }
             }
         }
         Ok(state)

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{Address, BlockHash, BlockNumber, B256};
+use alloy_primitives::{keccak256, Address, BlockHash, BlockNumber, B256};
 use metrics::{Counter, Histogram};
 use reth_chain_state::{EthPrimitives, StateTrieOverlayManager};
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
@@ -730,7 +730,19 @@ where
         accounts: &[Address],
     ) -> ProviderResult<HashedPostState> {
         let mut state = self.provider.hashed_post_state_for_accounts(accounts)?;
-        state.extend_from_sorted(&self.hashed_post_state);
+        for address in accounts {
+            let hashed_address = keccak256(address);
+            if let Some(account) =
+                self.hashed_post_state.accounts.iter().find_map(|(address, account)| {
+                    (*address == hashed_address).then_some(*account)
+                })
+            {
+                state.accounts.insert(hashed_address, account);
+            }
+            if let Some(storage) = self.hashed_post_state.storages.get(&hashed_address) {
+                state.storages.insert(hashed_address, storage.clone().into());
+            }
+        }
         Ok(state)
     }
 }


### PR DESCRIPTION
## Summary
- filter `OverlayStateProvider::hashed_post_state_for_accounts` overlay updates to the requested accounts
- prevents auxiliary proof roots from including unrelated in-memory state updates when full-state accounts are requested

## Validation
- cargo check -p reth-provider -p reth-engine-tree

Prompted by: @rkrasiuk