### PR TITLE
fix(db): avoid rustdoc ICE for libmdbx re-export

### DIFF
--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -6,6 +6,7 @@ use reth_tracing::tracing::{info, warn};
 use std::path::Path;
 
 pub use crate::implementation::mdbx::*;
+#[doc(no_inline)]
 pub use reth_libmdbx::*;
 
 /// Tables that have been removed from the schema but may still exist on disk from previous


### PR DESCRIPTION
Marks the `reth-libmdbx` glob re-export from `reth-db::mdbx` as `#[doc(no_inline)]` so rustdoc does not inline the generated MDBX FFI extern crate.

This avoids the nightly rustdoc ICE on `reth_libmdbx::ffi` while preserving the public re-export.

https://github.com/paradigmxyz/reth/actions/runs/28548107113/job/84723451021?pr=25774