### PR TITLE
fix(engine): log pending stalled proof targets

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -865,9 +865,7 @@ where
             let mut account_targets = self
                 .account_updates
                 .keys()
-                .filter_map(|target| {
-                    self.fetched_account_targets.get(target).map(|min_len| (*target, *min_len))
-                })
+                .map(|target| (*target, self.fetched_account_targets.get(target).copied()))
                 .collect::<Vec<_>>();
             account_targets.sort_unstable();
             let account_targets_truncated =
@@ -879,10 +877,12 @@ where
                 .iter()
                 .flat_map(|(address, updates)| {
                     let fetched_targets = self.fetched_storage_targets.get(address);
-                    updates.keys().filter_map(move |target| {
-                        fetched_targets
-                            .and_then(|targets| targets.get(target))
-                            .map(|min_len| (*address, *target, *min_len))
+                    updates.keys().map(move |target| {
+                        (
+                            *address,
+                            *target,
+                            fetched_targets.and_then(|targets| targets.get(target)).copied(),
+                        )
                     })
                 })
                 .collect::<Vec<_>>();

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -863,9 +863,11 @@ where
             const MAX_STALLED_PROOF_TARGETS_TO_LOG: usize = 5;
 
             let mut account_targets = self
-                .fetched_account_targets
-                .iter()
-                .map(|(target, min_len)| (*target, *min_len))
+                .account_updates
+                .keys()
+                .filter_map(|target| {
+                    self.fetched_account_targets.get(target).map(|min_len| (*target, *min_len))
+                })
                 .collect::<Vec<_>>();
             account_targets.sort_unstable();
             let account_targets_truncated =
@@ -873,10 +875,15 @@ where
             account_targets.truncate(MAX_STALLED_PROOF_TARGETS_TO_LOG);
 
             let mut storage_targets = self
-                .fetched_storage_targets
+                .storage_updates
                 .iter()
-                .flat_map(|(address, targets)| {
-                    targets.iter().map(|(target, min_len)| (*address, *target, *min_len))
+                .flat_map(|(address, updates)| {
+                    let fetched_targets = self.fetched_storage_targets.get(address);
+                    updates.keys().filter_map(move |target| {
+                        fetched_targets
+                            .and_then(|targets| targets.get(target))
+                            .map(|min_len| (*address, *target, *min_len))
+                    })
                 })
                 .collect::<Vec<_>>();
             storage_targets.sort_unstable();


### PR DESCRIPTION
Follow-up to #26325.

Restricts the sparse trie stalled-proof diagnostic to fetched account and storage targets that still have pending updates. This avoids logging proof targets that were fetched earlier and already drained.