### PR TITLE
perf(net): avoid copying decrypted ECIES message body

### DIFF
--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -136,11 +136,14 @@ impl Decoder for ECIESCodec {
                     }
 
                     let mut data = buf.split_to(self.ecies.body_len());
-                    let mut ret = BytesMut::new();
-                    ret.extend_from_slice(self.ecies.read_body(&mut data)?);
+                    let body_len = {
+                        let body = self.ecies.read_body(&mut data)?;
+                        body.len()
+                    };
+                    data.truncate(body_len);
 
                     self.state = ECIESState::Header;
-                    return Ok(Some(IngressECIESValue::Message(ret)))
+                    return Ok(Some(IngressECIESValue::Message(data)))
                 }
             }
         }


### PR DESCRIPTION
Extracted from #26033.

`ECIESCodec::decode` copied the decrypted body into a freshly allocated `BytesMut` for every incoming message. `read_body` decrypts in place and returns a prefix of the passed buffer, so we can truncate the already split-off buffer and hand it out directly, saving an allocation and a memcpy per received message on the ingress hot path.