### PR TITLE
feat(engine): persistence hook

### DIFF
--- a/crates/engine/tree/src/launch.rs
+++ b/crates/engine/tree/src/launch.rs
@@ -9,7 +9,7 @@ use crate::{
     chain::ChainOrchestrator,
     download::BasicBlockDownloader,
     engine::{EngineApiKind, EngineApiRequest, EngineApiRequestHandler, EngineHandler},
-    persistence::PersistenceHandle,
+    persistence::{PersistenceHandle, PersistenceHook},
     tree::{EngineApiTreeHandler, EngineValidator, TreeConfig, WaitForCaches},
 };
 use futures::Stream;
@@ -67,6 +67,7 @@ pub fn build_engine_orchestrator<N, Client, S, V, C>(
     evm_config: C,
     changeset_cache: ChangesetCache,
     runtime: Runtime,
+    persistence_hook: Box<dyn PersistenceHook<N>>,
 ) -> ChainOrchestrator<
     EngineHandler<
         EngineApiRequestHandler<EngineApiRequest<N::Payload, N::Primitives>, N::Primitives>,
@@ -84,8 +85,12 @@ where
 {
     let downloader = BasicBlockDownloader::new(client, consensus.clone());
 
-    let persistence_handle =
-        PersistenceHandle::<N::Primitives>::spawn_service(provider, pruner, sync_metrics_tx);
+    let persistence_handle = PersistenceHandle::<N::Primitives>::spawn_service_with_hook(
+        provider,
+        pruner,
+        sync_metrics_tx,
+        persistence_hook,
+    );
 
     let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
 

--- a/crates/engine/tree/src/persistence/hook.rs
+++ b/crates/engine/tree/src/persistence/hook.rs
@@ -1,0 +1,69 @@
+use reth_chain_state::ExecutedBlock;
+use reth_provider::{providers::ProviderNodeTypes, DatabaseProviderFactory, ProviderFactory};
+use std::fmt;
+
+/// A hook invoked by the engine persistence task when blocks are saved.
+pub trait PersistenceHook<N: ProviderNodeTypes>: Send + Sync {
+    /// Invoked before a non-empty `save_blocks` batch is written to storage.
+    fn on_save_blocks(
+        &self,
+        provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        blocks: &[ExecutedBlock<N::Primitives>],
+    );
+}
+
+impl<F, N> PersistenceHook<N> for F
+where
+    N: ProviderNodeTypes,
+    F: Fn(
+            &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+            &[ExecutedBlock<N::Primitives>],
+        ) + Send
+        + Sync,
+{
+    fn on_save_blocks(
+        &self,
+        provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        blocks: &[ExecutedBlock<N::Primitives>],
+    ) {
+        self(provider, blocks)
+    }
+}
+
+/// A no-op [`PersistenceHook`] that does nothing.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct NoopPersistenceHook;
+
+impl<N: ProviderNodeTypes> PersistenceHook<N> for NoopPersistenceHook {
+    fn on_save_blocks(
+        &self,
+        _provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        _blocks: &[ExecutedBlock<N::Primitives>],
+    ) {
+    }
+}
+
+/// Multiple [`PersistenceHook`]s that are executed in order.
+pub struct PersistenceHooks<N: ProviderNodeTypes>(pub Vec<BoxedPersistenceHook<N>>);
+
+impl<N: ProviderNodeTypes> fmt::Debug for PersistenceHooks<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PersistenceHooks").field("len", &self.0.len()).finish()
+    }
+}
+
+impl<N: ProviderNodeTypes> PersistenceHook<N> for PersistenceHooks<N> {
+    fn on_save_blocks(
+        &self,
+        provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        blocks: &[ExecutedBlock<N::Primitives>],
+    ) {
+        for hook in &self.0 {
+            hook.on_save_blocks(provider, blocks);
+        }
+    }
+}
+
+/// Boxed [`PersistenceHook`] for the given provider node types.
+pub type BoxedPersistenceHook<N> = Box<dyn PersistenceHook<N>>;

--- a/crates/engine/tree/src/persistence/hook.rs
+++ b/crates/engine/tree/src/persistence/hook.rs
@@ -1,33 +1,23 @@
 use reth_chain_state::ExecutedBlock;
+use reth_errors::ProviderResult;
 use reth_provider::{providers::ProviderNodeTypes, DatabaseProviderFactory, ProviderFactory};
 use std::fmt;
 
-/// A hook invoked by the engine persistence task when blocks are saved.
+/// A hook invoked by the engine persistence task when blocks are saved or removed.
 pub trait PersistenceHook<N: ProviderNodeTypes>: Send + Sync {
     /// Invoked before a non-empty `save_blocks` batch is written to storage.
-    fn on_save_blocks(
+    fn save_blocks(
         &self,
         provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
         blocks: &[ExecutedBlock<N::Primitives>],
-    );
-}
+    ) -> ProviderResult<()>;
 
