### PR TITLE
feat(prune): add custom pruner segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9682,6 +9682,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "assert_matches",
+ "auto_impl",
  "itertools 0.14.0",
  "metrics",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9404,6 +9404,7 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-prune",
  "reth-revm",
  "reth-rpc",
  "reth-rpc-api",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -66,6 +66,7 @@ tower.workspace = true
 [dev-dependencies]
 reth-db.workspace = true
 reth-exex.workspace = true
+reth-prune.workspace = true
 reth-e2e-test-utils.workspace = true
 reth-tasks.workspace = true
 reth-testing-utils.workspace = true

--- a/crates/ethereum/node/tests/it/builder.rs
+++ b/crates/ethereum/node/tests/it/builder.rs
@@ -111,6 +111,59 @@ fn test_eth_launcher_with_tokio_runtime() {
 }
 
 #[test]
+fn test_install_custom_prune_segment() {
+    use reth_prune::{
+        segments::{PruneInput, Segment},
+        PruneMode, PruneProgress, PrunePurpose, PruneSegment, PrunerError, SegmentOutput,
+        SegmentOutputCheckpoint,
+    };
+
+    /// A no-op prune segment as a downstream node would define it, generic over the provider.
+    #[derive(Debug)]
+    struct CustomSegment;
+
+    impl<Provider> Segment<Provider> for CustomSegment {
+        fn segment(&self) -> PruneSegment {
+            PruneSegment::Custom(0)
+        }
+
+        fn mode(&self) -> Option<PruneMode> {
+            Some(PruneMode::Distance(100_000))
+        }
+
+        fn purpose(&self) -> PrunePurpose {
+            PrunePurpose::User
+        }
+
+        fn prune(
+            &self,
+            _provider: &Provider,
+            input: PruneInput,
+        ) -> Result<SegmentOutput, PrunerError> {
+            Ok(SegmentOutput {
+                progress: PruneProgress::Finished,
+                pruned: 0,
+                checkpoint: Some(SegmentOutputCheckpoint {
+                    block_number: Some(input.to_block),
+                    tx_number: None,
+                }),
+            })
+        }
+    }
+
+    let config = NodeConfig::test();
+    let db = create_test_rw_db();
+    let _builder = NodeBuilder::new(config)
+        .with_database(db)
+        .with_types::<EthereumNode>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .install_prune_segment(CustomSegment)
+        .install_prune_segment_if(false, CustomSegment)
+        .check_launch();
+}
+
+#[test]
 fn test_node_setup() {
     let config = NodeConfig::test();
     let db = create_test_rw_db();

--- a/crates/node/builder/src/builder/add_ons.rs
+++ b/crates/node/builder/src/builder/add_ons.rs
@@ -1,6 +1,9 @@
 //! Node add-ons. Depend on core [`NodeComponents`](crate::NodeComponents).
 
-use reth_node_api::{FullNodeComponents, NodeAddOns};
+use reth_db_api::database::Database;
+use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDBAdapter};
+use reth_provider::DatabaseProvider;
+use reth_prune::segments::Segment;
 
 use crate::{exex::BoxedLaunchExEx, hooks::NodeHooks};
 
@@ -12,6 +15,20 @@ pub struct AddOns<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub hooks: NodeHooks<Node, AddOns>,
     /// The `ExExs` (execution extensions) of the node.
     pub exexs: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
+    /// Additional prune segments that are run by the node's pruner, see
+    /// [`PruneSegment::Custom`](reth_prune::PruneSegment::Custom).
+    pub prune_segments: Vec<Box<dyn Segment<PrunerProviderRW<Node>>>>,
     /// Additional captured addons.
     pub add_ons: AddOns,
 }
+
+/// The read-write database provider type the node's pruner operates on, for the given
+/// [`FullNodeTypes`].
+///
+/// This is the provider type that custom [`Segment`] implementations installed via
+/// [`NodeBuilderWithComponents::install_prune_segment`](crate::NodeBuilderWithComponents::install_prune_segment)
+/// are invoked with.
+pub type PrunerProviderRW<N> = DatabaseProvider<
+    <<N as FullNodeTypes>::DB as Database>::TXMut,
+    NodeTypesWithDBAdapter<<N as FullNodeTypes>::Types, <N as FullNodeTypes>::DB>,
+>;

--- a/crates/node/builder/src/builder/add_ons.rs
+++ b/crates/node/builder/src/builder/add_ons.rs
@@ -4,6 +4,7 @@ use reth_db_api::database::Database;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypesWithDBAdapter};
 use reth_provider::DatabaseProvider;
 use reth_prune::segments::Segment;
+use std::sync::Arc;
 
 use crate::{exex::BoxedLaunchExEx, hooks::NodeHooks};
 
@@ -15,9 +16,12 @@ pub struct AddOns<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub hooks: NodeHooks<Node, AddOns>,
     /// The `ExExs` (execution extensions) of the node.
     pub exexs: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
-    /// Additional prune segments that are run by the node's pruner, see
+    /// Additional prune segments that are run by the node's pruners, see
     /// [`PruneSegment::Custom`](reth_prune::PruneSegment::Custom).
-    pub prune_segments: Vec<Box<dyn Segment<PrunerProviderRW<Node>>>>,
+    ///
+    /// Segments are `Arc`ed because each instance is shared between the engine-driven pruner and
+    /// the pipeline's prune stage.
+    pub prune_segments: Vec<Arc<dyn Segment<PrunerProviderRW<Node>>>>,
     /// Additional captured addons.
     pub add_ons: AddOns,
 }

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -674,7 +674,7 @@ where
         }
     }
 
-    /// Installs an additional prune segment in the node's pruner.
+    /// Installs an additional prune segment in the node's pruners.
     ///
     /// See [`NodeBuilderWithComponents::install_prune_segment`].
     pub fn install_prune_segment<S>(self, segment: S) -> Self
@@ -687,7 +687,7 @@ where
         }
     }
 
