### PR TITLE
refactor(trie): drop unused BlockAccessList state-root message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10604,7 +10604,6 @@ dependencies = [
 name = "reth-trie-parallel"
 version = "2.3.0"
 dependencies = [
- "alloy-eip7928",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -200,10 +200,6 @@ where
                 StateRootMessage::FinishedStateUpdates => {
                     SparseTrieTaskMessage::FinishedStateUpdates
                 }
-                StateRootMessage::BlockAccessList(_) => {
-                    idle_start = Instant::now();
-                    continue;
-                }
                 StateRootMessage::HashedStateUpdate(state) => {
                     SparseTrieTaskMessage::HashedState(state)
                 }

--- a/crates/trie/parallel/Cargo.toml
+++ b/crates/trie/parallel/Cargo.toml
@@ -21,7 +21,6 @@ reth-tasks = { workspace = true, features = ["rayon"] }
 reth-trie.workspace = true
 
 # alloy
-alloy-eip7928.workspace = true
 alloy-evm.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -1,7 +1,6 @@
 //! State root task interface types shared between the engine tree and the payload builder.
 
 use crate::root::ParallelStateRootError;
-use alloy_eip7928::BlockAccessList;
 use alloy_primitives::{keccak256, B256};
 use derive_more::derive::Deref;
 use reth_trie::{updates::TrieUpdates, HashedPostState, HashedStorage, MultiProofTargetsV2};
@@ -18,11 +17,6 @@ pub enum StateRootMessage {
     StateUpdate(EvmState),
     /// Pre-hashed state update from BAL conversion that can be applied directly without proofs.
     HashedStateUpdate(HashedPostState),
-    /// Block Access List (EIP-7928; BAL) containing complete state changes for the block.
-    ///
-    /// When received, the task generates a single state update from the BAL and processes it.
-    /// No further messages are expected after receiving this variant.
-    BlockAccessList(Arc<BlockAccessList>),
     /// Signals state update stream end.
     ///
     /// This is triggered by block execution, indicating that no additional state updates are


### PR DESCRIPTION
Nothing constructs StateRootMessage::BlockAccessList since the BAL-to-hashed-state conversion moved into the prewarm task, and the sparse trie task silently discarded it. Also drops the now-unused alloy-eip7928 dependency from reth-trie-parallel.