### PR TITLE
perf(net): optimize eth stream polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8522,6 +8522,7 @@ dependencies = [
  "reth-ecies",
  "reth-eth-wire-types",
  "reth-ethereum-forks",
+ "reth-ethereum-primitives",
  "reth-metrics",
  "reth-network-peers",
  "reth-primitives-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8510,6 +8510,7 @@ dependencies = [
  "arbitrary",
  "async-stream",
  "bytes",
+ "codspeed-criterion-compat",
  "derive_more",
  "futures",
  "pin-project",

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -682,6 +682,10 @@ impl ECIES {
         32
     }
 
+    pub(crate) const fn message_frame_len(payload_len: usize) -> usize {
+        Self::header_len() + Self::align_16(payload_len) + 16
+    }
+
     pub const fn body_len(&self) -> usize {
         let len = self.body_size.unwrap();
         Self::align_16(len) + 16

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -697,11 +697,11 @@ impl ECIES {
     pub fn write_body(&mut self, out: &mut BytesMut, data: &[u8]) {
         let len = Self::align_16(data.len());
         let old_len = out.len();
+        out.reserve(len + 16);
+        out.extend_from_slice(data);
         out.resize(old_len + len, 0);
 
         let encrypted = &mut out[old_len..old_len + len];
-        encrypted[..data.len()].copy_from_slice(data);
-
         self.egress_aes.as_mut().unwrap().apply_keystream(encrypted);
         self.egress_mac.as_mut().unwrap().update_body(encrypted);
         let tag = self.egress_mac.as_mut().unwrap().digest();

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -136,11 +136,14 @@ impl Decoder for ECIESCodec {
                     }
 
                     let mut data = buf.split_to(self.ecies.body_len());
-                    let mut ret = BytesMut::new();
-                    ret.extend_from_slice(self.ecies.read_body(&mut data)?);
+                    let body_len = {
+                        let body = self.ecies.read_body(&mut data)?;
+                        body.len()
+                    };
+                    data.truncate(body_len);
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::Message(ret)))
+                    return Ok(Some(IngressECIESValue::Message(data)))
                 }
             }
         }

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -1,7 +1,8 @@
 //! The ECIES Stream implementation which wraps over [`AsyncRead`] and [`AsyncWrite`].
 
 use crate::{
-    codec::ECIESCodec, error::ECIESErrorImpl, ECIESError, EgressECIESValue, IngressECIESValue,
+    algorithm::ECIES, codec::ECIESCodec, error::ECIESErrorImpl, ECIESError, EgressECIESValue,
+    IngressECIESValue,
 };
 use alloy_primitives::{
     bytes::{Bytes, BytesMut},
@@ -40,6 +41,13 @@ impl<Io> ECIESStream<Io> {
     fn post_handshake(mut stream: Framed<Io, ECIESCodec>, remote_id: PeerId) -> Self {
         stream.set_backpressure_boundary(POST_HANDSHAKE_BACKPRESSURE_BOUNDARY);
         Self { stream, remote_id }
+    }
+
+    /// Returns true if the next message can be encoded without crossing the framed write buffer
+    /// backpressure boundary.
+    pub fn can_buffer_message(&self, payload_len: usize) -> bool {
+        self.stream.write_buffer().len().saturating_add(ECIES::message_frame_len(payload_len)) <
+            self.stream.backpressure_boundary()
     }
 }
 

--- a/crates/net/ecies/src/stream.rs
+++ b/crates/net/ecies/src/stream.rs
@@ -25,6 +25,7 @@ use tokio_util::codec::{Decoder, Framed};
 use tracing::{instrument, trace};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+const POST_HANDSHAKE_BACKPRESSURE_BOUNDARY: usize = 1024 * 1024;
 
 /// `ECIES` stream over TCP exchanging raw bytes
 #[derive(Debug)]
@@ -33,6 +34,13 @@ pub struct ECIESStream<Io> {
     #[pin]
     stream: Framed<Io, ECIESCodec>,
     remote_id: PeerId,
+}
+
+impl<Io> ECIESStream<Io> {
+    fn post_handshake(mut stream: Framed<Io, ECIESCodec>, remote_id: PeerId) -> Self {
+        stream.set_backpressure_boundary(POST_HANDSHAKE_BACKPRESSURE_BOUNDARY);
+        Self { stream, remote_id }
+    }
 }
 
 impl<Io> ECIESStream<Io>
@@ -85,7 +93,7 @@ where
 
         trace!("parsing ecies ack ...");
         if matches!(msg, IngressECIESValue::Ack) {
-            Ok(Self { stream: transport, remote_id })
+            Ok(Self::post_handshake(transport, remote_id))
         } else {
             Err(ECIESErrorImpl::InvalidHandshake {
                 expected: IngressECIESValue::Ack,
@@ -118,7 +126,7 @@ where
         trace!("sending ecies ack");
         transport.send(EgressECIESValue::Ack).await?;
 
-        Ok(Self { stream: transport, remote_id })
+        Ok(Self::post_handshake(transport, remote_id))
     }
 
     /// Get the remote id
@@ -185,6 +193,7 @@ mod tests {
             // roughly based off of the design of tokio::net::TcpListener
             let (incoming, _) = listener.accept().await.unwrap();
             let mut stream = ECIESStream::incoming(incoming, server_key).await.unwrap();
+            assert_eq!(stream.stream.backpressure_boundary(), POST_HANDSHAKE_BACKPRESSURE_BOUNDARY);
 
             // use the stream to get the next message
             let message = stream.next().await.unwrap().unwrap();
@@ -198,6 +207,10 @@ mod tests {
         let outgoing = TcpStream::connect(addr).await.unwrap();
         let mut client_stream =
             ECIESStream::connect(outgoing, client_key, server_id).await.unwrap();
+        assert_eq!(
+            client_stream.stream.backpressure_boundary(),
+            POST_HANDSHAKE_BACKPRESSURE_BOUNDARY
+        );
         client_stream.send(Bytes::from("hello")).await.unwrap();
 
         // make sure the server receives the message and asserts before ending the test

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -588,12 +588,32 @@ fn decode_fixed_width_usize_list(
 
     if payload.len() == capacity {
         let mut values = Vec::with_capacity(capacity);
-        for byte in payload {
+        if capacity < 4 {
+            for byte in payload {
+                match *byte {
+                    value @ 0..=0x7f => values.push(value as usize),
+                    EMPTY_STRING_CODE => values.push(0),
+                    _ => return None,
+                }
+            }
+
+            return Some(Ok(values))
+        }
+
+        for (slot, byte) in values.spare_capacity_mut().iter_mut().zip(payload) {
             match *byte {
-                value @ 0..=0x7f => values.push(value as usize),
-                EMPTY_STRING_CODE => values.push(0),
+                value @ 0..=0x7f => {
+                    slot.write(value as usize);
+                }
+                EMPTY_STRING_CODE => {
+                    slot.write(0);
+                }
                 _ => return None,
             }
+        }
+        // SAFETY: the loop above initialized exactly one slot for each payload byte.
+        unsafe {
+            values.set_len(capacity);
         }
 
         return Some(Ok(values))
@@ -612,7 +632,24 @@ fn decode_fixed_width_usize_list(
     let prefix = EMPTY_STRING_CODE + value_len as u8;
     let mut values = Vec::with_capacity(capacity);
     if value_len == 1 {
-        for chunk in payload.chunks_exact(encoded_len) {
+        if capacity < 4 {
+            for chunk in payload.chunks_exact(encoded_len) {
+                if chunk[0] != prefix {
+                    return None
+                }
+                let value = chunk[1];
+                if value < EMPTY_STRING_CODE {
+                    return Some(Err(alloy_rlp::Error::NonCanonicalSingleByte))
+                }
+                values.push(value as usize);
+            }
+
+            return Some(Ok(values))
+        }
+
+        for (slot, chunk) in
+            values.spare_capacity_mut().iter_mut().zip(payload.chunks_exact(encoded_len))
+        {
             if chunk[0] != prefix {
                 return None
             }
@@ -620,7 +657,11 @@ fn decode_fixed_width_usize_list(
             if value < EMPTY_STRING_CODE {
                 return Some(Err(alloy_rlp::Error::NonCanonicalSingleByte))
             }
-            values.push(value as usize);
+            slot.write(value as usize);
+        }
+        // SAFETY: the loop above initialized exactly one slot for each encoded value.
+        unsafe {
+            values.set_len(capacity);
         }
 
         return Some(Ok(values))
@@ -628,7 +669,24 @@ fn decode_fixed_width_usize_list(
 
     match value_len {
         2 => {
-            for chunk in payload.chunks_exact(encoded_len) {
+            if capacity < 4 {
+                for chunk in payload.chunks_exact(encoded_len) {
+                    if chunk[0] != prefix {
+                        return None
+                    }
+                    let bytes = [chunk[1], chunk[2]];
+                    if bytes[0] == 0 {
+                        return Some(Err(alloy_rlp::Error::LeadingZero))
+                    }
+                    values.push(u16::from_be_bytes(bytes) as usize);
+                }
+
+                return Some(Ok(values))
+            }
+
+            for (slot, chunk) in
+                values.spare_capacity_mut().iter_mut().zip(payload.chunks_exact(encoded_len))
+            {
                 if chunk[0] != prefix {
                     return None
                 }
@@ -636,7 +694,11 @@ fn decode_fixed_width_usize_list(
                 if bytes[0] == 0 {
                     return Some(Err(alloy_rlp::Error::LeadingZero))
                 }
-                values.push(u16::from_be_bytes(bytes) as usize);
+                slot.write(u16::from_be_bytes(bytes) as usize);
+            }
+            // SAFETY: the loop above initialized exactly one slot for each encoded value.
+            unsafe {
+                values.set_len(capacity);
             }
 
             return Some(Ok(values))
@@ -1672,6 +1734,25 @@ mod tests {
 
         assert_eq!(decoded, expected);
         assert!(input.is_empty());
+    }
+
+    #[test]
+    fn eth_68_tx_hash_decode_fixed_width_size_metadata() {
+        for sizes in [vec![0x80; 4], vec![0x400; 4]] {
+            let expected = NewPooledTransactionHashes68 {
+                types: vec![0x02; sizes.len()],
+                hashes: (1..=sizes.len()).map(|idx| B256::repeat_byte(idx as u8)).collect(),
+                sizes,
+            };
+            let mut encoded = Vec::new();
+            expected.encode(&mut encoded);
+
+            let mut input = encoded.as_ref();
+            let decoded = NewPooledTransactionHashes68::decode(&mut input).unwrap();
+
+            assert_eq!(decoded, expected);
+            assert!(input.is_empty());
+        }
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -528,6 +528,19 @@ fn decode_fixed_width_usize_list(
         return payload.is_empty().then(|| Ok(Vec::new()))
     }
 
+    if payload.len() == capacity {
+        let mut values = Vec::with_capacity(capacity);
+        for byte in payload {
+            match *byte {
+                value @ 0..=0x7f => values.push(value as usize),
+                EMPTY_STRING_CODE => values.push(0),
+                _ => return None,
+            }
+        }
+
+        return Some(Ok(values))
+    }
+
     let encoded_len = payload.len().checked_div(capacity)?;
     if !payload.len().is_multiple_of(capacity) {
         return None
@@ -1530,6 +1543,26 @@ mod tests {
 
         let result = NewPooledTransactionHashes68::decode(&mut leading_zero.as_ref());
         assert_eq!(result.unwrap_err(), alloy_rlp::Error::LeadingZero);
+    }
+
+    #[test]
+    fn eth_68_tx_hash_decode_single_byte_size_metadata() {
+        let expected = NewPooledTransactionHashes68 {
+            types: vec![0x02, 0x02],
+            sizes: vec![0, 0x7f],
+            hashes: vec![
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+                b256!("0x0000000000000000000000000000000000000000000000000000000000000002"),
+            ],
+        };
+        let mut encoded = Vec::new();
+        expected.encode(&mut encoded);
+
+        let mut input = encoded.as_ref();
+        let decoded = NewPooledTransactionHashes68::decode(&mut input).unwrap();
+
+        assert_eq!(decoded, expected);
+        assert!(input.is_empty());
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -422,9 +422,7 @@ impl From<NewPooledTransactionHashes72> for NewPooledTransactionHashes {
 
 /// This informs peers of transaction hashes for transactions that have appeared on the network,
 /// but have not been included in a block.
-#[derive(
-    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, Default, Deref, DerefMut, IntoIterator,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deref, DerefMut, IntoIterator)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[add_arbitrary_tests(rlp)]
@@ -442,6 +440,16 @@ impl NewPooledTransactionHashes66 {
     }
 }
 
+impl Encodable for NewPooledTransactionHashes66 {
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        encode_b256_rlp_list(&self.0, out);
+    }
+
+    fn length(&self) -> usize {
+        b256_rlp_list_length(&self.0)
+    }
+}
+
 impl Decodable for NewPooledTransactionHashes66 {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         decode_b256_rlp_list(buf).map(Self)
@@ -456,6 +464,23 @@ impl From<Vec<B256>> for NewPooledTransactionHashes66 {
 
 const RLP_B256_ENCODED_LEN: usize = 33;
 const RLP_B256_STRING_PREFIX: u8 = EMPTY_STRING_CODE + 32;
+
+const fn b256_rlp_list_payload_length(hashes: &[B256]) -> usize {
+    RLP_B256_ENCODED_LEN * hashes.len()
+}
+
+const fn b256_rlp_list_length(hashes: &[B256]) -> usize {
+    Header { list: true, payload_length: b256_rlp_list_payload_length(hashes) }
+        .length_with_payload()
+}
+
+fn encode_b256_rlp_list(hashes: &[B256], out: &mut dyn bytes::BufMut) {
+    Header { list: true, payload_length: b256_rlp_list_payload_length(hashes) }.encode(out);
+    for hash in hashes {
+        out.put_u8(RLP_B256_STRING_PREFIX);
+        out.put_slice(hash.as_slice());
+    }
+}
 
 fn decode_b256_rlp_list(buf: &mut &[u8]) -> alloy_rlp::Result<Vec<B256>> {
     let Header { list, payload_length } = Header::decode(buf)?;
@@ -770,40 +795,22 @@ impl NewPooledTransactionHashes68 {
         self.extend(txs);
         self
     }
+
+    fn payload_length(&self) -> usize {
+        self.types.as_slice().length() + self.sizes.length() + b256_rlp_list_length(&self.hashes)
+    }
 }
 
 impl Encodable for NewPooledTransactionHashes68 {
     fn encode(&self, out: &mut dyn bytes::BufMut) {
-        #[derive(RlpEncodable)]
-        struct EncodableNewPooledTransactionHashes68<'a> {
-            types: &'a [u8],
-            sizes: &'a Vec<usize>,
-            hashes: &'a Vec<B256>,
-        }
-
-        let encodable = EncodableNewPooledTransactionHashes68 {
-            types: &self.types[..],
-            sizes: &self.sizes,
-            hashes: &self.hashes,
-        };
-
-        encodable.encode(out);
+        Header { list: true, payload_length: self.payload_length() }.encode(out);
+        self.types.as_slice().encode(out);
+        self.sizes.encode(out);
+        encode_b256_rlp_list(&self.hashes, out);
     }
+
     fn length(&self) -> usize {
-        #[derive(RlpEncodable)]
-        struct EncodableNewPooledTransactionHashes68<'a> {
-            types: &'a [u8],
-            sizes: &'a Vec<usize>,
-            hashes: &'a Vec<B256>,
-        }
-
-        let encodable = EncodableNewPooledTransactionHashes68 {
-            types: &self.types[..],
-            sizes: &self.sizes,
-            hashes: &self.hashes,
-        };
-
-        encodable.length()
+        Header { list: true, payload_length: self.payload_length() }.length_with_payload()
     }
 }
 
@@ -958,7 +965,7 @@ impl NewPooledTransactionHashes72 {
     fn payload_length(&self) -> usize {
         self.types.as_slice().length() +
             self.sizes.length() +
-            self.hashes.length() +
+            b256_rlp_list_length(&self.hashes) +
             self.cell_mask.as_ref().map_or(1, Encodable::length)
     }
 }
@@ -968,7 +975,7 @@ impl Encodable for NewPooledTransactionHashes72 {
         Header { list: true, payload_length: self.payload_length() }.encode(out);
         self.types.as_slice().encode(out);
         self.sizes.encode(out);
-        self.hashes.encode(out);
+        encode_b256_rlp_list(&self.hashes, out);
         if let Some(cell_mask) = &self.cell_mask {
             cell_mask.encode(out);
         } else {

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -568,6 +568,73 @@ fn decode_fixed_width_usize_list(
         return Some(Ok(values))
     }
 
+    match value_len {
+        2 => {
+            for chunk in payload.chunks_exact(encoded_len) {
+                if chunk[0] != prefix {
+                    return None
+                }
+                let bytes = [chunk[1], chunk[2]];
+                if bytes[0] == 0 {
+                    return Some(Err(alloy_rlp::Error::LeadingZero))
+                }
+                values.push(u16::from_be_bytes(bytes) as usize);
+            }
+
+            return Some(Ok(values))
+        }
+        3 => {
+            for chunk in payload.chunks_exact(encoded_len) {
+                if chunk[0] != prefix {
+                    return None
+                }
+                let bytes = &chunk[1..4];
+                if bytes[0] == 0 {
+                    return Some(Err(alloy_rlp::Error::LeadingZero))
+                }
+                values.push(
+                    ((bytes[0] as usize) << 16) | ((bytes[1] as usize) << 8) | bytes[2] as usize,
+                );
+            }
+
+            return Some(Ok(values))
+        }
+        4 => {
+            for chunk in payload.chunks_exact(encoded_len) {
+                if chunk[0] != prefix {
+                    return None
+                }
+                let bytes = [chunk[1], chunk[2], chunk[3], chunk[4]];
+                if bytes[0] == 0 {
+                    return Some(Err(alloy_rlp::Error::LeadingZero))
+                }
+                values.push(u32::from_be_bytes(bytes) as usize);
+            }
+
+            return Some(Ok(values))
+        }
+        8 => {
+            for chunk in payload.chunks_exact(encoded_len) {
+                if chunk[0] != prefix {
+                    return None
+                }
+                let bytes = [
+                    chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7], chunk[8],
+                ];
+                if bytes[0] == 0 {
+                    return Some(Err(alloy_rlp::Error::LeadingZero))
+                }
+                let Ok(value) = usize::try_from(u64::from_be_bytes(bytes)) else {
+                    return Some(Err(alloy_rlp::Error::Overflow))
+                };
+                values.push(value);
+            }
+
+            return Some(Ok(values))
+        }
+        _ => {}
+    }
+
     for chunk in payload.chunks_exact(encoded_len) {
         if chunk[0] != prefix {
             return None

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -506,6 +506,11 @@ fn decode_usize_rlp_list_with_capacity(
     }
 
     let (mut payload, rest) = buf.split_at(payload_length);
+    if let Some(values) = decode_fixed_width_usize_list(payload, capacity) {
+        *buf = rest;
+        return values
+    }
+
     let mut values = Vec::with_capacity(capacity);
     while !payload.is_empty() {
         values.push(usize::decode(&mut payload)?);
@@ -513,6 +518,61 @@ fn decode_usize_rlp_list_with_capacity(
     *buf = rest;
 
     Ok(values)
+}
+
+fn decode_fixed_width_usize_list(
+    payload: &[u8],
+    capacity: usize,
+) -> Option<alloy_rlp::Result<Vec<usize>>> {
+    if capacity == 0 {
+        return payload.is_empty().then(|| Ok(Vec::new()))
+    }
+
+    let encoded_len = payload.len().checked_div(capacity)?;
+    if !payload.len().is_multiple_of(capacity) {
+        return None
+    }
+
+    let value_len = encoded_len.checked_sub(1)?;
+    if value_len == 0 || value_len > core::mem::size_of::<usize>() {
+        return None
+    }
+
+    let prefix = EMPTY_STRING_CODE + value_len as u8;
+    let mut values = Vec::with_capacity(capacity);
+    if value_len == 1 {
+        for chunk in payload.chunks_exact(encoded_len) {
+            if chunk[0] != prefix {
+                return None
+            }
+            let value = chunk[1];
+            if value < EMPTY_STRING_CODE {
+                return Some(Err(alloy_rlp::Error::NonCanonicalSingleByte))
+            }
+            values.push(value as usize);
+        }
+
+        return Some(Ok(values))
+    }
+
+    for chunk in payload.chunks_exact(encoded_len) {
+        if chunk[0] != prefix {
+            return None
+        }
+
+        let value_bytes = &chunk[1..];
+        if value_len > 1 && value_bytes[0] == 0 {
+            return Some(Err(alloy_rlp::Error::LeadingZero))
+        }
+
+        let mut value = 0usize;
+        for byte in value_bytes {
+            value = (value << 8) | *byte as usize;
+        }
+        values.push(value);
+    }
+
+    Some(Ok(values))
 }
 
 /// Same as [`NewPooledTransactionHashes66`] but extends that beside the transaction hashes,
@@ -1455,6 +1515,21 @@ mod tests {
         for vector in vectors {
             test_encoding_vector(vector);
         }
+    }
+
+    #[test]
+    fn eth_68_tx_hash_decode_rejects_non_canonical_size_metadata() {
+        let mut single_byte = vec![0xe6, 0x02, 0xc2, 0x81, 0x7f, 0xe1, 0xa0];
+        single_byte.extend_from_slice(&[0x42; 32]);
+
+        let result = NewPooledTransactionHashes68::decode(&mut single_byte.as_ref());
+        assert_eq!(result.unwrap_err(), alloy_rlp::Error::NonCanonicalSingleByte);
+
+        let mut leading_zero = vec![0xe7, 0x02, 0xc3, 0x82, 0x00, 0x80, 0xe1, 0xa0];
+        leading_zero.extend_from_slice(&[0x42; 32]);
+
+        let result = NewPooledTransactionHashes68::decode(&mut leading_zero.as_ref());
+        assert_eq!(result.unwrap_err(), alloy_rlp::Error::LeadingZero);
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{
 };
 use alloy_rlp::{
     Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
-    RlpEncodableWrapper,
+    RlpEncodableWrapper, EMPTY_STRING_CODE,
 };
 use core::{fmt::Debug, mem};
 use derive_more::{Constructor, Deref, DerefMut, From, IntoIterator};
@@ -423,16 +423,7 @@ impl From<NewPooledTransactionHashes72> for NewPooledTransactionHashes {
 /// This informs peers of transaction hashes for transactions that have appeared on the network,
 /// but have not been included in a block.
 #[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    RlpEncodableWrapper,
-    RlpDecodableWrapper,
-    Default,
-    Deref,
-    DerefMut,
-    IntoIterator,
+    Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, Default, Deref, DerefMut, IntoIterator,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -451,10 +442,77 @@ impl NewPooledTransactionHashes66 {
     }
 }
 
+impl Decodable for NewPooledTransactionHashes66 {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        decode_b256_rlp_list(buf).map(Self)
+    }
+}
+
 impl From<Vec<B256>> for NewPooledTransactionHashes66 {
     fn from(v: Vec<B256>) -> Self {
         Self(v)
     }
+}
+
+const RLP_B256_ENCODED_LEN: usize = 33;
+const RLP_B256_STRING_PREFIX: u8 = EMPTY_STRING_CODE + 32;
+
+fn decode_b256_rlp_list(buf: &mut &[u8]) -> alloy_rlp::Result<Vec<B256>> {
+    let Header { list, payload_length } = Header::decode(buf)?;
+    if !list {
+        return Err(alloy_rlp::Error::UnexpectedString)
+    }
+
+    let (payload, rest) = buf.split_at(payload_length);
+    let hashes =
+        decode_canonical_b256_list(payload).map_or_else(|| decode_b256_list(payload), Ok)?;
+    *buf = rest;
+
+    Ok(hashes)
+}
+
+fn decode_canonical_b256_list(payload: &[u8]) -> Option<Vec<B256>> {
+    let (chunks, remainder) = payload.as_chunks::<RLP_B256_ENCODED_LEN>();
+    if !remainder.is_empty() {
+        return None
+    }
+
+    let mut hashes = Vec::with_capacity(chunks.len());
+    for chunk in chunks {
+        if chunk[0] != RLP_B256_STRING_PREFIX {
+            return None
+        }
+        hashes.push(B256::from_slice(&chunk[1..]));
+    }
+
+    Some(hashes)
+}
+
+fn decode_b256_list(mut payload: &[u8]) -> alloy_rlp::Result<Vec<B256>> {
+    let mut hashes = Vec::new();
+    while !payload.is_empty() {
+        hashes.push(B256::decode(&mut payload)?);
+    }
+    Ok(hashes)
+}
+
+fn decode_usize_rlp_list_with_capacity(
+    buf: &mut &[u8],
+    capacity: usize,
+) -> alloy_rlp::Result<Vec<usize>> {
+    let Header { list, payload_length } = Header::decode(buf)?;
+    if !list {
+        return Err(alloy_rlp::Error::UnexpectedString)
+    }
+
+    let (mut payload, rest) = buf.split_at(payload_length);
+    let mut values = Vec::with_capacity(capacity);
+    while !payload.is_empty() {
+        values.push(usize::decode(&mut payload)?);
+    }
+    *buf = rest;
+
+    Ok(values)
 }
 
 /// Same as [`NewPooledTransactionHashes66`] but extends that beside the transaction hashes,
@@ -611,19 +669,24 @@ impl Encodable for NewPooledTransactionHashes68 {
 
 impl Decodable for NewPooledTransactionHashes68 {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        #[derive(RlpDecodable)]
-        struct EncodableNewPooledTransactionHashes68 {
-            types: Bytes,
-            sizes: Vec<usize>,
-            hashes: Vec<B256>,
+        let Header { list, payload_length } = Header::decode(buf)?;
+        if !list {
+            return Err(alloy_rlp::Error::UnexpectedString)
         }
 
-        let encodable = EncodableNewPooledTransactionHashes68::decode(buf)?;
-        let msg = Self {
-            types: encodable.types.into(),
-            sizes: encodable.sizes,
-            hashes: encodable.hashes,
-        };
+        let (mut payload, rest) = buf.split_at(payload_length);
+        let types = Bytes::decode(&mut payload)?;
+        let sizes = decode_usize_rlp_list_with_capacity(&mut payload, types.len())?;
+        let hashes = decode_b256_rlp_list(&mut payload)?;
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: payload_length,
+                got: payload_length - payload.len(),
+            })
+        }
+        *buf = rest;
+
+        let msg = Self { types: types.into(), sizes, hashes };
 
         if msg.hashes.len() != msg.types.len() {
             return Err(alloy_rlp::Error::ListLengthMismatch {
@@ -790,8 +853,8 @@ impl Decodable for NewPooledTransactionHashes72 {
 
         let (mut payload, rest) = buf.split_at(payload_length);
         let types = Bytes::decode(&mut payload)?;
-        let sizes = Vec::<usize>::decode(&mut payload)?;
-        let hashes = Vec::<B256>::decode(&mut payload)?;
+        let sizes = decode_usize_rlp_list_with_capacity(&mut payload, types.len())?;
+        let hashes = decode_b256_rlp_list(&mut payload)?;
         let Some(first_byte) = payload.first().copied() else {
             return Err(alloy_rlp::Error::InputTooShort)
         };
@@ -1226,6 +1289,33 @@ mod tests {
         blocks.push(BlockHashNumber { hash: B256::random(), number: 2 });
         let latest = blocks.latest().unwrap();
         assert_eq!(latest.number, 100);
+    }
+
+    #[test]
+    fn eth_66_tx_hash_decode_fast_path() {
+        let expected = NewPooledTransactionHashes66(vec![
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000002"),
+        ]);
+        let mut encoded = Vec::new();
+        expected.encode(&mut encoded);
+        encoded.push(alloy_rlp::EMPTY_STRING_CODE);
+
+        let mut input = encoded.as_ref();
+        let decoded = NewPooledTransactionHashes66::decode(&mut input).unwrap();
+
+        assert_eq!(decoded, expected);
+        assert_eq!(input, &[alloy_rlp::EMPTY_STRING_CODE]);
+    }
+
+    #[test]
+    fn eth_66_tx_hash_decode_rejects_non_canonical_hash() {
+        let mut encoded = vec![0xe2, 0xb8, 0x20];
+        encoded.extend_from_slice(&[0x42; 32]);
+
+        let result = NewPooledTransactionHashes66::decode(&mut encoded.as_ref());
+
+        assert!(matches!(result, Err(alloy_rlp::Error::NonCanonicalSize)));
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -173,7 +173,7 @@ pub fn decode_list_with_memory_budget<T: Decodable + InMemorySize>(
     let (payload, rest) = buf.split_at(header.payload_length);
     let mut payload = payload;
 
-    let mut txs = Vec::new();
+    let mut txs = Vec::with_capacity(estimated_transaction_list_capacity(header.payload_length));
     let mut total_size = 0usize;
 
     while !payload.is_empty() {
@@ -189,6 +189,23 @@ pub fn decode_list_with_memory_budget<T: Decodable + InMemorySize>(
 
     *buf = rest;
     Ok(txs)
+}
+
+// Keep this as a conservative hint: small lists stay allocation-free until the first push, while
+// large untrusted payloads cannot force an outsized preallocation.
+const MIN_TRANSACTION_RLP_SIZE_ESTIMATE: usize = 128;
+const MIN_PREALLOCATED_TRANSACTIONS: usize = 4;
+const MAX_PREALLOCATED_TRANSACTIONS: usize = 1024;
+
+const fn estimated_transaction_list_capacity(payload_length: usize) -> usize {
+    let estimate = payload_length / MIN_TRANSACTION_RLP_SIZE_ESTIMATE;
+    if estimate < MIN_PREALLOCATED_TRANSACTIONS {
+        0
+    } else if estimate > MAX_PREALLOCATED_TRANSACTIONS {
+        MAX_PREALLOCATED_TRANSACTIONS
+    } else {
+        estimate
+    }
 }
 
 /// Same as [`Transactions`] but this is intended as egress message send from local to _many_ peers.

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -519,12 +519,28 @@ fn decode_canonical_b256_list(payload: &[u8]) -> Option<Vec<B256>> {
         return None
     }
 
+    if chunks.len() < 4 {
+        let mut hashes = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            if chunk[0] != RLP_B256_STRING_PREFIX {
+                return None
+            }
+            hashes.push(B256::from_slice(&chunk[1..]));
+        }
+
+        return Some(hashes)
+    }
+
     let mut hashes = Vec::with_capacity(chunks.len());
-    for chunk in chunks {
+    for (slot, chunk) in hashes.spare_capacity_mut().iter_mut().zip(chunks) {
         if chunk[0] != RLP_B256_STRING_PREFIX {
             return None
         }
-        hashes.push(B256::from_slice(&chunk[1..]));
+        slot.write(B256::from_slice(&chunk[1..]));
+    }
+    // SAFETY: the loop above initialized exactly one slot for each chunk.
+    unsafe {
+        hashes.set_len(chunks.len());
     }
 
     Some(hashes)
@@ -1460,6 +1476,8 @@ mod tests {
         let expected = NewPooledTransactionHashes66(vec![
             b256!("0x0000000000000000000000000000000000000000000000000000000000000001"),
             b256!("0x0000000000000000000000000000000000000000000000000000000000000002"),
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000003"),
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000004"),
         ]);
         let mut encoded = Vec::new();
         expected.encode(&mut encoded);

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -18,10 +18,7 @@ use crate::{
     SharedTransactions,
 };
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
-use alloy_primitives::{
-    bytes::{Buf, BufMut},
-    Bytes,
-};
+use alloy_primitives::bytes::{Buf, BufMut, Bytes};
 use alloy_rlp::{length_of_length, Decodable, Encodable, Header};
 use core::fmt::Debug;
 
@@ -228,7 +225,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 buf.advance(raw_payload.len());
                 EthMessage::Other(RawCapabilityMessage::new(
                     message_type.to_u8() as usize,
-                    raw_payload.into(),
+                    raw_payload,
                 ))
             }
         };
@@ -498,6 +495,25 @@ impl<N: NetworkPrimitives> EthMessage<N> {
 
         self
     }
+
+    /// Encodes this message to its id-prefixed `RLPx` message bytes.
+    pub fn encoded(self) -> Bytes {
+        match self {
+            Self::NewBlockHashes(hashes) => {
+                encode_protocol_payload(EthMessageID::NewBlockHashes, &hashes)
+            }
+            Self::NewPooledTransactionHashes66(hashes) => {
+                encode_protocol_payload(EthMessageID::NewPooledTransactionHashes, &hashes)
+            }
+            Self::NewPooledTransactionHashes68(hashes) => {
+                encode_protocol_payload(EthMessageID::NewPooledTransactionHashes, &hashes)
+            }
+            Self::NewPooledTransactionHashes72(hashes) => {
+                encode_protocol_payload(EthMessageID::NewPooledTransactionHashes, &hashes)
+            }
+            this => alloy_rlp::encode(ProtocolMessage::from(this)).into(),
+        }
+    }
 }
 
 impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
@@ -561,6 +577,13 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::Other(unknown) => unknown.length(),
         }
     }
+}
+
+fn encode_protocol_payload<T: Encodable>(message_type: EthMessageID, payload: &T) -> Bytes {
+    let mut out = Vec::with_capacity(message_type.length() + payload.length());
+    message_type.encode(&mut out);
+    payload.encode(&mut out);
+    out.into()
 }
 
 /// Represents broadcast messages of [`EthMessage`] with the same object that can be sent to
@@ -903,12 +926,13 @@ mod tests {
     use super::MessageError;
     use crate::{
         message::{EthBroadcastMessage, ProtocolBroadcastMessage, RequestPair},
-        BlockAccessLists, EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion,
-        GetBlockAccessLists, GetNodeData, NodeData, ProtocolMessage, RawCapabilityMessage,
-        SharedTransactions,
+        BlockAccessLists, BlockHashNumber, EthMessage, EthMessageID, EthNetworkPrimitives,
+        EthVersion, GetBlockAccessLists, GetNodeData, NewBlockHashes, NewPooledTransactionHashes66,
+        NewPooledTransactionHashes68, NewPooledTransactionHashes72, NodeData, ProtocolMessage,
+        RawCapabilityMessage, SharedTransactions,
     };
     use alloy_consensus::TxLegacy;
-    use alloy_primitives::{hex, Bytes as AlloyBytes, Signature, TxKind, U256};
+    use alloy_primitives::{hex, Bytes as AlloyBytes, Signature, TxKind, B128, B256, U256};
     use alloy_rlp::{Decodable, Encodable, Error};
     use reth_ethereum_primitives::{BlockBody, Transaction, TransactionSigned};
     use std::sync::Arc;
@@ -944,6 +968,43 @@ mod tests {
         let expected = alloy_rlp::encode(ProtocolBroadcastMessage::from(msg.clone()));
 
         assert_eq!(msg.encoded().as_ref(), expected.as_slice());
+    }
+
+    fn assert_eth_message_encoded_matches_protocol(msg: EthMessage<EthNetworkPrimitives>) {
+        let expected = alloy_rlp::encode(ProtocolMessage::from(msg.clone()));
+
+        assert_eq!(msg.encoded().as_ref(), expected.as_slice());
+    }
+
+    #[test]
+    fn hash_announcements_encoded_match_protocol_encoding() {
+        let hashes =
+            vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02), B256::repeat_byte(0x03)];
+
+        assert_eth_message_encoded_matches_protocol(EthMessage::NewBlockHashes(NewBlockHashes(
+            vec![
+                BlockHashNumber { hash: hashes[0], number: 1 },
+                BlockHashNumber { hash: hashes[1], number: 2 },
+            ],
+        )));
+        assert_eth_message_encoded_matches_protocol(EthMessage::NewPooledTransactionHashes66(
+            NewPooledTransactionHashes66(hashes.clone()),
+        ));
+        assert_eth_message_encoded_matches_protocol(EthMessage::NewPooledTransactionHashes68(
+            NewPooledTransactionHashes68 {
+                types: vec![0, 1, 2],
+                sizes: vec![1, 128, 1024],
+                hashes: hashes.clone(),
+            },
+        ));
+        assert_eth_message_encoded_matches_protocol(EthMessage::NewPooledTransactionHashes72(
+            NewPooledTransactionHashes72 {
+                types: vec![0, 1, 2],
+                sizes: vec![1, 128, 1024],
+                hashes,
+                cell_mask: Some(B128::repeat_byte(0x11)),
+            },
+        ));
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -17,7 +17,7 @@ use crate::{
     NetworkPrimitives, NewPooledTransactionHashes72, RawCapabilityMessage, Receipts69, Receipts70,
     SharedTransactions,
 };
-use alloc::{boxed::Box, string::String, sync::Arc};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use alloy_primitives::{
     bytes::{Buf, BufMut},
     Bytes,
@@ -591,7 +591,24 @@ impl<N: NetworkPrimitives> EthBroadcastMessage<N> {
 
     /// Encodes this broadcast to its id-prefixed `RLPx` message bytes.
     pub fn encoded(self) -> alloy_primitives::bytes::Bytes {
-        alloy_rlp::encode(ProtocolBroadcastMessage::from(self)).into()
+        match self {
+            Self::Transactions(transactions) => {
+                let payload_length = transactions.iter().map(Encodable::length).sum();
+                let header = Header { list: true, payload_length };
+                let mut out = Vec::with_capacity(
+                    EthMessageID::Transactions.length() + header.length() + payload_length,
+                );
+                EthMessageID::Transactions.encode(&mut out);
+                header.encode(&mut out);
+                for tx in transactions.0 {
+                    tx.encode(&mut out);
+                }
+                out.into()
+            }
+            this @ Self::NewBlock(_) => {
+                alloy_rlp::encode(ProtocolBroadcastMessage::from(this)).into()
+            }
+        }
     }
 }
 
@@ -885,18 +902,48 @@ where
 mod tests {
     use super::MessageError;
     use crate::{
-        message::RequestPair, BlockAccessLists, EthMessage, EthMessageID, EthNetworkPrimitives,
-        EthVersion, GetBlockAccessLists, GetNodeData, NodeData, ProtocolMessage,
-        RawCapabilityMessage,
+        message::{EthBroadcastMessage, ProtocolBroadcastMessage, RequestPair},
+        BlockAccessLists, EthMessage, EthMessageID, EthNetworkPrimitives, EthVersion,
+        GetBlockAccessLists, GetNodeData, NodeData, ProtocolMessage, RawCapabilityMessage,
+        SharedTransactions,
     };
-    use alloy_primitives::hex;
+    use alloy_consensus::TxLegacy;
+    use alloy_primitives::{hex, Bytes as AlloyBytes, Signature, TxKind, U256};
     use alloy_rlp::{Decodable, Encodable, Error};
-    use reth_ethereum_primitives::BlockBody;
+    use reth_ethereum_primitives::{BlockBody, Transaction, TransactionSigned};
+    use std::sync::Arc;
 
     fn encode<T: Encodable>(value: T) -> Vec<u8> {
         let mut buf = vec![];
         value.encode(&mut buf);
         buf
+    }
+
+    fn signed_legacy_tx(nonce: u64) -> Arc<TransactionSigned> {
+        Arc::new(TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                chain_id: Some(1),
+                nonce,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Create,
+                value: U256::ZERO,
+                input: AlloyBytes::from(vec![0x42; 128]),
+            }),
+            Signature::test_signature(),
+        ))
+    }
+
+    #[test]
+    fn broadcast_transactions_encoded_matches_protocol_encoding() {
+        let msg =
+            EthBroadcastMessage::<EthNetworkPrimitives>::Transactions(SharedTransactions(vec![
+                signed_legacy_tx(0),
+                signed_legacy_tx(1),
+            ]));
+        let expected = alloy_rlp::encode(ProtocolBroadcastMessage::from(msg.clone()));
+
+        assert_eq!(msg.encoded().as_ref(), expected.as_slice());
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -633,21 +633,29 @@ impl<N: NetworkPrimitives> EthBroadcastMessage<N> {
         match self {
             Self::Transactions(transactions) => {
                 let payload_length = transactions.iter().map(Encodable::length).sum();
-                let header = Header { list: true, payload_length };
-                let mut out = Vec::with_capacity(
-                    EthMessageID::Transactions.length() + header.length() + payload_length,
-                );
-                EthMessageID::Transactions.encode(&mut out);
-                header.encode(&mut out);
-                for tx in transactions.0 {
-                    tx.encode(&mut out);
-                }
-                out.into()
+                Self::encoded_transactions_with_payload_length(transactions, payload_length)
             }
             this @ Self::NewBlock(_) => {
                 alloy_rlp::encode(ProtocolBroadcastMessage::from(this)).into()
             }
         }
+    }
+
+    /// Encodes a Transactions broadcast with a caller-provided RLP payload length.
+    pub fn encoded_transactions_with_payload_length(
+        transactions: SharedTransactions<N::BroadcastedTransaction>,
+        payload_length: usize,
+    ) -> alloy_primitives::bytes::Bytes {
+        let header = Header { list: true, payload_length };
+        let mut out = Vec::with_capacity(
+            EthMessageID::Transactions.length() + header.length() + payload_length,
+        );
+        EthMessageID::Transactions.encode(&mut out);
+        header.encode(&mut out);
+        for tx in transactions.0 {
+            tx.encode(&mut out);
+        }
+        out.into()
     }
 }
 

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -108,7 +108,23 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         tx_memory_budget: usize,
     ) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
+        let message = Self::decode_message_payload_with_tx_memory_budget(
+            version,
+            message_type,
+            buf,
+            tx_memory_budget,
+        )?;
 
+        Ok(Self { message_type, message })
+    }
+
+    /// Decodes a message payload after the message id has already been read.
+    pub fn decode_message_payload_with_tx_memory_budget(
+        version: EthVersion,
+        message_type: EthMessageID,
+        buf: &mut &[u8],
+        tx_memory_budget: usize,
+    ) -> Result<EthMessage<N>, MessageError> {
         // For EIP-7642 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md):
         // pre-merge (legacy) status messages include total difficulty, whereas eth/69 omits it.
         let message = match message_type {
@@ -229,7 +245,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 ))
             }
         };
-        Ok(Self { message_type, message })
+        Ok(message)
     }
 }
 
@@ -712,6 +728,33 @@ pub enum EthMessageID {
 }
 
 impl EthMessageID {
+    /// Returns the corresponding [`EthMessageID`] for a raw message id.
+    pub const fn from_u8(id: u8) -> Self {
+        match id {
+            0x00 => Self::Status,
+            0x01 => Self::NewBlockHashes,
+            0x02 => Self::Transactions,
+            0x03 => Self::GetBlockHeaders,
+            0x04 => Self::BlockHeaders,
+            0x05 => Self::GetBlockBodies,
+            0x06 => Self::BlockBodies,
+            0x07 => Self::NewBlock,
+            0x08 => Self::NewPooledTransactionHashes,
+            0x09 => Self::GetPooledTransactions,
+            0x0a => Self::PooledTransactions,
+            0x0d => Self::GetNodeData,
+            0x0e => Self::NodeData,
+            0x0f => Self::GetReceipts,
+            0x10 => Self::Receipts,
+            0x11 => Self::BlockRangeUpdate,
+            0x12 => Self::GetBlockAccessLists,
+            0x13 => Self::BlockAccessLists,
+            0x14 => Self::GetCells,
+            0x15 => Self::Cells,
+            _ => Self::Other(id),
+        }
+    }
+
     /// Returns the corresponding `u8` value for an `EthMessageID`.
     pub const fn to_u8(&self) -> u8 {
         match self {
@@ -773,31 +816,9 @@ impl Encodable for EthMessageID {
 
 impl Decodable for EthMessageID {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let id = match buf.first().ok_or(alloy_rlp::Error::InputTooShort)? {
-            0x00 => Self::Status,
-            0x01 => Self::NewBlockHashes,
-            0x02 => Self::Transactions,
-            0x03 => Self::GetBlockHeaders,
-            0x04 => Self::BlockHeaders,
-            0x05 => Self::GetBlockBodies,
-            0x06 => Self::BlockBodies,
-            0x07 => Self::NewBlock,
-            0x08 => Self::NewPooledTransactionHashes,
-            0x09 => Self::GetPooledTransactions,
-            0x0a => Self::PooledTransactions,
-            0x0d => Self::GetNodeData,
-            0x0e => Self::NodeData,
-            0x0f => Self::GetReceipts,
-            0x10 => Self::Receipts,
-            0x11 => Self::BlockRangeUpdate,
-            0x12 => Self::GetBlockAccessLists,
-            0x13 => Self::BlockAccessLists,
-            0x14 => Self::GetCells,
-            0x15 => Self::Cells,
-            unknown => Self::Other(*unknown),
-        };
+        let id = *buf.first().ok_or(alloy_rlp::Error::InputTooShort)?;
         buf.advance(1);
-        Ok(id)
+        Ok(Self::from_u8(id))
     }
 }
 

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -49,6 +49,7 @@ reth-eth-wire-types = { workspace = true, features = ["arbitrary"] }
 reth-tracing.workspace = true
 
 alloy-consensus.workspace = true
+criterion.workspace = true
 test-fuzz.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 rand.workspace = true
@@ -94,3 +95,7 @@ serde = [
 name = "fuzz_roundtrip"
 path = "tests/fuzz_roundtrip.rs"
 required-features = ["arbitrary", "serde"]
+
+[[bench]]
+name = "ethstream"
+harness = false

--- a/crates/net/eth-wire/Cargo.toml
+++ b/crates/net/eth-wire/Cargo.toml
@@ -47,6 +47,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 reth-primitives-traits = { workspace = true, features = ["arbitrary"] }
 reth-eth-wire-types = { workspace = true, features = ["arbitrary"] }
 reth-tracing.workspace = true
+reth-ethereum-primitives.workspace = true
 
 alloy-consensus.workspace = true
 criterion.workspace = true

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -28,6 +28,7 @@ use std::{
 
 const MESSAGE_COUNT: usize = 1024;
 const HASHES_PER_ANNOUNCEMENT: usize = 64;
+const SMALL_TX_SIZE: usize = 64;
 const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
 const ECIES_PAYLOAD_LEN: usize = 512;
 
@@ -51,12 +52,20 @@ fn message_for_version_with_hashes(
     version: EthVersion,
     hash_count: usize,
 ) -> EthMessage<EthNetworkPrimitives> {
+    message_for_version_with_hashes_and_size(version, hash_count, 128)
+}
+
+fn message_for_version_with_hashes_and_size(
+    version: EthVersion,
+    hash_count: usize,
+    size: usize,
+) -> EthMessage<EthNetworkPrimitives> {
     let hashes = hashes(hash_count);
 
     if version.is_eth72() {
         return EthMessage::NewPooledTransactionHashes72(NewPooledTransactionHashes72 {
             types: vec![0x02; hash_count],
-            sizes: vec![128; hash_count],
+            sizes: vec![size; hash_count],
             hashes,
             cell_mask: None,
         })
@@ -65,7 +74,7 @@ fn message_for_version_with_hashes(
     if version.has_eth68_metadata() {
         return EthMessage::NewPooledTransactionHashes68(NewPooledTransactionHashes68 {
             types: vec![0x02; hash_count],
-            sizes: vec![128; hash_count],
+            sizes: vec![size; hash_count],
             hashes,
         })
     }
@@ -142,9 +151,20 @@ fn encoded_wire_message_for_version_with_hashes(
     version: EthVersion,
     hash_count: usize,
 ) -> BytesMut {
+    encoded_wire_message_for_version_with_hashes_and_size(version, hash_count, 128)
+}
+
+fn encoded_wire_message_for_version_with_hashes_and_size(
+    version: EthVersion,
+    hash_count: usize,
+    size: usize,
+) -> BytesMut {
     runtime().block_on(async {
         let mut stream = eth_stream_with_version(MockTransport::default(), version);
-        stream.send(message_for_version_with_hashes(version, hash_count)).await.unwrap();
+        stream
+            .send(message_for_version_with_hashes_and_size(version, hash_count, size))
+            .await
+            .unwrap();
         stream.inner().inner().sent[0].clone().into()
     })
 }
@@ -547,6 +567,39 @@ fn bench_recv_messages(c: &mut Criterion) {
             |b| {
                 let encoded =
                     encoded_wire_message_for_version_with_hashes(version, HASHES_PER_ANNOUNCEMENT);
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut stream = eth_stream_with_version(
+                            MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT),
+                            version,
+                        );
+                        let mut decode_buf = BytesMut::new();
+                        for _ in 0..MESSAGE_COUNT {
+                            black_box(
+                                poll_fn(|cx| {
+                                    Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                                })
+                                .await
+                                .unwrap()
+                                .unwrap(),
+                            );
+                        }
+                    });
+                })
+            },
+        );
+
+        group.bench_function(
+            format!(
+                "recv_hash_announcements_eth{}_{}_hashes_small_sizes",
+                version as u8, HASHES_PER_ANNOUNCEMENT
+            ),
+            |b| {
+                let encoded = encoded_wire_message_for_version_with_hashes_and_size(
+                    version,
+                    HASHES_PER_ANNOUNCEMENT,
+                    SMALL_TX_SIZE,
+                );
                 b.iter(|| {
                     rt.block_on(async {
                         let mut stream = eth_stream_with_version(

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 const MESSAGE_COUNT: usize = 1024;
+const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 8;
 
 fn shared_capabilities() -> SharedCapabilities {
     SharedCapabilities::try_new(
@@ -56,6 +57,14 @@ fn transaction_broadcast() -> EthBroadcastMessage<EthNetworkPrimitives> {
 
 fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
     EthStream::new(EthVersion::Eth66, P2PStream::new(transport, shared_capabilities()))
+}
+
+fn active_session_eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
+    let mut stream = eth_stream(transport);
+    stream
+        .inner_mut()
+        .set_outgoing_message_buffer_capacity(ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY);
+    stream
 }
 
 fn runtime() -> tokio::runtime::Runtime {
@@ -136,6 +145,20 @@ fn bench_send_messages(c: &mut Criterion) {
                 for _ in 0..MESSAGE_COUNT {
                     stream.send(message()).await.unwrap();
                 }
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+
+    group.bench_function("send_hash_announcements_batched", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = active_session_eth_stream(MockTransport::default());
+                for _ in 0..MESSAGE_COUNT {
+                    poll_fn(|cx| Pin::new(&mut stream).poll_ready(cx)).await.unwrap();
+                    Pin::new(&mut stream).start_send(message()).unwrap();
+                }
+                stream.flush().await.unwrap();
                 black_box(stream.inner().inner().sent.len());
             });
         })

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -12,7 +12,7 @@ use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
     capability::SharedCapabilities, message::EthBroadcastMessage, Capability, EthMessage,
     EthNetworkPrimitives, EthStream, EthVersion, NewPooledTransactionHashes68,
-    NewPooledTransactionHashes72, P2PStream, SharedTransactions,
+    NewPooledTransactionHashes72, P2PStream, SharedTransactions, Transactions,
 };
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use reth_network_peers::pk2id;
@@ -87,8 +87,8 @@ fn hashes(count: usize) -> Vec<B256> {
     (0..count).map(|idx| B256::repeat_byte(idx as u8)).collect()
 }
 
-fn transaction(nonce: u64) -> Arc<TransactionSigned> {
-    Arc::new(TransactionSigned::new_unhashed(
+fn signed_transaction(nonce: u64) -> TransactionSigned {
+    TransactionSigned::new_unhashed(
         Transaction::Legacy(TxLegacy {
             chain_id: Some(1),
             nonce,
@@ -99,7 +99,11 @@ fn transaction(nonce: u64) -> Arc<TransactionSigned> {
             input: AlloyBytes::from(vec![0x42; 128]),
         }),
         Signature::test_signature(),
-    ))
+    )
+}
+
+fn transaction(nonce: u64) -> Arc<TransactionSigned> {
+    Arc::new(signed_transaction(nonce))
 }
 
 fn transaction_broadcast() -> EthBroadcastMessage<EthNetworkPrimitives> {
@@ -166,6 +170,15 @@ fn encoded_wire_message_for_version_with_hashes_and_size(
             .send(message_for_version_with_hashes_and_size(version, hash_count, size))
             .await
             .unwrap();
+        stream.inner().inner().sent[0].clone().into()
+    })
+}
+
+fn encoded_transactions_wire_message(tx_count: usize) -> BytesMut {
+    runtime().block_on(async {
+        let mut stream = eth_stream(MockTransport::default());
+        let txs = (0..tx_count as u64).map(signed_transaction).collect();
+        stream.send(EthMessage::Transactions(Transactions(txs))).await.unwrap();
         stream.inner().inner().sent[0].clone().into()
     })
 }
@@ -535,6 +548,29 @@ fn bench_recv_messages(c: &mut Criterion) {
             });
         })
     });
+
+    for tx_count in [1, 2, 8] {
+        group.bench_function(format!("recv_transaction_broadcasts_{tx_count}_txs"), |b| {
+            let encoded = encoded_transactions_wire_message(tx_count);
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut stream =
+                        eth_stream(MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT));
+                    let mut decode_buf = BytesMut::new();
+                    for _ in 0..MESSAGE_COUNT {
+                        black_box(
+                            poll_fn(|cx| {
+                                Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                            })
+                            .await
+                            .unwrap()
+                            .unwrap(),
+                        );
+                    }
+                });
+            })
+        });
+    }
 
     for version in [EthVersion::Eth68, EthVersion::Eth72] {
         group.bench_function(format!("recv_hash_announcements_eth{}", version as u8), |b| {

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -187,12 +187,13 @@ async fn send_and_receive_ethstream_hash_announcements(count: usize, capacity: u
     let mut stream = EthStream::<_, EthNetworkPrimitives>::new(EthVersion::Eth66, p2p);
 
     let mut remaining = count;
+    let mut encode_buf = BytesMut::new();
     while remaining > 0 {
         poll_fn(|cx| Pin::new(&mut stream).poll_ready(cx)).await.unwrap();
         let batch = stream.inner().available_outgoing_capacity().min(remaining);
         assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
         for _ in 0..batch {
-            Pin::new(&mut stream).start_send(message()).unwrap();
+            stream.start_send_with_encode_buf(message(), &mut encode_buf).unwrap();
         }
         remaining -= batch;
     }

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 const MESSAGE_COUNT: usize = 1024;
-const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 8;
+const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
 
 fn shared_capabilities() -> SharedCapabilities {
     SharedCapabilities::try_new(
@@ -60,10 +60,15 @@ fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
 }
 
 fn active_session_eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
+    active_session_eth_stream_with_capacity(transport, ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY)
+}
+
+fn active_session_eth_stream_with_capacity(
+    transport: MockTransport,
+    capacity: usize,
+) -> EthStream<P2PStream<MockTransport>> {
     let mut stream = eth_stream(transport);
-    stream
-        .inner_mut()
-        .set_outgoing_message_buffer_capacity(ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY);
+    stream.inner_mut().set_outgoing_message_buffer_capacity(capacity);
     stream
 }
 
@@ -77,6 +82,23 @@ fn encoded_wire_message() -> BytesMut {
         stream.send(message()).await.unwrap();
         stream.inner().inner().sent[0].clone().into()
     })
+}
+
+async fn send_hash_announcements_in_active_session_batches(
+    stream: &mut EthStream<P2PStream<MockTransport>>,
+    count: usize,
+) {
+    let mut remaining = count;
+    while remaining > 0 {
+        poll_fn(|cx| Pin::new(&mut *stream).poll_ready(cx)).await.unwrap();
+        let batch = stream.inner().available_outgoing_capacity().min(remaining);
+        assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
+        for _ in 0..batch {
+            Pin::new(&mut *stream).start_send(message()).unwrap();
+        }
+        remaining -= batch;
+    }
+    stream.flush().await.unwrap();
 }
 
 #[derive(Default)]
@@ -154,15 +176,25 @@ fn bench_send_messages(c: &mut Criterion) {
         b.iter(|| {
             rt.block_on(async {
                 let mut stream = active_session_eth_stream(MockTransport::default());
-                for _ in 0..MESSAGE_COUNT {
-                    poll_fn(|cx| Pin::new(&mut stream).poll_ready(cx)).await.unwrap();
-                    Pin::new(&mut stream).start_send(message()).unwrap();
-                }
-                stream.flush().await.unwrap();
+                send_hash_announcements_in_active_session_batches(&mut stream, MESSAGE_COUNT).await;
                 black_box(stream.inner().inner().sent.len());
             });
         })
     });
+
+    for capacity in [8, 16, 64] {
+        group.bench_function(format!("send_hash_announcements_batched_capacity_{capacity}"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut stream =
+                        active_session_eth_stream_with_capacity(MockTransport::default(), capacity);
+                    send_hash_announcements_in_active_session_batches(&mut stream, MESSAGE_COUNT)
+                        .await;
+                    black_box(stream.inner().inner().sent.len());
+                });
+            })
+        });
+    }
 
     group.bench_function("send_transaction_broadcasts", |b| {
         let broadcast = transaction_broadcast();

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -197,7 +197,7 @@ async fn send_and_receive_ethstream_hash_announcements(count: usize, capacity: u
         }
         remaining -= batch;
     }
-    stream.flush().await.unwrap();
+    poll_fn(|cx| Pin::new(stream.inner_mut()).poll_flush_ecies_buffered(cx)).await.unwrap();
 
     server.await.unwrap()
 }

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 const MESSAGE_COUNT: usize = 1024;
+const HASHES_PER_ANNOUNCEMENT: usize = 64;
 const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
 const ECIES_PAYLOAD_LEN: usize = 512;
 
@@ -43,24 +44,37 @@ fn message() -> EthMessage<EthNetworkPrimitives> {
 }
 
 fn message_for_version(version: EthVersion) -> EthMessage<EthNetworkPrimitives> {
+    message_for_version_with_hashes(version, 1)
+}
+
+fn message_for_version_with_hashes(
+    version: EthVersion,
+    hash_count: usize,
+) -> EthMessage<EthNetworkPrimitives> {
+    let hashes = hashes(hash_count);
+
     if version.is_eth72() {
         return EthMessage::NewPooledTransactionHashes72(NewPooledTransactionHashes72 {
-            types: vec![0x02],
-            sizes: vec![128],
-            hashes: vec![B256::repeat_byte(0x42)],
+            types: vec![0x02; hash_count],
+            sizes: vec![128; hash_count],
+            hashes,
             cell_mask: None,
         })
     }
 
     if version.has_eth68_metadata() {
         return EthMessage::NewPooledTransactionHashes68(NewPooledTransactionHashes68 {
-            types: vec![0x02],
-            sizes: vec![128],
-            hashes: vec![B256::repeat_byte(0x42)],
+            types: vec![0x02; hash_count],
+            sizes: vec![128; hash_count],
+            hashes,
         })
     }
 
-    EthMessage::NewPooledTransactionHashes66(vec![B256::repeat_byte(0x42)].into())
+    EthMessage::NewPooledTransactionHashes66(hashes.into())
+}
+
+fn hashes(count: usize) -> Vec<B256> {
+    (0..count).map(|idx| B256::repeat_byte(idx as u8)).collect()
 }
 
 fn transaction(nonce: u64) -> Arc<TransactionSigned> {
@@ -121,9 +135,16 @@ fn encoded_wire_message() -> BytesMut {
 }
 
 fn encoded_wire_message_for_version(version: EthVersion) -> BytesMut {
+    encoded_wire_message_for_version_with_hashes(version, 1)
+}
+
+fn encoded_wire_message_for_version_with_hashes(
+    version: EthVersion,
+    hash_count: usize,
+) -> BytesMut {
     runtime().block_on(async {
         let mut stream = eth_stream_with_version(MockTransport::default(), version);
-        stream.send(message_for_version(version)).await.unwrap();
+        stream.send(message_for_version_with_hashes(version, hash_count)).await.unwrap();
         stream.inner().inner().sent[0].clone().into()
     })
 }
@@ -479,6 +500,36 @@ fn bench_recv_messages(c: &mut Criterion) {
                 });
             })
         });
+
+        group.bench_function(
+            format!(
+                "recv_hash_announcements_eth{}_{}_hashes",
+                version as u8, HASHES_PER_ANNOUNCEMENT
+            ),
+            |b| {
+                let encoded =
+                    encoded_wire_message_for_version_with_hashes(version, HASHES_PER_ANNOUNCEMENT);
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut stream = eth_stream_with_version(
+                            MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT),
+                            version,
+                        );
+                        let mut decode_buf = BytesMut::new();
+                        for _ in 0..MESSAGE_COUNT {
+                            black_box(
+                                poll_fn(|cx| {
+                                    Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                                })
+                                .await
+                                .unwrap()
+                                .unwrap(),
+                            );
+                        }
+                    });
+                })
+            },
+        );
     }
 }
 

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
     B256,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::{future::poll_fn, Sink, SinkExt, Stream, StreamExt};
+use futures::{future::poll_fn, Sink, SinkExt, Stream};
 use reth_eth_wire::{
     capability::SharedCapabilities, Capability, EthMessage, EthNetworkPrimitives, EthStream,
     EthVersion, P2PStream,
@@ -129,8 +129,16 @@ fn bench_recv_messages(c: &mut Criterion) {
             rt.block_on(async {
                 let mut stream =
                     eth_stream(MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT));
+                let mut decode_buf = BytesMut::new();
                 for _ in 0..MESSAGE_COUNT {
-                    black_box(stream.next().await.unwrap().unwrap());
+                    black_box(
+                        poll_fn(|cx| {
+                            Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                        })
+                        .await
+                        .unwrap()
+                        .unwrap(),
+                    );
                 }
             });
         })

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -29,6 +29,7 @@ use std::{
 const MESSAGE_COUNT: usize = 1024;
 const HASHES_PER_ANNOUNCEMENT: usize = 64;
 const SMALL_TX_SIZE: usize = 64;
+const MEDIUM_TX_SIZE: usize = 1024;
 const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
 const ECIES_PAYLOAD_LEN: usize = 512;
 
@@ -599,6 +600,39 @@ fn bench_recv_messages(c: &mut Criterion) {
                     version,
                     HASHES_PER_ANNOUNCEMENT,
                     SMALL_TX_SIZE,
+                );
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut stream = eth_stream_with_version(
+                            MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT),
+                            version,
+                        );
+                        let mut decode_buf = BytesMut::new();
+                        for _ in 0..MESSAGE_COUNT {
+                            black_box(
+                                poll_fn(|cx| {
+                                    Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                                })
+                                .await
+                                .unwrap()
+                                .unwrap(),
+                            );
+                        }
+                    });
+                })
+            },
+        );
+
+        group.bench_function(
+            format!(
+                "recv_hash_announcements_eth{}_{}_hashes_medium_sizes",
+                version as u8, HASHES_PER_ANNOUNCEMENT
+            ),
+            |b| {
+                let encoded = encoded_wire_message_for_version_with_hashes_and_size(
+                    version,
+                    HASHES_PER_ANNOUNCEMENT,
+                    MEDIUM_TX_SIZE,
                 );
                 b.iter(|| {
                     rt.block_on(async {

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -1,0 +1,141 @@
+#![allow(missing_docs)]
+
+use alloy_primitives::{
+    bytes::{Bytes, BytesMut},
+    B256,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures::{future::poll_fn, Sink, SinkExt, Stream, StreamExt};
+use reth_eth_wire::{
+    capability::SharedCapabilities, Capability, EthMessage, EthNetworkPrimitives, EthStream,
+    EthVersion, P2PStream,
+};
+use std::{
+    collections::VecDeque,
+    hint::black_box,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+const MESSAGE_COUNT: usize = 1024;
+
+fn shared_capabilities() -> SharedCapabilities {
+    SharedCapabilities::try_new(
+        vec![EthVersion::Eth66.into()],
+        vec![Capability::eth(EthVersion::Eth66)],
+    )
+    .unwrap()
+}
+
+fn message() -> EthMessage<EthNetworkPrimitives> {
+    EthMessage::NewPooledTransactionHashes66(vec![B256::repeat_byte(0x42)].into())
+}
+
+fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
+    EthStream::new(EthVersion::Eth66, P2PStream::new(transport, shared_capabilities()))
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap()
+}
+
+fn encoded_wire_message() -> BytesMut {
+    runtime().block_on(async {
+        let mut stream = eth_stream(MockTransport::default());
+        stream.send(message()).await.unwrap();
+        stream.inner().inner().sent[0].clone().into()
+    })
+}
+
+#[derive(Default)]
+struct MockTransport {
+    incoming: VecDeque<io::Result<BytesMut>>,
+    sent: Vec<Bytes>,
+}
+
+impl MockTransport {
+    fn with_incoming(message: BytesMut, count: usize) -> Self {
+        Self { incoming: (0..count).map(|_| Ok(message.clone())).collect(), sent: Vec::new() }
+    }
+}
+
+impl Stream for MockTransport {
+    type Item = io::Result<BytesMut>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.incoming.pop_front())
+    }
+}
+
+impl Sink<Bytes> for MockTransport {
+    type Error = io::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
+        self.sent.push(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn bench_poll_ready_idle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ethstream");
+    let rt = runtime();
+    group.bench_function("poll_ready_idle", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = eth_stream(MockTransport::default());
+                for _ in 0..MESSAGE_COUNT {
+                    black_box(poll_fn(|cx| Pin::new(&mut stream).poll_ready(cx)).await).unwrap();
+                }
+            });
+        })
+    });
+}
+
+fn bench_send_messages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ethstream");
+    let rt = runtime();
+    group.bench_function("send_hash_announcements", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = eth_stream(MockTransport::default());
+                for _ in 0..MESSAGE_COUNT {
+                    stream.send(message()).await.unwrap();
+                }
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+}
+
+fn bench_recv_messages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ethstream");
+    let rt = runtime();
+    group.bench_function("recv_hash_announcements", |b| {
+        let encoded = encoded_wire_message();
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream =
+                    eth_stream(MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT));
+                for _ in 0..MESSAGE_COUNT {
+                    black_box(stream.next().await.unwrap().unwrap());
+                }
+            });
+        })
+    });
+}
+
+criterion_group!(benches, bench_poll_ready_idle, bench_send_messages, bench_recv_messages);
+criterion_main!(benches);

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -11,7 +11,8 @@ use futures::{future::poll_fn, Sink, SinkExt, Stream, StreamExt};
 use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
     capability::SharedCapabilities, message::EthBroadcastMessage, Capability, EthMessage,