-    /// Installs an additional prune segment in the node's pruner if the condition is true.
+    /// Installs an additional prune segment in the node's pruners if the condition is true.
     ///
     /// See [`NodeBuilderWithComponents::install_prune_segment`].
     pub fn install_prune_segment_if<S>(self, cond: bool, segment: S) -> Self

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -4,6 +4,7 @@
 #![allow(missing_debug_implementations)]
 
 use crate::{
+    builder::add_ons::PrunerProviderRW,
     common::WithConfigs,
     components::NodeComponentsBuilder,
     node::FullNode,
@@ -36,6 +37,7 @@ use reth_provider::{
     providers::{BlockchainProvider, NodeTypesForProvider, RocksDBProvider},
     ChainSpecProvider, FullProvider,
 };
+use reth_prune::segments::Segment;
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{PoolConfig, PoolTransaction, TransactionPool};
 use secp256k1::SecretKey;
@@ -670,6 +672,32 @@ where
         } else {
             self
         }
+    }
+
+    /// Installs an additional prune segment in the node's pruner.
+    ///
+    /// See [`NodeBuilderWithComponents::install_prune_segment`].
+    pub fn install_prune_segment<S>(self, segment: S) -> Self
+    where
+        S: Segment<PrunerProviderRW<NodeAdapter<T, CB::Components>>> + 'static,
+    {
+        Self {
+            builder: self.builder.install_prune_segment(segment),
+            task_executor: self.task_executor,
+        }
+    }
+
+    /// Installs an additional prune segment in the node's pruner if the condition is true.
+    ///
+    /// See [`NodeBuilderWithComponents::install_prune_segment`].
+    pub fn install_prune_segment_if<S>(self, cond: bool, segment: S) -> Self
+    where
+        S: Segment<PrunerProviderRW<NodeAdapter<T, CB::Components>>> + 'static,
+    {
+        if cond {
+            return self.install_prune_segment(segment)
+        }
+        self
     }
 
     /// Launches the node with the given launcher.

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -20,7 +20,7 @@ use reth_node_core::node_config::NodeConfig;
 use reth_provider::providers::RocksDBProvider;
 use reth_prune::segments::Segment;
 use reth_tasks::TaskExecutor;
-use std::{fmt, fmt::Debug, future::Future};
+use std::{fmt, fmt::Debug, future::Future, sync::Arc};
 
 /// A node builder that also has the configured types.
 pub struct NodeBuilderWithTypes<T: FullNodeTypes> {
@@ -239,7 +239,7 @@ where
         self
     }
 
-    /// Installs an additional prune segment in the node's pruner.
+    /// Installs an additional prune segment in the node's pruners.
     ///
     /// This allows downstream consumers to prune custom data alongside the built-in segments,
     /// without modifying reth's [`PruneSegment`](reth_prune::PruneSegment) for every downstream
@@ -248,20 +248,19 @@ where
     /// persisted, and are pruned after the built-in segments, sharing the pruner's delete limit
     /// and timeout per run.
     ///
-    /// # Note
-    ///
-    /// Custom segments only run in the pruner that is driven by the consensus engine. They are
-    /// not part of the pipeline's prune stage that is used during initial sync, so they catch up
-    /// once the node is live.
+    /// The segment runs everywhere pruning happens: in the pipeline's prune stage during initial
+    /// (backfill) sync, and in the pruner driven by the consensus engine during live sync. Both
+    /// share the segment's persisted checkpoint, so no work is repeated when the node switches
+    /// between the two.
     pub fn install_prune_segment<S>(mut self, segment: S) -> Self
     where
         S: Segment<PrunerProviderRW<NodeAdapter<T, CB::Components>>> + 'static,
     {
-        self.add_ons.prune_segments.push(Box::new(segment));
+        self.add_ons.prune_segments.push(Arc::new(segment));
         self
     }
 
-    /// Installs an additional prune segment in the node's pruner if the condition is true.
+    /// Installs an additional prune segment in the node's pruners if the condition is true.
     ///
     /// See [`Self::install_prune_segment`].
     pub fn install_prune_segment_if<S>(self, cond: bool, segment: S) -> Self

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -6,6 +6,7 @@
 //! before the node can be launched.
 
 use crate::{
+    builder::add_ons::PrunerProviderRW,
     components::{NodeComponents, NodeComponentsBuilder},
     hooks::NodeHooks,
     launch::LaunchNode,
@@ -17,6 +18,7 @@ use reth_exex::ExExContext;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes};
 use reth_node_core::node_config::NodeConfig;
 use reth_provider::providers::RocksDBProvider;
+use reth_prune::segments::Segment;
 use reth_tasks::TaskExecutor;
 use std::{fmt, fmt::Debug, future::Future};
 
@@ -52,7 +54,12 @@ impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
             adapter,
             rocksdb_provider,
             components_builder,
-            add_ons: AddOns { hooks: NodeHooks::default(), exexs: Vec::new(), add_ons: () },
+            add_ons: AddOns {
+                hooks: NodeHooks::default(),
+                exexs: Vec::new(),
+                prune_segments: Vec::new(),
+                add_ons: (),
+            },
         }
     }
 }
@@ -181,7 +188,12 @@ where
             adapter,
             rocksdb_provider,
             components_builder,
-            add_ons: AddOns { hooks: NodeHooks::default(), exexs: Vec::new(), add_ons },
+            add_ons: AddOns {
+                hooks: NodeHooks::default(),
+                exexs: Vec::new(),
+                prune_segments: Vec::new(),
+                add_ons,
+            },
         }
     }
 }
