### PR TITLE
fix(engine): construct prune retention set in sparse trie task

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1198,7 +1198,7 @@ where
     /// processing is complete. Returns `None` if the head is not canonical and processing
     /// should continue.
     fn handle_canonical_head(
-        &self,
+        &mut self,
         state: ForkchoiceState,
         attrs: &Option<T::PayloadAttributes>, // Changed to reference
     ) -> ProviderResult<Option<TreeOutcome<OnForkChoiceUpdated>>> {
@@ -3282,7 +3282,7 @@ where
     /// Note: At this point, the fork choice update is considered to be VALID, however, we can still
     /// return an error if the payload attributes are invalid.
     fn process_payload_attributes(
-        &self,
+        &mut self,
         attributes: T::PayloadAttributes,
         head: &N::BlockHeader,
         state: ForkchoiceState,
@@ -3310,6 +3310,7 @@ where
             head,
             attributes.timestamp(),
             &self.state,
+            &mut self.pending_sparse_trie_prune,
         );
 
         // send the payload to the builder and return the receiver for the pending payload

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -142,6 +142,8 @@ where
 pub struct EngineApiTreeState<N: NodePrimitives> {
     /// Tracks the state of the blockchain tree.
     tree_state: TreeState<N>,
+    /// Whether the next sparse trie task should attempt cache pruning during trie preservation.
+    pending_sparse_trie_prune: bool,
     /// Tracks the forkchoice state updates received by the CL.
     forkchoice_state_tracker: ForkchoiceStateTracker,
     /// Buffer of detached blocks.
@@ -167,6 +169,7 @@ impl<N: NodePrimitives> EngineApiTreeState<N> {
             ),
             buffer: BlockBuffer::new(block_buffer_limit),
             tree_state: TreeState::new(canonical_block, engine_kind, state_trie_overlays),
+            pending_sparse_trie_prune: false,
             forkchoice_state_tracker: ForkchoiceStateTracker::default(),
         }
     }
@@ -174,6 +177,39 @@ impl<N: NodePrimitives> EngineApiTreeState<N> {
     /// Returns a reference to the tree state.
     pub const fn tree_state(&self) -> &TreeState<N> {
         &self.tree_state
+    }
+
+    /// Returns whether sparse trie pruning is pending.
+    pub const fn pending_sparse_trie_prune(&self) -> bool {
+        self.pending_sparse_trie_prune
+    }
+
+    /// Sets whether sparse trie pruning is pending for the next sparse trie task.
+    pub const fn set_pending_sparse_trie_prune(&mut self, pending: bool) {
+        self.pending_sparse_trie_prune = pending;
+    }
+
+    /// Takes a pending sparse trie prune request, if any, and snapshots the in-memory parent chain
+    /// ending at `parent_hash`.
+    ///
+    /// `None` means no prune request is pending. `Some(Vec::new())` means a prune was requested,
+    /// but no in-memory parent-chain blocks were found for the parent hash; the sparse trie task
+    /// should still prune using the current block's changed paths.
+    pub fn take_sparse_trie_prune_blocks(
+        &mut self,
+        parent_hash: B256,
+    ) -> Option<Vec<ExecutedBlock<N>>> {
+        if !self.pending_sparse_trie_prune {
+            return None
+        }
+
+        self.pending_sparse_trie_prune = false;
+        Some(
+            self.tree_state
+                .blocks_by_hash(parent_hash)
+                .map(|(_, blocks)| blocks)
+                .unwrap_or_default(),
+        )
     }
 
     /// Returns true if the block has been marked as invalid.
@@ -317,8 +353,6 @@ where
     /// Set when an FCU with payload attributes is received, cleared on the next FCU without.
     /// Suppresses persistence cycles during payload building.
     building_payload: bool,
-    /// Whether the next sparse trie task should attempt cache pruning during trie preservation.
-    pending_sparse_trie_prune: bool,
     /// Task runtime for spawning blocking work on named, reusable threads.
     runtime: reth_tasks::Runtime,
 }
@@ -412,7 +446,6 @@ where
             changeset_cache,
             execution_timing_stats: B256Map::default(),
             building_payload: false,
-            pending_sparse_trie_prune: false,
             runtime,
         }
     }
@@ -1364,7 +1397,7 @@ where
         debug!(target: "engine::tree", ?new_tip_num, last_persisted_block_number=?self.persistence_state.last_persisted_block.number, "Removing blocks using persistence task");
         if new_tip_num < self.persistence_state.last_persisted_block.number {
             debug!(target: "engine::tree", ?new_tip_num, "Starting remove blocks job");
-            self.pending_sparse_trie_prune = false;
+            self.state.set_pending_sparse_trie_prune(false);
             let (tx, rx) = crossbeam_channel::bounded(1);
             let _ = self.persistence.remove_blocks_above(new_tip_num, tx);
             self.persistence_state.start_remove(new_tip_num, rx);
@@ -1815,7 +1848,7 @@ where
         if ctrl.is_unwind() {
             // the node reset so we need to clear everything above that height so that backfill
             // height is the new canonical block.
-            self.pending_sparse_trie_prune = false;
+            self.state.set_pending_sparse_trie_prune(false);
             self.state.tree_state.reset(backfill_num_hash)
         } else {
             self.state.tree_state.remove_until(
@@ -2144,7 +2177,7 @@ where
             number: self.persistence_state.last_persisted_block.number,
             hash: self.persistence_state.last_persisted_block.hash,
         });
-        self.pending_sparse_trie_prune = self.should_prune_sparse_trie();
+        self.state.set_pending_sparse_trie_prune(self.should_prune_sparse_trie());
         Ok(())
     }
 
@@ -2679,7 +2712,7 @@ where
             let old_first = old.first().map(|first| first.recovered_block().num_hash());
             trace!(target: "engine::tree", ?new_first, ?old_first, "Reorg detected, new and old first blocks");
 
-            self.pending_sparse_trie_prune = false;
+            self.state.set_pending_sparse_trie_prune(false);
             self.update_reorg_metrics(old.len(), old_first);
             self.reinsert_reorged_blocks(new.clone());
             self.reinsert_reorged_blocks(old.clone());
@@ -2993,11 +3026,7 @@ where
         // as this indicates there's already a canonical block at that height.
         let is_fork = block_id.block.number <= self.state.tree_state.current_canonical_head.number;
 
-        let ctx = TreeCtx::new(
-            &mut self.state,
-            &self.canonical_in_memory_state,
-            &mut self.pending_sparse_trie_prune,
-        );
+        let ctx = TreeCtx::new(&mut self.state, &self.canonical_in_memory_state);
 
         let start = Instant::now();
 
@@ -3288,8 +3317,7 @@ where
             state.head_block_hash,
             head,
             attributes.timestamp(),
-            &self.state,
-            &mut self.pending_sparse_trie_prune,
+            &mut self.state,
         );
 
         // send the payload to the builder and return the receiver for the pending payload

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -37,7 +37,7 @@ use reth_provider::{
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
-use reth_trie::{prefix_set::TriePrefixSetsMut, ComputedTrieData};
+use reth_trie::ComputedTrieData;
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
 use state::TreeState;
@@ -317,9 +317,8 @@ where
     /// Set when an FCU with payload attributes is received, cleared on the next FCU without.
     /// Suppresses persistence cycles during payload building.
     building_payload: bool,
-    /// Retained paths from the latest persistence cleanup to apply during the next sparse trie
-    /// cache preservation.
-    pending_sparse_trie_prune: Option<TriePrefixSetsMut>,
+    /// Whether the next sparse trie task should attempt cache pruning during trie preservation.
+    pending_sparse_trie_prune: bool,
     /// Task runtime for spawning blocking work on named, reusable threads.
     runtime: reth_tasks::Runtime,
 }
@@ -413,7 +412,7 @@ where
             changeset_cache,
             execution_timing_stats: B256Map::default(),
             building_payload: false,
-            pending_sparse_trie_prune: None,
+            pending_sparse_trie_prune: false,
             runtime,
         }
     }
