### PR TITLE
perf(net): reduce idle polling work in ActiveSession

### DIFF
--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -614,7 +614,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         let current = Duration::from_millis(self.internal_request_timeout.load(Ordering::Relaxed));
         let request_timeout = calculate_new_timeout(current, elapsed);
         self.internal_request_timeout.store(request_timeout.as_millis() as u64, Ordering::Relaxed);
-        self.internal_request_timeout_interval = tokio::time::interval(request_timeout);
+        self.internal_request_timeout_interval = request_timeout_interval(request_timeout);
     }
 
     /// If a termination message is queued this will try to send it
@@ -662,6 +662,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
         // The main poll loop that drives the session
         'main: loop {
             let mut progress = false;
+            let mut receive_pending = false;
 
             // we prioritize incoming commands sent from the session manager
             loop {
@@ -800,7 +801,10 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
 
                 match this.conn.poll_next_unpin(cx) {
-                    Poll::Pending => break,
+                    Poll::Pending => {
+                        receive_pending = true;
+                        break
+                    }
                     Poll::Ready(None) => {
                         if this.is_disconnecting() {
                             break
@@ -855,6 +859,16 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                 }
             }
 
+            // Avoid one extra empty outer-loop pass after the wire is pending, unless the receive
+            // pass produced work that should be driven immediately.
+            if receive_pending &&
+                this.queued_outgoing.is_empty() &&
+                this.pending_message_to_session.is_none() &&
+                this.received_requests_from_remote.is_empty()
+            {
+                break 'main
+            }
+
             if !progress {
                 break 'main
             }
@@ -880,13 +894,15 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
             }
         }
 
-        while this.internal_request_timeout_interval.poll_tick(cx).is_ready() {
-            // check for timed out requests
-            if this.check_timed_out_requests(Instant::now()) &&
-                let Poll::Ready(Ok(_)) = this.to_session_manager.poll_reserve(cx)
-            {
-                let msg = ActiveSessionMessage::ProtocolBreach { peer_id: this.remote_peer_id };
-                this.pending_message_to_session = Some(msg);
+        if !this.inflight_requests.is_empty() {
+            while this.internal_request_timeout_interval.poll_tick(cx).is_ready() {
+                // check for timed out requests
+                if this.check_timed_out_requests(Instant::now()) &&
+                    let Poll::Ready(Ok(_)) = this.to_session_manager.poll_reserve(cx)
+                {
+                    let msg = ActiveSessionMessage::ProtocolBreach { peer_id: this.remote_peer_id };
+                    this.pending_message_to_session = Some(msg);
+                }
             }
         }
 
@@ -1064,6 +1080,16 @@ impl<N: NetworkPrimitives> From<EthBroadcastMessage<N>> for OutgoingMessage<N> {
     }
 }
 
+/// Returns the interval used to check for timed out requests.
+///
+/// Uses delayed missed-tick behavior because the interval is only polled while requests are in
+/// flight, so ticks that elapsed while the session was idle must not fire in a burst.
+pub(super) fn request_timeout_interval(timeout: Duration) -> Interval {
+    let mut interval = tokio::time::interval(timeout);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval
+}
+
 /// Calculates a new timeout using an updated estimation of the RTT
 #[inline]
 fn calculate_new_timeout(current_timeout: Duration, estimated_rtt: Duration) -> Duration {
@@ -1099,6 +1125,10 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     /// Returns the number of queued response messages.
     pub(crate) const fn response_count(&self) -> usize {
         self.queued_responses
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.messages.is_empty()
     }
 
     pub(crate) fn push_back(&mut self, message: OutgoingMessage<N>) {
@@ -1291,7 +1321,7 @@ mod tests {
                             BroadcastItemCounter::new(),
                         ),
                         received_requests_from_remote: Default::default(),
-                        internal_request_timeout_interval: tokio::time::interval(
+                        internal_request_timeout_interval: request_timeout_interval(
                             INITIAL_REQUEST_TIMEOUT,
                         ),
                         internal_request_timeout: Arc::new(AtomicU64::new(
@@ -1486,6 +1516,9 @@ mod tests {
         session.protocol_breach_request_timeout = drop_timeout;
         session.internal_request_timeout_interval =
             tokio::time::interval_at(tokio::time::Instant::now(), request_timeout);
+        session
+            .internal_request_timeout_interval
+            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let (tx, rx) = oneshot::channel();
         let req = PeerRequest::GetBlockBodies { request: GetBlockBodies(vec![]), response: tx };
         session.on_internal_peer_request(req, Instant::now());

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -48,7 +48,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
 use tracing::{instrument, trace};
 
-use crate::session::active::{BroadcastItemCounter, RANGE_UPDATE_INTERVAL};
+use crate::session::active::{
+    request_timeout_interval, BroadcastItemCounter, RANGE_UPDATE_INTERVAL,
+};
 pub use conn::EthRlpxConnection;
 use handle::SessionCommandSender;
 pub use handle::{
@@ -594,7 +596,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                         broadcast_items.clone(),
                     ),
                     received_requests_from_remote: Default::default(),
-                    internal_request_timeout_interval: tokio::time::interval(
+                    internal_request_timeout_interval: request_timeout_interval(
                         self.initial_internal_request_timeout,
                     ),
                     internal_request_timeout: Arc::clone(&timeout),


### PR DESCRIPTION
Extracted from #26033.

The session future always ran one more pass over its command channels, request channels, and the sink after the wire returned `Pending`, even when the receive pass produced no outgoing messages, no pending session-manager message, and no received peer requests — that pass is guaranteed to find nothing since all sources were already drained to `Pending` with wakers registered. It now breaks out of the main loop directly in that case.

The request timeout interval is also only polled while requests are actually in flight, and it now uses delayed missed-tick behavior so ticks that elapsed while the interval went unpolled don't fire in a burst once a new request arrives.