### PR TITLE
fix(rpc): estimate eip-2780 basic transfers

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -2,7 +2,10 @@ use crate::utils::{eth_payload_attributes, eth_payload_attributes_amsterdam};
 use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig};
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, Bytes, B256, U256};
-use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder, SendableTx};
+use alloy_provider::{
+    network::{EthereumWallet, TransactionBuilder},
+    Provider, ProviderBuilder, SendableTx,
+};
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequestV3, BuilderBlockValidationRequestV4,
     BuilderBlockValidationRequestV6, SignedBidSubmissionV3, SignedBidSubmissionV4,
@@ -15,7 +18,7 @@ use alloy_rpc_types_engine::{
 use alloy_rpc_types_eth::TransactionRequest;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
-use reth_e2e_test_utils::setup_engine;
+use reth_e2e_test_utils::{setup_engine, wallet::Wallet};
 use reth_network::{types::NatResolver, PeersInfo};
 use reth_node_builder::{NodeBuilder, NodeHandle};
 use reth_node_core::{
@@ -411,6 +414,55 @@ async fn test_flashbots_validate_v6() -> eyre::Result<()> {
         .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV6".into(), (&request,))
         .await
         .is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_estimate_gas_basic_transfers_post_amsterdam() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .amsterdam_activated()
+            .build(),
+    );
+
+    let (mut nodes, _) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes_amsterdam,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let mut signers = Wallet::new(2).wallet_gen();
+    let sender = signers.remove(0);
+    let existing_recipient = signers.remove(0);
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(sender.clone()))
+        .connect_http(node.rpc_url());
+
+    let from = sender.address();
+    let self_call_gas =
+        provider.estimate_gas(TransactionRequest::default().with_from(from).with_to(from)).await?;
+    assert_eq!(self_call_gas, 12_000);
+
+    let existing_recipient_gas = provider
+        .estimate_gas(
+            TransactionRequest::default().with_from(from).with_to(existing_recipient.address()),
+        )
+        .await?;
+    assert_eq!(existing_recipient_gas, 15_000);
+
+    let empty_recipient = Address::repeat_byte(0xfe);
+    let empty_recipient_gas = provider
+        .estimate_gas(TransactionRequest::default().with_from(from).with_to(empty_recipient))
+        .await?;
+    assert_eq!(empty_recipient_gas, 15_000);
 
     Ok(())
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -29,9 +29,13 @@ use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GA
 use revm::{
     context::Block,
     context_interface::{result::ExecutionResult, Cfg, Transaction},
-    primitives::KECCAK_EMPTY,
+    primitives::{hardfork::SpecId, KECCAK_EMPTY},
 };
 use tracing::trace;
+
+// EIP-2780 constants are not exposed by revm yet.
+const EIP2780_TX_BASE_COST: u64 = 12_000;
+const EIP2780_COLD_ACCOUNT_ACCESS: u64 = 3_000;
 
 /// Gas execution estimates
 pub trait EstimateCall: Call {
@@ -124,7 +128,8 @@ pub trait EstimateCall: Call {
                 Ok(Some(account)) => {
                     account.bytecode_hash.is_none() || account.bytecode_hash == Some(KECCAK_EMPTY)
                 }
-                _ => true,
+                Ok(None) => true, // absent account has no code
+                Err(_) => false,  // unknown state, do not shortcut
             }
         } else {
             false
@@ -141,6 +146,14 @@ pub trait EstimateCall: Call {
 
         // If the provided gas limit is less than computed cap, use that
         tx_env.set_gas_limit(tx_env.gas_limit().min(highest_gas_limit));
+
+        let spec = Cfg::spec(&evm_env.cfg_env).into();
+        if is_basic_transfer &&
+            let Some(gas) = eip2780_zero_value_basic_transfer_gas(&tx_env, spec) &&
+            gas <= highest_gas_limit
+        {
+            return Ok(U256::from(gas))
+        }
 
         // Create EVM instance once and reuse it throughout the entire estimation process
         let mut evm = self.evm_config().evm_with_env(&mut db, evm_env);
@@ -356,6 +369,28 @@ pub trait EstimateCall: Call {
             }
         }
     }
+}
+
+fn eip2780_zero_value_basic_transfer_gas<T>(tx: &T, spec: SpecId) -> Option<u64>
+where
+    T: Transaction,
+{
+    if !spec.is_enabled_in(SpecId::AMSTERDAM) ||
+        !tx.input().is_empty() ||
+        !tx.value().is_zero() ||
+        tx.authorization_list_len() != 0 ||
+        tx.access_list().is_some_and(|mut access_list| access_list.next().is_some())
+    {
+        return None
+    }
+
+    let TxKind::Call(to) = tx.kind() else { return None };
+
+    let mut gas = EIP2780_TX_BASE_COST;
+    if tx.caller() != to {
+        gas += EIP2780_COLD_ACCOUNT_ACCESS;
+    }
+    Some(gas)
 }
 
 /// Updates the highest and lowest gas limits for binary search based on the execution result.


### PR DESCRIPTION
Fixes post-Amsterdam `eth_estimateGas` for zero-value basic transfers so the RPC no longer returns the legacy `21_000` minimum for EIP-2780 cases.

The basic-transfer shortcut previously returned `MIN_TRANSACTION_GAS` after a successful probe. EIP-2780 decomposes that intrinsic cost, so self-calls should estimate to `12_000` and zero-value calls to distinct no-code accounts should estimate to `15_000`.

Adds an Amsterdam e2e RPC test covering self, existing recipient, and empty recipient estimates.