-    EthNetworkPrimitives, EthStream, EthVersion, P2PStream, SharedTransactions,
+    EthNetworkPrimitives, EthStream, EthVersion, NewPooledTransactionHashes68,
+    NewPooledTransactionHashes72, P2PStream, SharedTransactions,
 };
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use reth_network_peers::pk2id;
@@ -30,14 +31,35 @@ const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
 const ECIES_PAYLOAD_LEN: usize = 512;
 
 fn shared_capabilities() -> SharedCapabilities {
-    SharedCapabilities::try_new(
-        vec![EthVersion::Eth66.into()],
-        vec![Capability::eth(EthVersion::Eth66)],
-    )
-    .unwrap()
+    shared_capabilities_for(EthVersion::Eth66)
+}
+
+fn shared_capabilities_for(version: EthVersion) -> SharedCapabilities {
+    SharedCapabilities::try_new(vec![version.into()], vec![Capability::eth(version)]).unwrap()
 }
 
 fn message() -> EthMessage<EthNetworkPrimitives> {
+    message_for_version(EthVersion::Eth66)
+}
+
+fn message_for_version(version: EthVersion) -> EthMessage<EthNetworkPrimitives> {
+    if version.is_eth72() {
+        return EthMessage::NewPooledTransactionHashes72(NewPooledTransactionHashes72 {
+            types: vec![0x02],
+            sizes: vec![128],
+            hashes: vec![B256::repeat_byte(0x42)],
+            cell_mask: None,
+        })
+    }
+
+    if version.has_eth68_metadata() {
+        return EthMessage::NewPooledTransactionHashes68(NewPooledTransactionHashes68 {
+            types: vec![0x02],
+            sizes: vec![128],
+            hashes: vec![B256::repeat_byte(0x42)],
+        })
+    }
+
     EthMessage::NewPooledTransactionHashes66(vec![B256::repeat_byte(0x42)].into())
 }
 
