### PR TITLE
feat(prune): add row-budgeted dupsort pruning

### DIFF
--- a/crates/prune/prune/src/db_ext.rs
+++ b/crates/prune/prune/src/db_ext.rs
@@ -1,6 +1,6 @@
 use crate::PruneLimiter;
 use reth_db_api::{
-    cursor::{DbCursorRO, DbCursorRW, RangeWalker},
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, RangeWalker},
     table::{DupSort, Table, TableRow},
     transaction::{DbTx, DbTxMut},
     DatabaseError,
@@ -193,6 +193,44 @@ pub(crate) trait DbTxPruneExt: DbTxMut + DbTx {
 
         Ok((starting_entries - ending_entries, done))
     }
+
+    /// Prune duplicate entries for a single DUPSORT key.
+    ///
+    /// Returns the number of rows pruned and whether all duplicate entries for the key were
+    /// deleted.
+    #[allow(dead_code)]
+    fn prune_dupsort_key_entries<T: DupSort>(
+        &self,
+        key: T::Key,
+        limiter: &mut PruneLimiter,
+    ) -> Result<(usize, bool), DatabaseError> {
+        let mut cursor = self.cursor_dup_write::<T>()?;
+        let mut entry = cursor.seek_exact(key)?;
+
+        let mut deleted_entries = 0;
+
+        while entry.is_some() && !limiter.is_limit_reached() {
+            cursor.delete_current()?;
+            limiter.increment_deleted_entries_count();
+            deleted_entries += 1;
+            entry = cursor.next_dup()?;
+        }
+
+        // an entry remaining means the loop stopped because a limit was reached
+        let done = entry.is_none();
+        if !done {
+            debug!(
+                target: "providers::db",
+                ?limiter,
+                deleted_entries_limit = %limiter.is_deleted_entries_limit_reached(),
+                time_limit = %limiter.is_time_limit_reached(),
+                table = %T::NAME,
+                "Pruning limit reached"
+            );
+        }
+
+        Ok((deleted_entries, done))
+    }
 }
 
 impl<Tx> DbTxPruneExt for Tx where Tx: DbTxMut + DbTx {}
