### PR TITLE
perf(network): use fixed hasher for peer maps

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -6,6 +6,7 @@ use crate::{
     swarm::NetworkConnectionState,
     trusted_peers_resolver::TrustedPeersResolver,
 };
+use alloy_primitives::map::{hash_map::Entry, FbBuildHasher, HashMap, HashSet};
 use futures::StreamExt;
 
 use rand::Rng;
@@ -24,7 +25,7 @@ use reth_network_types::{
     PersistedPeerInfo, ReputationChangeKind, ReputationChangeOutcome, ReputationChangeWeights,
 };
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    collections::VecDeque,
     fmt::Display,
     io::{self},
     net::{IpAddr, SocketAddr},
@@ -49,12 +50,12 @@ use tracing::{trace, warn};
 #[derive(Debug)]
 pub struct PeersManager {
     /// All peers known to the network
-    peers: HashMap<PeerId, Peer>,
+    peers: HashMap<PeerId, Peer, FbBuildHasher<64>>,
     /// The set of trusted peer ids.
     ///
     /// This tracks peer ids that are considered trusted, but for which we don't necessarily have
     /// an address: [`Self::add_trusted_peer_id`]
-    trusted_peer_ids: HashSet<PeerId>,
+    trusted_peer_ids: HashSet<PeerId, FbBuildHasher<64>>,
     /// A resolver used to periodically resolve DNS names for trusted peers. This updates the
     /// peer's address when the DNS records change.
     trusted_peers_resolver: TrustedPeersResolver,
@@ -73,7 +74,7 @@ pub struct PeersManager {
     /// Tracks unwanted ips/peer ids.
     ban_list: BanList,
     /// Tracks currently backed off peers.
-    backed_off_peers: HashMap<PeerId, std::time::Instant>,
+    backed_off_peers: HashMap<PeerId, std::time::Instant, FbBuildHasher<64>>,
     /// Interval at which to check for peers to unban and release from the backoff map.
     release_interval: Interval,
     /// How long to ban bad peers.
@@ -131,9 +132,12 @@ impl PeersManager {
         // We use half of the interval to decrease the max duration to `150%` in worst case
         let unban_interval = ban_duration.min(backoff_durations.low) / 2;
 
-        let mut peers =
-            HashMap::with_capacity(trusted_nodes.len() + basic_nodes.len() + persisted_peers.len());
-        let mut trusted_peer_ids = HashSet::with_capacity(trusted_nodes.len());
+        let mut peers: HashMap<PeerId, Peer, FbBuildHasher<64>> = HashMap::with_capacity_and_hasher(
+            trusted_nodes.len() + basic_nodes.len() + persisted_peers.len(),
+            Default::default(),
+        );
+        let mut trusted_peer_ids: HashSet<PeerId, FbBuildHasher<64>> =
+            HashSet::with_capacity_and_hasher(trusted_nodes.len(), Default::default());
 
         for trusted_peer in &trusted_nodes {
             match trusted_peer.resolve_blocking() {

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     session::active::ActiveSession,
 };
 use active::QueuedOutgoingMessages;
+use alloy_primitives::map::{FbBuildHasher, HashMap};
 use counter::SessionCounter;
 use futures::{future::Either, io, FutureExt, StreamExt};
 use reth_ecies::{stream::ECIESStream, ECIESError};
@@ -32,7 +33,6 @@ use reth_tasks::Runtime;
 use rustc_hash::FxHashMap;
 use secp256k1::SecretKey;
 use std::{
-    collections::HashMap,
     future::Future,
     net::SocketAddr,
     sync::{atomic::AtomicU64, Arc},
@@ -95,7 +95,7 @@ pub struct SessionManager<N: NetworkPrimitives> {
     /// session is authenticated, it can be moved to the `active_session` set.
     pending_sessions: FxHashMap<SessionId, PendingSessionHandle>,
     /// All active sessions that are ready to exchange messages.
-    active_sessions: HashMap<PeerId, ActiveSessionHandle<N>>,
+    active_sessions: HashMap<PeerId, ActiveSessionHandle<N>, FbBuildHasher<64>>,
     /// The original Sender half of the [`PendingSessionEvent`] channel.
     ///
     /// When a new (pending) session is created, the corresponding [`PendingSessionHandle`] will
@@ -213,7 +213,9 @@ impl<N: NetworkPrimitives> SessionManager<N> {
     }
 
     /// Returns a borrowed reference to the active sessions.
-    pub const fn active_sessions(&self) -> &HashMap<PeerId, ActiveSessionHandle<N>> {
+    pub const fn active_sessions(
+        &self,
+    ) -> &HashMap<PeerId, ActiveSessionHandle<N>, FbBuildHasher<64>> {
         &self.active_sessions
     }
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -10,7 +10,10 @@ use crate::{
     FetchClient,
 };
 use alloy_consensus::BlockHeader;
-use alloy_primitives::B256;
+use alloy_primitives::{
+    map::{FbBuildHasher, HashMap},
+    B256,
+};
 use rand::seq::SliceRandom;
 use reth_eth_wire::{
     BlockHashNumber, Capabilities, DisconnectReason, EthNetworkPrimitives, GetReceipts70,
@@ -23,7 +26,7 @@ use reth_network_peers::PeerId;
 use reth_network_types::{PeerAddr, PeerKind};
 use reth_primitives_traits::Block;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::VecDeque,
     fmt,
     net::{IpAddr, SocketAddr},
     ops::Deref,
@@ -76,7 +79,7 @@ impl Deref for BlockNumReader {
 #[derive(Debug)]
 pub struct NetworkState<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// All active peers and their state.
-    active_peers: HashMap<PeerId, ActivePeer<N>>,
+    active_peers: HashMap<PeerId, ActivePeer<N>, FbBuildHasher<64>>,
     /// Manages connections to peers.
     peers_manager: PeersManager,
     /// Buffered messages until polled.

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -36,7 +36,10 @@ use crate::{
     metrics::TransactionFetcherMetrics,
 };
 use alloy_consensus::transaction::PooledTransaction;
-use alloy_primitives::{map::FbBuildHasher, TxHash};
+use alloy_primitives::{
+    map::{FbBuildHasher, HashMap},
+    TxHash,
+};
 use derive_more::{Constructor, Deref};
 use futures::{stream::FuturesUnordered, Future, FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
@@ -51,7 +54,6 @@ use reth_network_peers::PeerId;
 use reth_primitives_traits::SignedTransaction;
 use schnellru::ByLength;
 use std::{
-    collections::HashMap,
     pin::Pin,
     task::{ready, Context, Poll},
     time::Duration,
@@ -417,7 +419,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     /// the request by checking the transactions seen by the peer against the buffer.
     pub fn on_fetch_pending_hashes(
         &mut self,
-        peers: &HashMap<PeerId, PeerMetadata<N>>,
+        peers: &HashMap<PeerId, PeerMetadata<N>, FbBuildHasher<64>>,
         has_capacity_wrt_pending_pool_imports: impl Fn(usize) -> bool,
     ) -> bool {
         let mut hashes_to_request = RequestTxHashes::with_capacity(
@@ -1491,7 +1493,7 @@ mod test {
         for hash in &seen_hashes {
             peer_2_data.seen_transactions.insert(*hash);
         }
-        let mut peers = HashMap::default();
+        let mut peers: HashMap<PeerId, _, FbBuildHasher<64>> = HashMap::default();
         peers.insert(peer_1, peer_1_data);
         peers.insert(peer_2, peer_2_data);
 
@@ -1551,7 +1553,7 @@ mod test {
         assert_eq!(tx_fetcher.num_pending_hashes(), 1);
 
         // pass empty peers map — both peers are "disconnected"
-        let peers = HashMap::new();
+        let peers: HashMap<PeerId, PeerMetadata, FbBuildHasher<64>> = HashMap::default();
         tx_fetcher.on_fetch_pending_hashes(&peers, |_| true);
 
         // hash should be re-buffered, not lost

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     NetworkHandle, TxTypesCounter,
 };
 use alloy_primitives::{
-    map::{B256Map, B256Set, FbBuildHasher},
+    map::{hash_map::Entry, B256Map, B256Set, FbBuildHasher, HashMap, HashSet},
     TxHash, B256,
 };
 use constants::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
@@ -70,7 +70,6 @@ use reth_transaction_pool::{
     PropagatedTransactions, TransactionPool, ValidPoolTransaction,
 };
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -312,7 +311,7 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     /// Bad imports.
     bad_imports: LruCache<TxHash, FbBuildHasher<32>>,
     /// All the connected peers.
-    peers: HashMap<PeerId, PeerMetadata<N>>,
+    peers: HashMap<PeerId, PeerMetadata<N>, FbBuildHasher<64>>,
     /// Send half for the command channel.
     ///
     /// This is kept so that a new [`TransactionsHandle`] can be created at any time.
@@ -1202,7 +1201,7 @@ where
                 self.pool.on_propagated(propagated);
             }
             TransactionsCommand::GetTransactionHashes { peers, tx } => {
-                let mut res = HashMap::with_capacity(peers.len());
+                let mut res = HashMap::with_capacity_and_hasher(peers.len(), Default::default());
                 for peer_id in peers {
                     let hashes = self
                         .peers


### PR DESCRIPTION
Uses `FbBuildHasher<64>` for `PeerId` keyed maps in network peer/session state and transaction fetcher peer metadata.

This keeps the regular peer maps aligned with the existing fixed-byte hashing used by transaction fetcher LRU caches for `PeerId`.