### PR TITLE
feat(net): serve inbound `snap/2` requests

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -9,12 +9,19 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_rlp::Encodable;
 use futures::StreamExt;
 use reth_eth_wire::{
+    snap::{
+        AccountRangeMessage, BlockAccessListsMessage, ByteCodesMessage, SnapProtocolMessage,
+        StorageRangesMessage,
+    },
     BlockAccessLists, BlockBodies, BlockHeaders, Cells, EthNetworkPrimitives, GetBlockAccessLists,
     GetBlockBodies, GetBlockHeaders, GetCells, GetNodeData, GetReceipts, GetReceipts70,
     HeadersDirection, NetworkPrimitives, NodeData, Receipts, Receipts69, Receipts70,
 };
 use reth_network_api::test_utils::PeersHandle;
-use reth_network_p2p::error::RequestResult;
+use reth_network_p2p::{
+    error::{RequestError, RequestResult},
+    snap::client::SnapResponse,
+};
 use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
 use reth_storage_api::{BalProvider, BlockReader, GetBlockAccessListLimit, HeaderProvider};
@@ -379,6 +386,61 @@ where
             self.client.bal_store().get_by_hashes_with_limit(&request.0, limit).unwrap_or_default();
         let _ = response.send(Ok(BlockAccessLists(access_lists)));
     }
+
+    /// Handles `snap/2` (EIP-8189) requests.
+    ///
+    /// There's no state-trie-backed store yet, so `GetAccountRange`/`GetStorageRanges`/
+    /// `GetByteCodes` always answer with an empty (but valid) range. `GetBlockAccessLists` is
+    /// answered from the same [`BalProvider`] store eth71's `GetBlockAccessLists` uses, since both
+    /// serve the same underlying data.
+    fn on_snap_request(
+        &self,
+        _peer_id: PeerId,
+        request: SnapProtocolMessage,
+        response: oneshot::Sender<RequestResult<SnapResponse>>,
+    ) {
+        self.metrics.snap_requests_received_total.increment(1);
+
+        let result = match request {
+            SnapProtocolMessage::GetAccountRange(req) => {
+                Ok(SnapResponse::AccountRange(AccountRangeMessage {
+                    request_id: req.request_id,
+                    accounts: Vec::new(),
+                    proof: Vec::new(),
+                }))
+            }
+            SnapProtocolMessage::GetStorageRanges(req) => {
+                Ok(SnapResponse::StorageRanges(StorageRangesMessage {
+                    request_id: req.request_id,
+                    slots: req.account_hashes.iter().map(|_| Vec::new()).collect(),
+                    proof: Vec::new(),
+                }))
+            }
+            SnapProtocolMessage::GetByteCodes(req) => {
+                Ok(SnapResponse::ByteCodes(ByteCodesMessage {
+                    request_id: req.request_id,
+                    codes: Vec::new(),
+                }))
+            }
+            SnapProtocolMessage::GetBlockAccessLists(req) => {
+                let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(SOFT_RESPONSE_LIMIT);
+                let block_access_lists = self
+                    .client
+                    .bal_store()
+                    .get_by_hashes_with_limit(&req.block_hashes, limit)
+                    .unwrap_or_default();
+                Ok(SnapResponse::BlockAccessLists(BlockAccessListsMessage {
+                    request_id: req.request_id,
+                    block_access_lists: BlockAccessLists(block_access_lists),
+                }))
+            }
+            // The peer sent us a response-shaped message instead of a request; not something we
+            // asked for.
+            _ => Err(RequestError::BadResponse),
+        };
+
+        let _ = response.send(result);
+    }
 }
 
 /// An endless future.
@@ -429,6 +491,9 @@ where
                     }
                     IncomingEthRequest::GetCells { peer_id, request, response } => {
                         this.on_cells_request(peer_id, request, response)
+                    }
+                    IncomingEthRequest::GetSnap { peer_id, request, response } => {
+                        this.on_snap_request(peer_id, request, response)
                     }
                 }
             },