@@ -1365,7 +1364,7 @@ where
         debug!(target: "engine::tree", ?new_tip_num, last_persisted_block_number=?self.persistence_state.last_persisted_block.number, "Removing blocks using persistence task");
         if new_tip_num < self.persistence_state.last_persisted_block.number {
             debug!(target: "engine::tree", ?new_tip_num, "Starting remove blocks job");
-            self.pending_sparse_trie_prune = None;
+            self.pending_sparse_trie_prune = false;
             let (tx, rx) = crossbeam_channel::bounded(1);
             let _ = self.persistence.remove_blocks_above(new_tip_num, tx);
             self.persistence_state.start_remove(new_tip_num, rx);
@@ -1816,7 +1815,7 @@ where
         if ctrl.is_unwind() {
             // the node reset so we need to clear everything above that height so that backfill
             // height is the new canonical block.
-            self.pending_sparse_trie_prune = None;
+            self.pending_sparse_trie_prune = false;
             self.state.tree_state.reset(backfill_num_hash)
         } else {
             self.state.tree_state.remove_until(
@@ -2145,35 +2144,15 @@ where
             number: self.persistence_state.last_persisted_block.number,
             hash: self.persistence_state.last_persisted_block.hash,
         });
-        self.pending_sparse_trie_prune = self.sparse_trie_retained_paths_for_in_memory_blocks();
+        self.pending_sparse_trie_prune = self.should_prune_sparse_trie();
         Ok(())
     }
 
-    /// Builds sparse trie retained paths from all blocks still present in the in-memory tree.
-    fn sparse_trie_retained_paths_for_in_memory_blocks(&self) -> Option<TriePrefixSetsMut> {
-        if self.config.skip_state_root() ||
-            self.config.state_root_fallback() ||
-            !self.config.use_state_root_task()
-        {
-            return None
-        }
-
-        let mut retained_paths = TriePrefixSetsMut::default();
-        for block in self.state.tree_state.blocks_by_hash.values() {
-            let trie_data = block.trie_data();
-            let Some(changed_paths) = trie_data.changed_paths.as_deref() else {
-                // Custom state-root strategies may not track changed paths, so this is an
-                // expected way to opt out of pruning, not an anomaly.
-                debug!(
-                    target: "engine::tree",
-                    block = ?block.recovered_block().num_hash(),
-                    "Skipping sparse trie prune because changed paths for in-memory block are unknown"
-                );
-                return None
-            };
-            retained_paths.extend_ref(changed_paths);
-        }
-        Some(retained_paths)
+    /// Returns whether sparse trie pruning should be attempted by the next sparse trie task.
+    fn should_prune_sparse_trie(&self) -> bool {
+        !self.config.skip_state_root() &&
+            !self.config.state_root_fallback() &&
+            self.config.use_state_root_task()
     }
 
     /// Return an [`ExecutedBlock`] from database or in-memory state by hash.
@@ -2700,7 +2679,7 @@ where
             let old_first = old.first().map(|first| first.recovered_block().num_hash());
             trace!(target: "engine::tree", ?new_first, ?old_first, "Reorg detected, new and old first blocks");
 
-            self.pending_sparse_trie_prune = None;
+            self.pending_sparse_trie_prune = false;
             self.update_reorg_metrics(old.len(), old_first);
             self.reinsert_reorged_blocks(new.clone());
             self.reinsert_reorged_blocks(old.clone());

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2149,7 +2149,7 @@ where
     }
 
     /// Returns whether sparse trie pruning should be attempted by the next sparse trie task.
-    fn should_prune_sparse_trie(&self) -> bool {
+    const fn should_prune_sparse_trie(&self) -> bool {
         !self.config.skip_state_root() &&
             !self.config.state_root_fallback() &&
             self.config.use_state_root_task()

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -15,7 +15,7 @@ use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender
 use multiproof::*;
 use prewarm::PrewarmMetrics;
 use rayon::prelude::*;
-use reth_chain_state::{PreservedSparseTrie, StateTrieOverlayManager};
+use reth_chain_state::{ExecutedBlock, PreservedSparseTrie, StateTrieOverlayManager};
 use reth_evm::{
     block::ExecutableTxParts,
     execute::{ExecutableTxFor, WithTxEnv},
@@ -130,10 +130,10 @@ where
     bal_prewarm_pool: OnceLock<Arc<bal_prewarm_pool::BalPrewarmPool>>,
 }
 
-struct SparseTrieTaskOptions {
+struct SparseTrieTaskOptions<N: NodePrimitives> {
     parent_state_root: B256,
     chunk_size: usize,
-    pending_sparse_trie_prune: Option<TriePrefixSetsMut>,
+    pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
 }
 
 impl<Evm> PayloadProcessor<Evm>
@@ -278,7 +278,7 @@ where
         parent_state_root: B256,
         transaction_count: Option<usize>,
         config: &TreeConfig,
-        pending_sparse_trie_prune: Option<TriePrefixSetsMut>,
+        pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<Evm::Primitives>>>,
     ) -> StateRootHandle
     where
         F: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -307,10 +307,10 @@ where
             SparseTrieTaskOptions {
                 parent_state_root,
                 chunk_size: config.multiproof_chunk_size(),
-                pending_sparse_trie_prune: if self.disable_sparse_trie_cache_pruning {
+                pending_sparse_trie_prune_blocks: if self.disable_sparse_trie_cache_pruning {
                     None
                 } else {
-                    pending_sparse_trie_prune
+                    pending_sparse_trie_prune_blocks
                 },
             },
         );
@@ -554,10 +554,13 @@ where
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, StateRootTaskError>>,
         hashed_state_tx: mpsc::Sender<HashedPostState>,
         from_multi_proof: CrossbeamReceiver<StateRootMessage>,
-        options: SparseTrieTaskOptions,
+        options: SparseTrieTaskOptions<Evm::Primitives>,
     ) {
-        let SparseTrieTaskOptions { parent_state_root, chunk_size, pending_sparse_trie_prune } =
-            options;
+        let SparseTrieTaskOptions {
+            parent_state_root,
+            chunk_size,
+            pending_sparse_trie_prune_blocks,
+        } = options;
         let state_trie_overlays = self.state_trie_overlays.clone();
         let trie_metrics = self.trie_metrics.clone();
         let max_hot_slots = self.sparse_trie_max_hot_slots;
@@ -642,13 +645,16 @@ where
             let deferred = if let Some(result) = task_result {
                 let start = Instant::now();
                 let (mut trie, deferred) = task.into_trie_for_reuse();
-                if let Some(mut retained_paths) = pending_sparse_trie_prune {
+                if let Some(prune_blocks) = pending_sparse_trie_prune_blocks {
                     let changed_paths = result
                         .changed_paths
                         .as_deref()
                         .expect("sparse trie task always returns changed paths");
-                    retained_paths.extend_ref(changed_paths);
-                    trie.prune(max_hot_slots, max_hot_accounts, retained_paths);
+                    if let Some(retained_paths) =
+                        sparse_trie_retained_paths(prune_blocks, changed_paths)
+                    {
+                        trie.prune(max_hot_slots, max_hot_accounts, retained_paths);
+                    }
                 }
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram
@@ -728,6 +734,27 @@ where
             debug!(target: "engine::caching", ?block_with_parent, "Updated execution cache for inserted block");
         });
     }
+}
+
+fn sparse_trie_retained_paths<N: NodePrimitives>(
+    prune_blocks: Vec<ExecutedBlock<N>>,
+    current_changed_paths: &TriePrefixSetsMut,
+) -> Option<TriePrefixSetsMut> {
+    let mut retained_paths = TriePrefixSetsMut::default();
+    for block in prune_blocks {
+        let trie_data = block.trie_data();
+        let Some(changed_paths) = trie_data.changed_paths.as_deref() else {
+            debug!(
+                target: "engine::tree::payload_processor",
+                block = ?block.recovered_block().num_hash(),
+                "Skipping sparse trie prune because changed paths for in-memory block are unknown"
+            );
+            return None
+        };
+        retained_paths.extend_ref(changed_paths);
+    }
+    retained_paths.extend_ref(current_changed_paths);
+    Some(retained_paths)
 }
 
 /// Converts transactions sequentially and sends them to the prewarm and execute channels.
@@ -934,7 +961,7 @@ mod tests {
     use alloy_eips::eip1898::{BlockNumHash, BlockWithParent};
     use alloy_primitives::{map::HashMap, Address, B256, U256};
     use rand::Rng;
-    use reth_chain_state::StateTrieOverlayManager;
+    use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock, StateTrieOverlayManager};
     use reth_chainspec::ChainSpec;
     use reth_db_common::init::init_genesis;
     use reth_ethereum_primitives::EthPrimitives;
@@ -949,7 +976,12 @@ mod tests {
     };
     use reth_revm::db::BundleState;
     use reth_testing_utils::generators;