@@ -67,7 +89,14 @@ fn transaction_broadcast_payload_length(
 }
 
 fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
-    EthStream::new(EthVersion::Eth66, P2PStream::new(transport, shared_capabilities()))
+    eth_stream_with_version(transport, EthVersion::Eth66)
+}
+
+fn eth_stream_with_version(
+    transport: MockTransport,
+    version: EthVersion,
+) -> EthStream<P2PStream<MockTransport>> {
+    EthStream::new(version, P2PStream::new(transport, shared_capabilities_for(version)))
 }
 
 fn active_session_eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
@@ -88,9 +117,13 @@ fn runtime() -> tokio::runtime::Runtime {
 }
 
 fn encoded_wire_message() -> BytesMut {
+    encoded_wire_message_for_version(EthVersion::Eth66)
+}
+
+fn encoded_wire_message_for_version(version: EthVersion) -> BytesMut {
     runtime().block_on(async {
-        let mut stream = eth_stream(MockTransport::default());
-        stream.send(message()).await.unwrap();
+        let mut stream = eth_stream_with_version(MockTransport::default(), version);
+        stream.send(message_for_version(version)).await.unwrap();
         stream.inner().inner().sent[0].clone().into()
     })
 }
@@ -422,6 +455,31 @@ fn bench_recv_messages(c: &mut Criterion) {
             });
         })
     });
+
+    for version in [EthVersion::Eth68, EthVersion::Eth72] {
+        group.bench_function(format!("recv_hash_announcements_eth{}", version as u8), |b| {
+            let encoded = encoded_wire_message_for_version(version);
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut stream = eth_stream_with_version(
+                        MockTransport::with_incoming(encoded.clone(), MESSAGE_COUNT),
+                        version,
+                    );
+                    let mut decode_buf = BytesMut::new();
+                    for _ in 0..MESSAGE_COUNT {
+                        black_box(
+                            poll_fn(|cx| {
+                                Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                            })
+                            .await
+                            .unwrap()
+                            .unwrap(),
+                        );
+                    }
+                });
+            })
+        });
+    }
 }
 
 fn bench_ecies_messages(c: &mut Criterion) {

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -193,6 +193,10 @@ impl MockTransport {
     fn with_incoming(message: BytesMut, count: usize) -> Self {
         Self { incoming: (0..count).map(|_| Ok(message.clone())).collect(), sent: Vec::new() }
     }
+
+    fn with_incoming_messages(messages: impl IntoIterator<Item = BytesMut>) -> Self {
+        Self { incoming: messages.into_iter().map(Ok).collect(), sent: Vec::new() }
+    }
 }
 
 impl Stream for MockTransport {
@@ -335,6 +339,29 @@ fn bench_recv_messages(c: &mut Criterion) {
                         .unwrap(),
                     );
                 }
+            });
+        })
+    });
+
+    group.bench_function("recv_hash_announcements_with_ping_controls", |b| {
+        let encoded = encoded_wire_message();
+        let ping = BytesMut::from(&b"\x02\x01\0\xc0"[..]);
+        b.iter(|| {
+            rt.block_on(async {
+                let incoming = (0..MESSAGE_COUNT).flat_map(|_| [ping.clone(), encoded.clone()]);
+                let mut stream = eth_stream(MockTransport::with_incoming_messages(incoming));
+                let mut decode_buf = BytesMut::new();
+                for _ in 0..MESSAGE_COUNT {
+                    black_box(
+                        poll_fn(|cx| {
+                            Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf)
+                        })
+                        .await
+                        .unwrap()
+                        .unwrap(),
+                    );
+                }
+                black_box(stream.inner().inner().sent.len());
             });
         })
     });

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -10,9 +10,10 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use futures::{future::poll_fn, Sink, SinkExt, Stream, StreamExt};
 use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
-    capability::SharedCapabilities, message::EthBroadcastMessage, Capability, EthMessage,
-    EthNetworkPrimitives, EthStream, EthVersion, NewPooledTransactionHashes68,
-    NewPooledTransactionHashes72, P2PStream, SharedTransactions, Transactions,
+    capability::SharedCapabilities, message::EthBroadcastMessage, Capability, EncodedEthMessage,
+    EthMessage, EthNetworkPrimitives, EthStream, EthVersion, NewPooledTransactionHashes66,
+    NewPooledTransactionHashes68, NewPooledTransactionHashes72, P2PStream, SharedTransactions,
+    Transactions,
 };
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use reth_network_peers::pk2id;
@@ -116,6 +117,14 @@ fn transaction_broadcast_payload_length(
     transactions.iter().map(Encodable::length).sum()
 }
 
+fn encoded_hash_announcement() -> EncodedEthMessage {
+    let msg = EncodedEthMessage::new_pooled_transaction_hashes(
+        NewPooledTransactionHashes66(hashes(1)).into(),
+    );
+    msg.precompute_eth_only_compression().unwrap();
+    msg
+}
+
 fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
     eth_stream_with_version(transport, EthVersion::Eth66)
 }
@@ -212,6 +221,24 @@ async fn send_hash_announcements_in_active_session_batches_with_encode_buf(
         assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
         for _ in 0..batch {
             stream.start_send_with_encode_buf(message(), &mut encode_buf).unwrap();
+        }
+        remaining -= batch;
+    }
+    stream.flush().await.unwrap();
+}
+
+async fn send_hash_announcements_in_active_session_batches_preencoded(
+    stream: &mut EthStream<P2PStream<MockTransport>>,
+    count: usize,
+) {
+    let msg = encoded_hash_announcement();
+    let mut remaining = count;
+    while remaining > 0 {
+        poll_fn(|cx| Pin::new(&mut *stream).poll_ready(cx)).await.unwrap();
+        let batch = stream.inner().available_outgoing_capacity().min(remaining);
+        assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
+        for _ in 0..batch {
+            stream.start_send_encoded_eth_only(msg.clone()).unwrap();
         }
         remaining -= batch;
     }
@@ -380,6 +407,20 @@ fn bench_send_messages(c: &mut Criterion) {
             rt.block_on(async {
                 let mut stream = active_session_eth_stream(MockTransport::default());
                 send_hash_announcements_in_active_session_batches_with_encode_buf(
+                    &mut stream,
+                    MESSAGE_COUNT,
+                )
+                .await;
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+
+    group.bench_function("send_hash_announcements_batched_preencoded", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = active_session_eth_stream(MockTransport::default());
+                send_hash_announcements_in_active_session_batches_preencoded(
                     &mut stream,
                     MESSAGE_COUNT,
                 )

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{
     bytes::{Bytes, BytesMut},
     Bytes as AlloyBytes, Signature, TxKind, B256, U256,
 };
+use alloy_rlp::Encodable;
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::{future::poll_fn, Sink, SinkExt, Stream, StreamExt};
 use reth_ecies::stream::ECIESStream;
@@ -57,6 +58,12 @@ fn transaction(nonce: u64) -> Arc<TransactionSigned> {
 
 fn transaction_broadcast() -> EthBroadcastMessage<EthNetworkPrimitives> {
     EthBroadcastMessage::Transactions(SharedTransactions(vec![transaction(0), transaction(1)]))
+}
+
+fn transaction_broadcast_payload_length(
+    transactions: &SharedTransactions<TransactionSigned>,
+) -> usize {
+    transactions.iter().map(Encodable::length).sum()
 }
 
 fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
@@ -128,6 +135,50 @@ async fn send_and_receive_ecies_messages(count: usize) -> usize {
         client.send(payload.clone()).await.unwrap();
     }
     client.flush().await.unwrap();
+
+    server.await.unwrap()
+}
+
+async fn send_and_receive_ethstream_hash_announcements(count: usize, capacity: usize) -> usize {
+    let server_key = SecretKey::from_slice(&[3; 32]).unwrap();
+    let server_id = pk2id(&server_key.public_key(SECP256K1));
+    let client_key = SecretKey::from_slice(&[4; 32]).unwrap();
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+
+    let server = tokio::spawn(async move {
+        let ecies = ECIESStream::incoming(server_io, server_key).await.unwrap();
+        let p2p = P2PStream::new(ecies, shared_capabilities());
+        let mut stream = EthStream::<_, EthNetworkPrimitives>::new(EthVersion::Eth66, p2p);
+        let mut decode_buf = BytesMut::new();
+        let mut received = 0;
+        while received < count {
+            black_box(
+                poll_fn(|cx| Pin::new(&mut stream).poll_next_eth_message(cx, &mut decode_buf))
+                    .await
+                    .unwrap()
+                    .unwrap(),
+            );
+            received += 1;
+        }
+        received
+    });
+
+    let ecies = ECIESStream::connect(client_io, client_key, server_id).await.unwrap();
+    let mut p2p = P2PStream::new(ecies, shared_capabilities());
+    p2p.set_outgoing_message_buffer_capacity(capacity);
+    let mut stream = EthStream::<_, EthNetworkPrimitives>::new(EthVersion::Eth66, p2p);
+
+    let mut remaining = count;
+    while remaining > 0 {
+        poll_fn(|cx| Pin::new(&mut stream).poll_ready(cx)).await.unwrap();
+        let batch = stream.inner().available_outgoing_capacity().min(remaining);
+        assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
+        for _ in 0..batch {
+            Pin::new(&mut stream).start_send(message()).unwrap();
+        }
+        remaining -= batch;
+    }
+    stream.flush().await.unwrap();
 
     server.await.unwrap()
 }
@@ -240,6 +291,28 @@ fn bench_send_messages(c: &mut Criterion) {
             });
         })
     });
+
+    group.bench_function("send_transaction_broadcasts_cached_payload_length", |b| {
+        let EthBroadcastMessage::Transactions(transactions) = transaction_broadcast() else {
+            unreachable!()
+        };
+        let payload_length = transaction_broadcast_payload_length(&transactions);
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = eth_stream(MockTransport::default());
+                for _ in 0..MESSAGE_COUNT {
+                    stream
+                        .start_send_transactions_with_payload_length(
+                            transactions.clone(),
+                            payload_length,
+                        )
+                        .unwrap();
+                    stream.flush().await.unwrap();
+                }
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
 }
 
 fn bench_recv_messages(c: &mut Criterion) {
@@ -279,11 +352,30 @@ fn bench_ecies_messages(c: &mut Criterion) {
     });
 }
 
+fn bench_ethstream_ecies_messages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ethstream_ecies");
+    let rt = runtime();
+
+    for capacity in [8, 16, 32, 64, 128] {
+        group.bench_function(format!("send_hash_announcements_capacity_{capacity}"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    black_box(
+                        send_and_receive_ethstream_hash_announcements(MESSAGE_COUNT, capacity)
+                            .await,
+                    );
+                });
+            })
+        });
+    }
+}
+
 criterion_group!(
     benches,
     bench_poll_ready_idle,
     bench_send_messages,
     bench_recv_messages,
-    bench_ecies_messages
+    bench_ecies_messages,
+    bench_ethstream_ecies_messages
 );
 criterion_main!(benches);

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -355,6 +355,44 @@ fn bench_send_messages(c: &mut Criterion) {
         })
     });
 
