### PR TITLE
perf(net): cache full transaction propagation encoding

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -2,7 +2,10 @@
 
 use crate::{EthMessage, EthVersion, NetworkPrimitives};
 use alloc::{sync::Arc, vec::Vec};
+use alloy_consensus::transaction::TxHashRef;
+use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{
+    bytes::BufMut,
     map::{B256Map, B256Set},
     Bytes, TxHash, B128, B256, U128,
 };
@@ -14,7 +17,7 @@ use core::{fmt::Debug, mem};
 use derive_more::{Constructor, Deref, DerefMut, From, IntoIterator};
 use reth_codecs_derive::{add_arbitrary_tests, generate_tests};
 use reth_ethereum_primitives::TransactionSigned;
-use reth_primitives_traits::{Block, InMemorySize, SignedTransaction};
+use reth_primitives_traits::{sync::OnceLock, Block, InMemorySize, SignedTransaction};
 
 /// This informs peers of new blocks that have appeared on the network.
 #[derive(
@@ -204,6 +207,128 @@ pub struct SharedTransactions<T = TransactionSigned>(
     /// New transactions for the peer to include in its mempool.
     pub Vec<Arc<T>>,
 );
+
+/// A transaction that can be lazily encoded for pool-backed outbound propagation.
+pub trait BroadcastPoolTransaction:
+    Encodable + TxHashRef + Typed2718 + Send + Sync + 'static
+{
+}
+
+impl<T> BroadcastPoolTransaction for T where
+    T: Encodable + TxHashRef + Typed2718 + Send + Sync + 'static
+{
+}
+
+/// Shared cached encoding for an outbound transaction.
+///
+/// This keeps the transaction object and its encoded bytes behind shared references so cloned
+/// per-peer messages reuse the same EIP-2718 encoding.
+pub struct LazyEncoded<T: ?Sized> {
+    value: Arc<T>,
+    encoded: Arc<OnceLock<Bytes>>,
+}
+
+impl<T: ?Sized> Clone for LazyEncoded<T> {
+    fn clone(&self) -> Self {
+        Self { value: Arc::clone(&self.value), encoded: Arc::clone(&self.encoded) }
+    }
+}
+
+impl LazyEncoded<dyn BroadcastPoolTransaction> {
+    /// Wraps a transaction-like value and lazily caches its encoded bytes.
+    pub fn new<T>(value: T) -> Self
+    where
+        T: BroadcastPoolTransaction,
+    {
+        let value: Arc<dyn BroadcastPoolTransaction> = Arc::new(value);
+        Self { value, encoded: Arc::new(OnceLock::new()) }
+    }
+}
+
+impl<T: Encodable + ?Sized> Encodable for LazyEncoded<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let encoded = self.encoded.get_or_init(|| self.encode_uncached());
+        out.put_slice(encoded);
+    }
+
+    fn length(&self) -> usize {
+        self.encoded.get().map_or_else(|| self.value.length(), |encoded| encoded.len())
+    }
+}
+
+impl<T: Encodable + ?Sized> LazyEncoded<T> {
+    fn encode_uncached(&self) -> Bytes {
+        let mut out = Vec::with_capacity(self.value.length());
+        self.value.encode(&mut out);
+        out.into()
+    }
+}
+
+impl<T: TxHashRef + ?Sized> TxHashRef for LazyEncoded<T> {
+    fn tx_hash(&self) -> &TxHash {
+        self.value.tx_hash()
+    }
+}
+
+impl<T: Typed2718 + ?Sized> Typed2718 for LazyEncoded<T> {
+    fn ty(&self) -> u8 {
+        self.value.ty()
+    }
+}
+
+impl<T: ?Sized> Debug for LazyEncoded<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LazyEncoded")
+            .field("is_cached", &self.encoded.get().is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A lazily encoded transaction used for pool-backed full transaction propagation.
+pub type LazyEncodedTransaction = LazyEncoded<dyn BroadcastPoolTransaction>;
+
+/// Outbound-only full transaction propagation message backed by pool transactions.
+///
+/// This encodes to the same `Transactions` wire payload as [`SharedTransactions`], but is used by
+/// the transaction manager when the source is the pool. Unlike [`SharedTransactions`], it can wrap
+/// pool transaction references directly and cache each transaction's encoded bytes across per-peer
+/// messages.
+#[derive(Clone, Debug)]
+pub struct BroadcastPoolTransactions(pub Vec<LazyEncodedTransaction>);
+
+impl BroadcastPoolTransactions {
+    /// Returns the number of transactions in the list.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if there are no transactions in the list.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the transaction hashes.
+    pub fn iter_hashes(&self) -> impl Iterator<Item = &TxHash> + '_ {
+        self.0.iter().map(TxHashRef::tx_hash)
+    }
+}
+
+impl Encodable for BroadcastPoolTransactions {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let payload_length = self.0.iter().map(Encodable::length).sum();
+
+        Header { list: true, payload_length }.encode(out);
+        for tx in &self.0 {
+            tx.encode(out);
+        }
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.0.iter().map(Encodable::length).sum::<usize>();
+
+        Header { list: true, payload_length }.length() + payload_length
+    }
+}
 
 /// A wrapper type for all different new pooled transaction types
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1198,6 +1323,7 @@ mod tests {
     use alloy_consensus::{transaction::TxHashRef, Typed2718};
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{b256, hex, Signature, U256};
+    use proptest::prelude::*;
     use reth_ethereum_primitives::{Transaction, TransactionSigned};
     use std::str::FromStr;
 
@@ -1214,6 +1340,51 @@ mod tests {
 
         let decoded = T::decode(&mut encoded.as_ref()).unwrap();
         assert_eq!(expected_decoded, decoded);
+    }
+
+    fn encoded<T: Encodable>(value: &T) -> Vec<u8> {
+        let mut out = Vec::new();
+        value.encode(&mut out);
+        out
+    }
+
+    proptest! {
+        #[test]
+        fn broadcast_pool_transactions_match_shared_transactions_encoding(
+            txs in proptest::collection::vec(
+                proptest_arbitrary_interop::arb::<TransactionSigned>(),
+                0..32,
+            )
+        ) {
+            let shared = SharedTransactions::<TransactionSigned>(
+                txs.iter().cloned().map(Arc::new).collect(),
+            );
+            let broadcast = BroadcastPoolTransactions(
+                txs.iter().cloned().map(LazyEncoded::new).collect(),
+            );
+
+            prop_assert_eq!(broadcast.length(), shared.length());
+
+            let shared_encoded = encoded(&shared);
+            let broadcast_encoded = encoded(&broadcast);
+            prop_assert_eq!(&broadcast_encoded, &shared_encoded);
+
+            let broadcast_encoded_cached = encoded(&broadcast);
+            prop_assert_eq!(&broadcast_encoded_cached, &shared_encoded);
+
+            let mut shared_bytes = shared_encoded.as_slice();
+            let decoded_shared = SharedTransactions::<TransactionSigned>::decode(&mut shared_bytes)
+                .expect("shared transactions decode");
+            prop_assert!(shared_bytes.is_empty());
+
+            let mut broadcast_bytes = broadcast_encoded.as_slice();
+            let decoded_broadcast =
+                SharedTransactions::<TransactionSigned>::decode(&mut broadcast_bytes)
+                    .expect("broadcast pool transactions decode as shared transactions");
+            prop_assert!(broadcast_bytes.is_empty());
+
+            prop_assert_eq!(decoded_broadcast, decoded_shared);
+        }
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -252,7 +252,7 @@ impl<T: Encodable + ?Sized> Encodable for LazyEncoded<T> {
     }
 
     fn length(&self) -> usize {
-        self.encoded.get().map_or_else(|| self.value.length(), |encoded| encoded.len())
+        self.encoded.get_or_init(|| self.encode_uncached()).len()
     }
 }
 
@@ -292,21 +292,12 @@ pub type LazyEncodedTransaction = LazyEncoded<dyn BroadcastPoolTransaction>;
 /// This encodes to the same `Transactions` wire payload as [`SharedTransactions`], but is used by
 /// the transaction manager when the source is the pool. Unlike [`SharedTransactions`], it can wrap
 /// pool transaction references directly and cache each transaction's encoded bytes across per-peer
-/// messages.
-#[derive(Clone, Debug)]
+/// messages. Queued messages retain the pool-backed value and the shared cached bytes until they
+/// are sent.
+#[derive(Clone, Debug, Deref)]
 pub struct BroadcastPoolTransactions(pub Vec<LazyEncodedTransaction>);
 
 impl BroadcastPoolTransactions {
-    /// Returns the number of transactions in the list.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if there are no transactions in the list.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// Returns an iterator over the transaction hashes.
     pub fn iter_hashes(&self) -> impl Iterator<Item = &TxHash> + '_ {
         self.0.iter().map(TxHashRef::tx_hash)
@@ -315,18 +306,11 @@ impl BroadcastPoolTransactions {
 
 impl Encodable for BroadcastPoolTransactions {
     fn encode(&self, out: &mut dyn BufMut) {
-        let payload_length = self.0.iter().map(Encodable::length).sum();
-
-        Header { list: true, payload_length }.encode(out);
-        for tx in &self.0 {
-            tx.encode(out);
-        }
+        self.0.encode(out);
     }
 
     fn length(&self) -> usize {
-        let payload_length = self.0.iter().map(Encodable::length).sum::<usize>();
-
-        Header { list: true, payload_length }.length() + payload_length
+        self.0.length()
     }
 }
 

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -13,9 +13,9 @@ use super::{
     PooledTransactions, Receipts, Status, StatusEth69, Transactions,
 };
 use crate::{
-    status::StatusMessage, BlockRangeUpdate, Cells, EthNetworkPrimitives, EthVersion, GetCells,
-    NetworkPrimitives, NewPooledTransactionHashes72, RawCapabilityMessage, Receipts69, Receipts70,
-    SharedTransactions,
+    status::StatusMessage, BlockRangeUpdate, BroadcastPoolTransactions, Cells,
+    EthNetworkPrimitives, EthVersion, GetCells, NetworkPrimitives, NewPooledTransactionHashes72,
+    RawCapabilityMessage, Receipts69, Receipts70, SharedTransactions,
 };
 use alloc::{boxed::Box, string::String, sync::Arc};
 use alloy_primitives::{
@@ -570,12 +570,14 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
 /// never receive a hash of an object (block, transaction) it has already seen.
 ///
 /// Note: This is only useful for outgoing messages.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub enum EthBroadcastMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Represents a new block broadcast message.
     NewBlock(Arc<N::NewBlockPayload>),
     /// Represents a transactions broadcast message.
     Transactions(SharedTransactions<N::BroadcastedTransaction>),
+    /// Represents cached outbound pool transactions broadcast message.
+    BroadcastPoolTransactions(BroadcastPoolTransactions),
 }
 
 // === impl EthBroadcastMessage ===
@@ -585,7 +587,9 @@ impl<N: NetworkPrimitives> EthBroadcastMessage<N> {
     pub const fn message_id(&self) -> EthMessageID {
         match self {
             Self::NewBlock(_) => EthMessageID::NewBlock,
-            Self::Transactions(_) => EthMessageID::Transactions,
+            Self::Transactions(_) | Self::BroadcastPoolTransactions(_) => {
+                EthMessageID::Transactions
+            }
         }
     }
 
@@ -600,6 +604,7 @@ impl<N: NetworkPrimitives> Encodable for EthBroadcastMessage<N> {
         match self {
             Self::NewBlock(new_block) => new_block.encode(out),
             Self::Transactions(transactions) => transactions.encode(out),
+            Self::BroadcastPoolTransactions(transactions) => transactions.encode(out),
         }
     }
 
@@ -607,6 +612,7 @@ impl<N: NetworkPrimitives> Encodable for EthBroadcastMessage<N> {
         match self {
             Self::NewBlock(new_block) => new_block.length(),
             Self::Transactions(transactions) => transactions.length(),
+            Self::BroadcastPoolTransactions(transactions) => transactions.length(),
         }
     }
 }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -676,7 +676,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     msg,
                 });
             }