-    use reth_trie::{test_utils::state_root, HashedPostState};
+    use reth_trie::{
+        prefix_set::{PrefixSetMut, TriePrefixSetsMut},
+        test_utils::state_root,
+        HashedPostState, LazyTrieData,
+    };
+    use reth_trie_common::Nibbles;
     use reth_trie_db::ChangesetCache;
     use revm::state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot, TransactionId};
     use std::sync::Arc;
@@ -961,6 +993,30 @@ mod tests {
 
     fn state_trie_overlays() -> StateTrieOverlayManager<EthPrimitives> {
         StateTrieOverlayManager::default()
+    }
+
+    fn with_changed_paths(
+        block: ExecutedBlock<EthPrimitives>,
+        changed_paths: TriePrefixSetsMut,
+    ) -> ExecutedBlock<EthPrimitives> {
+        let mut trie_data = block.trie_data();
+        trie_data.changed_paths = Some(Arc::new(changed_paths));
+        ExecutedBlock::with_deferred_trie_data(
+            block.recovered_block,
+            block.execution_output,
+            LazyTrieData::ready(trie_data),
+        )
+    }
+
+    fn trie_changed_paths(account_path: u8, storage_path: u8) -> TriePrefixSetsMut {
+        TriePrefixSetsMut {
+            account_prefix_set: PrefixSetMut::from([Nibbles::from_nibbles([account_path])]),
+            storage_prefix_sets: HashMap::from_iter([(
+                B256::with_last_byte(account_path),
+                PrefixSetMut::from([Nibbles::from_nibbles([storage_path])]),
+            )]),
+            destroyed_accounts: Default::default(),
+        }
     }
 
     #[test]
@@ -997,6 +1053,30 @@ mod tests {
 
         let retry = execution_cache.get_cache_for(hash);
         assert!(retry.is_some(), "checkout should succeed after guard drop");
+    }
+
+    #[test]
+    fn sparse_trie_retained_paths_merges_prune_blocks_with_current_block() {
+        let blocks: Vec<_> = TestBlockBuilder::eth()
+            .get_executed_blocks(1..3)
+            .zip([trie_changed_paths(0x01, 0x02), trie_changed_paths(0x03, 0x04)])
+            .map(|(block, changed_paths)| with_changed_paths(block, changed_paths))
+            .collect();
+        let current_changed_paths = trie_changed_paths(0x05, 0x06);
+
+        let retained_paths =
+            super::sparse_trie_retained_paths(blocks, &current_changed_paths).unwrap().freeze();
+
+        assert_eq!(retained_paths.account_prefix_set.len(), 3);
+        assert_eq!(retained_paths.storage_prefix_sets.len(), 3);
+    }
+
+    #[test]
+    fn sparse_trie_retained_paths_skips_prune_when_changed_paths_missing() {
+        let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
+        let current_changed_paths = trie_changed_paths(0x01, 0x02);
+
+        assert!(super::sparse_trie_retained_paths(blocks, &current_changed_paths).is_none());
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -133,6 +133,12 @@ where
 struct SparseTrieTaskOptions<N: NodePrimitives> {
     parent_state_root: B256,
     chunk_size: usize,
+    /// In-memory ancestor blocks whose changed paths must be retained while pruning the sparse
+    /// trie.
+    ///
+    /// `None` means this sparse trie task should not prune. `Some(Vec::new())` still means pruning
+    /// was requested, but the task only needs to retain paths changed by the current block. If any
+    /// listed ancestor block lacks changed paths, the task skips pruning.
     pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
 }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -118,8 +118,8 @@ use reth_tasks::LazyHandle;
 use crate::tree::{
     payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle},
     state_root_strategy::{
-        take_pending_sparse_trie_prune_blocks, DefaultStateRootStrategy,
-        PayloadStateRootJobContext, StateRootJobContext, StateRootStrategy,
+        DefaultStateRootStrategy, PayloadStateRootJobContext, StateRootJobContext,
+        StateRootStrategy,
     },
 };
 use alloy_consensus::constants::KECCAK_EMPTY;
@@ -193,8 +193,6 @@ pub struct TreeCtx<'a, N: NodePrimitives> {
     state: &'a mut EngineApiTreeState<N>,
     /// Reference to the canonical in-memory state
     canonical_in_memory_state: &'a CanonicalInMemoryState<N>,
-    /// Pending sparse trie prune request to consume when spawning a sparse trie task.
-    pending_sparse_trie_prune: &'a mut bool,
 }
 
 impl<'a, N: NodePrimitives> std::fmt::Debug for TreeCtx<'a, N> {
@@ -202,7 +200,6 @@ impl<'a, N: NodePrimitives> std::fmt::Debug for TreeCtx<'a, N> {
         f.debug_struct("TreeCtx")
             .field("state", &"EngineApiTreeState")
             .field("canonical_in_memory_state", &self.canonical_in_memory_state)
-            .field("pending_sparse_trie_prune", &self.pending_sparse_trie_prune)
             .finish()
     }
 }
@@ -212,9 +209,8 @@ impl<'a, N: NodePrimitives> TreeCtx<'a, N> {
     pub const fn new(
         state: &'a mut EngineApiTreeState<N>,
         canonical_in_memory_state: &'a CanonicalInMemoryState<N>,
-        pending_sparse_trie_prune: &'a mut bool,
     ) -> Self {
-        Self { state, canonical_in_memory_state, pending_sparse_trie_prune }
+        Self { state, canonical_in_memory_state }
     }
 }
 
@@ -239,11 +235,7 @@ impl<'a, N: NodePrimitives> TreeCtx<'a, N> {
         &mut self,
         parent_hash: B256,
     ) -> Option<Vec<ExecutedBlock<N>>> {
-        take_pending_sparse_trie_prune_blocks(
-            self.pending_sparse_trie_prune,
-            self.state,
-            parent_hash,
-        )
+        self.state.take_sparse_trie_prune_blocks(parent_hash)
     }
 }
 
@@ -1724,16 +1716,12 @@ pub trait EngineValidator<
     ///
     /// `timestamp` is the timestamp of the payload being built, taken from the payload
     /// attributes.
-    ///
-    /// `pending_sparse_trie_prune` should be consumed only when the returned handle owns a sparse
-    /// trie task that can apply it.
     fn payload_state_root_handle_for(
         &self,
         parent_hash: B256,
         parent_header: &N::BlockHeader,
         timestamp: u64,
-        state: &EngineApiTreeState<N>,
-        pending_sparse_trie_prune: &mut bool,
+        state: &mut EngineApiTreeState<N>,
     ) -> Option<PayloadStateRootHandle>;
 }
 
@@ -1824,8 +1812,7 @@ where
         parent_hash: B256,
         parent_header: &N::BlockHeader,
         timestamp: u64,
