### PR TITLE
fix(net): reset reputation when admin unbans a peer

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -956,9 +956,15 @@ impl PeersManager {
         self.ban_list.ban_peer(peer_id);
     }
 
-    /// Removes the peer from the ban list.
+    /// Removes the peer from the ban list and resets its reputation.
     pub(crate) fn unban_peer_by_admin(&mut self, peer_id: PeerId) {
         self.ban_list.unban_peer(&peer_id);
+        if let Some(peer) = self.peers.get_mut(&peer_id) &&
+            peer.is_banned()
+        {
+            peer.unban();
+            self.queued_actions.push_back(PeerAction::UnBanPeer { peer_id });
+        }
     }
 
     /// Connect to the given peer. NOTE: if the maximum number of outbound sessions is reached,
@@ -1703,7 +1709,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_admin_unban_only_removes_banlist_entry() {
+    async fn test_admin_unban_resets_reputation() {
         let peer = PeerId::random();
         let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
         let mut peers = PeersManager::default();
@@ -1716,7 +1722,11 @@ mod tests {
         peers.unban_peer_by_admin(peer);
 
         assert!(!peers.ban_list.is_banned_peer(&peer));
-        assert!(peers.peers.get(&peer).is_some_and(Peer::is_banned));
+        assert!(!peers.peers.get(&peer).is_some_and(Peer::is_banned));
+        assert!(matches!(
+            peers.queued_actions.pop_front(),
+            Some(PeerAction::UnBanPeer { peer_id }) if peer_id == peer
+        ));
     }
 
     #[tokio::test]

--- a/docs/vocs/docs/pages/jsonrpc/admin.mdx
+++ b/docs/vocs/docs/pages/jsonrpc/admin.mdx
@@ -96,7 +96,7 @@ Returns `true` once the request has been accepted.
 
 ## `admin_unbanPeer`
 
-Removes a remote peer from the ban list.
+Removes a remote peer from the ban list and resets its reputation so it can reconnect.
 
 Returns `true` once the request has been accepted.
 


### PR DESCRIPTION
`unban_peer_by_admin` (#25140) only clears the ban-list entry. A reputation-banned peer keeps `reputation < BANNED_REPUTATION`, so incoming sessions are rejected via `DisconnectBannedIncoming`, it's excluded from `best_unconnected`, and `tick()` only heals connected peers — the peer stays unconnectable until restart, and removing the list entry cancels the `ban_list.evict` → `peer.unban()` reset natural expiry would have applied. The `Admin` trait documents this method as "Unbans a remote node". Mirror the expiry path (reset + `PeerAction::UnBanPeer`), gated on `is_banned()`; docs updated.