### PR TITLE
fix(txpool): skip EIP-7702 authorities from non-applicable authorizations

### DIFF
--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -685,7 +685,7 @@ where
             return TransactionValidationOutcome::Invalid(transaction, err)
         }
 
-        let authorities = self.recover_authorities(&transaction);
+        let authorities = self.recover_authorities(&transaction, &state);
         // Return the valid transaction
         TransactionValidationOutcome::Valid {
             balance: account.balance,
@@ -845,11 +845,63 @@ where
         Ok(maybe_blob_sidecar)
     }
 
-    /// Returns the recovered authorities for the given transaction
-    fn recover_authorities(&self, transaction: &Tx) -> std::option::Option<Vec<Address>> {
-        transaction
-            .authorization_list()
-            .map(|auths| auths.iter().flat_map(|auth| auth.recover_authority()).collect::<Vec<_>>())
+    /// Returns the recovered authorities of the given transaction whose authorization could
+    /// plausibly take effect, i.e. actually delegate the authority's account.
+    ///
+    /// An EIP-7702 authorization only delegates an account when it is applied at execution, which
+    /// requires its `chain_id` to be `0` or this chain's id and its `nonce` to equal the
+    /// authority's account nonce. An authorization that can never apply is a guaranteed no-op and
+    /// must not cause its authority to be tracked as (pending-)delegated. Otherwise anyone could
+    /// harvest a public, now-stale authorization a victim once signed and replay it in a cheap
+    /// transaction to register the victim as delegated, throttling the victim's own ordinary
+    /// transactions to the in-flight delegation slot limit even though nothing about the victim
+    /// changed on chain (see `TxPool::check_delegation_limit`).
+    ///
+    /// Only authorizations that are not provably no-ops are kept:
+    /// * a `chain_id` that is neither `0` nor this chain's id can never be applied here, and
+    /// * a nonce the authority has already advanced past on chain (`auth.nonce < account.nonce`)
+    ///   can never match the authority's account nonce again.
+    ///
+    /// Current and future authorization nonces are retained so genuinely pending delegations stay
+    /// protected, including self-sponsored ones whose authorization nonce is the sender's account
+    /// nonce plus one. If the authority's account cannot be read, the authorization is kept, so a
+    /// transient state error never silently drops the throttle.
+    fn recover_authorities<P>(
+        &self,
+        transaction: &Tx,
+        state: &P,
+    ) -> std::option::Option<Vec<Address>>
+    where
+        P: AccountInfoReader,
+    {
+        let chain_id = U256::from(self.chain_id());
+        transaction.authorization_list().map(|auths| {
+            auths
+                .iter()
+                .filter_map(|auth| {
+                    let authority = auth.recover_authority().ok()?;
+
+                    // An authorization for another chain can never be applied on this chain.
+                    if auth.chain_id != U256::ZERO && auth.chain_id != chain_id {
+                        return None
+                    }
+
+                    // An authorization whose nonce the authority has already surpassed on chain
+                    // can never match the account nonce again, so it is a guaranteed no-op.
+                    let account_nonce = state
+                        .basic_account(&authority)
+                        .ok()
+                        .flatten()
+                        .map(|account| account.nonce)
+                        .unwrap_or_default();
+                    if auth.nonce < account_nonce {
+                        return None
+                    }
+
+                    Some(authority)
+                })
+                .collect::<Vec<_>>()
+        })
     }
 
     /// Validates all given transactions.
@@ -1943,5 +1995,91 @@ mod tests {
 
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         assert!(outcome.is_valid()); // Should be valid because balance check is disabled
+    }
+
+    /// Regression test for the EIP-7702 mempool authority-throttle griefing vector
+    /// (<https://github.com/paradigmxyz/reth/issues/25909>).
+    ///
+    /// The pool throttles the in-flight transactions of any account it tracks as a
+    /// (pending-)delegated authority. Authorities used to be recovered from every authorization
+    /// regardless of whether it could ever be applied, so an attacker could replay a public,
+    /// now-stale authorization a victim once signed and register the victim as delegated,
+    /// throttling the victim's own ordinary transactions. Authorities whose authorization is a
+    /// guaranteed execution no-op (wrong chain id, or a nonce the authority has already advanced
+    /// past on chain) must therefore not be tracked.
+    #[test]
+    fn recover_authorities_skips_non_applicable_authorizations() {
+        use alloy_consensus::{EthereumTxEnvelope, SignableTransaction, TxEip4844, TxEip7702};
+        use alloy_eips::eip7702::Authorization;
+        use alloy_primitives::{Address, Signature};
+        use reth_primitives_traits::Recovered;
+        use reth_storage_api::StateProviderFactory;
+
+        let provider = MockEthProvider::default().with_genesis_block();
+        let validator = EthTransactionValidatorBuilder::new(provider.clone(), test_evm_config())
+            .build(InMemoryBlobStore::default());
+        let chain_id = validator.chain_id();
+
+        // A fixed signature makes each authorization recover to a deterministic authority whose
+        // value depends only on the signed fields (chain id, address, nonce), so distinct
+        // authorizations recover to distinct authorities.
+        let signed = |chain: u64, nonce: u64| {
+            Authorization { chain_id: U256::from(chain), address: Address::ZERO, nonce }
+                .into_signed(Signature::test_signature())
+        };
+
+        // Guaranteed no-op: the authority has advanced its account nonce past the replayed nonce.
+        let stale = signed(chain_id, 2);
+        // Applies now: the authorization nonce equals the authority's account nonce.
+        let current = signed(chain_id, 9);
+        // Applies later: a higher nonce, as produced by a self-sponsored delegation.
+        let future = signed(chain_id, 12);
+        // Guaranteed no-op: the authorization targets a different chain.
+        let wrong_chain = signed(chain_id + 1, 0);
+
+        let stale_authority = stale.recover_authority().unwrap();
+        let current_authority = current.recover_authority().unwrap();
+        let future_authority = future.recover_authority().unwrap();
+        let wrong_chain_authority = wrong_chain.recover_authority().unwrap();
+
+        // Sanity: the four authorities are distinct, so the assertions below are unambiguous.
+        let distinct =
+            [stale_authority, current_authority, future_authority, wrong_chain_authority]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>();
+        assert_eq!(distinct.len(), 4);
+
+        provider.add_account(stale_authority, ExtendedAccount::new(5, U256::MAX));
+        provider.add_account(current_authority, ExtendedAccount::new(9, U256::MAX));
+        provider.add_account(future_authority, ExtendedAccount::new(9, U256::MAX));
+
+        let tx = EthereumTxEnvelope::<TxEip4844>::Eip7702(
+            TxEip7702 {
+                chain_id,
+                gas_limit: 1000,
+                max_fee_per_gas: 10,
+                authorization_list: vec![
+                    stale.clone(),
+                    current.clone(),
+                    future.clone(),
+                    wrong_chain.clone(),
+                ],
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature()),
+        );
+        let tx = EthPooledTransaction::new(Recovered::new_unchecked(tx, Address::ZERO), 200);
+
+        let state = provider.latest().unwrap();
+        let authorities = validator.recover_authorities(&tx, &state).unwrap();
+
+        // Applicable authorizations are tracked ...
+        assert!(authorities.contains(&current_authority));
+        assert!(authorities.contains(&future_authority));
+        // ... while guaranteed no-ops are not, so a replayed authorization can no longer be used
+        // to register and throttle an arbitrary victim.
+        assert!(!authorities.contains(&stale_authority));
+        assert!(!authorities.contains(&wrong_chain_authority));
+        assert_eq!(authorities.len(), 2);
     }
 }