-        state: &EngineApiTreeState<N>,
-        pending_sparse_trie_prune: &mut bool,
+        state: &mut EngineApiTreeState<N>,
     ) -> Option<PayloadStateRootHandle> {
         let provider_builder = match self.state_provider_builder(parent_hash, state) {
             Ok(Some(provider_builder)) => provider_builder,
@@ -1854,7 +1841,6 @@ where
             provider_builder,
             overlay_factory,
             config: &self.config,
-            pending_sparse_trie_prune,
         }) {
             Ok(handle) => handle,
             Err(err) => {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1708,12 +1708,16 @@ pub trait EngineValidator<
     ///
     /// `timestamp` is the timestamp of the payload being built, taken from the payload
     /// attributes.
+    ///
+    /// `pending_sparse_trie_prune` should be consumed only when the returned handle owns a sparse
+    /// trie task that can apply it.
     fn payload_state_root_handle_for(
         &self,
         parent_hash: B256,
         parent_header: &N::BlockHeader,
         timestamp: u64,
         state: &EngineApiTreeState<N>,
+        pending_sparse_trie_prune: &mut Option<TriePrefixSetsMut>,
     ) -> Option<PayloadStateRootHandle>;
 }
 
@@ -1805,6 +1809,7 @@ where
         parent_header: &N::BlockHeader,
         timestamp: u64,
         state: &EngineApiTreeState<N>,
+        pending_sparse_trie_prune: &mut Option<TriePrefixSetsMut>,
     ) -> Option<PayloadStateRootHandle> {
         let provider_builder = match self.state_provider_builder(parent_hash, state) {
             Ok(Some(provider_builder)) => provider_builder,
@@ -1832,6 +1837,7 @@ where
             provider_builder,
             overlay_factory,
             &self.config,
+            pending_sparse_trie_prune,
         )) {
             Ok(handle) => handle,
             Err(err) => {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -118,8 +118,8 @@ use reth_tasks::LazyHandle;
 use crate::tree::{
     payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle},
     state_root_strategy::{
-        DefaultStateRootStrategy, PayloadStateRootJobContext, StateRootJobContext,
-        StateRootStrategy,
+        take_pending_sparse_trie_prune_blocks, DefaultStateRootStrategy,
+        PayloadStateRootJobContext, StateRootJobContext, StateRootStrategy,
     },
 };
 use alloy_consensus::constants::KECCAK_EMPTY;
@@ -234,22 +234,15 @@ impl<'a, N: NodePrimitives> TreeCtx<'a, N> {
         self.canonical_in_memory_state
     }
 
-    /// Takes the pending sparse trie prune request as in-memory ancestor blocks, if any.
+    /// Takes the pending sparse trie prune request as in-memory parent-chain blocks, if any.
     pub fn take_sparse_trie_prune_blocks(
         &mut self,
         parent_hash: B256,
     ) -> Option<Vec<ExecutedBlock<N>>> {
-        if !*self.pending_sparse_trie_prune {
-            return None
-        }
-
-        *self.pending_sparse_trie_prune = false;
-        Some(
-            self.state
-                .tree_state()
-                .blocks_by_hash(parent_hash)
-                .map(|(_, blocks)| blocks)
-                .unwrap_or_default(),
+        take_pending_sparse_trie_prune_blocks(
+            self.pending_sparse_trie_prune,
+            self.state,
+            parent_hash,
         )
     }
 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -194,7 +194,7 @@ pub struct TreeCtx<'a, N: NodePrimitives> {
     /// Reference to the canonical in-memory state
     canonical_in_memory_state: &'a CanonicalInMemoryState<N>,
     /// Pending sparse trie prune request to consume when spawning a sparse trie task.
-    pending_sparse_trie_prune: &'a mut Option<TriePrefixSetsMut>,
+    pending_sparse_trie_prune: &'a mut bool,
 }
 
 impl<'a, N: NodePrimitives> std::fmt::Debug for TreeCtx<'a, N> {
@@ -202,7 +202,7 @@ impl<'a, N: NodePrimitives> std::fmt::Debug for TreeCtx<'a, N> {
         f.debug_struct("TreeCtx")
             .field("state", &"EngineApiTreeState")
             .field("canonical_in_memory_state", &self.canonical_in_memory_state)
-            .field("pending_sparse_trie_prune", &self.pending_sparse_trie_prune.is_some())
+            .field("pending_sparse_trie_prune", &self.pending_sparse_trie_prune)
             .finish()
     }
 }
@@ -212,7 +212,7 @@ impl<'a, N: NodePrimitives> TreeCtx<'a, N> {
     pub const fn new(
         state: &'a mut EngineApiTreeState<N>,
         canonical_in_memory_state: &'a CanonicalInMemoryState<N>,
-        pending_sparse_trie_prune: &'a mut Option<TriePrefixSetsMut>,
+        pending_sparse_trie_prune: &'a mut bool,
     ) -> Self {
         Self { state, canonical_in_memory_state, pending_sparse_trie_prune }
     }
@@ -234,9 +234,23 @@ impl<'a, N: NodePrimitives> TreeCtx<'a, N> {
         self.canonical_in_memory_state
     }
 
-    /// Takes the pending sparse trie prune request, if any.
-    pub const fn take_sparse_trie_prune(&mut self) -> Option<TriePrefixSetsMut> {
-        self.pending_sparse_trie_prune.take()
+    /// Takes the pending sparse trie prune request as in-memory ancestor blocks, if any.
+    pub fn take_sparse_trie_prune_blocks(
+        &mut self,
+        parent_hash: B256,
+    ) -> Option<Vec<ExecutedBlock<N>>> {
+        if !*self.pending_sparse_trie_prune {
+            return None
+        }
+
+        *self.pending_sparse_trie_prune = false;
+        Some(
+            self.state
+                .tree_state()
+                .blocks_by_hash(parent_hash)
+                .map(|(_, blocks)| blocks)
+                .unwrap_or_default(),
+        )
     }
 }
 
@@ -597,10 +611,10 @@ where
         let parallel_bal_execution = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
 
         // Prepare the state-root job before execution so it can provide streaming hooks.
-        let pending_sparse_trie_prune = (!self.config.skip_state_root() &&
+        let pending_sparse_trie_prune_blocks = (!self.config.skip_state_root() &&
             !self.config.state_root_fallback() &&
             self.config.use_state_root_task())
-        .then(|| ctx.take_sparse_trie_prune())
+        .then(|| ctx.take_sparse_trie_prune_blocks(env.parent_hash))
         .flatten();
         let mut state_root_job =
             ensure_ok!(self.state_root_strategy.prepare(StateRootJobContext::new(
@@ -610,7 +624,7 @@ where
                 overlay_factory,
                 &self.config,
                 parallel_bal_execution,
-                pending_sparse_trie_prune,
+                pending_sparse_trie_prune_blocks,
             )));
         let state_root_job_name = state_root_job.name();
 
@@ -1717,7 +1731,7 @@ pub trait EngineValidator<
         parent_header: &N::BlockHeader,
         timestamp: u64,
         state: &EngineApiTreeState<N>,
-        pending_sparse_trie_prune: &mut Option<TriePrefixSetsMut>,
+        pending_sparse_trie_prune: &mut bool,
     ) -> Option<PayloadStateRootHandle>;
 }
 
@@ -1809,7 +1823,7 @@ where
         parent_header: &N::BlockHeader,
         timestamp: u64,
         state: &EngineApiTreeState<N>,
-        pending_sparse_trie_prune: &mut Option<TriePrefixSetsMut>,
+        pending_sparse_trie_prune: &mut bool,
     ) -> Option<PayloadStateRootHandle> {
         let provider_builder = match self.state_provider_builder(parent_hash, state) {
             Ok(Some(provider_builder)) => provider_builder,
@@ -1834,6 +1848,7 @@ where
             parent_hash,
             parent_header,
             timestamp,
+            state,
             provider_builder,
             overlay_factory,
             &self.config,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1843,17 +1843,17 @@ where
             Self::overlay_builder_for_parent(parent_hash, state, self.changeset_cache.clone()),
         );
 
-        match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext::new(
-            &self.payload_processor,
+        match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext {
+            payload_processor: &self.payload_processor,
             parent_hash,
             parent_header,
             timestamp,
             state,
             provider_builder,
             overlay_factory,
-            &self.config,
+            config: &self.config,
             pending_sparse_trie_prune,
-        )) {
+        }) {
             Ok(handle) => handle,
             Err(err) => {
                 warn!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1832,16 +1832,16 @@ where
             Self::overlay_builder_for_parent(parent_hash, state, self.changeset_cache.clone()),
         );
 
-        match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext {
-            payload_processor: &self.payload_processor,
+        match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext::new(
+            &self.payload_processor,
             parent_hash,
             parent_header,
             timestamp,
             state,
             provider_builder,
             overlay_factory,
-            config: &self.config,
-        }) {
+            &self.config,
+        )) {
             Ok(handle) => handle,
             Err(err) => {
                 warn!(

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -81,6 +81,31 @@ use std::{
 };
 use tracing::{debug, warn};
 
+/// Takes a pending sparse trie prune request, if any, and snapshots the in-memory parent chain
+/// ending at `parent_hash`.
+///
+/// `None` means no prune request is pending. `Some(Vec::new())` means a prune was requested, but no
+/// in-memory parent-chain blocks were found for the parent hash; the sparse trie task should still
+/// prune using the current block's changed paths.
+pub(crate) fn take_pending_sparse_trie_prune_blocks<N: NodePrimitives>(
+    pending_sparse_trie_prune: &mut bool,
+    state: &EngineApiTreeState<N>,
+    parent_hash: B256,
+) -> Option<Vec<ExecutedBlock<N>>> {
+    if !*pending_sparse_trie_prune {
+        return None
+    }
+
+    *pending_sparse_trie_prune = false;
+    Some(
+        state
+            .tree_state()
+            .blocks_by_hash(parent_hash)
+            .map(|(_, blocks)| blocks)
+            .unwrap_or_default(),
+    )
+}
+
 /// Strategy used by engine-tree validation to prepare per-block state-root work.
 pub trait StateRootStrategy<N, P, Evm>: Send + Sync
 where
@@ -182,19 +207,12 @@ where
         self.provider_builder.clone()
     }
 
-    /// Takes the pending sparse trie prune request as in-memory ancestor blocks, if any.
+    /// Takes the pending sparse trie prune request as in-memory parent-chain blocks, if any.
     pub fn take_sparse_trie_prune_blocks(&mut self) -> Option<Vec<ExecutedBlock<N>>> {
-        if !*self.pending_sparse_trie_prune {
-            return None
-        }
-
-        *self.pending_sparse_trie_prune = false;
-        Some(
-            self.state
-                .tree_state()
-                .blocks_by_hash(self.parent_hash)
-                .map(|(_, blocks)| blocks)
-                .unwrap_or_default(),
+        take_pending_sparse_trie_prune_blocks(
+            self.pending_sparse_trie_prune,
+            self.state,
+            self.parent_hash,
         )
     }
 }

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -51,9 +51,10 @@ use crate::tree::{
     },
     payload_processor::PayloadProcessor,
     payload_validator::LazyHashedPostState,
-    ExecutionEnv, StateProviderBuilder, TreeConfig,
+    EngineApiTreeState, ExecutionEnv, StateProviderBuilder, TreeConfig,
 };
 use alloy_primitives::B256;
+use reth_chain_state::ExecutedBlock;
 use reth_errors::ProviderResult;
 use reth_evm::{ConfigureEvm, OnStateHook};
 use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives, RecoveredBlock};
