### PR TITLE
fix: replace deprecated atomic fetch_update

### DIFF
--- a/crates/cli/commands/src/download/progress.rs
+++ b/crates/cli/commands/src/download/progress.rs
@@ -323,7 +323,7 @@ impl SharedProgress {
 }
 
 fn sub_bytes(counter: &AtomicU64, bytes: u64) {
-    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+    let _ = counter.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         Some(current.saturating_sub(bytes))
     });
 }

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -187,7 +187,7 @@ impl BlobStoreSize {
 
     #[inline]
     pub(crate) fn sub_size(&self, sub: usize) {
-        let _ = self.data_size.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        let _ = self.data_size.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))
         });
     }
@@ -204,7 +204,7 @@ impl BlobStoreSize {
 
     #[inline]
     pub(crate) fn sub_len(&self, sub: usize) {
-        let _ = self.num_blobs.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        let _ = self.num_blobs.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))
         });
     }


### PR DESCRIPTION
## Summary
- replace deprecated atomic `fetch_update` calls with `try_update`
- cover both the transaction pool blob store and CLI progress counter occurrences

## Testing
- `RUSTFLAGS='-D warnings' cargo check -p reth-transaction-pool --all-features --locked`
- `RUSTFLAGS='-D warnings' cargo check -p reth-cli-commands --all-features --locked`
- `cargo +nightly fmt --all --check`

Prompted by: @rkrasiuk
