### PR TITLE
fix(docs): 404 link to TaskExecutor in gRPC server section

### DIFF
--- a/docs/vocs/docs/pages/exex/remote.mdx
+++ b/docs/vocs/docs/pages/exex/remote.mdx
@@ -75,7 +75,7 @@ We will now create the ExEx and the gRPC server in our `src/exex.rs` file.
 ### gRPC server
 
 Let's create a minimal gRPC server that listens on the port `:10000`, and spawn it using
-the [NodeBuilder](https://reth.rs/docs/reth/builder/struct.NodeBuilder.html)'s [task executor](https://reth.rs/docs/reth/tasks/struct.TaskExecutor.html).
+the [NodeBuilder](https://reth.rs/docs/reth/builder/struct.NodeBuilder.html)'s [task executor](https://reth.rs/docs/reth/tasks/type.TaskExecutor.html).
 
 ```rust
 // [!include ~/snippets/sources/exex/remote/src/exex_1.rs]


### PR DESCRIPTION
Hi! I replaced 404 link in docs:

after: https://reth.rs/docs/reth/tasks/struct.TaskExecutor.html
before: https://reth.rs/docs/reth/tasks/type.TaskExecutor.html

https://reth.rs/exex/remote#grpc-server
<img width="1124" height="199" alt="image" src="https://github.com/user-attachments/assets/e81e268d-829e-4a64-baff-9535313c3b3f" />