+    for version in [EthVersion::Eth68, EthVersion::Eth72] {
+        group.bench_function(format!("send_hash_announcements_eth{}", version as u8), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut stream = eth_stream_with_version(MockTransport::default(), version);
+                    for _ in 0..MESSAGE_COUNT {
+                        stream.send(message_for_version(version)).await.unwrap();
+                    }
+                    black_box(stream.inner().inner().sent.len());
+                });
+            })
+        });
+
+        group.bench_function(
+            format!(
+                "send_hash_announcements_eth{}_{}_hashes",
+                version as u8, HASHES_PER_ANNOUNCEMENT
+            ),
+            |b| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut stream = eth_stream_with_version(MockTransport::default(), version);
+                        for _ in 0..MESSAGE_COUNT {
+                            stream
+                                .send(message_for_version_with_hashes(
+                                    version,
+                                    HASHES_PER_ANNOUNCEMENT,
+                                ))
+                                .await
+                                .unwrap();
+                        }
+                        black_box(stream.inner().inner().sent.len());
+                    });
+                })
+            },
+        );
+    }
+
     for capacity in [8, 16, 64] {
         group.bench_function(format!("send_hash_announcements_batched_capacity_{capacity}"), |b| {
             b.iter(|| {

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -112,6 +112,24 @@ async fn send_hash_announcements_in_active_session_batches(
     stream.flush().await.unwrap();
 }
 
+async fn send_hash_announcements_in_active_session_batches_with_encode_buf(
+    stream: &mut EthStream<P2PStream<MockTransport>>,
+    count: usize,
+) {
+    let mut encode_buf = BytesMut::new();
+    let mut remaining = count;
+    while remaining > 0 {
+        poll_fn(|cx| Pin::new(&mut *stream).poll_ready(cx)).await.unwrap();
+        let batch = stream.inner().available_outgoing_capacity().min(remaining);
+        assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
+        for _ in 0..batch {
+            stream.start_send_with_encode_buf(message(), &mut encode_buf).unwrap();
+        }
+        remaining -= batch;
+    }
+    stream.flush().await.unwrap();
+}
+
 async fn send_and_receive_ecies_messages(count: usize) -> usize {
     let server_key = SecretKey::from_slice(&[1; 32]).unwrap();
     let server_id = pk2id(&server_key.public_key(SECP256K1));
@@ -268,6 +286,20 @@ fn bench_send_messages(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("send_hash_announcements_batched_encode_buf", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = active_session_eth_stream(MockTransport::default());
+                send_hash_announcements_in_active_session_batches_with_encode_buf(
+                    &mut stream,
+                    MESSAGE_COUNT,
+                )
+                .await;
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+
     for capacity in [8, 16, 64] {
         group.bench_function(format!("send_hash_announcements_batched_capacity_{capacity}"), |b| {
             b.iter(|| {
@@ -309,6 +341,30 @@ fn bench_send_messages(c: &mut Criterion) {
                         .start_send_transactions_with_payload_length(
                             transactions.clone(),
                             payload_length,
+                        )
+                        .unwrap();
+                    stream.flush().await.unwrap();
+                }
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+
+    group.bench_function("send_transaction_broadcasts_cached_payload_length_encode_buf", |b| {
+        let EthBroadcastMessage::Transactions(transactions) = transaction_broadcast() else {
+            unreachable!()
+        };
+        let payload_length = transaction_broadcast_payload_length(&transactions);
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = eth_stream(MockTransport::default());
+                let mut encode_buf = BytesMut::new();
+                for _ in 0..MESSAGE_COUNT {
+                    stream
+                        .start_send_transactions_with_payload_length_and_encode_buf(
+                            transactions.clone(),
+                            payload_length,
+                            &mut encode_buf,
                         )
                         .unwrap();
                     stream.flush().await.unwrap();

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -1,20 +1,23 @@
 #![allow(missing_docs)]
 
+use alloy_consensus::TxLegacy;
 use alloy_primitives::{
     bytes::{Bytes, BytesMut},
-    B256,
+    Bytes as AlloyBytes, Signature, TxKind, B256, U256,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::{future::poll_fn, Sink, SinkExt, Stream};
 use reth_eth_wire::{
-    capability::SharedCapabilities, Capability, EthMessage, EthNetworkPrimitives, EthStream,
-    EthVersion, P2PStream,
+    capability::SharedCapabilities, message::EthBroadcastMessage, Capability, EthMessage,
+    EthNetworkPrimitives, EthStream, EthVersion, P2PStream, SharedTransactions,
 };
+use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use std::{
     collections::VecDeque,
     hint::black_box,
     io,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -30,6 +33,25 @@ fn shared_capabilities() -> SharedCapabilities {
 
 fn message() -> EthMessage<EthNetworkPrimitives> {
     EthMessage::NewPooledTransactionHashes66(vec![B256::repeat_byte(0x42)].into())
+}
+
+fn transaction(nonce: u64) -> Arc<TransactionSigned> {
+    Arc::new(TransactionSigned::new_unhashed(
+        Transaction::Legacy(TxLegacy {
+            chain_id: Some(1),
+            nonce,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Create,
+            value: U256::ZERO,
+            input: AlloyBytes::from(vec![0x42; 128]),
+        }),
+        Signature::test_signature(),
+    ))
+}
+
+fn transaction_broadcast() -> EthBroadcastMessage<EthNetworkPrimitives> {
+    EthBroadcastMessage::Transactions(SharedTransactions(vec![transaction(0), transaction(1)]))
 }
 
 fn eth_stream(transport: MockTransport) -> EthStream<P2PStream<MockTransport>> {
@@ -113,6 +135,20 @@ fn bench_send_messages(c: &mut Criterion) {
                 let mut stream = eth_stream(MockTransport::default());
                 for _ in 0..MESSAGE_COUNT {
                     stream.send(message()).await.unwrap();
+                }
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+
+    group.bench_function("send_transaction_broadcasts", |b| {
+        let broadcast = transaction_broadcast();
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = eth_stream(MockTransport::default());
+                for _ in 0..MESSAGE_COUNT {
+                    stream.start_send_broadcast(broadcast.clone()).unwrap();
+                    stream.flush().await.unwrap();
                 }
                 black_box(stream.inner().inner().sent.len());
             });

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -117,6 +117,16 @@ fn transaction_broadcast_payload_length(
     transactions.iter().map(Encodable::length).sum()
 }
 
+fn encoded_transaction_broadcast() -> EncodedEthMessage {
+    let EthBroadcastMessage::Transactions(transactions) = transaction_broadcast() else {
+        unreachable!()
+    };
+    let payload_length = transaction_broadcast_payload_length(&transactions);
+    let msg = EncodedEthMessage::transactions_broadcast(&transactions, payload_length);
+    msg.precompute_eth_only_compression().unwrap();
+    msg
+}
+
 fn encoded_hash_announcement() -> EncodedEthMessage {
     let msg = EncodedEthMessage::new_pooled_transaction_hashes(
         NewPooledTransactionHashes66(hashes(1)).into(),
@@ -535,6 +545,20 @@ fn bench_send_messages(c: &mut Criterion) {
                             &mut encode_buf,
                         )
                         .unwrap();
+                    stream.flush().await.unwrap();
+                }
+                black_box(stream.inner().inner().sent.len());
+            });
+        })
+    });
+
+    group.bench_function("send_transaction_broadcasts_preencoded", |b| {
+        let msg = encoded_transaction_broadcast();
+        b.iter(|| {
+            rt.block_on(async {
+                let mut stream = eth_stream(MockTransport::default());
+                for _ in 0..MESSAGE_COUNT {
+                    stream.start_send_encoded_eth_only(msg.clone()).unwrap();
                     stream.flush().await.unwrap();
                 }
                 black_box(stream.inner().inner().sent.len());

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -6,12 +6,15 @@ use alloy_primitives::{
     Bytes as AlloyBytes, Signature, TxKind, B256, U256,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::{future::poll_fn, Sink, SinkExt, Stream};
+use futures::{future::poll_fn, Sink, SinkExt, Stream, StreamExt};
+use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
     capability::SharedCapabilities, message::EthBroadcastMessage, Capability, EthMessage,
     EthNetworkPrimitives, EthStream, EthVersion, P2PStream, SharedTransactions,
 };
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
+use reth_network_peers::pk2id;
+use secp256k1::{SecretKey, SECP256K1};
 use std::{
     collections::VecDeque,
     hint::black_box,
@@ -23,6 +26,7 @@ use std::{
 
 const MESSAGE_COUNT: usize = 1024;
 const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
+const ECIES_PAYLOAD_LEN: usize = 512;
 
 fn shared_capabilities() -> SharedCapabilities {
     SharedCapabilities::try_new(
@@ -73,7 +77,7 @@ fn active_session_eth_stream_with_capacity(
 }
 
 fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap()
+    tokio::runtime::Builder::new_current_thread().enable_io().enable_time().build().unwrap()
 }
 
 fn encoded_wire_message() -> BytesMut {
@@ -99,6 +103,33 @@ async fn send_hash_announcements_in_active_session_batches(
         remaining -= batch;
     }
     stream.flush().await.unwrap();
+}
+
+async fn send_and_receive_ecies_messages(count: usize) -> usize {
+    let server_key = SecretKey::from_slice(&[1; 32]).unwrap();
+    let server_id = pk2id(&server_key.public_key(SECP256K1));
+    let client_key = SecretKey::from_slice(&[2; 32]).unwrap();
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+
+    let server = tokio::spawn(async move {
+        let mut stream = ECIESStream::incoming(server_io, server_key).await.unwrap();
+        let mut received = 0;
+        while received < count {
+            let msg = stream.next().await.unwrap().unwrap();
+            black_box(msg.len());
+            received += 1;
+        }
+        received
+    });
+
+    let mut client = ECIESStream::connect(client_io, client_key, server_id).await.unwrap();
+    let payload = Bytes::from(vec![0x42; ECIES_PAYLOAD_LEN]);
+    for _ in 0..count {
+        client.send(payload.clone()).await.unwrap();
+    }
+    client.flush().await.unwrap();
+
+    server.await.unwrap()
 }
 
 #[derive(Default)]
@@ -236,5 +267,23 @@ fn bench_recv_messages(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_poll_ready_idle, bench_send_messages, bench_recv_messages);
+fn bench_ecies_messages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eciesstream");
+    let rt = runtime();
+    group.bench_function("send_receive_messages", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                black_box(send_and_receive_ecies_messages(MESSAGE_COUNT).await);
+            });
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_poll_ready_idle,
+    bench_send_messages,
+    bench_recv_messages,
+    bench_ecies_messages
+);
 criterion_main!(benches);

--- a/crates/net/eth-wire/benches/ethstream.rs
+++ b/crates/net/eth-wire/benches/ethstream.rs
@@ -264,7 +264,7 @@ async fn send_and_receive_ethstream_hash_announcements(count: usize, capacity: u
     let mut remaining = count;
     let mut encode_buf = BytesMut::new();
     while remaining > 0 {
-        poll_fn(|cx| Pin::new(&mut stream).poll_ready(cx)).await.unwrap();
+        poll_fn(|cx| Pin::new(stream.inner_mut()).poll_ready_ecies_buffered(cx)).await.unwrap();
         let batch = stream.inner().available_outgoing_capacity().min(remaining);
         assert_ne!(batch, 0, "poll_ready returned ready without outgoing capacity");
         for _ in 0..batch {

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -199,7 +199,7 @@ where
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake));
         }
 
-        Ok(Bytes::from(alloy_rlp::encode(ProtocolMessage::from(item))))
+        Ok(item.encoded())
     }
 }
 
@@ -357,9 +357,7 @@ where
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 
-        self.project()
-            .inner
-            .start_send(Bytes::from(alloy_rlp::encode(ProtocolMessage::from(item))))?;
+        self.project().inner.start_send(item.encoded())?;
 
         Ok(())
     }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -260,6 +260,11 @@ impl EncodedEthMessage {
 
     /// Encodes a `NewPooledTransactionHashes` announcement.
     pub fn new_pooled_transaction_hashes(hashes: NewPooledTransactionHashes) -> Self {
+        Self::pooled_transaction_hashes(&hashes)
+    }
+
+    /// Encodes a `NewPooledTransactionHashes` announcement by reference.
+    pub fn pooled_transaction_hashes(hashes: &NewPooledTransactionHashes) -> Self {
         let mut out = BytesMut::new();
         EthMessageID::NewPooledTransactionHashes.encode(&mut out);
         match hashes {

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -11,7 +11,7 @@ use crate::{
         EthBroadcastMessage, MessageError, ProtocolBroadcastMessage, MAX_MESSAGE_SIZE,
         TX_MEMORY_BUDGET_MULTIPLIER,
     },
-    p2pstream::{P2PStream, HANDSHAKE_TIMEOUT},
+    p2pstream::{compress_eth_only_protocol_message, P2PStream, HANDSHAKE_TIMEOUT},
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     SharedTransactions, UnifiedStatus,
 };
@@ -19,12 +19,16 @@ use alloy_primitives::bytes::{Bytes, BytesMut};
 use alloy_rlp::{Encodable, Header};
 use futures::{ready, Sink, SinkExt};
 use pin_project::pin_project;
-use reth_eth_wire_types::{EthMessageID, NetworkPrimitives, RawCapabilityMessage};
+use reth_eth_wire_types::{
+    EthMessageID, NetworkPrimitives, NewBlockHashes, NewPooledTransactionHashes,
+    RawCapabilityMessage,
+};
 use reth_ethereum_forks::ForkFilter;
 use std::{
     future::Future,
     io,
     pin::Pin,
+    sync::{Arc, OnceLock},
     task::{Context, Poll},
     time::Duration,
 };
@@ -229,6 +233,94 @@ where
     }
 }
 
+/// An already encoded, id-prefixed eth protocol message.
+///
+/// The encoded bytes keep the eth-relative message id as the first byte. For eth-only p2p
+/// sessions the snappy-compressed wire frame can be cached and reused.
+#[derive(Clone, Debug)]
+pub struct EncodedEthMessage {
+    encoded: Bytes,
+    eth_only_compressed: Arc<OnceLock<Bytes>>,
+}
+
+impl EncodedEthMessage {
+    /// Creates a new encoded eth message.
+    pub fn new(encoded: Bytes) -> Self {
+        Self { encoded, eth_only_compressed: Arc::new(OnceLock::new()) }
+    }
+
+    /// Encodes a `NewBlockHashes` announcement.
+    pub fn new_block_hashes(hashes: NewBlockHashes) -> Self {
+        let mut out = BytesMut::new();
+        out.reserve(EthMessageID::NewBlockHashes.length() + hashes.length());
+        EthMessageID::NewBlockHashes.encode(&mut out);
+        hashes.encode(&mut out);
+        Self::new(out.freeze())
+    }
+
+    /// Encodes a `NewPooledTransactionHashes` announcement.
+    pub fn new_pooled_transaction_hashes(hashes: NewPooledTransactionHashes) -> Self {
+        let mut out = BytesMut::new();
+        EthMessageID::NewPooledTransactionHashes.encode(&mut out);
+        match hashes {
+            NewPooledTransactionHashes::Eth66(hashes) => hashes.encode(&mut out),
+            NewPooledTransactionHashes::Eth68(hashes) => hashes.encode(&mut out),
+            NewPooledTransactionHashes::Eth72(hashes) => hashes.encode(&mut out),
+        }
+        Self::new(out.freeze())
+    }
+
+    /// Encodes a `Transactions` broadcast with a precomputed RLP list payload length.
+    pub fn transactions_broadcast<T: Encodable>(
+        transactions: &SharedTransactions<T>,
+        payload_length: usize,
+    ) -> Self {
+        let header = Header { list: true, payload_length };
+        let mut out = BytesMut::with_capacity(
+            EthMessageID::Transactions.length() + header.length() + payload_length,
+        );
+        EthMessageID::Transactions.encode(&mut out);
+        header.encode(&mut out);
+        for tx in transactions.iter() {
+            tx.encode(&mut out);
+        }
+        Self::new(out.freeze())
+    }
+
+    /// Returns the encoded eth-relative protocol bytes.
+    pub const fn encoded(&self) -> &Bytes {
+        &self.encoded
+    }
+
+    /// Consumes the wrapper and returns the encoded eth-relative protocol bytes.
+    pub fn into_encoded(self) -> Bytes {
+        self.encoded
+    }
+
+    /// Precomputes the eth-only compressed frame if it is not already cached.
+    pub fn precompute_eth_only_compression(&self) -> Result<(), EthStreamError> {
+        self.eth_only_compressed()?;
+        Ok(())
+    }
+
+    fn eth_only_compressed(&self) -> Result<Bytes, EthStreamError> {
+        if let Some(compressed) = self.eth_only_compressed.get() {
+            return Ok(compressed.clone())
+        }
+
+        let compressed = compress_eth_only_protocol_message(&self.encoded)?;
+        if self.eth_only_compressed.set(compressed.clone()).is_err() {
+            return Ok(self
+                .eth_only_compressed
+                .get()
+                .expect("compressed frame set by another clone")
+                .clone())
+        }
+
+        Ok(compressed)
+    }
+}
+
 /// An `EthStream` wraps over any `Stream` that yields bytes and makes it
 /// compatible with eth-networking protocol messages, which get RLP encoded/decoded.
 #[pin_project]
@@ -324,6 +416,12 @@ where
         self.inner.start_send_unpin(msg.encoded())?;
         Ok(())
     }
+
+    /// Sends an already encoded eth protocol message.
+    pub fn start_send_encoded(&mut self, msg: EncodedEthMessage) -> Result<(), EthStreamError> {
+        self.inner.start_send_unpin(msg.into_encoded())?;
+        Ok(())
+    }
 }
 
 impl<S, E, N> Stream for EthStream<S, N>
@@ -399,6 +497,17 @@ where
     ) -> Result<(), EthStreamError> {
         encode_raw_capability_message(msg, encode_buf);
         self.inner.start_send_protocol_message(encode_buf)?;
+        Ok(())
+    }
+
+    /// Sends an already encoded eth protocol message by reusing its cached eth-only compressed
+    /// wire frame.
+    pub fn start_send_encoded_eth_only(
+        &mut self,
+        msg: EncodedEthMessage,
+    ) -> Result<(), EthStreamError> {
+        let compressed = msg.eth_only_compressed()?;
+        self.inner.start_send_precompressed_protocol_message(compressed)?;
         Ok(())
     }
 }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
     message::{EthBroadcastMessage, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
-    p2pstream::HANDSHAKE_TIMEOUT,
+    p2pstream::{P2PStream, HANDSHAKE_TIMEOUT},
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     UnifiedStatus,
 };
@@ -19,6 +19,7 @@ use reth_eth_wire_types::{EthMessageID, NetworkPrimitives, RawCapabilityMessage}
 use reth_ethereum_forks::ForkFilter;
 use std::{
     future::Future,
+    io,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -146,6 +147,11 @@ where
 
     /// Decodes incoming bytes into an [`EthMessage`].
     pub fn decode_message(&self, bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
+        self.decode_message_from_slice(&bytes)
+    }
+
+    /// Decodes incoming bytes into an [`EthMessage`].
+    pub fn decode_message_from_slice(&self, bytes: &[u8]) -> Result<EthMessage<N>, EthStreamError> {
         if bytes.len() > self.max_message_size {
             return Err(EthStreamError::MessageTooBig(bytes.len()));
         }
@@ -159,7 +165,7 @@ where
 
         let msg = match ProtocolMessage::decode_message_with_tx_memory_budget(
             self.version,
-            &mut bytes.as_ref(),
+            &mut &bytes[..],
             self.max_message_size * TX_MEMORY_BUDGET_MULTIPLIER,
         ) {
             Ok(m) => m,
@@ -299,6 +305,34 @@ where
     }
 }
 
+impl<S, N> EthStream<P2PStream<S>, N>
+where
+    S: Stream<Item = io::Result<BytesMut>> + Sink<Bytes, Error = io::Error> + Unpin,
+    N: NetworkPrimitives,
+{
+    /// Polls the underlying p2p stream and decodes the next eth message without returning an
+    /// intermediate p2p [`BytesMut`] to the caller.
+    pub fn poll_next_eth_message(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        decode_buf: &mut BytesMut,
+    ) -> Poll<Option<Result<EthMessage<N>, EthStreamError>>> {
+        let this = self.project();
+        let eth = this.eth;
+
+        let res = ready!(this
+            .inner
+            .poll_next_with(cx, decode_buf, |bytes| eth.decode_message_from_slice(bytes)));
+
+        match res {
+            Some(Ok(Ok(msg))) => Poll::Ready(Some(Ok(msg))),
+            Some(Ok(Err(err))) => Poll::Ready(Some(Err(err))),
+            Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
 impl<S, N> Sink<EthMessage<N>> for EthStream<S, N>
 where
     S: CanDisconnect<Bytes> + Unpin,
@@ -366,15 +400,18 @@ mod tests {
         ProtocolVersion, Status, StatusMessage,
     };
     use alloy_chains::NamedChain;
-    use alloy_primitives::{bytes::Bytes, B256, U256};
+    use alloy_primitives::{
+        bytes::{Bytes, BytesMut},
+        B256, U256,
+    };
     use alloy_rlp::Decodable;
-    use futures::{SinkExt, StreamExt};
+    use futures::{future::poll_fn, SinkExt, StreamExt};
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire_types::{EthNetworkPrimitives, UnifiedStatus};
     use reth_ethereum_forks::{ForkFilter, Head};
     use reth_network_peers::pk2id;
     use secp256k1::{SecretKey, SECP256K1};
-    use std::time::Duration;
+    use std::{pin::Pin, time::Duration};
     use tokio::net::{TcpListener, TcpStream};
     use tokio_util::codec::Decoder;
 
@@ -663,7 +700,12 @@ mod tests {
                 .unwrap();
 
             // use the stream to get the next message
-            let message = eth_stream.next().await.unwrap().unwrap();
+            let mut decode_buf = BytesMut::new();
+            let message =
+                poll_fn(|cx| Pin::new(&mut eth_stream).poll_next_eth_message(cx, &mut decode_buf))
+                    .await
+                    .unwrap()
+                    .unwrap();
             assert_eq!(message, test_msg_clone);
         });
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,7 +7,7 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
+    message::{EthBroadcastMessage, MessageError, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
     p2pstream::{P2PStream, HANDSHAKE_TIMEOUT},
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     UnifiedStatus,
@@ -152,28 +152,50 @@ where
 
     /// Decodes incoming bytes into an [`EthMessage`].
     pub fn decode_message_from_slice(&self, bytes: &[u8]) -> Result<EthMessage<N>, EthStreamError> {
-        if bytes.len() > self.max_message_size {
-            return Err(EthStreamError::MessageTooBig(bytes.len()));
+        let Some((&message_id, payload)) = bytes.split_first() else {
+            return Err(EthStreamError::InvalidMessage(MessageError::RlpError(
+                alloy_rlp::Error::InputTooShort,
+            )))
+        };
+
+        self.decode_message_payload(message_id, payload)
+    }
+
+    /// Decodes an incoming message after the p2p layer has already separated the eth message id
+    /// from the snappy-compressed payload.
+    pub fn decode_message_payload(
+        &self,
+        message_id: u8,
+        payload: &[u8],
+    ) -> Result<EthMessage<N>, EthStreamError> {
+        let message_size = payload.len() + 1;
+        if message_size > self.max_message_size {
+            return Err(EthStreamError::MessageTooBig(message_size));
         }
 
         if self.reject_block_announcements &&
-            let Some(&id) = bytes.first() &&
-            (id == EthMessageID::NewBlock.to_u8() || id == EthMessageID::NewBlockHashes.to_u8())
+            (message_id == EthMessageID::NewBlock.to_u8() ||
+                message_id == EthMessageID::NewBlockHashes.to_u8())
         {
-            return Err(EthStreamError::UnsupportedMessage { message_id: id });
+            return Err(EthStreamError::UnsupportedMessage { message_id });
         }
 
-        let msg = match ProtocolMessage::decode_message_with_tx_memory_budget(
+        let msg = match ProtocolMessage::decode_message_payload_with_tx_memory_budget(
             self.version,
-            &mut &bytes[..],
+            EthMessageID::from_u8(message_id),
+            &mut &payload[..],
             self.max_message_size * TX_MEMORY_BUDGET_MULTIPLIER,
         ) {
             Ok(m) => m,
             Err(err) => {
-                let msg = if bytes.len() > 50 {
-                    format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
+                let msg = if payload.len() > 50 {
+                    format!(
+                        "{message_id:02x}:{:02x?}...{:x?}",
+                        &payload[..10],
+                        &payload[payload.len() - 10..]
+                    )
                 } else {
-                    format!("{bytes:02x?}")
+                    format!("{message_id:02x}:{payload:02x?}")
                 };
                 debug!(
                     version=?self.version,
@@ -184,11 +206,11 @@ where
             }
         };
 
-        if matches!(msg.message, EthMessage::Status(_)) {
+        if matches!(msg, EthMessage::Status(_)) {
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake));
         }
 
-        Ok(msg.message)
+        Ok(msg)
     }
 
     /// Encodes an [`EthMessage`] to bytes.
@@ -320,9 +342,9 @@ where
         let this = self.project();
         let eth = this.eth;
 
-        let res = ready!(this
-            .inner
-            .poll_next_with(cx, decode_buf, |bytes| eth.decode_message_from_slice(bytes)));
+        let res = ready!(this.inner.poll_next_with(cx, decode_buf, |message_id, payload| {
+            eth.decode_message_payload(message_id, payload)
+        }));
 
         match res {
             Some(Ok(Ok(msg))) => Poll::Ready(Some(Ok(msg))),

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -10,7 +10,7 @@ use crate::{
     message::{EthBroadcastMessage, MessageError, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
     p2pstream::{P2PStream, HANDSHAKE_TIMEOUT},
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
-    UnifiedStatus,
+    SharedTransactions, UnifiedStatus,
 };
 use alloy_primitives::bytes::{Bytes, BytesMut};
 use futures::{ready, Sink, SinkExt};
@@ -297,6 +297,21 @@ where
         item: EthBroadcastMessage<N>,
     ) -> Result<(), EthStreamError> {
         self.inner.start_send_unpin(item.encoded())?;
+        Ok(())
+    }
+
+    /// Sends a Transactions broadcast with a precomputed RLP payload length.
+    pub fn start_send_transactions_with_payload_length(
+        &mut self,
+        transactions: SharedTransactions<N::BroadcastedTransaction>,
+        payload_length: usize,
+    ) -> Result<(), EthStreamError> {
+        self.inner.start_send_unpin(
+            EthBroadcastMessage::<N>::encoded_transactions_with_payload_length(
+                transactions,
+                payload_length,
+            ),
+        )?;
         Ok(())
     }
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,12 +7,16 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, MessageError, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
+    message::{
+        EthBroadcastMessage, MessageError, ProtocolBroadcastMessage, MAX_MESSAGE_SIZE,
+        TX_MEMORY_BUDGET_MULTIPLIER,
+    },
     p2pstream::{P2PStream, HANDSHAKE_TIMEOUT},
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     SharedTransactions, UnifiedStatus,
 };
 use alloy_primitives::bytes::{Bytes, BytesMut};
+use alloy_rlp::{Encodable, Header};
 use futures::{ready, Sink, SinkExt};
 use pin_project::pin_project;
 use reth_eth_wire_types::{EthMessageID, NetworkPrimitives, RawCapabilityMessage};
@@ -340,6 +344,123 @@ where
             None => Poll::Ready(None),
         }
     }
+}
+
+impl<S, N> EthStream<P2PStream<S>, N>
+where
+    S: Sink<Bytes, Error = io::Error> + Unpin + Send + Sync,
+    N: NetworkPrimitives,
+{
+    /// Same as [`Sink::start_send`] but encodes into caller-owned scratch space before compression.
+    pub fn start_send_with_encode_buf(
+        &mut self,
+        item: EthMessage<N>,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        if matches!(item, EthMessage::Status(_)) {
+            let _disconnect_future = self.inner.disconnect(DisconnectReason::ProtocolBreach);
+            return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
+        }
+
+        encode_eth_message(item, encode_buf);
+        self.inner.start_send_protocol_message(encode_buf)?;
+        Ok(())
+    }
+
+    /// Same as [`Self::start_send_broadcast`] but encodes into caller-owned scratch space.
+    pub fn start_send_broadcast_with_encode_buf(
+        &mut self,
+        item: EthBroadcastMessage<N>,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        encode_broadcast_message(item, encode_buf);
+        self.inner.start_send_protocol_message(encode_buf)?;
+        Ok(())
+    }
+
+    /// Sends a Transactions broadcast with a precomputed RLP payload length and caller-owned
+    /// scratch space.
+    pub fn start_send_transactions_with_payload_length_and_encode_buf(
+        &mut self,
+        transactions: SharedTransactions<N::BroadcastedTransaction>,
+        payload_length: usize,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        encode_transactions_broadcast_message(transactions, payload_length, encode_buf);
+        self.inner.start_send_protocol_message(encode_buf)?;
+        Ok(())
+    }
+
+    /// Sends a raw capability message using caller-owned scratch space.
+    pub fn start_send_raw_with_encode_buf(
+        &mut self,
+        msg: RawCapabilityMessage,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        encode_raw_capability_message(msg, encode_buf);
+        self.inner.start_send_protocol_message(encode_buf)?;
+        Ok(())
+    }
+}
+
+fn encode_eth_message<N: NetworkPrimitives>(item: EthMessage<N>, out: &mut BytesMut) {
+    out.clear();
+    out.reserve(EthMessageID::Status.length() + item.length());
+    match item {
+        EthMessage::NewBlockHashes(hashes) => {
+            EthMessageID::NewBlockHashes.encode(out);
+            hashes.encode(out);
+        }
+        EthMessage::NewPooledTransactionHashes66(hashes) => {
+            EthMessageID::NewPooledTransactionHashes.encode(out);
+            hashes.encode(out);
+        }
+        EthMessage::NewPooledTransactionHashes68(hashes) => {
+            EthMessageID::NewPooledTransactionHashes.encode(out);
+            hashes.encode(out);
+        }
+        EthMessage::NewPooledTransactionHashes72(hashes) => {
+            EthMessageID::NewPooledTransactionHashes.encode(out);
+            hashes.encode(out);
+        }
+        this => ProtocolMessage::from(this).encode(out),
+    }
+}
+
+fn encode_broadcast_message<N: NetworkPrimitives>(
+    item: EthBroadcastMessage<N>,
+    out: &mut BytesMut,
+) {
+    out.clear();
+    out.reserve(EthMessageID::Status.length() + item.length());
+    match item {
+        EthBroadcastMessage::Transactions(transactions) => {
+            let payload_length = transactions.iter().map(Encodable::length).sum();
+            encode_transactions_broadcast_message(transactions, payload_length, out);
+        }
+        this @ EthBroadcastMessage::NewBlock(_) => ProtocolBroadcastMessage::from(this).encode(out),
+    }
+}
+
+fn encode_transactions_broadcast_message<T: Encodable>(
+    transactions: SharedTransactions<T>,
+    payload_length: usize,
+    out: &mut BytesMut,
+) {
+    let header = Header { list: true, payload_length };
+    out.clear();
+    out.reserve(EthMessageID::Transactions.length() + header.length() + payload_length);
+    EthMessageID::Transactions.encode(out);
+    header.encode(out);
+    for tx in transactions.0 {
+        tx.encode(out);
+    }
+}
+
+fn encode_raw_capability_message(msg: RawCapabilityMessage, out: &mut BytesMut) {
+    out.clear();
+    out.reserve(msg.length());
+    msg.encode(out);
 }
 
 impl<S, N> EthStream<P2PStream<S>, N>
@@ -768,7 +889,9 @@ mod tests {
             .await
             .unwrap();
 
-        client_stream.send(test_msg).await.unwrap();
+        let mut encode_buf = BytesMut::new();
+        client_stream.start_send_with_encode_buf(test_msg, &mut encode_buf).unwrap();
+        client_stream.flush().await.unwrap();
 
         // make sure the server receives the message and asserts before ending the test
         handle.await.unwrap();

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -405,7 +405,6 @@ where
 
 fn encode_eth_message<N: NetworkPrimitives>(item: EthMessage<N>, out: &mut BytesMut) {
     out.clear();
-    out.reserve(EthMessageID::Status.length() + item.length());
     match item {
         EthMessage::NewBlockHashes(hashes) => {
             EthMessageID::NewBlockHashes.encode(out);
@@ -423,7 +422,10 @@ fn encode_eth_message<N: NetworkPrimitives>(item: EthMessage<N>, out: &mut Bytes
             EthMessageID::NewPooledTransactionHashes.encode(out);
             hashes.encode(out);
         }
-        this => ProtocolMessage::from(this).encode(out),
+        this => {
+            out.reserve(EthMessageID::Status.length() + this.length());
+            ProtocolMessage::from(this).encode(out);
+        }
     }
 }
 
@@ -432,13 +434,15 @@ fn encode_broadcast_message<N: NetworkPrimitives>(
     out: &mut BytesMut,
 ) {
     out.clear();
-    out.reserve(EthMessageID::Status.length() + item.length());
     match item {
         EthBroadcastMessage::Transactions(transactions) => {
             let payload_length = transactions.iter().map(Encodable::length).sum();
             encode_transactions_broadcast_message(transactions, payload_length, out);
         }
-        this @ EthBroadcastMessage::NewBlock(_) => ProtocolBroadcastMessage::from(this).encode(out),
+        this @ EthBroadcastMessage::NewBlock(_) => {
+            out.reserve(EthMessageID::Status.length() + this.length());
+            ProtocolBroadcastMessage::from(this).encode(out);
+        }
     }
 }
 

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -456,7 +456,7 @@ fn encode_transactions_broadcast_message<T: Encodable>(
     out.reserve(EthMessageID::Transactions.length() + header.length() + payload_length);
     EthMessageID::Transactions.encode(out);
     header.encode(out);
-    for tx in transactions.0 {
+    for tx in transactions.iter() {
         tx.encode(out);
     }
 }

--- a/crates/net/eth-wire/src/lib.rs
+++ b/crates/net/eth-wire/src/lib.rs
@@ -38,7 +38,7 @@ pub use tokio_util::codec::{
 pub use crate::{
     disconnect::CanDisconnect,
     eth_snap::{EthSnapMessage, EthSnapStream},
-    ethstream::{EthStream, EthStreamInner, UnauthedEthStream},
+    ethstream::{EncodedEthMessage, EthStream, EthStreamInner, UnauthedEthStream},
     hello::{HelloMessage, HelloMessageBuilder, HelloMessageWithProtocols},
     p2pstream::{
         DisconnectP2P, P2PMessage, P2PMessageID, P2PStream, UnauthedP2PStream, HANDSHAKE_TIMEOUT,

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -596,6 +596,7 @@ where
             }
 
             let mut conn_ready = true;
+            let mut sent_to_conn = false;
             loop {
                 match this.inner.conn.poll_ready_unpin(cx) {
                     Poll::Ready(Ok(())) => {
@@ -603,6 +604,7 @@ where
                             if let Err(err) = this.inner.conn.start_send_unpin(msg) {
                                 return Poll::Ready(Some(Err(err.into())))
                             }
+                            sent_to_conn = true;
                         } else {
                             break
                         }
@@ -618,6 +620,15 @@ where
                     Poll::Pending => {
                         conn_ready = false;
                         break
+                    }
+                }
+            }
+            if sent_to_conn {
+                match this.inner.conn.poll_flush_unpin(cx) {
+                    Poll::Ready(Ok(())) => {}
+                    Poll::Ready(Err(err)) => return Poll::Ready(Some(Err(err.into()))),
+                    Poll::Pending => {
+                        conn_ready = false;
                     }
                 }
             }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -13,6 +13,7 @@ use alloy_rlp::{Decodable, Encodable, Error as RlpError, EMPTY_LIST_CODE};
 use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_codecs::add_arbitrary_tests;
+use reth_ecies::stream::ECIESStream;
 use reth_metrics::metrics::counter;
 use reth_primitives_traits::GotExpected;
 use std::{
@@ -23,6 +24,7 @@ use std::{
     task::{ready, Context, Poll},
     time::Duration,
 };
+use tokio::io::AsyncWrite;
 use tokio_stream::Stream;
 use tracing::{debug, trace};
 
@@ -623,6 +625,41 @@ where
             this.inner.as_mut().start_send(message)?;
             *this.needs_flush = true;
         }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<Io> P2PStream<ECIESStream<Io>>
+where
+    Io: AsyncWrite + Unpin,
+{
+    /// Drains queued p2p frames into ECIES without polling ECIES readiness for every frame while
+    /// its framed write buffer remains under the configured backpressure boundary.
+    pub fn poll_flush_ecies_buffered(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), P2PStreamError>> {
+        {
+            let mut this = self.as_mut().project();
+            while let Some(message) = this.outgoing_messages.front() {
+                if !this.inner.as_ref().get_ref().can_buffer_message(message.len()) {
+                    ready!(this.inner.as_mut().poll_ready(cx))?;
+                }
+
+                let message = this.outgoing_messages.pop_front().expect("checked non-empty");
+                this.inner.as_mut().start_send(message)?;
+                *this.needs_flush = true;
+            }
+        }
+
+        let mut this = self.project();
+
+        if *this.needs_flush {
+            ready!(this.inner.as_mut().poll_flush(cx))?;
+            *this.needs_flush = false;
+        }
+        *this.needs_control_flush = false;
 
         Poll::Ready(Ok(()))
     }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -415,7 +415,9 @@ where
                 return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(id))))
             }
 
-            if let Some(res) = this.handle_fixed_ping_pong(id, &bytes[1..], cx) {
+            if id <= MAX_P2P_MESSAGE_ID &&
+                let Some(res) = this.handle_fixed_ping_pong(id, &bytes[1..], cx)
+            {
                 if let Err(err) = res {
                     return Poll::Ready(Some(Err(err)))
                 }
@@ -717,7 +719,9 @@ where
                 }
             }
 
-            if let Some(res) = this.handle_fixed_ping_pong(id, &bytes[1..], cx) {
+            if id <= MAX_P2P_MESSAGE_ID &&
+                let Some(res) = this.handle_fixed_ping_pong(id, &bytes[1..], cx)
+            {
                 if let Err(err) = res {
                     return Poll::Ready(Some(Err(err)))
                 }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -259,6 +259,10 @@ pub struct P2PStream<S> {
 
     /// Whether the underlying sink has accepted messages that still need to be flushed.
     needs_flush: bool,
+
+    /// Whether a queued p2p control message needs to be flushed even if no subprotocol messages
+    /// are sent by the caller.
+    needs_control_flush: bool,
 }
 
 impl<S> P2PStream<S> {
@@ -276,6 +280,7 @@ impl<S> P2PStream<S> {
             outgoing_message_buffer_capacity: MAX_P2P_CAPACITY,
             disconnecting: false,
             needs_flush: false,
+            needs_control_flush: false,
         }
     }
 
@@ -315,11 +320,13 @@ impl<S> P2PStream<S> {
     /// Queues in a _snappy_ encoded [`P2PMessage::Pong`] message.
     fn send_pong(&mut self) {
         self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Pong)));
+        self.needs_control_flush = true;
     }
 
     /// Queues in a _snappy_ encoded [`P2PMessage::Ping`] message.
     pub fn send_ping(&mut self) {
         self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Ping)));
+        self.needs_control_flush = true;
     }
 }
 
@@ -497,6 +504,7 @@ impl<S> DisconnectP2P for P2PStream<S> {
         compressed[0] = buf[0];
 
         self.outgoing_messages.push_back(compressed.into());
+        self.needs_control_flush = true;
         self.disconnecting = true;
         Ok(())
     }
@@ -517,6 +525,32 @@ where
     pub async fn disconnect(&mut self, reason: DisconnectReason) -> Result<(), P2PStreamError> {
         self.start_disconnect(reason)?;
         self.close().await
+    }
+}
+
+impl<S> P2PStream<S>
+where
+    S: Sink<Bytes, Error = io::Error> + Unpin,
+{
+    /// Drains queued p2p frames into the underlying sink without flushing the underlying sink.
+    fn poll_drain_outgoing(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), P2PStreamError>> {
+        loop {
+            let message = {
+                let mut this = self.as_mut().project();
+                if this.outgoing_messages.is_empty() {
+                    return Poll::Ready(Ok(()))
+                }
+                ready!(this.inner.as_mut().poll_ready(cx))?;
+                this.outgoing_messages.pop_front().expect("checked non-empty")
+            };
+
+            let mut this = self.as_mut().project();
+            this.inner.as_mut().start_send(message)?;
+            *this.needs_flush = true;
+        }
     }
 }
 
@@ -675,7 +709,7 @@ where
     type Error = P2PStreamError;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let mut should_flush = false;
+        let mut should_flush_control = false;
 
         {
             let this = self.as_mut().get_mut();
@@ -685,19 +719,21 @@ where
                 Poll::Pending => {}
                 Poll::Ready(Ok(PingerEvent::Ping)) => {
                     this.send_ping();
-                    should_flush = true;
+                    should_flush_control = true;
                 }
                 Poll::Ready(Ok(PingerEvent::Timeout) | Err(_)) => {
                     this.start_disconnect(DisconnectReason::PingTimeout)?;
-                    should_flush = true;
+                    should_flush_control = true;
                 }
             }
 
-            should_flush |= this.needs_flush || !this.has_outgoing_capacity();
+            should_flush_control |= this.needs_control_flush;
         }
 
-        if should_flush {
+        if should_flush_control {
             ready!(self.as_mut().poll_flush(cx))?;
+        } else if !self.has_outgoing_capacity() {
+            ready!(self.as_mut().poll_drain_outgoing(cx))?;
         }
 
         if self.has_outgoing_capacity() {
@@ -748,20 +784,16 @@ where
     }
 
     /// Returns `Poll::Ready(Ok(()))` when no buffered items remain.
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let mut this = self.project();
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.as_mut().poll_drain_outgoing(cx))?;
 
-        while !this.outgoing_messages.is_empty() {
-            ready!(this.inner.as_mut().poll_ready(cx))?;
-            let message = this.outgoing_messages.pop_front().expect("checked non-empty");
-            this.inner.as_mut().start_send(message)?;
-            *this.needs_flush = true;
-        }
+        let mut this = self.project();
 
         if *this.needs_flush {
             ready!(this.inner.as_mut().poll_flush(cx))?;
             *this.needs_flush = false;
         }
+        *this.needs_control_flush = false;
 
         Poll::Ready(Ok(()))
     }
@@ -925,9 +957,60 @@ impl TryFrom<u8> for P2PMessageID {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{capability::SharedCapability, test_utils::eth_hello, EthVersion, ProtocolVersion};
+    use crate::{
+        capability::SharedCapability, test_utils::eth_hello, Capability, EthVersion,
+        ProtocolVersion,
+    };
+    use futures::task::noop_waker_ref;
     use tokio::net::{TcpListener, TcpStream};
     use tokio_util::codec::Decoder;
+
+    #[derive(Default)]
+    struct FlushCountingTransport {
+        sent: Vec<Bytes>,
+        flushes: usize,
+    }
+
+    impl Stream for FlushCountingTransport {
+        type Item = io::Result<BytesMut>;
+
+        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Pending
+        }
+    }
+
+    impl Sink<Bytes> for FlushCountingTransport {
+        type Error = io::Error;
+
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(mut self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
+            self.sent.push(item);
+            Ok(())
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.flushes += 1;
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn shared_capabilities() -> SharedCapabilities {
+        SharedCapabilities::try_new(
+            vec![EthVersion::Eth66.into()],
+            vec![Capability::eth(EthVersion::Eth66)],
+        )
+        .unwrap()
+    }
 
     #[tokio::test]
     async fn test_can_disconnect() {
@@ -1129,5 +1212,35 @@ mod tests {
         let pong = P2PMessage::decode(&mut &snappy_pong[..]).unwrap();
         assert!(matches!(pong, P2PMessage::Pong));
         assert_eq!(alloy_rlp::encode(pong), &snappy_pong[..]);
+    }
+
+    #[tokio::test]
+    async fn poll_ready_drains_full_subprotocol_queue_without_flushing_inner() {
+        let mut stream = P2PStream::new(FlushCountingTransport::default(), shared_capabilities());
+        stream.set_outgoing_message_buffer_capacity(1);
+        Pin::new(&mut stream).start_send(Bytes::from_static(&[0x00, EMPTY_LIST_CODE])).unwrap();
+
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+        assert!(Pin::new(&mut stream).poll_ready(&mut cx).is_ready());
+
+        assert_eq!(stream.inner().sent.len(), 1);
+        assert_eq!(stream.inner().flushes, 0);
+
+        assert!(Pin::new(&mut stream).poll_flush(&mut cx).is_ready());
+        assert_eq!(stream.inner().flushes, 1);
+    }
+
+    #[tokio::test]
+    async fn poll_ready_flushes_queued_control_messages() {
+        let mut stream = P2PStream::new(FlushCountingTransport::default(), shared_capabilities());
+        stream.send_ping();
+
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+        assert!(Pin::new(&mut stream).poll_ready(&mut cx).is_ready());
+
+        assert_eq!(stream.inner().sent.len(), 1);
+        assert_eq!(stream.inner().flushes, 1);
     }
 }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -536,20 +536,15 @@ where
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), P2PStreamError>> {
-        loop {
-            let message = {
-                let mut this = self.as_mut().project();
-                if this.outgoing_messages.is_empty() {
-                    return Poll::Ready(Ok(()))
-                }
-                ready!(this.inner.as_mut().poll_ready(cx))?;
-                this.outgoing_messages.pop_front().expect("checked non-empty")
-            };
-
-            let mut this = self.as_mut().project();
+        let mut this = self.as_mut().project();
+        while !this.outgoing_messages.is_empty() {
+            ready!(this.inner.as_mut().poll_ready(cx))?;
+            let message = this.outgoing_messages.pop_front().expect("checked non-empty");
             this.inner.as_mut().start_send(message)?;
             *this.needs_flush = true;
         }
+
+        Poll::Ready(Ok(()))
     }
 }
 

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -306,6 +306,12 @@ impl<S> P2PStream<S> {
         self.outgoing_messages.len() < self.outgoing_message_buffer_capacity
     }
 
+    /// Returns how many additional outgoing messages can be queued before this stream needs to
+    /// flush.
+    pub fn available_outgoing_capacity(&self) -> usize {
+        self.outgoing_message_buffer_capacity.saturating_sub(self.outgoing_messages.len())
+    }
+
     /// Queues in a _snappy_ encoded [`P2PMessage::Pong`] message.
     fn send_pong(&mut self) {
         self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Pong)));

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -572,6 +572,45 @@ impl<S> P2PStream<S>
 where
     S: Sink<Bytes, Error = io::Error> + Unpin,
 {
+    /// Starts sending an id-prefixed subprotocol message from borrowed bytes.
+    ///
+    /// The input is only read during this call. The queued outgoing frame owns its compressed
+    /// bytes.
+    pub fn start_send_protocol_message(&mut self, item: &[u8]) -> Result<(), P2PStreamError> {
+        if item.len() > MAX_PAYLOAD_SIZE {
+            return Err(P2PStreamError::MessageTooBig {
+                message_size: item.len(),
+                max_size: MAX_PAYLOAD_SIZE,
+            })
+        }
+
+        if item.is_empty() {
+            return Err(P2PStreamError::EmptyProtocolMessage)
+        }
+
+        if !self.has_outgoing_capacity() {
+            return Err(P2PStreamError::SendBufferFull)
+        }
+
+        let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
+        let compressed_size =
+            self.encoder.compress(&item[1..], &mut compressed[1..]).map_err(|err| {
+                debug!(%err, msg=%hex::encode(&item[1..]), "error compressing p2p message");
+                err
+            })?;
+
+        // truncate the compressed buffer to the actual compressed size (plus one for the message
+        // id)
+        compressed.truncate(compressed_size + 1);
+
+        // all messages sent in this stream are subprotocol messages, so we need to switch the
+        // message id based on the offset
+        compressed[0] = item[0] + MAX_RESERVED_MESSAGE_ID + 1;
+        self.outgoing_messages.push_back(compressed.freeze());
+
+        Ok(())
+    }
+
     /// Drains queued p2p frames into the underlying sink without flushing the underlying sink.
     fn poll_drain_outgoing(
         mut self: Pin<&mut Self>,
@@ -787,42 +826,7 @@ where
     }
 
     fn start_send(self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
-        if item.len() > MAX_PAYLOAD_SIZE {
-            return Err(P2PStreamError::MessageTooBig {
-                message_size: item.len(),
-                max_size: MAX_PAYLOAD_SIZE,
-            })
-        }
-
-        if item.is_empty() {
-            // empty messages are not allowed
-            return Err(P2PStreamError::EmptyProtocolMessage)
-        }
-
-        // ensure we have free capacity
-        if !self.has_outgoing_capacity() {
-            return Err(P2PStreamError::SendBufferFull)
-        }
-
-        let this = self.project();
-
-        let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
-        let compressed_size =
-            this.encoder.compress(&item[1..], &mut compressed[1..]).map_err(|err| {
-                debug!(%err, msg=%hex::encode(&item[1..]), "error compressing p2p message");
-                err
-            })?;
-
-        // truncate the compressed buffer to the actual compressed size (plus one for the message
-        // id)
-        compressed.truncate(compressed_size + 1);
-
-        // all messages sent in this stream are subprotocol messages, so we need to switch the
-        // message id based on the offset
-        compressed[0] = item[0] + MAX_RESERVED_MESSAGE_ID + 1;
-        this.outgoing_messages.push_back(compressed.freeze());
-
-        Ok(())
+        self.get_mut().start_send_protocol_message(&item)
     }
 
     /// Returns `Poll::Ready(Ok(()))` when no buffered items remain.

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -256,6 +256,9 @@ pub struct P2PStream<S> {
     /// Whether this stream is currently in the process of disconnecting by sending a disconnect
     /// message.
     disconnecting: bool,
+
+    /// Whether the underlying sink has accepted messages that still need to be flushed.
+    needs_flush: bool,
 }
 
 impl<S> P2PStream<S> {
@@ -272,6 +275,7 @@ impl<S> P2PStream<S> {
             outgoing_messages: VecDeque::new(),
             outgoing_message_buffer_capacity: MAX_P2P_CAPACITY,
             disconnecting: false,
+            needs_flush: false,
         }
     }
 
@@ -537,32 +541,29 @@ where
     type Error = P2PStreamError;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let mut this = self.as_mut();
+        let mut should_flush = false;
 
-        // poll the pinger to determine if we should send a ping
-        match this.pinger.poll_ping(cx) {
-            Poll::Pending => {}
-            Poll::Ready(Ok(PingerEvent::Ping)) => {
-                this.send_ping();
-            }
-            _ => {
-                // encode the disconnect message
-                this.start_disconnect(DisconnectReason::PingTimeout)?;
+        {
+            let this = self.as_mut().get_mut();
 
-                // End the stream after ping related error
-                return Poll::Ready(Ok(()))
-            }
-        }
-
-        match this.inner.poll_ready_unpin(cx) {
-            Poll::Pending => {}
-            Poll::Ready(Err(err)) => return Poll::Ready(Err(P2PStreamError::Io(err))),
-            Poll::Ready(Ok(())) => {
-                let flushed = this.poll_flush(cx);
-                if flushed.is_ready() {
-                    return flushed
+            // Poll the pinger to determine if we should send a ping.
+            match this.pinger.poll_ping(cx) {
+                Poll::Pending => {}
+                Poll::Ready(Ok(PingerEvent::Ping)) => {
+                    this.send_ping();
+                    should_flush = true;
+                }
+                Poll::Ready(Ok(PingerEvent::Timeout) | Err(_)) => {
+                    this.start_disconnect(DisconnectReason::PingTimeout)?;
+                    should_flush = true;
                 }
             }
+
+            should_flush |= this.needs_flush || !this.has_outgoing_capacity();
+        }
+
+        if should_flush {
+            ready!(self.as_mut().poll_flush(cx))?;
         }
 
         if self.has_outgoing_capacity() {
@@ -619,24 +620,20 @@ where
     /// Returns `Poll::Ready(Ok(()))` when no buffered items remain.
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut this = self.project();
-        let poll_res = loop {
-            match this.inner.as_mut().poll_ready(cx) {
-                Poll::Pending => break Poll::Pending,
-                Poll::Ready(Err(err)) => break Poll::Ready(Err(err.into())),
-                Poll::Ready(Ok(())) => {
-                    let Some(message) = this.outgoing_messages.pop_front() else {
-                        break Poll::Ready(Ok(()))
-                    };
-                    if let Err(err) = this.inner.as_mut().start_send(message) {
-                        break Poll::Ready(Err(err.into()))
-                    }
-                }
-            }
-        };
 
-        ready!(this.inner.as_mut().poll_flush(cx))?;
+        while !this.outgoing_messages.is_empty() {
+            ready!(this.inner.as_mut().poll_ready(cx))?;
+            let message = this.outgoing_messages.pop_front().expect("checked non-empty");
+            this.inner.as_mut().start_send(message)?;
+            *this.needs_flush = true;
+        }
 
-        poll_res
+        if *this.needs_flush {
+            ready!(this.inner.as_mut().poll_flush(cx))?;
+            *this.needs_flush = false;
+        }
+
+        Poll::Ready(Ok(()))
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -317,6 +317,134 @@ impl<S> P2PStream<S> {
     }
 }
 
+impl<S> P2PStream<S>
+where
+    S: Stream<Item = io::Result<BytesMut>> + Sink<Bytes, Error = io::Error> + Unpin,
+{
+    /// Polls the stream for the next subprotocol message and decodes it before returning.
+    ///
+    /// Unlike the [`Stream`] implementation, this writes the decompressed message into a
+    /// caller-owned buffer, which avoids allocating a new [`BytesMut`] for callers that immediately
+    /// decode the message into an owned type.
+    pub(crate) fn poll_next_with<T, F>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        decode_buf: &mut BytesMut,
+        mut decode: F,
+    ) -> Poll<Option<Result<T, P2PStreamError>>>
+    where
+        F: FnMut(&[u8]) -> T,
+    {
+        let this = self.get_mut();
+
+        if this.disconnecting {
+            // if disconnecting, stop reading messages
+            return Poll::Ready(None)
+        }
+
+        // We loop to avoid returning `Pending` when a subprotocol message is queued behind p2p
+        // ping/pong maintenance messages.
+        while let Poll::Ready(res) = this.inner.poll_next_unpin(cx) {
+            let bytes = match res {
+                Some(Ok(bytes)) => bytes,
+                Some(Err(err)) => return Poll::Ready(Some(Err(err.into()))),
+                None => return Poll::Ready(None),
+            };
+
+            if bytes.is_empty() {
+                return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage)))
+            }
+
+            let id = bytes[0];
+            if id == P2PMessageID::Disconnect as u8 &&
+                let Ok(reason) = DisconnectReason::decode(&mut &bytes[1..])
+            {
+                return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))))
+            }
+
+            if id > MAX_P2P_MESSAGE_ID && id <= MAX_RESERVED_MESSAGE_ID {
+                return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(id))))
+            }
+
+            let decompressed_len = snap::raw::decompress_len(&bytes[1..])?;
+            if decompressed_len > MAX_PAYLOAD_SIZE {
+                return Poll::Ready(Some(Err(P2PStreamError::MessageTooBig {
+                    message_size: decompressed_len,
+                    max_size: MAX_PAYLOAD_SIZE,
+                })))
+            }
+
+            decode_buf.clear();
+            decode_buf.reserve(decompressed_len + 1);
+
+            let first_byte =
+                if id > MAX_RESERVED_MESSAGE_ID { id - MAX_RESERVED_MESSAGE_ID - 1 } else { 0 };
+            let spare = decode_buf.spare_capacity_mut();
+            spare[0].write(first_byte);
+            // SAFETY: `reserve` above ensures the spare capacity has at least
+            // `decompressed_len + 1` bytes. Snappy writes only to the provided output slice and
+            // reports how many bytes were initialized.
+            let output = unsafe {
+                std::slice::from_raw_parts_mut(
+                    spare.as_mut_ptr().add(1).cast::<u8>(),
+                    decompressed_len,
+                )
+            };
+
+            let written = this.decoder.decompress(&bytes[1..], output).map_err(|err| {
+                debug!(
+                    %err,
+                    msg=%hex::encode(&bytes[1..]),
+                    "error decompressing p2p message"
+                );
+                err
+            })?;
+            debug_assert_eq!(written, decompressed_len);
+            // SAFETY: byte 0 was initialized above and `decompress` initialized `written` bytes
+            // after it.
+            unsafe {
+                decode_buf.advance_mut(written + 1);
+            }
+
+            if id > MAX_RESERVED_MESSAGE_ID {
+                return Poll::Ready(Some(Ok(decode(decode_buf))))
+            }
+
+            match id {
+                _ if id == P2PMessageID::Ping as u8 => {
+                    trace!("Received Ping, Sending Pong");
+                    this.send_pong();
+                    // This is required because the `Sink` may not be polled externally, and if
+                    // that happens, the pong will never be sent.
+                    cx.waker().wake_by_ref();
+                }
+                _ if id == P2PMessageID::Hello as u8 => {
+                    return Poll::Ready(Some(Err(P2PStreamError::HandshakeError(
+                        P2PHandshakeError::HelloNotInHandshake,
+                    ))))
+                }
+                _ if id == P2PMessageID::Pong as u8 => this.pinger.on_pong()?,
+                _ if id == P2PMessageID::Disconnect as u8 => {
+                    let reason =
+                        DisconnectReason::decode(&mut &decode_buf[1..]).inspect_err(|err| {
+                            debug!(
+                                %err,
+                                msg=%hex::encode(&decode_buf[1..]),
+                                "Failed to decode disconnect message from peer"
+                            );
+                        })?;
+                    return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))))
+                }
+                _ => {
+                    unreachable!("unknown p2p message ids were handled before decompression")
+                }
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
 /// Gracefully disconnects the connection by sending a disconnect message and stop reading new
 /// messages.
 pub trait DisconnectP2P {
@@ -597,11 +725,7 @@ where
         let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
         let compressed_size =
             this.encoder.compress(&item[1..], &mut compressed[1..]).map_err(|err| {
-                debug!(
-                    %err,
-                    msg=%hex::encode(&item[1..]),
-                    "error compressing p2p message"
-                );
+                debug!(%err, msg=%hex::encode(&item[1..]), "error compressing p2p message");
                 err
             })?;
 

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -638,22 +638,70 @@ where
 {
     /// Drains queued p2p frames into ECIES without polling ECIES readiness for every frame while
     /// its framed write buffer remains under the configured backpressure boundary.
+    fn poll_drain_ecies_buffered(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), P2PStreamError>> {
+        let mut this = self.as_mut().project();
+        while let Some(message) = this.outgoing_messages.front() {
+            if !this.inner.as_ref().get_ref().can_buffer_message(message.len()) {
+                ready!(this.inner.as_mut().poll_ready(cx))?;
+            }
+
+            let message = this.outgoing_messages.pop_front().expect("checked non-empty");
+            this.inner.as_mut().start_send(message)?;
+            *this.needs_flush = true;
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    /// Polls readiness using the ECIES-aware buffered drain path for subprotocol messages.
+    pub fn poll_ready_ecies_buffered(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), P2PStreamError>> {
+        let mut should_flush_control = false;
+
+        {
+            let this = self.as_mut().get_mut();
+
+            // Poll the pinger to determine if we should send a ping.
+            match this.pinger.poll_ping(cx) {
+                Poll::Pending => {}
+                Poll::Ready(Ok(PingerEvent::Ping)) => {
+                    this.send_ping();
+                    should_flush_control = true;
+                }
+                Poll::Ready(Ok(PingerEvent::Timeout) | Err(_)) => {
+                    this.start_disconnect(DisconnectReason::PingTimeout)?;
+                    should_flush_control = true;
+                }
+            }
+
+            should_flush_control |= this.needs_control_flush;
+        }
+
+        if should_flush_control {
+            ready!(self.as_mut().poll_flush_ecies_buffered(cx))?;
+        } else if !self.has_outgoing_capacity() {
+            ready!(self.as_mut().poll_drain_ecies_buffered(cx))?;
+        }
+
+        if self.has_outgoing_capacity() {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    /// Drains queued p2p frames into ECIES without polling ECIES readiness for every frame while
+    /// its framed write buffer remains under the configured backpressure boundary.
     pub fn poll_flush_ecies_buffered(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), P2PStreamError>> {
-        {
-            let mut this = self.as_mut().project();
-            while let Some(message) = this.outgoing_messages.front() {
-                if !this.inner.as_ref().get_ref().can_buffer_message(message.len()) {
-                    ready!(this.inner.as_mut().poll_ready(cx))?;
-                }
-
-                let message = this.outgoing_messages.pop_front().expect("checked non-empty");
-                this.inner.as_mut().start_send(message)?;
-                *this.needs_flush = true;
-            }
-        }
+        ready!(self.as_mut().poll_drain_ecies_buffered(cx))?;
 
         let mut this = self.project();
 

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -331,7 +331,8 @@ where
     ///
     /// Unlike the [`Stream`] implementation, this writes the decompressed message into a
     /// caller-owned buffer, which avoids allocating a new [`BytesMut`] for callers that immediately
-    /// decode the message into an owned type.
+    /// decode the message into an owned type. The callback receives the subprotocol message id
+    /// with the p2p reserved offset stripped, and the decompressed message payload.
     pub(crate) fn poll_next_with<T, F>(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -339,7 +340,7 @@ where
         mut decode: F,
     ) -> Poll<Option<Result<T, P2PStreamError>>>
     where
-        F: FnMut(&[u8]) -> T,
+        F: FnMut(u8, &[u8]) -> T,
     {
         let this = self.get_mut();
 
@@ -381,20 +382,20 @@ where
             }
 
             decode_buf.clear();
-            decode_buf.reserve(decompressed_len + 1);
-
-            let first_byte =
-                if id > MAX_RESERVED_MESSAGE_ID { id - MAX_RESERVED_MESSAGE_ID - 1 } else { 0 };
+            decode_buf.reserve(decompressed_len);
             let spare = decode_buf.spare_capacity_mut();
-            spare[0].write(first_byte);
-            // SAFETY: `reserve` above ensures the spare capacity has at least
-            // `decompressed_len + 1` bytes. Snappy writes only to the provided output slice and
-            // reports how many bytes were initialized.
-            let output = unsafe {
-                std::slice::from_raw_parts_mut(
-                    spare.as_mut_ptr().add(1).cast::<u8>(),
-                    decompressed_len,
-                )
+            // SAFETY: `reserve` above ensures the spare capacity has at least `decompressed_len`
+            // bytes. Snappy writes only to the provided output slice and reports how many bytes
+            // were initialized.
+            let output = if decompressed_len == 0 {
+                &mut []
+            } else {
+                unsafe {
+                    std::slice::from_raw_parts_mut(
+                        spare.as_mut_ptr().cast::<u8>(),
+                        decompressed_len,
+                    )
+                }
             };
 
             let written = this.decoder.decompress(&bytes[1..], output).map_err(|err| {
@@ -406,14 +407,13 @@ where
                 err
             })?;
             debug_assert_eq!(written, decompressed_len);
-            // SAFETY: byte 0 was initialized above and `decompress` initialized `written` bytes
-            // after it.
+            // SAFETY: `decompress` initialized `written` bytes.
             unsafe {
-                decode_buf.advance_mut(written + 1);
+                decode_buf.advance_mut(written);
             }
 
             if id > MAX_RESERVED_MESSAGE_ID {
-                return Poll::Ready(Some(Ok(decode(decode_buf))))
+                return Poll::Ready(Some(Ok(decode(id - MAX_RESERVED_MESSAGE_ID - 1, decode_buf))))
             }
 
             match id {
@@ -432,10 +432,10 @@ where
                 _ if id == P2PMessageID::Pong as u8 => this.pinger.on_pong()?,
                 _ if id == P2PMessageID::Disconnect as u8 => {
                     let reason =
-                        DisconnectReason::decode(&mut &decode_buf[1..]).inspect_err(|err| {
+                        DisconnectReason::decode(&mut &decode_buf[..]).inspect_err(|err| {
                             debug!(
                                 %err,
-                                msg=%hex::encode(&decode_buf[1..]),
+                                msg=%hex::encode(&decode_buf[..]),
                                 "Failed to decode disconnect message from peer"
                             );
                         })?;

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -615,6 +615,32 @@ where
         Ok(())
     }
 
+    /// Starts sending an already-compressed p2p subprotocol frame.
+    ///
+    /// The frame must contain the wire message id as its first byte, including the p2p reserved
+    /// message-id offset. This is intended for eth-only sessions that can reuse a precompressed
+    /// broadcast frame across peers.
+    pub fn start_send_precompressed_protocol_message(
+        &mut self,
+        item: Bytes,
+    ) -> Result<(), P2PStreamError> {
+        if item.is_empty() {
+            return Err(P2PStreamError::EmptyProtocolMessage)
+        }
+
+        if item[0] <= MAX_RESERVED_MESSAGE_ID {
+            return Err(P2PStreamError::UnknownReservedMessageId(item[0]))
+        }
+
+        if !self.has_outgoing_capacity() {
+            return Err(P2PStreamError::SendBufferFull)
+        }
+
+        self.outgoing_messages.push_back(item);
+
+        Ok(())
+    }
+
     /// Drains queued p2p frames into the underlying sink without flushing the underlying sink.
     fn poll_drain_outgoing(
         mut self: Pin<&mut Self>,
@@ -630,6 +656,37 @@ where
 
         Poll::Ready(Ok(()))
     }
+}
+
+/// Compresses an id-prefixed eth protocol message for an eth-only p2p session.
+///
+/// The returned frame includes the p2p reserved message-id offset in the first byte, so it can be
+/// queued directly with [`P2PStream::start_send_precompressed_protocol_message`].
+pub(crate) fn compress_eth_only_protocol_message(item: &[u8]) -> Result<Bytes, P2PStreamError> {
+    if item.len() > MAX_PAYLOAD_SIZE {
+        return Err(P2PStreamError::MessageTooBig {
+            message_size: item.len(),
+            max_size: MAX_PAYLOAD_SIZE,
+        })
+    }
+
+    if item.is_empty() {
+        return Err(P2PStreamError::EmptyProtocolMessage)
+    }
+
+    let mut compressed = BytesMut::zeroed(1 + snap::raw::max_compress_len(item.len() - 1));
+    let compressed_size =
+        snap::raw::Encoder::new().compress(&item[1..], &mut compressed[1..]).map_err(|err| {
+            debug!(%err, msg=%hex::encode(&item[1..]), "error compressing p2p message");
+            err
+        })?;
+
+    compressed.truncate(compressed_size + 1);
+    compressed[0] = item[0]
+        .checked_add(MAX_RESERVED_MESSAGE_ID + 1)
+        .ok_or(P2PStreamError::UnknownReservedMessageId(item[0]))?;
+
+    Ok(compressed.freeze())
 }
 
 impl<Io> P2PStream<ECIESStream<Io>>
@@ -1347,6 +1404,21 @@ mod tests {
         let pong = P2PMessage::decode(&mut &snappy_pong[..]).unwrap();
         assert!(matches!(pong, P2PMessage::Pong));
         assert_eq!(alloy_rlp::encode(pong), &snappy_pong[..]);
+    }
+
+    #[tokio::test]
+    async fn precompressed_protocol_message_matches_regular_send() {
+        let msg = [0x08, EMPTY_LIST_CODE];
+        let mut regular = P2PStream::new(FlushCountingTransport::default(), shared_capabilities());
+        regular.start_send_protocol_message(&msg).unwrap();
+        let expected = regular.outgoing_messages.front().cloned().unwrap();
+
+        let precompressed = compress_eth_only_protocol_message(&msg).unwrap();
+        assert_eq!(precompressed, expected);
+
+        let mut stream = P2PStream::new(FlushCountingTransport::default(), shared_capabilities());
+        stream.start_send_precompressed_protocol_message(precompressed.clone()).unwrap();
+        assert_eq!(stream.outgoing_messages.front(), Some(&precompressed));
     }
 
     #[tokio::test]

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -40,6 +40,15 @@ pub const MAX_RESERVED_MESSAGE_ID: u8 = 0x0f;
 /// [`MAX_P2P_MESSAGE_ID`] is the maximum message ID in use for the `p2p` subprotocol.
 const MAX_P2P_MESSAGE_ID: u8 = P2PMessageID::Pong as u8;
 
+/// Snappy framed RLP empty list payload used by fixed `p2p` ping/pong control messages.
+const SNAPPY_EMPTY_LIST_PAYLOAD: &[u8] = &[0x01, 0x00, EMPTY_LIST_CODE];
+
+/// Wire-encoded `p2p` ping control message.
+const SNAPPY_PING_MESSAGE: &[u8] = &[0x02, 0x01, 0x00, EMPTY_LIST_CODE];
+
+/// Wire-encoded `p2p` pong control message.
+const SNAPPY_PONG_MESSAGE: &[u8] = &[0x03, 0x01, 0x00, EMPTY_LIST_CODE];
+
 /// [`HANDSHAKE_TIMEOUT`] determines the amount of time to wait before determining that a `p2p`
 /// handshake has timed out.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -318,14 +327,39 @@ impl<S> P2PStream<S> {
 
     /// Queues in a _snappy_ encoded [`P2PMessage::Pong`] message.
     fn send_pong(&mut self) {
-        self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Pong)));
+        self.outgoing_messages.push_back(Bytes::from_static(SNAPPY_PONG_MESSAGE));
         self.needs_control_flush = true;
     }
 
     /// Queues in a _snappy_ encoded [`P2PMessage::Ping`] message.
     pub fn send_ping(&mut self) {
-        self.outgoing_messages.push_back(Bytes::from(alloy_rlp::encode(P2PMessage::Ping)));
+        self.outgoing_messages.push_back(Bytes::from_static(SNAPPY_PING_MESSAGE));
         self.needs_control_flush = true;
+    }
+
+    /// Handles fixed-size ping/pong control messages without going through snappy decompression.
+    fn handle_fixed_ping_pong(
+        &mut self,
+        id: u8,
+        payload: &[u8],
+        cx: &Context<'_>,
+    ) -> Option<Result<(), P2PStreamError>> {
+        if payload != SNAPPY_EMPTY_LIST_PAYLOAD {
+            return None
+        }
+
+        match id {
+            _ if id == P2PMessageID::Ping as u8 => {
+                trace!("Received Ping, Sending Pong");
+                self.send_pong();
+                // This is required because the `Sink` may not be polled externally, and if
+                // that happens, the pong will never be sent.
+                cx.waker().wake_by_ref();
+                Some(Ok(()))
+            }
+            _ if id == P2PMessageID::Pong as u8 => Some(self.pinger.on_pong().map_err(Into::into)),
+            _ => None,
+        }
     }
 }
 
@@ -377,6 +411,13 @@ where
 
             if id > MAX_P2P_MESSAGE_ID && id <= MAX_RESERVED_MESSAGE_ID {
                 return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(id))))
+            }
+
+            if let Some(res) = this.handle_fixed_ping_pong(id, &bytes[1..], cx) {
+                if let Err(err) = res {
+                    return Poll::Ready(Some(Err(err)))
+                }
+                continue
             }
 
             let decompressed_len = snap::raw::decompress_len(&bytes[1..])?;
@@ -598,6 +639,13 @@ where
                 if let Ok(reason) = DisconnectReason::decode(&mut &bytes[1..]) {
                     return Poll::Ready(Some(Err(P2PStreamError::Disconnected(reason))))
                 }
+            }
+
+            if let Some(res) = this.handle_fixed_ping_pong(id, &bytes[1..], cx) {
+                if let Err(err) = res {
+                    return Poll::Ready(Some(Err(err)))
+                }
+                continue
             }
 
             // first check that the compressed message length does not exceed the max
@@ -844,15 +892,11 @@ impl Encodable for P2PMessage {
             Self::Disconnect(msg) => msg.encode(out),
             Self::Ping => {
                 // Ping payload is _always_ snappy encoded
-                out.put_u8(0x01);
-                out.put_u8(0x00);
-                out.put_u8(EMPTY_LIST_CODE);
+                out.put_slice(SNAPPY_EMPTY_LIST_PAYLOAD);
             }
             Self::Pong => {
                 // Pong payload is _always_ snappy encoded
-                out.put_u8(0x01);
-                out.put_u8(0x00);
-                out.put_u8(EMPTY_LIST_CODE);
+                out.put_slice(SNAPPY_EMPTY_LIST_PAYLOAD);
             }
         }
     }
@@ -861,8 +905,8 @@ impl Encodable for P2PMessage {
         let payload_len = match self {
             Self::Hello(msg) => msg.length(),
             Self::Disconnect(msg) => msg.length(),
-            // id + snappy encoded payload
-            Self::Ping | Self::Pong => 3, // len([0x01, 0x00, 0xc0]) = 3
+            // snappy encoded empty RLP list payload
+            Self::Ping | Self::Pong => SNAPPY_EMPTY_LIST_PAYLOAD.len(),
         };
         payload_len + 1 // (1 for length of p2p message id)
     }
@@ -961,6 +1005,7 @@ mod tests {
 
     #[derive(Default)]
     struct FlushCountingTransport {
+        incoming: VecDeque<io::Result<BytesMut>>,
         sent: Vec<Bytes>,
         flushes: usize,
     }
@@ -968,8 +1013,11 @@ mod tests {
     impl Stream for FlushCountingTransport {
         type Item = io::Result<BytesMut>;
 
-        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            Poll::Pending
+        fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match self.incoming.pop_front() {
+                Some(item) => Poll::Ready(Some(item)),
+                None => Poll::Pending,
+            }
         }
     }
 
@@ -1206,6 +1254,40 @@ mod tests {
         let pong = P2PMessage::decode(&mut &snappy_pong[..]).unwrap();
         assert!(matches!(pong, P2PMessage::Pong));
         assert_eq!(alloy_rlp::encode(pong), &snappy_pong[..]);
+    }
+
+    #[tokio::test]
+    async fn poll_next_with_skips_fixed_ping_control_message() {
+        let incoming = VecDeque::from([
+            Ok(BytesMut::from(SNAPPY_PING_MESSAGE)),
+            Ok(BytesMut::from(
+                &[
+                    MAX_RESERVED_MESSAGE_ID + 1,
+                    SNAPPY_EMPTY_LIST_PAYLOAD[0],
+                    SNAPPY_EMPTY_LIST_PAYLOAD[1],
+                    SNAPPY_EMPTY_LIST_PAYLOAD[2],
+                ][..],
+            )),
+        ]);
+        let transport = FlushCountingTransport { incoming, ..Default::default() };
+        let mut stream = P2PStream::new(transport, shared_capabilities());
+        let mut decode_buf = BytesMut::new();
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+
+        let res = Pin::new(&mut stream).poll_next_with(&mut cx, &mut decode_buf, |id, payload| {
+            (id, Bytes::copy_from_slice(payload))
+        });
+
+        match res {
+            Poll::Ready(Some(Ok((id, payload)))) => {
+                assert_eq!(id, 0);
+                assert_eq!(payload, Bytes::from_static(&[EMPTY_LIST_CODE]));
+            }
+            other => panic!("expected subprotocol message, got {other:?}"),
+        }
+        assert_eq!(stream.outgoing_messages.len(), 1);
+        assert_eq!(stream.outgoing_messages[0], Bytes::from_static(SNAPPY_PONG_MESSAGE));
     }
 
     #[tokio::test]

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -56,8 +56,7 @@ const PING_INTERVAL: Duration = Duration::from_secs(60);
 /// `p2p` stream.
 ///
 /// Note: this default is rather low because it is expected that the [`P2PStream`] wraps an
-/// [`ECIESStream`](reth_ecies::stream::ECIESStream) which internally already buffers a few MB of
-/// encoded data.
+/// [`ECIESStream`](reth_ecies::stream::ECIESStream) which internally already buffers encoded data.
 const MAX_P2P_CAPACITY: usize = 2;
 
 /// An un-authenticated [`P2PStream`]. This is consumed and returns a [`P2PStream`] after the

--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tokio::time::{Instant, Interval, Sleep};
+use tokio::time::{Instant, Sleep};
 use tokio_stream::Stream;
 
 /// The pinger is a simple state machine that sends a ping, waits for a pong,
@@ -13,7 +13,9 @@ use tokio_stream::Stream;
 #[derive(Debug)]
 pub(crate) struct Pinger {
     /// The timer used for the next ping.
-    ping_interval: Interval,
+    ping_timer: Pin<Box<Sleep>>,
+    /// The duration between pings.
+    ping_interval: Duration,
     /// The timer used to detect a ping timeout.
     timeout_timer: Pin<Box<Sleep>>,
     /// The timeout duration for each ping.
@@ -29,10 +31,12 @@ impl Pinger {
     /// and timeout duration.
     pub(crate) fn new(ping_interval: Duration, timeout_duration: Duration) -> Self {
         let now = Instant::now();
+        let ping_timer = tokio::time::sleep_until(now + ping_interval);
         let timeout_timer = tokio::time::sleep(timeout_duration);
         Self {
             state: PingState::Ready,
-            ping_interval: tokio::time::interval_at(now + ping_interval, ping_interval),
+            ping_timer: Box::pin(ping_timer),
+            ping_interval,
             timeout_timer: Box::pin(timeout_timer),
             timeout: timeout_duration,
         }
@@ -45,14 +49,14 @@ impl Pinger {
             PingState::Ready => Err(PingerError::UnexpectedPong),
             PingState::WaitingForPong => {
                 self.state = PingState::Ready;
-                self.ping_interval.reset();
+                self.ping_timer.as_mut().reset(Instant::now() + self.ping_interval);
                 Ok(())
             }
             PingState::TimedOut => {
                 // if we receive a pong after timeout then we also reset the state, since the
                 // connection was kept alive after timeout
                 self.state = PingState::Ready;
-                self.ping_interval.reset();
+                self.ping_timer.as_mut().reset(Instant::now() + self.ping_interval);
                 Ok(())
             }
         }
@@ -71,7 +75,7 @@ impl Pinger {
     ) -> Poll<Result<PingerEvent, PingerError>> {
         match self.state() {
             PingState::Ready => {
-                if self.ping_interval.poll_tick(cx).is_ready() {
+                if self.ping_timer.as_mut().poll(cx).is_ready() {
                     self.timeout_timer.as_mut().reset(Instant::now() + self.timeout);
                     self.state = PingState::WaitingForPong;
                     return Poll::Ready(Ok(PingerEvent::Ping))

--- a/crates/net/eth-wire/src/pinger.rs
+++ b/crates/net/eth-wire/src/pinger.rs
@@ -2,7 +2,7 @@ use crate::errors::PingerError;
 use std::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{Context, Poll, Waker},
     time::Duration,
 };
 use tokio::time::{Instant, Sleep};
@@ -14,10 +14,14 @@ use tokio_stream::Stream;
 pub(crate) struct Pinger {
     /// The timer used for the next ping.
     ping_timer: Pin<Box<Sleep>>,
+    /// The last task waker registered with the ping timer.
+    ping_waker: Option<Waker>,
     /// The duration between pings.
     ping_interval: Duration,
     /// The timer used to detect a ping timeout.
     timeout_timer: Pin<Box<Sleep>>,
+    /// The last task waker registered with the timeout timer.
+    timeout_waker: Option<Waker>,
     /// The timeout duration for each ping.
     timeout: Duration,
     /// Keeps track of the state
@@ -36,8 +40,10 @@ impl Pinger {
         Self {
             state: PingState::Ready,
             ping_timer: Box::pin(ping_timer),
+            ping_waker: None,
             ping_interval,
             timeout_timer: Box::pin(timeout_timer),
+            timeout_waker: None,
             timeout: timeout_duration,
         }
     }
@@ -50,6 +56,8 @@ impl Pinger {
             PingState::WaitingForPong => {
                 self.state = PingState::Ready;
                 self.ping_timer.as_mut().reset(Instant::now() + self.ping_interval);
+                self.ping_waker = None;
+                self.timeout_waker = None;
                 Ok(())
             }
             PingState::TimedOut => {
@@ -57,6 +65,8 @@ impl Pinger {
                 // connection was kept alive after timeout
                 self.state = PingState::Ready;
                 self.ping_timer.as_mut().reset(Instant::now() + self.ping_interval);
+                self.ping_waker = None;
+                self.timeout_waker = None;
                 Ok(())
             }
         }
@@ -75,17 +85,34 @@ impl Pinger {
     ) -> Poll<Result<PingerEvent, PingerError>> {
         match self.state() {
             PingState::Ready => {
+                if self.ping_waker.as_ref().is_some_and(|waker| waker.will_wake(cx.waker())) &&
+                    !self.ping_timer.is_elapsed()
+                {
+                    return Poll::Pending
+                }
+
                 if self.ping_timer.as_mut().poll(cx).is_ready() {
                     self.timeout_timer.as_mut().reset(Instant::now() + self.timeout);
+                    self.ping_waker = None;
+                    self.timeout_waker = None;
                     self.state = PingState::WaitingForPong;
                     return Poll::Ready(Ok(PingerEvent::Ping))
                 }
+                self.ping_waker = Some(cx.waker().clone());
             }
             PingState::WaitingForPong => {
+                if self.timeout_waker.as_ref().is_some_and(|waker| waker.will_wake(cx.waker())) &&
+                    !self.timeout_timer.is_elapsed()
+                {
+                    return Poll::Pending
+                }
+
                 if self.timeout_timer.as_mut().poll(cx).is_ready() {
+                    self.timeout_waker = None;
                     self.state = PingState::TimedOut;
                     return Poll::Ready(Ok(PingerEvent::Timeout))
                 }
+                self.timeout_waker = Some(cx.waker().clone());
             }
             PingState::TimedOut => {
                 // we treat continuous calls while in timeout as pending, since the connection is

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -707,10 +707,9 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             NetworkHandleMessage::SendTransaction { peer_id, msg } => {
                 self.swarm.sessions_mut().send_message(&peer_id, PeerMessage::SendTransactions(msg))
             }
-            NetworkHandleMessage::SendPooledTransactionHashes { peer_id, msg } => self
-                .swarm
-                .sessions_mut()
-                .send_message(&peer_id, PeerMessage::PooledTransactions(msg)),
+            NetworkHandleMessage::SendPooledTransactionHashes { peer_id, msg } => {
+                self.swarm.sessions_mut().send_pooled_transaction_hashes(&peer_id, msg)
+            }
             NetworkHandleMessage::AddTrustedPeerId(peer_id) => {
                 self.swarm.state_mut().add_trusted_peer_id(peer_id);
             }

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -705,7 +705,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                 self.swarm.sessions_mut().send_message(&peer_id, PeerMessage::EthRequest(request))
             }
             NetworkHandleMessage::SendTransaction { peer_id, msg } => {
-                self.swarm.sessions_mut().send_message(&peer_id, PeerMessage::SendTransactions(msg))
+                self.swarm.sessions_mut().send_transaction_broadcast(&peer_id, msg)
             }
             NetworkHandleMessage::SendPooledTransactionHashes { peer_id, msg } => {
                 self.swarm.sessions_mut().send_pooled_transaction_hashes(&peer_id, msg)

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -6,6 +6,7 @@
 use crate::types::{BlockAccessLists, Receipts69, Receipts70};
 use alloy_consensus::{BlockHeader, ReceiptWithBloom};
 use alloy_primitives::{Bytes, B256};
+use alloy_rlp::Encodable;
 use futures::FutureExt;
 use reth_eth_wire::{
     message::RequestPair, BlockBodies, BlockHeaders, BlockRangeUpdate, Cells, EthMessage,
@@ -41,6 +42,46 @@ impl<P: NewBlockPayload> NewBlockMessage<P> {
     }
 }
 
+/// Full transaction broadcast with its cached RLP list payload length.
+#[derive(Debug)]
+pub struct FullTransactionBroadcast<T> {
+    /// Transactions to broadcast.
+    pub transactions: SharedTransactions<T>,
+    /// Sum of encoded transaction lengths, excluding the outer list header.
+    pub payload_length: usize,
+}
+
+impl<T> FullTransactionBroadcast<T> {
+    /// Creates a new broadcast from transactions and a precomputed payload length.
+    pub const fn from_parts(transactions: SharedTransactions<T>, payload_length: usize) -> Self {
+        Self { transactions, payload_length }
+    }
+
+    /// Returns the number of transactions in the broadcast.
+    pub fn len(&self) -> usize {
+        self.transactions.len()
+    }
+
+    /// Returns whether the broadcast has no transactions.
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
+    }
+}
+
+impl<T: Encodable> FullTransactionBroadcast<T> {
+    /// Creates a new broadcast and computes its RLP list payload length.
+    pub fn new(transactions: SharedTransactions<T>) -> Self {
+        let payload_length = transactions.iter().map(Encodable::length).sum();
+        Self { transactions, payload_length }
+    }
+}
+
+impl<T: Encodable> From<SharedTransactions<T>> for FullTransactionBroadcast<T> {
+    fn from(transactions: SharedTransactions<T>) -> Self {
+        Self::new(transactions)
+    }
+}
+
 /// All Bi-directional eth-message variants that can be sent to a session or received from a
 /// session.
 #[derive(Debug)]
@@ -52,7 +93,7 @@ pub enum PeerMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Received transactions _from_ the peer
     ReceivedTransaction(Transactions<N::BroadcastedTransaction>),
     /// Broadcast transactions _from_ local _to_ a peer.
-    SendTransactions(SharedTransactions<N::BroadcastedTransaction>),
+    SendTransactions(FullTransactionBroadcast<N::BroadcastedTransaction>),
     /// Send new pooled transactions
     PooledTransactions(NewPooledTransactionHashes),
     /// All `eth` request variants.

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -1,6 +1,10 @@
 use crate::{
-    config::NetworkMode, message::PeerMessage, protocol::RlpxSubProtocol,
-    swarm::NetworkConnectionState, transactions::TransactionsHandle, FetchClient,
+    config::NetworkMode,
+    message::{FullTransactionBroadcast, PeerMessage},
+    protocol::RlpxSubProtocol,
+    swarm::NetworkConnectionState,
+    transactions::TransactionsHandle,
+    FetchClient,
 };
 use alloy_primitives::B256;
 use enr::Enr;
@@ -133,10 +137,19 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
 
     /// Send full transactions to the peer
     pub fn send_transactions(&self, peer_id: PeerId, msg: Vec<Arc<N::BroadcastedTransaction>>) {
-        self.send_message(NetworkHandleMessage::SendTransaction {
+        self.send_transaction_broadcast(
             peer_id,
-            msg: SharedTransactions(msg),
-        })
+            FullTransactionBroadcast::new(SharedTransactions(msg)),
+        )
+    }
+
+    /// Send full transactions with a precomputed payload length to the peer.
+    pub(crate) fn send_transaction_broadcast(
+        &self,
+        peer_id: PeerId,
+        msg: FullTransactionBroadcast<N::BroadcastedTransaction>,
+    ) {
+        self.send_message(NetworkHandleMessage::SendTransaction { peer_id, msg })
     }
 
     /// Send eth message to the peer.
@@ -566,7 +579,7 @@ pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives
         /// The ID of the peer to which the transactions are sent.
         peer_id: PeerId,
         /// The shared transactions to send.
-        msg: SharedTransactions<N::BroadcastedTransaction>,
+        msg: FullTransactionBroadcast<N::BroadcastedTransaction>,
     },
     /// Sends a list of transaction hashes to the given peer.
     SendPooledTransactionHashes {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -783,7 +783,6 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     .queued_outgoing
                                     .pop_front()
                                     .expect("send count is bounded by queued messages");
-                                progress = true;
                                 sent_message = true;
                                 let res = match msg {
                                     OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -789,6 +789,13 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     OutgoingMessage::Broadcast(msg) => {
                                         this.conn.start_send_broadcast(msg)
                                     }
+                                    OutgoingMessage::TransactionBroadcast {
+                                        transactions,
+                                        payload_length,
+                                    } => this.conn.start_send_transactions_with_payload_length(
+                                        transactions,
+                                        payload_length,
+                                    ),
                                     OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
                                 };
                                 if let Err(err) = res {
@@ -1036,6 +1043,11 @@ pub(crate) enum OutgoingMessage<N: NetworkPrimitives> {
     Eth(EthMessage<N>),
     /// A message that may be shared by multiple sessions.
     Broadcast(EthBroadcastMessage<N>),
+    /// A transactions broadcast with its cached RLP payload length.
+    TransactionBroadcast {
+        transactions: SharedTransactions<N::BroadcastedTransaction>,
+        payload_length: usize,
+    },
     /// A raw capability message
     Raw(RawCapabilityMessage),
 }
@@ -1065,8 +1077,11 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
             },
             Self::Broadcast(msg) => match msg {
                 EthBroadcastMessage::NewBlock(_) => 1,
-                EthBroadcastMessage::Transactions(txs) => txs.len(),
+                EthBroadcastMessage::Transactions(_) => unreachable!(
+                    "transaction broadcasts are stored as TransactionBroadcast messages"
+                ),
             },
+            Self::TransactionBroadcast { transactions, .. } => transactions.len(),
             Self::Raw(_) => 0,
         }
     }
@@ -1117,7 +1132,15 @@ impl<N: NetworkPrimitives> From<EthMessage<N>> for OutgoingMessage<N> {
 
 impl<N: NetworkPrimitives> From<EthBroadcastMessage<N>> for OutgoingMessage<N> {
     fn from(value: EthBroadcastMessage<N>) -> Self {
-        Self::Broadcast(value)
+        match value {
+            EthBroadcastMessage::NewBlock(block) => {
+                Self::Broadcast(EthBroadcastMessage::NewBlock(block))
+            }
+            EthBroadcastMessage::Transactions(transactions) => {
+                let payload_length = transactions_payload_length(&transactions);
+                Self::TransactionBroadcast { transactions, payload_length }
+            }
+        }
     }
 }
 
@@ -1143,9 +1166,6 @@ pub(crate) struct QueuedOutgoingMessages<N: NetworkPrimitives> {
     /// Number of queued response messages, tracked separately so the session can apply
     /// backpressure on incoming requests without scanning the whole queue.
     queued_responses: usize,
-    /// RLP payload length of the last queued transaction broadcast, if the last queued message is
-    /// a transaction broadcast.
-    last_transaction_broadcast_payload_length: Option<usize>,
     count: Gauge,
     /// Shared counter of buffered broadcast items for size-based backpressure.
     broadcast_items: BroadcastItemCounter,
@@ -1153,13 +1173,7 @@ pub(crate) struct QueuedOutgoingMessages<N: NetworkPrimitives> {
 
 impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     pub(crate) const fn new(metric: Gauge, broadcast_items: BroadcastItemCounter) -> Self {
-        Self {
-            messages: VecDeque::new(),
-            queued_responses: 0,
-            last_transaction_broadcast_payload_length: None,
-            count: metric,
-            broadcast_items,
-        }
+        Self { messages: VecDeque::new(), queued_responses: 0, count: metric, broadcast_items }
     }
 
     /// Returns the number of queued response messages.
@@ -1175,33 +1189,27 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
         self.messages.is_empty()
     }
 
-    pub(crate) fn push_back(&mut self, mut message: OutgoingMessage<N>) {
-        if let OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs)) = message {
-            let incoming_payload_length = transactions_payload_length(&txs);
-
-            if let Some(OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(existing))) =
-                self.messages.back_mut()
+    pub(crate) fn push_back(&mut self, message: OutgoingMessage<N>) {
+        let message =
+            if let OutgoingMessage::TransactionBroadcast { transactions, payload_length } = message
             {
-                let existing_payload_length = self
-                    .last_transaction_broadcast_payload_length
-                    .unwrap_or_else(|| transactions_payload_length(existing));
-
-                if transaction_broadcast_message_length(existing_payload_length)
-                    .saturating_add(transaction_broadcast_message_length(incoming_payload_length)) <=
-                    DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
+                if let Some(OutgoingMessage::TransactionBroadcast {
+                    transactions: existing,
+                    payload_length: existing_payload_length,
+                }) = self.messages.back_mut() &&
+                    transaction_broadcast_message_length(*existing_payload_length)
+                        .saturating_add(transaction_broadcast_message_length(payload_length)) <=
+                        DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
                 {
-                    existing.0.extend(txs.0);
-                    self.last_transaction_broadcast_payload_length =
-                        Some(existing_payload_length + incoming_payload_length);
+                    existing.0.extend(transactions.0);
+                    *existing_payload_length += payload_length;
                     return
                 }
-            }
 
-            self.last_transaction_broadcast_payload_length = Some(incoming_payload_length);
-            message = OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs));
-        } else {
-            self.last_transaction_broadcast_payload_length = None;
-        }
+                OutgoingMessage::TransactionBroadcast { transactions, payload_length }
+            } else {
+                message
+            };
 
         self.queued_responses += message.is_response() as usize;
         self.messages.push_back(message);
@@ -1215,9 +1223,6 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
             let items = msg.broadcast_item_count();
             if items > 0 {
                 self.broadcast_items.sub(items);
-            }
-            if self.messages.is_empty() {
-                self.last_transaction_broadcast_payload_length = None;
             }
         })
     }
@@ -1233,7 +1238,6 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
         } else {
             msg
         };
-        self.last_transaction_broadcast_payload_length = None;
         self.messages.push_back(EthMessage::from(msg).into());
         self.count.increment(1);
     }
@@ -1672,12 +1676,13 @@ mod tests {
         );
 
         assert_eq!(queued.messages.len(), 1);
-        let Some(OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs))) =
+        let Some(OutgoingMessage::TransactionBroadcast { transactions: txs, payload_length }) =
             queued.messages.front()
         else {
             panic!("expected queued transactions")
         };
         assert_eq!(txs.len(), 2);
+        assert_eq!(*payload_length, transactions_payload_length(txs));
     }
 
     #[test]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -21,15 +21,18 @@ use crate::{
         handle::{ActiveSessionMessage, SessionCommand},
         BlockRangeInfo, EthVersion, SessionId,
     },
+    transactions::constants::DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE,
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{bytes::BytesMut, Sealable};
+use alloy_rlp::Encodable;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::{Counter, Gauge};
 use reth_eth_wire::{
     errors::{EthHandshakeError, EthStreamError},
     message::{EthBroadcastMessage, MessageError},
     Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
+    SharedTransactions,
 };
 use reth_eth_wire_types::{message::RequestPair, NewPooledTransactionHashes, RawCapabilityMessage};
 use reth_metrics::common::mpsc::MeteredPollSender;
@@ -1079,6 +1082,27 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
             (_, incoming) => Some(incoming),
         }
     }
+
+    /// Tries to merge a full transaction broadcast into this message, consuming the incoming
+    /// transactions. Returns `Some(incoming)` back if the variants don't match or the merged
+    /// message would exceed the transaction broadcast soft limit.
+    fn try_merge_transactions(
+        &mut self,
+        incoming: SharedTransactions<N::BroadcastedTransaction>,
+    ) -> Option<SharedTransactions<N::BroadcastedTransaction>> {
+        let Self::Broadcast(EthBroadcastMessage::Transactions(existing)) = self else {
+            return Some(incoming)
+        };
+
+        if existing.length().saturating_add(incoming.length()) >
+            DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
+        {
+            return Some(incoming)
+        }
+
+        existing.0.extend(incoming.0);
+        None
+    }
 }
 
 impl<N: NetworkPrimitives> From<EthMessage<N>> for OutgoingMessage<N> {
@@ -1131,6 +1155,22 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     }
 
     pub(crate) fn push_back(&mut self, message: OutgoingMessage<N>) {
+        let message = if let Some(last) = self.messages.back_mut() {
+            match message {
+                OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs)) => {
+                    match last.try_merge_transactions(txs) {
+                        None => return,
+                        Some(txs) => {
+                            OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs))
+                        }
+                    }
+                }
+                message => message,
+            }
+        } else {
+            message
+        };
+
         self.queued_responses += message.is_response() as usize;
         self.messages.push_back(message);
         self.count.increment(1);
@@ -1186,7 +1226,9 @@ impl<N: NetworkPrimitives> Drop for QueuedOutgoingMessages<N> {
 mod tests {
     use super::*;
     use crate::session::{handle::PendingSessionEvent, start_pending_incoming_session};
+    use alloy_consensus::TxLegacy;
     use alloy_eips::eip2124::ForkFilter;
+    use alloy_primitives::{Signature, TxKind, U256};
     use reth_chainspec::MAINNET;
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire::{
@@ -1198,6 +1240,7 @@ mod tests {
         message::MAX_MESSAGE_SIZE, EthMessageID, NewPooledTransactionHashes72, RawCapabilityMessage,
     };
     use reth_ethereum_forks::EthereumHardfork;
+    use reth_ethereum_primitives::{Transaction, TransactionSigned};
     use reth_network_peers::pk2id;
     use reth_network_types::session::config::PROTOCOL_BREACH_REQUEST_TIMEOUT;
     use secp256k1::{SecretKey, SECP256K1};
@@ -1209,6 +1252,21 @@ mod tests {
     /// Returns a testing `HelloMessage` and new secretkey
     fn eth_hello(server_key: &SecretKey) -> HelloMessageWithProtocols {
         HelloMessageWithProtocols::builder(pk2id(&server_key.public_key(SECP256K1))).build()
+    }
+
+    fn signed_legacy_tx(nonce: u64, input_len: usize) -> Arc<TransactionSigned> {
+        Arc::new(TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                chain_id: Some(1),
+                nonce,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Create,
+                value: U256::ZERO,
+                input: vec![0; input_len].into(),
+            }),
+            Signature::test_signature(),
+        ))
     }
 
     struct SessionBuilder<N: NetworkPrimitives = EthNetworkPrimitives> {
@@ -1551,6 +1609,53 @@ mod tests {
             .into();
 
         assert_eq!(2, msg.broadcast_item_count());
+    }
+
+    #[test]
+    fn queued_outgoing_merges_consecutive_transaction_broadcasts() {
+        let mut queued = QueuedOutgoingMessages::<EthNetworkPrimitives>::new(
+            Gauge::noop(),
+            BroadcastItemCounter::new(),
+        );
+
+        queued.push_back(
+            EthBroadcastMessage::Transactions(SharedTransactions(vec![signed_legacy_tx(1, 0)]))
+                .into(),
+        );
+        queued.push_back(
+            EthBroadcastMessage::Transactions(SharedTransactions(vec![signed_legacy_tx(2, 0)]))
+                .into(),
+        );
+
+        assert_eq!(queued.messages.len(), 1);
+        let Some(OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs))) =
+            queued.messages.front()
+        else {
+            panic!("expected queued transactions")
+        };
+        assert_eq!(txs.len(), 2);
+    }
+
+    #[test]
+    fn queued_outgoing_preserves_transaction_broadcast_soft_limit() {
+        let mut queued = QueuedOutgoingMessages::<EthNetworkPrimitives>::new(
+            Gauge::noop(),
+            BroadcastItemCounter::new(),
+        );
+
+        queued.push_back(
+            EthBroadcastMessage::Transactions(SharedTransactions(vec![signed_legacy_tx(
+                1,
+                DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE,
+            )]))
+            .into(),
+        );
+        queued.push_back(
+            EthBroadcastMessage::Transactions(SharedTransactions(vec![signed_legacy_tx(2, 0)]))
+                .into(),
+        );
+
+        assert_eq!(queued.messages.len(), 2);
     }
 
     #[test]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -31,8 +31,8 @@ use metrics::{Counter, Gauge};
 use reth_eth_wire::{
     errors::{EthHandshakeError, EthStreamError},
     message::{EthBroadcastMessage, MessageError},
-    Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
-    SharedTransactions,
+    Capabilities, DisconnectP2P, DisconnectReason, EncodedEthMessage, EthMessage,
+    NetworkPrimitives, NewBlockPayload, SharedTransactions,
 };
 use reth_eth_wire_types::{message::RequestPair, NewPooledTransactionHashes, RawCapabilityMessage};
 use reth_metrics::common::mpsc::MeteredPollSender;
@@ -716,6 +716,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                             SessionCommand::Message(msg) => {
                                 this.on_internal_peer_message(msg);
                             }
+                            SessionCommand::EncodedBroadcast { msg, items } => {
+                                this.queued_outgoing
+                                    .push_back(OutgoingMessage::EncodedBroadcast { msg, items });
+                            }
                         }
                     }
                 }
