### PR TITLE
perf(net): skip no-op reputation changes

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -542,12 +542,18 @@ impl PeersManager {
     pub(crate) fn apply_reputation_change(&mut self, peer_id: &PeerId, rep: ReputationChangeKind) {
         trace!(target: "net::peers", ?peer_id, reputation=?rep, "applying reputation change");
 
+        let reputation_change = if rep.is_reset() {
+            None
+        } else {
+            let reputation_change = self.reputation_weights.change(rep).as_i32();
+            if reputation_change == 0 {
+                return
+            }
+            Some(reputation_change)
+        };
+
         let outcome = if let Some(peer) = self.peers.get_mut(peer_id) {
-            // First check if we should reset the reputation
-            if rep.is_reset() {
-                peer.reset_reputation()
-            } else {
-                let mut reputation_change = self.reputation_weights.change(rep).as_i32();
+            if let Some(mut reputation_change) = reputation_change {
                 if peer.is_trusted() || peer.is_static() {
                     // exempt trusted and static peers from reputation slashing for
                     if matches!(
@@ -567,6 +573,8 @@ impl PeersManager {
                     }
                 }
                 peer.apply_reputation(reputation_change, rep)
+            } else {
+                peer.reset_reputation()
             }
         } else {
             return


### PR DESCRIPTION
Skips zero-weight reputation changes before looking up peers in the peer map.

This avoids work on hot already-seen transaction reports while preserving reset handling and nonzero configured reputation changes.