@@ -224,6 +236,41 @@ where
         E: Future<Output = eyre::Result<()>> + Send,
     {
         self.add_ons.exexs.push((exex_id.into(), Box::new(exex)));
+        self
+    }
+
+    /// Installs an additional prune segment in the node's pruner.
+    ///
+    /// This allows downstream consumers to prune custom data alongside the built-in segments,
+    /// without modifying reth's [`PruneSegment`](reth_prune::PruneSegment) for every downstream
+    /// feature. Custom segments should use
+    /// [`PruneSegment::Custom`](reth_prune::PruneSegment::Custom) so their checkpoints can be
+    /// persisted, and are pruned after the built-in segments, sharing the pruner's delete limit
+    /// and timeout per run.
+    ///
+    /// # Note
+    ///
+    /// Custom segments only run in the pruner that is driven by the consensus engine. They are
+    /// not part of the pipeline's prune stage that is used during initial sync, so they catch up
+    /// once the node is live.
+    pub fn install_prune_segment<S>(mut self, segment: S) -> Self
+    where
+        S: Segment<PrunerProviderRW<NodeAdapter<T, CB::Components>>> + 'static,
+    {
+        self.add_ons.prune_segments.push(Box::new(segment));
+        self
+    }
+
+    /// Installs an additional prune segment in the node's pruner if the condition is true.
+    ///
+    /// See [`Self::install_prune_segment`].
+    pub fn install_prune_segment_if<S>(self, cond: bool, segment: S) -> Self
+    where
+        S: Segment<PrunerProviderRW<NodeAdapter<T, CB::Components>>> + 'static,
+    {
+        if cond {
+            return self.install_prune_segment(segment)
+        }
         self
     }
 

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -173,6 +173,7 @@ impl EngineNodeLauncher {
             maybe_exex_manager_handle.clone().unwrap_or_else(ExExManagerHandle::empty),
             ctx.era_import_source(),
             disabled_stages,
+            prune_segments.clone(),
         )?;
 
         // The new engine writes directly to static files. This ensures that they're up to the tip.
@@ -188,6 +189,8 @@ impl EngineNodeLauncher {
         let mut pruner = pruner_builder.build_with_provider_factory(ctx.provider_factory().clone());
         if !prune_segments.is_empty() {
             info!(target: "reth::cli", segments = prune_segments.len(), "Installing custom prune segments");
+            // The same segment instances also run in the pipeline's prune stage during backfill
+            // sync, sharing their checkpoints with the runs here.
             pruner.extend_segments(prune_segments);
         }
         let pruner_events = pruner.events();

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -88,7 +88,7 @@ impl EngineNodeLauncher {
             adapter: NodeTypesAdapter { database },
             rocksdb_provider,
             components_builder,
-            add_ons: AddOns { hooks, exexs: installed_exex, add_ons },
+            add_ons: AddOns { hooks, exexs: installed_exex, prune_segments, add_ons },
             config,
         } = target;
         let NodeHooks { on_component_initialized, on_node_started, .. } = hooks;
@@ -185,7 +185,11 @@ impl EngineNodeLauncher {
             pruner_builder =
                 pruner_builder.finished_exex_height(exex_manager_handle.finished_height());
         }
-        let pruner = pruner_builder.build_with_provider_factory(ctx.provider_factory().clone());
+        let mut pruner = pruner_builder.build_with_provider_factory(ctx.provider_factory().clone());
+        if !prune_segments.is_empty() {
+            info!(target: "reth::cli", segments = prune_segments.len(), "Installing custom prune segments");
+            pruner.extend_segments(prune_segments);
+        }
         let pruner_events = pruner.events();
         info!(target: "reth::cli", prune_config=?ctx.prune_config(), "Pruner initialized");
 

--- a/crates/node/builder/src/lib.rs
+++ b/crates/node/builder/src/lib.rs
@@ -27,7 +27,10 @@ pub mod components;
 pub use components::{NodeComponents, NodeComponentsBuilder};
 
 mod builder;
-pub use builder::{add_ons::AddOns, *};
+pub use builder::{
+    add_ons::{AddOns, PrunerProviderRW},
+    *,
+};
 
 mod launch;
 pub use launch::{

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -16,10 +16,11 @@ use reth_network_p2p::{
     bodies::downloader::BodyDownloader, headers::downloader::HeaderDownloader, BlockClient,
 };
 use reth_node_api::HeaderTy;
-use reth_provider::{providers::ProviderNodeTypes, ProviderFactory};
+use reth_provider::{providers::ProviderNodeTypes, DatabaseProviderFactory, ProviderFactory};
+use reth_prune::segments::Segment;
 use reth_stages::{
     prelude::DefaultStages,
-    stages::{EraImportSource, ExecutionStage},
+    stages::{EraImportSource, ExecutionStage, PruneStage},
     Pipeline, StageId, StageSet,
 };
 use reth_static_file::StaticFileProducer;
@@ -43,6 +44,7 @@ pub fn build_networked_pipeline<N, Client, Evm>(
     exex_manager_handle: ExExManagerHandle<N::Primitives>,
     era_import_source: Option<EraImportSource>,
     disabled_stages: &[StageId],
+    custom_prune_segments: Vec<Arc<dyn Segment<PipelineProviderRW<N>>>>,
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
@@ -72,10 +74,14 @@ where
         exex_manager_handle,
         era_import_source,
         disabled_stages,
+        custom_prune_segments,
     )?;
 
     Ok(pipeline)
 }
+
+/// The read-write database provider type the stages of a [`Pipeline<N>`] operate on.
+pub type PipelineProviderRW<N> = <ProviderFactory<N> as DatabaseProviderFactory>::ProviderRW;
 
 /// Builds the [Pipeline] with the given [`ProviderFactory`] and downloaders.
 #[expect(clippy::too_many_arguments)]
@@ -93,6 +99,7 @@ pub fn build_pipeline<N, H, B, Evm>(
     exex_manager_handle: ExExManagerHandle<N::Primitives>,
     era_import_source: Option<EraImportSource>,
     disabled_stages: &[StageId],
+    custom_prune_segments: Vec<Arc<dyn Segment<PipelineProviderRW<N>>>>,
 ) -> eyre::Result<Pipeline<N>>
 where
     N: ProviderNodeTypes,
@@ -109,30 +116,36 @@ where
 
     let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
 
+    let mut stages = DefaultStages::new(
+        provider_factory.clone(),
+        tip_rx,
+        Arc::clone(&consensus),
+        header_downloader,
+        body_downloader,
+        evm_config.clone(),
+        stage_config.clone(),
+        prune_config.segments.clone(),
+        era_import_source,
+    )
+    .set(ExecutionStage::new(
+        evm_config,
+        consensus,
+        stage_config.execution.into(),
+        stage_config.execution_external_clean_threshold(),
+        exex_manager_handle,
+    ));
+
+    if !custom_prune_segments.is_empty() {
+        stages = stages.set(
+            PruneStage::new(prune_config.segments, stage_config.prune.commit_threshold)
+                .with_custom_segments(custom_prune_segments),
+        );
+    }
+
     let pipeline = builder
         .with_tip_sender(tip_tx)
         .with_metrics_tx(metrics_tx)
-        .add_stages(
-            DefaultStages::new(
-                provider_factory.clone(),
-                tip_rx,
-                Arc::clone(&consensus),
-                header_downloader,
-                body_downloader,
-                evm_config.clone(),
-                stage_config.clone(),
-                prune_config.segments,
-                era_import_source,
-            )
-            .set(ExecutionStage::new(
-                evm_config,
-                consensus,
-                stage_config.execution.into(),
-                stage_config.execution_external_clean_threshold(),
-                exex_manager_handle,
-            ))
-            .disable_all(disabled_stages),
-        )
+        .add_stages(stages.disable_all(disabled_stages))
         .build(provider_factory, static_file_producer);
 
     Ok(pipeline)

--- a/crates/prune/prune/Cargo.toml
+++ b/crates/prune/prune/Cargo.toml
@@ -34,6 +34,7 @@ metrics.workspace = true
 alloy-primitives.workspace = true
 
 # misc
+auto_impl.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 itertools.workspace = true

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -112,6 +112,18 @@ impl<Provider, S> Pruner<Provider, S> {
         self.minimum_pruning_distance = Some(distance);
         self
     }
+
+    /// Appends additional segments to the pruner, e.g. custom segments defined by a downstream
+    /// node, see [`PruneSegment::Custom`](reth_prune_types::PruneSegment::Custom).
+    ///
+    /// The appended segments are pruned after the built-in ones and share the pruner's delete
+    /// limit and timeout per run.
+    pub fn extend_segments(
+        &mut self,
+        segments: impl IntoIterator<Item = Box<dyn Segment<Provider>>>,
+    ) {
+        self.segments.extend(segments);
+    }
 }
 
 impl<Provider, S> Pruner<Provider, S>