@@ -114,10 +115,11 @@ where
     parent_hash: B256,
     parent_header: &'a N::BlockHeader,
     timestamp: u64,
+    state: &'a EngineApiTreeState<N>,
     provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     config: &'a TreeConfig,
-    pending_sparse_trie_prune: &'a mut Option<TriePrefixSetsMut>,
+    pending_sparse_trie_prune: &'a mut bool,
 }
 
 impl<N, P, Evm> fmt::Debug for PayloadStateRootJobContext<'_, N, P, Evm>
@@ -130,7 +132,7 @@ where
             .field("parent_hash", &self.parent_hash)
             .field("parent_state_root", &self.parent_state_root())
             .field("timestamp", &self.timestamp)
-            .field("has_pending_sparse_trie_prune", &self.pending_sparse_trie_prune.is_some())
+            .field("pending_sparse_trie_prune", &self.pending_sparse_trie_prune)
             .finish_non_exhaustive()
     }
 }
@@ -146,16 +148,18 @@ where
         parent_hash: B256,
         parent_header: &'a N::BlockHeader,
         timestamp: u64,
+        state: &'a EngineApiTreeState<N>,
         provider_builder: StateProviderBuilder<N, P>,
         overlay_factory: OverlayStateProviderFactory<P, N>,
         config: &'a TreeConfig,
-        pending_sparse_trie_prune: &'a mut Option<TriePrefixSetsMut>,
+        pending_sparse_trie_prune: &'a mut bool,
     ) -> Self {
         Self {
             payload_processor,
             parent_hash,
             parent_header,
             timestamp,
+            state,
             provider_builder,
             overlay_factory,
             config,
@@ -201,9 +205,20 @@ where
         self.provider_builder.clone()
     }
 
-    /// Takes the pending sparse trie prune request, if any.
-    pub fn take_sparse_trie_prune(&mut self) -> Option<TriePrefixSetsMut> {
-        self.pending_sparse_trie_prune.take()
+    /// Takes the pending sparse trie prune request as in-memory ancestor blocks, if any.
+    pub fn take_sparse_trie_prune_blocks(&mut self) -> Option<Vec<ExecutedBlock<N>>> {
+        if !*self.pending_sparse_trie_prune {
+            return None
+        }
+
+        *self.pending_sparse_trie_prune = false;
+        Some(
+            self.state
+                .tree_state()
+                .blocks_by_hash(self.parent_hash)
+                .map(|(_, blocks)| blocks)
+                .unwrap_or_default(),
+        )
     }
 }
 
@@ -219,7 +234,7 @@ where
     overlay_factory: OverlayStateProviderFactory<P, N>,
     config: &'a TreeConfig,
     parallel_bal_execution: bool,
-    pending_sparse_trie_prune: Option<TriePrefixSetsMut>,
+    pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
 }
 
 impl<N, P, Evm> fmt::Debug for StateRootJobContext<'_, N, P, Evm>
@@ -230,7 +245,10 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StateRootJobContext")
             .field("parallel_bal_execution", &self.parallel_bal_execution)
-            .field("has_pending_sparse_trie_prune", &self.pending_sparse_trie_prune.is_some())
+            .field(
+                "has_pending_sparse_trie_prune",
+                &self.pending_sparse_trie_prune_blocks.is_some(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -248,7 +266,7 @@ where
         overlay_factory: OverlayStateProviderFactory<P, N>,
         config: &'a TreeConfig,
         parallel_bal_execution: bool,
-        pending_sparse_trie_prune: Option<TriePrefixSetsMut>,
+        pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
     ) -> Self {
         Self {
             payload_processor,
@@ -257,7 +275,7 @@ where
             overlay_factory,
             config,
             parallel_bal_execution,
-            pending_sparse_trie_prune,
+            pending_sparse_trie_prune_blocks,
         }
     }
 
@@ -441,7 +459,7 @@ where
             overlay_factory,
             config,
             parallel_bal_execution,
-            pending_sparse_trie_prune,
+            pending_sparse_trie_prune_blocks,
         } = ctx;
 
         if config.skip_state_root() {
@@ -469,7 +487,7 @@ where
             env.parent_state_root,
             Some(env.transaction_count),
             config,
-            pending_sparse_trie_prune,
+            pending_sparse_trie_prune_blocks,
         );
         let streams = handle.streams(!parallel_bal_execution);
         let hashed_state_rx = Some(handle.take_hashed_state_rx());
@@ -516,7 +534,7 @@ where
                     // workers.
                     None,
                     config,
-                    ctx.take_sparse_trie_prune(),
+                    ctx.take_sparse_trie_prune_blocks(),
                 )
                 .into_payload_state_root_handle(),
         ))

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -117,6 +117,7 @@ where
     provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     config: &'a TreeConfig,
+    pending_sparse_trie_prune: &'a mut Option<TriePrefixSetsMut>,
 }
 
 impl<N, P, Evm> fmt::Debug for PayloadStateRootJobContext<'_, N, P, Evm>
@@ -129,6 +130,7 @@ where
             .field("parent_hash", &self.parent_hash)
             .field("parent_state_root", &self.parent_state_root())
             .field("timestamp", &self.timestamp)
+            .field("has_pending_sparse_trie_prune", &self.pending_sparse_trie_prune.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -147,6 +149,7 @@ where
         provider_builder: StateProviderBuilder<N, P>,
         overlay_factory: OverlayStateProviderFactory<P, N>,
         config: &'a TreeConfig,
+        pending_sparse_trie_prune: &'a mut Option<TriePrefixSetsMut>,
     ) -> Self {
         Self {
             payload_processor,
@@ -156,6 +159,7 @@ where
             provider_builder,
             overlay_factory,
             config,
+            pending_sparse_trie_prune,
         }
     }
 
@@ -195,6 +199,11 @@ where
         P: Clone,
     {
         self.provider_builder.clone()
+    }
+
+    /// Takes the pending sparse trie prune request, if any.
+    pub fn take_sparse_trie_prune(&mut self) -> Option<TriePrefixSetsMut> {
+        self.pending_sparse_trie_prune.take()
     }
 }
 
