### PR TITLE
fix(metrics): support custom tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7978,6 +7978,7 @@ dependencies = [
  "eyre",
  "libc",
  "metrics",
+ "metrics-util",
  "page_size",
  "parking_lot",
  "proptest",

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -59,6 +59,7 @@ alloy-consensus.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 parking_lot.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 
 serde.workspace = true
 

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -315,9 +315,17 @@ impl DatabaseMetrics for DatabaseEnv {
     fn gauge_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
         let mut metrics = Vec::new();
 
+        // Report the static tables and any tracked custom tables, e.g. node-specific tables
+        // created through [`DatabaseEnv::create_and_track_tables_for`].
+        let custom_tables = self
+            .dbis
+            .keys()
+            .copied()
+            .filter(|name| Tables::ALL.iter().all(|table| table.name() != *name));
+
         let _ = self
             .view(|tx| {
-                for table in Tables::ALL.iter().map(Tables::name) {
+                for table in Tables::ALL.iter().map(Tables::name).chain(custom_tables) {
                     let table_db =
                         tx.inner().open_db(Some(table)).wrap_err("Could not open db.")?;
 
@@ -727,6 +735,84 @@ mod tests {
     #[test]
     fn db_creation() {
         let _tempdir = create_test_db(DatabaseEnvKind::RW);
+    }
+
+    #[test]
+    fn db_metrics_on_custom_table() {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        /// Tables outside the static [`crate::Tables`] set.
+        mod custom_tables {
+            use reth_db_api::{table::TableInfo, tables, TableSet, TableType, TableViewer};
+            use std::fmt;
+
+            tables! {
+                /// A node-specific table.
+                table CustomTable {
+                    type Key = u64;
+                    type Value = Vec<u8>;
+                }
+            }
+        }
+        use custom_tables::{CustomTable, Tables as CustomTables};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            let tempdir = tempfile::TempDir::new().expect(ERROR_TEMPDIR);
+            let mut env = DatabaseEnv::open(
+                tempdir.path(),
+                DatabaseEnvKind::RW,
+                DatabaseArguments::new(ClientVersion::default()),
+            )
+            .expect(ERROR_DB_CREATION);
+            env.create_tables().expect(ERROR_TABLE_CREATION);
+            env.create_and_track_tables_for::<CustomTables>().expect(ERROR_TABLE_CREATION);
+            let env = env.with_metrics();
+
+            let tx = env.tx_mut().expect(ERROR_INIT_TX);
+            tx.put::<CustomTable>(1, vec![0xff]).expect(ERROR_PUT);
+            assert_eq!(tx.get::<CustomTable>(1).expect(ERROR_GET), Some(vec![0xff]));
+
+            // Regression: opening a cursor on a table without pre-bound metric handles used to
+            // panic with "table operation metric handles not found".
+            let mut cursor = tx.cursor_write::<CustomTable>().expect("could not create cursor");
+            cursor.upsert(2, &vec![0xee]).expect(ERROR_UPSERT);
+            tx.commit().expect(ERROR_COMMIT);
+
+            // Table stat gauges must include tracked custom tables.
+            let gauges = env.gauge_metrics();
+            assert!(
+                gauges.iter().any(|(name, _, labels)| {
+                    *name == "db.table_size" &&
+                        labels.iter().any(|label| {
+                            label.key() == "table" && label.value() == "CustomTable"
+                        })
+                }),
+                "no table size gauge for the custom table"
+            );
+        });
+
+        // Operations on the custom table must be recorded like operations on static tables.
+        let snapshot = snapshotter.snapshot().into_vec();
+        let operation_calls = |operation: &str| {
+            snapshot.iter().find_map(|(key, _, _, value)| {
+                let key = key.key();
+                let matches = key.name() == "database.operation.calls_total" &&
+                    key.labels()
+                        .any(|label| label.key() == "table" && label.value() == "CustomTable") &&
+                    key.labels()
+                        .any(|label| label.key() == "operation" && label.value() == operation);
+                match value {
+                    DebugValue::Counter(count) if matches => Some(*count),
+                    _ => None,
+                }
+            })
+        };
+        assert_eq!(operation_calls("get"), Some(1));
+        assert_eq!(operation_calls("put-upsert"), Some(1));
+        assert_eq!(operation_calls("cursor-upsert"), Some(1));
     }
 
     #[test]

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -315,17 +315,9 @@ impl DatabaseMetrics for DatabaseEnv {
     fn gauge_metrics(&self) -> Vec<(&'static str, f64, Vec<Label>)> {
         let mut metrics = Vec::new();
 
-        // Report the static tables and any tracked custom tables, e.g. node-specific tables
-        // created through [`DatabaseEnv::create_and_track_tables_for`].
-        let custom_tables = self
-            .dbis
-            .keys()
-            .copied()
-            .filter(|name| Tables::ALL.iter().all(|table| table.name() != *name));
-
         let _ = self
             .view(|tx| {
-                for table in Tables::ALL.iter().map(Tables::name).chain(custom_tables) {
+                for table in self.dbis.keys().copied() {
                     let table_db =
                         tx.inner().open_db(Some(table)).wrap_err("Could not open db.")?;
 

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -3,7 +3,11 @@ use metrics::Histogram;
 use quanta::Instant;
 use reth_metrics::{metrics::Counter, Metrics};
 use rustc_hash::FxHashMap;
-use std::{array, sync::Arc, time::Duration};
+use std::{
+    array,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 use strum::{EnumCount, EnumIter, IntoEnumIterator};
 
 const LARGE_VALUE_THRESHOLD_BYTES: usize = 4096;
@@ -15,8 +19,15 @@ const LARGE_VALUE_THRESHOLD_BYTES: usize = 4096;
 /// Otherwise, metric recording will no-op.
 #[derive(Debug)]
 pub(crate) struct DatabaseEnvMetrics {
-    /// Caches per-table operation metric handles for all database operation metrics.
+    /// Caches per-table operation metric handles for all tables in the static [`Tables`] set.
+    /// Pre-populated at construction, so lookups on the hot path are lock-free.
     operations: FxHashMap<&'static str, TableOperationMetrics>,
+    /// Caches operation metric handles for tables outside the static [`Tables`] set, e.g.
+    /// node-specific tables created through
+    /// [`create_and_track_tables_for`](crate::DatabaseEnv::create_and_track_tables_for).
+    /// Such tables can be created at any point after metrics are enabled, so their handles are
+    /// bound lazily on first use.
+    custom_operations: RwLock<FxHashMap<&'static str, TableOperationMetrics>>,
     /// Caches `TransactionMetrics` handles for counters grouped by only transaction mode.
     /// Updated both at tx open and close.
     transactions: FxHashMap<TransactionMode, TransactionMetrics>,
@@ -35,6 +46,7 @@ impl DatabaseEnvMetrics {
         // to avoid runtime locks on the map when recording metrics.
         Self {
             operations: Self::generate_operation_handles(),
+            custom_operations: RwLock::new(FxHashMap::default()),
             transactions: Self::generate_transaction_handles(),
             transaction_outcomes: Self::generate_transaction_outcome_handles(),
         }
@@ -45,19 +57,21 @@ impl DatabaseEnvMetrics {
         let mut operations = FxHashMap::with_capacity_and_hasher(Tables::COUNT, Default::default());
 
         for table in Tables::ALL {
-            let table_name = table.name();
-            let metrics = array::from_fn(|index| {
-                let operation = Operation::from_index(index);
-                OperationMetrics::new_with_labels(&[
-                    (Labels::Table.as_str(), table_name),
-                    (Labels::Operation.as_str(), operation.as_str()),
-                ])
-            });
-
-            operations.insert(table_name, Arc::new(metrics));
+            operations.insert(table.name(), Self::operation_handles(table.name()));
         }
 
         operations
+    }
+
+    /// Creates pre-bound operation metric handles for one table.
+    fn operation_handles(table_name: &'static str) -> TableOperationMetrics {
+        Arc::new(array::from_fn(|index| {
+            let operation = Operation::from_index(index);
+            OperationMetrics::new_with_labels(&[
+                (Labels::Table.as_str(), table_name),
+                (Labels::Operation.as_str(), operation.as_str()),
+            ])
+        }))
     }
 
     /// Generate a map of all possible transaction modes to metric handles.
@@ -99,7 +113,6 @@ impl DatabaseEnvMetrics {
     }
 
     /// Record a metric for database operation executed in `f`.
-    /// Panics if a metric recorder is not found for the given table and operation.
     pub(crate) fn record_operation<R>(
         &self,
         table: &'static str,
@@ -108,15 +121,40 @@ impl DatabaseEnvMetrics {
         f: impl FnOnce() -> R,
     ) -> R {
         if let Some(metrics) = self.operations.get(table) {
-            metrics[operation.index()].record(value_size, f)
-        } else {
-            f()
+            return metrics[operation.index()].record(value_size, f)
         }
+        // Clone the handle out of the map, so the lock is not held across the database
+        // operation.
+        let metrics = self.clone_custom_table_operation_metrics(table);
+        metrics[operation.index()].record(value_size, f)
     }
 
     /// Returns pre-bound operation metric handles for a single table.
+    ///
+    /// Handles for tables in the static [`Tables`] set are pre-populated. Handles for other
+    /// tables are bound on first use, see [`Self::clone_custom_table_operation_metrics`].
     pub(crate) fn table_operation_metrics(&self, table: &'static str) -> TableOperationMetrics {
-        self.operations.get(table).expect("table operation metric handles not found").clone()
+        match self.operations.get(table) {
+            Some(metrics) => metrics.clone(),
+            None => self.clone_custom_table_operation_metrics(table),
+        }
+    }
+
+    /// Returns operation metric handles for a table outside the static [`Tables`] set, creating
+    /// and caching them on first use.
+    fn clone_custom_table_operation_metrics(&self, table: &'static str) -> TableOperationMetrics {
+        if let Some(metrics) = self.custom_operations.read().unwrap().get(table) {
+            return metrics.clone()
+        }
+        // Two threads can race past the read miss for the same table. The `entry` call under the
+        // write lock keeps a single cached handle, and metrics-rs resolves equal names and labels
+        // to the same series anyway.
+        self.custom_operations
+            .write()
+            .unwrap()
+            .entry(table)
+            .or_insert_with(|| Self::operation_handles(table))
+            .clone()
     }
 
     /// Record metrics for opening a database transaction.


### PR DESCRIPTION
With https://github.com/paradigmxyz/reth/pull/26308 it will become possible to create side tables for downstream users of reth to store aux data. However, there is a gap: if such table was actually used a panic would be raised because of the expectation of the closed-set of tables. This changeset fixes that by introducing a dynamic set of custom tables.
