### PR TITLE
chore(trie): trace arena sparse trie pruning and inherit spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10660,6 +10660,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "smallvec",
+ "strum 0.27.2",
  "tracing",
 ]
 

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -29,6 +29,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 slotmap = { workspace = true, optional = true }
+strum = { workspace = true, features = ["derive"] }
 
 # metrics
 reth-metrics = { workspace = true, optional = true }
@@ -68,6 +69,7 @@ std = [
     "tracing/std",
     "serde?/std",
     "serde_json?/std",
+    "strum/std",
     "reth-tracing/std",
     "either/std",
 ]

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -297,11 +297,7 @@ impl ArenaSparseSubtrie {
                 }
             } else {
                 // Not retained — blind the child slot in the new arena.
-                ArenaParallelSparseTrie::trace_pruned_subtree(
-                    &self.arena,
-                    old_child_idx,
-                    child_path,
-                );
+                ArenaParallelSparseTrie::trace_pruned_node(&self.arena[old_child_idx], child_path);
                 let rlp_node = self.arena[old_child_idx]
                     .state_ref()
                     .expect("child must have state")
@@ -2188,43 +2184,8 @@ impl ArenaParallelSparseTrie {
         }
     }
 
-    /// Emits trace logs for every revealed node reachable from `idx`.
-    fn trace_pruned_subtree(arena: &NodeArena, idx: Index, path: Nibbles) {
-        if !tracing::enabled!(target: TRACE_TARGET, tracing::Level::TRACE) {
-            return;
-        }
-
-        Self::trace_pruned_subtree_inner(arena, idx, path);
-    }
-
-    fn trace_pruned_subtree_inner(arena: &NodeArena, idx: Index, path: Nibbles) {
-        Self::trace_pruned_node(arena, idx, path);
-
-        match &arena[idx] {
-            ArenaSparseNode::Branch(branch) => {
-                let mut branch_path = path;
-                branch_path.extend(&branch.short_key);
-
-                for (nibble, child) in branch.child_iter() {
-                    let ArenaSparseNodeBranchChild::Revealed(child_idx) = child else {
-                        continue;
-                    };
-                    let mut child_path = branch_path;
-                    child_path.push_unchecked(nibble);
-                    Self::trace_pruned_subtree_inner(arena, *child_idx, child_path);
-                }
-            }
-            ArenaSparseNode::Subtrie(subtrie) => {
-                Self::trace_pruned_subtree_inner(&subtrie.arena, subtrie.root, subtrie.path);
-            }
-            ArenaSparseNode::EmptyRoot |
-            ArenaSparseNode::Leaf { .. } |
-            ArenaSparseNode::TakenSubtrie => {}
-        }
-    }
-
-    fn trace_pruned_node(arena: &NodeArena, idx: Index, path: Nibbles) {
-        match &arena[idx] {
+    fn trace_pruned_node(node: &ArenaSparseNode, path: Nibbles) {
+        match node {
             ArenaSparseNode::EmptyRoot => {
                 trace!(target: TRACE_TARGET, kind = "empty_root", ?path, "pruning node");
             }
@@ -2277,8 +2238,9 @@ impl ArenaParallelSparseTrie {
         idx: Index,
         nibble: Option<u8>,
     ) -> ArenaSparseNode {
-        Self::trace_pruned_subtree(arena, idx, cursor.head().expect("cursor is non-empty").path);
+        let path = cursor.head().expect("cursor is non-empty").path;
         let node = arena.remove(idx).expect("node must exist to be pruned");
+        Self::trace_pruned_node(&node, path);
         let rlp_node = node.state_ref().and_then(|s| s.cached_rlp_node()).cloned();
 
         if let Some(rlp_node) = rlp_node {

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -297,6 +297,11 @@ impl ArenaSparseSubtrie {
                 }
             } else {
                 // Not retained — blind the child slot in the new arena.
+                ArenaParallelSparseTrie::trace_pruned_subtree(
+                    &self.arena,
+                    old_child_idx,
+                    child_path,
+                );
                 let rlp_node = self.arena[old_child_idx]
                     .state_ref()
                     .expect("child must have state")
@@ -2183,6 +2188,86 @@ impl ArenaParallelSparseTrie {
         }
     }
 
+    /// Emits trace logs for every revealed node reachable from `idx`.
+    fn trace_pruned_subtree(arena: &NodeArena, idx: Index, path: Nibbles) {
+        if !tracing::enabled!(target: TRACE_TARGET, tracing::Level::TRACE) {
+            return;
+        }
+
+        Self::trace_pruned_subtree_inner(arena, idx, path);
+    }
+
+    fn trace_pruned_subtree_inner(arena: &NodeArena, idx: Index, path: Nibbles) {
+        Self::trace_pruned_node(arena, idx, path);
+
+        match &arena[idx] {
+            ArenaSparseNode::Branch(branch) => {
+                let mut branch_path = path;
+                branch_path.extend(&branch.short_key);
+
+                for (nibble, child) in branch.child_iter() {
+                    let ArenaSparseNodeBranchChild::Revealed(child_idx) = child else {
+                        continue;
+                    };
+                    let mut child_path = branch_path;
+                    child_path.push_unchecked(nibble);
+                    Self::trace_pruned_subtree_inner(arena, *child_idx, child_path);
+                }
+            }
+            ArenaSparseNode::Subtrie(subtrie) => {
+                Self::trace_pruned_subtree_inner(&subtrie.arena, subtrie.root, subtrie.path);
+            }
+            ArenaSparseNode::EmptyRoot |
+            ArenaSparseNode::Leaf { .. } |
+            ArenaSparseNode::TakenSubtrie => {}
+        }
+    }
+
+    fn trace_pruned_node(arena: &NodeArena, idx: Index, path: Nibbles) {
+        match &arena[idx] {
+            ArenaSparseNode::EmptyRoot => {
+                trace!(target: TRACE_TARGET, kind = "empty_root", ?path, "pruning node");
+            }
+            ArenaSparseNode::Branch(branch) => {
+                trace!(
+                    target: TRACE_TARGET,
+                    kind = "branch",
+                    ?path,
+                    short_key = ?branch.short_key,
+                    state_mask = ?branch.state_mask,
+                    num_children = branch.state_mask.count_bits(),
+                    "pruning node",
+                );
+            }
+            ArenaSparseNode::Leaf { key, value, .. } => {
+                let mut full_path = path;
+                full_path.extend(key);
+                trace!(
+                    target: TRACE_TARGET,
+                    kind = "leaf",
+                    ?path,
+                    ?full_path,
+                    value_len = value.len(),
+                    "pruning node",
+                );
+            }
+            ArenaSparseNode::Subtrie(subtrie) => {
+                trace!(
+                    target: TRACE_TARGET,
+                    kind = "subtrie",
+                    ?path,
+                    subtrie = ?subtrie.path,
+                    num_leaves = subtrie.num_leaves,
+                    num_dirty_leaves = subtrie.num_dirty_leaves,
+                    "pruning node",
+                );
+            }
+            ArenaSparseNode::TakenSubtrie => {
+                trace!(target: TRACE_TARGET, kind = "taken_subtrie", ?path, "pruning node");
+            }
+        }
+    }
+
     /// Removes a pruned node from the arena and blinds the parent's child slot with the node's
     /// cached RLP. If the node has no cached RLP (e.g. it was never hashed), the parent slot
     /// is left dangling — this is safe because the parent will also be removed during pruning.
@@ -2192,7 +2277,7 @@ impl ArenaParallelSparseTrie {
         idx: Index,
         nibble: Option<u8>,
     ) -> ArenaSparseNode {
-        trace!(target: TRACE_TARGET, path = ?cursor.head().unwrap().path, "pruning node");
+        Self::trace_pruned_subtree(arena, idx, cursor.head().expect("cursor is non-empty").path);
         let node = arena.remove(idx).expect("node must exist to be pruned");
         let rlp_node = node.state_ref().and_then(|s| s.cached_rlp_node()).cloned();
 

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2557,9 +2557,13 @@ impl SparseTrie for ArenaParallelSparseTrie {
         } else {
             use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
+            let parent_span = tracing::Span::current();
             let results: Vec<SparseTrieResult<()>> = taken
                 .par_iter_mut()
-                .map(|(_, subtrie, node_vec)| subtrie.reveal_nodes(node_vec))
+                .map(|(_, subtrie, node_vec)| {
+                    let _guard = parent_span.enter();
+                    subtrie.reveal_nodes(node_vec)
+                })
                 .collect();
 
             if let Some(err) = results.into_iter().find(|r| r.is_err()) {
@@ -2642,9 +2646,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
             } else {
                 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
+                let parent_span = tracing::Span::current();
                 taken = taken
                     .into_par_iter()
                     .map(|(idx, mut subtrie)| {
+                        let _guard = parent_span.enter();
                         subtrie.update_cached_rlp();
                         (idx, subtrie)
                     })
@@ -2903,9 +2909,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 pruned += taken
                     .par_iter_mut()
                     .map(|(_, subtrie, range)| {
+                        let _guard = parent_span.enter();
                         let _span = tracing::trace_span!(
                             target: TRACE_TARGET,
-                            parent: &parent_span,
                             "subtrie_prune",
                             subtrie = ?subtrie.path,
                         )
@@ -3177,7 +3183,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
         } else {
             use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
+            let parent_span = tracing::Span::current();
             taken.par_iter_mut().for_each(|(_, subtrie, range)| {
+                let _guard = parent_span.enter();
                 subtrie.update_leaves(&sorted[range.clone()]);
             });
         }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -298,13 +298,7 @@ impl ArenaSparseSubtrie {
             } else {
                 // Not retained — blind the child slot in the new arena.
                 let node = &self.arena[old_child_idx];
-                let variant = match node {
-                    ArenaSparseNode::EmptyRoot => "EmptyRoot",
-                    ArenaSparseNode::Branch(_) => "Branch",
-                    ArenaSparseNode::Leaf { .. } => "Leaf",
-                    ArenaSparseNode::Subtrie(_) => "Subtrie",
-                    ArenaSparseNode::TakenSubtrie => "TakenSubtrie",
-                };
+                let variant: &str = node.as_ref();
                 let rlp_node = node
                     .state_ref()
                     .expect("child must have state")
@@ -2209,13 +2203,7 @@ impl ArenaParallelSparseTrie {
     ) -> ArenaSparseNode {
         let path = cursor.head().expect("cursor is non-empty").path;
         let node = arena.remove(idx).expect("node must exist to be pruned");
-        let variant = match &node {
-            ArenaSparseNode::EmptyRoot => "EmptyRoot",
-            ArenaSparseNode::Branch(_) => "Branch",
-            ArenaSparseNode::Leaf { .. } => "Leaf",
-            ArenaSparseNode::Subtrie(_) => "Subtrie",
-            ArenaSparseNode::TakenSubtrie => "TakenSubtrie",
-        };
+        let variant: &str = node.as_ref();
         let rlp_node = node.state_ref().and_then(|s| s.cached_rlp_node()).cloned();
         trace!(
             target: TRACE_TARGET,

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -297,13 +297,27 @@ impl ArenaSparseSubtrie {
                 }
             } else {
                 // Not retained — blind the child slot in the new arena.
-                ArenaParallelSparseTrie::trace_pruned_node(&self.arena[old_child_idx], child_path);
-                let rlp_node = self.arena[old_child_idx]
+                let node = &self.arena[old_child_idx];
+                let variant = match node {
+                    ArenaSparseNode::EmptyRoot => "EmptyRoot",
+                    ArenaSparseNode::Branch(_) => "Branch",
+                    ArenaSparseNode::Leaf { .. } => "Leaf",
+                    ArenaSparseNode::Subtrie(_) => "Subtrie",
+                    ArenaSparseNode::TakenSubtrie => "TakenSubtrie",
+                };
+                let rlp_node = node
                     .state_ref()
                     .expect("child must have state")
                     .cached_rlp_node()
                     .cloned()
                     .expect("pruned child must have cached RLP (prune runs after hashing)");
+                trace!(
+                    target: TRACE_TARGET,
+                    path = ?child_path,
+                    variant = %variant,
+                    cached_rlp_node = ?rlp_node,
+                    "pruning node",
+                );
                 let ArenaSparseNode::Branch(b) = &mut new_arena[parent_new_idx] else {
                     unreachable!()
                 };
@@ -2184,51 +2198,6 @@ impl ArenaParallelSparseTrie {
         }
     }
 
-    fn trace_pruned_node(node: &ArenaSparseNode, path: Nibbles) {
-        match node {
-            ArenaSparseNode::EmptyRoot => {
-                trace!(target: TRACE_TARGET, kind = "empty_root", ?path, "pruning node");
-            }
-            ArenaSparseNode::Branch(branch) => {
-                trace!(
-                    target: TRACE_TARGET,
-                    kind = "branch",
-                    ?path,
-                    short_key = ?branch.short_key,
-                    state_mask = ?branch.state_mask,
-                    num_children = branch.state_mask.count_bits(),
-                    "pruning node",
-                );
-            }
-            ArenaSparseNode::Leaf { key, value, .. } => {
-                let mut full_path = path;
-                full_path.extend(key);
-                trace!(
-                    target: TRACE_TARGET,
-                    kind = "leaf",
-                    ?path,
-                    ?full_path,
-                    value_len = value.len(),
-                    "pruning node",
-                );
-            }
-            ArenaSparseNode::Subtrie(subtrie) => {
-                trace!(
-                    target: TRACE_TARGET,
-                    kind = "subtrie",
-                    ?path,
-                    subtrie = ?subtrie.path,
-                    num_leaves = subtrie.num_leaves,
-                    num_dirty_leaves = subtrie.num_dirty_leaves,
-                    "pruning node",
-                );
-            }
-            ArenaSparseNode::TakenSubtrie => {
-                trace!(target: TRACE_TARGET, kind = "taken_subtrie", ?path, "pruning node");
-            }
-        }
-    }
-
     /// Removes a pruned node from the arena and blinds the parent's child slot with the node's
     /// cached RLP. If the node has no cached RLP (e.g. it was never hashed), the parent slot
     /// is left dangling — this is safe because the parent will also be removed during pruning.
@@ -2240,8 +2209,21 @@ impl ArenaParallelSparseTrie {
     ) -> ArenaSparseNode {
         let path = cursor.head().expect("cursor is non-empty").path;
         let node = arena.remove(idx).expect("node must exist to be pruned");
-        Self::trace_pruned_node(&node, path);
+        let variant = match &node {
+            ArenaSparseNode::EmptyRoot => "EmptyRoot",
+            ArenaSparseNode::Branch(_) => "Branch",
+            ArenaSparseNode::Leaf { .. } => "Leaf",
+            ArenaSparseNode::Subtrie(_) => "Subtrie",
+            ArenaSparseNode::TakenSubtrie => "TakenSubtrie",
+        };
         let rlp_node = node.state_ref().and_then(|s| s.cached_rlp_node()).cloned();
+        trace!(
+            target: TRACE_TARGET,
+            ?path,
+            variant = %variant,
+            cached_rlp_node = ?rlp_node,
+            "pruning node",
+        );
 
         if let Some(rlp_node) = rlp_node {
             let parent_idx = cursor.parent().expect("pruned child has parent").index;

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -298,7 +298,6 @@ impl ArenaSparseSubtrie {
             } else {
                 // Not retained — blind the child slot in the new arena.
                 let node = &self.arena[old_child_idx];
-                let variant: &str = node.as_ref();
                 let rlp_node = node
                     .state_ref()
                     .expect("child must have state")
@@ -308,7 +307,7 @@ impl ArenaSparseSubtrie {
                 trace!(
                     target: TRACE_TARGET,
                     path = ?child_path,
-                    variant = %variant,
+                    variant = %AsRef::<str>::as_ref(node),
                     cached_rlp_node = ?rlp_node,
                     "pruning node",
                 );
@@ -2203,12 +2202,11 @@ impl ArenaParallelSparseTrie {
     ) -> ArenaSparseNode {
         let path = cursor.head().expect("cursor is non-empty").path;
         let node = arena.remove(idx).expect("node must exist to be pruned");
-        let variant: &str = node.as_ref();
         let rlp_node = node.state_ref().and_then(|s| s.cached_rlp_node()).cloned();
         trace!(
             target: TRACE_TARGET,
             ?path,
-            variant = %variant,
+            variant = %AsRef::<str>::as_ref(&node),
             cached_rlp_node = ?rlp_node,
             "pruning node",
         );

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -8,6 +8,7 @@ use alloy_trie::{BranchNodeCompact, TrieMask};
 use core::mem;
 use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNodeV2, RlpNode, TrieNodeV2};
 use smallvec::SmallVec;
+use strum::AsRefStr;
 
 /// Tracks whether a node's RLP encoding is cached or needs recomputation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -163,7 +164,7 @@ impl ArenaSparseNodeBranch {
 }
 
 /// A node in the arena-based sparse trie.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, AsRefStr)]
 pub(super) enum ArenaSparseNode {
     /// Indicates a trie with no nodes.
     EmptyRoot,


### PR DESCRIPTION
Adds trace logging for arena sparse trie pruning so upper trie nodes, subtrie containers, and pruned nodes within subtries report their path and kind when removed.

Also make sure that parent spans are inherited in all places where rayon is being invoked for parallelism.