@@ -482,10 +491,12 @@ where
 
     fn prepare_payload_builder(
         &self,
-        ctx: PayloadStateRootJobContext<'_, N, P, Evm>,
+        mut ctx: PayloadStateRootJobContext<'_, N, P, Evm>,
     ) -> ProviderResult<Option<PayloadStateRootHandle>> {
         let parent_state_root = ctx.parent_state_root();
-        let PayloadStateRootJobContext { payload_processor, overlay_factory, config, .. } = ctx;
+        let payload_processor = ctx.payload_processor;
+        let overlay_factory = ctx.overlay_factory.clone();
+        let config = ctx.config;
 
         // Sharing the engine state-root task with the payload builder is opt-in, and needs a
         // host that can run the task pipeline at all.
@@ -505,7 +516,7 @@ where
                     // workers.
                     None,
                     config,
-                    None,
+                    ctx.take_sparse_trie_prune(),
                 )
                 .into_payload_state_root_handle(),
         ))

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -111,15 +111,15 @@ where
     N: NodePrimitives,
     Evm: ConfigureEvm<Primitives = N>,
 {
-    payload_processor: &'a PayloadProcessor<Evm>,
-    parent_hash: B256,
-    parent_header: &'a N::BlockHeader,
-    timestamp: u64,
-    state: &'a EngineApiTreeState<N>,
-    provider_builder: StateProviderBuilder<N, P>,
-    overlay_factory: OverlayStateProviderFactory<P, N>,
-    config: &'a TreeConfig,
-    pending_sparse_trie_prune: &'a mut bool,
+    pub(crate) payload_processor: &'a PayloadProcessor<Evm>,
+    pub(crate) parent_hash: B256,
+    pub(crate) parent_header: &'a N::BlockHeader,
+    pub(crate) timestamp: u64,
+    pub(crate) state: &'a EngineApiTreeState<N>,
+    pub(crate) provider_builder: StateProviderBuilder<N, P>,
+    pub(crate) overlay_factory: OverlayStateProviderFactory<P, N>,
+    pub(crate) config: &'a TreeConfig,
+    pub(crate) pending_sparse_trie_prune: &'a mut bool,
 }
 
 impl<N, P, Evm> fmt::Debug for PayloadStateRootJobContext<'_, N, P, Evm>
@@ -142,31 +142,6 @@ where
     N: NodePrimitives,
     Evm: ConfigureEvm<Primitives = N>,
 {
-    /// Creates a new payload-builder state-root job context.
-    pub(crate) const fn new(
-        payload_processor: &'a PayloadProcessor<Evm>,
-        parent_hash: B256,
-        parent_header: &'a N::BlockHeader,
-        timestamp: u64,
-        state: &'a EngineApiTreeState<N>,
-        provider_builder: StateProviderBuilder<N, P>,
-        overlay_factory: OverlayStateProviderFactory<P, N>,
-        config: &'a TreeConfig,
-        pending_sparse_trie_prune: &'a mut bool,
-    ) -> Self {
-        Self {
-            payload_processor,
-            parent_hash,
-            parent_header,
-            timestamp,
-            state,
-            provider_builder,
-            overlay_factory,
-            config,
-            pending_sparse_trie_prune,
-        }
-    }
-
     /// Returns the parent block hash for the payload being built.
     pub const fn parent_hash(&self) -> B256 {
         self.parent_hash

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -113,14 +113,14 @@ where
     N: NodePrimitives,
     Evm: ConfigureEvm<Primitives = N>,
 {
-    pub(crate) payload_processor: &'a PayloadProcessor<Evm>,
-    pub(crate) parent_hash: B256,
-    pub(crate) parent_header: &'a N::BlockHeader,
-    pub(crate) timestamp: u64,
-    pub(crate) state: &'a mut EngineApiTreeState<N>,
-    pub(crate) provider_builder: StateProviderBuilder<N, P>,
-    pub(crate) overlay_factory: OverlayStateProviderFactory<P, N>,
-    pub(crate) config: &'a TreeConfig,
+    payload_processor: &'a PayloadProcessor<Evm>,
+    parent_hash: B256,
+    parent_header: &'a N::BlockHeader,
+    timestamp: u64,
+    state: &'a mut EngineApiTreeState<N>,
+    provider_builder: StateProviderBuilder<N, P>,
+    overlay_factory: OverlayStateProviderFactory<P, N>,
+    config: &'a TreeConfig,
 }
 
 impl<N, P, Evm> fmt::Debug for PayloadStateRootJobContext<'_, N, P, Evm>
@@ -143,6 +143,30 @@ where
     N: NodePrimitives,
     Evm: ConfigureEvm<Primitives = N>,
 {
+    /// Creates a payload-builder state-root job context.
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) const fn new(
+        payload_processor: &'a PayloadProcessor<Evm>,
+        parent_hash: B256,
+        parent_header: &'a N::BlockHeader,
+        timestamp: u64,
+        state: &'a mut EngineApiTreeState<N>,
+        provider_builder: StateProviderBuilder<N, P>,
+        overlay_factory: OverlayStateProviderFactory<P, N>,
+        config: &'a TreeConfig,
+    ) -> Self {
+        Self {
+            payload_processor,
+            parent_hash,
+            parent_header,
+            timestamp,
+            state,
+            provider_builder,
+            overlay_factory,
+            config,
+        }
+    }
+
     /// Returns the parent block hash for the payload being built.
     pub const fn parent_hash(&self) -> B256 {
         self.parent_hash

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -81,31 +81,6 @@ use std::{
 };
 use tracing::{debug, warn};
 
-/// Takes a pending sparse trie prune request, if any, and snapshots the in-memory parent chain
-/// ending at `parent_hash`.
-///
-/// `None` means no prune request is pending. `Some(Vec::new())` means a prune was requested, but no
-/// in-memory parent-chain blocks were found for the parent hash; the sparse trie task should still
-/// prune using the current block's changed paths.
-pub(crate) fn take_pending_sparse_trie_prune_blocks<N: NodePrimitives>(
-    pending_sparse_trie_prune: &mut bool,
-    state: &EngineApiTreeState<N>,
-    parent_hash: B256,
-) -> Option<Vec<ExecutedBlock<N>>> {
-    if !*pending_sparse_trie_prune {
-        return None
-    }
-
-    *pending_sparse_trie_prune = false;
-    Some(
-        state
-            .tree_state()
-            .blocks_by_hash(parent_hash)
-            .map(|(_, blocks)| blocks)
-            .unwrap_or_default(),
-    )
-}
-
 /// Strategy used by engine-tree validation to prepare per-block state-root work.
 pub trait StateRootStrategy<N, P, Evm>: Send + Sync
 where
@@ -142,11 +117,10 @@ where
     pub(crate) parent_hash: B256,
     pub(crate) parent_header: &'a N::BlockHeader,
     pub(crate) timestamp: u64,
-    pub(crate) state: &'a EngineApiTreeState<N>,
+    pub(crate) state: &'a mut EngineApiTreeState<N>,
     pub(crate) provider_builder: StateProviderBuilder<N, P>,
     pub(crate) overlay_factory: OverlayStateProviderFactory<P, N>,
     pub(crate) config: &'a TreeConfig,
-    pub(crate) pending_sparse_trie_prune: &'a mut bool,
 }
 
 impl<N, P, Evm> fmt::Debug for PayloadStateRootJobContext<'_, N, P, Evm>
@@ -159,7 +133,7 @@ where
             .field("parent_hash", &self.parent_hash)
             .field("parent_state_root", &self.parent_state_root())
             .field("timestamp", &self.timestamp)
-            .field("pending_sparse_trie_prune", &self.pending_sparse_trie_prune)
+            .field("pending_sparse_trie_prune", &self.state.pending_sparse_trie_prune())
             .finish_non_exhaustive()
     }
 }