@@ -728,6 +732,11 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     SessionCommand::Message(msg) => {
                         this.unbounded_broadcast_msgs.increment(1);
                         this.on_internal_peer_message(msg);
+                    }
+                    SessionCommand::EncodedBroadcast { msg, items } => {
+                        this.unbounded_broadcast_msgs.increment(1);
+                        this.queued_outgoing
+                            .push_back(OutgoingMessage::EncodedBroadcast { msg, items });
                     }
                     SessionCommand::Disconnect { reason } => {
                         let reason = reason.unwrap_or(DisconnectReason::DisconnectRequested);
@@ -813,6 +822,9 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                             payload_length,
                                             &mut this.conn_encode_buf,
                                         ),
+                                    OutgoingMessage::EncodedBroadcast { msg, .. } => {
+                                        this.conn.start_send_encoded(msg)
+                                    }
                                     OutgoingMessage::Raw(msg) => {
                                         this.conn.start_send_raw_with_encode_buf(
                                             msg,
@@ -1135,6 +1147,8 @@ pub(crate) enum OutgoingMessage<N: NetworkPrimitives> {
         transactions: SharedTransactions<N::BroadcastedTransaction>,
         payload_length: usize,
     },
+    /// An already encoded eth broadcast message.
+    EncodedBroadcast { msg: EncodedEthMessage, items: usize },
     /// A raw capability message
     Raw(RawCapabilityMessage),
 }
@@ -1169,6 +1183,7 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
                 ),
             },
             Self::TransactionBroadcast { transactions, .. } => transactions.len(),