@@ -201,14 +239,18 @@ impl<Tx> DbTxPruneExt for Tx where Tx: DbTxMut + DbTx {}
 mod tests {
     use super::DbTxPruneExt;
     use crate::PruneLimiter;
-    use reth_db_api::tables;
-    use reth_primitives_traits::SignerRecoverable;
+    use alloy_primitives::{B256, U256};
+    use reth_db_api::{tables, transaction::DbTxMut};
+    use reth_primitives_traits::{SignerRecoverable, StorageEntry};
     use reth_provider::{DBProvider, DatabaseProviderFactory};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
     };
 
     struct CountingIter {
@@ -242,6 +284,51 @@ mod tests {
         fn into_iter(self) -> Self::IntoIter {
             CountingIntoIter { inner: self.data.into_iter(), calls: self.calls }
         }
+    }
+
+    fn storage_entry(slot_byte: u8) -> StorageEntry {
+        StorageEntry { key: B256::with_last_byte(slot_byte), value: U256::from(slot_byte) }
+    }
+
+    fn insert_hashed_storages(db: &TestStageDB, rows: impl IntoIterator<Item = (u8, u8)>) {
+        let provider = db.factory.database_provider_rw().unwrap();
+        for (address_byte, slot_byte) in rows {
+            provider
+                .tx_ref()
+                .put::<tables::HashedStorages>(
+                    B256::with_last_byte(address_byte),
+                    storage_entry(slot_byte),
+                )
+                .expect("insert hashed storage");
+        }
+        provider.commit().expect("commit");
+    }
+
+    fn hashed_storage_slots(db: &TestStageDB, address_byte: u8) -> Vec<B256> {
+        db.table::<tables::HashedStorages>()
+            .unwrap()
+            .into_iter()
+            .filter_map(|(key, entry)| {
+                (key == B256::with_last_byte(address_byte)).then_some(entry.key)
+            })
+            .collect()
+    }
+
+    fn prune_hashed_storage_key(
+        db: &TestStageDB,
+        address_byte: u8,
+        limiter: &mut PruneLimiter,
+    ) -> (usize, bool) {
+        let provider = db.factory.database_provider_rw().unwrap();
+        let result = provider
+            .tx_ref()
+            .prune_dupsort_key_entries::<tables::HashedStorages>(
+                B256::with_last_byte(address_byte),
+                limiter,
+            )
+            .expect("prune hashed storages");
+        provider.commit().expect("commit");
+        result
     }
 
     #[test]
@@ -349,5 +436,98 @@ mod tests {
 
         provider.commit().expect("commit");
         assert_eq!(db.table::<tables::TransactionSenders>().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn prune_dupsort_key_entries_resumes_with_deleted_entries_budget() {
+        let db = TestStageDB::default();
+        insert_hashed_storages(&db, (0..5).map(|slot| (1, slot)));
+        insert_hashed_storages(&db, (10..12).map(|slot| (2, slot)));
+
+        let mut total_deleted = 0;
+
+        let mut limiter = PruneLimiter::default().set_deleted_entries_limit(2);
+        let (deleted, done) = prune_hashed_storage_key(&db, 1, &mut limiter);
+        total_deleted += deleted;
+        assert_eq!((deleted, done), (2, false));
+        assert_eq!(
+            hashed_storage_slots(&db, 1),
+            vec![B256::with_last_byte(2), B256::with_last_byte(3), B256::with_last_byte(4),]
+        );
+        assert_eq!(
+            hashed_storage_slots(&db, 2),
+            vec![B256::with_last_byte(10), B256::with_last_byte(11)]
+        );
+
+        let mut limiter = PruneLimiter::default().set_deleted_entries_limit(2);
+        let (deleted, done) = prune_hashed_storage_key(&db, 1, &mut limiter);
+        total_deleted += deleted;
+        assert_eq!((deleted, done), (2, false));
+        assert_eq!(hashed_storage_slots(&db, 1), vec![B256::with_last_byte(4)]);
+        assert_eq!(
+            hashed_storage_slots(&db, 2),
+            vec![B256::with_last_byte(10), B256::with_last_byte(11)]
+        );
+
+        let mut limiter = PruneLimiter::default().set_deleted_entries_limit(2);
+        let (deleted, done) = prune_hashed_storage_key(&db, 1, &mut limiter);
+        total_deleted += deleted;
+        assert_eq!((deleted, done), (1, true));
+        assert!(hashed_storage_slots(&db, 1).is_empty());
+        assert_eq!(
+            hashed_storage_slots(&db, 2),
+            vec![B256::with_last_byte(10), B256::with_last_byte(11)]
+        );
+        assert_eq!(total_deleted, 5);
+    }
+
+    #[test]
+    fn prune_dupsort_key_entries_stops_on_time_limit() {
+        let db = TestStageDB::default();
+        insert_hashed_storages(&db, (0..3).map(|slot| (1, slot)));
+
+        let mut limiter = PruneLimiter::default().set_time_limit(Duration::from_nanos(1));
+        std::thread::sleep(Duration::from_millis(1));
+
+        let (deleted, done) = prune_hashed_storage_key(&db, 1, &mut limiter);
+
+        assert_eq!((deleted, done), (0, false));
+        assert!(limiter.is_time_limit_reached());
+        assert_eq!(
+            hashed_storage_slots(&db, 1),
+            vec![B256::with_last_byte(0), B256::with_last_byte(1), B256::with_last_byte(2)]
+        );
+    }
+
+    #[test]
+    fn prune_dupsort_key_entries_missing_key_is_done() {
+        let db = TestStageDB::default();
+        insert_hashed_storages(&db, (0..3).map(|slot| (1, slot)));
+
+        let mut limiter = PruneLimiter::default().set_deleted_entries_limit(2);
+        let result = prune_hashed_storage_key(&db, 2, &mut limiter);
+
+        assert_eq!(result, (0, true));
+        assert_eq!(
+            hashed_storage_slots(&db, 1),
+            vec![B256::with_last_byte(0), B256::with_last_byte(1), B256::with_last_byte(2)]
+        );
+    }
+
+    #[test]
+    fn prune_dupsort_key_entries_leaves_other_keys_untouched() {
+        let db = TestStageDB::default();
+        insert_hashed_storages(&db, (0..3).map(|slot| (1, slot)));
+        insert_hashed_storages(&db, (10..13).map(|slot| (2, slot)));
+
+        let mut limiter = PruneLimiter::default();
+        let result = prune_hashed_storage_key(&db, 1, &mut limiter);
+
+        assert_eq!(result, (3, true));
+        assert!(hashed_storage_slots(&db, 1).is_empty());
+        assert_eq!(
+            hashed_storage_slots(&db, 2),
+            vec![B256::with_last_byte(10), B256::with_last_byte(11), B256::with_last_byte(12),]
+        );
     }
 }


### PR DESCRIPTION
Adds `DbTxPruneExt::prune_dupsort_key_entries` for deleting duplicate rows under a single DUPSORT key with the pruner limiter charged per value. Each run seeks to the first surviving duplicate for the key, so interrupted calls resume without persisting cursor state.