### PR TITLE
perf(txpool): reduce validation-to-insertion overhead

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -133,3 +133,8 @@ arbitrary = [
 name = "saturated_pool"
 harness = false
 required-features = ["test-utils"]
+
+[[bench]]
+name = "validation_pipeline"
+harness = false
+required-features = ["test-utils"]

--- a/crates/transaction-pool/benches/validation_pipeline.rs
+++ b/crates/transaction-pool/benches/validation_pipeline.rs
@@ -1,0 +1,453 @@
+#![allow(missing_docs)]
+
+//! Microbenchmarks for validation dispatch and the validation-to-insertion pipeline.
+
+use alloy_primitives::{Address, B256};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use futures_util::future::join_all;
+use reth_evm_ethereum::EthEvmConfig;
+use reth_primitives_traits::SignedTransaction;
+use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+use reth_transaction_pool::{
+    blobstore::InMemoryBlobStore,
+    noop::MockTransactionValidator,
+    test_utils::{MockOrdering, MockTransaction, TransactionBuilder},
+    validate::EthTransactionValidatorBuilder,
+    AddedTransactionOutcome, EthPooledTransaction, EthTransactionValidator, Pool, PoolConfig,
+    PoolResult, PoolTransaction, TransactionOrigin, TransactionPool, TransactionValidationOutcome,
+    TransactionValidationTaskExecutor, TransactionValidator,
+};
+use std::hint::black_box;
+use tokio::runtime::{Builder, Runtime};
+
+type DirectPool = Pool<MockTransactionValidator<MockTransaction>, MockOrdering, InMemoryBlobStore>;
+type TaskValidator = TransactionValidationTaskExecutor<MockTransactionValidator<MockTransaction>>;
+type TaskPool = Pool<TaskValidator, MockOrdering, InMemoryBlobStore>;
+type EthValidator = EthTransactionValidator<MockEthProvider, EthPooledTransaction, EthEvmConfig>;
+type InsertResults = Vec<PoolResult<AddedTransactionOutcome>>;
+
+fn runtime() -> Runtime {
+    Builder::new_multi_thread().worker_threads(2).enable_all().build().unwrap()
+}
+
+fn make_transaction(id: u64) -> MockTransaction {
+    make_transaction_for(id, id, 0)
+}
+
+fn make_transaction_for(id: u64, sender_id: u64, nonce: u64) -> MockTransaction {
+    let mut hash = [0u8; 32];
+    hash[24..].copy_from_slice(&id.to_be_bytes());
+    let mut sender = [0u8; 20];
+    sender[12..].copy_from_slice(&sender_id.to_be_bytes());
+
+    MockTransaction::eip1559()
+        .with_hash(B256::from(hash))
+        .with_sender(Address::from(sender))
+        .with_nonce(nonce)
+        .with_gas_limit(21_000)
+        .with_max_fee(1_000_000_000)
+        .with_priority_fee(1_000_000)
+        .with_size(128)
+}
+
+fn distinct_transactions(count: usize) -> Vec<MockTransaction> {
+    (0..count).map(|index| make_transaction(index as u64 + 1)).collect()
+}
+
+fn same_sender_transactions(count: usize) -> Vec<MockTransaction> {
+    (0..count).map(|index| make_transaction_for(index as u64 + 1, 1, index as u64)).collect()
+}
+
+fn make_eth_transaction(signer_id: u64, nonce: u64) -> EthPooledTransaction {
+    let mut signer = [0u8; 32];
+    signer[24..].copy_from_slice(&signer_id.max(1).to_be_bytes());
+    let transaction = TransactionBuilder::default()
+        .signer(B256::from(signer))
+        .nonce(nonce)
+        .gas_limit(100_000)
+        .max_fee_per_gas(1_000_000_000)
+        .max_priority_fee_per_gas(1_000_000)
+        .into_eip1559()
+        .try_into_recovered()
+        .unwrap();
+    EthPooledTransaction::try_from_consensus(transaction).unwrap()
+}
+
+fn eth_validation_fixture(
+    count: usize,
+    same_sender: bool,
+) -> (EthValidator, Vec<EthPooledTransaction>) {
+    let provider = MockEthProvider::default().with_genesis_block();
+    let transactions = (0..count)
+        .map(|index| {
+            let signer_id = if same_sender { 1 } else { index as u64 + 1 };
+            let nonce = if same_sender { index as u64 } else { 0 };
+            let transaction = make_eth_transaction(signer_id, nonce);
+            provider.add_account(
+                transaction.sender(),
+                ExtendedAccount::new(0, alloy_primitives::U256::MAX),
+            );
+            transaction
+        })
+        .collect();
+    let validator = EthTransactionValidatorBuilder::new(provider, EthEvmConfig::mainnet())
+        .build(InMemoryBlobStore::default());
+    (validator, transactions)
+}
+
+fn direct_pool(config: PoolConfig) -> DirectPool {
+    Pool::new(
+        MockTransactionValidator::default(),
+        MockOrdering::default(),
+        InMemoryBlobStore::default(),
+        config,
+    )
+}
+
+fn task_pool(validator: TaskValidator) -> TaskPool {
+    Pool::new(
+        validator,
+        MockOrdering::default(),
+        InMemoryBlobStore::default(),
+        PoolConfig::default(),
+    )
+}
+
+fn task_validator(runtime: &Runtime) -> TaskValidator {
+    // Keep channel handoff isolated from the production task pool. These are dispatch
+    // microbenchmarks, not a model of production task scheduling.
+    let (validator, task) =
+        TransactionValidationTaskExecutor::new(MockTransactionValidator::default());
+    runtime.spawn(task.run());
+    validator
+}
+
+fn assert_valid<T: PoolTransaction>(label: &str, outcomes: &[TransactionValidationOutcome<T>]) {
+    for outcome in outcomes {
+        match outcome {
+            TransactionValidationOutcome::Valid { .. } => {}
+            TransactionValidationOutcome::Invalid(_, err) => {
+                panic!("{label} returned an invalid outcome: {err:?}")
+            }
+            TransactionValidationOutcome::Error(_, err) => {
+                panic!("{label} returned an error outcome: {err:?}")
+            }
+        }
+    }
+}
+
+fn assert_inserted(results: &[PoolResult<AddedTransactionOutcome>]) {
+    assert!(results.iter().all(Result::is_ok));
+}
+
+#[inline(never)]
+fn insert_direct_batch(
+    runtime: &Runtime,
+    pool: DirectPool,
+    transactions: Vec<MockTransaction>,
+) -> (DirectPool, InsertResults) {
+    let results =
+        runtime.block_on(pool.add_transactions(TransactionOrigin::External, transactions));
+    (pool, results)
+}
+
+#[inline(never)]
+fn insert_task_batch(
+    runtime: &Runtime,
+    pool: TaskPool,
+    transactions: Vec<MockTransaction>,
+) -> (TaskPool, InsertResults) {
+    let results =
+        runtime.block_on(pool.add_transactions(TransactionOrigin::External, transactions));
+    (pool, results)
+}
+
+fn bench_validation(c: &mut Criterion) {
+    let runtime = runtime();
+    let direct = MockTransactionValidator::default();
+    let dispatched = task_validator(&runtime);
+    let single_transaction = make_transaction(1);
+    let (eth_single_validator, eth_single_transactions) = eth_validation_fixture(1, false);
+
+    assert_valid(
+        "direct single",
+        &[runtime.block_on(
+            direct.validate_transaction(TransactionOrigin::External, single_transaction.clone()),
+        )],
+    );
+    assert_valid(
+        "task single",
+        &[runtime.block_on(
+            dispatched
+                .validate_transaction(TransactionOrigin::External, single_transaction.clone()),
+        )],
+    );
+    assert_valid(
+        "eth single",
+        &[eth_single_validator
+            .validate_one(TransactionOrigin::External, eth_single_transactions[0].clone())],
+    );
+
+    let mut group = c.benchmark_group("transaction_validation");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("direct_single", |b| {
+        b.iter_batched(
+            || single_transaction.clone(),
+            |transaction| {
+                black_box(runtime.block_on(
+                    direct.validate_transaction(TransactionOrigin::External, transaction),
+                ))
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("task_dispatch_single", |b| {
+        b.iter_batched(
+            || single_transaction.clone(),
+            |transaction| {
+                black_box(runtime.block_on(
+                    dispatched.validate_transaction(TransactionOrigin::External, transaction),
+                ))
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("eth_single", |b| {
+        b.iter_batched(
+            || eth_single_transactions[0].clone(),
+            |transaction| {
+                black_box(
+                    eth_single_validator.validate_one(TransactionOrigin::External, transaction),
+                )
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    for batch_size in [16usize, 128] {
+        let transactions = distinct_transactions(batch_size);
+        let (eth_distinct_validator, eth_distinct_transactions) =
+            eth_validation_fixture(batch_size, false);
+        let (eth_same_sender_validator, eth_same_sender_transactions) =
+            eth_validation_fixture(batch_size, true);
+
+        assert_valid(
+            "direct batch",
+            &runtime.block_on(direct.validate_transactions_with_origin(
+                TransactionOrigin::External,
+                transactions.clone(),
+            )),
+        );
+        assert_valid(
+            "task batch",
+            &runtime.block_on(dispatched.validate_transactions_with_origin(
+                TransactionOrigin::External,
+                transactions.clone(),
+            )),
+        );
+        assert_valid(
+            "task concurrent batch",
+            &runtime.block_on(join_all(transactions.iter().cloned().map(|transaction| {
+                dispatched.validate_transaction(TransactionOrigin::External, transaction)
+            }))),
+        );
+        assert_valid(
+            "eth distinct batch",
+            &runtime.block_on(eth_distinct_validator.validate_transactions_with_origin(
+                TransactionOrigin::External,
+                eth_distinct_transactions.clone(),
+            )),
+        );
+        assert_valid(
+            "eth same-sender batch",
+            &runtime.block_on(eth_same_sender_validator.validate_transactions_with_origin(
+                TransactionOrigin::External,
+                eth_same_sender_transactions.clone(),
+            )),
+        );
+
+        group.throughput(Throughput::Elements(batch_size as u64));
+        group.bench_function(format!("direct_batch_{batch_size}"), |b| {
+            b.iter_batched(
+                || transactions.clone(),
+                |transactions| {
+                    black_box(runtime.block_on(direct.validate_transactions_with_origin(
+                        TransactionOrigin::External,
+                        transactions,
+                    )))
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        group.bench_function(format!("task_dispatch_batch_{batch_size}"), |b| {
+            b.iter_batched(
+                || transactions.clone(),
+                |transactions| {
+                    black_box(runtime.block_on(dispatched.validate_transactions_with_origin(
+                        TransactionOrigin::External,
+                        transactions,
+                    )))
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        group.bench_function(format!("task_dispatch_concurrent_{batch_size}"), |b| {
+            b.iter_batched(
+                || transactions.clone(),
+                |transactions| {
+                    black_box(runtime.block_on(join_all(transactions.into_iter().map(
+                        |transaction| {
+                            dispatched
+                                .validate_transaction(TransactionOrigin::External, transaction)
+                        },
+                    ))))
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        group.bench_function(format!("eth_batch_{batch_size}_distinct_senders"), |b| {
+            b.iter_batched(
+                || eth_distinct_transactions.clone(),
+                |transactions| {
+                    black_box(runtime.block_on(
+                        eth_distinct_validator.validate_transactions_with_origin(
+                            TransactionOrigin::External,
+                            transactions,
+                        ),
+                    ))
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        group.bench_function(format!("eth_batch_{batch_size}_same_sender"), |b| {
+            b.iter_batched(
+                || eth_same_sender_transactions.clone(),
+                |transactions| {
+                    black_box(runtime.block_on(
+                        eth_same_sender_validator.validate_transactions_with_origin(
+                            TransactionOrigin::External,
+                            transactions,
+                        ),
+                    ))
+                },
+                BatchSize::LargeInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_validation_to_insert(c: &mut Criterion) {
+    let runtime = runtime();
+    let dispatched = task_validator(&runtime);
+    let single_transaction = make_transaction(1);
+
+    let direct_preflight = direct_pool(PoolConfig::default());
+    assert!(runtime
+        .block_on(
+            direct_preflight
+                .add_transaction(TransactionOrigin::External, single_transaction.clone(),)
+        )
+        .is_ok());
+    let task_preflight = task_pool(dispatched.clone());
+    assert!(runtime
+        .block_on(
+            task_preflight
+                .add_transaction(TransactionOrigin::External, single_transaction.clone(),)
+        )
+        .is_ok());
+
+    let mut group = c.benchmark_group("validation_to_insert");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("direct_single_empty_pool", |b| {
+        b.iter_batched(
+            || (direct_pool(PoolConfig::default()), single_transaction.clone()),
+            |(pool, transaction)| {
+                let result = runtime
+                    .block_on(pool.add_transaction(TransactionOrigin::External, transaction));
+                black_box((pool, result))
+            },
+            BatchSize::LargeInput,
+        )
+    });
+
+    group.bench_function("task_dispatch_single_empty_pool", |b| {
+        b.iter_batched(
+            || (task_pool(dispatched.clone()), single_transaction.clone()),
+            |(pool, transaction)| {
+                let result = runtime
+                    .block_on(pool.add_transaction(TransactionOrigin::External, transaction));
+                black_box((pool, result))
+            },
+            BatchSize::LargeInput,
+        )
+    });
+
+    // 512 is a non-default stress point; the default per-account limit is 16 transactions.
+    for batch_size in [16usize, 128, 512] {
+        let transactions = distinct_transactions(batch_size);
+        let same_sender = same_sender_transactions(batch_size);
+        let same_sender_config = PoolConfig { max_account_slots: batch_size, ..Default::default() };
+
+        let (preflight_pool, preflight_results) =
+            insert_direct_batch(&runtime, direct_pool(PoolConfig::default()), transactions.clone());
+        assert_inserted(&preflight_results);
+        drop(preflight_pool);
+        if batch_size <= 128 {
+            let (preflight_pool, preflight_results) =
+                insert_task_batch(&runtime, task_pool(dispatched.clone()), transactions.clone());
+            assert_inserted(&preflight_results);
+            drop(preflight_pool);
+        }
+        let (preflight_pool, preflight_results) = insert_direct_batch(
+            &runtime,
+            direct_pool(same_sender_config.clone()),
+            same_sender.clone(),
+        );
+        assert_inserted(&preflight_results);
+        drop(preflight_pool);
+
+        group.throughput(Throughput::Elements(batch_size as u64));
+        group.bench_function(format!("direct_batch_{batch_size}_empty_pool"), |b| {
+            b.iter_batched(
+                || (direct_pool(PoolConfig::default()), transactions.clone()),
+                |(pool, transactions)| black_box(insert_direct_batch(&runtime, pool, transactions)),
+                BatchSize::LargeInput,
+            )
+        });
+
+        if batch_size <= 128 {
+            group.bench_function(format!("task_dispatch_batch_{batch_size}_empty_pool"), |b| {
+                b.iter_batched(
+                    || (task_pool(dispatched.clone()), transactions.clone()),
+                    |(pool, transactions)| {
+                        black_box(insert_task_batch(&runtime, pool, transactions))
+                    },
+                    BatchSize::LargeInput,
+                )
+            });
+        }
+
+        group.bench_function(format!("direct_same_sender_batch_{batch_size}_empty_pool"), |b| {
+            b.iter_batched(
+                || (direct_pool(same_sender_config.clone()), same_sender.clone()),
+                |(pool, transactions)| black_box(insert_direct_batch(&runtime, pool, transactions)),
+                BatchSize::LargeInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_validation, bench_validation_to_insert);
+criterion_main!(benches);

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -498,8 +498,7 @@ where
         transaction: Self::Transaction,
     ) -> PoolResult<AddedTransactionOutcome> {
         let tx = self.validate(origin, transaction).await;
-        let mut results = self.pool.add_transactions(origin, std::iter::once(tx));
-        results.pop().expect("result length is the same as the input")
+        self.pool.add_transaction(origin, tx)
     }
 
     async fn add_transactions(
@@ -510,11 +509,8 @@ where
         if transactions.is_empty() {
             return Vec::new()
         }
-        let validated = self
-            .pool
-            .validator()
-            .validate_transactions(transactions.into_iter().map(|tx| (origin, tx)))
-            .await;
+        let validated =
+            self.pool.validator().validate_transactions_with_origin(origin, transactions).await;
         self.pool.add_transactions(origin, validated)
     }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -572,10 +572,7 @@ where
     ///
     /// Returns the outcome and optionally metadata to be processed after the pool lock is
     /// released.
-    ///
-    /// Note: this is only used internally by [`Self::add_transactions()`], all new transaction(s)
-    /// come in through that function, either as a batch or `std::iter::once`.
-    fn add_transaction(
+    fn add_transaction_locked(
         &self,
         pool: &mut RwLockWriteGuard<'_, TxPool<T>>,
         origin: TransactionOrigin,
@@ -590,7 +587,13 @@ where
                 bytecode_hash,
                 authorities,
             } => {
-                let sender_id = self.get_sender_id(transaction.sender());
+                let (sender_id, authority_ids) = {
+                    let mut identifiers = self.identifiers.write();
+                    let sender_id = identifiers.sender_id_or_create(transaction.sender());
+                    let authority_ids =
+                        authorities.map(|auths| identifiers.sender_ids_or_create(auths));
+                    (sender_id, authority_ids)
+                };
                 let transaction_id = TransactionId::new(sender_id, transaction.nonce());
 
                 // split the valid transaction and the blob sidecar if it has any
@@ -611,7 +614,7 @@ where
                     propagate,
                     timestamp: Instant::now(),
                     origin,
-                    authority_ids: authorities.map(|auths| self.get_sender_ids(auths)),
+                    authority_ids,
                 };
 
                 let added = match pool.add_transaction(tx, balance, state_nonce, bytecode_hash) {
@@ -636,6 +639,32 @@ where
         }
     }
 
+    /// Adds a single validated transaction to the pool.
+    pub(crate) fn add_transaction(
+        &self,
+        origin: TransactionOrigin,
+        tx: TransactionValidationOutcome<T::Transaction>,
+    ) -> PoolResult<AddedTransactionOutcome> {
+        let (mut result, added_meta, discarded) = {
+            let mut pool = self.pool.write();
+            let (result, added_meta) = self.add_transaction_locked(&mut pool, origin, tx);
+            let discarded = if added_meta.is_some() {
+                let discarded = pool.discard_worst();
+                pool.update_size_metrics();
+                discarded
+            } else {
+                Default::default()
+            };
+            (result, added_meta, discarded)
+        };
+
+        if let Some(meta) = added_meta {
+            self.on_added_transaction(meta);
+        }
+        self.process_discarded_results(std::slice::from_mut(&mut result), discarded);
+        result
+    }
+
     /// Adds a transaction and returns the event stream.
     pub fn add_transaction_and_subscribe(
         &self,
@@ -648,8 +677,7 @@ where
             self.mark_event_listener_installed();
             events
         };
-        let mut results = self.add_transactions(origin, std::iter::once(tx));
-        results.pop().expect("result length is the same as the input")?;
+        self.add_transaction(origin, tx)?;
         Ok(listener)
     }
 
@@ -673,34 +701,29 @@ where
             Item = (TransactionOrigin, TransactionValidationOutcome<T::Transaction>),
         >,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        let mut transactions = transactions.into_iter();
+        let capacity = transactions.size_hint().0;
+
         // Collect results and metadata while holding the pool write lock
         let (mut results, added_metas, discarded) = {
             let mut pool = self.pool.write();
             let mut added_metas = Vec::new();
+            let mut results = Vec::with_capacity(capacity);
 
-            let results = transactions
-                .into_iter()
-                .map(|(origin, tx)| {
-                    let (result, meta) = self.add_transaction(&mut pool, origin, tx);
-
-                    // Only collect metadata for successful insertions
-                    if result.is_ok() &&
-                        let Some(meta) = meta
-                    {
-                        added_metas.push(meta);
-                    }
-
-                    result
-                })
-                .collect::<Vec<_>>();
-
+            for (origin, tx) in transactions.by_ref() {
+                let (result, meta) = self.add_transaction_locked(&mut pool, origin, tx);
+                if let Some(meta) = meta {
+                    added_metas.push(meta);
+                }
+                results.push(result);
+            }
             // Enforce the pool size limits if at least one transaction was added successfully
-            let discarded = if results.iter().any(Result::is_ok) {
+            let discarded = if added_metas.is_empty() {
+                Default::default()
+            } else {
                 let discarded = pool.discard_worst();
                 pool.update_size_metrics();
                 discarded
-            } else {
-                Default::default()
             };
 
             (results, added_metas, discarded)
@@ -710,26 +733,41 @@ where
             self.on_added_transaction(meta);
         }
 
-        if !discarded.is_empty() {
-            // Delete any blobs associated with discarded blob transactions
-            self.delete_discarded_blobs(discarded.iter());
-            self.with_event_listener(|listener| listener.discarded_many(&discarded));
-
-            let discarded_hashes =
-                discarded.into_iter().map(|tx| *tx.hash()).collect::<HashSet<_>>();
-
-            // A newly added transaction may be immediately discarded, so we need to
-            // adjust the result here
-            for res in &mut results {
-                if let Ok(AddedTransactionOutcome { hash, .. }) = res &&
-                    discarded_hashes.contains(hash)
-                {
-                    *res = Err(PoolError::new(*hash, PoolErrorKind::DiscardedOnInsert))
-                }
-            }
-        };
+        self.process_discarded_results(&mut results, discarded);
 
         results
+    }
+
+    fn process_discarded_results(
+        &self,
+        results: &mut [PoolResult<AddedTransactionOutcome>],
+        discarded: Vec<Arc<ValidPoolTransaction<T::Transaction>>>,
+    ) {
+        if discarded.is_empty() {
+            return
+        }
+
+        self.delete_discarded_blobs(discarded.iter());
+        self.with_event_listener(|listener| listener.discarded_many(&discarded));
+
+        if results.len() == 1 {
+            let added_hash = results[0].as_ref().ok().map(|outcome| outcome.hash);
+            if let Some(hash) = added_hash &&
+                discarded.iter().any(|tx| *tx.hash() == hash)
+            {
+                results[0] = Err(PoolError::new(hash, PoolErrorKind::DiscardedOnInsert));
+            }
+            return
+        }
+
+        let discarded_hashes = discarded.iter().map(|tx| *tx.hash()).collect::<HashSet<_>>();
+        for res in results {
+            if let Ok(AddedTransactionOutcome { hash, .. }) = res &&
+                discarded_hashes.contains(hash)
+            {
+                *res = Err(PoolError::new(*hash, PoolErrorKind::DiscardedOnInsert))
+            }
+        }
     }
 
     /// Process a transaction that was added to the pool.
@@ -1661,6 +1699,7 @@ impl<T: PoolTransaction> OnNewCanonicalStateOutcome<T> {
 mod tests {
     use crate::{
         blobstore::{BlobStore, InMemoryBlobStore},
+        error::PoolErrorKind,
         identifier::SenderId,
         test_utils::{MockTransaction, TestPoolBuilder},
         validate::ValidTransaction,
@@ -1669,6 +1708,40 @@ mod tests {
     use alloy_eips::{eip4844::BlobTransactionSidecar, eip7594::BlobTransactionSidecarVariant};
     use alloy_primitives::Address;
     use std::{fs, path::PathBuf};
+
+    #[test]
+    fn single_transaction_reports_discard_on_insert() {
+        let limit = SubPoolLimit::new(0, usize::MAX);
+        let config = PoolConfig {
+            pending_limit: limit,
+            basefee_limit: limit,
+            queued_limit: limit,
+            blob_limit: limit,
+            ..Default::default()
+        }
+        .with_disabled_protocol_base_fee();
+        let test_pool = &TestPoolBuilder::default().with_config(config).pool;
+        let tx = MockTransaction::legacy();
+        let hash = *tx.get_hash();
+
+        let err = test_pool
+            .add_transaction(
+                TransactionOrigin::External,
+                TransactionValidationOutcome::Valid {
+                    balance: U256::MAX,
+                    state_nonce: 0,
+                    bytecode_hash: None,
+                    transaction: ValidTransaction::Valid(tx),
+                    propagate: true,
+                    authorities: None,
+                },
+            )
+            .unwrap_err();
+
+        assert_eq!(err.hash, hash);
+        assert!(matches!(err.kind, PoolErrorKind::DiscardedOnInsert));
+        assert!(test_pool.is_empty());
+    }
 
     #[test]
     fn test_discard_blobs_on_blob_tx_eviction() {

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -33,7 +33,10 @@ use reth_primitives_traits::{
     transaction::error::InvalidTransactionError, Account, BlockTy, GotExpected, HeaderTy,
     SealedBlock,
 };
-use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, BytecodeReader, StateProviderFactory};
+use reth_storage_api::{
+    errors::ProviderError, AccountInfoReader, BlockReaderIdExt, BytecodeReader, StateProviderBox,
+    StateProviderFactory,
+};
 use reth_tasks::Runtime;
 use revm::context_interface::Cfg;
 use std::{
@@ -80,6 +83,8 @@ pub type StatefulValidationFn<T> = Arc<
 pub struct EthTransactionValidator<Client, T, Evm> {
     /// This type fetches account info from the db
     client: Client,
+    /// The chain ID transactions must use.
+    chain_id: u64,
     /// Blobstore used for fetching re-injected blob transactions.
     blob_store: Box<dyn BlobStore>,
     /// tracks activated forks relevant for transaction validation
@@ -165,11 +170,8 @@ impl<Client, Tx, Evm> EthTransactionValidator<Client, Tx, Evm> {
     }
 
     /// Returns the configured chain id
-    pub fn chain_id(&self) -> u64
-    where
-        Client: ChainSpecProvider,
-    {
-        self.client().chain_spec().chain().id()
+    pub const fn chain_id(&self) -> u64 {
+        self.chain_id
     }
 
     /// Returns the configured client
@@ -372,7 +374,8 @@ where
         origin: TransactionOrigin,
         transaction: Tx,
     ) -> TransactionValidationOutcome<Tx> {
-        self.validate_one_with_provider(origin, transaction, &mut None)
+        let mut state: Option<StateProviderBox> = None;
+        self.validate_one_with_provider(origin, transaction, &mut state, || self.client.latest())
     }
 
     /// Validates a single transaction with the provided state provider.
@@ -387,26 +390,33 @@ where
         transaction: Tx,
         state: &mut Option<Box<dyn AccountInfoReader + Send>>,
     ) -> TransactionValidationOutcome<Tx> {
-        self.validate_one_with_provider(origin, transaction, state)
+        self.validate_one_with_provider(origin, transaction, state, || {
+            self.client.latest().map(|state| Box::new(state) as Box<dyn AccountInfoReader + Send>)
+        })
     }
 
     /// Validates a single transaction using an optional cached state provider.
     /// If no provider is passed, a new one will be created. This allows reusing
     /// the same provider across multiple txs.
-    fn validate_one_with_provider(
+    fn validate_one_with_provider<P, F>(
         &self,
         origin: TransactionOrigin,
         transaction: Tx,
-        maybe_state: &mut Option<Box<dyn AccountInfoReader + Send>>,
-    ) -> TransactionValidationOutcome<Tx> {
+        maybe_state: &mut Option<P>,
+        state_provider: F,
+    ) -> TransactionValidationOutcome<Tx>
+    where
+        P: AccountInfoReader,
+        F: FnOnce() -> Result<P, ProviderError>,
+    {
         match self.validate_stateless(origin, &transaction) {
             Ok(()) => {
                 // stateless checks passed, pass transaction down stateful validation pipeline
                 // If we don't have a state provider yet, fetch the latest state
                 if maybe_state.is_none() {
-                    match self.client.latest() {
+                    match state_provider() {
                         Ok(new_state) => {
-                            *maybe_state = Some(Box::new(new_state));
+                            *maybe_state = Some(new_state);
                         }
                         Err(err) => {
                             return TransactionValidationOutcome::Error(
@@ -417,7 +427,7 @@ where
                     }
                 }
 
-                let state = maybe_state.as_deref().expect("provider is set");
+                let state = maybe_state.as_ref().expect("provider is set");
 
                 self.validate_stateful(origin, transaction, state)
             }
@@ -863,10 +873,12 @@ where
         &self,
         transactions: impl IntoIterator<Item = (TransactionOrigin, Tx)>,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut provider = None;
+        let mut provider: Option<StateProviderBox> = None;
         transactions
             .into_iter()
-            .map(|(origin, tx)| self.validate_one_with_provider(origin, tx, &mut provider))
+            .map(|(origin, tx)| {
+                self.validate_one_with_provider(origin, tx, &mut provider, || self.client.latest())
+            })
             .collect()
     }
 
@@ -876,10 +888,12 @@ where
         origin: TransactionOrigin,
         transactions: impl IntoIterator<Item = Tx> + Send,
     ) -> Vec<TransactionValidationOutcome<Tx>> {
-        let mut provider = None;
+        let mut provider: Option<StateProviderBox> = None;
         transactions
             .into_iter()
-            .map(|tx| self.validate_one_with_provider(origin, tx, &mut provider))
+            .map(|tx| {
+                self.validate_one_with_provider(origin, tx, &mut provider, || self.client.latest())
+            })
             .collect()
     }
 
@@ -1002,6 +1016,8 @@ where
 #[derive(Debug)]
 pub struct EthTransactionValidatorBuilder<Client, Evm> {
     client: Client,
+    /// The chain ID transactions must use.
+    chain_id: u64,
     /// The EVM configuration to use for validation.
     evm_config: Evm,
     /// Fork indicator whether we are in the Shanghai stage.
@@ -1084,6 +1100,7 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
         Self {
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M.into(),
             client,
+            chain_id: chain_spec.chain().id(),
             evm_config,
             minimum_priority_fee: None,
             additional_tasks: 1,
@@ -1310,6 +1327,7 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
     {
         let Self {
             client,
+            chain_id,
             evm_config,
             shanghai,
             cancun,
@@ -1349,6 +1367,7 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
 
         EthTransactionValidator {
             client,
+            chain_id,
             eip2718,
             eip1559,
             fork_tracker,

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -269,6 +269,17 @@ where
         }
     }
 
+    async fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        match self {
+            Self::Left(v) => v.validate_transactions_with_origin(origin, transactions).await,
+            Self::Right(v) => v.validate_transactions_with_origin(origin, transactions).await,
+        }
+    }
+
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
         match self {
             Self::Left(v) => v.on_new_head_block(new_tip_block),

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -245,14 +245,12 @@ where
         let (tx, rx) = oneshot::channel();
         {
             let res = {
-                let to_validation_task = self.to_validation_task.clone();
                 let validator = self.validator.clone();
                 let fut = Box::pin(async move {
                     let res = validator.validate_transaction(origin, transaction).await;
                     let _ = tx.send(res);
                 });
-                let to_validation_task = to_validation_task.lock().await;
-                to_validation_task.send(fut).await
+                self.to_validation_task.lock().await.send(fut).await
             };
             if res.is_err() {
                 return TransactionValidationOutcome::Error(
@@ -281,44 +279,64 @@ where
         let (tx, rx) = oneshot::channel();
         {
             let res = {
-                let to_validation_task = self.to_validation_task.clone();
                 let validator = self.validator.clone();
                 let fut = Box::pin(async move {
                     let res = validator.validate_transactions(transactions).await;
                     let _ = tx.send(res);
                 });
-                let to_validation_task = to_validation_task.lock().await;
-                to_validation_task.send(fut).await
+                self.to_validation_task.lock().await.send(fut).await
             };
             if res.is_err() {
-                return hashes
-                    .into_iter()
-                    .map(|hash| {
-                        TransactionValidationOutcome::Error(
-                            hash,
-                            Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                        )
-                    })
-                    .collect();
+                return validation_service_error_outcomes(hashes)
             }
         }
         match rx.await {
             Ok(res) => res,
-            Err(_) => hashes
-                .into_iter()
-                .map(|hash| {
-                    TransactionValidationOutcome::Error(
-                        hash,
-                        Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                    )
-                })
-                .collect(),
+            Err(_) => validation_service_error_outcomes(hashes),
+        }
+    }
+
+    async fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let transactions: Vec<_> = transactions.into_iter().collect();
+        let hashes: Vec<_> = transactions.iter().map(|tx| *tx.hash()).collect();
+        let (tx, rx) = oneshot::channel();
+        let validator = self.validator.clone();
+        let fut = Box::pin(async move {
+            let res = validator.validate_transactions_with_origin(origin, transactions).await;
+            let _ = tx.send(res);
+        });
+
+        if self.to_validation_task.lock().await.send(fut).await.is_err() {
+            return validation_service_error_outcomes(hashes)
+        }
+
+        match rx.await {
+            Ok(res) => res,
+            Err(_) => validation_service_error_outcomes(hashes),
         }
     }
 
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
         self.validator.on_new_head_block(new_tip_block)
     }
+}
+
+fn validation_service_error_outcomes<T: PoolTransaction>(
+    hashes: Vec<alloy_primitives::TxHash>,
+) -> Vec<TransactionValidationOutcome<T>> {
+    hashes
+        .into_iter()
+        .map(|hash| {
+            TransactionValidationOutcome::Error(
+                hash,
+                Box::new(TransactionValidatorError::ValidationServiceUnreachable),
+            )
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -330,6 +348,7 @@ mod tests {
         TransactionOrigin,
     };
     use alloy_primitives::{Address, U256};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
     struct NoopValidator;
@@ -376,5 +395,85 @@ mod tests {
         let out = executor.validate_transactions(txs).await;
         assert_eq!(out.len(), 2);
         assert!(out.iter().all(|o| matches!(o, TransactionValidationOutcome::Valid { .. })));
+    }
+
+    #[derive(Debug)]
+    struct SameOriginBatchValidator {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl TransactionValidator for SameOriginBatchValidator {
+        type Transaction = MockTransaction;
+        type Block = reth_ethereum_primitives::Block;
+
+        async fn validate_transaction(
+            &self,
+            _origin: TransactionOrigin,
+            _transaction: Self::Transaction,
+        ) -> TransactionValidationOutcome<Self::Transaction> {
+            panic!("same-origin batches must use the batch validator")
+        }
+
+        async fn validate_transactions_with_origin(
+            &self,
+            origin: TransactionOrigin,
+            transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+        ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            transactions
+                .into_iter()
+                .map(|transaction| TransactionValidationOutcome::Valid {
+                    balance: U256::ZERO,
+                    state_nonce: 0,
+                    bytecode_hash: None,
+                    transaction: ValidTransaction::Valid(transaction),
+                    propagate: matches!(origin, TransactionOrigin::Local),
+                    authorities: None,
+                })
+                .collect()
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_forwards_same_origin_batches() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (executor, task) = TransactionValidationTaskExecutor::new(SameOriginBatchValidator {
+            calls: calls.clone(),
+        });
+        tokio::spawn(task.run());
+
+        let transactions = vec![MockTransaction::legacy(), MockTransaction::eip1559()];
+        let expected_hashes = transactions.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
+        let outcomes = executor
+            .validate_transactions_with_origin(TransactionOrigin::Local, transactions)
+            .await;
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        let actual = outcomes
+            .into_iter()
+            .map(|outcome| match outcome {
+                TransactionValidationOutcome::Valid { transaction, propagate, .. } => {
+                    assert!(propagate);
+                    *transaction.hash()
+                }
+                _ => panic!("expected valid transaction"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected_hashes);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn executor_handles_concurrent_sends() {
+        let (executor, task) = TransactionValidationTaskExecutor::new(NoopValidator);
+        tokio::spawn(task.run());
+
+        let outcomes = futures_util::future::join_all((0..32).map(|_| {
+            executor.validate_transaction(TransactionOrigin::External, MockTransaction::legacy())
+        }))
+        .await;
+
+        assert!(outcomes
+            .iter()
+            .all(|outcome| matches!(outcome, TransactionValidationOutcome::Valid { .. })));
     }
 }


### PR DESCRIPTION
Routes same-origin batches through specialized validation, adds a dedicated single-transaction insertion path, and removes redundant chain-spec, state-provider, identifier, and result-processing work in the validation-to-pool pipeline. Paired Criterion runs reduce dispatch latency by 11-35%, single insertion by 11%, and 128-item insertion by 25%.

Validated with `cargo nextest run -p reth-transaction-pool --features test-utils`, package all-target/all-feature clippy with `-D warnings`, benchmark compilation, nightly formatting, and Samply profiles. Workspace-wide all-feature clippy reaches the optional revmc crates but requires LLVM 22; this host has LLVM 21.