+            Self::EncodedBroadcast { items, .. } => *items,
             Self::Raw(_) => 0,
         }
     }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -760,7 +760,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             // session messages are queued.
             let mut sent_message = false;
             if this.queued_outgoing.is_empty() {
-                match this.conn.poll_ready_unpin(cx) {
+                match this.conn.poll_ready_session(cx) {
                     Poll::Pending | Poll::Ready(Ok(())) => {}
                     Poll::Ready(Err(err)) => {
                         debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "connection not ready to send message");
@@ -769,7 +769,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
             } else {
                 loop {
-                    match this.conn.poll_ready_unpin(cx) {
+                    match this.conn.poll_ready_session(cx) {
                         Poll::Pending => break,
                         Poll::Ready(Err(err)) => {
                             debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "connection not ready to send message");

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -836,7 +836,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     this.conn_encode_buf = BytesMut::new();
                 }
 
-                match this.conn.poll_flush_unpin(cx) {
+                match this.conn.poll_flush_buffered(cx) {
                     Poll::Pending | Poll::Ready(Ok(())) => {}
                     Poll::Ready(Err(err)) => {
                         debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to flush messages");

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -461,7 +461,10 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 self.on_internal_peer_request(req, deadline);
             }
             PeerMessage::SendTransactions(msg) => {
-                self.queued_outgoing.push_back(EthBroadcastMessage::Transactions(msg).into());
+                self.queued_outgoing.push_back(OutgoingMessage::TransactionBroadcast {
+                    transactions: msg.transactions,
+                    payload_length: msg.payload_length,
+                });
             }
             PeerMessage::BlockRangeUpdated(_) => {}
             PeerMessage::ReceivedTransaction(_) => {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -10,7 +10,7 @@ use std::{
         atomic::{AtomicU64, AtomicUsize},
         Arc,
     },
-    task::{ready, Context, Poll},
+    task::{ready, Context, Poll, Waker},
     time::{Duration, Instant},
 };
 
@@ -44,7 +44,7 @@ use reth_primitives_traits::Block;
 use rustc_hash::FxHashMap;
 use tokio::{
     sync::{mpsc, mpsc::error::TrySendError, oneshot},
-    time::Interval,
+    time::{Instant as TokioInstant, Interval, Sleep},
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
@@ -206,7 +206,7 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     /// Optional interval for sending periodic range updates to the remote peer (eth69+)
     /// The interval is set to one epoch duration (~6.4 minutes), but updates are only sent when
     /// the block height has advanced by at least one epoch (32 blocks) since the last update
-    pub(crate) range_update_interval: Option<Interval>,
+    pub(crate) range_update_interval: Option<RangeUpdateInterval>,
     /// The last latest block number we sent in a range update
     /// Used to avoid sending unnecessary updates when block height hasn't changed significantly
     pub(crate) last_sent_latest_block: Option<u64>,
@@ -1002,6 +1002,52 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
     }
 }
 
+/// Long-period ticker for eth/69 block range updates.
+///
+/// Active sessions can be polled frequently by unrelated socket or channel activity. Tokio's
+/// interval registers with the timer on every pending poll, so this caches the registered waker
+/// between ticks and only polls the underlying sleep again when the timer elapsed or the task waker
+/// changed.
+pub(crate) struct RangeUpdateInterval {
+    sleep: Pin<Box<Sleep>>,
+    period: Duration,
+    waker: Option<Waker>,
+}
+
+impl RangeUpdateInterval {
+    /// Creates a new range update interval with the given first tick and period.
+    pub(crate) fn new(start: TokioInstant, period: Duration) -> Self {
+        Self { sleep: Box::pin(tokio::time::sleep_until(start)), period, waker: None }
+    }
+
+    /// Polls for the next tick using delayed missed-tick behavior.
+    fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if self.waker.as_ref().is_some_and(|waker| waker.will_wake(cx.waker())) &&
+            !self.sleep.is_elapsed()
+        {
+            return Poll::Pending
+        }
+
+        if self.sleep.as_mut().poll(cx).is_pending() {
+            self.waker = Some(cx.waker().clone());
+            return Poll::Pending
+        }
+
+        let timeout = self.sleep.deadline();
+        let now = TokioInstant::now();
+        let next = if now > timeout + Duration::from_millis(5) {
+            now + self.period
+        } else {
+            timeout.checked_add(self.period).unwrap_or_else(|| now + self.period)
+        };
+
+        self.sleep.as_mut().reset(next);
+        self.waker = None;
+
+        Poll::Ready(())
+    }
+}
+
 /// Tracks a request received from the peer
 pub(crate) struct ReceivedRequest<N: NetworkPrimitives> {
     /// Protocol Identifier
@@ -1772,6 +1818,27 @@ mod tests {
             &request,
             EthVersion::Eth71
         ));
+    }
+
+    #[tokio::test]
+    async fn range_update_interval_ticks_repeatedly() {
+        let mut interval = RangeUpdateInterval::new(
+            TokioInstant::now() + Duration::from_millis(5),
+            Duration::from_millis(5),
+        );
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            std::future::poll_fn(|cx| interval.poll_tick(cx)),
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            std::future::poll_fn(|cx| interval.poll_tick(cx)),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -464,6 +464,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 self.queued_outgoing.push_back(OutgoingMessage::TransactionBroadcast {
                     transactions: msg.transactions,
                     payload_length: msg.payload_length,
+                    encoded: None,
                 });
             }
             PeerMessage::BlockRangeUpdated(_) => {}
@@ -716,9 +717,18 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                             SessionCommand::Message(msg) => {
                                 this.on_internal_peer_message(msg);
                             }
-                            SessionCommand::EncodedBroadcast { msg, items } => {
+                            SessionCommand::PooledTransactionHashes { msg, encoded } => {
                                 this.queued_outgoing
-                                    .push_back(OutgoingMessage::EncodedBroadcast { msg, items });
+                                    .push_pooled_hashes_with_encoded(msg, Some(encoded));
+                            }
+                            SessionCommand::TransactionBroadcast { msg, encoded } => {
+                                this.queued_outgoing.push_back(
+                                    OutgoingMessage::TransactionBroadcast {
+                                        transactions: msg.transactions,
+                                        payload_length: msg.payload_length,
+                                        encoded: Some(encoded),
+                                    },
+                                );
                             }
                         }
                     }
@@ -733,10 +743,17 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         this.unbounded_broadcast_msgs.increment(1);
                         this.on_internal_peer_message(msg);
                     }
-                    SessionCommand::EncodedBroadcast { msg, items } => {
+                    SessionCommand::PooledTransactionHashes { msg, encoded } => {
                         this.unbounded_broadcast_msgs.increment(1);
-                        this.queued_outgoing
-                            .push_back(OutgoingMessage::EncodedBroadcast { msg, items });
+                        this.queued_outgoing.push_pooled_hashes_with_encoded(msg, Some(encoded));
+                    }
+                    SessionCommand::TransactionBroadcast { msg, encoded } => {
+                        this.unbounded_broadcast_msgs.increment(1);
+                        this.queued_outgoing.push_back(OutgoingMessage::TransactionBroadcast {
+                            transactions: msg.transactions,
+                            payload_length: msg.payload_length,
+                            encoded: Some(encoded),
+                        });
                     }
                     SessionCommand::Disconnect { reason } => {
                         let reason = reason.unwrap_or(DisconnectReason::DisconnectRequested);
@@ -815,15 +832,27 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     OutgoingMessage::TransactionBroadcast {
                                         transactions,
                                         payload_length,
-                                    } => this
-                                        .conn
-                                        .start_send_transactions_with_payload_length_and_encode_buf(
-                                            transactions,
-                                            payload_length,
-                                            &mut this.conn_encode_buf,
-                                        ),
-                                    OutgoingMessage::EncodedBroadcast { msg, .. } => {
-                                        this.conn.start_send_encoded(msg)
+                                        encoded,
+                                    } => {
+                                        if let Some(encoded) = encoded {
+                                            this.conn.start_send_encoded(encoded)
+                                        } else {
+                                            this.conn.start_send_transactions_with_payload_length_and_encode_buf(
+                                                transactions,
+                                                payload_length,
+                                                &mut this.conn_encode_buf,
+                                            )
+                                        }
+                                    }
+                                    OutgoingMessage::PooledTransactionHashes { msg, encoded } => {
+                                        if let Some(encoded) = encoded {
+                                            this.conn.start_send_encoded(encoded)
+                                        } else {
+                                            this.conn.start_send_with_encode_buf(
+                                                EthMessage::from(msg),
+                                                &mut this.conn_encode_buf,
+                                            )
+                                        }
                                     }
                                     OutgoingMessage::Raw(msg) => {
                                         this.conn.start_send_raw_with_encode_buf(
@@ -1142,13 +1171,14 @@ pub(crate) enum OutgoingMessage<N: NetworkPrimitives> {
     Eth(EthMessage<N>),
     /// A message that may be shared by multiple sessions.
     Broadcast(EthBroadcastMessage<N>),
+    /// Pooled transaction hashes with an optional cached encoded frame.
+    PooledTransactionHashes { msg: NewPooledTransactionHashes, encoded: Option<EncodedEthMessage> },
     /// A transactions broadcast with its cached RLP payload length.
     TransactionBroadcast {
         transactions: SharedTransactions<N::BroadcastedTransaction>,
         payload_length: usize,
+        encoded: Option<EncodedEthMessage>,
     },
-    /// An already encoded eth broadcast message.
-    EncodedBroadcast { msg: EncodedEthMessage, items: usize },
     /// A raw capability message
     Raw(RawCapabilityMessage),
 }
@@ -1182,8 +1212,8 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
                     "transaction broadcasts are stored as TransactionBroadcast messages"
                 ),
             },
+            Self::PooledTransactionHashes { msg, .. } => msg.len(),
             Self::TransactionBroadcast { transactions, .. } => transactions.len(),
-            Self::EncodedBroadcast { items, .. } => *items,
             Self::Raw(_) => 0,
         }
     }
@@ -1194,34 +1224,43 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
         &mut self,
         incoming: NewPooledTransactionHashes,
     ) -> Option<NewPooledTransactionHashes> {
-        let Self::Eth(eth) = self else { return Some(incoming) };
-        match (eth, incoming) {
-            (
-                EthMessage::NewPooledTransactionHashes66(existing),
-                NewPooledTransactionHashes::Eth66(inc),
-            ) => {
-                existing.extend(inc);
-                None
+        match self {
+            Self::PooledTransactionHashes { msg, encoded } => {
+                let merged = merge_pooled_transaction_hashes(msg, incoming);
+                if merged.is_none() {
+                    *encoded = None;
+                }
+                merged
             }
-            (
-                EthMessage::NewPooledTransactionHashes68(existing),
-                NewPooledTransactionHashes::Eth68(inc),
-            ) => {
-                existing.hashes.extend(inc.hashes);
-                existing.sizes.extend(inc.sizes);
-                existing.types.extend(inc.types);
-                None
-            }
-            (
-                EthMessage::NewPooledTransactionHashes72(existing),
-                NewPooledTransactionHashes::Eth72(inc),
-            ) => {
-                existing.hashes.extend(inc.hashes);
-                existing.sizes.extend(inc.sizes);
-                existing.types.extend(inc.types);
-                None
-            }
-            (_, incoming) => Some(incoming),
+            Self::Eth(eth) => match (eth, incoming) {
+                (
+                    EthMessage::NewPooledTransactionHashes66(existing),
+                    NewPooledTransactionHashes::Eth66(inc),
+                ) => {
+                    existing.extend(inc);
+                    None
+                }
+                (
+                    EthMessage::NewPooledTransactionHashes68(existing),
+                    NewPooledTransactionHashes::Eth68(inc),
+                ) => {
+                    existing.hashes.extend(inc.hashes);
+                    existing.sizes.extend(inc.sizes);
+                    existing.types.extend(inc.types);
+                    None
+                }
+                (
+                    EthMessage::NewPooledTransactionHashes72(existing),
+                    NewPooledTransactionHashes::Eth72(inc),
+                ) => {
+                    existing.hashes.extend(inc.hashes);
+                    existing.sizes.extend(inc.sizes);
+                    existing.types.extend(inc.types);
+                    None
+                }
+                (_, incoming) => Some(incoming),
+            },
+            _ => Some(incoming),
         }
     }
 }
@@ -1240,7 +1279,7 @@ impl<N: NetworkPrimitives> From<EthBroadcastMessage<N>> for OutgoingMessage<N> {
             }
             EthBroadcastMessage::Transactions(transactions) => {
                 let payload_length = transactions_payload_length(&transactions);
-                Self::TransactionBroadcast { transactions, payload_length }
+                Self::TransactionBroadcast { transactions, payload_length, encoded: None }
             }
         }
     }
