### PR TITLE
fix(prune): derive receipts static file size from prune distance

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -73,14 +73,14 @@ use reth_provider::{
     ProviderFactory, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
     StaticFileProviderBuilder, StaticFileProviderFactory, StorageSettingsCache,
 };
-use reth_prune::{PruneModes, PrunerBuilder};
+use reth_prune::{PruneMode, PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
 use reth_rpc_layer::JwtSecret;
 use reth_stages::{
     sets::DefaultStages, stages::EraImportSource, MetricEvent, PipelineBuilder, PipelineTarget,
     StageId, StageSet,
 };
-use reth_static_file::StaticFileProducer;
+use reth_static_file::{blocks_per_file_for_prune_distance, StaticFileProducer, StaticFileSegment};
 use reth_tasks::TaskExecutor;
 use reth_tracing::{
     throttle,
@@ -487,11 +487,25 @@ where
         let static_files_config = &self.toml_config().static_files;
         static_files_config.validate()?;
 
+        let prune_config = self.prune_config();
+
+        let mut blocks_per_file = static_files_config.as_blocks_per_file_map();
+        // Receipts in static files are pruned by deleting whole files, so with the default file
+        // size a distance-based prune target is only reached every 500k blocks. Unless a file size
+        // is explicitly configured, derive one from the prune distance so retention tracks the
+        // configured distance.
+        if blocks_per_file.get(StaticFileSegment::Receipts).is_none() &&
+            let Some(PruneMode::Distance(distance)) = prune_config.segments.receipts
+        {
+            blocks_per_file
+                .insert(StaticFileSegment::Receipts, blocks_per_file_for_prune_distance(distance));
+        }
+
         // Apply per-segment blocks_per_file configuration
         let static_file_provider =
             StaticFileProviderBuilder::read_write(self.data_dir().static_files())
                 .with_metrics()
-                .with_blocks_per_file_for_segments(&static_files_config.as_blocks_per_file_map())
+                .with_blocks_per_file_for_segments(&blocks_per_file)
                 .with_genesis_block_number(self.chain_spec().genesis().number.unwrap_or_default())
                 .build()?;
 
@@ -506,7 +520,6 @@ where
                 .build()?
         };
 
-        let prune_config = self.prune_config();
         let balstore_cache_size = self
             .node_config()
             .db

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -97,6 +97,26 @@ pub const fn find_fixed_range(
     SegmentRangeInclusive::new(start, start + blocks_per_static_file - 1)
 }
 
+/// Derives the number of blocks per static file for a segment that is pruned with a distance
+/// prune mode.
+///
+/// Static file segments are pruned by deleting whole files, so the file size bounds how much
+/// data is retained beyond the configured distance: a file only becomes deletable once the
+/// prune target has moved past its end. A quarter of the distance keeps the worst-case
+/// retention overshoot at ~25% while only a handful of files are live at any time. The result
+/// is clamped to avoid excessive file churn for small distances and is never larger than
+/// [`DEFAULT_BLOCKS_PER_STATIC_FILE`].
+pub const fn blocks_per_file_for_prune_distance(distance: u64) -> u64 {
+    let blocks = distance / 4;
+    if blocks < 1_000 {
+        1_000
+    } else if blocks > DEFAULT_BLOCKS_PER_STATIC_FILE {
+        DEFAULT_BLOCKS_PER_STATIC_FILE
+    } else {
+        blocks
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #24591

On storage v2 receipts live in static files and distance pruning deletes whole files, so with the default 500k blocks per file a file only becomes deletable once the prune target has moved past its end. In practice `--prune.receipts.distance` appears to do nothing and up to ~500k + distance blocks of receipts are retained (this also affects `--full`, which uses `Distance(10064)`).

Unless `blocks_per_file.receipts` is explicitly configured (CLI, toml, or `--minimal`), receipt files are now sized at a quarter of the configured distance, clamped to [1k, 500k], so on-disk retention tracks the configured distance with at most ~25% overshoot. Same idea as `--minimal`'s 10k blocks per file.

Note for existing nodes: the current in-progress receipts file is finished with the old size, so the smaller files (and effective pruning) kick in once it completes.