### PR TITLE
fix(engine): restore state root task parallelism gate

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -70,6 +70,23 @@ const fn default_cross_block_cache_size() -> usize {
     }
 }
 
+/// Determines if the host has enough parallelism to run the payload processor.
+///
+/// It requires at least 5 parallel threads:
+/// - Engine in main thread that spawns the state root task.
+/// - Multiproof task in payload processor
+/// - Sparse Trie task in payload processor
+/// - Multiproof computation spawned in payload processor
+/// - Storage root computation spawned in trie parallel proof
+pub fn has_enough_parallelism() -> bool {
+    #[cfg(feature = "std")]
+    {
+        std::thread::available_parallelism().is_ok_and(|num| num.get() >= 5)
+    }
+    #[cfg(not(feature = "std"))]
+    false
+}
+
 /// The configuration of the engine tree.
 #[derive(Debug, Clone)]
 pub struct TreeConfig {
@@ -109,6 +126,16 @@ pub struct TreeConfig {
     state_provider_metrics: bool,
     /// Cross-block cache size in bytes.
     cross_block_cache_size: usize,
+    /// Whether the host has enough parallelism to run the state root task, see
+    /// [`has_enough_parallelism`].
+    ///
+    /// The state root task pipeline occupies at least 5 threads that block on each other (engine
+    /// main thread, multiproof task, sparse trie task, multiproof computation, storage root
+    /// computation). On hosts with fewer parallel threads these components can starve each other
+    /// and stall payload validation entirely, so state-root strategy selection
+    /// ([`Self::use_state_root_task`]) must keep falling back to synchronous state root
+    /// computation when this is `false`.
+    has_enough_parallelism: bool,
     /// Multiproof task chunk size for proof targets.
     multiproof_chunk_size: usize,
     /// Number of reserved CPU cores for non-reth processes
@@ -203,6 +230,7 @@ impl Default for TreeConfig {
             disable_prewarming: false,
             state_provider_metrics: false,
             cross_block_cache_size: DEFAULT_CROSS_BLOCK_CACHE_SIZE,
+            has_enough_parallelism: has_enough_parallelism(),
             multiproof_chunk_size: DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
             reserved_cpu_cores: DEFAULT_RESERVED_CPU_CORES,
             precompile_cache_disabled: false,
@@ -245,6 +273,7 @@ impl TreeConfig {
         disable_prewarming: bool,
         state_provider_metrics: bool,
         cross_block_cache_size: usize,
+        has_enough_parallelism: bool,
         multiproof_chunk_size: usize,
         reserved_cpu_cores: usize,
         precompile_cache_disabled: bool,
@@ -277,6 +306,7 @@ impl TreeConfig {
             disable_prewarming,
             state_provider_metrics,
             cross_block_cache_size,
+            has_enough_parallelism,
             multiproof_chunk_size,
             reserved_cpu_cores,
             precompile_cache_disabled,
@@ -503,6 +533,20 @@ impl TreeConfig {
     pub const fn with_cross_block_cache_size(mut self, cross_block_cache_size: usize) -> Self {
         self.cross_block_cache_size = cross_block_cache_size;
         self
+    }
+
+    /// Setter for has enough parallelism.
+    pub const fn with_has_enough_parallelism(mut self, has_enough_parallelism: bool) -> Self {
+        self.has_enough_parallelism = has_enough_parallelism;
+        self
+    }
+
+    /// Whether or not to use the state root task.
+    ///
+    /// The state root task requires at least 5 parallel threads, see
+    /// [`has_enough_parallelism`].
+    pub const fn use_state_root_task(&self) -> bool {
+        self.has_enough_parallelism
     }
 
     /// Setter for state provider metrics.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2150,7 +2150,10 @@ where
 
     /// Builds sparse trie retained paths from all blocks still present in the in-memory tree.
     fn sparse_trie_retained_paths_for_in_memory_blocks(&self) -> Option<SparseTrieRetainedPaths> {
-        if self.config.skip_state_root() || self.config.state_root_fallback() {
+        if self.config.skip_state_root() ||
+            self.config.state_root_fallback() ||
+            !self.config.use_state_root_task()
+        {
             return None
         }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1790,13 +1790,15 @@ where
     /// Determines the state root computation strategy based on configuration.
     ///
     /// The sparse trie state-root task is the default computed-root path. `state_root_fallback`
-    /// forces serial computation for tests and debugging.
+    /// forces serial computation for tests and debugging, and hosts without enough parallelism
+    /// for the state-root task pipeline also compute the root synchronously, see
+    /// [`TreeConfig::use_state_root_task`].
     fn plan_state_root_computation(&self) -> StateRootStrategy<N> {
         if self.config.skip_state_root() {
             StateRootStrategy::Skipped
         } else if let Some(custom_state_root) = &self.custom_state_root {
             StateRootStrategy::Custom(custom_state_root.clone())
-        } else if self.config.state_root_fallback() {
+        } else if self.config.state_root_fallback() || !self.config.use_state_root_task() {
             StateRootStrategy::Synchronous
         } else {
             StateRootStrategy::StateRootTask

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -193,7 +193,7 @@ impl TestHarness {
         let payload_validator = MockEngineValidator;
 
         let (from_tree_tx, from_tree_rx) = unbounded_channel();
-        let tree_config = TreeConfig::default();
+        let tree_config = TreeConfig::default().with_has_enough_parallelism(true);
         let runtime = reth_tasks::Runtime::test();
         let state_trie_overlays =
             StateTrieOverlayManager::new(runtime.state_trie_overlay_worker_pool());
@@ -619,8 +619,9 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled(
     let blocks: Vec<_> =
         TestBlockBuilder::eth().get_executed_blocks(1..4).map(with_known_changed_paths).collect();
     let configs = [
-        TreeConfig::default().with_state_root_fallback(true),
-        TreeConfig::default().with_skip_state_root(true),
+        TreeConfig::default().with_has_enough_parallelism(false),
+        TreeConfig::default().with_has_enough_parallelism(true).with_state_root_fallback(true),
+        TreeConfig::default().with_has_enough_parallelism(true).with_skip_state_root(true),
     ];
 
     for config in configs {

--- a/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
@@ -33,7 +33,7 @@ fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
                 .build(),
         ))
         .with_network(NetworkSetup::single_node())
-        .with_tree_config(TreeConfig::default())
+        .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true))
 }
 
 /// This test:

--- a/crates/engine/tree/tests/e2e-testsuite/main.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/main.rs
@@ -36,7 +36,7 @@ fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
                 .build(),
         ))
         .with_network(NetworkSetup::single_node())
-        .with_tree_config(TreeConfig::default())
+        .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true))
 }
 
 /// Creates a v2 storage mode setup for engine tree e2e tests.
@@ -218,7 +218,7 @@ async fn test_engine_tree_buffered_blocks_are_eventually_connected_e2e() -> Resu
                         .build(),
                 ))
                 .with_network(NetworkSetup::multi_node_unconnected(2)) // Need 2 disconnected nodes
-                .with_tree_config(TreeConfig::default()),
+                .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true)),
         )
         // node 0 produces blocks 1 and 2 locally without broadcasting
         .with_action(SelectActiveNode::new(0))
