### PR TITLE
refactor(engine): drop parallel state root

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -70,23 +70,6 @@ const fn default_cross_block_cache_size() -> usize {
     }
 }
 
-/// Determines if the host has enough parallelism to run the payload processor.
-///
-/// It requires at least 5 parallel threads:
-/// - Engine in main thread that spawns the state root task.
-/// - Multiproof task in payload processor
-/// - Sparse Trie task in payload processor
-/// - Multiproof computation spawned in payload processor
-/// - Storage root computation spawned in trie parallel proof
-pub fn has_enough_parallelism() -> bool {
-    #[cfg(feature = "std")]
-    {
-        std::thread::available_parallelism().is_ok_and(|num| num.get() >= 5)
-    }
-    #[cfg(not(feature = "std"))]
-    false
-}
-
 /// The configuration of the engine tree.
 #[derive(Debug, Clone)]
 pub struct TreeConfig {
@@ -115,9 +98,6 @@ pub struct TreeConfig {
     /// This is used as a cutoff to prevent long-running sequential block execution when we receive
     /// a batch of downloaded blocks.
     max_execute_block_batch_size: usize,
-    /// Whether to use the legacy state root calculation method instead of the
-    /// new state root task.
-    legacy_state_root: bool,
     /// Whether to always compare trie updates from the state root task to the trie updates from
     /// the regular state root calculation.
     always_compare_trie_updates: bool,
@@ -129,8 +109,6 @@ pub struct TreeConfig {
     state_provider_metrics: bool,
     /// Cross-block cache size in bytes.
     cross_block_cache_size: usize,
-    /// Whether the host has enough parallelism to run state root task.
-    has_enough_parallelism: bool,
     /// Multiproof task chunk size for proof targets.
     multiproof_chunk_size: usize,
     /// Number of reserved CPU cores for non-reth processes
@@ -220,13 +198,11 @@ impl Default for TreeConfig {
             max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
             max_execute_block_batch_size: DEFAULT_MAX_EXECUTE_BLOCK_BATCH_SIZE,
-            legacy_state_root: false,
             always_compare_trie_updates: false,
             disable_state_cache: false,
             disable_prewarming: false,
             state_provider_metrics: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE,
-            has_enough_parallelism: has_enough_parallelism(),
             multiproof_chunk_size: DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_disabled: false,
@@ -264,13 +240,11 @@ impl TreeConfig {
         max_invalid_header_cache_length: u32,
         invalid_header_hit_eviction_threshold: u8,
         max_execute_block_batch_size: usize,
-        legacy_state_root: bool,
         always_compare_trie_updates: bool,
         disable_state_cache: bool,
         disable_prewarming: bool,
         state_provider_metrics: bool,
         cross_block_cache_size: usize,
-        has_enough_parallelism: bool,
         multiproof_chunk_size: usize,
         reserved_cpu_cores: usize,
         precompile_cache_disabled: bool,
@@ -298,13 +272,11 @@ impl TreeConfig {
             max_invalid_header_cache_length,
             invalid_header_hit_eviction_threshold,
             max_execute_block_batch_size,
-            legacy_state_root,
             always_compare_trie_updates,
             disable_state_cache,
             disable_prewarming,
             state_provider_metrics,
             cross_block_cache_size,
-            has_enough_parallelism,
             multiproof_chunk_size,
             reserved_cpu_cores,
             precompile_cache_disabled,
@@ -381,12 +353,6 @@ impl TreeConfig {
     /// Return the number of reserved CPU cores for non-reth processes
     pub const fn reserved_cpu_cores(&self) -> usize {
         self.reserved_cpu_cores
-    }
-
-    /// Returns whether to use the legacy state root calculation method instead
-    /// of the new state root task
-    pub const fn legacy_state_root(&self) -> bool {
-        self.legacy_state_root
     }
 
     /// Returns whether or not state provider metrics are enabled.
@@ -511,12 +477,6 @@ impl TreeConfig {
         self
     }
 
-    /// Setter for whether to use the legacy state root calculation method.
-    pub const fn with_legacy_state_root(mut self, legacy_state_root: bool) -> Self {
-        self.legacy_state_root = legacy_state_root;
-        self
-    }
-
     /// Setter for whether to disable state cache.
     pub const fn without_state_cache(mut self, disable_state_cache: bool) -> Self {
         self.disable_state_cache = disable_state_cache;
@@ -542,12 +502,6 @@ impl TreeConfig {
     /// Setter for cross block cache size.
     pub const fn with_cross_block_cache_size(mut self, cross_block_cache_size: usize) -> Self {
         self.cross_block_cache_size = cross_block_cache_size;
-        self
-    }
-
-    /// Setter for has enough parallelism.
-    pub const fn with_has_enough_parallelism(mut self, has_enough_parallelism: bool) -> Self {
-        self.has_enough_parallelism = has_enough_parallelism;
         self
     }
 
@@ -585,11 +539,6 @@ impl TreeConfig {
     pub const fn with_unwind_canonical_header(mut self, unwind_canonical_header: bool) -> Self {
         self.allow_unwind_canonical_header = unwind_canonical_header;
         self
-    }
-
-    /// Whether or not to use state root task
-    pub const fn use_state_root_task(&self) -> bool {
-        self.has_enough_parallelism && !self.legacy_state_root
     }
 
     /// Returns whether cache metrics recording is disabled.

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -511,8 +511,6 @@ pub(crate) struct BalMetrics {
 pub struct BlockValidationMetrics {
     /// Total number of storage tries updated in the state root calculation
     pub state_root_storage_tries_updated_total: Counter,
-    /// Total number of times the parallel state root computation fell back to regular.
-    pub state_root_parallel_fallback_total: Counter,
     /// Total number of times the state root task failed but the fallback succeeded.
     pub state_root_task_fallback_success_total: Counter,
     /// Total number of times the state root task timed out and a sequential fallback was spawned.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2150,10 +2150,7 @@ where
 
     /// Builds sparse trie retained paths from all blocks still present in the in-memory tree.
     fn sparse_trie_retained_paths_for_in_memory_blocks(&self) -> Option<SparseTrieRetainedPaths> {
-        if self.config.skip_state_root() ||
-            self.config.state_root_fallback() ||
-            !self.config.use_state_root_task()
-        {
+        if self.config.skip_state_root() || self.config.state_root_fallback() {
             return None
         }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -13,7 +13,7 @@
 //!    blocks and runs header, parent-header, and pre-execution consensus validation.
 //! 2. Build the parent state provider, EVM environment, transaction iterator, lazy ancestor
 //!    overlay, and optional decoded EIP-7928 block access list (BAL).
-//! 3. Choose the state-root strategy: `StateRootTask`, `Parallel`, `Synchronous`, or `Custom`.
+//! 3. Choose the state-root strategy: `StateRootTask`, `Synchronous`, or `Custom`.
 //! 4. Spawn the payload processor. This always prepares transaction conversion and prewarming; the
 //!    `StateRootTask` strategy also starts proof workers and the sparse trie task.
 //! 5. Execute the block. BAL payloads use the parallel BAL execute path only when state caching and
@@ -21,8 +21,8 @@
 //!    the BAL before post-execution consensus uses the decoded BAL hash.
 //! 6. Stop prewarming, terminate execution caching, spawn `hash-post-state`, await
 //!    `payload-convert` and `receipt-root`, then run post-execution consensus validation.
-//! 7. Resolve the state root from the selected strategy and fall back to serial computation when a
-//!    non-custom parallel path fails to produce a usable root.
+//! 7. Resolve the state root from the selected strategy and fall back to serial computation when
+//!    the state-root task fails to produce a usable root.
 //! 8. Verify the header state root, spawn deferred trie input computation, and return the executed
 //!    block without waiting for that deferred trie task on the hot path.
 //!
@@ -79,8 +79,6 @@
 //!     Hash-->>Main: hashed post state
 //!     alt StateRootTask
 //!         Trie-->>Main: state root and trie updates
-//!     else Parallel
-//!         Main->>Main: compute ParallelStateRoot
 //!     else Custom
 //!         Main->>Main: call custom root function
 //!     else Synchronous or fallback
@@ -153,7 +151,7 @@ use reth_provider::{
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
 use reth_trie::{prefix_set::TriePrefixSetsMut, updates::TrieUpdates, HashedPostState};
 use reth_trie_db::ChangesetCache;
-use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
+use reth_trie_parallel::root::ParallelStateRootError;
 use std::{
     collections::HashMap,
     sync::{
@@ -886,28 +884,6 @@ where
                         );
                 }
             }
-            StateRootStrategy::Parallel => {
-                debug!(target: "engine::tree::payload_validator", "Using parallel state root algorithm");
-                match self.compute_state_root_parallel(
-                    provider_factory,
-                    overlay_builder,
-                    &hashed_state,
-                ) {
-                    Ok(result) => {
-                        let elapsed = root_time.elapsed();
-                        info!(
-                            target: "engine::tree::payload_validator",
-                            regular_state_root = ?result.0,
-                            ?elapsed,
-                            "Regular root task finished"
-                        );
-                        maybe_state_root = Some((result.0, Arc::new(result.1), None, elapsed));
-                    }
-                    Err(error) => {
-                        debug!(target: "engine::tree::payload_validator", %error, "Parallel state root computation failed");
-                    }
-                }
-            }
             StateRootStrategy::Synchronous => {}
             StateRootStrategy::Custom(custom) => {
                 let (state_root, trie_updates) = ensure_ok_post_block!(
@@ -924,21 +900,14 @@ where
             }
         }
 
-        // Determine the state root.
-        // If the state root was computed in parallel, we use it.
-        // Otherwise, we fall back to computing it synchronously.
+        // Determine the state root. If the selected strategy did not produce one, compute it
+        // synchronously.
         let (state_root, trie_output, changed_paths, root_elapsed) = if let Some(maybe_state_root) =
             maybe_state_root
         {
             maybe_state_root
         } else {
-            // fallback is to compute the state root regularly in sync
-            if self.config.state_root_fallback() {
-                debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
-            } else {
-                warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
-                self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
-            }
+            debug!(target: "engine::tree::payload_validator", "Computing state root synchronously");
 
             let (root, updates) = ensure_ok_post_block!(
                 provider_builder
@@ -1407,35 +1376,6 @@ where
         Ok((executor, senders))
     }
 
-    /// Compute state root for the given hashed post state in parallel.
-    ///
-    /// Uses an overlay factory which provides the state of the parent block, along with the
-    /// [`HashedPostState`] containing the changes of this block, to compute the state root and
-    /// trie updates for this block.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(_)` if computed successfully.
-    /// Returns `Err(_)` if error was encountered during computation.
-    #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
-    fn compute_state_root_parallel(
-        &self,
-        provider_factory: P,
-        overlay_builder: OverlayBuilder<N>,
-        hashed_state: &LazyHashedPostState,
-    ) -> Result<(B256, TrieUpdates), ParallelStateRootError> {
-        let hashed_state = hashed_state.get();
-        // The `hashed_state` argument will be taken into account as part of the overlay, but we
-        // need to use the prefix sets which were generated from it to indicate to the
-        // ParallelStateRoot which parts of the trie need to be recomputed.
-        let prefix_sets = hashed_state.construct_prefix_sets().freeze();
-        let overlay_builder =
-            overlay_builder.with_extended_hashed_state_overlay(hashed_state.clone_into_sorted());
-        let overlay_factory = OverlayStateProviderFactory::new(provider_factory, overlay_builder);
-        ParallelStateRoot::new(overlay_factory, prefix_sets, self.runtime.clone())
-            .incremental_root_with_updates()
-    }
-
     /// Compute state root for the given hashed post state in serial.
     ///
     /// Uses the same provider construction path as main execution and computes the state root and
@@ -1460,7 +1400,7 @@ where
     ///
     /// Returns `ProviderResult<Result<...>>` where the outer `ProviderResult` captures
     /// unrecoverable errors from the sequential fallback (e.g. DB errors), while the inner
-    /// `Result` captures parallel state root task errors that can still fall back to serial.
+    /// `Result` captures state-root task errors that can still fall back to serial.
     #[instrument(
         level = "debug",
         target = "engine::tree::payload_validator",
@@ -1570,10 +1510,9 @@ where
 
     /// Compares trie updates from the state root task with serial state root computation.
     ///
-    /// This is used for debugging and validating the correctness of the parallel state root
-    /// task implementation. When enabled via `--engine.state-root-task-compare-updates`, this
-    /// method runs a separate serial state root computation and compares the resulting trie
-    /// updates.
+    /// This is used for debugging and validating the correctness of the state-root task. When
+    /// enabled via `--engine.state-root-task-compare-updates`, this method runs a separate serial
+    /// state root computation and compares the resulting trie updates.
     fn compare_trie_updates_with_serial(
         &self,
         state_provider_builder: StateProviderBuilder<N, P>,
@@ -1736,7 +1675,6 @@ where
     /// the selected strategy:
     /// - `Skipped`: Trusts the header state root and does not compute trie state.
     /// - `StateRootTask`: Uses a dedicated task for state root computation with proof generation
-    /// - `Parallel`: Computes state root in parallel with block execution
     /// - `Synchronous`: Falls back to sequential execution and state root computation
     ///
     /// The method handles strategy fallbacks if the preferred computed-root approach fails.
@@ -1795,7 +1733,6 @@ where
                 Ok(handle)
             }
             StateRootStrategy::Skipped |
-            StateRootStrategy::Parallel |
             StateRootStrategy::Synchronous |
             StateRootStrategy::Custom(_) => {
                 let start = Instant::now();
@@ -1850,8 +1787,8 @@ where
 
     /// Determines the state root computation strategy based on configuration.
     ///
-    /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
-    /// too expensive because it requires walking all paths in every proof.
+    /// The sparse trie state-root task is the default computed-root path. `state_root_fallback`
+    /// forces serial computation for tests and debugging.
     fn plan_state_root_computation(&self) -> StateRootStrategy<N> {
         if self.config.skip_state_root() {
             StateRootStrategy::Skipped
@@ -1859,10 +1796,8 @@ where
             StateRootStrategy::Custom(custom_state_root.clone())
         } else if self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
-        } else if self.config.use_state_root_task() {
-            StateRootStrategy::StateRootTask
         } else {
-            StateRootStrategy::Parallel
+            StateRootStrategy::StateRootTask
         }
     }
 
@@ -2101,8 +2036,6 @@ enum StateRootStrategy<N: NodePrimitives> {
     Skipped,
     /// Use the state root task (background sparse trie computation).
     StateRootTask,
-    /// Run the parallel state root computation on the calling thread.
-    Parallel,
     /// Fall back to synchronous computation via the state provider.
     Synchronous,
     /// Custom state root computation strategy.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -193,8 +193,7 @@ impl TestHarness {
         let payload_validator = MockEngineValidator;
 
         let (from_tree_tx, from_tree_rx) = unbounded_channel();
-        let tree_config =
-            TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true);
+        let tree_config = TreeConfig::default();
         let runtime = reth_tasks::Runtime::test();
         let state_trie_overlays =
             StateTrieOverlayManager::new(runtime.state_trie_overlay_worker_pool());
@@ -620,16 +619,8 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled(
     let blocks: Vec<_> =
         TestBlockBuilder::eth().get_executed_blocks(1..4).map(with_known_changed_paths).collect();
     let configs = [
-        TreeConfig::default().with_legacy_state_root(true).with_has_enough_parallelism(true),
-        TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(false),
-        TreeConfig::default()
-            .with_legacy_state_root(false)
-            .with_has_enough_parallelism(true)
-            .with_state_root_fallback(true),
-        TreeConfig::default()
-            .with_legacy_state_root(false)
-            .with_has_enough_parallelism(true)
-            .with_skip_state_root(true),
+        TreeConfig::default().with_state_root_fallback(true),
+        TreeConfig::default().with_skip_state_root(true),
     ];
 
     for config in configs {
@@ -1514,8 +1505,7 @@ fn test_on_new_payload_malformed_payload() {
     }
 }
 
-/// Test different `StateRootStrategy` paths: `StateRootTask` with empty/non-empty prefix sets,
-/// `Parallel`, `Synchronous`
+/// Test different `StateRootStrategy` paths: `StateRootTask` and `Synchronous`.
 #[test]
 fn test_state_root_strategy_paths() {
     reth_tracing::init_test_tracing();
@@ -1523,11 +1513,8 @@ fn test_state_root_strategy_paths() {
     let mut test_harness = TestHarness::new(MAINNET.clone());
 
     // Test multiple scenarios to ensure different StateRootStrategy paths are taken:
-    // 1. `StateRootTask` with empty prefix_sets → uses payload_processor.spawn()
-    // 2. `StateRootTask` with non-empty prefix_sets → switches to `Parallel`, uses
-    //    spawn_cache_exclusive()
-    // 3. `Parallel` strategy → uses spawn_cache_exclusive()
-    // 4. `Synchronous` strategy → uses spawn_cache_exclusive()
+    // 1. `StateRootTask` strategy uses payload_processor.spawn()
+    // 2. `Synchronous` strategy uses spawn_cache_exclusive()
 
     let s1 = include_str!("../../test-data/holesky/1.rlp");
     let data1 = Bytes::from_str(s1).unwrap();
@@ -1572,9 +1559,8 @@ fn test_state_root_strategy_paths() {
 
     // This test passes if multiple StateRootStrategy scenarios work correctly,
     // confirming that passing arguments directly doesn't break:
-    // - `StateRootTask` strategy with empty/non-empty prefix_sets
-    // - Dynamic strategy switching (StateRootTask → Parallel)
-    // - Parallel and Synchronous strategy paths
+    // - `StateRootTask` strategy
+    // - `Synchronous` strategy
     // - All parameter passing through the args struct
 }
 
@@ -1584,7 +1570,7 @@ fn test_state_root_strategy_paths() {
 //
 // This test suite exercises `validate_block_with_state` across different scenarios including:
 // - Basic block validation with state root computation
-// - Strategy selection based on conditions (`StateRootTask`, `Parallel`, `Synchronous`)
+// - Strategy selection based on conditions (`StateRootTask`, `Synchronous`)
 // - Trie update retention and discard logic
 // - Error precedence handling (consensus vs execution errors)
 // - Different validation scenarios (valid, invalid consensus, invalid execution blocks)

--- a/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
@@ -33,9 +33,7 @@ fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
                 .build(),
         ))
         .with_network(NetworkSetup::single_node())
-        .with_tree_config(
-            TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true),
-        )
+        .with_tree_config(TreeConfig::default())
 }
 
 /// This test:

--- a/crates/engine/tree/tests/e2e-testsuite/main.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/main.rs
@@ -36,9 +36,7 @@ fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
                 .build(),
         ))
         .with_network(NetworkSetup::single_node())
-        .with_tree_config(
-            TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true),
-        )
+        .with_tree_config(TreeConfig::default())
 }
 
 /// Creates a v2 storage mode setup for engine tree e2e tests.
@@ -220,11 +218,7 @@ async fn test_engine_tree_buffered_blocks_are_eventually_connected_e2e() -> Resu
                         .build(),
                 ))
                 .with_network(NetworkSetup::multi_node_unconnected(2)) // Need 2 disconnected nodes
-                .with_tree_config(
-                    TreeConfig::default()
-                        .with_legacy_state_root(false)
-                        .with_has_enough_parallelism(true),
-                ),
+                .with_tree_config(TreeConfig::default()),
         )
         // node 0 produces blocks 1 and 2 locally without broadcasting
         .with_action(SelectActiveNode::new(0))
@@ -312,11 +306,7 @@ async fn test_engine_tree_live_sync_transition_eventually_canonical_e2e() -> Res
                         .build(),
                 ))
                 .with_network(NetworkSetup::multi_node(2)) // Two connected nodes
-                .with_tree_config(
-                    TreeConfig::default()
-                        .with_legacy_state_root(false)
-                        .with_has_enough_parallelism(true),
-                ),
+                .with_tree_config(TreeConfig::default()),
         )
         // Both nodes start with the same base chain (1 block)
         .with_action(SelectActiveNode::new(0))
@@ -425,9 +415,7 @@ fn disk_reorg_setup(storage_v2: bool) -> Setup<EthEngineTypes> {
                 .build(),
         ))
         .with_network(NetworkSetup::multi_node_unconnected(2))
-        .with_tree_config(
-            TreeConfig::default().with_legacy_state_root(false).with_has_enough_parallelism(true),
-        );
+        .with_tree_config(TreeConfig::default());
     if storage_v2 {
         setup = setup.with_storage_v2();
     }

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -486,7 +486,6 @@ async fn test_share_sparse_trie_with_payload_builder() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let tree_config = TreeConfig::default()
-        .with_legacy_state_root(false)
         .with_share_execution_cache_with_payload_builder(true)
         .with_share_sparse_trie_with_payload_builder(true);
 
@@ -521,7 +520,7 @@ async fn test_share_sparse_trie_with_payload_builder() -> eyre::Result<()> {
 /// Tests that sparse trie allocation reuse works correctly across consecutive blocks.
 ///
 /// This test exercises the sparse trie allocation reuse path by:
-/// 1. Starting a node with parallel state root computation enabled
+/// 1. Starting a node with the state-root task enabled
 /// 2. Advancing multiple consecutive blocks with random transactions
 /// 3. Verifying that all blocks are successfully validated (state roots match)
 ///
@@ -532,11 +531,9 @@ async fn test_share_sparse_trie_with_payload_builder() -> eyre::Result<()> {
 async fn test_sparse_trie_reuse_across_blocks() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // Use parallel state root (non-legacy) with pruning enabled
-    let tree_config = TreeConfig::default()
-        .with_legacy_state_root(false)
-        .with_sparse_trie_prune_depth(2)
-        .with_sparse_trie_max_hot_slots(100);
+    // Use the state-root task with pruning enabled.
+    let tree_config =
+        TreeConfig::default().with_sparse_trie_prune_depth(2).with_sparse_trie_max_hot_slots(100);
 
     let (mut nodes, _wallet) = setup_engine::<EthereumNode>(
         1,

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -30,7 +30,6 @@ pub struct DefaultEngineValues {
     persistence_backpressure_threshold: u64,
     memory_block_buffer_target: u64,
     invalid_header_hit_eviction_threshold: u8,
-    legacy_state_root_task_enabled: bool,
     state_cache_disabled: bool,
     prewarming_disabled: bool,
     state_provider_metrics: bool,
@@ -91,12 +90,6 @@ impl DefaultEngineValues {
     /// Set the invalid header cache hit eviction threshold
     pub const fn with_invalid_header_hit_eviction_threshold(mut self, v: u8) -> Self {
         self.invalid_header_hit_eviction_threshold = v;
-        self
-    }
-
-    /// Set whether to enable legacy state root task by default
-    pub const fn with_legacy_state_root_task_enabled(mut self, v: bool) -> Self {
-        self.legacy_state_root_task_enabled = v;
         self
     }
 
@@ -267,7 +260,6 @@ impl Default for DefaultEngineValues {
             persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
-            legacy_state_root_task_enabled: false,
             state_cache_disabled: false,
             prewarming_disabled: false,
             state_provider_metrics: false,
@@ -338,8 +330,10 @@ pub struct EngineArgs {
     #[arg(long = "engine.invalid-header-cache-hit-eviction-threshold", default_value_t = DefaultEngineValues::get_global().invalid_header_hit_eviction_threshold)]
     pub invalid_header_hit_eviction_threshold: u8,
 
-    /// Enable legacy state root
-    #[arg(long = "engine.legacy-state-root", default_value_t = DefaultEngineValues::get_global().legacy_state_root_task_enabled)]
+    /// CAUTION: This CLI flag has no effect anymore, use --engine.state-root-fallback if you
+    /// want to force synchronous state root computation
+    #[arg(long = "engine.legacy-state-root", default_value_t = false, hide = true)]
+    #[deprecated]
     pub legacy_state_root_task_enabled: bool,
 
     /// CAUTION: This CLI flag has no effect anymore, use --engine.disable-caching-and-prewarming
@@ -559,7 +553,6 @@ impl Default for EngineArgs {
             persistence_backpressure_threshold: _,
             memory_block_buffer_target,
             invalid_header_hit_eviction_threshold,
-            legacy_state_root_task_enabled,
             state_cache_disabled,
             prewarming_disabled,
             state_provider_metrics,
@@ -592,8 +585,8 @@ impl Default for EngineArgs {
             persistence_backpressure_threshold: None,
             memory_block_buffer_target,
             invalid_header_hit_eviction_threshold,
-            legacy_state_root_task_enabled,
             state_root_task_compare_updates,
+            legacy_state_root_task_enabled: false,
             caching_and_prewarming_enabled: true,
             state_cache_disabled,
             prewarming_disabled,
@@ -658,12 +651,15 @@ impl EngineArgs {
 
     /// Creates a [`TreeConfig`] from the engine arguments.
     pub fn tree_config(&self) -> TreeConfig {
+        #[allow(deprecated)]
+        if self.legacy_state_root_task_enabled {
+            tracing::warn!(target: "reth::cli", "--engine.legacy-state-root has no effect anymore, use --engine.state-root-fallback to force synchronous state root computation");
+        }
         let config = TreeConfig::default()
             .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold())
             .with_persistence_threshold(self.persistence_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
             .with_invalid_header_hit_eviction_threshold(self.invalid_header_hit_eviction_threshold)
-            .with_legacy_state_root(self.legacy_state_root_task_enabled)
             .without_state_cache(self.state_cache_disabled)
             .without_prewarming(self.prewarming_disabled)
             .with_state_provider_metrics(self.state_provider_metrics)

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -998,9 +998,6 @@ Engine:
 
           [default: 128]
 
-      --engine.legacy-state-root
-          Enable legacy state root
-
       --engine.disable-state-cache
           Disable state cache
 


### PR DESCRIPTION
The sparse trie task has been around for a while and the legacy parallel state root can go now.

This PR removes it hiding the flag --engine.legacy-state-root and printing a warning in case it was passed. The serial fallback still remains.

This PR leaves removing the actual Parallel machinery for a follow-up.

This also removes has_enough_parallelism, which was only used in this path. It doesn't appear it would actually lead to a problem on low-core device.