-            PeerMessage::SendTransactions(_) => {
+            PeerMessage::SendTransactions(_) | PeerMessage::SendBroadcastPoolTransactions(_) => {
                 unreachable!("Not emitted by session")
             }
             PeerMessage::BlockRangeUpdated(_) => {}
@@ -707,6 +707,10 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             NetworkHandleMessage::SendTransaction { peer_id, msg } => {
                 self.swarm.sessions_mut().send_message(&peer_id, PeerMessage::SendTransactions(msg))
             }
+            NetworkHandleMessage::SendBroadcastPoolTransactions { peer_id, msg } => self
+                .swarm
+                .sessions_mut()
+                .send_message(&peer_id, PeerMessage::SendBroadcastPoolTransactions(msg)),
             NetworkHandleMessage::SendPooledTransactionHashes { peer_id, msg } => self
                 .swarm
                 .sessions_mut()

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -8,10 +8,11 @@ use alloy_consensus::{BlockHeader, ReceiptWithBloom};
 use alloy_primitives::{Bytes, B256};
 use futures::FutureExt;
 use reth_eth_wire::{
-    message::RequestPair, BlockBodies, BlockHeaders, BlockRangeUpdate, Cells, EthMessage,
-    EthNetworkPrimitives, GetBlockAccessLists, GetBlockBodies, GetBlockHeaders, GetReceipts,
-    NetworkPrimitives, NewBlock, NewBlockHashes, NewBlockPayload, NewPooledTransactionHashes,
-    NodeData, PooledTransactions, Receipts, SharedTransactions, Transactions,
+    message::RequestPair, BlockBodies, BlockHeaders, BlockRangeUpdate, BroadcastPoolTransactions,
+    Cells, EthMessage, EthNetworkPrimitives, GetBlockAccessLists, GetBlockBodies, GetBlockHeaders,
+    GetReceipts, NetworkPrimitives, NewBlock, NewBlockHashes, NewBlockPayload,
+    NewPooledTransactionHashes, NodeData, PooledTransactions, Receipts, SharedTransactions,
+    Transactions,
 };
 use reth_eth_wire_types::RawCapabilityMessage;
 use reth_network_api::PeerRequest;
@@ -53,6 +54,8 @@ pub enum PeerMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     ReceivedTransaction(Transactions<N::BroadcastedTransaction>),
     /// Broadcast transactions _from_ local _to_ a peer.
     SendTransactions(SharedTransactions<N::BroadcastedTransaction>),
+    /// Broadcast cached pool transactions _from_ local _to_ a peer.
+    SendBroadcastPoolTransactions(BroadcastPoolTransactions),
     /// Send new pooled transactions
     PooledTransactions(NewPooledTransactionHashes),
     /// All `eth` request variants.
@@ -73,6 +76,7 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
             Self::NewBlock(_) => "NewBlock",
             Self::ReceivedTransaction(_) => "ReceivedTransaction",
             Self::SendTransactions(_) => "SendTransactions",
+            Self::SendBroadcastPoolTransactions(_) => "SendBroadcastPoolTransactions",
             Self::PooledTransactions(_) => "PooledTransactions",
             Self::EthRequest(_) => "EthRequest",
             Self::BlockRangeUpdated(_) => "BlockRangeUpdated",
@@ -88,6 +92,7 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
             Self::NewBlockHashes(_) |
                 Self::NewBlock(_) |
                 Self::SendTransactions(_) |
+                Self::SendBroadcastPoolTransactions(_) |
                 Self::PooledTransactions(_)
         )
     }
@@ -98,6 +103,7 @@ impl<N: NetworkPrimitives> PeerMessage<N> {
             Self::NewBlockHashes(msg) => msg.len(),
             Self::ReceivedTransaction(msg) => msg.len(),
             Self::SendTransactions(msg) => msg.len(),
+            Self::SendBroadcastPoolTransactions(msg) => msg.len(),
             Self::PooledTransactions(msg) => msg.len(),
             Self::NewBlock(_) |
             Self::EthRequest(_) |

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -9,8 +9,8 @@ use parking_lot::Mutex;
 use reth_discv4::{Discv4, NatResolver};
 use reth_discv5::Discv5;
 use reth_eth_wire::{
-    BlockRangeUpdate, DisconnectReason, EthNetworkPrimitives, NetworkPrimitives,
-    NewPooledTransactionHashes, SharedTransactions,
+    BlockRangeUpdate, BroadcastPoolTransactions, DisconnectReason, EthNetworkPrimitives,
+    NetworkPrimitives, NewPooledTransactionHashes, SharedTransactions,
 };
 use reth_ethereum_forks::Head;
 use reth_network_api::{
@@ -137,6 +137,15 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
             peer_id,
             msg: SharedTransactions(msg),
         })
+    }
+
+    /// Send cached full pool transactions to the peer.
+    pub(crate) fn send_broadcast_pool_transactions(
+        &self,
+        peer_id: PeerId,
+        msg: BroadcastPoolTransactions,
+    ) {
+        self.send_message(NetworkHandleMessage::SendBroadcastPoolTransactions { peer_id, msg })
     }
 
     /// Send eth message to the peer.
@@ -567,6 +576,13 @@ pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives
         peer_id: PeerId,
         /// The shared transactions to send.
         msg: SharedTransactions<N::BroadcastedTransaction>,
