### PR TITLE
fix(nix): include m4 in native build inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
         nativeBuildInputs = [
           pkgs.pkg-config
           pkgs.libgit2
+          pkgs.m4
           pkgs.perl
         ];
 


### PR DESCRIPTION
## Summary
- Add `pkgs.m4` to shared `nativeBuildInputs` so `gmp-mpfr-sys` can run GMP configure inside the Nix build/dev environment.

## Testing
- `git diff --check`
- Not run: `nix fmt` / `nix flake check` (`nix` is not installed in this sandbox)

Prompted by: @shekhirin