### PR TITLE
fix: pass lazy hashedpoststate arg type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8372,6 +8372,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-tasks",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.18",

--- a/crates/engine/primitives/Cargo.toml
+++ b/crates/engine/primitives/Cargo.toml
@@ -21,6 +21,7 @@ reth-ethereum-primitives.workspace = true
 reth-chain-state.workspace = true
 reth-errors.workspace = true
 reth-trie-common.workspace = true
+reth-tasks.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -217,7 +217,7 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     }
 
     /// Verifies payload post-execution w.r.t. hashed state updates.
-    fn validate_block_post_execution_with_hashed_state<'a>(
+    fn validate_block_post_execution_with_hashed_state(
         &self,
         _state_updates: &LazyHashedPostState,
         _block: &RecoveredBlock<Self::Block>,

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -20,6 +20,7 @@ use reth_payload_primitives::{
 use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
 use reth_trie_common::HashedPostState;
 use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
 
 // Re-export [`ExecutionPayload`] moved to `reth_payload_primitives`
 #[cfg(feature = "std")]
@@ -45,6 +46,9 @@ pub use invalid_block_hook::{InvalidBlockHook, InvalidBlockHooks, NoopInvalidBlo
 
 pub mod config;
 pub use config::*;
+
+/// Handle to a [`HashedPostState`] computed on a background thread.
+pub type LazyHashedPostState = reth_tasks::LazyHandle<Arc<HashedPostState>>;
 
 /// This type defines the versioned types of the engine API based on the [ethereum engine API](https://github.com/ethereum/execution-apis/tree/main/src/engine).
 ///
@@ -215,7 +219,7 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     /// Verifies payload post-execution w.r.t. hashed state updates.
     fn validate_block_post_execution_with_hashed_state<'a>(
         &self,
-        _state_updates: &dyn FnOnce() -> &'a HashedPostState,
+        _state_updates: &LazyHashedPostState,
         _block: &RecoveredBlock<Self::Block>,
     ) -> Result<(), ConsensusError> {
         // method not used by l1

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -149,7 +149,7 @@ use reth_provider::{
     StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
-use reth_trie::{updates::TrieUpdates, HashedPostState};
+use reth_trie::updates::TrieUpdates;
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::{Address, KECCAK_EMPTY};
@@ -870,11 +870,9 @@ where
                     hashed_state = maybe_new_hashed_state.unwrap_or_else(|| {
                         LazyHandle::ready(Arc::new(self.provider.hashed_post_state(&output.state)))
                     });
-                    hashed_state_validate_result =
-                        self.validator.validate_block_post_execution_with_hashed_state(
-                            &|| hashed_state.get(),
-                            &block,
-                        );
+                    hashed_state_validate_result = self
+                        .validator
+                        .validate_block_post_execution_with_hashed_state(&hashed_state, &block);
                 }
             }
             StateRootStrategy::Parallel => {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -124,7 +124,8 @@ use reth_chain_state::{
 };
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
-    ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
+    ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook,
+    LazyHashedPostState, PayloadValidator,
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
@@ -164,9 +165,6 @@ use std::{
 use tracing::{debug, debug_span, error, info, instrument, trace, warn, Level, Span};
 
 pub use crate::tree::types::ValidationOutcome;
-
-/// Handle to a [`HashedPostState`] computed on a background thread.
-type LazyHashedPostState = reth_tasks::LazyHandle<Arc<HashedPostState>>;
 
 /// Multiplier over the parent's gas limit beyond which a block's claimed gas usage cannot be
 /// legitimate. Gas limit can change by at most 1/1024 per block, so anything over this is rejected
@@ -767,8 +765,7 @@ where
             "validate_block_post_execution_with_hashed_state"
         )
         .in_scope(|| {
-            self.validator
-                .validate_block_post_execution_with_hashed_state(&|| hashed_state.get(), &block)
+            self.validator.validate_block_post_execution_with_hashed_state(&hashed_state, &block)
         });
 
         let root_time = Instant::now();


### PR DESCRIPTION
## Description

`&dyn FnOnce() -> &'a HashedPostState` is not actually callable in the validator function.