### PR TITLE
feat(trie): add sparse state trie witness

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -369,6 +369,8 @@ where
         };
 
         #[cfg(feature = "trie-debug")]
+        let trie_witness = self.trie.witness();
+        #[cfg(feature = "trie-debug")]
         let debug_recorders = self.trie.take_debug_recorders();
         let changed_paths = Some(Arc::new(self.trie.take_changed_paths().unwrap_or_default()));
 
@@ -391,6 +393,8 @@ where
             changed_paths,
             #[cfg(feature = "trie-debug")]
             debug_recorders,
+            #[cfg(feature = "trie-debug")]
+            trie_witness,
         })
     }
 

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -628,9 +628,10 @@ where
         &self,
         block: &RecoveredBlock<N::Block>,
         output: &BlockExecutionOutput<N::Receipt>,
+        hashed_state: &LazyHashedPostState,
         outcome: StateRootComputeOutcome,
     ) -> ProviderResult<StateRootJobOutcome> {
-        let outcome = self.sparse_outcome(block, output, outcome);
+        let outcome = self.sparse_outcome(block, output, hashed_state, outcome);
         if outcome.state_root == block.header().state_root() {
             return Ok(outcome)
         }
@@ -647,6 +648,7 @@ where
         &self,
         _block: &RecoveredBlock<N::Block>,
         output: &BlockExecutionOutput<N::Receipt>,
+        hashed_state: &LazyHashedPostState,
         outcome: StateRootComputeOutcome,
     ) -> StateRootJobOutcome {
         let StateRootComputeOutcome {
@@ -670,7 +672,7 @@ where
             if _has_diff {
                 self.write_sparse_trie_debug_artifacts(
                     _block.header().number(),
-                    output,
+                    hashed_state,
                     &debug_recorders,
                     &trie_witness,
                 );
@@ -681,7 +683,7 @@ where
         if state_root != _block.header().state_root() {
             self.write_sparse_trie_debug_artifacts(
                 _block.header().number(),
-                output,
+                hashed_state,
                 &debug_recorders,
                 &trie_witness,
             );
@@ -694,11 +696,11 @@ where
     fn write_sparse_trie_debug_artifacts(
         &self,
         block_number: u64,
-        output: &BlockExecutionOutput<N::Receipt>,
+        hashed_state: &LazyHashedPostState,
         recorders: &[(Option<B256>, TrieDebugRecorder)],
         trie_witness: &B256Map<Bytes>,
     ) {
-        let fallback_trie_witness = self.fallback_sparse_trie_witness(output);
+        let fallback_trie_witness = self.fallback_sparse_trie_witness(hashed_state);
         write_sparse_trie_debug_artifacts(
             block_number,
             recorders,
@@ -710,20 +712,9 @@ where
     #[cfg(feature = "trie-debug")]
     fn fallback_sparse_trie_witness(
         &self,
-        output: &BlockExecutionOutput<N::Receipt>,
+        hashed_state: &LazyHashedPostState,
     ) -> Option<B256Map<Bytes>> {
-        let provider = match self.provider_builder.clone().build() {
-            Ok(provider) => provider,
-            Err(err) => {
-                warn!(
-                    target: "engine::tree::state_root_strategy",
-                    %err,
-                    "Failed to build provider for fallback trie witness"
-                );
-                return None
-            }
-        };
-        let hashed_state = provider.hashed_post_state(&output.state);
+        let hashed_state = hashed_state.get().as_ref().clone();
         let overlay_provider = match self.overlay_factory.database_provider_ro() {
             Ok(provider) => provider,
             Err(err) => {
@@ -770,11 +761,11 @@ where
         &mut self,
         block: &RecoveredBlock<N::Block>,
         output: Arc<BlockExecutionOutput<N::Receipt>>,
-        _hashed_state: &LazyHashedPostState,
+        hashed_state: &LazyHashedPostState,
     ) -> ProviderResult<StateRootJobOutcome> {
         if self.timeout.is_none() {
             return match self.handle.state_root() {
-                Ok(outcome) => self.verified_sparse_outcome(block, &output, outcome),
+                Ok(outcome) => self.verified_sparse_outcome(block, &output, hashed_state, outcome),
                 Err(err) => {
                     debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
                     self.compute_serial(&output)
@@ -785,7 +776,9 @@ where
         let timeout = self.timeout.expect("checked above");
         let task_rx = self.handle.take_state_root_rx();
         let fallback_rx = match task_rx.recv_timeout(timeout) {
-            Ok(Ok(outcome)) => return self.verified_sparse_outcome(block, &output, outcome),
+            Ok(Ok(outcome)) => {
+                return self.verified_sparse_outcome(block, &output, hashed_state, outcome)
+            }
             Ok(Err(err)) => {
                 debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
                 Self::serial_fallback(
@@ -815,7 +808,7 @@ where
 
         loop {
             if let Ok(Ok(outcome)) = task_rx.try_recv() {
-                let outcome = self.sparse_outcome(block, &output, outcome);
+                let outcome = self.sparse_outcome(block, &output, hashed_state, outcome);
                 if outcome.state_root == block.header().state_root() {
                     return Ok(outcome)
                 }

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -54,6 +54,8 @@ use crate::tree::{
     ExecutionEnv, StateProviderBuilder, TreeConfig,
 };
 use alloy_primitives::B256;
+#[cfg(feature = "trie-debug")]
+use alloy_primitives::{map::B256Map, Bytes};
 use reth_errors::ProviderResult;
 use reth_evm::{ConfigureEvm, OnStateHook};
 use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives, RecoveredBlock};
@@ -651,6 +653,8 @@ where
             changed_paths,
             #[cfg(feature = "trie-debug")]
             debug_recorders,
+            #[cfg(feature = "trie-debug")]
+            trie_witness,
         } = outcome;
 
         if self.compare_trie_updates {
@@ -662,13 +666,17 @@ where
             );
             #[cfg(feature = "trie-debug")]
             if _has_diff {
-                write_trie_debug_recorders(_block.header().number(), &debug_recorders);
+                write_trie_debug_recorders(
+                    _block.header().number(),
+                    &debug_recorders,
+                    &trie_witness,
+                );
             }
         }
 
         #[cfg(feature = "trie-debug")]
         if state_root != _block.header().state_root() {
-            write_trie_debug_recorders(_block.header().number(), &debug_recorders);
+            write_trie_debug_recorders(_block.header().number(), &debug_recorders, &trie_witness);
         }
 
         StateRootJobOutcome::new(state_root, trie_updates).with_changed_paths(changed_paths)
@@ -836,7 +844,11 @@ where
 ///
 /// The file is written to the current working directory as `trie_debug_block_{block_number}.json`.
 #[cfg(feature = "trie-debug")]
-fn write_trie_debug_recorders(block_number: u64, recorders: &[(Option<B256>, TrieDebugRecorder)]) {
+fn write_trie_debug_recorders(
+    block_number: u64,
+    recorders: &[(Option<B256>, TrieDebugRecorder)],
+    trie_witness: &B256Map<Bytes>,
+) {
     let path = format!("trie_debug_block_{block_number}.json");
     match serde_json::to_string_pretty(recorders) {
         Ok(json) => match std::fs::write(&path, json) {
@@ -861,6 +873,34 @@ fn write_trie_debug_recorders(block_number: u64, recorders: &[(Option<B256>, Tri
                 target: "engine::tree::state_root_strategy",
                 %err,
                 "Failed to serialize trie debug recorders"
+            );
+        }
+    }
+
+    let path = format!("trie_witness_block_{block_number}.json");
+    match serde_json::to_string_pretty(trie_witness) {
+        Ok(json) => match std::fs::write(&path, json) {
+            Ok(()) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %path,
+                    "Wrote trie witness to file"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %err,
+                    %path,
+                    "Failed to write trie witness"
+                );
+            }
+        },
+        Err(err) => {
+            warn!(
+                target: "engine::tree::state_root_strategy",
+                %err,
+                "Failed to serialize trie witness"
             );
         }
     }

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -666,7 +666,7 @@ where
             );
             #[cfg(feature = "trie-debug")]
             if _has_diff {
-                write_trie_debug_recorders(
+                write_sparse_trie_debug_artifacts(
                     _block.header().number(),
                     &debug_recorders,
                     &trie_witness,
@@ -676,7 +676,11 @@ where
 
         #[cfg(feature = "trie-debug")]
         if state_root != _block.header().state_root() {
-            write_trie_debug_recorders(_block.header().number(), &debug_recorders, &trie_witness);
+            write_sparse_trie_debug_artifacts(
+                _block.header().number(),
+                &debug_recorders,
+                &trie_witness,
+            );
         }
 
         StateRootJobOutcome::new(state_root, trie_updates).with_changed_paths(changed_paths)
@@ -840,11 +844,12 @@ where
     false
 }
 
-/// Writes trie debug recorders to a JSON file for the given block number.
+/// Writes sparse trie debug artifacts to JSON files for the given block number.
 ///
-/// The file is written to the current working directory as `trie_debug_block_{block_number}.json`.
+/// Files are written to the current working directory as `trie_debug_block_{block_number}.json`
+/// and `sparse_trie_witness_block_{block_number}.json`.
 #[cfg(feature = "trie-debug")]
-fn write_trie_debug_recorders(
+fn write_sparse_trie_debug_artifacts(
     block_number: u64,
     recorders: &[(Option<B256>, TrieDebugRecorder)],
     trie_witness: &B256Map<Bytes>,
@@ -877,7 +882,7 @@ fn write_trie_debug_recorders(
         }
     }
 
-    let path = format!("trie_witness_block_{block_number}.json");
+    let path = format!("sparse_trie_witness_block_{block_number}.json");
     match serde_json::to_string_pretty(trie_witness) {
         Ok(json) => match std::fs::write(&path, json) {
             Ok(()) => {

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -64,6 +64,8 @@ use reth_provider::{
     DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider, ProviderError,
     StateProviderFactory, StateReader, StateRootProvider,
 };
+#[cfg(feature = "trie-debug")]
+use reth_trie::witness::TrieWitness;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, prefix_set::TriePrefixSetsMut,
     trie_cursor::TrieCursorFactory, updates::TrieUpdates, HashedPostState,
@@ -666,8 +668,9 @@ where
             );
             #[cfg(feature = "trie-debug")]
             if _has_diff {
-                write_sparse_trie_debug_artifacts(
+                self.write_sparse_trie_debug_artifacts(
                     _block.header().number(),
+                    output,
                     &debug_recorders,
                     &trie_witness,
                 );
@@ -676,14 +679,76 @@ where
 
         #[cfg(feature = "trie-debug")]
         if state_root != _block.header().state_root() {
-            write_sparse_trie_debug_artifacts(
+            self.write_sparse_trie_debug_artifacts(
                 _block.header().number(),
+                output,
                 &debug_recorders,
                 &trie_witness,
             );
         }
 
         StateRootJobOutcome::new(state_root, trie_updates).with_changed_paths(changed_paths)
+    }
+
+    #[cfg(feature = "trie-debug")]
+    fn write_sparse_trie_debug_artifacts(
+        &self,
+        block_number: u64,
+        output: &BlockExecutionOutput<N::Receipt>,
+        recorders: &[(Option<B256>, TrieDebugRecorder)],
+        trie_witness: &B256Map<Bytes>,
+    ) {
+        let fallback_trie_witness = self.fallback_sparse_trie_witness(output);
+        write_sparse_trie_debug_artifacts(
+            block_number,
+            recorders,
+            trie_witness,
+            fallback_trie_witness.as_ref(),
+        );
+    }
+
+    #[cfg(feature = "trie-debug")]
+    fn fallback_sparse_trie_witness(
+        &self,
+        output: &BlockExecutionOutput<N::Receipt>,
+    ) -> Option<B256Map<Bytes>> {
+        let provider = match self.provider_builder.clone().build() {
+            Ok(provider) => provider,
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %err,
+                    "Failed to build provider for fallback trie witness"
+                );
+                return None
+            }
+        };
+        let hashed_state = provider.hashed_post_state(&output.state);
+        let overlay_provider = match self.overlay_factory.database_provider_ro() {
+            Ok(provider) => provider,
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %err,
+                    "Failed to build overlay provider for fallback trie witness"
+                );
+                return None
+            }
+        };
+
+        match TrieWitness::new(&overlay_provider, &overlay_provider)
+            .compute_post_state_witness(hashed_state)
+        {
+            Ok(witness) => Some(witness),
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %err,
+                    "Failed to compute fallback trie witness"
+                );
+                None
+            }
+        }
     }
 }
 
@@ -847,12 +912,14 @@ where
 /// Writes sparse trie debug artifacts to JSON files for the given block number.
 ///
 /// Files are written to the current working directory as `trie_debug_block_{block_number}.json`
-/// and `sparse_trie_witness_block_{block_number}.json`.
+/// and `sparse_trie_witness_block_{block_number}.json`. When available, the serial fallback
+/// witness is also written as `fallback_sparse_trie_witness_block_{block_number}.json`.
 #[cfg(feature = "trie-debug")]
 fn write_sparse_trie_debug_artifacts(
     block_number: u64,
     recorders: &[(Option<B256>, TrieDebugRecorder)],
     trie_witness: &B256Map<Bytes>,
+    fallback_trie_witness: Option<&B256Map<Bytes>>,
 ) {
     let path = format!("trie_debug_block_{block_number}.json");
     match serde_json::to_string_pretty(recorders) {
@@ -906,6 +973,36 @@ fn write_sparse_trie_debug_artifacts(
                 target: "engine::tree::state_root_strategy",
                 %err,
                 "Failed to serialize trie witness"
+            );
+        }
+    }
+
+    let Some(fallback_trie_witness) = fallback_trie_witness else { return };
+
+    let path = format!("fallback_sparse_trie_witness_block_{block_number}.json");
+    match serde_json::to_string_pretty(fallback_trie_witness) {
+        Ok(json) => match std::fs::write(&path, json) {
+            Ok(()) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %path,
+                    "Wrote fallback trie witness to file"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::state_root_strategy",
+                    %err,
+                    %path,
+                    "Failed to write fallback trie witness"
+                );
+            }
+        },
+        Err(err) => {
+            warn!(
+                target: "engine::tree::state_root_strategy",
+                %err,
+                "Failed to serialize fallback trie witness"
             );
         }
     }

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -9,6 +9,8 @@
 
 use crate::error::StateRootTaskError;
 use alloy_evm::block::OnStateHook;
+#[cfg(feature = "trie-debug")]
+use alloy_primitives::Bytes;
 use alloy_primitives::{keccak256, map::B256Map, B256};
 use reth_trie::{
     prefix_set::TriePrefixSetsMut, updates::TrieUpdates, HashedPostState, HashedStorage,
@@ -48,6 +50,9 @@ pub struct StateRootComputeOutcome {
     /// and `Some(address)` for storage tries.
     #[cfg(feature = "trie-debug")]
     pub debug_recorders: Vec<(Option<B256>, reth_trie_sparse::debug_recorder::TrieDebugRecorder)>,
+    /// Trie witness collected from all revealed sparse tries.
+    #[cfg(feature = "trie-debug")]
+    pub trie_witness: B256Map<Bytes>,
 }
 
 /// Handle to a background sparse trie state root computation.
@@ -624,6 +629,8 @@ mod tests {
                 changed_paths: None,
                 #[cfg(feature = "trie-debug")]
                 debug_recorders: Vec::new(),
+                #[cfg(feature = "trie-debug")]
+                trie_witness: B256Map::default(),
             }))
             .unwrap();
         let outcome = handle.state_root().expect("outcome is delivered");

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -247,6 +247,31 @@ impl ArenaCursor {
             self.needs_pop = false;
         }
 
+        self.next_after_pending_pop(arena, should_descend)
+    }
+
+    /// Read-only variant of [`Self::next`] for traversals that do not need dirty-state
+    /// propagation when popping cursor entries.
+    #[instrument(level = "trace", target = TRACE_TARGET, skip_all, ret)]
+    pub(super) fn next_ref(
+        &mut self,
+        arena: &NodeArena,
+        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
+    ) -> NextResult {
+        if self.needs_pop {
+            self.stack.pop().expect("pop can't be called on empty stack");
+            self.needs_pop = false;
+        }
+
+        self.next_after_pending_pop(arena, should_descend)
+    }
+
+    /// Advances the cursor after any pending pop has already been handled by the caller.
+    fn next_after_pending_pop(
+        &mut self,
+        arena: &NodeArena,
+        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
+    ) -> NextResult {
         loop {
             let Some(head) = self.stack.last_mut() else {
                 return NextResult::Done;
@@ -275,62 +300,6 @@ impl ArenaCursor {
 
                 if should_descend(child_depth, &arena[child_idx]) {
                     // Record where to resume iteration when we return to this entry.
-                    self.stack.last_mut().expect("head exists").next_dense_idx =
-                        branch_child_idx.get() + 1;
-                    let path = self.child_path(arena, nibble);
-                    self.push(arena, child_idx, path);
-                    descended = true;
-                    break;
-                }
-            }
-
-            if !descended {
-                self.needs_pop = true;
-                return NextResult::Branch;
-            }
-        }
-    }
-
-    /// Read-only variant of [`Self::next`] for traversals that do not need dirty-state
-    /// propagation when popping cursor entries.
-    #[instrument(level = "trace", target = TRACE_TARGET, skip_all, ret)]
-    pub(super) fn next_ref(
-        &mut self,
-        arena: &NodeArena,
-        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
-    ) -> NextResult {
-        if self.needs_pop {
-            self.stack.pop().expect("pop can't be called on empty stack");
-            self.needs_pop = false;
-        }
-
-        loop {
-            let Some(head) = self.stack.last_mut() else {
-                return NextResult::Done;
-            };
-            let head_idx = head.index;
-
-            let ArenaSparseNode::Branch(branch) = &arena[head_idx] else {
-                self.needs_pop = true;
-                return NextResult::NonBranch;
-            };
-
-            let state_mask = branch.state_mask;
-            let start = head.next_dense_idx;
-            let child_depth = self.stack.len();
-
-            let mut descended = false;
-            for (branch_child_idx, nibble) in BranchChildIter::new(state_mask) {
-                if branch_child_idx.get() < start {
-                    continue;
-                }
-
-                let child_idx = match &arena[head_idx].branch_ref().children[branch_child_idx] {
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => *child_idx,
-                    ArenaSparseNodeBranchChild::Blinded(_) => continue,
-                };
-
-                if should_descend(child_depth, &arena[child_idx]) {
                     self.stack.last_mut().expect("head exists").next_dense_idx =
                         branch_child_idx.get() + 1;
                     let path = self.child_path(arena, nibble);

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -291,6 +291,62 @@ impl ArenaCursor {
         }
     }
 
+    /// Read-only variant of [`Self::next`] for traversals that do not need dirty-state
+    /// propagation when popping cursor entries.
+    #[instrument(level = "trace", target = TRACE_TARGET, skip_all, ret)]
+    pub(super) fn next_ref(
+        &mut self,
+        arena: &NodeArena,
+        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
+    ) -> NextResult {
+        if self.needs_pop {
+            self.stack.pop().expect("pop can't be called on empty stack");
+            self.needs_pop = false;
+        }
+
+        loop {
+            let Some(head) = self.stack.last_mut() else {
+                return NextResult::Done;
+            };
+            let head_idx = head.index;
+
+            let ArenaSparseNode::Branch(branch) = &arena[head_idx] else {
+                self.needs_pop = true;
+                return NextResult::NonBranch;
+            };
+
+            let state_mask = branch.state_mask;
+            let start = head.next_dense_idx;
+            let child_depth = self.stack.len();
+
+            let mut descended = false;
+            for (branch_child_idx, nibble) in BranchChildIter::new(state_mask) {
+                if branch_child_idx.get() < start {
+                    continue;
+                }
+
+                let child_idx = match &arena[head_idx].branch_ref().children[branch_child_idx] {
+                    ArenaSparseNodeBranchChild::Revealed(child_idx) => *child_idx,
+                    ArenaSparseNodeBranchChild::Blinded(_) => continue,
+                };
+
+                if should_descend(child_depth, &arena[child_idx]) {
+                    self.stack.last_mut().expect("head exists").next_dense_idx =
+                        branch_child_idx.get() + 1;
+                    let path = self.child_path(arena, nibble);
+                    self.push(arena, child_idx, path);
+                    descended = true;
+                    break;
+                }
+            }
+
+            if !descended {
+                self.needs_pop = true;
+                return NextResult::Branch;
+            }
+        }
+    }
+
     /// Pops the stack until the head is an ancestor of `full_path`, then descends from that head
     /// toward `full_path`, pushing revealed branch (and leaf) children onto the stack until the
     /// deepest ancestor is reached.

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -247,31 +247,6 @@ impl ArenaCursor {
             self.needs_pop = false;
         }
 
-        self.next_after_pending_pop(arena, should_descend)
-    }
-
-    /// Read-only variant of [`Self::next`] for traversals that do not need dirty-state
-    /// propagation when popping cursor entries.
-    #[instrument(level = "trace", target = TRACE_TARGET, skip_all, ret)]
-    pub(super) fn next_ref(
-        &mut self,
-        arena: &NodeArena,
-        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
-    ) -> NextResult {
-        if self.needs_pop {
-            self.stack.pop().expect("pop can't be called on empty stack");
-            self.needs_pop = false;
-        }
-
-        self.next_after_pending_pop(arena, should_descend)
-    }
-
-    /// Advances the cursor after any pending pop has already been handled by the caller.
-    fn next_after_pending_pop(
-        &mut self,
-        arena: &NodeArena,
-        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
-    ) -> NextResult {
         loop {
             let Some(head) = self.stack.last_mut() else {
                 return NextResult::Done;

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1495,8 +1495,8 @@ impl ArenaParallelSparseTrie {
         }
     }
 
-    /// Records all revealed nodes in one arena using cursor post-order traversal.
-    fn record_arena_witness_nodes(
+    /// Records all revealed nodes in an arena using cursor post-order traversal.
+    fn record_witness_nodes(
         arena: &NodeArena,
         root: Index,
         cursor: &mut ArenaCursor,
@@ -1507,26 +1507,6 @@ impl ArenaParallelSparseTrie {
 
         loop {
             match cursor.next_ref(arena, |_, node| {
-                matches!(node, ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. })
-            }) {
-                NextResult::Done => break,
-                NextResult::Branch | NextResult::NonBranch => {
-                    let idx = cursor.head().expect("cursor is non-empty").index;
-                    let rlp_node = Self::record_arena_witness_node(arena, idx, rlp_nodes, witness);
-                    rlp_nodes.insert(idx, rlp_node);
-                }
-            }
-        }
-    }
-
-    /// Records all revealed nodes in the upper arena and any revealed subtries.
-    fn record_witness_nodes(&self, witness: &mut B256Map<Bytes>) {
-        let mut cursor = ArenaCursor::default();
-        let mut rlp_nodes = HashMap::default();
-        cursor.reset(&self.upper_arena, self.root, Nibbles::default());
-
-        loop {
-            match cursor.next_ref(&self.upper_arena, |_, node| {
                 matches!(
                     node,
                     ArenaSparseNode::Branch(_) |
@@ -1537,11 +1517,11 @@ impl ArenaParallelSparseTrie {
                 NextResult::Done => break,
                 NextResult::Branch | NextResult::NonBranch => {
                     let idx = cursor.head().expect("cursor is non-empty").index;
-                    let rlp_node = match &self.upper_arena[idx] {
+                    let rlp_node = match &arena[idx] {
                         ArenaSparseNode::Subtrie(subtrie) => {
                             let mut subtrie_cursor = ArenaCursor::default();
                             let mut subtrie_rlp_nodes = HashMap::default();
-                            Self::record_arena_witness_nodes(
+                            Self::record_witness_nodes(
                                 &subtrie.arena,
                                 subtrie.root,
                                 &mut subtrie_cursor,
@@ -1557,12 +1537,7 @@ impl ArenaParallelSparseTrie {
                             );
                             root_rlp_node
                         }
-                        _ => Self::record_arena_witness_node(
-                            &self.upper_arena,
-                            idx,
-                            &mut rlp_nodes,
-                            witness,
-                        ),
+                        _ => Self::record_arena_witness_node(arena, idx, rlp_nodes, witness),
                     };
                     rlp_nodes.insert(idx, rlp_node);
                 }
@@ -2827,7 +2802,17 @@ impl SparseTrie for ArenaParallelSparseTrie {
     }
 
     fn witness(&self, witness: &mut B256Map<Bytes>) {
-        self.record_witness_nodes(witness);
+        let mut cursor = ArenaCursor::default();
+        let mut rlp_nodes = HashMap::default();
+        Self::record_witness_nodes(
+            &self.upper_arena,
+            self.root,
+            &mut cursor,
+            &mut rlp_nodes,
+            witness,
+        );
+        rlp_nodes.remove(&self.root);
+        debug_assert!(rlp_nodes.is_empty(), "all witness RLP nodes must be consumed");
     }
 
     fn find_leaf(

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1437,64 +1437,6 @@ impl ArenaParallelSparseTrie {
         witness.entry(keccak256(encoded)).or_insert_with(|| Bytes::from(encoded.to_vec()));
     }
 
-    /// Records the node at `idx` using already-recorded child `RlpNode`s, returning the `RlpNode`
-    /// reference for this node.
-    fn record_arena_witness_node(
-        arena: &NodeArena,
-        idx: Index,
-        child_rlp_nodes: &mut HashMap<Index, RlpNode>,
-        witness: &mut B256Map<Bytes>,
-    ) -> RlpNode {
-        match &arena[idx] {
-            ArenaSparseNode::EmptyRoot => {
-                Self::record_witness_node(witness, &[0x80]);
-                RlpNode::word_rlp(&EMPTY_ROOT_HASH)
-            }
-            ArenaSparseNode::Leaf { key, value, .. } => {
-                let mut encoded = Vec::new();
-                let rlp_node = LeafNodeRef::new(key, value).rlp(&mut encoded);
-                Self::record_witness_node(witness, &encoded);
-                rlp_node
-            }
-            ArenaSparseNode::Branch(branch) => {
-                let mut stack = Vec::with_capacity(branch.children.len());
-                for (_, child) in branch.child_iter() {
-                    let rlp_node = match child {
-                        ArenaSparseNodeBranchChild::Blinded(rlp_node) => rlp_node.clone(),
-                        ArenaSparseNodeBranchChild::Revealed(child_idx) => child_rlp_nodes
-                            .remove(child_idx)
-                            .expect("revealed child must be recorded before parent branch"),
-                    };
-                    stack.push(rlp_node);
-                }
-
-                let mut branch_rlp = Vec::new();
-                let branch_rlp_node =
-                    BranchNodeRef::new(&stack, branch.state_mask).rlp(&mut branch_rlp);
-                // A branch with a short key is encoded as an extension node pointing to the
-                // branch. Witness consumers need both the extension and the branch node.
-                Self::record_witness_node(witness, &branch_rlp);
-
-                if branch.short_key.is_empty() {
-                    branch_rlp_node
-                } else {
-                    let mut extension_rlp = Vec::new();
-                    let extension_rlp_node =
-                        ExtensionNodeRef::new(&branch.short_key, branch_rlp_node.as_slice())
-                            .rlp(&mut extension_rlp);
-                    Self::record_witness_node(witness, &extension_rlp);
-                    extension_rlp_node
-                }
-            }
-            ArenaSparseNode::Subtrie(_) => {
-                unreachable!("subtries are recorded separately before their upper parent branch")
-            }
-            ArenaSparseNode::TakenSubtrie => {
-                unreachable!("TakenSubtrie should not be present outside of active operations")
-            }
-        }
-    }
-
     /// Records all revealed nodes in an arena using cursor post-order traversal.
     fn record_witness_nodes(
         arena: &NodeArena,
@@ -1518,6 +1460,53 @@ impl ArenaParallelSparseTrie {
                 NextResult::Branch | NextResult::NonBranch => {
                     let idx = cursor.head().expect("cursor is non-empty").index;
                     let rlp_node = match &arena[idx] {
+                        ArenaSparseNode::EmptyRoot => {
+                            Self::record_witness_node(witness, &[0x80]);
+                            RlpNode::word_rlp(&EMPTY_ROOT_HASH)
+                        }
+                        ArenaSparseNode::Leaf { key, value, .. } => {
+                            let mut encoded = Vec::new();
+                            let rlp_node = LeafNodeRef::new(key, value).rlp(&mut encoded);
+                            Self::record_witness_node(witness, &encoded);
+                            rlp_node
+                        }
+                        ArenaSparseNode::Branch(branch) => {
+                            let mut stack = Vec::with_capacity(branch.children.len());
+                            for (_, child) in branch.child_iter() {
+                                let rlp_node = match child {
+                                    ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
+                                        rlp_node.clone()
+                                    }
+                                    ArenaSparseNodeBranchChild::Revealed(child_idx) => {
+                                        rlp_nodes.remove(child_idx).expect(
+                                            "revealed child must be recorded before parent branch",
+                                        )
+                                    }
+                                };
+                                stack.push(rlp_node);
+                            }
+
+                            let mut branch_rlp = Vec::new();
+                            let branch_rlp_node =
+                                BranchNodeRef::new(&stack, branch.state_mask).rlp(&mut branch_rlp);
+                            // A branch with a short key is encoded as an extension node pointing to
+                            // the branch. Witness consumers need both the extension and the branch
+                            // node.
+                            Self::record_witness_node(witness, &branch_rlp);
+
+                            if branch.short_key.is_empty() {
+                                branch_rlp_node
+                            } else {
+                                let mut extension_rlp = Vec::new();
+                                let extension_rlp_node = ExtensionNodeRef::new(
+                                    &branch.short_key,
+                                    branch_rlp_node.as_slice(),
+                                )
+                                .rlp(&mut extension_rlp);
+                                Self::record_witness_node(witness, &extension_rlp);
+                                extension_rlp_node
+                            }
+                        }
                         ArenaSparseNode::Subtrie(subtrie) => {
                             let mut subtrie_cursor = ArenaCursor::default();
                             let mut subtrie_rlp_nodes = HashMap::default();
@@ -1537,7 +1526,11 @@ impl ArenaParallelSparseTrie {
                             );
                             root_rlp_node
                         }
-                        _ => Self::record_arena_witness_node(arena, idx, rlp_nodes, witness),
+                        ArenaSparseNode::TakenSubtrie => {
+                            unreachable!(
+                                "TakenSubtrie should not be present outside of active operations"
+                            )
+                        }
                     };
                     rlp_nodes.insert(idx, rlp_node);
                 }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1442,7 +1442,7 @@ impl ArenaParallelSparseTrie {
     fn record_arena_witness_node(
         arena: &NodeArena,
         idx: Index,
-        child_rlp_nodes: &HashMap<Index, RlpNode>,
+        child_rlp_nodes: &mut HashMap<Index, RlpNode>,
         witness: &mut B256Map<Bytes>,
     ) -> RlpNode {
         match &arena[idx] {
@@ -1462,8 +1462,7 @@ impl ArenaParallelSparseTrie {
                     let rlp_node = match child {
                         ArenaSparseNodeBranchChild::Blinded(rlp_node) => rlp_node.clone(),
                         ArenaSparseNodeBranchChild::Revealed(child_idx) => child_rlp_nodes
-                            .get(child_idx)
-                            .cloned()
+                            .remove(child_idx)
                             .expect("revealed child must be recorded before parent branch"),
                     };
                     stack.push(rlp_node);
@@ -1549,15 +1548,19 @@ impl ArenaParallelSparseTrie {
                                 &mut subtrie_rlp_nodes,
                                 witness,
                             );
-                            subtrie_rlp_nodes
-                                .get(&subtrie.root)
-                                .cloned()
-                                .expect("cursor traversal must record the subtrie root node")
+                            let root_rlp_node = subtrie_rlp_nodes
+                                .remove(&subtrie.root)
+                                .expect("cursor traversal must record the subtrie root node");
+                            debug_assert!(
+                                subtrie_rlp_nodes.is_empty(),
+                                "all subtrie child RLP nodes must be consumed"
+                            );
+                            root_rlp_node
                         }
                         _ => Self::record_arena_witness_node(
                             &self.upper_arena,
                             idx,
-                            &rlp_nodes,
+                            &mut rlp_nodes,
                             witness,
                         ),
                     };

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1439,7 +1439,7 @@ impl ArenaParallelSparseTrie {
 
     /// Records all revealed nodes in an arena using cursor post-order traversal.
     fn record_witness_nodes(
-        arena: &NodeArena,
+        arena: &mut NodeArena,
         root: Index,
         cursor: &mut ArenaCursor,
         rlp_nodes: &mut HashMap<Index, RlpNode>,
@@ -1459,7 +1459,7 @@ impl ArenaParallelSparseTrie {
                 NextResult::Done => break,
                 NextResult::Branch | NextResult::NonBranch => {
                     let idx = cursor.head().expect("cursor is non-empty").index;
-                    let rlp_node = match &arena[idx] {
+                    let rlp_node = match &mut arena[idx] {
                         ArenaSparseNode::EmptyRoot => {
                             Self::record_witness_node(witness, &[0x80]);
                             RlpNode::word_rlp(&EMPTY_ROOT_HASH)
@@ -1508,12 +1508,11 @@ impl ArenaParallelSparseTrie {
                             }
                         }
                         ArenaSparseNode::Subtrie(subtrie) => {
-                            let mut subtrie_cursor = ArenaCursor::default();
                             let mut subtrie_rlp_nodes = HashMap::default();
                             Self::record_witness_nodes(
-                                &subtrie.arena,
+                                &mut subtrie.arena,
                                 subtrie.root,
-                                &mut subtrie_cursor,
+                                &mut subtrie.buffers.cursor,
                                 &mut subtrie_rlp_nodes,
                                 witness,
                             );
@@ -2794,13 +2793,12 @@ impl SparseTrie for ArenaParallelSparseTrie {
         Self::get_leaf_value_in_arena(&self.upper_arena, self.root, full_path, 0)
     }
 
-    fn witness(&self, witness: &mut B256Map<Bytes>) {
-        let mut cursor = ArenaCursor::default();
+    fn witness(&mut self, witness: &mut B256Map<Bytes>) {
         let mut rlp_nodes = HashMap::default();
         Self::record_witness_nodes(
-            &self.upper_arena,
+            &mut self.upper_arena,
             self.root,
-            &mut cursor,
+            &mut self.buffers.cursor,
             &mut rlp_nodes,
             witness,
         );

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1448,7 +1448,7 @@ impl ArenaParallelSparseTrie {
         cursor.reset(arena, root, Nibbles::default());
 
         loop {
-            match cursor.next_ref(arena, |_, node| {
+            match cursor.next(arena, |_, node| {
                 matches!(
                     node,
                     ArenaSparseNode::Branch(_) |

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -10,7 +10,11 @@ use nodes::{
 
 use crate::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdates};
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
-use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
+use alloy_primitives::{
+    keccak256,
+    map::{B256Map, HashMap},
+    Bytes, B256,
+};
 use alloy_trie::TrieMask;
 use core::{cmp::Reverse, mem};
 use reth_execution_errors::SparseTrieResult;
@@ -1433,16 +1437,17 @@ impl ArenaParallelSparseTrie {
         witness.entry(keccak256(encoded)).or_insert_with(|| Bytes::from(encoded.to_vec()));
     }
 
-    /// Records all revealed nodes reachable from `root` and returns the `RlpNode` reference for
-    /// the root node.
+    /// Records the node at `idx` using already-recorded child `RlpNode`s, returning the `RlpNode`
+    /// reference for this node.
     fn record_arena_witness_node(
         arena: &NodeArena,
-        root: Index,
+        idx: Index,
+        child_rlp_nodes: &HashMap<Index, RlpNode>,
         witness: &mut B256Map<Bytes>,
     ) -> RlpNode {
-        match &arena[root] {
+        match &arena[idx] {
             ArenaSparseNode::EmptyRoot => {
-                witness.entry(EMPTY_ROOT_HASH).or_insert_with(|| Bytes::from(vec![0x80]));
+                Self::record_witness_node(witness, &[0x80]);
                 RlpNode::word_rlp(&EMPTY_ROOT_HASH)
             }
             ArenaSparseNode::Leaf { key, value, .. } => {
@@ -1456,9 +1461,10 @@ impl ArenaParallelSparseTrie {
                 for (_, child) in branch.child_iter() {
                     let rlp_node = match child {
                         ArenaSparseNodeBranchChild::Blinded(rlp_node) => rlp_node.clone(),
-                        ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                            Self::record_arena_witness_node(arena, *child_idx, witness)
-                        }
+                        ArenaSparseNodeBranchChild::Revealed(child_idx) => child_rlp_nodes
+                            .get(child_idx)
+                            .cloned()
+                            .expect("revealed child must be recorded before parent branch"),
                     };
                     stack.push(rlp_node);
                 }
@@ -1479,11 +1485,79 @@ impl ArenaParallelSparseTrie {
                     extension_rlp_node
                 }
             }
-            ArenaSparseNode::Subtrie(subtrie) => {
-                Self::record_arena_witness_node(&subtrie.arena, subtrie.root, witness)
+            ArenaSparseNode::Subtrie(_) => {
+                unreachable!("subtries are recorded separately before their upper parent branch")
             }
             ArenaSparseNode::TakenSubtrie => {
                 unreachable!("TakenSubtrie should not be present outside of active operations")
+            }
+        }
+    }
+
+    /// Records all revealed nodes in one arena using cursor post-order traversal, returning the
+    /// `RlpNode` reference for the root node.
+    fn record_arena_witness_nodes(
+        arena: &NodeArena,
+        root: Index,
+        cursor: &mut ArenaCursor,
+        witness: &mut B256Map<Bytes>,
+    ) -> RlpNode {
+        let mut rlp_nodes = HashMap::default();
+        cursor.reset(arena, root, Nibbles::default());
+
+        loop {
+            match cursor.next_ref(arena, |_, node| {
+                matches!(node, ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. })
+            }) {
+                NextResult::Done => break,
+                NextResult::Branch | NextResult::NonBranch => {
+                    let idx = cursor.head().expect("cursor is non-empty").index;
+                    let rlp_node = Self::record_arena_witness_node(arena, idx, &rlp_nodes, witness);
+                    rlp_nodes.insert(idx, rlp_node);
+                }
+            }
+        }
+
+        rlp_nodes.remove(&root).expect("cursor traversal must record the root node")
+    }
+
+    /// Records all revealed nodes in the upper arena and any revealed subtries.
+    fn record_witness_nodes(&self, witness: &mut B256Map<Bytes>) {
+        let mut cursor = ArenaCursor::default();
+        let mut rlp_nodes = HashMap::default();
+        cursor.reset(&self.upper_arena, self.root, Nibbles::default());
+
+        loop {
+            match cursor.next_ref(&self.upper_arena, |_, node| {
+                matches!(
+                    node,
+                    ArenaSparseNode::Branch(_) |
+                        ArenaSparseNode::Leaf { .. } |
+                        ArenaSparseNode::Subtrie(_)
+                )
+            }) {
+                NextResult::Done => break,
+                NextResult::Branch | NextResult::NonBranch => {
+                    let idx = cursor.head().expect("cursor is non-empty").index;
+                    let rlp_node = match &self.upper_arena[idx] {
+                        ArenaSparseNode::Subtrie(subtrie) => {
+                            let mut subtrie_cursor = ArenaCursor::default();
+                            Self::record_arena_witness_nodes(
+                                &subtrie.arena,
+                                subtrie.root,
+                                &mut subtrie_cursor,
+                                witness,
+                            )
+                        }
+                        _ => Self::record_arena_witness_node(
+                            &self.upper_arena,
+                            idx,
+                            &rlp_nodes,
+                            witness,
+                        ),
+                    };
+                    rlp_nodes.insert(idx, rlp_node);
+                }
             }
         }
     }
@@ -2745,7 +2819,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
     }
 
     fn witness(&self, witness: &mut B256Map<Bytes>) {
-        Self::record_arena_witness_node(&self.upper_arena, self.root, witness);
+        self.record_witness_nodes(witness);
     }
 
     fn find_leaf(

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -10,7 +10,7 @@ use nodes::{
 
 use crate::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdates};
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
-use alloy_primitives::{keccak256, map::B256Map, B256};
+use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
 use alloy_trie::TrieMask;
 use core::{cmp::Reverse, mem};
 use reth_execution_errors::SparseTrieResult;
@@ -1428,6 +1428,66 @@ impl ArenaParallelSparseTrie {
         rlp_node
     }
 
+    /// Records an RLP-encoded trie node in the witness.
+    fn record_witness_node(witness: &mut B256Map<Bytes>, encoded: &[u8]) {
+        witness.entry(keccak256(encoded)).or_insert_with(|| Bytes::from(encoded.to_vec()));
+    }
+
+    /// Records all revealed nodes reachable from `root` and returns the `RlpNode` reference for
+    /// the root node.
+    fn record_arena_witness_node(
+        arena: &NodeArena,
+        root: Index,
+        witness: &mut B256Map<Bytes>,
+    ) -> RlpNode {
+        match &arena[root] {
+            ArenaSparseNode::EmptyRoot => {
+                witness.entry(EMPTY_ROOT_HASH).or_insert_with(|| Bytes::from(vec![0x80]));
+                RlpNode::word_rlp(&EMPTY_ROOT_HASH)
+            }
+            ArenaSparseNode::Leaf { key, value, .. } => {
+                let mut encoded = Vec::new();
+                let rlp_node = LeafNodeRef::new(key, value).rlp(&mut encoded);
+                Self::record_witness_node(witness, &encoded);
+                rlp_node
+            }
+            ArenaSparseNode::Branch(branch) => {
+                let mut stack = Vec::with_capacity(branch.children.len());
+                for (_, child) in branch.child_iter() {
+                    let rlp_node = match child {
+                        ArenaSparseNodeBranchChild::Blinded(rlp_node) => rlp_node.clone(),
+                        ArenaSparseNodeBranchChild::Revealed(child_idx) => {
+                            Self::record_arena_witness_node(arena, *child_idx, witness)
+                        }
+                    };
+                    stack.push(rlp_node);
+                }
+
+                let mut branch_rlp = Vec::new();
+                let branch_rlp_node =
+                    BranchNodeRef::new(&stack, branch.state_mask).rlp(&mut branch_rlp);
+                Self::record_witness_node(witness, &branch_rlp);
+
+                if branch.short_key.is_empty() {
+                    branch_rlp_node
+                } else {
+                    let mut extension_rlp = Vec::new();
+                    let extension_rlp_node =
+                        ExtensionNodeRef::new(&branch.short_key, branch_rlp_node.as_slice())
+                            .rlp(&mut extension_rlp);
+                    Self::record_witness_node(witness, &extension_rlp);
+                    extension_rlp_node
+                }
+            }
+            ArenaSparseNode::Subtrie(subtrie) => {
+                Self::record_arena_witness_node(&subtrie.arena, subtrie.root, witness)
+            }
+            ArenaSparseNode::TakenSubtrie => {
+                unreachable!("TakenSubtrie should not be present outside of active operations")
+            }
+        }
+    }
+
     /// Immutable traversal to find a leaf value at `full_path` starting from `root` in `arena`.
     /// `path_offset` is the number of nibbles already consumed from `full_path`.
     fn get_leaf_value_in_arena<'a>(
@@ -2682,6 +2742,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
     fn get_leaf_value(&self, full_path: &Nibbles) -> Option<&Vec<u8>> {
         Self::get_leaf_value_in_arena(&self.upper_arena, self.root, full_path, 0)
+    }
+
+    fn witness(&self, witness: &mut B256Map<Bytes>) {
+        Self::record_arena_witness_node(&self.upper_arena, self.root, witness);
     }
 
     fn find_leaf(

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1496,15 +1496,14 @@ impl ArenaParallelSparseTrie {
         }
     }
 
-    /// Records all revealed nodes in one arena using cursor post-order traversal, returning the
-    /// `RlpNode` reference for the root node.
+    /// Records all revealed nodes in one arena using cursor post-order traversal.
     fn record_arena_witness_nodes(
         arena: &NodeArena,
         root: Index,
         cursor: &mut ArenaCursor,
+        rlp_nodes: &mut HashMap<Index, RlpNode>,
         witness: &mut B256Map<Bytes>,
-    ) -> RlpNode {
-        let mut rlp_nodes = HashMap::default();
+    ) {
         cursor.reset(arena, root, Nibbles::default());
 
         loop {
@@ -1514,13 +1513,11 @@ impl ArenaParallelSparseTrie {
                 NextResult::Done => break,
                 NextResult::Branch | NextResult::NonBranch => {
                     let idx = cursor.head().expect("cursor is non-empty").index;
-                    let rlp_node = Self::record_arena_witness_node(arena, idx, &rlp_nodes, witness);
+                    let rlp_node = Self::record_arena_witness_node(arena, idx, rlp_nodes, witness);
                     rlp_nodes.insert(idx, rlp_node);
                 }
             }
         }
-
-        rlp_nodes.remove(&root).expect("cursor traversal must record the root node")
     }
 
     /// Records all revealed nodes in the upper arena and any revealed subtries.
@@ -1544,12 +1541,18 @@ impl ArenaParallelSparseTrie {
                     let rlp_node = match &self.upper_arena[idx] {
                         ArenaSparseNode::Subtrie(subtrie) => {
                             let mut subtrie_cursor = ArenaCursor::default();
+                            let mut subtrie_rlp_nodes = HashMap::default();
                             Self::record_arena_witness_nodes(
                                 &subtrie.arena,
                                 subtrie.root,
                                 &mut subtrie_cursor,
+                                &mut subtrie_rlp_nodes,
                                 witness,
-                            )
+                            );
+                            subtrie_rlp_nodes
+                                .get(&subtrie.root)
+                                .cloned()
+                                .expect("cursor traversal must record the subtrie root node")
                         }
                         _ => Self::record_arena_witness_node(
                             &self.upper_arena,

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1472,6 +1472,8 @@ impl ArenaParallelSparseTrie {
                 let mut branch_rlp = Vec::new();
                 let branch_rlp_node =
                     BranchNodeRef::new(&stack, branch.state_mask).rlp(&mut branch_rlp);
+                // A branch with a short key is encoded as an extension node pointing to the
+                // branch. Witness consumers need both the extension and the branch node.
                 Self::record_witness_node(witness, &branch_rlp);
 
                 if branch.short_key.is_empty() {

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -317,10 +317,10 @@ where
     ///
     /// The witness maps `keccak256(rlp_node)` to the full RLP-encoded trie node. Blind account or
     /// storage tries are skipped.
-    pub fn witness(&self) -> B256Map<Bytes> {
+    pub fn witness(&mut self) -> B256Map<Bytes> {
         let mut witness = B256Map::default();
         self.state.witness(&mut witness);
-        for trie in self.storage.tries.values() {
+        for trie in self.storage.tries.values_mut() {
             trie.witness(&mut witness);
         }
         witness

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -1288,10 +1288,11 @@ mod tests {
     fn witness_collects_extension_and_branch_nodes() {
         let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
         let state_mask = TrieMask::new(0b11);
-        let stack = vec![
-            RlpNode::word_rlp(&B256::repeat_byte(0x01)),
-            RlpNode::word_rlp(&B256::repeat_byte(0x02)),
-        ];
+        let leaf_0_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 62), vec![0x01]));
+        let leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 62), vec![0x02]));
+        let leaf_0 = alloy_rlp::encode(&leaf_0_node);
+        let leaf_1 = alloy_rlp::encode(&leaf_1_node);
+        let stack = vec![RlpNode::from_rlp(&leaf_0), RlpNode::from_rlp(&leaf_1)];
         let branch_node = TrieNodeV2::Branch(BranchNodeV2 {
             key: Nibbles::default(),
             stack: stack.clone(),
@@ -1309,11 +1310,19 @@ mod tests {
 
         sparse
             .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
-                account_proofs: vec![ProofTrieNodeV2 {
-                    path: Nibbles::default(),
-                    node: extension_node,
-                    masks: None,
-                }],
+                account_proofs: vec![
+                    ProofTrieNodeV2 { path: Nibbles::default(), node: extension_node, masks: None },
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xa, 0x0]),
+                        node: leaf_0_node,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xa, 0x1]),
+                        node: leaf_1_node,
+                        masks: None,
+                    },
+                ],
                 ..Default::default()
             })
             .unwrap();
@@ -1321,7 +1330,9 @@ mod tests {
         let witness = sparse.witness();
         assert_witness_contains_node(&witness, &branch);
         assert_witness_contains_node(&witness, &extension);
-        assert_eq!(witness.len(), 2);
+        assert_witness_contains_node(&witness, &leaf_0);
+        assert_witness_contains_node(&witness, &leaf_1);
+        assert_eq!(witness.len(), 4);
     }
 
     #[test]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -5,7 +5,7 @@ use crate::{
     RevealableSparseTrie,
 };
 use alloc::vec::Vec;
-use alloy_primitives::{map::B256Map, B256};
+use alloy_primitives::{map::B256Map, Bytes, B256};
 use either::Either;
 use reth_execution_errors::{SparseStateTrieResult, SparseTrieErrorKind};
 use reth_trie_common::{
@@ -311,6 +311,19 @@ where
         address: B256,
     ) -> &mut RevealableSparseTrie<S> {
         self.storage.get_or_create_trie_mut(address)
+    }
+
+    /// Returns a trie witness for all currently revealed account and storage trie nodes.
+    ///
+    /// The witness maps `keccak256(rlp_node)` to the full RLP-encoded trie node. Blind account or
+    /// storage tries are skipped.
+    pub fn witness(&self) -> B256Map<Bytes> {
+        let mut witness = B256Map::default();
+        self.state.witness(&mut witness);
+        for trie in self.storage.tries.values() {
+            trie.witness(&mut witness);
+        }
+        witness
     }
 
     /// Reveal unknown trie paths from multiproof.
@@ -777,9 +790,9 @@ mod tests {
     use super::*;
     use crate::{ArenaParallelSparseTrie, LeafLookup, LeafUpdate};
     use alloy_primitives::{
-        b256,
+        b256, keccak256,
         map::{HashMap, HashSet},
-        U256,
+        Bytes, U256,
     };
     use arbitrary::Arbitrary;
     use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -798,6 +811,10 @@ mod tests {
         let mut nibbles = Nibbles::from_nibbles(suffix);
         nibbles.extend(&Nibbles::from_nibbles_unchecked(vec![0; total_len - suffix.len()]));
         nibbles
+    }
+
+    fn assert_witness_contains_node(witness: &B256Map<Bytes>, node: &[u8]) {
+        assert_eq!(witness.get(&keccak256(node)).map(|bytes| bytes.as_ref()), Some(node));
     }
 
     fn apply_account_update(sparse: &mut SparseStateTrie, address: B256, update: LeafUpdate) {
@@ -1180,6 +1197,131 @@ mod tests {
             .unwrap()
             .get_leaf_value(&full_path_0)
             .is_none());
+    }
+
+    #[test]
+    fn witness_collects_revealed_account_and_storage_nodes() {
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
+        let account = B256::with_last_byte(0x01);
+
+        let account_leaf_0_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), vec![0x10]));
+        let account_leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), vec![0x11]));
+        let account_leaf_0 = alloy_rlp::encode(&account_leaf_0_node);
+        let account_leaf_1 = alloy_rlp::encode(&account_leaf_1_node);
+        let account_branch_node = TrieNodeV2::Branch(BranchNodeV2 {
+            key: Nibbles::default(),
+            stack: vec![RlpNode::from_rlp(&account_leaf_0), RlpNode::from_rlp(&account_leaf_1)],
+            state_mask: TrieMask::new(0b11),
+            branch_rlp_node: None,
+        });
+        let account_branch = alloy_rlp::encode(&account_branch_node);
+
+        let storage_leaf_0_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), vec![0x20]));
+        let storage_leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), vec![0x21]));
+        let storage_leaf_0 = alloy_rlp::encode(&storage_leaf_0_node);
+        let storage_leaf_1 = alloy_rlp::encode(&storage_leaf_1_node);
+        let storage_branch_node = TrieNodeV2::Branch(BranchNodeV2 {
+            key: Nibbles::default(),
+            stack: vec![RlpNode::from_rlp(&storage_leaf_0), RlpNode::from_rlp(&storage_leaf_1)],
+            state_mask: TrieMask::new(0b11),
+            branch_rlp_node: None,
+        });
+        let storage_branch = alloy_rlp::encode(&storage_branch_node);
+
+        sparse
+            .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+                account_proofs: vec![
+                    ProofTrieNodeV2 {
+                        path: Nibbles::default(),
+                        node: account_branch_node,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0x0]),
+                        node: account_leaf_0_node,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0x1]),
+                        node: account_leaf_1_node,
+                        masks: None,
+                    },
+                ],
+                storage_proofs: B256Map::from_iter([(
+                    account,
+                    vec![
+                        ProofTrieNodeV2 {
+                            path: Nibbles::default(),
+                            node: storage_branch_node,
+                            masks: None,
+                        },
+                        ProofTrieNodeV2 {
+                            path: Nibbles::from_nibbles([0x0]),
+                            node: storage_leaf_0_node,
+                            masks: None,
+                        },
+                        ProofTrieNodeV2 {
+                            path: Nibbles::from_nibbles([0x1]),
+                            node: storage_leaf_1_node,
+                            masks: None,
+                        },
+                    ],
+                )]),
+            })
+            .unwrap();
+
+        let witness = sparse.witness();
+        for node in [
+            &account_branch,
+            &account_leaf_0,
+            &account_leaf_1,
+            &storage_branch,
+            &storage_leaf_0,
+            &storage_leaf_1,
+        ] {
+            assert_witness_contains_node(&witness, node);
+        }
+        assert_eq!(witness.len(), 6);
+    }
+
+    #[test]
+    fn witness_collects_extension_and_branch_nodes() {
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
+        let state_mask = TrieMask::new(0b11);
+        let stack = vec![
+            RlpNode::word_rlp(&B256::repeat_byte(0x01)),
+            RlpNode::word_rlp(&B256::repeat_byte(0x02)),
+        ];
+        let branch_node = TrieNodeV2::Branch(BranchNodeV2 {
+            key: Nibbles::default(),
+            stack: stack.clone(),
+            state_mask,
+            branch_rlp_node: None,
+        });
+        let branch = alloy_rlp::encode(&branch_node);
+        let extension_node = TrieNodeV2::Branch(BranchNodeV2 {
+            key: Nibbles::from_nibbles([0xa]),
+            stack,
+            state_mask,
+            branch_rlp_node: Some(RlpNode::from_rlp(&branch)),
+        });
+        let extension = alloy_rlp::encode(&extension_node);
+
+        sparse
+            .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+                account_proofs: vec![ProofTrieNodeV2 {
+                    path: Nibbles::default(),
+                    node: extension_node,
+                    masks: None,
+                }],
+                ..Default::default()
+            })
+            .unwrap();
+
+        let witness = sparse.witness();
+        assert_witness_contains_node(&witness, &branch);
+        assert_witness_contains_node(&witness, &extension);
+        assert_eq!(witness.len(), 2);
     }
 
     #[test]

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -145,7 +145,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// The witness maps `keccak256(rlp_node)` to the full RLP-encoded trie node. Blinded children
     /// are included as references inside their revealed parents, but are not added as separate
     /// witness entries.
-    fn witness(&self, witness: &mut B256Map<Bytes>);
+    fn witness(&mut self, witness: &mut B256Map<Bytes>);
 
     /// Attempts to find a leaf node at the specified path.
     ///

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{
     map::{B256Map, HashMap, HashSet},
-    B256,
+    Bytes, B256,
 };
 use alloy_trie::BranchNodeCompact;
 use reth_execution_errors::SparseTrieResult;
@@ -139,6 +139,13 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// - The value has not yet been revealed. In order to determine which is true, one would need
     ///   an exclusion proof.
     fn get_leaf_value(&self, full_path: &Nibbles) -> Option<&Vec<u8>>;
+
+    /// Adds all revealed trie nodes to the provided witness.
+    ///
+    /// The witness maps `keccak256(rlp_node)` to the full RLP-encoded trie node. Blinded children
+    /// are included as references inside their revealed parents, but are not added as separate
+    /// witness entries.
+    fn witness(&self, witness: &mut B256Map<Bytes>);
 
     /// Attempts to find a leaf node at the specified path.
     ///

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2,7 +2,7 @@ use crate::{
     ArenaParallelSparseTrie, LeafUpdate, SparseTrie as SparseTrieTrait, SparseTrieUpdates,
 };
 use alloc::{borrow::Cow, boxed::Box};
-use alloy_primitives::{map::B256Map, B256};
+use alloy_primitives::{map::B256Map, Bytes, B256};
 use reth_execution_errors::{SparseTrieErrorKind, SparseTrieResult};
 use reth_trie_common::{
     prefix_set::PrefixSetMut, BranchNodeMasks, Nibbles, ProofTrieNodeV2, RlpNode, TrieMask,
@@ -195,6 +195,13 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     /// Returns true if the root node is cached and does not need any recomputation.
     pub fn is_root_cached(&self) -> bool {
         self.as_revealed_ref().is_some_and(|trie| trie.is_root_cached())
+    }
+
+    /// Adds all revealed trie nodes to the provided witness.
+    pub fn witness(&self, witness: &mut B256Map<Bytes>) {
+        if let Self::Revealed(trie) = self {
+            trie.witness(witness);
+        }
     }
 
     /// Returns the root hash along with any accumulated update information.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -198,7 +198,7 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     }
 
     /// Adds all revealed trie nodes to the provided witness.
-    pub fn witness(&self, witness: &mut B256Map<Bytes>) {
+    pub fn witness(&mut self, witness: &mut B256Map<Bytes>) {
         if let Self::Revealed(trie) = self {
             trie.witness(witness);
         }

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -109,7 +109,22 @@ where
     /// # Arguments
     ///
     /// `state` - state transition containing both modified and touched accounts and storage slots.
-    pub fn compute(
+    pub fn compute(self, state: HashedPostState) -> Result<B256Map<Bytes>, TrieWitnessError> {
+        self.compute_inner::<false>(state)
+    }
+
+    /// Compute the post-state sparse trie witness for the trie.
+    ///
+    /// Applies `state` on top of the current trie state and returns all nodes revealed in the
+    /// resulting sparse trie.
+    pub fn compute_post_state_witness(
+        self,
+        state: HashedPostState,
+    ) -> Result<B256Map<Bytes>, TrieWitnessError> {
+        self.compute_inner::<true>(state)
+    }
+
+    fn compute_inner<const POST_STATE: bool>(
         mut self,
         mut state: HashedPostState,
     ) -> Result<B256Map<Bytes>, TrieWitnessError> {
@@ -152,7 +167,9 @@ where
         }
 
         // Record all nodes from multiproof in the witness.
-        self.record_multiproof_nodes(&multiproof);
+        if !POST_STATE {
+            self.record_multiproof_nodes(&multiproof);
+        }
 
         let mut sparse_trie = SparseStateTrie::new();
         sparse_trie.reveal_decoded_multiproof_v2(multiproof)?;
@@ -225,7 +242,9 @@ where
                 )
                 .with_prefix_sets_mut(self.prefix_sets.clone())
                 .multiproof_v2(targets)?;
-                self.record_multiproof_nodes(&multiproof);
+                if !POST_STATE {
+                    self.record_multiproof_nodes(&multiproof);
+                }
                 sparse_trie.reveal_decoded_multiproof_v2(multiproof)?;
             }
         }
@@ -253,11 +272,12 @@ where
                 if let Some(storage_trie) = sparse_trie.storage_trie_mut(&hashed_address) {
                     storage_trie.root()
                 } else {
-                    let record_root_node = !self.mode.is_canonical() ||
-                        state
-                            .storages
-                            .get(&hashed_address)
-                            .is_some_and(|storage| !storage.storage.is_empty());
+                    let record_root_node = !POST_STATE &&
+                        (!self.mode.is_canonical() ||
+                            state
+                                .storages
+                                .get(&hashed_address)
+                                .is_some_and(|storage| !storage.storage.is_empty()));
                     self.account_storage_root(hashed_address, record_root_node)?
                 };
 
@@ -298,9 +318,16 @@ where
                 )
                 .with_prefix_sets_mut(self.prefix_sets.clone())
                 .multiproof_v2(targets)?;
-                self.record_multiproof_nodes(&multiproof);
+                if !POST_STATE {
+                    self.record_multiproof_nodes(&multiproof);
+                }
                 sparse_trie.reveal_decoded_multiproof_v2(multiproof)?;
             }
+        }
+
+        if POST_STATE {
+            sparse_trie.root()?;
+            return Ok(sparse_trie.witness())
         }
 
         if self.mode.is_canonical() {


### PR DESCRIPTION
Adds SparseStateTrie::witness to collect a flat trie witness from every currently revealed account and storage trie node. The arena sparse trie encodes revealed nodes directly so the witness includes compressed extension branches in the same shape as existing trie witness generation.