+    },
+    /// Sends cached full pool transactions to the given peer.
+    SendBroadcastPoolTransactions {
+        /// The ID of the peer to which the transactions are sent.
+        peer_id: PeerId,
+        /// The cached pool transactions to send.
+        msg: BroadcastPoolTransactions,
     },
     /// Sends a list of transaction hashes to the given peer.
     SendPooledTransactionHashes {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -437,6 +437,10 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             PeerMessage::SendTransactions(msg) => {
                 self.queued_outgoing.push_back(EthBroadcastMessage::Transactions(msg).into());
             }
+            PeerMessage::SendBroadcastPoolTransactions(msg) => {
+                self.queued_outgoing
+                    .push_back(EthBroadcastMessage::BroadcastPoolTransactions(msg).into());
+            }
             PeerMessage::BlockRangeUpdated(_) => {}
             PeerMessage::ReceivedTransaction(_) => {
                 unreachable!("Not emitted by network")
@@ -1004,6 +1008,7 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
             Self::Broadcast(msg) => match msg {
                 EthBroadcastMessage::NewBlock(_) => 1,
                 EthBroadcastMessage::Transactions(txs) => txs.len(),
+                EthBroadcastMessage::BroadcastPoolTransactions(txs) => txs.len(),
             },
             Self::Raw(_) => 0,
         }

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1766,16 +1766,26 @@ impl PropagationMode {
 #[derive(Debug, Clone)]
 struct PropagateTransaction<T = TransactionSigned> {
     is_broadcastable_in_full: bool,
+    /// Size advertised in `NewPooledTransactionHashes` metadata and used for full broadcast
+    /// soft-limit accounting.
+    ///
+    /// This is the network encoded transaction size. For pool-backed blob transactions, this is
+    /// the pool's cached encoded length, which includes the sidecar returned by
+    /// `PooledTransactions`.
     propagation_size: usize,
     transaction: LazyEncodedTransaction,
     _marker: PhantomData<fn() -> T>,
 }
 
 impl<T: SignedTransaction> PropagateTransaction<T> {
-    /// Create a new instance from a transaction.
+    /// Create a new instance from a transaction supplied directly for propagation.
+    ///
+    /// Direct transactions use their EIP-2718 encoded length so eth/68+ hash announcements carry
+    /// the same size metadata as [`NewPooledTransactionHashes68::push`] and
+    /// [`NewPooledTransactionHashes72::push`].
     fn new(transaction: T) -> Self {
         let is_broadcastable_in_full = transaction.is_broadcastable_in_full();
-        let propagation_size = transaction.length();
+        let propagation_size = transaction.encode_2718_len();
 
         Self {
             is_broadcastable_in_full,
@@ -1786,6 +1796,10 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
     }
 
     /// Create a new instance from a pooled transaction.
+    ///
+    /// Pool transactions already cache the network encoded size used by txpool admission and
+    /// pooled hash announcements. For blob transactions, this includes the sidecar size expected in
+    /// a `PooledTransactions` response.
     fn pool_tx<P>(tx: Arc<ValidPoolTransaction<P>>) -> Self
     where
         P: PoolTransaction<Consensus = T>,
@@ -1806,6 +1820,7 @@ impl<T> PropagateTransaction<T> {
         self.transaction.tx_hash()
     }
 
+    /// Returns the network encoded size used for propagation limits and hash metadata.
     const fn propagation_size(&self) -> usize {
         self.propagation_size
     }
@@ -2334,7 +2349,7 @@ mod tests {
         NetworkConfigBuilder, NetworkManager,
     };
     use alloy_consensus::{Transaction as _, TxEip1559, TxLegacy};
-    use alloy_eips::eip4844::BlobTransactionValidationError;
+    use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionValidationError};
     use alloy_primitives::{hex, Signature, TxKind, B256, U256};
     use alloy_rlp::Decodable;
     use futures::FutureExt;
@@ -3146,6 +3161,17 @@ mod tests {
         // for retry
         assert_eq!(tx_fetcher.num_pending_hashes(), 0);
         assert_eq!(tx_fetcher.active_peers.len(), 0);
+    }
+
+    #[test]
+    fn test_direct_propagation_transaction_uses_2718_size() {
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let tx = tx_gen.gen_eip1559();
+        let expected_size = tx.encode_2718_len();
+
+        let tx = PropagateTransaction::new(tx);
+
+        assert_eq!(tx.propagation_size(), expected_size);
     }
 
     #[test]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -54,7 +54,7 @@ use reth_eth_wire::{
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, NewPooledTransactionHashes72,
     PooledTransactions, RequestTxHashes, Transactions, ValidAnnouncementData,
 };
-use reth_ethereum_primitives::TxType;
+use reth_ethereum_primitives::{TransactionSigned, TxType};
 use reth_metrics::common::mpsc::MemoryBoundedReceiver;
 use reth_network_api::{
     events::{PeerEvent, SessionInfo},
@@ -74,7 +74,7 @@ use reth_transaction_pool::{
     PropagatedTransactions, TransactionPool, ValidPoolTransaction,
 };
 use std::{
-    cell::OnceCell,
+    marker::PhantomData,
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -904,18 +904,18 @@ where
         // filter all transactions unknown to the peer
         let mut full_transactions = FullTransactionsBuilder::new(peer.version);
 
-        let to_propagate = self.pool.get_all(txs).into_iter().map(PropagatePooledTransaction::new);
+        let to_propagate = self.pool.get_all(txs).into_iter().map(PropagateTransaction::pool_tx);
 
         if propagation_mode.is_forced() {
             // skip cache check if forced
-            full_transactions.extend_pooled(to_propagate);
+            full_transactions.extend(to_propagate);
         } else {
             // Iterate through the transactions to propagate and fill the hashes and full
             // transaction
             for tx in to_propagate {
                 if !peer.seen_transactions.contains(tx.tx_hash()) {
                     // Only include if the peer hasn't seen the transaction
-                    full_transactions.push(PropagateTransactionItem::Pooled(&tx));
+                    full_transactions.push(&tx);
                 }
             }
         }
@@ -977,7 +977,7 @@ where
             };
 
             let to_propagate =
-                self.pool.get_all(hashes).into_iter().map(PropagatePooledTransaction::new);
+                self.pool.get_all(hashes).into_iter().map(PropagateTransaction::pool_tx);
 
             let mut propagated = PropagatedTransactions::default();
 
@@ -985,12 +985,12 @@ where
             let mut hashes = PooledTransactionsHashesBuilder::new(peer.version);
 
             if propagation_mode.is_forced() {
-                hashes.extend_pooled(to_propagate)
+                hashes.extend(to_propagate)
             } else {
                 for tx in to_propagate {
                     if !peer.seen_transactions.contains(tx.tx_hash()) {
                         // Include if the peer hasn't seen it
-                        hashes.push(PropagateTransactionItem::Pooled(&tx));
+                        hashes.push(&tx);
                     }
                 }
             }
@@ -1030,7 +1030,7 @@ where
     /// Note: EIP-4844 are disallowed from being broadcast in full and are only ever sent as hashes, see also <https://eips.ethereum.org/EIPS/eip-4844#networking>.
     fn propagate_transactions(
         &mut self,
-        to_propagate: PropagateTransactions<Pool::Transaction>,
+        to_propagate: Vec<PropagateTransaction<N::BroadcastedTransaction>>,
         propagation_mode: PropagationMode,
     ) -> PropagatedTransactions {
         let mut propagated = PropagatedTransactions::default();
@@ -1143,7 +1143,7 @@ where
             return
         }
         let propagated = self.propagate_transactions(
-            PropagateTransactions::pooled(self.pool.get_all(hashes)),
+            self.pool.get_all(hashes).into_iter().map(PropagateTransaction::pool_tx).collect(),
             PropagationMode::Basic,
         );
 
@@ -1203,10 +1203,7 @@ where
             }
             TransactionsCommand::PropagateTransactions(txs) => self.propagate_all(txs),
             TransactionsCommand::BroadcastTransactions(txs) => {
-                let propagated = self.propagate_transactions(
-                    PropagateTransactions::Tx(txs),
-                    PropagationMode::Forced,
-                );
+                let propagated = self.propagate_transactions(txs, PropagationMode::Forced);
                 self.pool.on_propagated(propagated);
             }
             TransactionsCommand::GetTransactionHashes { peers, tx } => {
@@ -1765,153 +1762,64 @@ impl PropagationMode {
     }
 }
 
-/// A transaction supplied directly for full propagation.
+/// A transaction that's about to be propagated to multiple peers.
 #[derive(Debug, Clone)]
-struct PropagateTransaction {
+struct PropagateTransaction<T = TransactionSigned> {
     is_broadcastable_in_full: bool,
+    propagation_size: usize,
     transaction: LazyEncodedTransaction,
+    _marker: PhantomData<fn() -> T>,
 }
 
-impl PropagateTransaction {
+impl<T: SignedTransaction> PropagateTransaction<T> {
     /// Create a new instance from a transaction.
-    fn new<T: SignedTransaction>(transaction: T) -> Self {
+    fn new(transaction: T) -> Self {
         let is_broadcastable_in_full = transaction.is_broadcastable_in_full();
+        let propagation_size = transaction.length();
 
-        Self { is_broadcastable_in_full, transaction: LazyEncoded::new(transaction) }
+        Self {
+            is_broadcastable_in_full,
+            propagation_size,
+            transaction: LazyEncoded::new(transaction),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a new instance from a pooled transaction.
+    fn pool_tx<P>(tx: Arc<ValidPoolTransaction<P>>) -> Self
+    where
+        P: PoolTransaction<Consensus = T>,
+    {
+        let is_broadcastable_in_full = tx.transaction.consensus_ref().is_broadcastable_in_full();
+        let propagation_size = tx.encoded_length();
+        Self {
+            is_broadcastable_in_full,
+            propagation_size,
+            transaction: LazyEncoded::new(PropagatePooledTransactionEncoder::new(tx)),
+            _marker: PhantomData,
+        }
     }
 }
 
-/// A pooled transaction that's about to be propagated to multiple peers.
-#[derive(Debug)]
-struct PropagatePooledTransaction<P: PoolTransaction> {
-    transaction: Arc<ValidPoolTransaction<P>>,
-    shared: OnceCell<LazyEncodedTransaction>,
-}
-
-impl<P: PoolTransaction> PropagatePooledTransaction<P> {
-    const fn new(transaction: Arc<ValidPoolTransaction<P>>) -> Self {
-        Self { transaction, shared: OnceCell::new() }
-    }
-
+impl<T> PropagateTransaction<T> {
     fn tx_hash(&self) -> &TxHash {
-        self.transaction.hash()
-    }
-}
-
-/// Transactions that are about to be propagated to multiple peers.
-#[derive(Debug)]
-enum PropagateTransactions<P: PoolTransaction> {
-    /// Transactions from the pool.
-    Pooled(Vec<PropagatePooledTransaction<P>>),
-    /// Transactions supplied directly through the transactions handle.
-    Tx(Vec<PropagateTransaction>),
-}
-
-impl<P: PoolTransaction> PropagateTransactions<P> {
-    /// Wraps pool transactions once so every per-peer full broadcast shares the same lazy encoding.
-    fn pooled(transactions: Vec<Arc<ValidPoolTransaction<P>>>) -> Self {
-        Self::Pooled(transactions.into_iter().map(PropagatePooledTransaction::new).collect())
+        self.transaction.tx_hash()
     }
 
-    const fn len(&self) -> usize {
-        match self {
-            Self::Pooled(transactions) => transactions.len(),
-            Self::Tx(transactions) => transactions.len(),
-        }
-    }
-}
-
-impl<'a, P: PoolTransaction> IntoIterator for &'a PropagateTransactions<P> {
-    type Item = PropagateTransactionItem<'a, P>;
-    type IntoIter = PropagateTransactionIter<'a, P>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match self {
-            PropagateTransactions::Pooled(transactions) => {
-                PropagateTransactionIter::Pooled(transactions.iter())
-            }
-            PropagateTransactions::Tx(transactions) => {
-                PropagateTransactionIter::Tx(transactions.iter())
-            }
-        }
-    }
-}
-
-enum PropagateTransactionIter<'a, P: PoolTransaction> {
-    Pooled(std::slice::Iter<'a, PropagatePooledTransaction<P>>),
-    Tx(std::slice::Iter<'a, PropagateTransaction>),
-}
-
-impl<'a, P: PoolTransaction> Iterator for PropagateTransactionIter<'a, P> {
-    type Item = PropagateTransactionItem<'a, P>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::Pooled(transactions) => transactions.next().map(PropagateTransactionItem::Pooled),
-            Self::Tx(transactions) => transactions.next().map(PropagateTransactionItem::Tx),
-        }
-    }
-}
-
-/// A transaction item borrowed from a [`PropagateTransactions`] batch.
-enum PropagateTransactionItem<'a, P: PoolTransaction> {
-    /// A pooled transaction.
-    Pooled(&'a PropagatePooledTransaction<P>),
-    /// A transaction supplied directly through the transactions handle.
-    Tx(&'a PropagateTransaction),
-}
-
-impl<P: PoolTransaction> Clone for PropagateTransactionItem<'_, P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<P: PoolTransaction> Copy for PropagateTransactionItem<'_, P> {}
-
-impl<P: PoolTransaction> PropagateTransactionItem<'_, P> {
-    fn tx_hash(&self) -> &TxHash {
-        match self {
-            Self::Pooled(transaction) => transaction.transaction.hash(),
-            Self::Tx(transaction) => transaction.transaction.tx_hash(),
-        }
-    }
-
-    fn propagation_size(&self) -> usize {
-        match self {
-            Self::Pooled(transaction) => transaction.transaction.encoded_length(),
-            Self::Tx(transaction) => transaction.transaction.length(),
-        }
+    const fn propagation_size(&self) -> usize {
+        self.propagation_size
     }
 
     fn tx_type(&self) -> u8 {
-        match self {
-            Self::Pooled(transaction) => transaction.transaction.transaction.ty(),
-            Self::Tx(transaction) => transaction.transaction.ty(),
-        }
+        self.transaction.ty()
     }
 
-    fn is_broadcastable_in_full(&self) -> bool {
-        match self {
-            Self::Pooled(transaction) => {
-                transaction.transaction.transaction.consensus_ref().is_broadcastable_in_full()
-            }
-            Self::Tx(transaction) => transaction.is_broadcastable_in_full,
-        }
+    const fn is_broadcastable_in_full(&self) -> bool {
+        self.is_broadcastable_in_full
     }
 
     fn shared(&self) -> LazyEncodedTransaction {
-        match self {
-            Self::Pooled(transaction) => transaction
-                .shared
-                .get_or_init(|| {
-                    LazyEncoded::new(PropagatePooledTransactionEncoder::new(
-                        transaction.transaction.clone(),
-                    ))
-                })
-                .clone(),
-            Self::Tx(transaction) => transaction.transaction.clone(),
-        }
+        self.transaction.clone()
     }
 }
 
@@ -1995,7 +1903,7 @@ impl PropagateTransactionsBuilder {
 
 impl PropagateTransactionsBuilder {
     /// Appends a transaction to the list.
-    fn push<P: PoolTransaction>(&mut self, transaction: PropagateTransactionItem<'_, P>) {
+    fn push<T>(&mut self, transaction: &PropagateTransaction<T>) {
         match self {
             Self::Pooled(builder) => builder.push(transaction),
             Self::Full(builder) => builder.push(transaction),
@@ -2061,12 +1969,9 @@ impl FullTransactionsBuilder {
     }
 
     /// Appends all transactions.
-    fn extend_pooled<P>(&mut self, txs: impl IntoIterator<Item = PropagatePooledTransaction<P>>)
-    where
-        P: PoolTransaction,
-    {
+    fn extend<T>(&mut self, txs: impl IntoIterator<Item = PropagateTransaction<T>>) {
         for tx in txs {
-            self.push(PropagateTransactionItem::Pooled(&tx))
+            self.push(&tx)
         }
     }
 
@@ -2079,7 +1984,7 @@ impl FullTransactionsBuilder {
     /// If the transaction is unsuitable for broadcast or would exceed the softlimit, it is appended
     /// to list of pooled transactions, (e.g. 4844 transactions).
     /// See also [`SignedTransaction::is_broadcastable_in_full`].
-    fn push<P: PoolTransaction>(&mut self, transaction: PropagateTransactionItem<'_, P>) {
+    fn push<T>(&mut self, transaction: &PropagateTransaction<T>) {
         // Do not send full 4844 transaction hashes to peers.
         //
         //  Nodes MUST NOT automatically broadcast blob transactions to their peers.
@@ -2155,16 +2060,13 @@ impl PooledTransactionsHashesBuilder {
     }
 
     /// Appends all hashes
-    fn extend_pooled<P>(&mut self, txs: impl IntoIterator<Item = PropagatePooledTransaction<P>>)
-    where
-        P: PoolTransaction,
-    {
+    fn extend<T>(&mut self, txs: impl IntoIterator<Item = PropagateTransaction<T>>) {
         for tx in txs {
-            self.push(PropagateTransactionItem::Pooled(&tx));
+            self.push(&tx);
         }
     }
 
-    fn push<P: PoolTransaction>(&mut self, tx: PropagateTransactionItem<'_, P>) {
+    fn push<T>(&mut self, tx: &PropagateTransaction<T>) {
         match self {
             Self::Eth66(msg) => msg.push(*tx.tx_hash()),
             Self::Eth68(msg) => {
@@ -2318,7 +2220,7 @@ enum TransactionsCommand<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Propagate a collection of hashes to all peers.
     PropagateTransactions(Vec<TxHash>),
     /// Propagate a collection of broadcastable transactions in full to all peers.
-    BroadcastTransactions(Vec<PropagateTransaction>),
+    BroadcastTransactions(Vec<PropagateTransaction<N::BroadcastedTransaction>>),
     /// Request transaction hashes known by specific peers from the [`TransactionsManager`].
     GetTransactionHashes { peers: Vec<PeerId>, tx: oneshot::Sender<HashMap<PeerId, B256Set>> },
     /// Requests a clone of the sender channel to the peer.
@@ -3252,10 +3154,9 @@ mod tests {
         assert!(builder.is_empty());
 
         let mut tx_gen = TransactionGenerator::new(rand::rng());
-        let tx = PropagatePooledTransaction::new(valid_eth_pool_transaction(
-            tx_gen.gen_eip1559_pooled(),
-        ));
-        builder.push(PropagateTransactionItem::Pooled(&tx));
+        let tx =
+            PropagateTransaction::pool_tx(valid_eth_pool_transaction(tx_gen.gen_eip1559_pooled()));
+        builder.push(&tx);
         assert!(!builder.is_empty());
 
         let txs = builder.build();
@@ -3296,9 +3197,8 @@ mod tests {
         let mut tx = tx_gen.gen_eip1559_pooled();
         // create a transaction that still fits
         tx.encoded_length = DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE + 1;
-        let tx = valid_eth_pool_transaction(tx);
-        let tx = PropagatePooledTransaction::new(tx);
-        builder.push(PropagateTransactionItem::Pooled(&tx));
+        let tx = PropagateTransaction::pool_tx(valid_eth_pool_transaction(tx));
+        builder.push(&tx);
         assert!(!builder.is_empty());
 
         let txs = builder.clone().build();
@@ -3306,7 +3206,7 @@ mod tests {
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
 
-        builder.push(PropagateTransactionItem::Pooled(&tx));
+        builder.push(&tx);
 
         let txs = builder.clone().build();
         let pooled = txs.pooled.unwrap();
@@ -3321,10 +3221,9 @@ mod tests {
         assert!(builder.is_empty());
 
         let mut tx_gen = TransactionGenerator::new(rand::rng());
-        let tx = PropagatePooledTransaction::new(valid_eth_pool_transaction(
-            tx_gen.gen_eip4844_pooled(),
-        ));
-        builder.push(PropagateTransactionItem::Pooled(&tx));
+        let tx =
+            PropagateTransaction::pool_tx(valid_eth_pool_transaction(tx_gen.gen_eip4844_pooled()));
+        builder.push(&tx);
         assert!(!builder.is_empty());
 
         let txs = builder.clone().build();
@@ -3332,10 +3231,9 @@ mod tests {
         let txs = txs.pooled.unwrap();
         assert_eq!(txs.len(), 1);
 
-        let tx = PropagatePooledTransaction::new(valid_eth_pool_transaction(
-            tx_gen.gen_eip1559_pooled(),
-        ));
-        builder.push(PropagateTransactionItem::Pooled(&tx));
+        let tx =
+            PropagateTransaction::pool_tx(valid_eth_pool_transaction(tx_gen.gen_eip1559_pooled()));
+        builder.push(&tx);
 
         let txs = builder.clone().build();
         let pooled = txs.pooled.unwrap();
@@ -3377,7 +3275,7 @@ mod tests {
         propagate.push(eip4844_tx.clone());
 
         let propagated = tx_manager.propagate_transactions(
-            PropagateTransactions::pooled(propagate.clone()),
+            propagate.clone().into_iter().map(PropagateTransaction::pool_tx).collect(),
             PropagationMode::Basic,
         );
         assert_eq!(propagated.len(), 2);
@@ -3396,7 +3294,7 @@ mod tests {
 
         // propagate again
         let propagated = tx_manager.propagate_transactions(
-            PropagateTransactions::pooled(propagate),
+            propagate.into_iter().map(PropagateTransaction::pool_tx).collect(),
             PropagationMode::Basic,
         );
         assert!(propagated.is_empty());
@@ -3427,8 +3325,10 @@ mod tests {
         let last_sent = *txs[txs.len() - 2].hash();
         let truncated = *txs[txs.len() - 1].hash();
 
-        let propagated = tx_manager
-            .propagate_transactions(PropagateTransactions::pooled(txs), PropagationMode::Basic);
+        let propagated = tx_manager.propagate_transactions(
+            txs.into_iter().map(PropagateTransaction::pool_tx).collect(),
+            PropagationMode::Basic,
+        );
 
         // the truncated hash was not sent, so it must not be tracked as seen by the peer
         assert!(propagated.get(&truncated).is_none());

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -38,19 +38,23 @@ use crate::{
     transactions::config::{StrictEthAnnouncementFilter, TransactionPropagationKind},
     NetworkHandle, TxTypesCounter,
 };
+use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::{
+    bytes::BufMut,
     map::{hash_map::Entry, B256Map, B256Set, FbBuildHasher, HashMap, HashSet},
     TxHash, B256,
 };
+use alloy_rlp::Encodable;
 use constants::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use reth_eth_wire::{
-    DedupPayload, EthNetworkPrimitives, EthVersion, GetPooledTransactions, HandleMempoolData,
-    HandleVersionedMempoolData, NetworkPrimitives, NewPooledTransactionHashes,
+    BroadcastPoolTransactions, DedupPayload, EthNetworkPrimitives, EthVersion,
+    GetPooledTransactions, HandleMempoolData, HandleVersionedMempoolData, LazyEncoded,
+    LazyEncodedTransaction, NetworkPrimitives, NewPooledTransactionHashes,
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, NewPooledTransactionHashes72,
     PooledTransactions, RequestTxHashes, Transactions, ValidAnnouncementData,
 };
-use reth_ethereum_primitives::{TransactionSigned, TxType};
+use reth_ethereum_primitives::TxType;
 use reth_metrics::common::mpsc::MemoryBoundedReceiver;
 use reth_network_api::{
     events::{PeerEvent, SessionInfo},
@@ -70,6 +74,7 @@ use reth_transaction_pool::{
     PropagatedTransactions, TransactionPool, ValidPoolTransaction,
 };
 use std::{
+    cell::OnceCell,
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -899,18 +904,18 @@ where
         // filter all transactions unknown to the peer
         let mut full_transactions = FullTransactionsBuilder::new(peer.version);
 
-        let to_propagate = self.pool.get_all(txs).into_iter().map(PropagateTransaction::pool_tx);
+        let to_propagate = self.pool.get_all(txs).into_iter().map(PropagatePooledTransaction::new);
 
         if propagation_mode.is_forced() {
             // skip cache check if forced
-            full_transactions.extend(to_propagate);
+            full_transactions.extend_pooled(to_propagate);
         } else {
             // Iterate through the transactions to propagate and fill the hashes and full
             // transaction
             for tx in to_propagate {
                 if !peer.seen_transactions.contains(tx.tx_hash()) {
                     // Only include if the peer hasn't seen the transaction
-                    full_transactions.push(&tx);
+                    full_transactions.push(PropagateTransactionItem::Pooled(&tx));
                 }
             }
         }
@@ -920,7 +925,7 @@ where
             return None
         }
 
-        let PropagateTransactions { pooled, full } = full_transactions.build();
+        let PeerPropagationMessages { pooled, full } = full_transactions.build();
 
         // send hashes if any
         if let Some(new_pooled_hashes) = pooled {
@@ -936,14 +941,14 @@ where
 
         // send full transactions, if any
         if let Some(new_full_transactions) = full {
-            for tx in &new_full_transactions {
-                propagated.record(*tx.tx_hash(), PropagateKind::Full(peer_id));
+            for hash in new_full_transactions.iter_hashes() {
+                propagated.record(*hash, PropagateKind::Full(peer_id));
                 // mark transaction as seen by peer
-                peer.seen_transactions.insert(*tx.tx_hash());
+                peer.seen_transactions.insert(*hash);
             }
 
             // send full transactions
-            self.network.send_transactions(peer_id, new_full_transactions);
+            self.network.send_broadcast_pool_transactions(peer_id, new_full_transactions);
         }
 
         // Update propagated transactions metrics
@@ -972,7 +977,7 @@ where
             };
 
             let to_propagate =
-                self.pool.get_all(hashes).into_iter().map(PropagateTransaction::pool_tx);
+                self.pool.get_all(hashes).into_iter().map(PropagatePooledTransaction::new);
 
             let mut propagated = PropagatedTransactions::default();
 
@@ -980,12 +985,12 @@ where
             let mut hashes = PooledTransactionsHashesBuilder::new(peer.version);
 
             if propagation_mode.is_forced() {
-                hashes.extend(to_propagate)
+                hashes.extend_pooled(to_propagate)
             } else {
                 for tx in to_propagate {
                     if !peer.seen_transactions.contains(tx.tx_hash()) {
                         // Include if the peer hasn't seen it
-                        hashes.push(&tx);
+                        hashes.push(PropagateTransactionItem::Pooled(&tx));
                     }
                 }
             }
@@ -1025,7 +1030,7 @@ where
     /// Note: EIP-4844 are disallowed from being broadcast in full and are only ever sent as hashes, see also <https://eips.ethereum.org/EIPS/eip-4844#networking>.
     fn propagate_transactions(
         &mut self,
-        to_propagate: Vec<PropagateTransaction<N::BroadcastedTransaction>>,
+        to_propagate: PropagateTransactions<Pool::Transaction>,
         propagation_mode: PropagationMode,
     ) -> PropagatedTransactions {
         let mut propagated = PropagatedTransactions::default();
@@ -1043,6 +1048,7 @@ where
                 // skip peers we should not propagate to
                 continue
             }
+
             // determine whether to send full tx objects or hashes.
             let mut builder = if num_full_peers < max_num_full {
                 num_full_peers += 1;
@@ -1075,7 +1081,7 @@ where
                 continue
             }
 
-            let PropagateTransactions { pooled, full } = builder.build();
+            let PeerPropagationMessages { pooled, full } = builder.build();
 
             // send hashes if any
             if let Some(mut new_pooled_hashes) = pooled {
@@ -1110,14 +1116,14 @@ where
 
             // send full transactions, if any
             if let Some(new_full_transactions) = full {
-                for tx in &new_full_transactions {
-                    propagated.record(*tx.tx_hash(), PropagateKind::Full(*peer_id));
+                for hash in new_full_transactions.iter_hashes() {
+                    propagated.record(*hash, PropagateKind::Full(*peer_id));
                 }
 
                 trace!(target: "net::tx", ?peer_id, num_txs=?new_full_transactions.len(), "Propagating full transactions to peer");
 
                 // send full transactions
-                self.network.send_transactions(*peer_id, new_full_transactions);
+                self.network.send_broadcast_pool_transactions(*peer_id, new_full_transactions);
             }
         }
 
@@ -1137,7 +1143,7 @@ where
             return
         }
         let propagated = self.propagate_transactions(
-            self.pool.get_all(hashes).into_iter().map(PropagateTransaction::pool_tx).collect(),
+            PropagateTransactions::pooled(self.pool.get_all(hashes)),
             PropagationMode::Basic,
         );
 
@@ -1197,7 +1203,10 @@ where
             }
             TransactionsCommand::PropagateTransactions(txs) => self.propagate_all(txs),
             TransactionsCommand::BroadcastTransactions(txs) => {
-                let propagated = self.propagate_transactions(txs, PropagationMode::Forced);
+                let propagated = self.propagate_transactions(
+                    PropagateTransactions::Tx(txs),
+                    PropagationMode::Forced,
+                );
                 self.pool.on_propagated(propagated);
             }
             TransactionsCommand::GetTransactionHashes { peers, tx } => {
@@ -1756,45 +1765,203 @@ impl PropagationMode {
     }
 }
 
-/// A transaction that's about to be propagated to multiple peers.
+/// A transaction supplied directly for full propagation.
 #[derive(Debug, Clone)]
-struct PropagateTransaction<T = TransactionSigned> {
-    size: usize,
-    transaction: Arc<T>,
+struct PropagateTransaction {
+    is_broadcastable_in_full: bool,
+    transaction: LazyEncodedTransaction,
 }
 
-impl<T: SignedTransaction> PropagateTransaction<T> {
+impl PropagateTransaction {
     /// Create a new instance from a transaction.
-    pub fn new(transaction: T) -> Self {
-        let size = transaction.length();
-        Self { size, transaction: Arc::new(transaction) }
-    }
+    fn new<T: SignedTransaction>(transaction: T) -> Self {
+        let is_broadcastable_in_full = transaction.is_broadcastable_in_full();
 
-    /// Create a new instance from a pooled transaction
-    fn pool_tx<P>(tx: Arc<ValidPoolTransaction<P>>) -> Self
-    where
-        P: PoolTransaction<Consensus = T>,
-    {
-        let size = tx.encoded_length();
-        let transaction = tx.transaction.clone_into_consensus();
-        let transaction = Arc::new(transaction.into_inner());
-        Self { size, transaction }
+        Self { is_broadcastable_in_full, transaction: LazyEncoded::new(transaction) }
+    }
+}
+
+/// A pooled transaction that's about to be propagated to multiple peers.
+#[derive(Debug)]
+struct PropagatePooledTransaction<P: PoolTransaction> {
+    transaction: Arc<ValidPoolTransaction<P>>,
+    shared: OnceCell<LazyEncodedTransaction>,
+}
+
+impl<P: PoolTransaction> PropagatePooledTransaction<P> {
+    const fn new(transaction: Arc<ValidPoolTransaction<P>>) -> Self {
+        Self { transaction, shared: OnceCell::new() }
     }
 
     fn tx_hash(&self) -> &TxHash {
-        self.transaction.tx_hash()
+        self.transaction.hash()
+    }
+}
+
+/// Transactions that are about to be propagated to multiple peers.
+#[derive(Debug)]
+enum PropagateTransactions<P: PoolTransaction> {
+    /// Transactions from the pool.
+    Pooled(Vec<PropagatePooledTransaction<P>>),
+    /// Transactions supplied directly through the transactions handle.
+    Tx(Vec<PropagateTransaction>),
+}
+
+impl<P: PoolTransaction> PropagateTransactions<P> {
+    /// Wraps pool transactions once so every per-peer full broadcast shares the same lazy encoding.
+    fn pooled(transactions: Vec<Arc<ValidPoolTransaction<P>>>) -> Self {
+        Self::Pooled(transactions.into_iter().map(PropagatePooledTransaction::new).collect())
+    }
+
+    const fn len(&self) -> usize {
+        match self {
+            Self::Pooled(transactions) => transactions.len(),
+            Self::Tx(transactions) => transactions.len(),
+        }
+    }
+}
+
+impl<'a, P: PoolTransaction> IntoIterator for &'a PropagateTransactions<P> {
+    type Item = PropagateTransactionItem<'a, P>;
+    type IntoIter = PropagateTransactionIter<'a, P>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            PropagateTransactions::Pooled(transactions) => {
+                PropagateTransactionIter::Pooled(transactions.iter())
+            }
+            PropagateTransactions::Tx(transactions) => {
+                PropagateTransactionIter::Tx(transactions.iter())
+            }
+        }
+    }
+}
+
+enum PropagateTransactionIter<'a, P: PoolTransaction> {
+    Pooled(std::slice::Iter<'a, PropagatePooledTransaction<P>>),
+    Tx(std::slice::Iter<'a, PropagateTransaction>),
+}
+
+impl<'a, P: PoolTransaction> Iterator for PropagateTransactionIter<'a, P> {
+    type Item = PropagateTransactionItem<'a, P>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Pooled(transactions) => transactions.next().map(PropagateTransactionItem::Pooled),
+            Self::Tx(transactions) => transactions.next().map(PropagateTransactionItem::Tx),
+        }
+    }
+}
+
+/// A transaction item borrowed from a [`PropagateTransactions`] batch.
+enum PropagateTransactionItem<'a, P: PoolTransaction> {
+    /// A pooled transaction.
+    Pooled(&'a PropagatePooledTransaction<P>),
+    /// A transaction supplied directly through the transactions handle.
+    Tx(&'a PropagateTransaction),
+}
+
+impl<P: PoolTransaction> Clone for PropagateTransactionItem<'_, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<P: PoolTransaction> Copy for PropagateTransactionItem<'_, P> {}
+
+impl<P: PoolTransaction> PropagateTransactionItem<'_, P> {
+    fn tx_hash(&self) -> &TxHash {
+        match self {
+            Self::Pooled(transaction) => transaction.transaction.hash(),
+            Self::Tx(transaction) => transaction.transaction.tx_hash(),
+        }
+    }
+
+    fn propagation_size(&self) -> usize {
+        match self {
+            Self::Pooled(transaction) => transaction.transaction.encoded_length(),
+            Self::Tx(transaction) => transaction.transaction.length(),
+        }
+    }
+
+    fn tx_type(&self) -> u8 {
+        match self {
+            Self::Pooled(transaction) => transaction.transaction.transaction.ty(),
+            Self::Tx(transaction) => transaction.transaction.ty(),
+        }
+    }
+
+    fn is_broadcastable_in_full(&self) -> bool {
+        match self {
+            Self::Pooled(transaction) => {
+                transaction.transaction.transaction.consensus_ref().is_broadcastable_in_full()
+            }
+            Self::Tx(transaction) => transaction.is_broadcastable_in_full,
+        }
+    }
+
+    fn shared(&self) -> LazyEncodedTransaction {
+        match self {
+            Self::Pooled(transaction) => transaction
+                .shared
+                .get_or_init(|| {
+                    LazyEncoded::new(PropagatePooledTransactionEncoder::new(
+                        transaction.transaction.clone(),
+                    ))
+                })
+                .clone(),
+            Self::Tx(transaction) => transaction.transaction.clone(),
+        }
+    }
+}
+
+/// A pooled transaction encoder that avoids cloning into the consensus transaction for propagation.
+#[derive(Debug)]
+struct PropagatePooledTransactionEncoder<P: PoolTransaction> {
+    transaction: Arc<ValidPoolTransaction<P>>,
+}
+
+impl<P: PoolTransaction> PropagatePooledTransactionEncoder<P> {
+    const fn new(transaction: Arc<ValidPoolTransaction<P>>) -> Self {
+        Self { transaction }
+    }
+
+    fn encode_uncached(&self, out: &mut dyn BufMut) {
+        (*self.transaction.transaction.consensus_ref().inner()).encode(out);
+    }
+}
+
+impl<P: PoolTransaction> Encodable for PropagatePooledTransactionEncoder<P> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.encode_uncached(out);
+    }
+
+    fn length(&self) -> usize {
+        (*self.transaction.transaction.consensus_ref().inner()).length()
+    }
+}
+
+impl<P: PoolTransaction> TxHashRef for PropagatePooledTransactionEncoder<P> {
+    fn tx_hash(&self) -> &TxHash {
+        self.transaction.hash()
+    }
+}
+
+impl<P: PoolTransaction> Typed2718 for PropagatePooledTransactionEncoder<P> {
+    fn ty(&self) -> u8 {
+        self.transaction.transaction.ty()
     }
 }
 
 /// Helper type to construct the appropriate message to send to the peer based on whether the peer
 /// should receive them in full or as pooled
 #[derive(Debug, Clone)]
-enum PropagateTransactionsBuilder<T> {
+enum PropagateTransactionsBuilder {
     Pooled(PooledTransactionsHashesBuilder),
-    Full(FullTransactionsBuilder<T>),
+    Full(FullTransactionsBuilder),
 }
 
-impl<T> PropagateTransactionsBuilder<T> {
+impl PropagateTransactionsBuilder {
     /// Create a builder for pooled transactions with capacity for the expected number of
     /// transactions.
     fn pooled(version: EthVersion, capacity: usize) -> Self {
@@ -1816,19 +1983,19 @@ impl<T> PropagateTransactionsBuilder<T> {
     }
 
     /// Consumes the type and returns the built messages that should be sent to the peer.
-    fn build(self) -> PropagateTransactions<T> {
+    fn build(self) -> PeerPropagationMessages {
         match self {
             Self::Pooled(pooled) => {
-                PropagateTransactions { pooled: Some(pooled.build()), full: None }
+                PeerPropagationMessages { pooled: Some(pooled.build()), full: None }
             }
             Self::Full(full) => full.build(),
         }
     }
 }
 
-impl<T: SignedTransaction> PropagateTransactionsBuilder<T> {
+impl PropagateTransactionsBuilder {
     /// Appends a transaction to the list.
-    fn push(&mut self, transaction: &PropagateTransaction<T>) {
+    fn push<P: PoolTransaction>(&mut self, transaction: PropagateTransactionItem<'_, P>) {
         match self {
             Self::Pooled(builder) => builder.push(transaction),
             Self::Full(builder) => builder.push(transaction),
@@ -1837,11 +2004,11 @@ impl<T: SignedTransaction> PropagateTransactionsBuilder<T> {
 }
 
 /// Represents how the transactions should be sent to a peer if any.
-struct PropagateTransactions<T> {
+struct PeerPropagationMessages {
     /// The pooled transaction hashes to send.
     pooled: Option<NewPooledTransactionHashes>,
     /// The transactions to send in full.
-    full: Option<Vec<Arc<T>>>,
+    full: Option<BroadcastPoolTransactions>,
 }
 
 /// Helper type for constructing the full transaction message that enforces the
@@ -1849,16 +2016,16 @@ struct PropagateTransactions<T> {
 /// and enforces other propagation rules for EIP-4844 and tracks those transactions that can't be
 /// broadcasted in full.
 #[derive(Debug, Clone)]
-struct FullTransactionsBuilder<T> {
+struct FullTransactionsBuilder {
     /// The soft limit to enforce for a single broadcast message of full transactions.
     total_size: usize,
     /// All transactions to be broadcasted.
-    transactions: Vec<Arc<T>>,
+    transactions: Vec<LazyEncodedTransaction>,
     /// Transactions that didn't fit into the broadcast message
     pooled: PooledTransactionsHashesBuilder,
 }
 
-impl<T> FullTransactionsBuilder<T> {
+impl FullTransactionsBuilder {
     /// Create a builder for the negotiated version of the peer's session
     fn new(version: EthVersion) -> Self {
         Self {
@@ -1886,18 +2053,20 @@ impl<T> FullTransactionsBuilder<T> {
     }
 
     /// Returns the messages that should be propagated to the peer.
-    fn build(self) -> PropagateTransactions<T> {
+    fn build(self) -> PeerPropagationMessages {
         let pooled = Some(self.pooled.build()).filter(|pooled| !pooled.is_empty());
-        let full = Some(self.transactions).filter(|full| !full.is_empty());
-        PropagateTransactions { pooled, full }
+        let full =
+            (!self.transactions.is_empty()).then_some(BroadcastPoolTransactions(self.transactions));
+        PeerPropagationMessages { pooled, full }
     }
-}
 
-impl<T: SignedTransaction> FullTransactionsBuilder<T> {
     /// Appends all transactions.
-    fn extend(&mut self, txs: impl IntoIterator<Item = PropagateTransaction<T>>) {
+    fn extend_pooled<P>(&mut self, txs: impl IntoIterator<Item = PropagatePooledTransaction<P>>)
+    where
+        P: PoolTransaction,
+    {
         for tx in txs {
-            self.push(&tx)
+            self.push(PropagateTransactionItem::Pooled(&tx))
         }
     }
 
@@ -1910,7 +2079,7 @@ impl<T: SignedTransaction> FullTransactionsBuilder<T> {
     /// If the transaction is unsuitable for broadcast or would exceed the softlimit, it is appended
     /// to list of pooled transactions, (e.g. 4844 transactions).
     /// See also [`SignedTransaction::is_broadcastable_in_full`].
-    fn push(&mut self, transaction: &PropagateTransaction<T>) {
+    fn push<P: PoolTransaction>(&mut self, transaction: PropagateTransactionItem<'_, P>) {
         // Do not send full 4844 transaction hashes to peers.
         //
         //  Nodes MUST NOT automatically broadcast blob transactions to their peers.
@@ -1919,12 +2088,12 @@ impl<T: SignedTransaction> FullTransactionsBuilder<T> {
         //  via `GetPooledTransactions`.
         //
         // From: <https://eips.ethereum.org/EIPS/eip-4844#networking>
-        if !transaction.transaction.is_broadcastable_in_full() {
+        if !transaction.is_broadcastable_in_full() {
             self.pooled.push(transaction);
             return
         }
 
-        let new_size = self.total_size + transaction.size;
+        let new_size = self.total_size + transaction.propagation_size();
         if new_size > DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE &&
             self.total_size > 0
         {
@@ -1934,7 +2103,7 @@ impl<T: SignedTransaction> FullTransactionsBuilder<T> {
         }
 
         self.total_size = new_size;
-        self.transactions.push(Arc::clone(&transaction.transaction));
+        self.transactions.push(transaction.shared());
     }
 }
 
@@ -1986,27 +2155,27 @@ impl PooledTransactionsHashesBuilder {
     }
 
     /// Appends all hashes
-    fn extend<T: SignedTransaction>(
-        &mut self,
-        txs: impl IntoIterator<Item = PropagateTransaction<T>>,
-    ) {
+    fn extend_pooled<P>(&mut self, txs: impl IntoIterator<Item = PropagatePooledTransaction<P>>)
+    where
+        P: PoolTransaction,
+    {
         for tx in txs {
-            self.push(&tx);
+            self.push(PropagateTransactionItem::Pooled(&tx));
         }
     }
 
-    fn push<T: SignedTransaction>(&mut self, tx: &PropagateTransaction<T>) {
+    fn push<P: PoolTransaction>(&mut self, tx: PropagateTransactionItem<'_, P>) {
         match self {
             Self::Eth66(msg) => msg.push(*tx.tx_hash()),
             Self::Eth68(msg) => {
                 msg.hashes.push(*tx.tx_hash());
-                msg.sizes.push(tx.size);
-                msg.types.push(tx.transaction.ty());
+                msg.sizes.push(tx.propagation_size());
+                msg.types.push(tx.tx_type());
             }
             Self::Eth72(msg) => {
                 msg.hashes.push(*tx.tx_hash());
-                msg.sizes.push(tx.size);
-                msg.types.push(tx.transaction.ty());
+                msg.sizes.push(tx.propagation_size());
+                msg.types.push(tx.tx_type());
             }
         }
     }
@@ -2149,7 +2318,7 @@ enum TransactionsCommand<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Propagate a collection of hashes to all peers.
     PropagateTransactions(Vec<TxHash>),
     /// Propagate a collection of broadcastable transactions in full to all peers.
-    BroadcastTransactions(Vec<PropagateTransaction<N::BroadcastedTransaction>>),
+    BroadcastTransactions(Vec<PropagateTransaction>),
     /// Request transaction hashes known by specific peers from the [`TransactionsManager`].
     GetTransactionHashes { peers: Vec<PeerId>, tx: oneshot::Sender<HashMap<PeerId, B256Set>> },
     /// Requests a clone of the sender channel to the peer.
@@ -2262,7 +2431,7 @@ mod tests {
         transactions::config::RelaxedEthAnnouncementFilter,
         NetworkConfigBuilder, NetworkManager,
     };
-    use alloy_consensus::{TxEip1559, TxLegacy};
+    use alloy_consensus::{Transaction as _, TxEip1559, TxLegacy};
     use alloy_eips::eip4844::BlobTransactionValidationError;
     use alloy_primitives::{hex, Signature, TxKind, B256, U256};
     use alloy_rlp::Decodable;
@@ -2277,16 +2446,86 @@ mod tests {
     use reth_storage_api::noop::NoopProvider;
     use reth_tasks::Runtime;
     use reth_transaction_pool::{
+        blobstore::InMemoryBlobStore,
         error::{Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError},
-        test_utils::{testing_pool, MockTransaction, MockTransactionFactory, TestPool},
+        identifier::SenderIdentifiers,
+        test_utils::{
+            testing_pool, MockTransaction, MockTransactionFactory, OkValidator, TestPool,
+            TransactionGenerator,
+        },
+        CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionOrigin, ValidPoolTransaction,
     };
     use secp256k1::SecretKey;
     use std::{
         future::poll_fn,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
+        time::Instant,
     };
     use tracing::error;
+
+    type EthTestPool = Pool<
+        OkValidator<EthPooledTransaction>,
+        CoinbaseTipOrdering<EthPooledTransaction>,
+        InMemoryBlobStore,
+    >;
+
+    async fn new_eth_tx_manager() -> (
+        TransactionsManager<EthTestPool, EthNetworkPrimitives>,
+        NetworkManager<EthNetworkPrimitives>,
+    ) {
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let client = NoopProvider::default();
+
+        let config = NetworkConfigBuilder::new(secret_key, Runtime::test())
+            .listener_port(0)
+            .disable_discovery()
+            .build(client);
+
+        let pool = Pool::new(
+            OkValidator::default(),
+            CoinbaseTipOrdering::default(),
+            InMemoryBlobStore::default(),
+            Default::default(),
+        );
+
+        let transactions_manager_config = config.transactions_manager_config.clone();
+        let (_network_handle, network, transactions, _) = NetworkManager::new(config)
+            .await
+            .unwrap()
+            .into_builder()
+            .transactions(pool.clone(), transactions_manager_config)
+            .split_with_handle();
+
+        (transactions, network)
+    }
+
+    fn valid_eth_pool_transaction(
+        transaction: EthPooledTransaction,
+    ) -> Arc<ValidPoolTransaction<EthPooledTransaction>> {
+        let mut ids = SenderIdentifiers::default();
+        let transaction_id =
+            ids.sender_id_or_create(transaction.sender()).into_transaction_id(transaction.nonce());
+
+        Arc::new(ValidPoolTransaction {
+            propagate: false,
+            transaction_id,
+            transaction,
+            timestamp: Instant::now(),
+            origin: TransactionOrigin::External,
+            authority_ids: None,
+        })
+    }
+
+    fn gen_eip1559_pooled_with_nonce<R: rand::RngCore>(
+        tx_gen: &mut TransactionGenerator<R>,
+        nonce: u64,
+    ) -> EthPooledTransaction {
+        EthPooledTransaction::try_from_consensus(
+            tx_gen.transaction().nonce(nonce).into_eip1559().try_into_recovered().unwrap(),
+        )
+        .unwrap()
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_ignored_tx_broadcasts_while_initially_syncing() {
@@ -3009,13 +3248,14 @@ mod tests {
 
     #[test]
     fn test_transaction_builder_empty() {
-        let mut builder =
-            PropagateTransactionsBuilder::<TransactionSigned>::pooled(EthVersion::Eth68, 0);
+        let mut builder = PropagateTransactionsBuilder::pooled(EthVersion::Eth68, 0);
         assert!(builder.is_empty());
 
-        let mut factory = MockTransactionFactory::default();
-        let tx = PropagateTransaction::pool_tx(Arc::new(factory.create_eip1559()));
-        builder.push(&tx);
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let tx = PropagatePooledTransaction::new(valid_eth_pool_transaction(
+            tx_gen.gen_eip1559_pooled(),
+        ));
+        builder.push(PropagateTransactionItem::Pooled(&tx));
         assert!(!builder.is_empty());
 
         let txs = builder.build();
@@ -3025,18 +3265,40 @@ mod tests {
     }
 
     #[test]
+    fn test_pooled_propagation_transaction_encoder_length_matches_network_encoding() {
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let tx = valid_eth_pool_transaction(tx_gen.gen_eip1559_pooled());
+        let pooled = PropagatePooledTransactionEncoder::new(tx);
+
+        let mut pooled_encoded = Vec::new();
+        pooled.encode(&mut pooled_encoded);
+        assert_eq!(pooled.length(), pooled_encoded.len());
+
+        let broadcast = BroadcastPoolTransactions(vec![LazyEncoded::new(pooled)]);
+        let mut first_encoded = Vec::new();
+        broadcast.encode(&mut first_encoded);
+        let mut second_encoded = Vec::new();
+        broadcast.encode(&mut second_encoded);
+        assert_eq!(first_encoded, second_encoded);
+
+        let mut encoded = first_encoded.as_slice();
+        let decoded = Transactions::<TransactionSigned>::decode(&mut encoded).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert!(encoded.is_empty());
+    }
+
+    #[test]
     fn test_transaction_builder_large() {
-        let mut builder =
-            PropagateTransactionsBuilder::<TransactionSigned>::full(EthVersion::Eth68, 0);
+        let mut builder = PropagateTransactionsBuilder::full(EthVersion::Eth68, 0);
         assert!(builder.is_empty());
 
-        let mut factory = MockTransactionFactory::default();
-        let mut tx = factory.create_eip1559();
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let mut tx = tx_gen.gen_eip1559_pooled();
         // create a transaction that still fits
-        tx.transaction.set_size(DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE + 1);
-        let tx = Arc::new(tx);
-        let tx = PropagateTransaction::pool_tx(tx);
-        builder.push(&tx);
+        tx.encoded_length = DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE + 1;
+        let tx = valid_eth_pool_transaction(tx);
+        let tx = PropagatePooledTransaction::new(tx);
+        builder.push(PropagateTransactionItem::Pooled(&tx));
         assert!(!builder.is_empty());
 
         let txs = builder.clone().build();
@@ -3044,7 +3306,7 @@ mod tests {
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
 
-        builder.push(&tx);
+        builder.push(PropagateTransactionItem::Pooled(&tx));
 
         let txs = builder.clone().build();
         let pooled = txs.pooled.unwrap();
@@ -3055,13 +3317,14 @@ mod tests {
 
     #[test]
     fn test_transaction_builder_eip4844() {
-        let mut builder =
-            PropagateTransactionsBuilder::<TransactionSigned>::full(EthVersion::Eth68, 0);
+        let mut builder = PropagateTransactionsBuilder::full(EthVersion::Eth68, 0);
         assert!(builder.is_empty());
 
-        let mut factory = MockTransactionFactory::default();
-        let tx = PropagateTransaction::pool_tx(Arc::new(factory.create_eip4844()));
-        builder.push(&tx);
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let tx = PropagatePooledTransaction::new(valid_eth_pool_transaction(
+            tx_gen.gen_eip4844_pooled(),
+        ));
+        builder.push(PropagateTransactionItem::Pooled(&tx));
         assert!(!builder.is_empty());
 
         let txs = builder.clone().build();
@@ -3069,8 +3332,10 @@ mod tests {
         let txs = txs.pooled.unwrap();
         assert_eq!(txs.len(), 1);
 
-        let tx = PropagateTransaction::pool_tx(Arc::new(factory.create_eip1559()));
-        builder.push(&tx);
+        let tx = PropagatePooledTransaction::new(valid_eth_pool_transaction(
+            tx_gen.gen_eip1559_pooled(),
+        ));
+        builder.push(PropagateTransactionItem::Pooled(&tx));
 
         let txs = builder.clone().build();
         let pooled = txs.pooled.unwrap();
@@ -3083,7 +3348,7 @@ mod tests {
     async fn test_propagate_full() {
         reth_tracing::init_test_tracing();
 
-        let (mut tx_manager, network) = new_tx_manager().await;
+        let (mut tx_manager, network) = new_eth_tx_manager().await;
         let peer_id = PeerId::random();
 
         // ensure not syncing
@@ -3105,14 +3370,16 @@ mod tests {
         tx_manager
             .on_network_event(NetworkEvent::ActivePeerSession { info: session_info, messages });
         let mut propagate = vec![];
-        let mut factory = MockTransactionFactory::default();
-        let eip1559_tx = Arc::new(factory.create_eip1559());
-        propagate.push(PropagateTransaction::pool_tx(eip1559_tx.clone()));
-        let eip4844_tx = Arc::new(factory.create_eip4844());
-        propagate.push(PropagateTransaction::pool_tx(eip4844_tx.clone()));
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let eip1559_tx = valid_eth_pool_transaction(tx_gen.gen_eip1559_pooled());
+        propagate.push(eip1559_tx.clone());
+        let eip4844_tx = valid_eth_pool_transaction(tx_gen.gen_eip4844_pooled());
+        propagate.push(eip4844_tx.clone());
 
-        let propagated =
-            tx_manager.propagate_transactions(propagate.clone(), PropagationMode::Basic);
+        let propagated = tx_manager.propagate_transactions(
+            PropagateTransactions::pooled(propagate.clone()),
+            PropagationMode::Basic,
+        );
         assert_eq!(propagated.len(), 2);
         let prop_txs = propagated.get(eip1559_tx.transaction.hash()).unwrap();
         assert_eq!(prop_txs.len(), 1);
@@ -3128,7 +3395,10 @@ mod tests {
         peer.seen_transactions.contains(eip4844_tx.transaction.hash());
 
         // propagate again
-        let propagated = tx_manager.propagate_transactions(propagate, PropagationMode::Basic);
+        let propagated = tx_manager.propagate_transactions(
+            PropagateTransactions::pooled(propagate),
+            PropagationMode::Basic,
+        );
         assert!(propagated.is_empty());
     }
 
@@ -3136,7 +3406,7 @@ mod tests {
     async fn test_truncated_hash_announcement_not_marked_seen() {
         reth_tracing::init_test_tracing();
 
-        let (mut tx_manager, network) = new_tx_manager().await;
+        let (mut tx_manager, network) = new_eth_tx_manager().await;
         // all peers receive hash announcements only
         tx_manager.config.propagation_mode = TransactionPropagationMode::Max(0);
 
@@ -3148,14 +3418,17 @@ mod tests {
         tx_manager.peers.insert(peer_id, peer);
 
         // one more transaction than fits into a single hashes broadcast message
-        let mut factory = MockTransactionFactory::default();
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
         let txs = (0..=SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE)
-            .map(|_| PropagateTransaction::pool_tx(Arc::new(factory.create_eip1559())))
+            .map(|nonce| {
+                valid_eth_pool_transaction(gen_eip1559_pooled_with_nonce(&mut tx_gen, nonce as u64))
+            })
             .collect::<Vec<_>>();
-        let last_sent = *txs[txs.len() - 2].tx_hash();
-        let truncated = *txs[txs.len() - 1].tx_hash();
+        let last_sent = *txs[txs.len() - 2].hash();
+        let truncated = *txs[txs.len() - 1].hash();
 
-        let propagated = tx_manager.propagate_transactions(txs, PropagationMode::Basic);
+        let propagated = tx_manager
+            .propagate_transactions(PropagateTransactions::pooled(txs), PropagationMode::Basic);
 
         // the truncated hash was not sent, so it must not be tracked as seen by the peer
         assert!(propagated.get(&truncated).is_none());
@@ -3168,7 +3441,7 @@ mod tests {
     async fn test_propagate_pending_txs_while_initially_syncing() {
         reth_tracing::init_test_tracing();
 
-        let (mut tx_manager, network) = new_tx_manager().await;
+        let (mut tx_manager, network) = new_eth_tx_manager().await;
         let peer_id = PeerId::random();
 
         // Keep the node in initial sync mode.
@@ -3179,17 +3452,19 @@ mod tests {
         let (peer, _rx) = new_mock_session(peer_id, EthVersion::Eth68);
         tx_manager.peers.insert(peer_id, peer);
 
-        let tx = MockTransaction::eip1559();
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let tx = gen_eip1559_pooled_with_nonce(&mut tx_gen, 0);
+        let tx_hash = *tx.hash();
         tx_manager
             .pool
             .add_transaction(reth_transaction_pool::TransactionOrigin::External, tx.clone())
             .await
             .expect("transaction should be accepted into the pool");
 
-        tx_manager.on_new_pending_transactions(vec![*tx.get_hash()]);
+        tx_manager.on_new_pending_transactions(vec![tx_hash]);
 
         let peer = tx_manager.peers.get(&peer_id).expect("peer should exist");
-        assert!(peer.seen_transactions.contains(tx.get_hash()));
+        assert!(peer.seen_transactions.contains(&tx_hash));
     }
 
     #[tokio::test]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -54,7 +54,7 @@ use reth_eth_wire::{
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, NewPooledTransactionHashes72,
     PooledTransactions, RequestTxHashes, Transactions, ValidAnnouncementData,
 };
-use reth_ethereum_primitives::{TransactionSigned, TxType};
+use reth_ethereum_primitives::TxType;
 use reth_metrics::common::mpsc::MemoryBoundedReceiver;
 use reth_network_api::{
     events::{PeerEvent, SessionInfo},
@@ -74,7 +74,6 @@ use reth_transaction_pool::{
     PropagatedTransactions, TransactionPool, ValidPoolTransaction,
 };
 use std::{
-    marker::PhantomData,
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -925,7 +924,7 @@ where
             return None
         }
 
-        let PeerPropagationMessages { pooled, full } = full_transactions.build();
+        let PropagateTransactions { pooled, full } = full_transactions.build();
 
         // send hashes if any
         if let Some(new_pooled_hashes) = pooled {
@@ -1030,7 +1029,7 @@ where
     /// Note: EIP-4844 are disallowed from being broadcast in full and are only ever sent as hashes, see also <https://eips.ethereum.org/EIPS/eip-4844#networking>.
     fn propagate_transactions(
         &mut self,
-        to_propagate: Vec<PropagateTransaction<N::BroadcastedTransaction>>,
+        to_propagate: Vec<PropagateTransaction>,
         propagation_mode: PropagationMode,
     ) -> PropagatedTransactions {
         let mut propagated = PropagatedTransactions::default();
@@ -1081,7 +1080,7 @@ where
                 continue
             }
 
-            let PeerPropagationMessages { pooled, full } = builder.build();
+            let PropagateTransactions { pooled, full } = builder.build();
 
             // send hashes if any
             if let Some(mut new_pooled_hashes) = pooled {
@@ -1764,7 +1763,7 @@ impl PropagationMode {
 
 /// A transaction that's about to be propagated to multiple peers.
 #[derive(Debug, Clone)]
-struct PropagateTransaction<T = TransactionSigned> {
+struct PropagateTransaction {
     is_broadcastable_in_full: bool,
     /// Size advertised in `NewPooledTransactionHashes` metadata and used for full broadcast
     /// soft-limit accounting.
@@ -1774,16 +1773,15 @@ struct PropagateTransaction<T = TransactionSigned> {
     /// `PooledTransactions`.
     propagation_size: usize,
     transaction: LazyEncodedTransaction,
-    _marker: PhantomData<fn() -> T>,
 }
 
-impl<T: SignedTransaction> PropagateTransaction<T> {
+impl PropagateTransaction {
     /// Create a new instance from a transaction supplied directly for propagation.
     ///
     /// Direct transactions use their EIP-2718 encoded length so eth/68+ hash announcements carry
     /// the same size metadata as [`NewPooledTransactionHashes68::push`] and
     /// [`NewPooledTransactionHashes72::push`].
-    fn new(transaction: T) -> Self {
+    fn new<T: SignedTransaction>(transaction: T) -> Self {
         let is_broadcastable_in_full = transaction.is_broadcastable_in_full();
         let propagation_size = transaction.encode_2718_len();
 
@@ -1791,7 +1789,6 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
             is_broadcastable_in_full,
             propagation_size,
             transaction: LazyEncoded::new(transaction),
-            _marker: PhantomData,
         }
     }
 
@@ -1800,22 +1797,16 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
     /// Pool transactions already cache the network encoded size used by txpool admission and
     /// pooled hash announcements. For blob transactions, this includes the sidecar size expected in
     /// a `PooledTransactions` response.
-    fn pool_tx<P>(tx: Arc<ValidPoolTransaction<P>>) -> Self
-    where
-        P: PoolTransaction<Consensus = T>,
-    {
+    fn pool_tx<P: PoolTransaction>(tx: Arc<ValidPoolTransaction<P>>) -> Self {
         let is_broadcastable_in_full = tx.transaction.consensus_ref().is_broadcastable_in_full();
         let propagation_size = tx.encoded_length();
         Self {
             is_broadcastable_in_full,
             propagation_size,
             transaction: LazyEncoded::new(PropagatePooledTransactionEncoder::new(tx)),
-            _marker: PhantomData,
         }
     }
-}
 
-impl<T> PropagateTransaction<T> {
     fn tx_hash(&self) -> &TxHash {
         self.transaction.tx_hash()
     }
@@ -1906,10 +1897,10 @@ impl PropagateTransactionsBuilder {
     }
 
     /// Consumes the type and returns the built messages that should be sent to the peer.
-    fn build(self) -> PeerPropagationMessages {
+    fn build(self) -> PropagateTransactions {
         match self {
             Self::Pooled(pooled) => {
-                PeerPropagationMessages { pooled: Some(pooled.build()), full: None }
+                PropagateTransactions { pooled: Some(pooled.build()), full: None }
             }
             Self::Full(full) => full.build(),
         }
@@ -1918,7 +1909,7 @@ impl PropagateTransactionsBuilder {
 
 impl PropagateTransactionsBuilder {
     /// Appends a transaction to the list.
-    fn push<T>(&mut self, transaction: &PropagateTransaction<T>) {
+    fn push(&mut self, transaction: &PropagateTransaction) {
         match self {
             Self::Pooled(builder) => builder.push(transaction),
             Self::Full(builder) => builder.push(transaction),
@@ -1927,7 +1918,7 @@ impl PropagateTransactionsBuilder {
 }
 
 /// Represents how the transactions should be sent to a peer if any.
-struct PeerPropagationMessages {
+struct PropagateTransactions {
     /// The pooled transaction hashes to send.
     pooled: Option<NewPooledTransactionHashes>,
     /// The transactions to send in full.
@@ -1976,15 +1967,15 @@ impl FullTransactionsBuilder {
     }
 
     /// Returns the messages that should be propagated to the peer.
-    fn build(self) -> PeerPropagationMessages {
+    fn build(self) -> PropagateTransactions {
         let pooled = Some(self.pooled.build()).filter(|pooled| !pooled.is_empty());
         let full =
             (!self.transactions.is_empty()).then_some(BroadcastPoolTransactions(self.transactions));
-        PeerPropagationMessages { pooled, full }
+        PropagateTransactions { pooled, full }
     }
 
     /// Appends all transactions.
-    fn extend<T>(&mut self, txs: impl IntoIterator<Item = PropagateTransaction<T>>) {
+    fn extend(&mut self, txs: impl IntoIterator<Item = PropagateTransaction>) {
         for tx in txs {
             self.push(&tx)
         }
@@ -1999,7 +1990,7 @@ impl FullTransactionsBuilder {
     /// If the transaction is unsuitable for broadcast or would exceed the softlimit, it is appended
     /// to list of pooled transactions, (e.g. 4844 transactions).
     /// See also [`SignedTransaction::is_broadcastable_in_full`].
-    fn push<T>(&mut self, transaction: &PropagateTransaction<T>) {
+    fn push(&mut self, transaction: &PropagateTransaction) {
         // Do not send full 4844 transaction hashes to peers.
         //
         //  Nodes MUST NOT automatically broadcast blob transactions to their peers.
@@ -2075,13 +2066,13 @@ impl PooledTransactionsHashesBuilder {
     }
 
     /// Appends all hashes
-    fn extend<T>(&mut self, txs: impl IntoIterator<Item = PropagateTransaction<T>>) {
+    fn extend(&mut self, txs: impl IntoIterator<Item = PropagateTransaction>) {
         for tx in txs {
             self.push(&tx);
         }
     }
 
-    fn push<T>(&mut self, tx: &PropagateTransaction<T>) {
+    fn push(&mut self, tx: &PropagateTransaction) {
         match self {
             Self::Eth66(msg) => msg.push(*tx.tx_hash()),
             Self::Eth68(msg) => {
@@ -2235,7 +2226,7 @@ enum TransactionsCommand<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Propagate a collection of hashes to all peers.
     PropagateTransactions(Vec<TxHash>),
     /// Propagate a collection of broadcastable transactions in full to all peers.
-    BroadcastTransactions(Vec<PropagateTransaction<N::BroadcastedTransaction>>),
+    BroadcastTransactions(Vec<PropagateTransaction>),
     /// Request transaction hashes known by specific peers from the [`TransactionsManager`].
     GetTransactionHashes { peers: Vec<PeerId>, tx: oneshot::Sender<HashMap<PeerId, B256Set>> },
     /// Requests a clone of the sender channel to the peer.


### PR DESCRIPTION
Adds a separate BroadcastPoolTransactions path alongside the existing SharedTransactions send path. The new outbound-only path encodes the same Transactions wire payload, but transaction-manager propagation can wrap pool-backed transactions as LazyEncoded<dyn BroadcastPoolTransaction>, where BroadcastPoolTransaction is Encodable + TxHashRef + Typed2718.

This reuses cached EIP-2718 bytes across peer sessions without cloning pool transactions into consensus form, while SharedTransactions remains the normal shared transaction list representation.