### PR TITLE
feat(engine): pass parent state to the post-execution hashed-state hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8317,6 +8317,7 @@ dependencies = [
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-storage-api",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8313,6 +8313,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-execution-errors",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",

--- a/crates/engine/primitives/Cargo.toml
+++ b/crates/engine/primitives/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-evm = { workspace = true, optional = true }
+reth-execution-errors.workspace = true
 reth-execution-types.workspace = true
 reth-payload-primitives.workspace = true
 reth-payload-builder-primitives = { workspace = true, optional = true }
@@ -44,6 +45,7 @@ trie-debug = []
 std = [
     "dep:reth-evm",
     "dep:reth-payload-builder-primitives",
+    "reth-execution-errors/std",
     "reth-execution-types/std",
     "reth-ethereum-primitives/std",
     "reth-primitives-traits/std",

--- a/crates/engine/primitives/Cargo.toml
+++ b/crates/engine/primitives/Cargo.toml
@@ -21,6 +21,7 @@ reth-ethereum-primitives.workspace = true
 reth-chain-state.workspace = true
 reth-errors.workspace = true
 reth-trie-common.workspace = true
+reth-storage-api.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
@@ -47,6 +48,7 @@ std = [
     "reth-ethereum-primitives/std",
     "reth-primitives-traits/std",
     "reth-trie-common/std",
+    "reth-storage-api/std",
     "alloy-primitives/std",
     "alloy-consensus/std",
     "alloy-rpc-types-engine/std",

--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -1,5 +1,7 @@
 use alloc::boxed::Box;
 use alloy_rpc_types_engine::ForkchoiceUpdateError;
+use reth_errors::ConsensusError;
+use reth_storage_api::errors::ProviderError;
 
 /// Represents all error cases when handling a new payload.
 ///
@@ -44,4 +46,20 @@ impl BeaconForkChoiceUpdateError {
     pub fn internal<E: core::error::Error + Send + Sync + 'static>(e: E) -> Self {
         Self::Internal(Box::new(e))
     }
+}
+
+/// Error returned by
+/// [`PayloadValidator::validate_block_post_execution_with_hashed_state`](crate::PayloadValidator::validate_block_post_execution_with_hashed_state).
+///
+/// Distinguishes a block that violates a post-execution consensus rule from an internal failure to
+/// load the state needed to run the check, so the engine does not mark a block invalid over a
+/// transient provider error.
+#[derive(Debug, thiserror::Error)]
+pub enum PostExecutionValidationError {
+    /// The block violates a post-execution consensus rule.
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
+    /// Loading the state required to validate the block failed.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
 }

--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use alloy_rpc_types_engine::ForkchoiceUpdateError;
-use reth_errors::ConsensusError;
-use reth_storage_api::errors::ProviderError;
+use reth_errors::{BlockExecutionError, BlockValidationError, ConsensusError, ProviderError};
+use reth_execution_errors::InternalBlockExecutionError;
 
 /// Represents all error cases when handling a new payload.
 ///
@@ -48,18 +48,73 @@ impl BeaconForkChoiceUpdateError {
     }
 }
 
-/// Error returned by
-/// [`PayloadValidator::validate_block_post_execution_with_hashed_state`](crate::PayloadValidator::validate_block_post_execution_with_hashed_state).
-///
-/// Distinguishes a block that violates a post-execution consensus rule from an internal failure to
-/// load the state needed to run the check, so the engine does not mark a block invalid over a
-/// transient provider error.
+/// All error variants possible when inserting or validating a block.
 #[derive(Debug, thiserror::Error)]
-pub enum PostExecutionValidationError {
-    /// The block violates a post-execution consensus rule.
+pub enum InsertBlockErrorKind {
+    /// Block violated consensus rules.
     #[error(transparent)]
     Consensus(#[from] ConsensusError),
-    /// Loading the state required to validate the block failed.
+    /// Block execution failed.
+    #[error(transparent)]
+    Execution(#[from] BlockExecutionError),
+    /// Provider error.
     #[error(transparent)]
     Provider(#[from] ProviderError),
+    /// Other errors.
+    #[error(transparent)]
+    Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
+}
+
+impl InsertBlockErrorKind {
+    /// Returns whether the error was caused by an invalid block.
+    pub const fn is_validation_error(&self) -> bool {
+        matches!(self, Self::Consensus(_) | Self::Execution(BlockExecutionError::Validation(_)))
+    }
+
+    /// Returns an [`InsertBlockValidationError`] if the error is caused by an invalid block.
+    ///
+    /// Returns an [`InsertBlockFatalError`] if the error is caused by an error that is not
+    /// validation related or is otherwise fatal.
+    ///
+    /// This is intended to be used to determine if we should respond `INVALID` as a response when
+    /// processing a new block.
+    pub fn ensure_validation_error(
+        self,
+    ) -> Result<InsertBlockValidationError, InsertBlockFatalError> {
+        match self {
+            Self::Consensus(err) => Ok(InsertBlockValidationError::Consensus(err)),
+            Self::Execution(err) => match err {
+                BlockExecutionError::Validation(err) => {
+                    Ok(InsertBlockValidationError::Validation(err))
+                }
+                BlockExecutionError::Internal(error) => {
+                    Err(InsertBlockFatalError::BlockExecutionError(error))
+                }
+            },
+            Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
+            Self::Other(err) => Err(InternalBlockExecutionError::Other(err).into()),
+        }
+    }
+}
+
+/// Error variants that are not caused by invalid blocks.
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockFatalError {
+    /// A provider error.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    /// An internal or fatal block execution error.
+    #[error(transparent)]
+    BlockExecutionError(#[from] InternalBlockExecutionError),
+}
+
+/// Error variants that are caused by invalid blocks.
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockValidationError {
+    /// Block violated consensus rules.
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
+    /// Validation error, transparently wrapping [`BlockValidationError`].
+    #[error(transparent)]
+    Validation(#[from] BlockValidationError),
 }

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -12,12 +12,12 @@
 extern crate alloc;
 
 use alloy_consensus::BlockHeader;
-use reth_errors::ConsensusError;
 use reth_payload_primitives::{
     EngineApiMessageVersion, EngineObjectValidationError, InvalidPayloadAttributesError,
     NewPayloadError, PayloadAttributes, PayloadOrAttributes, PayloadTypes,
 };
 use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
+use reth_storage_api::{StateProviderBox, errors::ProviderResult};
 use reth_trie_common::HashedPostState;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -213,11 +213,19 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
     }
 
     /// Verifies payload post-execution w.r.t. hashed state updates.
+    ///
+    /// `parent_state` lazily builds the overlay-aware provider for the block's parent that the
+    /// engine used for execution — resolving even a not-yet-canonical in-memory parent. It is only
+    /// built if the implementation needs it (the L1 default does not).
     fn validate_block_post_execution_with_hashed_state<'a>(
         &self,
         _state_updates: &dyn FnOnce() -> &'a HashedPostState,
         _block: &RecoveredBlock<Self::Block>,
-    ) -> Result<(), ConsensusError> {
+        _parent_state: impl FnOnce() -> ProviderResult<StateProviderBox>,
+    ) -> Result<(), PostExecutionValidationError>
+    where
+        Self: Sized,
+    {
         // method not used by l1
         Ok(())
     }

--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -17,7 +17,7 @@ use reth_payload_primitives::{
     NewPayloadError, PayloadAttributes, PayloadOrAttributes, PayloadTypes,
 };
 use reth_primitives_traits::{Block, RecoveredBlock, SealedBlock};
-use reth_storage_api::{StateProviderBox, errors::ProviderResult};
+use reth_storage_api::{errors::ProviderResult, StateProviderBox};
 use reth_trie_common::HashedPostState;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -222,7 +222,7 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
         _state_updates: &dyn FnOnce() -> &'a HashedPostState,
         _block: &RecoveredBlock<Self::Block>,
         _parent_state: impl FnOnce() -> ProviderResult<StateProviderBox>,
-    ) -> Result<(), PostExecutionValidationError>
+    ) -> Result<(), InsertBlockErrorKind>
     where
         Self: Sized,
     {

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -3,8 +3,10 @@
 use crate::tree::payload_processor::bal::BalExecutionError;
 use alloy_consensus::BlockHeader;
 use reth_consensus::ConsensusError;
-use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
-use reth_evm::execute::InternalBlockExecutionError;
+pub use reth_engine_primitives::{
+    InsertBlockErrorKind, InsertBlockFatalError, InsertBlockValidationError,
+};
+use reth_errors::ProviderError;
 use reth_payload_primitives::NewPayloadError;
 use reth_primitives_traits::{Block, BlockBody, SealedBlock};
 
@@ -105,23 +107,6 @@ impl<B: Block> std::fmt::Debug for InsertBlockError<B> {
     }
 }
 
-/// All error variants possible when inserting a block
-#[derive(Debug, thiserror::Error)]
-pub enum InsertBlockErrorKind {
-    /// Block violated consensus rules.
-    #[error(transparent)]
-    Consensus(#[from] ConsensusError),
-    /// Block execution failed.
-    #[error(transparent)]
-    Execution(#[from] BlockExecutionError),
-    /// Provider error.
-    #[error(transparent)]
-    Provider(#[from] ProviderError),
-    /// Other errors.
-    #[error(transparent)]
-    Other(#[from] Box<dyn core::error::Error + Send + Sync + 'static>),
-}
-
 impl From<BalExecutionError> for InsertBlockErrorKind {
     fn from(e: BalExecutionError) -> Self {
         match e {
@@ -131,59 +116,6 @@ impl From<BalExecutionError> for InsertBlockErrorKind {
             BalExecutionError::Other(inner) => Self::Other(inner),
         }
     }
-}
-
-impl InsertBlockErrorKind {
-    /// Returns an [`InsertBlockValidationError`] if the error is caused by an invalid block.
-    ///
-    /// Returns an [`InsertBlockFatalError`] if the error is caused by an error that is not
-    /// validation related or is otherwise fatal.
-    ///
-    /// This is intended to be used to determine if we should respond `INVALID` as a response when
-    /// processing a new block.
-    pub fn ensure_validation_error(
-        self,
-    ) -> Result<InsertBlockValidationError, InsertBlockFatalError> {
-        match self {
-            Self::Consensus(err) => Ok(InsertBlockValidationError::Consensus(err)),
-            // other execution errors that are considered internal errors
-            Self::Execution(err) => {
-                match err {
-                    BlockExecutionError::Validation(err) => {
-                        Ok(InsertBlockValidationError::Validation(err))
-                    }
-                    // these are internal errors, not caused by an invalid block
-                    BlockExecutionError::Internal(error) => {
-                        Err(InsertBlockFatalError::BlockExecutionError(error))
-                    }
-                }
-            }
-            Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
-            Self::Other(err) => Err(InternalBlockExecutionError::Other(err).into()),
-        }
-    }
-}
-
-/// Error variants that are not caused by invalid blocks
-#[derive(Debug, thiserror::Error)]
-pub enum InsertBlockFatalError {
-    /// A provider error
-    #[error(transparent)]
-    Provider(#[from] ProviderError),
-    /// An internal / fatal block execution error
-    #[error(transparent)]
-    BlockExecutionError(#[from] InternalBlockExecutionError),
-}
-
-/// Error variants that are caused by invalid blocks
-#[derive(Debug, thiserror::Error)]
-pub enum InsertBlockValidationError {
-    /// Block violated consensus rules.
-    #[error(transparent)]
-    Consensus(#[from] ConsensusError),
-    /// Validation error, transparently wrapping [`BlockValidationError`]
-    #[error(transparent)]
-    Validation(#[from] BlockValidationError),
 }
 
 /// Errors that may occur when inserting a payload.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -130,7 +130,6 @@ use reth_chain_state::{
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
     ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
-    PostExecutionValidationError,
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
@@ -843,16 +842,10 @@ where
         }
 
         if let Err(err) = hashed_state_validate_result {
-            let err_kind: InsertBlockErrorKind = match err {
-                PostExecutionValidationError::Consensus(err) => {
-                    // only a consensus violation marks the block invalid; a provider error is an
-                    // internal failure to load the state the check needs, not an invalid block
-                    self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
-                    err.into()
-                }
-                PostExecutionValidationError::Provider(err) => err.into(),
-            };
-            return Err(InsertBlockError::new(block.into_sealed_block(), err_kind).into())
+            if err.is_validation_error() {
+                self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
+            }
+            return Err(InsertBlockError::new(block.into_sealed_block(), err).into())
         }
 
         self.metrics.block_validation.record_state_root(&trie_output, root_elapsed.as_secs_f64());

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -130,6 +130,7 @@ use reth_chain_state::{
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
     ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
+    PostExecutionValidationError,
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
@@ -797,8 +798,11 @@ where
             "validate_block_post_execution_with_hashed_state"
         )
         .in_scope(|| {
-            self.validator
-                .validate_block_post_execution_with_hashed_state(&|| hashed_state.get(), &block)
+            self.validator.validate_block_post_execution_with_hashed_state(
+                &|| hashed_state.get(),
+                &block,
+                || provider_builder.build(),
+            )
         });
 
         let root_start = Instant::now();
@@ -830,15 +834,25 @@ where
                 "validate_block_post_execution_with_hashed_state"
             )
             .in_scope(|| {
-                self.validator
-                    .validate_block_post_execution_with_hashed_state(&|| hashed_state.get(), &block)
+                self.validator.validate_block_post_execution_with_hashed_state(
+                    &|| hashed_state.get(),
+                    &block,
+                    || provider_builder.build(),
+                )
             });
         }
 
         if let Err(err) = hashed_state_validate_result {
-            // call post-block hook
-            self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
-            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
+            let err_kind: InsertBlockErrorKind = match err {
+                PostExecutionValidationError::Consensus(err) => {
+                    // only a consensus violation marks the block invalid; a provider error is an
+                    // internal failure to load the state the check needs, not an invalid block
+                    self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
+                    err.into()
+                }
+                PostExecutionValidationError::Provider(err) => err.into(),
+            };
+            return Err(InsertBlockError::new(block.into_sealed_block(), err_kind).into())
         }
 
         self.metrics.block_validation.record_state_root(&trie_output, root_elapsed.as_secs_f64());


### PR DESCRIPTION
## Description

`PayloadValidator::validate_block_post_execution_with_hashed_state` is the hook L2s use to
verify state-derived header commitments after execution — e.g. the OP Stack
`L2ToL1MessagePasser` storage root that Isthmus stores in the `withdrawals_root` header field.

Until now the hook received only the hashed state updates and the block. To recompute a
state-derived commitment, an implementation had to re-resolve the parent state from its own
provider, which only sees the canonical chain. When a block's parent is an
executed-but-not-yet-canonical in-memory tree block, that lookup fails and the implementation
has no parent state to validate against — so the check is silently skipped. This is exactly the
limitation the FIXME in the OP Stack implementation of this hook documents:

https://github.com/ethereum-optimism/optimism/blob/3f0679391a4c5a7903a98f55287e6abdf832fbe2/rust/op-reth/crates/node/src/engine.rs#L135-L137

The engine tree already builds an overlay-aware `StateProviderBuilder` for the parent (it uses it
for execution and the state-root computation), so the correct parent state is already on hand.
This passes it to the hook.

How the OP Stack consumes the new argument (draft): https://github.com/ethereum-optimism/optimism/pull/21649

## Changes

- `validate_block_post_execution_with_hashed_state` gains a
  `parent_state: impl FnOnce() -> ProviderResult<StateProviderBox>` argument — a **lazy** builder
  for the overlay-aware provider of the block's parent (the same state execution used). It resolves
  the parent state whether the parent is canonical, persisted, or an in-memory tree block.
- The engine tree passes `|| provider_builder.build()` at both call sites.
- The builder is only invoked if the implementation needs it, so the L1 default impl (which ignores
  it) builds nothing — no per-block cost on paths that don't use the hook.
- The method carries `where Self: Sized`. The hook is only ever called on the concrete validator in
  the engine tree, never through `dyn PayloadValidator`, so this keeps the trait object-safe while
  allowing the generic (statically dispatched) closure.
- The hook now returns `Result<(), PostExecutionValidationError>` — a small `Consensus | Provider`
  enum in `reth-engine-primitives`. Since the parent state is built inside the hook, a failure to
  build it is surfaced as a provider error, and the engine calls `on_invalid_block` only for the
  `Consensus` variant — a transient state-load failure no longer marks a valid block invalid.

## Breaking change

This changes the signature of `PayloadValidator::validate_block_post_execution_with_hashed_state`.
Implementations that override it must add the new parameter and invoke it to obtain the parent
state. The default no-op impl is behaviorally unchanged, so validators that don't override it are
unaffected.

## Testing

- `cargo test -p reth-engine-primitives -p reth-engine-tree` passes locally: 129 `reth-engine-tree`
  unit tests + 14 `e2e-testsuite` integration tests, 0 failures (`reth-engine-primitives` and
  doctests included).
- `reth-engine-primitives` also builds with `--no-default-features` (`no_std`).
- No behavioral change to reth's own validation paths: the default impl remains a no-op and the new
  argument is lazily built, so it is never constructed unless an implementation asks for it.