@@ -1292,26 +1331,31 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     }
 
     pub(crate) fn push_back(&mut self, message: OutgoingMessage<N>) {
-        let message =
-            if let OutgoingMessage::TransactionBroadcast { transactions, payload_length } = message
+        let message = if let OutgoingMessage::TransactionBroadcast {
+            transactions,
+            payload_length,
+            encoded,
+        } = message
+        {
+            if let Some(OutgoingMessage::TransactionBroadcast {
+                transactions: existing,
+                payload_length: existing_payload_length,
+                encoded: existing_encoded,
+            }) = self.messages.back_mut() &&
+                transaction_broadcast_message_length(*existing_payload_length)
+                    .saturating_add(transaction_broadcast_message_length(payload_length)) <=
+                    DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
             {
-                if let Some(OutgoingMessage::TransactionBroadcast {
-                    transactions: existing,
-                    payload_length: existing_payload_length,
-                }) = self.messages.back_mut() &&
-                    transaction_broadcast_message_length(*existing_payload_length)
-                        .saturating_add(transaction_broadcast_message_length(payload_length)) <=
-                        DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
-                {
-                    existing.0.extend(transactions.0);
-                    *existing_payload_length += payload_length;
-                    return
-                }
+                existing.0.extend(transactions.0);
+                *existing_payload_length += payload_length;
+                *existing_encoded = None;
+                return
+            }
 
-                OutgoingMessage::TransactionBroadcast { transactions, payload_length }
-            } else {
-                message
-            };
+            OutgoingMessage::TransactionBroadcast { transactions, payload_length, encoded }
+        } else {
+            message
+        };
 
         self.queued_responses += message.is_response() as usize;
         self.messages.push_back(message);
@@ -1332,6 +1376,15 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     /// Pushes a pooled transaction hash announcement, merging into the last queued message if
     /// it is the same variant (eth66, eth68, or eth72).
     pub(crate) fn push_pooled_hashes(&mut self, msg: NewPooledTransactionHashes) {
+        self.push_pooled_hashes_with_encoded(msg, None);
+    }
+
+    /// Pushes a pooled transaction hash announcement with an optional cached encoded frame.
+    pub(crate) fn push_pooled_hashes_with_encoded(
+        &mut self,
+        msg: NewPooledTransactionHashes,
+        encoded: Option<EncodedEthMessage>,
+    ) {
         let msg = if let Some(last) = self.messages.back_mut() {
             match last.try_merge_hashes(msg) {
                 None => return,
@@ -1340,7 +1393,7 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
         } else {
             msg
         };
-        self.messages.push_back(EthMessage::from(msg).into());
+        self.messages.push_back(OutgoingMessage::PooledTransactionHashes { msg, encoded });
         self.count.increment(1);
     }
 
@@ -1356,6 +1409,31 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
 
 fn transactions_payload_length<T: Encodable>(transactions: &SharedTransactions<T>) -> usize {
     transactions.iter().map(Encodable::length).sum()
+}
+
+fn merge_pooled_transaction_hashes(
+    existing: &mut NewPooledTransactionHashes,
+    incoming: NewPooledTransactionHashes,
+) -> Option<NewPooledTransactionHashes> {
+    match (existing, incoming) {
+        (NewPooledTransactionHashes::Eth66(existing), NewPooledTransactionHashes::Eth66(inc)) => {
+            existing.extend(inc);
+            None
+        }
+        (NewPooledTransactionHashes::Eth68(existing), NewPooledTransactionHashes::Eth68(inc)) => {
+            existing.hashes.extend(inc.hashes);
+            existing.sizes.extend(inc.sizes);
+            existing.types.extend(inc.types);
+            None
+        }
+        (NewPooledTransactionHashes::Eth72(existing), NewPooledTransactionHashes::Eth72(inc)) => {
+            existing.hashes.extend(inc.hashes);
+            existing.sizes.extend(inc.sizes);
+            existing.types.extend(inc.types);
+            None
+        }
+        (_, incoming) => Some(incoming),
+    }
 }
 
 pub(super) fn request_timeout_interval(timeout: Duration) -> Interval {
@@ -1384,7 +1462,7 @@ mod tests {
     use crate::session::{handle::PendingSessionEvent, start_pending_incoming_session};
     use alloy_consensus::TxLegacy;
     use alloy_eips::eip2124::ForkFilter;
-    use alloy_primitives::{Signature, TxKind, U256};
+    use alloy_primitives::{Signature, TxKind, B256, U256};
     use reth_chainspec::MAINNET;
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire::{
@@ -1788,8 +1866,9 @@ mod tests {
         );
 
         assert_eq!(queued.messages.len(), 1);
-        let Some(OutgoingMessage::TransactionBroadcast { transactions: txs, payload_length }) =
-            queued.messages.front()
+        let Some(OutgoingMessage::TransactionBroadcast {
+            transactions: txs, payload_length, ..
+        }) = queued.messages.front()
         else {
             panic!("expected queued transactions")
         };
@@ -1817,6 +1896,64 @@ mod tests {
         );
 
         assert_eq!(queued.messages.len(), 2);
+    }
+
+    #[test]
+    fn queued_outgoing_invalidates_encoded_transaction_broadcast_on_merge() {
+        let mut queued = QueuedOutgoingMessages::<EthNetworkPrimitives>::new(
+            Gauge::noop(),
+            BroadcastItemCounter::new(),
+        );
+
+        let tx = SharedTransactions(vec![signed_legacy_tx(1, 0)]);
+        let payload_length = transactions_payload_length(&tx);
+        let encoded = EncodedEthMessage::transactions_broadcast(&tx, payload_length);
+        queued.push_back(OutgoingMessage::TransactionBroadcast {
+            transactions: tx,
+            payload_length,
+            encoded: Some(encoded),
+        });
+
+        let tx = SharedTransactions(vec![signed_legacy_tx(2, 0)]);
+        let payload_length = transactions_payload_length(&tx);
+        let encoded = EncodedEthMessage::transactions_broadcast(&tx, payload_length);
+        queued.push_back(OutgoingMessage::TransactionBroadcast {
+            transactions: tx,
+            payload_length,
+            encoded: Some(encoded),
+        });
+
+        assert_eq!(queued.messages.len(), 1);
+        let Some(OutgoingMessage::TransactionBroadcast { encoded, .. }) = queued.messages.front()
+        else {
+            panic!("expected queued transactions")
+        };
+        assert!(encoded.is_none());
+    }
+
+    #[test]
+    fn queued_outgoing_invalidates_encoded_pooled_hashes_on_merge() {
+        let mut queued = QueuedOutgoingMessages::<EthNetworkPrimitives>::new(
+            Gauge::noop(),
+            BroadcastItemCounter::new(),
+        );
+
+        let hashes = NewPooledTransactionHashes::Eth66(vec![B256::repeat_byte(1)].into());
+        let encoded = EncodedEthMessage::pooled_transaction_hashes(&hashes);
+        queued.push_pooled_hashes_with_encoded(hashes, Some(encoded));
+
+        let hashes = NewPooledTransactionHashes::Eth66(vec![B256::repeat_byte(2)].into());
+        let encoded = EncodedEthMessage::pooled_transaction_hashes(&hashes);
+        queued.push_pooled_hashes_with_encoded(hashes, Some(encoded));
+
+        assert_eq!(queued.messages.len(), 1);
+        let Some(OutgoingMessage::PooledTransactionHashes { msg, encoded }) =
+            queued.messages.front()
+        else {
+            panic!("expected queued hashes")
+        };
+        assert_eq!(msg.len(), 2);
+        assert!(encoded.is_none());
     }
 
     #[test]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -684,6 +684,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
         // The main poll loop that drives the session
         'main: loop {
             let mut progress = false;
+            let mut receive_pending = false;
 
             // we prioritize incoming commands sent from the session manager
             loop {
@@ -895,7 +896,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 let msg = this.conn.poll_next_eth_message(cx, &mut this.conn_decode_buf);
 
                 match msg {
-                    Poll::Pending => break,
+                    Poll::Pending => {
+                        receive_pending = true;
+                        break
+                    }
                     Poll::Ready(None) => {
                         if this.is_disconnecting() {
                             break
@@ -940,6 +944,16 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         }
                     }
                 }
+            }
+
+            // Avoid one extra empty outer-loop pass after the wire is pending, unless the receive
+            // pass produced work that should be driven immediately.
+            if receive_pending &&
+                this.queued_outgoing.is_empty() &&
+                this.pending_message_to_session.is_none() &&
+                this.received_requests_from_remote.is_empty()
+            {
+                break 'main
             }
 
             if !progress {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -636,7 +636,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         let current = Duration::from_millis(self.internal_request_timeout.load(Ordering::Relaxed));
         let request_timeout = calculate_new_timeout(current, elapsed);
         self.internal_request_timeout.store(request_timeout.as_millis() as u64, Ordering::Relaxed);
-        self.internal_request_timeout_interval = tokio::time::interval(request_timeout);
+        self.internal_request_timeout_interval = request_timeout_interval(request_timeout);
     }
 
     /// If a termination message is queued this will try to send it
@@ -981,13 +981,15 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             }
         }
 
-        while this.internal_request_timeout_interval.poll_tick(cx).is_ready() {
-            // check for timed out requests
-            if this.check_timed_out_requests(Instant::now()) &&
-                let Poll::Ready(Ok(_)) = this.to_session_manager.poll_reserve(cx)
-            {
-                let msg = ActiveSessionMessage::ProtocolBreach { peer_id: this.remote_peer_id };
-                this.pending_message_to_session = Some(msg);
+        if !this.inflight_requests.is_empty() {
+            while this.internal_request_timeout_interval.poll_tick(cx).is_ready() {
+                // check for timed out requests
+                if this.check_timed_out_requests(Instant::now()) &&
+                    let Poll::Ready(Ok(_)) = this.to_session_manager.poll_reserve(cx)
+                {
+                    let msg = ActiveSessionMessage::ProtocolBreach { peer_id: this.remote_peer_id };
+                    this.pending_message_to_session = Some(msg);
+                }
             }
         }
 
@@ -1292,6 +1294,12 @@ fn transactions_payload_length<T: Encodable>(transactions: &SharedTransactions<T
     transactions.iter().map(Encodable::length).sum()
 }
 
+pub(super) fn request_timeout_interval(timeout: Duration) -> Interval {
+    let mut interval = tokio::time::interval(timeout);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval
+}
+
 const fn transaction_broadcast_message_length(payload_length: usize) -> usize {
     Header { list: true, payload_length }.length_with_payload()
 }
@@ -1469,7 +1477,7 @@ mod tests {
                             BroadcastItemCounter::new(),
                         ),
                         received_requests_from_remote: Default::default(),
-                        internal_request_timeout_interval: tokio::time::interval(
+                        internal_request_timeout_interval: request_timeout_interval(
                             INITIAL_REQUEST_TIMEOUT,
                         ),
                         internal_request_timeout: Arc::new(AtomicU64::new(
@@ -1664,6 +1672,9 @@ mod tests {
         session.protocol_breach_request_timeout = drop_timeout;
         session.internal_request_timeout_interval =
             tokio::time::interval_at(tokio::time::Instant::now(), request_timeout);
+        session
+            .internal_request_timeout_interval
+            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let (tx, rx) = oneshot::channel();
         let req = PeerRequest::GetBlockBodies { request: GetBlockBodies(vec![]), response: tx };
         session.on_internal_peer_request(req, Instant::now());

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -761,21 +761,35 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         return this.close_on_error(err, cx)
                     }
                     Poll::Ready(Ok(())) => {
-                        let Some(msg) = this.queued_outgoing.pop_front() else {
-                            // no more messages to send over the wire
+                        let capacity = this.conn.available_outgoing_capacity();
+                        if capacity == 0 {
                             break
-                        };
-                        progress = true;
-                        sent_message = true;
-                        let res = match msg {
-                            OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
-                            OutgoingMessage::Broadcast(msg) => this.conn.start_send_broadcast(msg),
-                            OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
-                        };
-                        if let Err(err) = res {
-                            debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
-                            // notify the manager
-                            return this.close_on_error(err, cx)
+                        }
+
+                        let mut drained_queue = false;
+                        for _ in 0..capacity {
+                            let Some(msg) = this.queued_outgoing.pop_front() else {
+                                drained_queue = true;
+                                break
+                            };
+                            progress = true;
+                            sent_message = true;
+                            let res = match msg {
+                                OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
+                                OutgoingMessage::Broadcast(msg) => {
+                                    this.conn.start_send_broadcast(msg)
+                                }
+                                OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
+                            };
+                            if let Err(err) = res {
+                                debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
+                                // notify the manager
+                                return this.close_on_error(err, cx)
+                            }
+                        }
+
+                        if drained_queue {
+                            break
                         }
                     }
                 }

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -82,6 +82,13 @@ const MAX_QUEUED_OUTGOING_RESPONSES: usize = 4;
 /// Minimum capacity to retain for buffered incoming requests from the remote peer.
 const MIN_RECEIVED_REQUESTS_CAPACITY: usize = 1;
 
+/// Maximum number of incoming wire messages to process in one poll before yielding back to the
+/// scheduler.
+const ACTIVE_SESSION_RECEIVE_BUDGET: usize = 32;
+
+/// Shrink burst-grown buffers only after they are far above their retained steady-state capacity.
+const SHRINK_CAPACITY_MULTIPLIER: usize = 4;
+
 /// Soft limit for the total number of buffered outgoing broadcast items (e.g. transaction hashes).
 ///
 /// Many small broadcast messages carrying a single tx hash each are equivalent in cost to one
@@ -207,7 +214,14 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
     /// Shrinks the capacity of the internal buffers.
     pub fn shrink_to_fit(&mut self) {
-        self.received_requests_from_remote.shrink_to(MIN_RECEIVED_REQUESTS_CAPACITY);
+        if self.received_requests_from_remote.len() <= MIN_RECEIVED_REQUESTS_CAPACITY &&
+            self.received_requests_from_remote.capacity() >
+                MIN_RECEIVED_REQUESTS_CAPACITY
+                    .saturating_mul(SHRINK_CAPACITY_MULTIPLIER)
+                    .max(16)
+        {
+            self.received_requests_from_remote.shrink_to(MIN_RECEIVED_REQUESTS_CAPACITY);
+        }
         self.queued_outgoing.shrink_to(MAX_QUEUED_OUTGOING_RESPONSES);
     }
 
@@ -652,7 +666,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
         // If the budget is exhausted we manually yield back control to the (coop) scheduler. This
         // manual yield point should prevent situations where polling appears to be frozen. See also <https://tokio.rs/blog/2020-04-preemption>
         // And tokio's docs on cooperative scheduling <https://docs.rs/tokio/latest/tokio/task/#cooperative-scheduling>
-        let mut budget = 4;
+        let mut budget = ACTIVE_SESSION_RECEIVE_BUDGET;
 
         // The main poll loop that drives the session
         'main: loop {
@@ -705,10 +719,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
             }
 
-            let deadline = this.request_deadline();
-
+            let mut deadline = None;
             while let Poll::Ready(Some(req)) = this.internal_request_rx.poll_next_unpin(cx) {
                 progress = true;
+                let deadline = *deadline.get_or_insert_with(|| this.request_deadline());
                 this.on_internal_peer_request(req, deadline);
             }
 
@@ -727,36 +741,50 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
             }
 
-            // Send messages by advancing the sink and queuing in buffered messages
-            while this.conn.poll_ready_unpin(cx).is_ready() {
-                if let Some(msg) = this.queued_outgoing.pop_front() {
-                    progress = true;
-                    let res = match msg {
-                        OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
-                        OutgoingMessage::Broadcast(msg) => this.conn.start_send_broadcast(msg),
-                        OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
-                    };
-                    if let Err(err) = res {
-                        debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
-                        // notify the manager
+            // Send messages by advancing the sink and queuing buffered messages. `poll_ready`
+            // also drives p2p maintenance such as ping/pong, so we still poll it once when no
+            // session messages are queued.
+            let mut sent_message = false;
+            loop {
+                match this.conn.poll_ready_unpin(cx) {
+                    Poll::Pending => break,
+                    Poll::Ready(Err(err)) => {
+                        debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "connection not ready to send message");
                         return this.close_on_error(err, cx)
                     }
-                } else {
-                    // no more messages to send over the wire
-                    break
+                    Poll::Ready(Ok(())) => {
+                        let Some(msg) = this.queued_outgoing.pop_front() else {
+                            // no more messages to send over the wire
+                            break
+                        };
+                        progress = true;
+                        sent_message = true;
+                        let res = match msg {
+                            OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
+                            OutgoingMessage::Broadcast(msg) => this.conn.start_send_broadcast(msg),
+                            OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
+                        };
+                        if let Err(err) = res {
+                            debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
+                            // notify the manager
+                            return this.close_on_error(err, cx)
+                        }
+                    }
+                }
+            }
+
+            if sent_message {
+                match this.conn.poll_flush_unpin(cx) {
+                    Poll::Pending | Poll::Ready(Ok(())) => {}
+                    Poll::Ready(Err(err)) => {
+                        debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to flush messages");
+                        return this.close_on_error(err, cx)
+                    }
                 }
             }
 
             // read incoming messages from the wire
             'receive: loop {
-                // ensure we still have enough budget for another iteration
-                budget -= 1;
-                if budget == 0 {
-                    // make sure we're woken up again
-                    cx.waker().wake_by_ref();
-                    break 'main
-                }
-
                 // try to resend the pending message that we could not send because the channel was
                 // full. [`PollSender`] will ensure that we're woken up again when the channel is
                 // ready to receive the message, and will only error if the channel is closed.
@@ -764,6 +792,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     match this.to_session_manager.poll_reserve(cx) {
                         Poll::Ready(Ok(_)) => {
                             let _ = this.to_session_manager.send_item(msg);
+                            progress = true;
                         }
                         Poll::Ready(Err(_)) => return Poll::Ready(()),
                         Poll::Pending => {
@@ -794,6 +823,13 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     break 'receive
                 }
 
+                // ensure we still have enough budget for another wire message
+                if budget == 0 {
+                    // make sure we're woken up again
+                    cx.waker().wake_by_ref();
+                    break 'main
+                }
+
                 match this.conn.poll_next_unpin(cx) {
                     Poll::Pending => break,
                     Poll::Ready(None) => {
@@ -804,6 +840,8 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         return this.emit_disconnect(cx)
                     }
                     Poll::Ready(Some(res)) => {
+                        budget -= 1;
+                        progress = true;
                         match res {
                             Ok(msg) => {
                                 trace!(target: "net::session", msg_id=?msg.message_id(), remote_peer_id=?this.remote_peer_id, "received eth message");
@@ -811,7 +849,6 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                 match this.on_incoming_message(msg) {
                                     OnIncomingMessageOutcome::Ok => {
                                         // handled successfully
-                                        progress = true;
                                     }
                                     OnIncomingMessageOutcome::BadMessage { error, message } => {
                                         debug!(target: "net::session", %error, msg=?message, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
@@ -1116,7 +1153,12 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     }
 
     pub(crate) fn shrink_to(&mut self, min_capacity: usize) {
-        self.messages.shrink_to(min_capacity);
+        if self.messages.len() <= min_capacity &&
+            self.messages.capacity() >
+                min_capacity.saturating_mul(SHRINK_CAPACITY_MULTIPLIER).max(16)
+        {
+            self.messages.shrink_to(min_capacity);
+        }
     }
 }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -753,43 +753,55 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             // also drives p2p maintenance such as ping/pong, so we still poll it once when no
             // session messages are queued.
             let mut sent_message = false;
-            loop {
+            if this.queued_outgoing.is_empty() {
                 match this.conn.poll_ready_unpin(cx) {
-                    Poll::Pending => break,
+                    Poll::Pending | Poll::Ready(Ok(())) => {}
                     Poll::Ready(Err(err)) => {
                         debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "connection not ready to send message");
                         return this.close_on_error(err, cx)
                     }
-                    Poll::Ready(Ok(())) => {
-                        let capacity = this.conn.available_outgoing_capacity();
-                        if capacity == 0 {
-                            break
+                }
+            } else {
+                loop {
+                    match this.conn.poll_ready_unpin(cx) {
+                        Poll::Pending => break,
+                        Poll::Ready(Err(err)) => {
+                            debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "connection not ready to send message");
+                            return this.close_on_error(err, cx)
                         }
-
-                        let mut drained_queue = false;
-                        for _ in 0..capacity {
-                            let Some(msg) = this.queued_outgoing.pop_front() else {
-                                drained_queue = true;
+                        Poll::Ready(Ok(())) => {
+                            let send_count = this
+                                .conn
+                                .available_outgoing_capacity()
+                                .min(this.queued_outgoing.len());
+                            if send_count == 0 {
                                 break
-                            };
-                            progress = true;
-                            sent_message = true;
-                            let res = match msg {
-                                OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
-                                OutgoingMessage::Broadcast(msg) => {
-                                    this.conn.start_send_broadcast(msg)
-                                }
-                                OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
-                            };
-                            if let Err(err) = res {
-                                debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
-                                // notify the manager
-                                return this.close_on_error(err, cx)
                             }
-                        }
 
-                        if drained_queue {
-                            break
+                            for _ in 0..send_count {
+                                let msg = this
+                                    .queued_outgoing
+                                    .pop_front()
+                                    .expect("send count is bounded by queued messages");
+                                progress = true;
+                                sent_message = true;
+                                let res = match msg {
+                                    OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
+                                    OutgoingMessage::Broadcast(msg) => {
+                                        this.conn.start_send_broadcast(msg)
+                                    }
+                                    OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
+                                };
+                                if let Err(err) = res {
+                                    debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
+                                    // notify the manager
+                                    return this.close_on_error(err, cx)
+                                }
+                            }
+
+                            if this.queued_outgoing.is_empty() {
+                                break
+                            }
                         }
                     }
                 }
@@ -1154,6 +1166,14 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     /// Returns the number of queued response messages.
     pub(crate) const fn response_count(&self) -> usize {
         self.queued_responses
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.messages.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.messages.is_empty()
     }
 
     pub(crate) fn push_back(&mut self, mut message: OutgoingMessage<N>) {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -23,7 +23,7 @@ use crate::{
     },
 };
 use alloy_eips::merge::EPOCH_SLOTS;
-use alloy_primitives::Sealable;
+use alloy_primitives::{bytes::BytesMut, Sealable};
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::{Counter, Gauge};
 use reth_eth_wire::{
@@ -86,6 +86,9 @@ const MIN_RECEIVED_REQUESTS_CAPACITY: usize = 1;
 /// scheduler.
 const ACTIVE_SESSION_RECEIVE_BUDGET: usize = 32;
 
+/// Maximum direct-decode scratch capacity retained after polling an eth message.
+const MAX_RETAINED_DECODE_BUF_CAPACITY: usize = 64 * 1024;
+
 /// Shrink burst-grown buffers only after they are far above their retained steady-state capacity.
 const SHRINK_CAPACITY_MULTIPLIER: usize = 4;
 
@@ -147,6 +150,8 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     pub(crate) next_id: u64,
     /// The underlying connection.
     pub(crate) conn: EthRlpxConnection<N>,
+    /// Scratch buffer for decoding eth-only p2p messages directly from the connection.
+    pub(crate) conn_decode_buf: BytesMut,
     /// Identifier of the node we're connected to.
     pub(crate) remote_peer_id: PeerId,
     /// The address we're connected to.
@@ -830,7 +835,12 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     break 'main
                 }
 
-                match this.conn.poll_next_unpin(cx) {
+                let msg = this.conn.poll_next_eth_message(cx, &mut this.conn_decode_buf);
+                if this.conn_decode_buf.capacity() > MAX_RETAINED_DECODE_BUF_CAPACITY {
+                    this.conn_decode_buf = BytesMut::new();
+                }
+
+                match msg {
                     Poll::Pending => break,
                     Poll::Ready(None) => {
                         if this.is_disconnecting() {
@@ -1310,6 +1320,7 @@ mod tests {
                         internal_request_rx: ReceiverStream::new(messages_rx).fuse(),
                         inflight_requests: Default::default(),
                         conn,
+                        conn_decode_buf: Default::default(),
                         queued_outgoing: QueuedOutgoingMessages::new(
                             Gauge::noop(),
                             BroadcastItemCounter::new(),

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -871,9 +871,6 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
 
                 let msg = this.conn.poll_next_eth_message(cx, &mut this.conn_decode_buf);
-                if this.conn_decode_buf.capacity() > MAX_RETAINED_DECODE_BUF_CAPACITY {
-                    this.conn_decode_buf = BytesMut::new();
-                }
 
                 match msg {
                     Poll::Pending => break,
@@ -885,6 +882,9 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                         return this.emit_disconnect(cx)
                     }
                     Poll::Ready(Some(res)) => {
+                        if this.conn_decode_buf.capacity() > MAX_RETAINED_DECODE_BUF_CAPACITY {
+                            this.conn_decode_buf = BytesMut::new();
+                        }
                         budget -= 1;
                         progress = true;
                         match res {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -92,6 +92,9 @@ const ACTIVE_SESSION_RECEIVE_BUDGET: usize = 32;
 /// Maximum direct-decode scratch capacity retained after polling an eth message.
 const MAX_RETAINED_DECODE_BUF_CAPACITY: usize = 64 * 1024;
 
+/// Maximum direct-encode scratch capacity retained after sending eth messages.
+const MAX_RETAINED_ENCODE_BUF_CAPACITY: usize = 64 * 1024;
+
 /// Shrink burst-grown buffers only after they are far above their retained steady-state capacity.
 const SHRINK_CAPACITY_MULTIPLIER: usize = 4;
 
@@ -155,6 +158,8 @@ pub(crate) struct ActiveSession<N: NetworkPrimitives> {
     pub(crate) conn: EthRlpxConnection<N>,
     /// Scratch buffer for decoding eth-only p2p messages directly from the connection.
     pub(crate) conn_decode_buf: BytesMut,
+    /// Scratch buffer for encoding eth-only p2p messages before compression.
+    pub(crate) conn_encode_buf: BytesMut,
     /// Identifier of the node we're connected to.
     pub(crate) remote_peer_id: PeerId,
     /// The address we're connected to.
@@ -785,18 +790,31 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                     .expect("send count is bounded by queued messages");
                                 sent_message = true;
                                 let res = match msg {
-                                    OutgoingMessage::Eth(msg) => this.conn.start_send_unpin(msg),
+                                    OutgoingMessage::Eth(msg) => this
+                                        .conn
+                                        .start_send_with_encode_buf(msg, &mut this.conn_encode_buf),
                                     OutgoingMessage::Broadcast(msg) => {
-                                        this.conn.start_send_broadcast(msg)
+                                        this.conn.start_send_broadcast_with_encode_buf(
+                                            msg,
+                                            &mut this.conn_encode_buf,
+                                        )
                                     }
                                     OutgoingMessage::TransactionBroadcast {
                                         transactions,
                                         payload_length,
-                                    } => this.conn.start_send_transactions_with_payload_length(
-                                        transactions,
-                                        payload_length,
-                                    ),
-                                    OutgoingMessage::Raw(msg) => this.conn.start_send_raw(msg),
+                                    } => this
+                                        .conn
+                                        .start_send_transactions_with_payload_length_and_encode_buf(
+                                            transactions,
+                                            payload_length,
+                                            &mut this.conn_encode_buf,
+                                        ),
+                                    OutgoingMessage::Raw(msg) => {
+                                        this.conn.start_send_raw_with_encode_buf(
+                                            msg,
+                                            &mut this.conn_encode_buf,
+                                        )
+                                    }
                                 };
                                 if let Err(err) = res {
                                     debug!(target: "net::session", %err, remote_peer_id=?this.remote_peer_id, "failed to send message");
@@ -814,6 +832,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             }
 
             if sent_message {
+                if this.conn_encode_buf.capacity() > MAX_RETAINED_ENCODE_BUF_CAPACITY {
+                    this.conn_encode_buf = BytesMut::new();
+                }
+
                 match this.conn.poll_flush_unpin(cx) {
                     Poll::Pending | Poll::Ready(Ok(())) => {}
                     Poll::Ready(Err(err)) => {
@@ -1427,6 +1449,7 @@ mod tests {
                         inflight_requests: Default::default(),
                         conn,
                         conn_decode_buf: Default::default(),
+                        conn_encode_buf: Default::default(),
                         queued_outgoing: QueuedOutgoingMessages::new(
                             Gauge::noop(),
                             BroadcastItemCounter::new(),

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{bytes::BytesMut, Sealable};
-use alloy_rlp::Encodable;
+use alloy_rlp::{Encodable, Header};
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::{Counter, Gauge};
 use reth_eth_wire::{
@@ -1096,27 +1096,6 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
             (_, incoming) => Some(incoming),
         }
     }
-
-    /// Tries to merge a full transaction broadcast into this message, consuming the incoming
-    /// transactions. Returns `Some(incoming)` back if the variants don't match or the merged
-    /// message would exceed the transaction broadcast soft limit.
-    fn try_merge_transactions(
-        &mut self,
-        incoming: SharedTransactions<N::BroadcastedTransaction>,
-    ) -> Option<SharedTransactions<N::BroadcastedTransaction>> {
-        let Self::Broadcast(EthBroadcastMessage::Transactions(existing)) = self else {
-            return Some(incoming)
-        };
-
-        if existing.length().saturating_add(incoming.length()) >
-            DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
-        {
-            return Some(incoming)
-        }
-
-        existing.0.extend(incoming.0);
-        None
-    }
 }
 
 impl<N: NetworkPrimitives> From<EthMessage<N>> for OutgoingMessage<N> {
@@ -1153,6 +1132,9 @@ pub(crate) struct QueuedOutgoingMessages<N: NetworkPrimitives> {
     /// Number of queued response messages, tracked separately so the session can apply
     /// backpressure on incoming requests without scanning the whole queue.
     queued_responses: usize,
+    /// RLP payload length of the last queued transaction broadcast, if the last queued message is
+    /// a transaction broadcast.
+    last_transaction_broadcast_payload_length: Option<usize>,
     count: Gauge,
     /// Shared counter of buffered broadcast items for size-based backpressure.
     broadcast_items: BroadcastItemCounter,
@@ -1160,7 +1142,13 @@ pub(crate) struct QueuedOutgoingMessages<N: NetworkPrimitives> {
 
 impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     pub(crate) const fn new(metric: Gauge, broadcast_items: BroadcastItemCounter) -> Self {
-        Self { messages: VecDeque::new(), queued_responses: 0, count: metric, broadcast_items }
+        Self {
+            messages: VecDeque::new(),
+            queued_responses: 0,
+            last_transaction_broadcast_payload_length: None,
+            count: metric,
+            broadcast_items,
+        }
     }
 
     /// Returns the number of queued response messages.
@@ -1168,22 +1156,33 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
         self.queued_responses
     }
 
-    pub(crate) fn push_back(&mut self, message: OutgoingMessage<N>) {
-        let message = if let Some(last) = self.messages.back_mut() {
-            match message {
-                OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs)) => {
-                    match last.try_merge_transactions(txs) {
-                        None => return,
-                        Some(txs) => {
-                            OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs))
-                        }
-                    }
+    pub(crate) fn push_back(&mut self, mut message: OutgoingMessage<N>) {
+        if let OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs)) = message {
+            let incoming_payload_length = transactions_payload_length(&txs);
+
+            if let Some(OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(existing))) =
+                self.messages.back_mut()
+            {
+                let existing_payload_length = self
+                    .last_transaction_broadcast_payload_length
+                    .unwrap_or_else(|| transactions_payload_length(existing));
+
+                if transaction_broadcast_message_length(existing_payload_length)
+                    .saturating_add(transaction_broadcast_message_length(incoming_payload_length)) <=
+                    DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE
+                {
+                    existing.0.extend(txs.0);
+                    self.last_transaction_broadcast_payload_length =
+                        Some(existing_payload_length + incoming_payload_length);
+                    return
                 }
-                message => message,
             }
+
+            self.last_transaction_broadcast_payload_length = Some(incoming_payload_length);
+            message = OutgoingMessage::Broadcast(EthBroadcastMessage::Transactions(txs));
         } else {
-            message
-        };
+            self.last_transaction_broadcast_payload_length = None;
+        }
 
         self.queued_responses += message.is_response() as usize;
         self.messages.push_back(message);
@@ -1197,6 +1196,9 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
             let items = msg.broadcast_item_count();
             if items > 0 {
                 self.broadcast_items.sub(items);
+            }
+            if self.messages.is_empty() {
+                self.last_transaction_broadcast_payload_length = None;
             }
         })
     }
@@ -1212,6 +1214,7 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
         } else {
             msg
         };
+        self.last_transaction_broadcast_payload_length = None;
         self.messages.push_back(EthMessage::from(msg).into());
         self.count.increment(1);
     }
@@ -1224,6 +1227,14 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
             self.messages.shrink_to(min_capacity);
         }
     }
+}
+
+fn transactions_payload_length<T: Encodable>(transactions: &SharedTransactions<T>) -> usize {
+    transactions.iter().map(Encodable::length).sum()
+}
+
+const fn transaction_broadcast_message_length(payload_length: usize) -> usize {
+    Header { list: true, payload_length }.length_with_payload()
 }
 
 impl<N: NetworkPrimitives> Drop for QueuedOutgoingMessages<N> {

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -7,8 +7,8 @@ use reth_eth_wire::{
     errors::EthStreamError,
     message::EthBroadcastMessage,
     multiplex::{ProtocolProxy, RlpxSatelliteStream},
-    EthMessage, EthNetworkPrimitives, EthStream, EthVersion, NetworkPrimitives, P2PStream,
-    SharedTransactions,
+    EncodedEthMessage, EthMessage, EthNetworkPrimitives, EthStream, EthVersion, NetworkPrimitives,
+    P2PStream, SharedTransactions,
 };
 use reth_eth_wire_types::RawCapabilityMessage;
 use std::{
@@ -179,6 +179,15 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         match self {
             Self::EthOnly(conn) => conn.start_send_raw_with_encode_buf(msg, encode_buf),
             Self::Satellite(conn) => conn.primary_mut().start_send_raw(msg),
+        }
+    }
+
+    /// Sends an already encoded eth protocol message.
+    #[inline]
+    pub fn start_send_encoded(&mut self, msg: EncodedEthMessage) -> Result<(), EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => conn.start_send_encoded_eth_only(msg),
+            Self::Satellite(conn) => conn.primary_mut().start_send_encoded(msg),
         }
     }
 

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -207,6 +207,22 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         }
     }
 
+    /// Polls send readiness, bypassing the generic eth stream sink wrapper for eth-only sessions.
+    #[inline]
+    pub(crate) fn poll_ready_session(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), EthStreamError>> {
+        unsafe {
+            match self {
+                Self::EthOnly(conn) => {
+                    Pin::new_unchecked(conn.inner_mut()).poll_ready(cx).map_err(Into::into)
+                }
+                Self::Satellite(conn) => Pin::new_unchecked(conn).poll_ready(cx),
+            }
+        }
+    }
+
     /// Flushes the connection, using the ECIES-aware buffered drain path for eth-only sessions.
     pub(crate) fn poll_flush_buffered(
         &mut self,

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -206,6 +206,21 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
             }
         }
     }
+
+    /// Flushes the connection, using the ECIES-aware buffered drain path for eth-only sessions.
+    pub(crate) fn poll_flush_buffered(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), EthStreamError>> {
+        unsafe {
+            match self {
+                Self::EthOnly(conn) => Pin::new_unchecked(conn.inner_mut())
+                    .poll_flush_ecies_buffered(cx)
+                    .map_err(Into::into),
+                Self::Satellite(conn) => Pin::new_unchecked(conn).poll_flush(cx),
+            }
+        }
+    }
 }
 
 impl<N: NetworkPrimitives> From<EthPeerConnection<N>> for EthRlpxConnection<N> {

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -8,6 +8,7 @@ use reth_eth_wire::{
     message::EthBroadcastMessage,
     multiplex::{ProtocolProxy, RlpxSatelliteStream},
     EthMessage, EthNetworkPrimitives, EthStream, EthVersion, NetworkPrimitives, P2PStream,
+    SharedTransactions,
 };
 use reth_eth_wire_types::RawCapabilityMessage;
 use std::{
@@ -95,6 +96,23 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         match self {
             Self::EthOnly(conn) => conn.start_send_broadcast(item),
             Self::Satellite(conn) => conn.primary_mut().start_send_broadcast(item),
+        }
+    }
+
+    /// Sends a transactions broadcast with a precomputed RLP payload length.
+    #[inline]
+    pub fn start_send_transactions_with_payload_length(
+        &mut self,
+        transactions: SharedTransactions<N::BroadcastedTransaction>,
+        payload_length: usize,
+    ) -> Result<(), EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => {
+                conn.start_send_transactions_with_payload_length(transactions, payload_length)
+            }
+            Self::Satellite(conn) => conn
+                .primary_mut()
+                .start_send_transactions_with_payload_length(transactions, payload_length),
         }
     }
 

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -75,6 +75,17 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         }
     }
 
+    /// Returns how many messages can be started after one successful readiness poll.
+    #[inline]
+    pub(crate) fn available_outgoing_capacity(&self) -> usize {
+        match self {
+            Self::EthOnly(conn) => conn.inner().available_outgoing_capacity(),
+            // Satellite eth messages are first queued into the protocol proxy. Keep the generic
+            // sink contract for that path and only batch direct eth-only p2p streams.
+            Self::Satellite(_) => 1,
+        }
+    }
+
     /// Same as [`Sink::start_send`] but accepts a [`EthBroadcastMessage`] instead.
     #[inline]
     pub fn start_send_broadcast(

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -215,9 +215,9 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
     ) -> Poll<Result<(), EthStreamError>> {
         unsafe {
             match self {
-                Self::EthOnly(conn) => {
-                    Pin::new_unchecked(conn.inner_mut()).poll_ready(cx).map_err(Into::into)
-                }
+                Self::EthOnly(conn) => Pin::new_unchecked(conn.inner_mut())
+                    .poll_ready_ecies_buffered(cx)
+                    .map_err(Into::into),
                 Self::Satellite(conn) => Pin::new_unchecked(conn).poll_ready(cx),
             }
         }

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -1,5 +1,6 @@
 //! Connection types for a session
 
+use alloy_primitives::bytes::BytesMut;
 use futures::{Sink, Stream};
 use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
@@ -100,6 +101,22 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         match self {
             Self::EthOnly(conn) => conn.set_reject_block_announcements(reject),
             Self::Satellite(conn) => conn.primary_mut().set_reject_block_announcements(reject),
+        }
+    }
+
+    /// Polls the next eth message, using `decode_buf` as scratch space for eth-only p2p streams.
+    pub(crate) fn poll_next_eth_message(
+        &mut self,
+        cx: &mut Context<'_>,
+        decode_buf: &mut BytesMut,
+    ) -> Poll<Option<Result<EthMessage<N>, EthStreamError>>> {
+        unsafe {
+            match self {
+                Self::EthOnly(conn) => {
+                    Pin::new_unchecked(&mut **conn).poll_next_eth_message(cx, decode_buf)
+                }
+                Self::Satellite(conn) => Pin::new_unchecked(conn).poll_next(cx),
+            }
         }
     }
 }

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -1,7 +1,7 @@
 //! Connection types for a session
 
 use alloy_primitives::bytes::BytesMut;
-use futures::{Sink, Stream};
+use futures::{Sink, SinkExt, Stream};
 use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
     errors::EthStreamError,
@@ -99,6 +99,32 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         }
     }
 
+    /// Sends an eth message using caller-owned scratch space for eth-only connections.
+    #[inline]
+    pub fn start_send_with_encode_buf(
+        &mut self,
+        item: EthMessage<N>,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => conn.start_send_with_encode_buf(item, encode_buf),
+            Self::Satellite(conn) => conn.primary_mut().start_send_unpin(item),
+        }
+    }
+
+    /// Sends an eth broadcast using caller-owned scratch space for eth-only connections.
+    #[inline]
+    pub fn start_send_broadcast_with_encode_buf(
+        &mut self,
+        item: EthBroadcastMessage<N>,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => conn.start_send_broadcast_with_encode_buf(item, encode_buf),
+            Self::Satellite(conn) => conn.primary_mut().start_send_broadcast(item),
+        }
+    }
+
     /// Sends a transactions broadcast with a precomputed RLP payload length.
     #[inline]
     pub fn start_send_transactions_with_payload_length(
@@ -116,10 +142,42 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         }
     }
 
+    /// Sends a transactions broadcast using caller-owned scratch space for eth-only connections.
+    #[inline]
+    pub fn start_send_transactions_with_payload_length_and_encode_buf(
+        &mut self,
+        transactions: SharedTransactions<N::BroadcastedTransaction>,
+        payload_length: usize,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => conn.start_send_transactions_with_payload_length_and_encode_buf(
+                transactions,
+                payload_length,
+                encode_buf,
+            ),
+            Self::Satellite(conn) => conn
+                .primary_mut()
+                .start_send_transactions_with_payload_length(transactions, payload_length),
+        }
+    }
+
     /// Sends a raw capability message over the connection
     pub fn start_send_raw(&mut self, msg: RawCapabilityMessage) -> Result<(), EthStreamError> {
         match self {
             Self::EthOnly(conn) => conn.start_send_raw(msg),
+            Self::Satellite(conn) => conn.primary_mut().start_send_raw(msg),
+        }
+    }
+
+    /// Sends a raw capability message using caller-owned scratch space for eth-only connections.
+    pub fn start_send_raw_with_encode_buf(
+        &mut self,
+        msg: RawCapabilityMessage,
+        encode_buf: &mut BytesMut,
+    ) -> Result<(), EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => conn.start_send_raw_with_encode_buf(msg, encode_buf),
             Self::Satellite(conn) => conn.primary_mut().start_send_raw(msg),
         }
     }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -1,7 +1,7 @@
 //! Session handles.
 
 use crate::{
-    message::PeerMessage,
+    message::{FullTransactionBroadcast, PeerMessage},
     session::{active::BroadcastItemCounter, conn::EthRlpxConnection, Direction, SessionId},
     PendingSessionHandshakeError,
 };
