### PR TITLE
fix(net): advertise the bound RLPx port in the discv5 ENR

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -399,6 +399,12 @@ impl Config {
     pub const fn rlpx_socket(&self) -> &SocketAddr {
         &self.tcp_socket
     }
+
+    /// Sets the port of the `RLPx` TCP socket to advertise. This allows advertising the actually
+    /// bound listener port when the configured port was 0 (OS-assigned).
+    pub const fn set_rlpx_port(&mut self, port: u16) {
+        self.tcp_socket.set_port(port);
+    }
 }
 
 /// Returns the IPv4 discovery socket if one is configured.

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -161,6 +161,9 @@ impl Discovery {
 
         // Start discv5, wiring in the shared socket if in shared-port mode.
         let (discv5, discv5_updates) = if let Some(mut config) = discv5_config {
+            // the config's rlpx port predates the listener bind and is 0 with `--port 0`
+            config.set_rlpx_port(tcp_addr.port());
+
             if let Some(socket) = shared_socket {
                 let discv5_cfg = config.discv5_config_mut();
 
@@ -511,6 +514,28 @@ mod tests {
         )
         .await
         .expect("should build discv5 with discv4 downgrade")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn discv5_enr_advertises_bound_rlpx_port() {
+        reth_tracing::init_test_tracing();
+
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+
+        // rlpx port 0 in the config, like `--port 0` pre-bind; only `tcp_addr` has the bound port
+        let tcp_addr: SocketAddr = "127.0.0.1:30307".parse().unwrap();
+        let discv5_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let discv5_config = reth_discv5::Config::builder((Ipv4Addr::LOCALHOST, 0).into())
+            .discv5_config(discv5::ConfigBuilder::new(discv5_addr.into()).build())
+            .build();
+
+        let discovery =
+            Discovery::new(tcp_addr, discv5_addr, secret_key, None, Some(discv5_config), None)
+                .await
+                .unwrap();
+
+        let enr = discovery.discv5.as_ref().unwrap().with_discv5(|discv5| discv5.local_enr());
+        assert_eq!(enr.tcp4(), Some(tcp_addr.port()));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -161,8 +161,8 @@ impl Discovery {
 
         // Start discv5, wiring in the shared socket if in shared-port mode.
         let (discv5, discv5_updates) = if let Some(mut config) = discv5_config {
-            // the config's rlpx port predates the listener bind and is 0 with `--port 0`
-            config.set_rlpx_port(tcp_addr.port());
+            // Set OS-assigned advertised RLPx ports to the bound listener port.
+            set_bound_rlpx_port_if_unset(&mut config, tcp_addr.port());
 
             if let Some(socket) = shared_socket {
                 let discv5_cfg = config.discv5_config_mut();
@@ -407,6 +407,12 @@ impl Discovery {
     }
 }
 
+const fn set_bound_rlpx_port_if_unset(config: &mut reth_discv5::Config, port: u16) {
+    if config.rlpx_socket().port() == 0 {
+        config.set_rlpx_port(port);
+    }
+}
+
 impl Drop for Discovery {
     fn drop(&mut self) {
         if let Some(discv4) = &self.discv4 {
@@ -516,26 +522,36 @@ mod tests {
         .expect("should build discv5 with discv4 downgrade")
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn discv5_enr_advertises_bound_rlpx_port() {
-        reth_tracing::init_test_tracing();
-
+    #[test]
+    fn discv5_enr_advertises_bound_rlpx_port() {
         let secret_key = SecretKey::new(&mut rand_08::thread_rng());
 
-        // rlpx port 0 in the config, like `--port 0` pre-bind; only `tcp_addr` has the bound port
-        let tcp_addr: SocketAddr = "127.0.0.1:30307".parse().unwrap();
+        let bound_rlpx_port = 30307;
         let discv5_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let discv5_config = reth_discv5::Config::builder((Ipv4Addr::LOCALHOST, 0).into())
+        let mut discv5_config = reth_discv5::Config::builder((Ipv4Addr::LOCALHOST, 0).into())
             .discv5_config(discv5::ConfigBuilder::new(discv5_addr.into()).build())
             .build();
 
-        let discovery =
-            Discovery::new(tcp_addr, discv5_addr, secret_key, None, Some(discv5_config), None)
-                .await
-                .unwrap();
+        set_bound_rlpx_port_if_unset(&mut discv5_config, bound_rlpx_port);
 
-        let enr = discovery.discv5.as_ref().unwrap().with_discv5(|discv5| discv5.local_enr());
-        assert_eq!(enr.tcp4(), Some(tcp_addr.port()));
+        let (enr, _, _, _) = reth_discv5::build_local_enr(&secret_key, &discv5_config);
+        assert_eq!(enr.tcp4(), Some(bound_rlpx_port));
+    }
+
+    #[test]
+    fn discv5_enr_preserves_configured_rlpx_port() {
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+
+        let advertised_addr: SocketAddr = "127.0.0.1:30308".parse().unwrap();
+        let discv5_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut discv5_config = reth_discv5::Config::builder(advertised_addr)
+            .discv5_config(discv5::ConfigBuilder::new(discv5_addr.into()).build())
+            .build();
+
+        set_bound_rlpx_port_if_unset(&mut discv5_config, 30307);
+
+        let (enr, _, _, _) = reth_discv5::build_local_enr(&secret_key, &discv5_config);
+        assert_eq!(enr.tcp4(), Some(advertised_addr.port()));
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
With `--port 0`, the discv5 ENR advertised the pre-bind RLPx port (`tcp=0`)
while the discv4 record already advertised the actual bound listener port, so
the two discovery stacks disagreed about the node's TCP endpoint. `Discovery::new`
now stamps the bound port onto the discv5 config before starting it, matching
what it already does for the discv4 record.

Surfaced while discussing #26089.