@@ -210,7 +222,9 @@ where
                         tip_block_number,
                         segment.segment(),
                         segment.purpose(),
-                        self.minimum_pruning_distance,
+                        // A minimum declared by the segment itself takes precedence over the
+                        // pruner-wide override, see `Segment::min_blocks`.
+                        segment.min_blocks().or(self.minimum_pruning_distance),
                     )
                 })
                 .transpose()?
@@ -380,9 +394,56 @@ fn is_stage_finished<Provider: StageCheckpointReader>(
 
 #[cfg(test)]
 mod tests {
-    use crate::Pruner;
+    use crate::{
+        segments::{PruneInput, Segment},
+        Pruner, PrunerError,
+    };
     use reth_exex_types::FinishedExExHeight;
-    use reth_provider::test_utils::create_test_provider_factory;
+    use reth_provider::{test_utils::create_test_provider_factory, PruneCheckpointReader};
+    use reth_prune_types::{
+        PruneCheckpoint, PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput,
+        SegmentOutputCheckpoint,
+    };
+
+    /// A segment as a downstream node would define it: prunes nothing from the database, but
+    /// reports progress and saves checkpoints under a custom [`PruneSegment`].
+    #[derive(Debug)]
+    struct CustomSegment {
+        min_blocks: Option<u64>,
+    }
+
+    impl<Provider> Segment<Provider> for CustomSegment {
+        fn segment(&self) -> PruneSegment {
+            PruneSegment::Custom(42)
+        }
+
+        fn mode(&self) -> Option<PruneMode> {
+            Some(PruneMode::Distance(5))
+        }
+
+        fn purpose(&self) -> PrunePurpose {
+            PrunePurpose::User
+        }
+
+        fn min_blocks(&self) -> Option<u64> {
+            self.min_blocks
+        }
+
+        fn prune(
+            &self,
+            _provider: &Provider,
+            input: PruneInput,
+        ) -> Result<SegmentOutput, PrunerError> {
+            Ok(SegmentOutput {
+                progress: PruneProgress::Finished,
+                pruned: 1,
+                checkpoint: Some(SegmentOutputCheckpoint {
+                    block_number: Some(input.to_block),
+                    tx_number: None,
+                }),
+            })
+        }
+    }
 
     #[test]
     fn is_pruning_needed() {
@@ -422,5 +483,98 @@ mod tests {
         // Adjust tip block number to the finished ExEx height that reaches the threshold
         finished_exex_height_tx.send(FinishedExExHeight::Height(third_block_number)).unwrap();
         assert!(pruner.is_pruning_needed(third_block_number));
+    }
+
+    #[test]
+    fn prunes_custom_segment_and_persists_checkpoint() {
+        let provider_factory = create_test_provider_factory();
+
+        let (_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+
+        let mut pruner = Pruner::new_with_factory(
+            provider_factory.clone(),
+            vec![],
+            1,
+            usize::MAX,
+            None,
+            finished_exex_height_rx,
+        );
+        pruner.extend_segments([
+            Box::new(CustomSegment { min_blocks: Some(0) }) as Box<dyn Segment<_>>
+        ]);
+
+        let output = pruner.run(10).expect("pruner run");
+        assert!(output.progress.is_finished());
+        assert_eq!(output.segments.len(), 1);
+        assert_eq!(output.segments[0].0, PruneSegment::Custom(42));
+
+        // The checkpoint is persisted in the database under the custom segment key
+        let provider = provider_factory.provider().unwrap();
+        assert_eq!(
+            provider.get_prune_checkpoint(PruneSegment::Custom(42)).unwrap(),
+            Some(PruneCheckpoint {
+                block_number: Some(5),
+                tx_number: None,
+                prune_mode: PruneMode::Distance(5)
+            })
+        );
+        // Other segments, including other custom ids, are unaffected
+        assert_eq!(provider.get_prune_checkpoint(PruneSegment::Custom(41)).unwrap(), None);
+        assert_eq!(provider.get_prune_checkpoint(PruneSegment::SenderRecovery).unwrap(), None);
+        drop(provider);
+
+        // A subsequent run passes the previous checkpoint back to the segment and advances it
+        pruner.run(11).expect("pruner run");
+        assert_eq!(
+            provider_factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::Custom(42))
+                .unwrap()
+                .and_then(|checkpoint| checkpoint.block_number),
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn custom_segment_min_blocks_precedence() {
+        let provider_factory = create_test_provider_factory();
+
+        // Without a segment-declared minimum, custom segments fall back to the conservative
+        // `PruneSegment::min_blocks`, which is incompatible with `Distance(5)`
+        let (_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let mut pruner = Pruner::new_with_factory(
+            provider_factory.clone(),
+            vec![Box::new(CustomSegment { min_blocks: None }) as Box<dyn Segment<_>>],
+            1,
+            usize::MAX,
+            None,
+            finished_exex_height_rx.clone(),
+        );
+        assert!(pruner.run(10).is_err());
+
+        // A segment-declared minimum takes precedence over the pruner-wide override
+        let mut pruner = Pruner::new_with_factory(
+            provider_factory.clone(),
+            vec![Box::new(CustomSegment { min_blocks: Some(0) }) as Box<dyn Segment<_>>],
+            1,
+            usize::MAX,
+            None,
+            finished_exex_height_rx,
+        )
+        .with_minimum_pruning_distance(100);
+        let output = pruner.run(10).expect("pruner run");
+        assert!(output.progress.is_finished());
+        assert_eq!(
+            provider_factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::Custom(42))
+                .unwrap()
+                .and_then(|checkpoint| checkpoint.block_number),
+            Some(5)
+        );
     }
 }

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -118,11 +118,16 @@ impl<Provider, S> Pruner<Provider, S> {
     ///
     /// The appended segments are pruned after the built-in ones and share the pruner's delete
     /// limit and timeout per run.
-    pub fn extend_segments(
-        &mut self,
-        segments: impl IntoIterator<Item = Box<dyn Segment<Provider>>>,
-    ) {
-        self.segments.extend(segments);
+    ///
+    /// Accepts any [`Segment`] implementation, including `Arc<dyn Segment>`, which allows a
+    /// single segment instance to be shared between multiple pruners, e.g. the engine-driven
+    /// pruner and the pipeline's prune stage.
+    pub fn extend_segments<Seg>(&mut self, segments: impl IntoIterator<Item = Seg>)
+    where
+        Seg: Segment<Provider> + 'static,
+    {
+        self.segments
+            .extend(segments.into_iter().map(|segment| Box::new(segment) as Box<dyn Segment<_>>));
     }
 }
 
@@ -500,9 +505,7 @@ mod tests {
             None,
             finished_exex_height_rx,
         );
-        pruner.extend_segments([
-            Box::new(CustomSegment { min_blocks: Some(0) }) as Box<dyn Segment<_>>
-        ]);
+        pruner.extend_segments([CustomSegment { min_blocks: Some(0) }]);
 
         let output = pruner.run(10).expect("pruner run");
         assert!(output.progress.is_finished());

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -142,17 +142,30 @@ pub trait Segment<Provider>: Debug + Send + Sync {
     fn required_stage(&self) -> Option<StageId> {
         None
     }
+
+    /// Minimum number of blocks to keep in the database for this segment, overriding the
+    /// default of [`PruneSegment::min_blocks`].
+    ///
+    /// If this returns `Some`, the returned value takes precedence over both the pruner-wide
+    /// minimum pruning distance and the [`PruneSegment::min_blocks`] default. This is primarily
+    /// an extension point for [`PruneSegment::Custom`] segments, which otherwise fall back to
+    /// the conservative
+    /// [`MINIMUM_UNWIND_SAFE_DISTANCE`](reth_prune_types::MINIMUM_UNWIND_SAFE_DISTANCE).
+    fn min_blocks(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Segment pruning input, see [`Segment::prune`].
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone))]
 pub struct PruneInput {
-    pub(crate) previous_checkpoint: Option<PruneCheckpoint>,
+    /// Checkpoint from the previous pruner run for this segment, if any.
+    pub previous_checkpoint: Option<PruneCheckpoint>,
     /// Target block up to which the pruning needs to be done, inclusive.
-    pub(crate) to_block: BlockNumber,
+    pub to_block: BlockNumber,
     /// Limits pruning of a segment.
-    pub(crate) limiter: PruneLimiter,
+    pub limiter: PruneLimiter,
 }
 
 impl PruneInput {
@@ -164,7 +177,7 @@ impl PruneInput {
     /// 2. If checkpoint doesn't exist, return 0.
     ///
     /// To get the range end: get last tx number for `to_block`.
-    pub(crate) fn get_next_tx_num_range<Provider: BlockReader>(
+    pub fn get_next_tx_num_range<Provider: BlockReader>(
         &self,
         provider: &Provider,
     ) -> ProviderResult<Option<RangeInclusive<TxNumber>>> {
@@ -210,7 +223,7 @@ impl PruneInput {
     /// 2. If checkpoint doesn't exist, use block 0.
     ///
     /// To get the range end: use block `to_block`.
-    pub(crate) fn get_next_block_range(&self) -> Option<RangeInclusive<BlockNumber>> {
+    pub fn get_next_block_range(&self) -> Option<RangeInclusive<BlockNumber>> {
         let from_block = self.get_start_next_block_range();
         let range = from_block..=self.to_block;
         if range.is_empty() {
@@ -224,7 +237,7 @@ impl PruneInput {
     ///
     /// 1. If checkpoint exists, use next block.
     /// 2. If checkpoint doesn't exist, use block 0.
-    pub(crate) fn get_start_next_block_range(&self) -> u64 {
+    pub fn get_start_next_block_range(&self) -> u64 {
         self.previous_checkpoint
             .and_then(|checkpoint| checkpoint.block_number)
             // Checkpoint exists, prune from the next block after the highest pruned one

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -110,6 +110,9 @@ where
 /// 2. If [`Segment::prune`] returned a [`Some`] in `checkpoint` of [`SegmentOutput`], call
 ///    [`Segment::save_checkpoint`].
 /// 3. Subtract `pruned` of [`SegmentOutput`] from `delete_limit` of next [`PruneInput`].
+// The `Arc` impl allows a single segment instance to be shared between multiple pruners, e.g. the
+// engine-driven pruner and the pipeline's prune stage.
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait Segment<Provider>: Debug + Send + Sync {
     /// Segment of data that's pruned.
     fn segment(&self) -> PruneSegment;

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 /// VERY IMPORTANT NOTE: new variants must be added to the end of this enum, and old variants which
 /// are no longer used must not be removed from this enum. The variant index is encoded directly
 /// when writing to the `PruneCheckpoint` table, so changing the order here will corrupt the table.
+/// This also applies to [`Self::Custom`]: its position must not change, and the wrapped id is
+/// encoded into the table key as well.
 #[derive(Debug, Display, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, EnumIter)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
@@ -43,6 +45,17 @@ pub enum PruneSegment {
     MerkleChangeSets,
     /// Prune segment responsible for bodies (transactions in static files).
     Bodies,
+    /// Prune segment defined by a downstream consumer of reth, e.g. a custom node built on the
+    /// SDK.
+    ///
+    /// The wrapped id identifies the custom segment and is encoded into the
+    /// `PruneCheckpoints` table key, so it must remain stable for the lifetime of the
+    /// database. Downstream projects are responsible for keeping their ids unique.
+    ///
+    /// Built-in reth segments never use this variant.
+    #[strum(disabled)]
+    #[display("Custom({_0})")]
+    Custom(u8),
 }
 
 #[cfg(test)]
@@ -54,20 +67,25 @@ impl Default for PruneSegment {
 }
 
 impl PruneSegment {
-    /// Returns an iterator over all variants of [`PruneSegment`].
+    /// Returns an iterator over all built-in variants of [`PruneSegment`].
     ///
     /// Excludes deprecated variants that are no longer used, but can still be found in the
-    /// database.
+    /// database, as well as [`Self::Custom`] segments, which are defined by downstream consumers
+    /// and cannot be enumerated.
     pub fn variants() -> impl Iterator<Item = Self> {
         Self::iter()
     }
 
     /// Returns minimum number of blocks to keep in the database for this segment.
+    ///
+    /// For [`Self::Custom`] segments this returns the conservative
+    /// [`MINIMUM_UNWIND_SAFE_DISTANCE`]. Custom segments can override this via
+    /// `Segment::min_blocks` in `reth-prune`.
     pub const fn min_blocks(&self) -> u64 {
         match self {
             Self::SenderRecovery | Self::TransactionLookup => 0,
             Self::Receipts | Self::Bodies => MINIMUM_DISTANCE,
-            Self::ContractLogs | Self::AccountHistory | Self::StorageHistory => {
+            Self::ContractLogs | Self::AccountHistory | Self::StorageHistory | Self::Custom(_) => {
                 MINIMUM_UNWIND_SAFE_DISTANCE
             }
             #[expect(deprecated)]
@@ -131,5 +149,52 @@ mod tests {
             assert!(!segments.contains(&PruneSegment::Transactions));
             assert!(!segments.contains(&PruneSegment::MerkleChangeSets));
         }
+
+        // Custom segments cannot be enumerated
+        assert!(!segments.iter().any(|segment| matches!(segment, PruneSegment::Custom(_))));
+    }
+
+    // Guards the on-disk format of the `PruneCheckpoints` table key: the variant index (and the
+    // custom segment id) are encoded directly, so these bytes must never change.
+    #[test]
+    fn test_prune_segment_compact_backwards_compat() {
+        use reth_codecs::Compact;
+
+        let cases = [
+            (PruneSegment::SenderRecovery, vec![0]),
+            (PruneSegment::TransactionLookup, vec![1]),
+            (PruneSegment::Receipts, vec![2]),
+            (PruneSegment::ContractLogs, vec![3]),
+            (PruneSegment::AccountHistory, vec![4]),
+            (PruneSegment::StorageHistory, vec![5]),
+            #[expect(deprecated)]
+            (PruneSegment::Headers, vec![6]),
+            #[expect(deprecated)]
+            (PruneSegment::Transactions, vec![7]),
+            #[expect(deprecated)]
+            (PruneSegment::MerkleChangeSets, vec![8]),
+            (PruneSegment::Bodies, vec![9]),
+            // `Custom(0)` has an empty id payload because integers are compact-encoded without
+            // leading zero bytes
+            (PruneSegment::Custom(0), vec![10]),
+            (PruneSegment::Custom(42), vec![10, 42]),
+            (PruneSegment::Custom(u8::MAX), vec![10, u8::MAX]),
+        ];
+
+        for (segment, expected) in cases {
+            let mut buf = Vec::new();
+            segment.to_compact(&mut buf);
+            assert_eq!(buf, expected, "encoding changed for {segment:?}");
+
+            // Note: the returned remainder is not checked because the derived enum
+            // `from_compact` does not advance the buffer past a variant's field payload.
+            let (decoded, _) = PruneSegment::from_compact(&buf, buf.len());
+            assert_eq!(decoded, segment);
+        }
+    }
+
+    #[test]
+    fn test_custom_segment_display() {
+        assert_eq!(PruneSegment::Custom(3).to_string(), "Custom(3)");
     }
 }

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -325,11 +325,14 @@ impl<E: ConfigureEvm> OfflineStages<E> {
 impl<E, Provider> StageSet<Provider> for OfflineStages<E>
 where
     E: ConfigureEvm,
+    // `'static` is required to store the (empty) `dyn Segment<Provider>` custom segment list in
+    // the prune stages.
+    Provider: 'static,
     ExecutionStages<E>: StageSet<Provider>,
-    PruneSenderRecoveryStage: Stage<Provider>,
+    PruneSenderRecoveryStage<Provider>: Stage<Provider>,
     HashingStages: StageSet<Provider>,
     HistoryIndexingStages: StageSet<Provider>,
-    PruneStage: Stage<Provider>,
+    PruneStage<Provider>: Stage<Provider>,
 {
     fn builder(self) -> StageSetBuilder<Provider> {
         ExecutionStages::new(

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -5,12 +5,14 @@ use reth_provider::{
     RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderFactory,
 };
 use reth_prune::{
-    PruneMode, PruneModes, PruneSegment, PrunerBuilder, SegmentOutput, SegmentOutputCheckpoint,
+    segments::Segment, PruneMode, PruneModes, PruneSegment, PrunerBuilder, SegmentOutput,
+    SegmentOutputCheckpoint,
 };
 use reth_stages_api::{
     ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_storage_api::{ChangeSetReader, StorageChangeSetReader, StorageSettingsCache};
+use std::{fmt, sync::Arc};
 use tracing::info;
 
 /// The prune stage that runs the pruner with the provided prune modes.
@@ -24,20 +26,47 @@ use tracing::info;
 ///
 /// `commit_threshold` is the maximum number of entries to prune before committing
 /// progress to the database.
-#[derive(Debug)]
-pub struct PruneStage {
+pub struct PruneStage<Provider> {
     prune_modes: PruneModes,
     commit_threshold: usize,
+    /// Additional segments to prune besides the built-in ones, e.g. custom segments defined by a
+    /// downstream node, see [`PruneSegment::Custom`].
+    ///
+    /// Segments are `Arc`ed so a single instance can be shared with the pruner that runs during
+    /// live sync.
+    custom_segments: Vec<Arc<dyn Segment<Provider>>>,
 }
 
-impl PruneStage {
+impl<Provider> PruneStage<Provider> {
     /// Crate new prune stage with the given prune modes and commit threshold.
     pub const fn new(prune_modes: PruneModes, commit_threshold: usize) -> Self {
-        Self { prune_modes, commit_threshold }
+        Self { prune_modes, commit_threshold, custom_segments: Vec::new() }
+    }
+
+    /// Appends additional segments to prune besides the built-in ones, e.g. custom segments
+    /// defined by a downstream node, see [`PruneSegment::Custom`].
+    pub fn with_custom_segments(
+        mut self,
+        segments: impl IntoIterator<Item = Arc<dyn Segment<Provider>>>,
+    ) -> Self {
+        self.custom_segments.extend(segments);
+        self
     }
 }
 
-impl<Provider> Stage<Provider> for PruneStage
+// Not derived to avoid requiring `Provider: Debug`, which the stage only uses as the `dyn
+// Segment` parameter.
+impl<Provider> fmt::Debug for PruneStage<Provider> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PruneStage")
+            .field("prune_modes", &self.prune_modes)
+            .field("commit_threshold", &self.commit_threshold)
+            .field("custom_segments", &self.custom_segments)
+            .finish()
+    }
+}
+
+impl<Provider> Stage<Provider> for PruneStage<Provider>
 where
     Provider: DBProvider<Tx: DbTxMut>
         + PruneCheckpointReader
@@ -50,7 +79,9 @@ where
         > + StorageSettingsCache
         + ChangeSetReader
         + StorageChangeSetReader
-        + RocksDBProviderFactory,
+        + RocksDBProviderFactory
+        // `'static` is required to pass the custom `dyn Segment<Provider>` segments to the pruner
+        + 'static,
 {
     fn id(&self) -> StageId {
         StageId::Prune
@@ -61,6 +92,7 @@ where
             .segments(self.prune_modes.clone())
             .delete_limit(self.commit_threshold)
             .build::<Provider>(provider.static_file_provider());
+        pruner.extend_segments(self.custom_segments.iter().cloned());
 
         let result = pruner.run_with_provider(provider, input.target())?;
         if result.progress.is_finished() {
@@ -132,10 +164,16 @@ where
 ///
 /// Should be run right after `Execution`, unlike [`PruneStage`] which runs at the end.
 /// This lets subsequent stages reuse the freed pages instead of growing the freelist.
-#[derive(Debug)]
-pub struct PruneSenderRecoveryStage(PruneStage);
+pub struct PruneSenderRecoveryStage<Provider>(PruneStage<Provider>);
 
-impl PruneSenderRecoveryStage {
+// Not derived to avoid requiring `Provider: Debug`, see [`PruneStage`]'s `Debug` impl.
+impl<Provider> fmt::Debug for PruneSenderRecoveryStage<Provider> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PruneSenderRecoveryStage").field(&self.0).finish()
+    }
+}
+
+impl<Provider> PruneSenderRecoveryStage<Provider> {
     /// Create new prune sender recovery stage with the given prune mode and commit threshold.
     pub fn new(prune_mode: PruneMode, commit_threshold: usize) -> Self {
         Self(PruneStage::new(
@@ -145,7 +183,7 @@ impl PruneSenderRecoveryStage {
     }
 }
 
-impl<Provider> Stage<Provider> for PruneSenderRecoveryStage
+impl<Provider> Stage<Provider> for PruneSenderRecoveryStage<Provider>
 where
     Provider: DBProvider<Tx: DbTxMut>
         + PruneCheckpointReader
@@ -158,7 +196,8 @@ where
         > + StorageSettingsCache
         + ChangeSetReader
         + StorageChangeSetReader
-        + RocksDBProviderFactory,
+        + RocksDBProviderFactory
+        + 'static,
 {
     fn id(&self) -> StageId {
         StageId::PruneSenderRecovery
@@ -195,7 +234,7 @@ mod tests {
     use super::*;
     use crate::test_utils::{
         stage_test_suite_ext, ExecuteStageTestRunner, StageTestRunner, StorageKind,
-        TestRunnerError, TestStageDB, UnwindStageTestRunner,
+        TestRunnerError, TestStageDB, TestStageProvider, UnwindStageTestRunner,
     };
     use alloy_primitives::B256;
     use reth_ethereum_primitives::Block;
@@ -214,20 +253,17 @@ mod tests {
     }
 
     impl StageTestRunner for PruneTestRunner {
-        type S = PruneStage;
+        type S = PruneStage<TestStageProvider>;
 
         fn db(&self) -> &TestStageDB {
             &self.db
         }
 
         fn stage(&self) -> Self::S {
-            PruneStage {
-                prune_modes: PruneModes {
-                    sender_recovery: Some(PruneMode::Full),
-                    ..Default::default()
-                },
-                commit_threshold: usize::MAX,
-            }
+            PruneStage::new(
+                PruneModes { sender_recovery: Some(PruneMode::Full), ..Default::default() },
+                usize::MAX,
+            )
         }
     }
 
@@ -289,5 +325,69 @@ mod tests {
         fn validate_unwind(&self, _input: UnwindInput) -> Result<(), TestRunnerError> {
             Ok(())
         }
+    }
+
+    /// A user-defined segment, as a downstream node would install via the node builder: prunes
+    /// nothing, but records checkpoints under [`PruneSegment::Custom`].
+    #[derive(Debug)]
+    struct CustomSegment;
+
+    impl<Provider> Segment<Provider> for CustomSegment {
+        fn segment(&self) -> PruneSegment {
+            PruneSegment::Custom(7)
+        }
+
+        fn mode(&self) -> Option<PruneMode> {
+            Some(PruneMode::Full)
+        }
+
+        fn purpose(&self) -> reth_prune::PrunePurpose {
+            reth_prune::PrunePurpose::User
+        }
+
+        fn min_blocks(&self) -> Option<u64> {
+            Some(0)
+        }
+
+        fn prune(
+            &self,
+            _provider: &Provider,
+            input: reth_prune::segments::PruneInput,
+        ) -> Result<SegmentOutput, reth_prune::PrunerError> {
+            Ok(SegmentOutput {
+                progress: reth_prune::PruneProgress::Finished,
+                pruned: 0,
+                checkpoint: Some(SegmentOutputCheckpoint {
+                    block_number: Some(input.to_block),
+                    tx_number: None,
+                }),
+            })
+        }
+    }
+
+    #[test]
+    fn prune_stage_runs_custom_segments() {
+        use reth_provider::DatabaseProviderFactory;
+        use reth_prune::PruneCheckpoint;
+        use std::sync::Arc;
+
+        let db = TestStageDB::default();
+        let mut stage = PruneStage::new(PruneModes::default(), usize::MAX)
+            .with_custom_segments([Arc::new(CustomSegment) as Arc<dyn Segment<_>>]);
+
+        let provider = db.factory.database_provider_rw().unwrap();
+        let input = ExecInput { target: Some(10), checkpoint: None };
+        let output = stage.execute(&provider, input).expect("stage execution");
+        assert!(output.done);
+
+        // The custom segment's checkpoint is persisted under its custom segment key
+        assert_eq!(
+            provider.get_prune_checkpoint(PruneSegment::Custom(7)).unwrap(),
+            Some(PruneCheckpoint {
+                block_number: Some(10),
+                tx_number: None,
+                prune_mode: PruneMode::Full
+            })
+        );
     }
 }

--- a/crates/stages/stages/src/test_utils/mod.rs
+++ b/crates/stages/stages/src/test_utils/mod.rs
@@ -9,7 +9,8 @@ pub(crate) use macros::*;
 mod runner;
 #[cfg(test)]
 pub(crate) use runner::{
-    ExecuteStageTestRunner, StageTestRunner, TestRunnerError, UnwindStageTestRunner,
+    ExecuteStageTestRunner, StageTestRunner, TestRunnerError, TestStageProvider,
+    UnwindStageTestRunner,
 };
 
 mod test_db;

--- a/crates/stages/stages/src/test_utils/runner.rs
+++ b/crates/stages/stages/src/test_utils/runner.rs
@@ -17,10 +17,13 @@ pub(crate) enum TestRunnerError {
     Provider(#[from] ProviderError),
 }
 
+/// The database provider type stages are run against in tests.
+pub(crate) type TestStageProvider =
+    DatabaseProvider<<TempDatabase<DatabaseEnv> as Database>::TXMut, MockNodeTypesWithDB>;
+
 /// A generic test runner for stages.
 pub(crate) trait StageTestRunner {
-    type S: Stage<DatabaseProvider<<TempDatabase<DatabaseEnv> as Database>::TXMut, MockNodeTypesWithDB>>
-        + 'static;
+    type S: Stage<TestStageProvider> + 'static;
 
     /// Return a reference to the database.
     fn db(&self) -> &TestStageDB;

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -175,11 +175,13 @@ impl Decode for PackedStoredNibblesSubKey {
 }
 
 impl Encode for PruneSegment {
-    type Encoded = [u8; 1];
+    // Built-in variants encode to a single byte holding the variant index.
+    // `PruneSegment::Custom` additionally appends its id, so the encoding is variable-length.
+    type Encoded = Vec<u8>;
 
     fn encode(self) -> Self::Encoded {
-        let mut buf = [0u8];
-        self.to_compact(&mut buf.as_mut());
+        let mut buf = Vec::with_capacity(2);
+        self.to_compact(&mut buf);
         buf
     }
 }
@@ -303,5 +305,28 @@ mod tests {
         validate_bitflag_backwards_compat!(StoredBlockBodyIndices, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockWithdrawals, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StorageHashingCheckpoint, UnusedBits::NotZero);
+    }
+
+    // The `PruneCheckpoints` table key must be stable across releases: built-in segments encode
+    // to their single variant-index byte, custom segments append their id.
+    #[test]
+    fn test_prune_segment_key_backwards_compatibility() {
+        use super::*;
+        use reth_prune_types::PruneSegment;
+
+        for (segment, expected) in [
+            (PruneSegment::SenderRecovery, vec![0u8]),
+            (PruneSegment::TransactionLookup, vec![1]),
+            (PruneSegment::Receipts, vec![2]),
+            (PruneSegment::ContractLogs, vec![3]),
+            (PruneSegment::AccountHistory, vec![4]),
+            (PruneSegment::StorageHistory, vec![5]),
+            (PruneSegment::Bodies, vec![9]),
+            (PruneSegment::Custom(0), vec![10]),
+            (PruneSegment::Custom(42), vec![10, 42]),
+        ] {
+            assert_eq!(segment.encode(), expected, "key encoding changed for {segment:?}");
+            assert_eq!(PruneSegment::decode(&expected).unwrap(), segment);
+        }
     }
 }


### PR DESCRIPTION
This allows reth sdk consumers to add additional custom prune segments.

Adds a `Custom(u8)` variant to `PruneSegment`, taking in account the `VERY IMPORTANT NOTE` about adding prune segments. May change this, as it does not add much flexibility if we want to add prune segments in the future.