### PR TITLE
chore: fix receipt filter formatting

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2547,11 +2547,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
                     let receipt_idx = first_tx_index + idx as u64;
                     // Skip writing receipt if log filter is active and it does not have any logs
                     // to retain
-                    if !receipt
-                        .logs()
-                        .iter()
-                        .any(|log| allowed_addresses.contains(&log.address))
-                    {
+                    if !receipt.logs().iter().any(|log| allowed_addresses.contains(&log.address)) {
                         continue
                     }
 


### PR DESCRIPTION
Fixes the `cargo fmt --all --check` failure in #26258 by applying the rustfmt diff reported by CI.

Prompted by: @DaniPopes