### PR TITLE
rocksdb: reclaim disk space when clearing a column family

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -517,6 +517,15 @@ impl RocksDBProviderInner {
         self.db_rw().delete_range_cf(cf, from, to)
     }
 
+    fn delete_file_in_range_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &rocksdb::ColumnFamily,
+        from: K,
+        to: K,
+    ) -> Result<(), rocksdb::Error> {
+        self.db_rw().delete_file_in_range_cf(cf, from, to)
+    }
+
     /// Returns an iterator over a column family.
     fn iterator_cf(
         &self,
@@ -936,6 +945,17 @@ impl RocksDBProvider {
         let cf = self.get_cf_handle::<T>()?;
 
         self.0.delete_range_cf(cf, &[] as &[u8], &[0xFF; 256]).map_err(|e| {
+            ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
+                message: e.to_string().into(),
+                code: -1,
+            }))
+        })?;
+
+        // A range tombstone spanning the whole column family barely moves the
+        // pending-compaction estimate, so auto-compaction is never scheduled and the shadowed
+        // SST files (and their disk space) stay around until an unrelated full compaction runs.
+        // Drop the files in the deleted range directly so `clear` reclaims the space right away.
+        self.0.delete_file_in_range_cf(cf, &[] as &[u8], &[0xFF; 256]).map_err(|e| {
             ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
                 message: e.to_string().into(),
                 code: -1,


### PR DESCRIPTION
While pruning a storage-v2 node I noticed `reth prune` marks a large amount of data for deletion but the disk usage barely changes until the very end of the run. It traces back to `RocksDBProvider::clear`.

## Problem

`clear` wipes a column family with a single `delete_range_cf` over the whole key space:

```rust
self.0.delete_range_cf(cf, &[] as &[u8], &[0xFF; 256])?;
```

That records one range tombstone but does not remove the underlying SST files. A tombstone that spans the entire CF adds almost nothing to RocksDB's pending-compaction estimate, so auto-compaction is never scheduled and the files (and their disk space) stay on disk until some later, unrelated full compaction happens to run.

Where this bites: when `reth prune` fully prunes `transaction_lookup` on a storage-v2 datadir it calls `clear::<TransactionHashNumbers>()`. On a mainnet-sized node that column family is hundreds of GB; after the clear everything is logically gone but nothing is freed. The space only comes back in the `flush_and_compact` at the very end of the prune command — and only if the run gets that far.

## Change

After the range tombstone, drop the files in the same range with `delete_file_in_range_cf`, so `clear` reclaims the space itself instead of deferring it to a later compaction:

```rust
self.0.delete_range_cf(cf, &[] as &[u8], &[0xFF; 256])?;
self.0.delete_file_in_range_cf(cf, &[] as &[u8], &[0xFF; 256])?;
```

`delete_file_in_range_cf` only drops files whose key range is fully contained in the deleted range, so it is cheap (no rewrite) and correct for partial-range callers too — files that straddle the boundary are left to the range tombstone, which is why the tombstone is kept.

Added a small `delete_file_in_range_cf` wrapper on `RocksDBProviderInner` mirroring the existing `delete_range_cf` one.