@@ -536,6 +601,17 @@ pub enum IncomingEthRequest<N: NetworkPrimitives = EthNetworkPrimitives> {
         request: GetCells,
         /// The channel sender for the response containing cells.
         response: oneshot::Sender<RequestResult<Cells>>,
+    },
+    /// Request a `snap/2` message from the peer.
+    ///
+    /// The response should be sent through the channel.
+    GetSnap {
+        /// The ID of the peer to request from.
+        peer_id: PeerId,
+        /// The `snap/2` request.
+        request: SnapProtocolMessage,
+        /// The channel sender for the response.
+        response: oneshot::Sender<RequestResult<SnapResponse>>,
     },
 }
 

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -9,10 +9,7 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_rlp::Encodable;
 use futures::StreamExt;
 use reth_eth_wire::{
-    snap::{
-        AccountRangeMessage, BlockAccessListsMessage, ByteCodesMessage, SnapProtocolMessage,
-        StorageRangesMessage,
-    },
+    snap::{BlockAccessListsMessage, SnapProtocolMessage},
     BlockAccessLists, BlockBodies, BlockHeaders, Cells, EthNetworkPrimitives, GetBlockAccessLists,
     GetBlockBodies, GetBlockHeaders, GetCells, GetNodeData, GetReceipts, GetReceipts70,
     HeadersDirection, NetworkPrimitives, NodeData, Receipts, Receipts69, Receipts70,
@@ -389,10 +386,11 @@ where
 
     /// Handles `snap/2` (EIP-8189) requests.
     ///
-    /// There's no state-trie-backed store yet, so `GetAccountRange`/`GetStorageRanges`/
-    /// `GetByteCodes` always answer with an empty (but valid) range. `GetBlockAccessLists` is
-    /// answered from the same [`BalProvider`] store eth71's `GetBlockAccessLists` uses, since both
-    /// serve the same underlying data.
+    /// `GetAccountRange`/`GetStorageRanges`/`GetByteCodes` stay unsupported until a real
+    /// state-trie-backed store exists; an empty response would falsely claim served data.
+    /// `GetBlockAccessLists` is answered from the same [`BalProvider`] store eth71's
+    /// `GetBlockAccessLists` uses, since both serve the same
+    /// underlying data.
     fn on_snap_request(
         &self,
         _peer_id: PeerId,
@@ -402,28 +400,14 @@ where
         self.metrics.snap_requests_received_total.increment(1);
 
         let result = match request {
-            SnapProtocolMessage::GetAccountRange(req) => {
-                Ok(SnapResponse::AccountRange(AccountRangeMessage {
-                    request_id: req.request_id,
-                    accounts: Vec::new(),
-                    proof: Vec::new(),
-                }))
-            }
-            SnapProtocolMessage::GetStorageRanges(req) => {
-                Ok(SnapResponse::StorageRanges(StorageRangesMessage {
-                    request_id: req.request_id,
-                    slots: req.account_hashes.iter().map(|_| Vec::new()).collect(),
-                    proof: Vec::new(),
-                }))
-            }
-            SnapProtocolMessage::GetByteCodes(req) => {
-                Ok(SnapResponse::ByteCodes(ByteCodesMessage {
-                    request_id: req.request_id,
-                    codes: Vec::new(),
-                }))
-            }
-            SnapProtocolMessage::GetBlockAccessLists(req) => {
-                let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(SOFT_RESPONSE_LIMIT);
+            SnapProtocolMessage::GetAccountRange(_) |
+            SnapProtocolMessage::GetStorageRanges(_) |
+            SnapProtocolMessage::GetByteCodes(_) => Err(RequestError::UnsupportedCapability),
+            SnapProtocolMessage::GetBlockAccessLists(mut req) => {
+                req.block_hashes.truncate(MAX_BLOCK_ACCESS_LISTS_SERVE);
+                let limit = GetBlockAccessListLimit::ResponseSizeSoftLimit(
+                    (req.response_bytes as usize).min(SOFT_RESPONSE_LIMIT),
+                );
                 let block_access_lists = self
                     .client
                     .bal_store()

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -50,7 +50,6 @@ use reth_network_api::{
     test_utils::PeersHandle,
     EthProtocolInfo, NetworkEvent, NetworkStatus, PeerInfo, PeerRequest,
 };
-use reth_network_p2p::error::RequestError;
 use reth_network_peers::{NodeRecord, PeerId};
 use reth_network_types::ReputationChangeKind;
 use reth_storage_api::BlockNumReader;
@@ -584,10 +583,8 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     response,
                 });
             }
-            PeerRequest::GetSnap { response, .. } => {
-                // No snap/2 server yet, inbound snap/2 requests are not served.
-                let _ = response.send(Err(RequestError::UnsupportedCapability));
-            }
+            PeerRequest::GetSnap { request, response } => self
+                .delegate_eth_request(IncomingEthRequest::GetSnap { peer_id, request, response }),
         }
     }
 

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -15,7 +15,7 @@ use reth_eth_wire::{
     Transactions,
 };
 use reth_eth_wire_types::{snap::SnapProtocolMessage, RawCapabilityMessage};
