### PR TITLE
chore(deps): sync dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  cooldown:
-    default-days: 7
-- package-ecosystem: "cargo"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  cooldown:
-    default-days: 7
-  labels:
-    - "A-dependencies"
-  commit-message:
-    prefix: "chore(deps)"
-  open-pull-requests-limit: 1
-  groups:
-    cargo-weekly:
-      applies-to: "version-updates"
-      patterns: ["*"]
-      update-types: ["minor", "patch"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    cooldown:
+      default-days: 7
+    groups:
+      ci-weekly:
+        patterns:
+          - '*'
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      cargo-weekly:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,13 @@ updates:
       timezone: UTC
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
+    labels:
+      - "A-dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 1
     groups:
       cargo-weekly:
-        patterns:
-          - '*'
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Syncs Reth's Dependabot schedule with Foundry by using the same Monday 09:00 UTC cadence and GitHub Actions weekly group. Keeps the existing Reth Cargo labels, commit prefix, open PR limit, and minor/patch grouping.