### PR DESCRIPTION
## Problem

Fixes #25909.

`EthTransactionValidator` recovers an authority from **every** EIP-7702 authorization carried by a
type-4 transaction and hands it to the pool, which tracks that authority in
`AllTransactions::auths` and throttles the authority's *own* ordinary transactions to
`max_inflight_delegated_slot_limit` (default 1) via `TxPool::check_delegation_limit`.

Recovery only did ECDSA recovery, with no check that the authorization could ever be applied.
Because authorizations are public (they travel in type-4 txs through the mempool and on-chain), an
attacker can harvest any authorization a victim ever signed and replay it inside a cheap,
perpetually-queued type-4 transaction.  The victim is registered as delegated and their own legacy /
1559 / etc. transactions are throttled network-wide, even though the replayed authorization is a
guaranteed execution no-op (stale nonce, or a mismatched chain id) and nothing about the victim
changed on chain.

## Fix

Gate authority recovery on execution-plausibility in `recover_authorities`, using the state already
available in `validate_stateful`.  An authority is dropped when its authorization is a guaranteed
no-op:

- **wrong chain**: `chain_id` is neither `0` nor this chain's id (stateless), or
- **surpassed nonce**: `auth.nonce < authority.account.nonce` . . . the account has already advanced
  past the authorization nonce, so the exact-match required at execution can never hold again.

Current and future authorization nonces are **kept**, so genuinely pending delegations remain
protected. This deliberately drops only *strictly stale* nonces (`<`) rather than requiring exact
equality (`==`): a self-sponsored delegation (an EOA delegating itself, the common 7702 pattern)
has `auth.nonce == sender.account.nonce + 1` at execution, because the sender's nonce is
incremented before authorizations are processed, so its committed nonce at pool-validation time is
one below the authorization nonce.  An exact-equality gate would therefore wrongly stop tracking
self-sponsored delegations.  If the authority's account cannot be read, the authorization is kept,
so a transient state error never silently drops the throttle.

## Test

`recover_authorities_skips_non_applicable_authorizations` builds a type-4 tx carrying four
authorizations (stale / current / future / wrong-chain), configures each recovered authority's
on-chain nonce in a mock provider, and asserts only the current and future authorizations are
tracked.

## Scope and a known residual

This closes the reported vector completely: harvesting *any historical* authorization a victim ever
signed (a guaranteed no-op) can no longer register the victim as delegated.

What remains, by design, is that a *currently-applicable or future* authorization
(`auth.nonce >= account.nonce`) is still tracked. That is intentional: such an account is genuinely
about to be delegatable, so throttling it matches the mechanism's purpose, and keeping future
nonces is what preserves self-sponsored delegations.  The tracking also self-heals: a stale queued
attacker tx is evicted at `max_tx_lifetime`, and a replacement re-runs recovery and drops the
now-stale authority via `remove_auths`.

A deeper hardening (out of scope here, larger change): prune an `auths` entry during
`on_canonical_state_change` once the authority's on-chain nonce advances past its tracked
authorization nonce, which would require storing `auth.nonce` alongside the tx hash in the `auths`
map (today only a tx-hash set is kept).  I'd be happy to follow up separately if maintainers prefer that.