@@ -306,7 +306,7 @@ async fn test_engine_tree_live_sync_transition_eventually_canonical_e2e() -> Res
                         .build(),
                 ))
                 .with_network(NetworkSetup::multi_node(2)) // Two connected nodes
-                .with_tree_config(TreeConfig::default()),
+                .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true)),
         )
         // Both nodes start with the same base chain (1 block)
         .with_action(SelectActiveNode::new(0))
@@ -415,7 +415,7 @@ fn disk_reorg_setup(storage_v2: bool) -> Setup<EthEngineTypes> {
                 .build(),
         ))
         .with_network(NetworkSetup::multi_node_unconnected(2))
-        .with_tree_config(TreeConfig::default());
+        .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true));
     if storage_v2 {
         setup = setup.with_storage_v2();
     }


### PR DESCRIPTION
#26069 removed `has_enough_parallelism()` and made `StateRootTask` the unconditional computed-root strategy. The state root task pipeline occupies at least 5 threads that block on each other, so on low-parallelism hosts concurrent payload validations deadlock on the shared singleton worker threads (`sparse-trie`, `hash-post-state`, proof workers) and payload validation stalls indefinitely.

This hangs `reth-node-ethereum::e2e p2p::test_tx_propagation` deterministically on the 4-vCPU integration runner: every `test / ethereum` job since 48e567c25c times out at 300s on all retries (first failing main run: https://github.com/paradigmxyz/reth/actions/runs/28603873661). The deadlock also reproduces intermittently on 48e567c25c on a 12-core machine, with stack samples showing the circular wait between validations holding one singleton thread while blocking on another.

This restores the parallelism gate, planning `StateRootStrategy::Synchronous` instead of the removed `Parallel` strategy when the host has fewer than 5 parallel threads, and documents the requirement on the `TreeConfig` field so the gate is not removed again. The underlying cross-validation deadlock in the state root task pipeline exists independently of core count and should be addressed separately.