### PR TITLE
perf(net): optimize pooled transaction recovery

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1454,21 +1454,20 @@ where
 
         let txs_len = transactions.len();
 
-        let new_txs = transactions
-            .into_par_iter()
-            .filter_map(|tx| match tx.try_into_recovered() {
-                Ok(tx) => Some(Pool::Transaction::from_pooled(tx)),
-                Err(badtx) => {
-                    trace!(target: "net::tx",
-                        peer_id=format!("{peer_id:#}"),
-                        hash=%badtx.tx_hash(),
-                        client_version=%client_version,
-                        "failed ecrecovery for transaction"
-                    );
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        let recover = |tx| match Pool::Transaction::try_recover(tx) {
+            Ok(tx) => Some(tx),
+            Err(badtx) => {
+                trace!(target: "net::tx",
+                    peer_id=format!("{peer_id:#}"),
+                    hash=%badtx.tx_hash(),
+                    client_version=%client_version,
+                    "failed ecrecovery for transaction"
+                );
+                None
+            }
+        };
+
+        let new_txs = transactions.into_par_iter().filter_map(recover).collect::<Vec<_>>();
 
         has_bad_transactions |= new_txs.len() != txs_len;
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1367,6 +1367,14 @@ pub trait PoolTransaction:
     /// Define a method to convert from the `Pooled` type to `Self`
     fn from_pooled(pooled: Recovered<Self::Pooled>) -> Self;
 
+    /// Recovers and converts a pooled transaction into this pool transaction type.
+    ///
+    /// Implementations can override this to combine signature recovery with construction of
+    /// transaction-specific cached metadata.
+    fn try_recover(pooled: Self::Pooled) -> Result<Self, Self::Pooled> {
+        pooled.try_into_recovered().map(Self::from_pooled)
+    }
+
     /// Decodes and recovers a raw transaction into this pool transaction type.
     ///
     /// Implementations can override this to avoid constructing the pooled transaction as an
@@ -1379,9 +1387,7 @@ pub trait PoolTransaction:
         let transaction = Self::Pooled::decode_2718_exact(data)
             .map_err(|_| RawPoolTransactionError::FailedToDecodeSignedTransaction)?;
 
-        transaction
-            .try_into_recovered()
-            .map(Self::from_pooled)
+        Self::try_recover(transaction)
             .map_err(|_| RawPoolTransactionError::InvalidTransactionSignature)
     }
 


### PR DESCRIPTION
Adds `PoolTransaction::try_recover` so pooled transaction types can combine signature recovery with construction of cached metadata. The tx manager uses that hook for P2P imports; recovery remains Rayon-backed for all batch sizes.

The i9-9900K microbench rejected the small-batch serial threshold experiment, so that code was removed before this push.

| decoded tx batch | sequential | Rayon | threshold `32` |
| --- | ---: | ---: | ---: |
| `4` | `32.6us/tx` | `19.5us/tx` | `34.3us/tx` |
| `8` | `34.7us/tx` | `12.4us/tx` | `33.7us/tx` |
| `16` | `33.3us/tx` | `8.3us/tx` | `34.8us/tx` |
| `24` | `34.9us/tx` | `7.8us/tx` | `33.8us/tx` |

Tempo follow-up: tempoxyz/tempo#6733

Checks:
- `cargo +nightly fmt --all --check`
- `cargo +nightly check -p reth-transaction-pool -p reth-network`
- `cargo +nightly test -p reth-network --lib transactions::tests`