@@ -209,11 +183,7 @@ where
 
     /// Takes the pending sparse trie prune request as in-memory parent-chain blocks, if any.
     pub fn take_sparse_trie_prune_blocks(&mut self) -> Option<Vec<ExecutedBlock<N>>> {
-        take_pending_sparse_trie_prune_blocks(
-            self.pending_sparse_trie_prune,
-            self.state,
-            self.parent_hash,
-        )
+        self.state.take_sparse_trie_prune_blocks(self.parent_hash)
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -23,9 +23,10 @@ use reth_chain_state::{test_utils::TestBlockBuilder, BlockState, StateTrieOverla
 use reth_chainspec::{ChainSpec, HOLESKY, MAINNET};
 use reth_engine_primitives::{EngineApiValidator, ForkchoiceStatus, NoopInvalidBlockHook};
 use reth_ethereum_consensus::EthBeaconConsensus;
-use reth_ethereum_engine_primitives::EthEngineTypes;
+use reth_ethereum_engine_primitives::{EthEngineTypes, EthPayloadAttributes};
 use reth_ethereum_primitives::{Block, EthPrimitives};
 use reth_evm_ethereum::MockEvmConfig;
+use reth_payload_builder::PayloadServiceCommand;
 use reth_primitives_traits::Block as _;
 use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore, RawBal};
 use reth_tasks::spawn_os_thread;
@@ -198,6 +199,7 @@ struct TestHarness {
         FromEngine<EngineApiRequest<EthEngineTypes, EthPrimitives>, Block>,
     >,
     from_tree_rx: UnboundedReceiver<EngineApiEvent>,
+    payload_command_rx: UnboundedReceiver<PayloadServiceCommand<EthEngineTypes>>,
     blocks: Vec<ExecutedBlock>,
     action_rx: Receiver<PersistenceAction>,
     block_builder: TestBlockBuilder,
@@ -206,9 +208,13 @@ struct TestHarness {
 
 impl TestHarness {
     fn new(chain_spec: Arc<ChainSpec>) -> Self {
+        Self::with_config(chain_spec, TreeConfig::default().with_has_enough_parallelism(true))
+    }
+
+    fn with_config(chain_spec: Arc<ChainSpec>, tree_config: TreeConfig) -> Self {
         use std::sync::mpsc::channel;
         let (action_tx, action_rx) = channel();
-        Self::with_persistence_channel(chain_spec, action_tx, action_rx)
+        Self::with_persistence_channel_and_config(chain_spec, action_tx, action_rx, tree_config)
     }
 
     #[expect(dead_code)]
@@ -222,6 +228,20 @@ impl TestHarness {
         action_tx: Sender<PersistenceAction>,
         action_rx: Receiver<PersistenceAction>,
     ) -> Self {
+        Self::with_persistence_channel_and_config(
+            chain_spec,
+            action_tx,
+            action_rx,
+            TreeConfig::default().with_has_enough_parallelism(true),
+        )
+    }
+
+    fn with_persistence_channel_and_config(
+        chain_spec: Arc<ChainSpec>,
+        action_tx: Sender<PersistenceAction>,
+        action_rx: Receiver<PersistenceAction>,
+        tree_config: TreeConfig,
+    ) -> Self {
         let persistence_handle = PersistenceHandle::new(action_tx);
 
         let consensus = Arc::new(EthBeaconConsensus::new(chain_spec.clone()));
@@ -231,7 +251,6 @@ impl TestHarness {
         let payload_validator = MockEngineValidator;
 
         let (from_tree_tx, from_tree_rx) = unbounded_channel();
-        let tree_config = TreeConfig::default().with_has_enough_parallelism(true);
         let runtime = reth_tasks::Runtime::test();
         let state_trie_overlays =
             StateTrieOverlayManager::new(runtime.state_trie_overlay_worker_pool());
@@ -248,7 +267,7 @@ impl TestHarness {
         );
         let canonical_in_memory_state = CanonicalInMemoryState::with_head(header, None, None);
 
-        let (to_payload_service, _payload_command_rx) = unbounded_channel();
+        let (to_payload_service, payload_command_rx) = unbounded_channel();
         let payload_builder = PayloadBuilderHandle::new(to_payload_service);
 
         let evm_config = MockEvmConfig::default();
@@ -258,7 +277,7 @@ impl TestHarness {
             consensus.clone(),
             evm_config.clone(),
             payload_validator,
-            TreeConfig::default(),
+            tree_config.clone(),
             Box::new(NoopInvalidBlockHook::default()),
             changeset_cache.clone(),
             state_trie_overlays,
@@ -287,6 +306,7 @@ impl TestHarness {
             to_tree_tx: tree.incoming_tx.clone(),
             tree,
             from_tree_rx,
+            payload_command_rx,
             blocks: vec![],
             action_rx,
             block_builder,
@@ -723,6 +743,47 @@ fn remove_blocks_clears_pending_sparse_trie_prune_request() {
     test_harness.tree.remove_blocks(9);
 
     assert!(test_harness.tree.pending_sparse_trie_prune.is_none());
+}
+
+#[test]
+fn process_payload_attributes_threads_sparse_trie_prune_into_payload_builder_task() {
+    let config = TreeConfig::default()
+        .with_has_enough_parallelism(true)
+        .with_share_sparse_trie_with_payload_builder(true);
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
+    let mut test_harness = TestHarness::with_config(MAINNET.clone(), config).with_blocks(blocks);
+    let head =
+        test_harness.blocks.last().unwrap().recovered_block().clone_sealed_header().clone_header();
+    let head_hash = test_harness.blocks.last().unwrap().recovered_block().hash();
+    let state = test_harness.fcu_state(head_hash);
+    test_harness.tree.pending_sparse_trie_prune = Some(trie_changed_paths(
+        Nibbles::from_nibbles([0x01]),
+        B256::with_last_byte(0x01),
+        Nibbles::from_nibbles([0x02]),
+    ));
+
+    let updated = test_harness.tree.process_payload_attributes(
+        EthPayloadAttributes {
+            timestamp: head.timestamp() + 1,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: Default::default(),
+            withdrawals: None,
+            parent_beacon_block_root: None,
+            slot_number: None,
+            target_gas_limit: None,
+        },
+        &head,
+        state,
+    );
+
+    assert_eq!(updated.forkchoice_status(), ForkchoiceStatus::Valid);
+    assert!(test_harness.tree.pending_sparse_trie_prune.is_none());
+
+    let command = test_harness.payload_command_rx.try_recv().unwrap();
+    let PayloadServiceCommand::BuildNewPayload(input, _, _) = command else {
+        panic!("expected build new payload command")
+    };
+    assert!(input.state_root_handle.is_some());
 }
 
 #[tokio::test]

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -494,7 +494,6 @@ impl ValidatorTestHarness {
         let ctx = TreeCtx::new(
             &mut self.harness.tree.state,
             &self.harness.tree.canonical_in_memory_state,
-            &mut self.harness.tree.pending_sparse_trie_prune,
         );
         let result = self.validator.validate_block(block, ctx);
         self.metrics.record_validation(result.is_ok());
@@ -626,7 +625,7 @@ fn on_new_persisted_block_queues_sparse_trie_prune_request() {
 
     test_harness.tree.on_new_persisted_block().unwrap();
 
-    assert!(test_harness.tree.pending_sparse_trie_prune);
+    assert!(test_harness.tree.state.pending_sparse_trie_prune());
 }
 
 #[test]
@@ -640,7 +639,7 @@ fn on_new_persisted_block_queues_sparse_trie_prune_when_changed_paths_unknown() 
 
     test_harness.tree.on_new_persisted_block().unwrap();
 
-    assert!(test_harness.tree.pending_sparse_trie_prune);
+    assert!(test_harness.tree.state.pending_sparse_trie_prune());
 }
 
 #[test]
@@ -663,7 +662,7 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled(
 
         test_harness.tree.on_new_persisted_block().unwrap();
 
-        assert!(!test_harness.tree.pending_sparse_trie_prune);
+        assert!(!test_harness.tree.state.pending_sparse_trie_prune());
     }
 }
 
@@ -672,11 +671,11 @@ fn remove_blocks_clears_pending_sparse_trie_prune_request() {
     let mut test_harness = TestHarness::new(MAINNET.clone());
     test_harness.tree.persistence_state.last_persisted_block =
         BlockNumHash { hash: B256::random(), number: 10 };
-    test_harness.tree.pending_sparse_trie_prune = true;
+    test_harness.tree.state.set_pending_sparse_trie_prune(true);
 
     test_harness.tree.remove_blocks(9);
 
-    assert!(!test_harness.tree.pending_sparse_trie_prune);
+    assert!(!test_harness.tree.state.pending_sparse_trie_prune());
 }
 
 #[test]
@@ -690,7 +689,7 @@ fn process_payload_attributes_threads_sparse_trie_prune_into_payload_builder_tas
         test_harness.blocks.last().unwrap().recovered_block().clone_sealed_header().clone_header();
     let head_hash = test_harness.blocks.last().unwrap().recovered_block().hash();
     let state = test_harness.fcu_state(head_hash);
-    test_harness.tree.pending_sparse_trie_prune = true;
+    test_harness.tree.state.set_pending_sparse_trie_prune(true);
 
     let updated = test_harness.tree.process_payload_attributes(
         EthPayloadAttributes {
@@ -707,7 +706,7 @@ fn process_payload_attributes_threads_sparse_trie_prune_into_payload_builder_tas
     );
 
     assert_eq!(updated.forkchoice_status(), ForkchoiceStatus::Valid);
-    assert!(!test_harness.tree.pending_sparse_trie_prune);
+    assert!(!test_harness.tree.state.pending_sparse_trie_prune());
 
     let command = test_harness.payload_command_rx.try_recv().unwrap();
     let PayloadServiceCommand::BuildNewPayload(input, _, _) = command else {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -30,11 +30,8 @@ use reth_payload_builder::PayloadServiceCommand;
 use reth_primitives_traits::Block as _;
 use reth_provider::{test_utils::MockEthProvider, BalStoreHandle, InMemoryBalStore, RawBal};
 use reth_tasks::spawn_os_thread;
-use reth_trie::{
-    prefix_set::{PrefixSetMut, TriePrefixSetsMut},
-    LazyTrieData,
-};
-use reth_trie_common::{ComputedTrieData, Nibbles};
+use reth_trie::{prefix_set::TriePrefixSetsMut, LazyTrieData};
+use reth_trie_common::ComputedTrieData;
 use std::{
     collections::BTreeMap,
     str::FromStr,
@@ -61,31 +58,6 @@ fn with_changed_paths(
 
 fn with_empty_changed_paths(block: ExecutedBlock<EthPrimitives>) -> ExecutedBlock<EthPrimitives> {
     with_changed_paths(block, TriePrefixSetsMut::default())
-}
-
-fn trie_changed_paths(
-    account_path: Nibbles,
-    storage_account: B256,
-    storage_path: Nibbles,
-) -> TriePrefixSetsMut {
-    TriePrefixSetsMut {
-        account_prefix_set: PrefixSetMut::from([account_path]),
-        storage_prefix_sets: B256Map::from_iter([(
-            storage_account,
-            PrefixSetMut::from([storage_path]),
-        )]),
-        destroyed_accounts: Default::default(),
-    }
-}
-
-fn merged_changed_paths(blocks: &[ExecutedBlock<EthPrimitives>]) -> TriePrefixSetsMut {
-    let mut merged = TriePrefixSetsMut::default();
-    for block in blocks {
-        let trie_data = block.trie_data();
-        let changed_paths = trie_data.changed_paths.as_deref().expect("changed paths are present");
-        merged.extend_ref(changed_paths);
-    }
-    merged
 }
 
 /// Mock engine validator for tests
@@ -645,58 +617,6 @@ async fn test_tree_persist_blocks() {
 
 #[test]
 fn on_new_persisted_block_queues_sparse_trie_prune_request() {
-    let changed_paths = [
-        trie_changed_paths(
-            Nibbles::from_nibbles([0x01]),
-            B256::with_last_byte(0x01),
-            Nibbles::from_nibbles([0x02]),
-        ),
-        trie_changed_paths(
-            Nibbles::from_nibbles([0x03]),
-            B256::with_last_byte(0x02),
-            Nibbles::from_nibbles([0x04]),
-        ),
-        trie_changed_paths(
-            Nibbles::from_nibbles([0x05]),
-            B256::with_last_byte(0x03),
-            Nibbles::from_nibbles([0x06]),
-        ),
-    ];
-    let blocks: Vec<_> = TestBlockBuilder::eth()
-        .get_executed_blocks(1..4)
-        .zip(changed_paths)
-        .map(|(block, changed_paths)| with_changed_paths(block, changed_paths))
-        .collect();
-    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    test_harness
-        .tree
-        .persistence_state
-        .finish(blocks[0].recovered_block().hash(), blocks[0].recovered_block().number);
-
-    test_harness.tree.on_new_persisted_block().unwrap();
-
-    let retained_paths =
-        test_harness.tree.pending_sparse_trie_prune.as_ref().unwrap().clone().freeze();
-    let expected_retained_paths = merged_changed_paths(&blocks[1..]).freeze();
-
-    assert_eq!(
-        retained_paths.account_prefix_set.slice(),
-        expected_retained_paths.account_prefix_set.slice()
-    );
-    assert_eq!(
-        retained_paths.storage_prefix_sets.len(),
-        expected_retained_paths.storage_prefix_sets.len()
-    );
-    for (storage_account, expected_slots) in expected_retained_paths.storage_prefix_sets {
-        assert_eq!(
-            retained_paths.storage_prefix_sets[&storage_account].slice(),
-            expected_slots.slice()
-        );
-    }
-}
-
-#[test]
-fn on_new_persisted_block_skips_sparse_trie_prune_when_changed_paths_unknown() {
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
     let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
     test_harness
@@ -706,7 +626,21 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_changed_paths_unknown() {
 
     test_harness.tree.on_new_persisted_block().unwrap();
 
-    assert!(test_harness.tree.pending_sparse_trie_prune.is_none());
+    assert!(test_harness.tree.pending_sparse_trie_prune);
+}
+
+#[test]
+fn on_new_persisted_block_queues_sparse_trie_prune_when_changed_paths_unknown() {
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
+    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
+    test_harness
+        .tree
+        .persistence_state
+        .finish(blocks[0].recovered_block().hash(), blocks[0].recovered_block().number);
+
+    test_harness.tree.on_new_persisted_block().unwrap();
+
+    assert!(test_harness.tree.pending_sparse_trie_prune);
 }
 
 #[test]
@@ -729,7 +663,7 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled(
 
         test_harness.tree.on_new_persisted_block().unwrap();
 
-        assert!(test_harness.tree.pending_sparse_trie_prune.is_none());
+        assert!(!test_harness.tree.pending_sparse_trie_prune);
     }
 }
 
@@ -738,11 +672,11 @@ fn remove_blocks_clears_pending_sparse_trie_prune_request() {
     let mut test_harness = TestHarness::new(MAINNET.clone());
     test_harness.tree.persistence_state.last_persisted_block =
         BlockNumHash { hash: B256::random(), number: 10 };
-    test_harness.tree.pending_sparse_trie_prune = Some(Default::default());
+    test_harness.tree.pending_sparse_trie_prune = true;
 
     test_harness.tree.remove_blocks(9);
 
-    assert!(test_harness.tree.pending_sparse_trie_prune.is_none());
+    assert!(!test_harness.tree.pending_sparse_trie_prune);
 }
 
 #[test]
@@ -756,11 +690,7 @@ fn process_payload_attributes_threads_sparse_trie_prune_into_payload_builder_tas
         test_harness.blocks.last().unwrap().recovered_block().clone_sealed_header().clone_header();
     let head_hash = test_harness.blocks.last().unwrap().recovered_block().hash();
     let state = test_harness.fcu_state(head_hash);
-    test_harness.tree.pending_sparse_trie_prune = Some(trie_changed_paths(
-        Nibbles::from_nibbles([0x01]),
-        B256::with_last_byte(0x01),
-        Nibbles::from_nibbles([0x02]),
-    ));
+    test_harness.tree.pending_sparse_trie_prune = true;
 
     let updated = test_harness.tree.process_payload_attributes(
         EthPayloadAttributes {
@@ -777,7 +707,7 @@ fn process_payload_attributes_threads_sparse_trie_prune_into_payload_builder_tas
     );
 
     assert_eq!(updated.forkchoice_status(), ForkchoiceStatus::Valid);
-    assert!(test_harness.tree.pending_sparse_trie_prune.is_none());
+    assert!(!test_harness.tree.pending_sparse_trie_prune);
 
     let command = test_harness.payload_command_rx.try_recv().unwrap();
     let PayloadServiceCommand::BuildNewPayload(input, _, _) = command else {


### PR DESCRIPTION
This fixes one race condition and one wiring oversight. Neither of these are really bugs at the moment because pruning is best effort, but after #25952 that won't be the case.

The wiring oversight is that the sparse trie queue job was previously not being threaded through to payload builder, so we could miss an entire pruning job.

The bigger bug is a race condition in how the prune retention set and payload builder could interact. Normally, with payload validation, the following sequence occurs:

* validation of block M+1 starts
* persistence of N..=M finishes
    * validation blocks the engine task, so on_persistence_complete has to wait until validation finishes
* validation of M+1 finishes, M+1 added to in-memory chain
* on_persistence_complete runs, queues pruning using retention set based on N..=M+1

But with payload _building_ engine task isn't blocked, building happens asynchronously, so the following can happen:

* building of block M+1 starts (async)
* persistence of N..=M finishes
* on_persistence_complete runs, queues pruning using retention set based on N..=M (missing M+1!)
* building of M+1 finishes
* validation of M+2 starts, runs queued prune job, retains only changes from N..=M, does not retain changes from M+1

We fix this by not constructing the retention set in the engine task as part of on_persistence_complete. Instead the queued job is simply a boolean, and we pass the necessary ExecutedBlocks to the sparse trie task when it is initialized based on its parent_hash, that way we never miss any blocks. The sparse trie task constructs the retention set after SR is computed, so this has the added benefit of making retention set construction async.