-impl<F, N> PersistenceHook<N> for F
-where
-    N: ProviderNodeTypes,
-    F: Fn(
-            &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
-            &[ExecutedBlock<N::Primitives>],
-        ) + Send
-        + Sync,
-{
-    fn on_save_blocks(
+    /// Invoked before blocks above `new_tip_num` are removed from storage.
+    fn remove_blocks(
         &self,
-        provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
-        blocks: &[ExecutedBlock<N::Primitives>],
-    ) {
-        self(provider, blocks)
-    }
+        _provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        _new_tip_num: u64,
+    ) -> ProviderResult<()>;
 }
 
 /// A no-op [`PersistenceHook`] that does nothing.
@@ -36,11 +26,20 @@ where
 pub struct NoopPersistenceHook;
 
 impl<N: ProviderNodeTypes> PersistenceHook<N> for NoopPersistenceHook {
-    fn on_save_blocks(
+    fn save_blocks(
         &self,
         _provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
         _blocks: &[ExecutedBlock<N::Primitives>],
-    ) {
+    ) -> ProviderResult<()> {
+        Ok(())
+    }
+
+    fn remove_blocks(
+        &self,
+        _provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        _new_tip_num: u64,
+    ) -> ProviderResult<()> {
+        Ok(())
     }
 }
 
@@ -54,14 +53,20 @@ impl<N: ProviderNodeTypes> fmt::Debug for PersistenceHooks<N> {
 }
 
 impl<N: ProviderNodeTypes> PersistenceHook<N> for PersistenceHooks<N> {
-    fn on_save_blocks(
+    fn save_blocks(
         &self,
         provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
         blocks: &[ExecutedBlock<N::Primitives>],
-    ) {
-        for hook in &self.0 {
-            hook.on_save_blocks(provider, blocks);
-        }
+    ) -> ProviderResult<()> {
+        self.0.iter().try_for_each(|hook| hook.save_blocks(provider, blocks))
+    }
+
+    fn remove_blocks(
+        &self,
+        provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
+        new_tip_num: u64,
+    ) -> ProviderResult<()> {
+        self.0.iter().try_for_each(|hook| hook.remove_blocks(provider, new_tip_num))
     }
 }
 

--- a/crates/engine/tree/src/persistence/hook.rs
+++ b/crates/engine/tree/src/persistence/hook.rs
@@ -1,22 +1,31 @@
+use alloy_eips::BlockNumHash;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::ProviderResult;
 use reth_provider::{providers::ProviderNodeTypes, DatabaseProviderFactory, ProviderFactory};
 use std::fmt;
 
 /// A hook invoked by the engine persistence task when blocks are saved or removed.
+///
+/// [`Self::save_blocks`] is invoked before the engine persists a non-empty block batch to the
+/// database. [`Self::remove_blocks`] is invoked after a non-empty block range has been removed from
+/// the database, before the removal is committed.
+///
+/// Hooks receive the same writable provider used by the persistence operation, so auxiliary writes
+/// performed by the hook are committed with the corresponding save or removal.
 pub trait PersistenceHook<N: ProviderNodeTypes>: Send + Sync {
-    /// Invoked before a non-empty `save_blocks` batch is written to storage.
+    /// Invoked before a non-empty block batch is persisted to the database.
     fn save_blocks(
         &self,
         provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
         blocks: &[ExecutedBlock<N::Primitives>],
     ) -> ProviderResult<()>;
 
-    /// Invoked before blocks above `new_tip_num` are removed from storage.
+    /// Invoked after a non-empty block range is removed from the database, before the removal is
+    /// committed.
     fn remove_blocks(
         &self,
         _provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
-        _new_tip_num: u64,
+        _blocks: &[BlockNumHash],
     ) -> ProviderResult<()>;
 }
 
@@ -37,7 +46,7 @@ impl<N: ProviderNodeTypes> PersistenceHook<N> for NoopPersistenceHook {
     fn remove_blocks(
         &self,
         _provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
-        _new_tip_num: u64,
+        _blocks: &[BlockNumHash],
     ) -> ProviderResult<()> {
         Ok(())
     }
@@ -64,9 +73,9 @@ impl<N: ProviderNodeTypes> PersistenceHook<N> for PersistenceHooks<N> {
     fn remove_blocks(
         &self,
         provider: &<ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW,
-        new_tip_num: u64,
+        blocks: &[BlockNumHash],
     ) -> ProviderResult<()> {
-        self.0.iter().try_for_each(|hook| hook.remove_blocks(provider, new_tip_num))
+        self.0.iter().try_for_each(|hook| hook.remove_blocks(provider, blocks))
     }
 }
 

--- a/crates/engine/tree/src/persistence/mod.rs
+++ b/crates/engine/tree/src/persistence/mod.rs
@@ -63,9 +63,9 @@ where
     /// Pending safe block number to be committed with the next block save.
     /// This avoids triggering a separate fsync for each safe block update.
     pending_safe_block: Option<u64>,
-    /// Hook invoked before non-empty block batches are saved.
+    /// Hook invoked before blocks are saved or removed.
     #[debug(skip)]
-    save_blocks_hook: BoxedPersistenceHook<N>,
+    persistence_hook: BoxedPersistenceHook<N>,
 }
 
 impl<N> PersistenceService<N>
@@ -94,12 +94,12 @@ where
         incoming: Receiver<PersistenceAction<N::Primitives>>,
         pruner: PrunerWithFactory<ProviderFactory<N>>,
         sync_metrics_tx: MetricEventsSender,
-        save_blocks_hook: BoxedPersistenceHook<N>,
+        persistence_hook: BoxedPersistenceHook<N>,
     ) -> Self {
         Self {
             provider,
             incoming,
-            save_blocks_hook,
+            persistence_hook,
             pruner,
             metrics: PersistenceMetrics::default(),
             sync_metrics_tx,
@@ -161,6 +161,7 @@ where
         let provider_rw = self.provider.database_provider_rw()?;
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
+        self.persistence_hook.remove_blocks(&provider_rw, new_tip_num)?;
         provider_rw.remove_block_and_execution_above(new_tip_num)?;
         provider_rw.commit()?;
 
@@ -187,7 +188,7 @@ where
 
         if let Some(last) = last_block {
             let provider_rw = self.provider.database_provider_rw()?;
-            self.save_blocks_hook.on_save_blocks(&provider_rw, &blocks);
+            self.persistence_hook.save_blocks(&provider_rw, &blocks)?;
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
 
             if let Some(finalized) = pending_finalized {
@@ -327,7 +328,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
         provider_factory: ProviderFactory<N>,
         pruner: PrunerWithFactory<ProviderFactory<N>>,
         sync_metrics_tx: MetricEventsSender,
-        save_blocks_hook: BoxedPersistenceHook<N>,
+        persistence_hook: BoxedPersistenceHook<N>,
     ) -> PersistenceHandle<N::Primitives>
     where
         N: ProviderNodeTypes,
@@ -341,7 +342,7 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
             db_service_rx,
             pruner,
             sync_metrics_tx,
-            save_blocks_hook,
+            persistence_hook,
         );
         let join_handle = spawn_os_thread("persistence", || {
             if let Err(err) = db_service.run() {
@@ -459,8 +460,35 @@ mod tests {
     type TestProviderRW =
         <ProviderFactory<MockNodeTypesWithDB> as DatabaseProviderFactory>::ProviderRW;
 
+    #[derive(Clone, Default, Debug)]
+    struct TestPersistenceHook {
+        saved_blocks: Arc<std::sync::Mutex<HashSet<u64>>>,
+        removed_tip: Arc<std::sync::Mutex<Option<u64>>>,
+    }
+
+    impl PersistenceHook<MockNodeTypesWithDB> for TestPersistenceHook {
+        fn save_blocks(
+            &self,
+            provider: &TestProviderRW,
+            blocks: &[ExecutedBlock<EthPrimitives>],
+        ) -> ProviderResult<()> {
+            provider.save_safe_block_number(1).unwrap();
+            let mut saved = self.saved_blocks.lock().unwrap();
+            for block in blocks {
+                saved.insert(block.recovered_block().num_hash().number);
+            }
+            Ok(())
+        }
+
+        fn remove_blocks(&self, provider: &TestProviderRW, new_tip_num: u64) -> ProviderResult<()> {
+            provider.save_safe_block_number(new_tip_num).unwrap();
+            *self.removed_tip.lock().unwrap() = Some(new_tip_num);
+            Ok(())
+        }
+    }
+
     fn persistence_handle_with_hook(
-        save_blocks_hook: Box<dyn PersistenceHook<MockNodeTypesWithDB>>,
+        persistence_hook: Box<dyn PersistenceHook<MockNodeTypesWithDB>>,
     ) -> PersistenceHandle<EthPrimitives> {
         let provider = create_test_provider_factory();
 
@@ -475,7 +503,7 @@ mod tests {
             provider,
             pruner,
             sync_metrics_tx,
-            save_blocks_hook,
+            persistence_hook,
         )
     }
 
@@ -613,22 +641,12 @@ mod tests {
         let pruner =
             Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
         let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
-        let persisted_blocks = Arc::new(std::sync::Mutex::new(HashSet::default()));
-        let persistence_hook = {
-            let persisted_blocks = persisted_blocks.clone();
-            Box::new(move |provider: &TestProviderRW, blocks: &[ExecutedBlock<EthPrimitives>]| {
-                provider.save_safe_block_number(1).unwrap();
-                let mut persisted = persisted_blocks.lock().unwrap();
-                for block in blocks {
-                    persisted.insert(block.recovered_block().num_hash().number);
-                }
-            })
-        };
+        let persistence_hook = TestPersistenceHook::default();
         let handle = PersistenceHandle::<EthPrimitives>::spawn_service_with_hook(
             provider.clone(),
             pruner,
             sync_metrics_tx,
-            persistence_hook,
+            Box::new(persistence_hook.clone()),
         );
 
         let mut test_block_builder = TestBlockBuilder::eth();
@@ -645,7 +663,46 @@ mod tests {
             Some(1)
         );
 
-        assert_eq!(persisted_blocks.lock().unwrap().clone(), HashSet::from([0, 1, 2]));
+        assert_eq!(
+            persistence_hook.saved_blocks.lock().unwrap().clone(),
+            [0_u64, 1, 2].into_iter().collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn test_remove_blocks_invokes_hook() {
+        reth_tracing::init_test_tracing();
+        let provider = create_test_provider_factory();
+        let (_finished_exex_height_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let pruner =
+            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
+        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+        let persistence_hook = TestPersistenceHook::default();
+        let handle = PersistenceHandle::<EthPrimitives>::spawn_service_with_hook(
+            provider.clone(),
+            pruner,
+            sync_metrics_tx,
+            Box::new(persistence_hook.clone()),
+        );
+
+        let mut test_block_builder = TestBlockBuilder::eth();
+        let blocks = test_block_builder.get_executed_blocks(0..3).collect::<Vec<_>>();
+        let tip_hash = blocks[1].recovered_block().hash();
+        let (save_tx, save_rx) = crossbeam_channel::bounded(1);
+        handle.save_blocks(blocks, save_tx).unwrap();
+        save_rx.recv().unwrap();
+
+        let (remove_tx, remove_rx) = crossbeam_channel::bounded(1);
+        handle.remove_blocks_above(1, remove_tx).unwrap();
+
+        let result = remove_rx.recv().unwrap();
+        assert_eq!(result.last_block.unwrap(), BlockNumHash { number: 1, hash: tip_hash });
+        assert_eq!(*persistence_hook.removed_tip.lock().unwrap(), Some(1));
+        assert_eq!(
+            provider.database_provider_ro().unwrap().last_safe_block_number().unwrap(),
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/engine/tree/src/persistence/mod.rs
+++ b/crates/engine/tree/src/persistence/mod.rs
@@ -23,6 +23,9 @@ use std::{
 use thiserror::Error;
 use tracing::{debug, error, instrument, warn};
 
+mod hook;
+pub use hook::{BoxedPersistenceHook, NoopPersistenceHook, PersistenceHook, PersistenceHooks};
+
 /// Unified result of any persistence operation.
 #[derive(Debug)]
 pub struct PersistenceResult {
@@ -39,7 +42,7 @@ pub struct PersistenceResult {
 ///
 /// This should be spawned in its own thread with [`std::thread::spawn`], since this performs
 /// blocking I/O operations in an endless loop.
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct PersistenceService<N>
 where
     N: ProviderNodeTypes,
@@ -60,6 +63,9 @@ where
     /// Pending safe block number to be committed with the next block save.
     /// This avoids triggering a separate fsync for each safe block update.
     pending_safe_block: Option<u64>,
+    /// Hook invoked before non-empty block batches are saved.
+    #[debug(skip)]
+    save_blocks_hook: BoxedPersistenceHook<N>,
 }
 
 impl<N> PersistenceService<N>
@@ -73,9 +79,27 @@ where
         pruner: PrunerWithFactory<ProviderFactory<N>>,
         sync_metrics_tx: MetricEventsSender,
     ) -> Self {
+        Self::new_with_hook(
+            provider,
+            incoming,
+            pruner,
+            sync_metrics_tx,
+            Box::new(NoopPersistenceHook::default()),
+        )
+    }
+
+    /// Create a new persistence service with a custom persistence hook.
+    pub fn new_with_hook(
+        provider: ProviderFactory<N>,
+        incoming: Receiver<PersistenceAction<N::Primitives>>,
+        pruner: PrunerWithFactory<ProviderFactory<N>>,
+        sync_metrics_tx: MetricEventsSender,
+        save_blocks_hook: BoxedPersistenceHook<N>,
+    ) -> Self {
         Self {
             provider,
             incoming,
+            save_blocks_hook,
             pruner,
             metrics: PersistenceMetrics::default(),
             sync_metrics_tx,
@@ -163,6 +187,7 @@ where
 
         if let Some(last) = last_block {
             let provider_rw = self.provider.database_provider_rw()?;
+            self.save_blocks_hook.on_save_blocks(&provider_rw, &blocks);
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
 
             if let Some(finalized) = pending_finalized {
@@ -284,12 +309,40 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
     where
         N: ProviderNodeTypes,
     {
+        Self::spawn_service_with_hook(
+            provider_factory,
+            pruner,
+            sync_metrics_tx,
+            Box::new(NoopPersistenceHook::default()),
+        )
+    }
+
+    /// Create a new [`PersistenceHandle`], and spawn the persistence service with a custom
+    /// persistence hook.
+    ///
+    /// The returned handle can be cloned and shared. When all clones are dropped, the service
+    /// thread will be joined, ensuring graceful shutdown before resources (like `RocksDB`) are
+    /// released.
+    pub fn spawn_service_with_hook<N>(
+        provider_factory: ProviderFactory<N>,
+        pruner: PrunerWithFactory<ProviderFactory<N>>,
+        sync_metrics_tx: MetricEventsSender,
+        save_blocks_hook: BoxedPersistenceHook<N>,
+    ) -> PersistenceHandle<N::Primitives>
+    where
+        N: ProviderNodeTypes,
+    {
         // create the initial channels
         let (db_service_tx, db_service_rx) = std::sync::mpsc::channel();
 
         // spawn the persistence service
-        let db_service =
-            PersistenceService::new(provider_factory, db_service_rx, pruner, sync_metrics_tx);
+        let db_service = PersistenceService::new_with_hook(
+            provider_factory,
+            db_service_rx,
+            pruner,
+            sync_metrics_tx,
+            save_blocks_hook,
+        );
         let join_handle = spawn_os_thread("persistence", || {
             if let Err(err) = db_service.run() {
                 error!(target: "engine::persistence", ?err, "Persistence service failed");
@@ -388,21 +441,27 @@ impl Drop for ServiceGuard {
 mod tests {
     use super::*;
     use alloy_eips::NumHash;
-    use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256, U256};
+    use alloy_primitives::{map::HashSet, BlockHash, BlockNumber, Bytes, B256, U256};
     use reth_chain_state::test_utils::TestBlockBuilder;
     use reth_exex_types::FinishedExExHeight;
     use reth_provider::{
         providers::{ProviderFactoryBuilder, ReadOnlyConfig},
-        test_utils::{create_test_provider_factory, MockNodeTypes},
+        test_utils::{create_test_provider_factory, MockNodeTypes, MockNodeTypesWithDB},
         AccountReader, BalConfig, BalNotificationStream, BalStore, BalStoreHandle,
-        ChainSpecProvider, HeaderProvider, InMemoryBalStore, ProviderError, ProviderResult, RawBal,
-        StorageSettingsCache, TryIntoHistoricalStateProvider,
+        ChainSpecProvider, ChainStateBlockReader, DatabaseProviderFactory, HeaderProvider,
+        InMemoryBalStore, ProviderError, ProviderResult, RawBal, StorageSettingsCache,
+        TryIntoHistoricalStateProvider,
     };
     use reth_prune::Pruner;
     use reth_prune_types::PruneMode;
     use tokio::sync::mpsc::unbounded_channel;
 
-    fn default_persistence_handle() -> PersistenceHandle<EthPrimitives> {
+    type TestProviderRW =
+        <ProviderFactory<MockNodeTypesWithDB> as DatabaseProviderFactory>::ProviderRW;
+
+    fn persistence_handle_with_hook(
+        save_blocks_hook: Box<dyn PersistenceHook<MockNodeTypesWithDB>>,
+    ) -> PersistenceHandle<EthPrimitives> {
         let provider = create_test_provider_factory();
 
         let (_finished_exex_height_tx, finished_exex_height_rx) =
@@ -412,7 +471,16 @@ mod tests {
             Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
 
         let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
-        PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx)
+        PersistenceHandle::<EthPrimitives>::spawn_service_with_hook(
+            provider,
+            pruner,
+            sync_metrics_tx,
+            save_blocks_hook,
+        )
+    }
+
+    fn default_persistence_handle() -> PersistenceHandle<EthPrimitives> {
+        persistence_handle_with_hook(Box::new(NoopPersistenceHook::default()))
     }
 
     #[test]
@@ -534,6 +602,50 @@ mod tests {
         handle.save_blocks(blocks, tx).unwrap();
         let result = rx.recv().unwrap();
         assert_eq!(last_hash, result.last_block.unwrap().hash);
+    }
+
+    #[test]
+    fn test_save_blocks_invokes_hook() {
+        reth_tracing::init_test_tracing();
+        let provider = create_test_provider_factory();
+        let (_finished_exex_height_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let pruner =
+            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
+        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+        let persisted_blocks = Arc::new(std::sync::Mutex::new(HashSet::default()));
+        let persistence_hook = {
+            let persisted_blocks = persisted_blocks.clone();
+            Box::new(move |provider: &TestProviderRW, blocks: &[ExecutedBlock<EthPrimitives>]| {
+                provider.save_safe_block_number(1).unwrap();
+                let mut persisted = persisted_blocks.lock().unwrap();
+                for block in blocks {
+                    persisted.insert(block.recovered_block().num_hash().number);
+                }
+            })
+        };
+        let handle = PersistenceHandle::<EthPrimitives>::spawn_service_with_hook(
+            provider.clone(),
+            pruner,
+            sync_metrics_tx,
+            persistence_hook,
+        );
+
+        let mut test_block_builder = TestBlockBuilder::eth();
+        let blocks = test_block_builder.get_executed_blocks(0..3).collect::<Vec<_>>();
+        let last_hash = blocks.last().unwrap().recovered_block().hash();
+        let (tx, rx) = crossbeam_channel::bounded(1);
+
+        handle.save_blocks(blocks, tx).unwrap();
+
+        let result = rx.recv().unwrap();
+        assert_eq!(last_hash, result.last_block.unwrap().hash);
+        assert_eq!(
+            provider.database_provider_ro().unwrap().last_safe_block_number().unwrap(),
+            Some(1)
+        );
+
+        assert_eq!(persisted_blocks.lock().unwrap().clone(), HashSet::from([0, 1, 2]));
     }
 
     #[test]

--- a/crates/engine/tree/src/persistence/mod.rs
+++ b/crates/engine/tree/src/persistence/mod.rs
@@ -161,8 +161,8 @@ where
         let provider_rw = self.provider.database_provider_rw()?;
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
-        self.persistence_hook.remove_blocks(&provider_rw, new_tip_num)?;
-        provider_rw.remove_block_and_execution_above(new_tip_num)?;
+        let removed_blocks = provider_rw.remove_block_and_execution_above(new_tip_num)?;
+        self.persistence_hook.remove_blocks(&provider_rw, &removed_blocks)?;
         provider_rw.commit()?;
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
@@ -463,7 +463,7 @@ mod tests {
     #[derive(Clone, Default, Debug)]
     struct TestPersistenceHook {
         saved_blocks: Arc<std::sync::Mutex<HashSet<u64>>>,
-        removed_tip: Arc<std::sync::Mutex<Option<u64>>>,
+        removed_blocks: Arc<std::sync::Mutex<Vec<BlockNumHash>>>,
     }
 
     impl PersistenceHook<MockNodeTypesWithDB> for TestPersistenceHook {
@@ -472,7 +472,7 @@ mod tests {
             provider: &TestProviderRW,
             blocks: &[ExecutedBlock<EthPrimitives>],
         ) -> ProviderResult<()> {
-            provider.save_safe_block_number(1).unwrap();
+            provider.save_safe_block_number(1)?;
             let mut saved = self.saved_blocks.lock().unwrap();
             for block in blocks {
                 saved.insert(block.recovered_block().num_hash().number);
@@ -480,9 +480,15 @@ mod tests {
             Ok(())
         }
 
-        fn remove_blocks(&self, provider: &TestProviderRW, new_tip_num: u64) -> ProviderResult<()> {
-            provider.save_safe_block_number(new_tip_num).unwrap();
-            *self.removed_tip.lock().unwrap() = Some(new_tip_num);
+        fn remove_blocks(
+            &self,
+            provider: &TestProviderRW,
+            blocks: &[BlockNumHash],
+        ) -> ProviderResult<()> {
+            if let Some(block) = blocks.last() {
+                provider.save_safe_block_number(block.number)?;
+            }
+            *self.removed_blocks.lock().unwrap() = blocks.to_vec();
             Ok(())
         }
     }
@@ -689,6 +695,7 @@ mod tests {
         let mut test_block_builder = TestBlockBuilder::eth();
         let blocks = test_block_builder.get_executed_blocks(0..3).collect::<Vec<_>>();
         let tip_hash = blocks[1].recovered_block().hash();
+        let removed_block = blocks[2].recovered_block().num_hash();
         let (save_tx, save_rx) = crossbeam_channel::bounded(1);
         handle.save_blocks(blocks, save_tx).unwrap();
         save_rx.recv().unwrap();
@@ -698,10 +705,10 @@ mod tests {
 
         let result = remove_rx.recv().unwrap();
         assert_eq!(result.last_block.unwrap(), BlockNumHash { number: 1, hash: tip_hash });
-        assert_eq!(*persistence_hook.removed_tip.lock().unwrap(), Some(1));
+        assert_eq!(*persistence_hook.removed_blocks.lock().unwrap(), vec![removed_block]);
         assert_eq!(
             provider.database_provider_ro().unwrap().last_safe_block_number().unwrap(),
-            Some(1)
+            Some(removed_block.number)
         );
     }
 

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -18,6 +18,7 @@ use reth_engine_tree::{
     chain::{ChainEvent, FromOrchestrator},
     engine::{EngineApiKind, EngineApiRequest, EngineRequestHandler},
     launch::build_engine_orchestrator,
+    persistence::NoopPersistenceHook,
     tree::TreeConfig,
 };
 use reth_engine_util::EngineMessageStreamExt;
@@ -269,6 +270,7 @@ impl EngineNodeLauncher {
             ctx.components().evm_config().clone(),
             changeset_cache,
             ctx.task_executor().clone(),
+            Box::new(NoopPersistenceHook::default()),
         );
 
         info!(target: "reth::cli", "Consensus engine initialized");

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -18,7 +18,6 @@ use reth_engine_tree::{
     chain::{ChainEvent, FromOrchestrator},
     engine::{EngineApiKind, EngineApiRequest, EngineRequestHandler},
     launch::build_engine_orchestrator,
-    persistence::NoopPersistenceHook,
     tree::TreeConfig,
 };
 use reth_engine_util::EngineMessageStreamExt;
@@ -205,6 +204,7 @@ impl EngineNodeLauncher {
             engine_events: event_sender.clone(),
         };
         let validator_builder = add_ons.engine_validator_builder();
+        let persistence_hook = validator_builder.persistence_hook(&add_ons_ctx)?;
         let state_trie_overlays =
             StateTrieOverlayManager::new(ctx.task_executor().state_trie_overlay_worker_pool());
 
@@ -270,7 +270,7 @@ impl EngineNodeLauncher {
             ctx.components().evm_config().clone(),
             changeset_cache,
             ctx.task_executor().clone(),
-            Box::new(NoopPersistenceHook::default()),
+            persistence_hook,
         );
 
         info!(target: "reth::cli", "Consensus engine initialized");

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -5,7 +5,10 @@ pub use jsonrpsee::{
     server::middleware::rpc::{RpcService, RpcServiceBuilder},
 };
 use reth_engine_tree::tree::WaitForCaches;
-pub use reth_engine_tree::tree::{BasicEngineValidator, EngineValidator};
+pub use reth_engine_tree::{
+    persistence::{BoxedPersistenceHook, NoopPersistenceHook, PersistenceHook},
+    tree::{BasicEngineValidator, EngineValidator},
+};
 pub use reth_rpc_builder::{
     middleware::{RethAuthHttpMiddleware, RethRpcMiddleware},
     Identity, Stack,
@@ -24,7 +27,8 @@ use reth_chain_state::{CanonStateSubscriptions, StateTrieOverlayManager};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineApiValidator, EngineTypes, FullNodeComponents, FullNodeTypes,
-    NodeAddOns, NodeTypes, PayloadTypes, PayloadValidator, PrimitivesTy, TreeConfig,
+    NodeAddOns, NodeTypes, NodeTypesWithDBAdapter, PayloadTypes, PayloadValidator, PrimitivesTy,
+    TreeConfig,
 };
 use reth_node_core::{
     cli::config::RethTransactionPoolConfig,
@@ -32,6 +36,7 @@ use reth_node_core::{
     version::{version_metadata, CLIENT_CODE},
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
+use reth_provider::providers::ProviderNodeTypes;
 use reth_rpc::{
     eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
     AdminApi,
@@ -1415,6 +1420,22 @@ pub trait EngineValidatorBuilder<Node: FullNodeComponents>: Send + Sync + Clone 
         changeset_cache: ChangesetCache,
         state_trie_overlays: StateTrieOverlayManager<PrimitivesTy<Node::Types>>,
     ) -> impl Future<Output = eyre::Result<Self::EngineValidator>> + Send;
+
+    /// Returns the hook installed into the engine persistence service.
+    ///
+    /// The hook runs inside the database transaction that saves block batches, so
+    /// implementations can persist auxiliary per-block data atomically with the blocks.
+    /// The default installs a hook that does nothing.
+    fn persistence_hook(
+        &self,
+        ctx: &AddOnsContext<'_, Node>,
+    ) -> eyre::Result<BoxedPersistenceHook<NodeTypesWithDBAdapter<Node::Types, Node::DB>>>
+    where
+        NodeTypesWithDBAdapter<Node::Types, Node::DB>: ProviderNodeTypes,
+    {
+        let _ = ctx;
+        Ok(Box::new(NoopPersistenceHook::default()))
+    }
 }
 
 /// Basic implementation of [`EngineValidatorBuilder`].

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -24,7 +24,7 @@ use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
     BlockHeader, TxReceipt,
 };
-use alloy_eips::BlockHashOrNumber;
+use alloy_eips::{BlockHashOrNumber, BlockNumHash};
 use alloy_primitives::{
     keccak256,
     map::{hash_map, AddressSet, B256Map, HashMap},
@@ -3486,7 +3486,10 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockExecutionWriter
         Ok(Chain::new(blocks, execution_state, BTreeMap::new()))
     }
 
-    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()> {
+    fn remove_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Vec<BlockNumHash>> {
         self.unwind_trie_state_from(block + 1)?;
 
         // remove execution res
@@ -3494,12 +3497,12 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockExecutionWriter
 
         // remove block bodies it is needed for both get block range and get block execution results
         // that is why it is deleted afterwards.
-        self.remove_blocks_above(block)?;
+        let removed_blocks = self.remove_blocks_above(block)?;
 
         // Update pipeline progress
         self.update_pipeline_stages(block, true)?;
 
-        Ok(())
+        Ok(removed_blocks)
     }
 }
 
@@ -3594,11 +3597,13 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
         Ok(())
     }
 
-    fn remove_blocks_above(&self, block: BlockNumber) -> ProviderResult<()> {
+    fn remove_blocks_above(&self, block: BlockNumber) -> ProviderResult<Vec<BlockNumHash>> {
         let last_block_number = self.last_block_number()?;
+
         // Clean up HeaderNumbers for blocks being removed, we must clear all indexes from MDBX.
-        for hash in self.canonical_hashes_range(block + 1, last_block_number + 1)? {
-            self.tx.delete::<tables::HeaderNumbers>(hash, None)?;
+        let canonical_hashes = self.canonical_hashes_range(block + 1, last_block_number + 1)?;
+        for hash in &canonical_hashes {
+            self.tx.delete::<tables::HeaderNumbers>(*hash, None)?;
         }
 
         // Get highest static file block for the total block range
@@ -3653,7 +3658,12 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
 
         self.remove_bodies_above(block)?;
 
-        Ok(())
+        let removed_num_hashes = canonical_hashes
+            .into_iter()
+            .zip(block + 1..=last_block_number)
+            .map(|(hash, number)| BlockNumHash { number, hash })
+            .collect::<Vec<_>>();
+        Ok(removed_num_hashes)
     }
 
     fn remove_bodies_above(&self, block: BlockNumber) -> ProviderResult<()> {

--- a/crates/storage/storage-api/src/block_writer.rs
+++ b/crates/storage/storage-api/src/block_writer.rs
@@ -1,5 +1,6 @@
 use crate::NodePrimitivesProvider;
 use alloc::vec::Vec;
+use alloy_eips::BlockNumHash;
 use alloy_primitives::BlockNumber;
 use reth_db_models::StoredBlockBodyIndices;
 use reth_execution_types::{Chain, ExecutionOutcome};
@@ -22,7 +23,12 @@ pub trait BlockExecutionWriter:
     /// Remove all of the blocks above the provided number and their execution result
     ///
     /// The passed block number will stay in the database.
-    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()>;
+    ///
+    /// Returns removed block number/hash pairs ordered by ascending block number.
+    fn remove_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Vec<BlockNumHash>>;
 }
 
 impl<T: BlockExecutionWriter> BlockExecutionWriter for &T {
@@ -33,7 +39,10 @@ impl<T: BlockExecutionWriter> BlockExecutionWriter for &T {
         (*self).take_block_and_execution_above(block)
     }
 
-    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()> {
+    fn remove_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<Vec<BlockNumHash>> {
         (*self).remove_block_and_execution_above(block)
     }
 }
@@ -69,7 +78,9 @@ pub trait BlockWriter {
     /// Removes all blocks above the given block number from the database.
     ///
     /// Note: This does not remove state or execution data.
-    fn remove_blocks_above(&self, block: BlockNumber) -> ProviderResult<()>;
+    ///
+    /// Returns removed block number/hash pairs ordered by ascending block number.
+    fn remove_blocks_above(&self, block: BlockNumber) -> ProviderResult<Vec<BlockNumHash>>;
 
     /// Removes all block bodies above the given block number from the database.
     fn remove_bodies_above(&self, block: BlockNumber) -> ProviderResult<()>;


### PR DESCRIPTION
## Description

Adds a configurable persistence hook that runs when the engine persistence task saves or removes block batches.

The hook receives the writable provider used for the save or removal, so auxiliary data can be written and committed with the same persistence transaction.