-use reth_network_api::PeerRequest;
+use reth_network_api::{PeerRequest, RequestMessage};
 use reth_network_p2p::{
     error::{RequestError, RequestResult},
     snap::client::SnapResponse,
@@ -285,14 +285,16 @@ pub enum PeerResponseResult<N: NetworkPrimitives = EthNetworkPrimitives> {
 // === impl PeerResponseResult ===
 
 impl<N: NetworkPrimitives> PeerResponseResult<N> {
-    /// Converts this response into an [`EthMessage`]
-    pub fn try_into_message(self, id: u64) -> RequestResult<EthMessage<N>> {
+    /// Converts this response into the [`RequestMessage`] to send back to the peer: an
+    /// [`EthMessage`] for every variant except [`Self::Snap`], which becomes a
+    /// [`SnapProtocolMessage`].
+    pub fn try_into_message(self, id: u64) -> RequestResult<RequestMessage<N>> {
         macro_rules! to_message {
             ($response:ident, $item:ident, $request_id:ident) => {
                 match $response {
                     Ok(res) => {
                         let request = RequestPair { request_id: $request_id, message: $item(res) };
-                        Ok(EthMessage::$item(request))
+                        Ok(RequestMessage::Eth(EthMessage::$item(request)))
                     }
                     Err(err) => Err(err),
                 }
@@ -320,27 +322,32 @@ impl<N: NetworkPrimitives> PeerResponseResult<N> {
             Self::Receipts70(resp) => match resp {
                 Ok(res) => {
                     let request = RequestPair { request_id: id, message: res };
-                    Ok(EthMessage::Receipts70(request))
+                    Ok(RequestMessage::Eth(EthMessage::Receipts70(request)))
                 }
                 Err(err) => Err(err),
             },
             Self::BlockAccessLists(resp) => match resp {
                 Ok(res) => {
                     let request = RequestPair { request_id: id, message: res };
-                    Ok(EthMessage::BlockAccessLists(request))
+                    Ok(RequestMessage::Eth(EthMessage::BlockAccessLists(request)))
                 }
                 Err(err) => Err(err),
             },
             Self::Cells(resp) => match resp {
                 Ok(res) => {
                     let request = RequestPair { request_id: id, message: res };
-                    Ok(EthMessage::Cells(request))
+                    Ok(RequestMessage::Eth(EthMessage::Cells(request)))
                 }
                 Err(err) => Err(err),
             },
-            // `snap/2` responses aren't `eth` wire messages and never reach this conversion: it's
-            // only used to answer inbound eth requests, and there's no snap/2 server yet.
-            Self::Snap(_) => Err(RequestError::UnsupportedCapability),
+            Self::Snap(resp) => match resp {
+                Ok(res) => {
+                    let mut message: SnapProtocolMessage = res.into();
+                    message.set_request_id(id);
+                    Ok(RequestMessage::Snap(message))
+                }
+                Err(err) => Err(err),
+            },
         }
     }
 

--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -560,6 +560,9 @@ pub struct EthRequestHandlerMetrics {
     /// Number of `GetBlockAccessLists` requests received
     pub(crate) eth_block_access_lists_requests_received_total: Counter,
 
+    /// Number of `snap/2` (EIP-8189) requests received
+    pub(crate) snap_requests_received_total: Counter,
+
     /// Duration in seconds of call to poll
     /// [`EthRequestHandler`](crate::eth_requests::EthRequestHandler).
     pub(crate) acc_duration_poll_eth_req_handler: Gauge,

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -1273,6 +1273,8 @@ mod tests {
     use super::*;
     use crate::session::{handle::PendingSessionEvent, start_pending_incoming_session};
     use alloy_eips::eip2124::ForkFilter;
+    use alloy_primitives::B256;
+    use futures::task::noop_waker;
     use reth_chainspec::MAINNET;
     use reth_ecies::stream::ECIESStream;
     use reth_eth_wire::{
@@ -1282,7 +1284,10 @@ mod tests {
     };
     use reth_eth_wire_types::{
         message::MAX_MESSAGE_SIZE,
-        snap::{AccountRangeMessage, BlockAccessListsMessage, GetBlockAccessListsMessage},
+        snap::{
+            AccountRangeMessage, BlockAccessListsMessage, GetAccountRangeMessage,
+            GetBlockAccessListsMessage,
+        },
         BlockAccessLists, EthMessageID, NewPooledTransactionHashes72,
     };
     use reth_ethereum_forks::EthereumHardfork;
@@ -1836,6 +1841,68 @@ mod tests {
         assert!(session.inflight_requests.is_empty());
         assert!(session.queued_outgoing.pop_front().is_none());
         assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::UnsupportedCapability);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn inbound_snap_request_round_trips_to_a_response() {
+        let mut builder = snap_session_builder();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
+            let _client_stream = client_stream;
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        tokio::task::spawn(fut);
+        let (incoming, _) = listener.accept().await.unwrap();
+        let mut session = builder.connect_incoming(incoming).await;
+
+        // The peer sends an inbound GetAccountRange request.
+        let outcome = session.on_incoming_snap_message(SnapProtocolMessage::GetAccountRange(
+            GetAccountRangeMessage {
+                request_id: 7,
+                root_hash: B256::ZERO,
+                starting_hash: B256::ZERO,
+                limit_hash: B256::ZERO,
+                response_bytes: 1024,
+            },
+        ));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert_eq!(session.received_requests_from_remote.len(), 1);
+
+        // It's routed upward instead of being served inline.
+        let Some(ActiveSessionMessage::ValidMessage {
+            message: PeerMessage::EthRequest(PeerRequest::GetSnap { request, response }),
+            ..
+        }) = builder.active_session_rx.next().await
+        else {
+            panic!("expected an outbound GetSnap request")
+        };
+        assert!(matches!(request, SnapProtocolMessage::GetAccountRange(_)));
+
+        // The handler answers with an empty-but-valid range.
+        let _ = response.send(Ok(SnapResponse::AccountRange(AccountRangeMessage {
+            request_id: 7,
+            accounts: Vec::new(),
+            proof: Vec::new(),
+        })));
+
+        // Drive the same conversion the session's main poll loop would.
+        let mut req = session.received_requests_from_remote.pop().unwrap();
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let Poll::Ready(resp) = req.rx.poll(&mut cx) else { panic!("response should be ready") };
+        session.handle_outgoing_response(req.request_id, resp);
+
+        // The reply goes out as a snap/2 message carrying the original request id, not an eth
+        // message.
+        let msg = session.queued_outgoing.pop_front().expect("response queued for send");
+        assert!(matches!(
+            msg,
+            OutgoingMessage::Snap(SnapProtocolMessage::AccountRange(AccountRangeMessage {
+                request_id: 7,
+                ..
+            }))
+        ));
     }
 
     #[test]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -396,9 +396,18 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     ) -> OnIncomingMessageOutcome<N> {
         let request_id = msg.request_id();
         if !msg.is_response() {
-            // Inbound snap requests are not served yet; the snap server lands separately.
-            trace!(target: "net::session", ?request_id, remote_peer_id=?self.remote_peer_id, "ignoring inbound snap request");
-            return OnIncomingMessageOutcome::Ok
+            let (tx, response) = oneshot::channel();
+            self.received_requests_from_remote.push(ReceivedRequest {
+                request_id,
+                rx: PeerResponse::Snap { response },
+                received: Instant::now(),
+            });
+            return self
+                .try_emit_request(PeerMessage::EthRequest(PeerRequest::GetSnap {
+                    request: msg,
+                    response: tx,
+                }))
+                .into()
         }
 
         let Some(req) = self.inflight_requests.remove(&request_id) else {
@@ -531,8 +540,11 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     /// This will queue the response to be sent to the peer
     fn handle_outgoing_response(&mut self, id: u64, resp: PeerResponseResult<N>) {
         match resp.try_into_message(id) {
-            Ok(msg) => {
+            Ok(RequestMessage::Eth(msg)) => {
                 self.queued_outgoing.push_back(msg.into());
+            }
+            Ok(RequestMessage::Snap(msg)) => {
+                self.queued_outgoing.push_back(OutgoingMessage::Snap(msg));
             }
             Err(err) => {
                 debug!(target: "net", %err, "Failed to respond to received request");

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -389,7 +389,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     /// Responses are correlated to the in-flight [`PeerRequest::GetSnap`] by `request_id` (shared
     /// with eth requests in [`Self::inflight_requests`]) and type-checked against the originally
     /// sent request kind; unsolicited or mismatched ones count as bad messages. Inbound requests
-    /// are ignored until the snap server lands.
+    /// are routed upward as [`PeerRequest::GetSnap`], same as any other eth request.
     fn on_incoming_snap_message(
         &mut self,
         mut msg: SnapProtocolMessage,

--- a/crates/net/p2p/src/snap/client.rs
+++ b/crates/net/p2p/src/snap/client.rs
@@ -36,6 +36,17 @@ impl TryFrom<SnapProtocolMessage> for SnapResponse {
     }
 }
 
+impl From<SnapResponse> for SnapProtocolMessage {
+    fn from(response: SnapResponse) -> Self {
+        match response {
+            SnapResponse::AccountRange(m) => Self::AccountRange(m),
+            SnapResponse::StorageRanges(m) => Self::StorageRanges(m),
+            SnapResponse::ByteCodes(m) => Self::ByteCodes(m),
+            SnapResponse::BlockAccessLists(m) => Self::BlockAccessLists(m),
+        }
+    }
+}
+
 /// The snap sync downloader client
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SnapClient: DownloadClient {

--- a/examples/network-proxy/src/main.rs
+++ b/examples/network-proxy/src/main.rs
@@ -94,6 +94,7 @@ async fn main() -> eyre::Result<()> {
                         IncomingEthRequest::GetReceipts70 { .. } => {}
                         IncomingEthRequest::GetBlockAccessLists { .. } => {}
                         IncomingEthRequest::GetCells { .. } => {}
+                        IncomingEthRequest::GetSnap { .. } => {}
                     }
              }
              transaction_message = transactions_rx.recv() => {


### PR DESCRIPTION
Routes inbound snap/2 (EIP-8189) requests through the existing `EthRequestHandler` instead of rejecting them with `UnsupportedCapability`.

`GetAccountRange/GetStorageRanges/GetByteCodes` currently answer wit empty-but-valid ranges,  **_there's no state-trie-backed store yet_**, this pr is routing/wiring only. 