### PR TITLE
chore: replace deprecated atomic fetch_update

### DIFF
--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -187,7 +187,7 @@ impl BlobStoreSize {
 
     #[inline]
     pub(crate) fn sub_size(&self, sub: usize) {
-        let _ = self.data_size.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        let _ = self.data_size.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))
         });
     }
@@ -204,7 +204,7 @@ impl BlobStoreSize {
 
     #[inline]
     pub(crate) fn sub_len(&self, sub: usize) {
-        let _ = self.num_blobs.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        let _ = self.num_blobs.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))
         });
     }


### PR DESCRIPTION
Fixes the clippy/book failures in #26250 by replacing deprecated `AtomicUsize::fetch_update` calls with `try_update`.

Validation:
- `cargo clippy -p reth-transaction-pool --all-targets --all-features -- -D warnings`

Prompted by: @DaniPopes