### PR TITLE
revert: rustdoc no_inline workaround

### DIFF
--- a/crates/storage/db/src/mdbx.rs
+++ b/crates/storage/db/src/mdbx.rs
@@ -6,7 +6,6 @@ use reth_tracing::tracing::{info, warn};
 use std::path::Path;
 
 pub use crate::implementation::mdbx::*;
-#[doc(no_inline)]
 pub use reth_libmdbx::*;
 
 /// Tables that have been removed from the schema but may still exist on disk from previous


### PR DESCRIPTION
Reverts the temporary rustdoc ICE workaround now that the upstream rustdoc panic has been fixed.

Prompted by: @DaniPopes