### PR TITLE
fix(txpool): account for access list in blob tx size limit

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1427,6 +1427,22 @@ pub trait PoolTransaction:
     /// Note: Implementations should cache this value.
     fn encoded_length(&self) -> usize;
 
+    /// Returns the length of the rlp encoded transaction object, excluding any blob sidecar.
+    ///
+    /// For every transaction except EIP-4844 blob transactions this equals
+    /// [`encoded_length`](Self::encoded_length). Blob transactions ingested from the network or
+    /// RPC cache the *pooled* encoding in [`encoded_length`](Self::encoded_length), which includes
+    /// the blob sidecar. The sidecar is not held in memory (it is cached separately), so pool size
+    /// limits must be measured against the sidecar-free (consensus) encoding, which still accounts
+    /// for the access list, blob versioned hashes, `to`, `value`, etc. that `input().len()` alone
+    /// would miss.
+    ///
+    /// The default returns [`encoded_length`](Self::encoded_length); sidecar-bearing
+    /// implementations override this to exclude the sidecar.
+    fn encoded_length_without_sidecar(&self) -> usize {
+        self.encoded_length()
+    }
+
     /// Ensures that the transaction's code size does not exceed the provided `max_init_code_size`.
     ///
     /// This is specifically relevant for contract creation transactions ([`TxKind::Create`]),
@@ -1620,6 +1636,20 @@ impl PoolTransaction for EthPooledTransaction {
     /// Returns the length of the rlp encoded object
     fn encoded_length(&self) -> usize {
         self.encoded_length
+    }
+
+    /// Returns the length of the rlp encoded object, excluding the blob sidecar.
+    fn encoded_length_without_sidecar(&self) -> usize {
+        // `self.transaction` always holds the consensus (sidecar-free) representation, even for
+        // blob transactions whose sidecar is split out into `blob_sidecar`. The cached
+        // `encoded_length` is the pooled encoding, so for a blob tx it includes the sidecar;
+        // recompute the consensus length in that case. Every other tx already caches a
+        // sidecar-free length.
+        if self.transaction.is_eip4844() {
+            self.transaction.encode_2718_len()
+        } else {
+            self.encoded_length
+        }
     }
 }
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -228,6 +228,10 @@ impl<Client, Tx, Evm> EthTransactionValidator<Client, Tx, Evm> {
 
     /// Returns the maximum size in bytes a single transaction can have in order to be accepted into
     /// the pool.
+    ///
+    /// Despite the `input_bytes` name this bounds the whole sidecar-free (consensus) encoded
+    /// length of a transaction, not just its `input` field. For blob transactions the blob sidecar
+    /// is excluded, since it is cached separately rather than kept in memory.
     pub const fn max_tx_input_bytes(&self) -> usize {
         self.max_tx_input_bytes
     }
@@ -482,28 +486,20 @@ where
             return Err(InvalidPoolTransactionError::Eip2681)
         }
 
-        // Reject transactions over defined size to prevent DOS attacks
-        if transaction.is_eip4844() {
-            // Since blob transactions are pulled instead of pushed, and only the consensus data is
-            // kept in memory while the sidecar is cached on disk, there is no critical limit that
-            // should be enforced. Still, enforcing some cap on the input bytes. blob txs also must
-            // be executable right away when they enter the pool.
-            let tx_input_len = transaction.input().len();
-            if tx_input_len > self.max_tx_input_bytes {
-                return Err(InvalidPoolTransactionError::OversizedData {
-                    size: tx_input_len,
-                    limit: self.max_tx_input_bytes,
-                })
-            }
-        } else {
-            // ensure the size of the non-blob transaction
-            let tx_size = transaction.encoded_length();
-            if tx_size > self.max_tx_input_bytes {
-                return Err(InvalidPoolTransactionError::OversizedData {
-                    size: tx_size,
-                    limit: self.max_tx_input_bytes,
-                })
-            }
+        // Reject transactions over the defined size to prevent DOS attacks.
+        //
+        // Blob transactions are pulled rather than pushed, and only their consensus data is kept
+        // in memory while the sidecar is cached separately, so the cap is enforced against the
+        // sidecar-free encoding via `encoded_length_without_sidecar`. Measuring the full consensus
+        // encoding (rather than just `input()`) counts the access list, blob versioned hashes,
+        // etc., closing a griefing vector where a tiny input paired with a large access list would
+        // otherwise slip past the cap. For non-blob transactions this equals `encoded_length`.
+        let tx_size = transaction.encoded_length_without_sidecar();
+        if tx_size > self.max_tx_input_bytes {
+            return Err(InvalidPoolTransactionError::OversizedData {
+                size: tx_size,
+                limit: self.max_tx_input_bytes,
+            })
         }
 
         // Check whether the init code size has been exceeded.
@@ -1257,7 +1253,10 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
         self
     }
 
