### PR TITLE
feat(tracing): include span attributes in OTLP logs

### DIFF
--- a/crates/tracing-otlp/Cargo.toml
+++ b/crates/tracing-otlp/Cargo.toml
@@ -42,6 +42,7 @@ otlp = [
 otlp-logs = [
     "otlp",
     "opentelemetry-appender-tracing",
+    "opentelemetry-appender-tracing/experimental_span_attributes",
     "opentelemetry-otlp/logs",
     "opentelemetry_sdk/logs",
 ]

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -110,11 +110,9 @@ pub fn log_layer(
         .with_batch_exporter(log_exporter)
         .build();
 
-    Ok(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::builder(
-        &logger_provider,
-    )
-    .with_tracing_span_attributes(TracingSpanAttributes::all())
-    .build())
+    Ok(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::builder(&logger_provider)
+        .with_tracing_span_attributes(TracingSpanAttributes::all())
+        .build())
 }
 
 /// Configuration for OTLP trace export.

--- a/crates/tracing-otlp/src/lib.rs
+++ b/crates/tracing-otlp/src/lib.rs
@@ -87,6 +87,7 @@ pub fn log_layer(
         opentelemetry_sdk::logs::SdkLogger,
     >,
 > {
+    use opentelemetry_appender_tracing::layer::TracingSpanAttributes;
     use opentelemetry_otlp::LogExporter;
     use opentelemetry_sdk::logs::SdkLoggerProvider;
 
@@ -109,7 +110,11 @@ pub fn log_layer(
         .with_batch_exporter(log_exporter)
         .build();
 
-    Ok(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&logger_provider))
+    Ok(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::builder(
+        &logger_provider,
+    )
+    .with_tracing_span_attributes(TracingSpanAttributes::all())
+    .build())
 }
 
 /// Configuration for OTLP trace export.


### PR DESCRIPTION
## Summary

Enable tracing span attribute enrichment for OTLP log export.

The current OTLP log bridge only records event fields. When logs are emitted inside active `tracing` spans, span fields are not copied onto the resulting OTLP log record. This enables `opentelemetry-appender-tracing`'s `experimental_span_attributes` feature and switches the OTLP log layer to the builder API with `TracingSpanAttributes::all()`.

This intentionally does not include span-name enrichment; that depends on a separate upstream OpenTelemetry appender API (https://github.com/open-telemetry/opentelemetry-rust/pull/3466).

## Validation

- `cargo +1.95.0 check -p reth-tracing-otlp --features otlp-logs`