@@ -10,6 +10,7 @@ use reth_eth_wire::{
     errors::EthStreamError, Capabilities, DisconnectReason, EncodedEthMessage, EthVersion,
     NetworkPrimitives, UnifiedStatus,
 };
+use reth_eth_wire_types::NewPooledTransactionHashes;
 use reth_network_api::PeerInfo;
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::PeerKind;
@@ -273,15 +274,39 @@ impl<N: NetworkPrimitives> SessionCommandSender<N> {
         }
     }
 
-    /// Sends an already encoded broadcast message to the session.
-    pub(crate) fn send_encoded_broadcast(&self, msg: EncodedEthMessage, items: usize) -> bool {
+    /// Sends pooled transaction hashes with a cached encoded frame to the session.
+    pub(crate) fn send_pooled_transaction_hashes(&self, msg: NewPooledTransactionHashes) -> bool {
+        let items = msg.len();
         if !self.broadcast_items.try_add(items) {
             return false
         }
 
-        let _ = msg.precompute_eth_only_compression();
-        let cmd = SessionCommand::EncodedBroadcast { msg, items };
+        let encoded = EncodedEthMessage::pooled_transaction_hashes(&msg);
+        let _ = encoded.precompute_eth_only_compression();
+        let cmd = SessionCommand::PooledTransactionHashes { msg, encoded };
 
+        self.try_send_accounted_broadcast(cmd, items)
+    }
+
+    /// Sends a full transaction broadcast with a cached encoded frame to the session.
+    pub(crate) fn send_transaction_broadcast(
+        &self,
+        msg: FullTransactionBroadcast<N::BroadcastedTransaction>,
+    ) -> bool {
+        let items = msg.len();
+        if !self.broadcast_items.try_add(items) {
+            return false
+        }
+
+        let encoded =
+            EncodedEthMessage::transactions_broadcast(&msg.transactions, msg.payload_length);
+        let _ = encoded.precompute_eth_only_compression();
+        let cmd = SessionCommand::TransactionBroadcast { msg, encoded };
+
+        self.try_send_accounted_broadcast(cmd, items)
+    }
+
+    fn try_send_accounted_broadcast(&self, cmd: SessionCommand<N>, items: usize) -> bool {
         match self.tx.try_send(cmd) {
             Ok(()) => true,
             Err(mpsc::error::TrySendError::Full(cmd)) => {
@@ -379,12 +404,19 @@ pub enum SessionCommand<N: NetworkPrimitives> {
     },
     /// Sends a message to the peer
     Message(PeerMessage<N>),
-    /// Sends an already encoded eth broadcast message to the peer.
-    EncodedBroadcast {
-        /// Encoded eth protocol message.
-        msg: EncodedEthMessage,
-        /// Number of broadcast items represented by the message.
-        items: usize,
+    /// Sends pooled transaction hashes with a cached encoded frame.
+    PooledTransactionHashes {
+        /// Pooled transaction hashes to send.
+        msg: NewPooledTransactionHashes,
+        /// Cached encoded eth protocol message.
+        encoded: EncodedEthMessage,
+    },
+    /// Sends a full transaction broadcast with a cached encoded frame.
+    TransactionBroadcast {
+        /// Full transactions to send.
+        msg: FullTransactionBroadcast<N::BroadcastedTransaction>,
+        /// Cached encoded eth protocol message.
+        encoded: EncodedEthMessage,
     },
 }
 

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use reth_ecies::ECIESError;
 use reth_eth_wire::{
-    errors::EthStreamError, Capabilities, DisconnectReason, EthVersion, NetworkPrimitives,
-    UnifiedStatus,
+    errors::EthStreamError, Capabilities, DisconnectReason, EncodedEthMessage, EthVersion,
+    NetworkPrimitives, UnifiedStatus,
 };
 use reth_network_api::PeerInfo;
 use reth_network_peers::{NodeRecord, PeerId};
@@ -273,6 +273,28 @@ impl<N: NetworkPrimitives> SessionCommandSender<N> {
         }
     }
 
+    /// Sends an already encoded broadcast message to the session.
+    pub(crate) fn send_encoded_broadcast(&self, msg: EncodedEthMessage, items: usize) -> bool {
+        if !self.broadcast_items.try_add(items) {
+            return false
+        }
+
+        let _ = msg.precompute_eth_only_compression();
+        let cmd = SessionCommand::EncodedBroadcast { msg, items };
+
+        match self.tx.try_send(cmd) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(cmd)) => {
+                let _ = self.unbounded_tx.send(cmd);
+                true
+            }
+            Err(_) => {
+                self.broadcast_items.sub(items);
+                false
+            }
+        }
+    }
+
     /// Returns the current number of in-flight broadcast items.
     pub(crate) fn queued_broadcast_items(&self) -> usize {
         self.broadcast_items.get()
@@ -357,6 +379,13 @@ pub enum SessionCommand<N: NetworkPrimitives> {
     },
     /// Sends a message to the peer
     Message(PeerMessage<N>),
+    /// Sends an already encoded eth broadcast message to the peer.
+    EncodedBroadcast {
+        /// Encoded eth protocol message.
+        msg: EncodedEthMessage,
+        /// Number of broadcast items represented by the message.
+        items: usize,
+    },
 }
 
 /// Message variants an active session can produce and send back to the

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -19,9 +19,9 @@ use futures::{future::Either, io, FutureExt, StreamExt};
 use reth_ecies::{stream::ECIESStream, ECIESError};
 use reth_eth_wire::{
     errors::EthStreamError, handshake::EthRlpxHandshake, multiplex::RlpxProtocolMultiplexer,
-    BlockRangeUpdate, Capabilities, DisconnectReason, EthStream, EthVersion,
-    HelloMessageWithProtocols, NetworkPrimitives, UnauthedP2PStream, UnifiedStatus,
-    HANDSHAKE_TIMEOUT,
+    BlockRangeUpdate, Capabilities, DisconnectReason, EncodedEthMessage, EthStream, EthVersion,
+    HelloMessageWithProtocols, NetworkPrimitives, NewPooledTransactionHashes, UnauthedP2PStream,
+    UnifiedStatus, HANDSHAKE_TIMEOUT,
 };
 use reth_ethereum_forks::{ForkFilter, ForkId, ForkTransition, Head};
 use reth_metrics::common::mpsc::MeteredPollSender;
@@ -401,6 +401,26 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         if let Some(session) = self.active_sessions.get(peer_id) &&
             !session.commands.send_message(msg)
         {
+            self.metrics.total_outgoing_peer_messages_dropped.increment(1);
+        }
+    }
+
+    /// Sends a pooled transaction hash announcement to the peer's session through the pre-encoded
+    /// broadcast path when the negotiated eth version supports it.
+    pub fn send_pooled_transaction_hashes(
+        &self,
+        peer_id: &PeerId,
+        msg: NewPooledTransactionHashes,
+    ) {
+        let Some(session) = self.active_sessions.get(peer_id) else { return };
+
+        if !msg.is_valid_for_version(session.version) {
+            return
+        }
+
+        let items = msg.len();
+        let msg = EncodedEthMessage::new_pooled_transaction_hashes(msg);
+        if !session.commands.send_encoded_broadcast(msg, items) {
             self.metrics.total_outgoing_peer_messages_dropped.increment(1);
         }
     }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -8,7 +8,7 @@ mod types;
 pub use types::BlockRangeInfo;
 
 use crate::{
-    message::PeerMessage,
+    message::{FullTransactionBroadcast, PeerMessage},
     metrics::SessionManagerMetrics,
     protocol::{IntoRlpxSubProtocol, OnNotSupported, RlpxSubProtocolHandlers, RlpxSubProtocols},
     session::active::ActiveSession,
@@ -19,7 +19,7 @@ use futures::{future::Either, io, FutureExt, StreamExt};
 use reth_ecies::{stream::ECIESStream, ECIESError};
 use reth_eth_wire::{
     errors::EthStreamError, handshake::EthRlpxHandshake, multiplex::RlpxProtocolMultiplexer,
-    BlockRangeUpdate, Capabilities, DisconnectReason, EncodedEthMessage, EthStream, EthVersion,
+    BlockRangeUpdate, Capabilities, DisconnectReason, EthStream, EthVersion,
     HelloMessageWithProtocols, NetworkPrimitives, NewPooledTransactionHashes, UnauthedP2PStream,
     UnifiedStatus, HANDSHAKE_TIMEOUT,
 };
@@ -418,9 +418,21 @@ impl<N: NetworkPrimitives> SessionManager<N> {
             return
         }
 
-        let items = msg.len();
-        let msg = EncodedEthMessage::new_pooled_transaction_hashes(msg);
-        if !session.commands.send_encoded_broadcast(msg, items) {
+        if !session.commands.send_pooled_transaction_hashes(msg) {
+            self.metrics.total_outgoing_peer_messages_dropped.increment(1);
+        }
+    }
+
+    /// Sends a full transaction broadcast to the peer's session through the pre-encoded broadcast
+    /// path.
+    pub fn send_transaction_broadcast(
+        &self,
+        peer_id: &PeerId,
+        msg: FullTransactionBroadcast<N::BroadcastedTransaction>,
+    ) {
+        let Some(session) = self.active_sessions.get(peer_id) else { return };
+
+        if !session.commands.send_transaction_broadcast(msg) {
             self.metrics.total_outgoing_peer_messages_dropped.increment(1);
         }
     }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -60,7 +60,7 @@ pub use reth_network_api::{Direction, PeerInfo};
 /// Active sessions batch several outgoing wire messages before forcing the lower p2p stream to
 /// flush into ECIES. The session itself still enforces byte/item backpressure for large responses
 /// and broadcasts, so this stays a small message-count buffer.
-const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 8;
+const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 32;
 
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -596,6 +596,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     inflight_requests: Default::default(),
                     conn,
                     conn_decode_buf: Default::default(),
+                    conn_encode_buf: Default::default(),
                     queued_outgoing: QueuedOutgoingMessages::new(
                         self.metrics.queued_outgoing_messages.clone(),
                         broadcast_items.clone(),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -48,7 +48,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
 use tracing::{instrument, trace};
 
-use crate::session::active::{BroadcastItemCounter, RANGE_UPDATE_INTERVAL};
+use crate::session::active::{
+    request_timeout_interval, BroadcastItemCounter, RANGE_UPDATE_INTERVAL,
+};
 pub use conn::EthRlpxConnection;
 use handle::SessionCommandSender;
 pub use handle::{
@@ -602,7 +604,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                         broadcast_items.clone(),
                     ),
                     received_requests_from_remote: Default::default(),
-                    internal_request_timeout_interval: tokio::time::interval(
+                    internal_request_timeout_interval: request_timeout_interval(
                         self.initial_internal_request_timeout,
                     ),
                     internal_request_timeout: Arc::clone(&timeout),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -49,7 +49,7 @@ use tokio_util::sync::PollSender;
 use tracing::{instrument, trace};
 
 use crate::session::active::{
-    request_timeout_interval, BroadcastItemCounter, RANGE_UPDATE_INTERVAL,
+    request_timeout_interval, BroadcastItemCounter, RangeUpdateInterval, RANGE_UPDATE_INTERVAL,
 };
 pub use conn::EthRlpxConnection;
 use handle::SessionCommandSender;
@@ -561,9 +561,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 // peers that don't properly handle the message).
                 let range_update_interval = (conn.version() >= EthVersion::Eth69).then(|| {
                     let start = tokio::time::Instant::now() + RANGE_UPDATE_INTERVAL;
-                    let mut interval = tokio::time::interval_at(start, RANGE_UPDATE_INTERVAL);
-                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-                    interval
+                    RangeUpdateInterval::new(start, RANGE_UPDATE_INTERVAL)
                 });
 
                 // Shared counter of in-flight broadcast items. The session task must decrement

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -587,6 +587,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     internal_request_rx: ReceiverStream::new(messages_rx).fuse(),
                     inflight_requests: Default::default(),
                     conn,
+                    conn_decode_buf: Default::default(),
                     queued_outgoing: QueuedOutgoingMessages::new(
                         self.metrics.queued_outgoing_messages.clone(),
                         broadcast_items.clone(),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -57,6 +57,11 @@ pub use handle::{
 };
 pub use reth_network_api::{Direction, PeerInfo};
 
+/// Active sessions batch several outgoing wire messages before forcing the lower p2p stream to
+/// flush into ECIES. The session itself still enforces byte/item backpressure for large responses
+/// and broadcasts, so this stays a small message-count buffer.
+const ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY: usize = 8;
+
 /// Internal identifier for active sessions.
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 pub struct SessionId(usize);
@@ -572,6 +577,9 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 if self.reject_block_announcements {
                     conn.set_reject_block_announcements(true);
                 }
+                conn.inner_mut().set_outgoing_message_buffer_capacity(
+                    ACTIVE_SESSION_P2P_OUTGOING_BUFFER_CAPACITY,
+                );
 
                 let session = ActiveSession {
                     next_id: 0,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -33,7 +33,9 @@ use crate::{
         DEFAULT_BUDGET_TRY_DRAIN_PENDING_POOL_IMPORTS, DEFAULT_BUDGET_TRY_DRAIN_STREAM,
     },
     cache::LruCache,
-    duration_metered_exec, metered_poll_nested_stream_with_budget,
+    duration_metered_exec,
+    message::FullTransactionBroadcast,
+    metered_poll_nested_stream_with_budget,
     metrics::{AnnouncedTxTypesMetrics, TransactionsManagerMetrics},
     transactions::config::{StrictEthAnnouncementFilter, TransactionPropagationKind},
     NetworkHandle, TxTypesCounter,
@@ -48,7 +50,7 @@ use reth_eth_wire::{
     DedupPayload, EthNetworkPrimitives, EthVersion, GetPooledTransactions, HandleMempoolData,
     HandleVersionedMempoolData, NetworkPrimitives, NewPooledTransactionHashes,
     NewPooledTransactionHashes66, NewPooledTransactionHashes68, NewPooledTransactionHashes72,
-    PooledTransactions, RequestTxHashes, Transactions, ValidAnnouncementData,
+    PooledTransactions, RequestTxHashes, SharedTransactions, Transactions, ValidAnnouncementData,
 };
 use reth_ethereum_primitives::{TransactionSigned, TxType};
 use reth_metrics::common::mpsc::MemoryBoundedReceiver;
@@ -937,14 +939,14 @@ where
 
         // send full transactions, if any
         if let Some(new_full_transactions) = full {
-            for tx in &new_full_transactions {
+            for tx in new_full_transactions.transactions.iter() {
                 propagated.record(*tx.tx_hash(), PropagateKind::Full(peer_id));
                 // mark transaction as seen by peer
                 peer.seen_transactions.insert(*tx.tx_hash());
             }
 
             // send full transactions
-            self.network.send_transactions(peer_id, new_full_transactions);
+            self.network.send_transaction_broadcast(peer_id, new_full_transactions);
         }
 
         // Update propagated transactions metrics
@@ -1111,14 +1113,14 @@ where
 
             // send full transactions, if any
             if let Some(new_full_transactions) = full {
-                for tx in &new_full_transactions {
+                for tx in new_full_transactions.transactions.iter() {
                     propagated.record(*tx.tx_hash(), PropagateKind::Full(*peer_id));
                 }
 
                 trace!(target: "net::tx", ?peer_id, num_txs=?new_full_transactions.len(), "Propagating full transactions to peer");
 
                 // send full transactions
-                self.network.send_transactions(*peer_id, new_full_transactions);
+                self.network.send_transaction_broadcast(*peer_id, new_full_transactions);
             }
         }
 
@@ -1761,14 +1763,15 @@ impl PropagationMode {
 #[derive(Debug, Clone)]
 struct PropagateTransaction<T = TransactionSigned> {
     size: usize,
+    payload_length: usize,
     transaction: Arc<T>,
 }
 
 impl<T: SignedTransaction> PropagateTransaction<T> {
     /// Create a new instance from a transaction.
     pub fn new(transaction: T) -> Self {
-        let size = transaction.length();
-        Self { size, transaction: Arc::new(transaction) }
+        let payload_length = transaction.length();
+        Self { size: payload_length, payload_length, transaction: Arc::new(transaction) }
     }
 
     /// Create a new instance from a pooled transaction
@@ -1778,8 +1781,9 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
     {
         let size = tx.encoded_length();
         let transaction = tx.transaction.clone_into_consensus();
+        let payload_length = transaction.length();
         let transaction = Arc::new(transaction.into_inner());
-        Self { size, transaction }
+        Self { size, payload_length, transaction }
     }
 
     fn tx_hash(&self) -> &TxHash {
@@ -1842,7 +1846,7 @@ struct PropagateTransactions<T> {
     /// The pooled transaction hashes to send.
     pooled: Option<NewPooledTransactionHashes>,
     /// The transactions to send in full.
-    full: Option<Vec<Arc<T>>>,
+    full: Option<FullTransactionBroadcast<T>>,
 }
 
 /// Helper type for constructing the full transaction message that enforces the
@@ -1853,6 +1857,8 @@ struct PropagateTransactions<T> {
 struct FullTransactionsBuilder<T> {
     /// The soft limit to enforce for a single broadcast message of full transactions.
     total_size: usize,
+    /// Sum of encoded transaction lengths for the final RLP list payload.
+    payload_length: usize,
     /// All transactions to be broadcasted.
     transactions: Vec<Arc<T>>,
     /// Transactions that didn't fit into the broadcast message
@@ -1864,6 +1870,7 @@ impl<T> FullTransactionsBuilder<T> {
     fn new(version: EthVersion) -> Self {
         Self {
             total_size: 0,
+            payload_length: 0,
             pooled: PooledTransactionsHashesBuilder::new(version),
             transactions: vec![],
         }
@@ -1876,6 +1883,7 @@ impl<T> FullTransactionsBuilder<T> {
     fn with_capacity(version: EthVersion, capacity: usize) -> Self {
         Self {
             total_size: 0,
+            payload_length: 0,
             pooled: PooledTransactionsHashesBuilder::new(version),
             transactions: Vec::with_capacity(capacity),
         }
@@ -1889,7 +1897,12 @@ impl<T> FullTransactionsBuilder<T> {
     /// Returns the messages that should be propagated to the peer.
     fn build(self) -> PropagateTransactions<T> {
         let pooled = Some(self.pooled.build()).filter(|pooled| !pooled.is_empty());
-        let full = Some(self.transactions).filter(|full| !full.is_empty());
+        let full = (!self.transactions.is_empty()).then(|| {
+            FullTransactionBroadcast::from_parts(
+                SharedTransactions(self.transactions),
+                self.payload_length,
+            )
+        });
         PropagateTransactions { pooled, full }
     }
 }
@@ -1935,6 +1948,7 @@ impl<T: SignedTransaction> FullTransactionsBuilder<T> {
         }
 
         self.total_size = new_size;
+        self.payload_length += transaction.payload_length;
         self.transactions.push(Arc::clone(&transaction.transaction));
     }
 }
@@ -2266,7 +2280,7 @@ mod tests {
     use alloy_consensus::{TxEip1559, TxLegacy};
     use alloy_eips::eip4844::BlobTransactionValidationError;
     use alloy_primitives::{hex, Signature, TxKind, B256, U256};
-    use alloy_rlp::Decodable;
+    use alloy_rlp::{Decodable, Encodable};
     use futures::FutureExt;
     use reth_chainspec::MIN_TRANSACTION_GAS;
     use reth_ethereum_primitives::{PooledTransactionVariant, Transaction, TransactionSigned};
@@ -3037,6 +3051,7 @@ mod tests {
         tx.transaction.set_size(DEFAULT_SOFT_LIMIT_BYTE_SIZE_TRANSACTIONS_BROADCAST_MESSAGE + 1);
         let tx = Arc::new(tx);
         let tx = PropagateTransaction::pool_tx(tx);
+        let tx_payload_length = tx.payload_length;
         builder.push(&tx);
         assert!(!builder.is_empty());
 
@@ -3044,6 +3059,11 @@ mod tests {
         assert!(txs.pooled.is_none());
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
+        assert_eq!(txs.payload_length, tx_payload_length);
+        assert_eq!(
+            txs.payload_length,
+            txs.transactions.iter().map(Encodable::length).sum::<usize>()
+        );
 
         builder.push(&tx);
 
@@ -3052,6 +3072,11 @@ mod tests {
         assert_eq!(pooled.len(), 1);
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
+        assert_eq!(txs.payload_length, tx_payload_length);
+        assert_eq!(
+            txs.payload_length,
+            txs.transactions.iter().map(Encodable::length).sum::<usize>()
+        );
     }
 
     #[test]
@@ -3078,6 +3103,11 @@ mod tests {
         assert_eq!(pooled.len(), 1);
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
+        assert_eq!(txs.payload_length, tx.payload_length);
+        assert_eq!(
+            txs.payload_length,
+            txs.transactions.iter().map(Encodable::length).sum::<usize>()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Optimizes ETH session throughput by reducing idle P2P readiness work, reusing/batching EthStream encode and send paths, draining P2P messages into ECIES in batches, and adding fast paths for pooled transaction hash encode/decode and size metadata. The hot RLP paths now avoid extra length passes and generic usize/hash decoding for fixed-width hash announcements while preserving canonical decode checks. Pooled hash encoders also write fixed-width B256 RLP lists directly for eth/66, eth/68, and eth/72 announcements.

ActiveSession now avoids re-entering the outer poll loop for one extra empty pass after the wire reaches `Pending`, while still continuing immediately when the receive pass produced outgoing responses, pending manager messages, or received peer requests that need to be driven. It also skips request-timeout timer polling while no requests are in flight and uses delayed missed ticks for that interval to avoid stale tick bursts.

The P2P batching change now explicitly flushes satellite multiplexer frames after partial batches are handed to `P2PStream`; this preserves the batching optimization for eth-only sessions while keeping multiplexed satellite protocol messages from stalling below the p2p queue capacity. Idle pinger maintenance also avoids re-polling unchanged Tokio timers after the same task waker has already been registered.

Local criterion runs on `reth-eth-wire/ethstream` showed idle readiness improving from ~44.3us to ~21.1us per 1024 polls, active-session-style sends from ~275.6us to ~182.9us, receives from ~343.2us to ~189.3us, 64-hash eth/68 receive from ~1.03ms to ~0.79ms, and 64-hash eth/72 receive from ~1.02ms to ~0.83ms. Additional size metadata fast paths improved small-size hash announcements by roughly 14-15% and 1024-byte size metadata by roughly 4-6% in targeted local runs; the latest direct B256 list encode improved 64-hash eth/68 sends by ~8% and eth/72 sends by ~2-3%, with the batched eth/66 send path neutral.