-    /// Sets a max size in bytes of a single transaction allowed into the pool
+    /// Sets a max size in bytes of a single transaction allowed into the pool.
+    ///
+    /// This bounds the sidecar-free (consensus) encoded length of a transaction, not just its
+    /// `input` field; for blob transactions the blob sidecar is excluded.
     pub const fn with_max_tx_input_bytes(mut self, max_tx_input_bytes: usize) -> Self {
         self.max_tx_input_bytes = max_tx_input_bytes;
         self
@@ -1480,12 +1479,15 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
 mod tests {
     use super::*;
     use crate::{
-        blobstore::InMemoryBlobStore, error::PoolErrorKind, traits::PoolTransaction,
-        CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionPool,
+        blobstore::InMemoryBlobStore, error::PoolErrorKind, test_utils::TransactionBuilder,
+        traits::PoolTransaction, CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionPool,
     };
     use alloy_consensus::Transaction;
-    use alloy_eips::eip2718::Decodable2718;
-    use alloy_primitives::{hex, U256};
+    use alloy_eips::{
+        eip2718::{Decodable2718, Encodable2718},
+        eip2930::{AccessList, AccessListItem},
+    };
+    use alloy_primitives::{hex, Address, B256, U256};
     use reth_ethereum_primitives::PooledTransactionVariant;
     use reth_evm_ethereum::EthEvmConfig;
     use reth_primitives_traits::SignedTransaction;
@@ -1906,6 +1908,46 @@ mod tests {
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         let invalid = outcome.as_invalid().unwrap();
         assert!(invalid.is_oversized());
+    }
+
+    #[test]
+    fn blob_tx_size_limit_accounts_for_access_list() {
+        let max_tx_input_bytes = 512;
+        let provider = MockEthProvider::default().with_genesis_block();
+        let validator = EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .with_max_tx_input_bytes(max_tx_input_bytes)
+            .build(InMemoryBlobStore::default());
+
+        let blob_tx_with_access_list = |storage_keys: usize| {
+            let access_list = AccessList(vec![AccessListItem {
+                address: Address::random(),
+                storage_keys: (0..storage_keys).map(|_| B256::random()).collect(),
+            }]);
+            let tx = TransactionBuilder::default()
+                .access_list(access_list)
+                .into_eip4844()
+                .try_into_recovered()
+                .unwrap();
+            let encoded_length = tx.encode_2718_len();
+            EthPooledTransaction::new(tx, encoded_length)
+        };
+
+        let is_oversized = |tx: &EthPooledTransaction| {
+            matches!(
+                validator.validate_stateless(TransactionOrigin::External, tx),
+                Err(InvalidPoolTransactionError::OversizedData { .. })
+            )
+        };
+
+        // A small access list keeps the consensus encoding under the cap.
+        let small = blob_tx_with_access_list(1);
+        assert!(!is_oversized(&small));
+
+        // A large access list pushes the consensus encoding far over the cap even though the input
+        // is empty, so it must be rejected (the pre-fix check only measured `input().len()`).
+        let large = blob_tx_with_access_list(64);
+        assert!(large.input().is_empty());
+        assert!(is_oversized(&large));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Summary

Closes #25866.

In `validate_stateless`, `max_tx_input_bytes` was applied to `input().len()` for
type-3 (blob) transactions but to `encoded_length()` for everything else.  For a blob
tx that meant the access list, `to`, `value`, and blob versioned hashes were not
counted, so a blob tx with a near-empty input and a large access list bypassed the
in-memory size cap.  That cap is the mempool's DoS bound on how much a single tx can
occupy in memory, so bypassing it is a griefing vector.

`encoded_length()` cannot simply be reused for blob txs: when a blob tx is ingested
from the network or RPC, its cached `encoded_length` is the *pooled* encoding, which
includes the blob sidecar, so measuring against it would reject every blob tx.

### Approach

Following the direction suggested in the issue:

- Add `PoolTransaction::encoded_length_without_sidecar()` with a default of
  `encoded_length()`.  Only sidecar-bearing implementations override it.
- Override it in `EthPooledTransaction`: its `transaction` field always stores the
  consensus (sidecar-free) representation even for blob txs (the sidecar lives in the
  separate `blob_sidecar` field), so `transaction.encode_2718_len()` yields the
  sidecar-free length.  Non-blob txs keep returning the cached `encoded_length`, so
  there is no extra work on the common path.
- `validate_stateless` now uses `encoded_length_without_sidecar()` for both branches.
   For non-blob txs this equals `encoded_length()`, so only blob-tx behavior changes.
- Document that `max_tx_input_bytes` bounds the sidecar-free encoded length, not just
  `input`. I did not rename the field/method/CLI flag, since `max_tx_input_bytes()`
  and `with_max_tx_input_bytes()` are public API and `--txpool.max-tx-input-bytes` is a
  user-facing CLI flag;  a rename would be a breaking change.  I'd be happy to do it as a
  separate breaking-change PR (with a deprecated alias) if maintainers prefer.

### Testing

Added `blob_tx_size_limit_accounts_for_access_list` (the repro from the issue),
verified it fails on the previous `input().len()` check and passes with this change.
`cargo test -p reth-transaction-pool` (validate::eth module), `cargo clippy`, and
`cargo fmt` are clean.
