### PR TITLE
perf(txpool): forward same-origin validation batches

### DIFF
--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -510,11 +510,8 @@ where
         if transactions.is_empty() {
             return Vec::new()
         }
-        let validated = self
-            .pool
-            .validator()
-            .validate_transactions(transactions.into_iter().map(|tx| (origin, tx)))
-            .await;
+        let validated =
+            self.pool.validator().validate_transactions_with_origin(origin, transactions).await;
         self.pool.add_transactions(origin, validated)
     }
 

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -269,6 +269,17 @@ where
         }
     }
 
+    async fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        match self {
+            Self::Left(v) => v.validate_transactions_with_origin(origin, transactions).await,
+            Self::Right(v) => v.validate_transactions_with_origin(origin, transactions).await,
+        }
+    }
+
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
         match self {
             Self::Left(v) => v.on_new_head_block(new_tip_block),

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -245,14 +245,12 @@ where
         let (tx, rx) = oneshot::channel();
         {
             let res = {
-                let to_validation_task = self.to_validation_task.clone();
                 let validator = self.validator.clone();
                 let fut = Box::pin(async move {
                     let res = validator.validate_transaction(origin, transaction).await;
                     let _ = tx.send(res);
                 });
-                let to_validation_task = to_validation_task.lock().await;
-                to_validation_task.send(fut).await
+                self.to_validation_task.lock().await.send(fut).await
             };
             if res.is_err() {
                 return TransactionValidationOutcome::Error(
@@ -281,44 +279,64 @@ where
         let (tx, rx) = oneshot::channel();
         {
             let res = {
-                let to_validation_task = self.to_validation_task.clone();
                 let validator = self.validator.clone();
                 let fut = Box::pin(async move {
                     let res = validator.validate_transactions(transactions).await;
                     let _ = tx.send(res);
                 });
-                let to_validation_task = to_validation_task.lock().await;
-                to_validation_task.send(fut).await
+                self.to_validation_task.lock().await.send(fut).await
             };
             if res.is_err() {
-                return hashes
-                    .into_iter()
-                    .map(|hash| {
-                        TransactionValidationOutcome::Error(
-                            hash,
-                            Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                        )
-                    })
-                    .collect();
+                return validation_service_error_outcomes(hashes)
             }
         }
         match rx.await {
             Ok(res) => res,
-            Err(_) => hashes
-                .into_iter()
-                .map(|hash| {
-                    TransactionValidationOutcome::Error(
-                        hash,
-                        Box::new(TransactionValidatorError::ValidationServiceUnreachable),
-                    )
-                })
-                .collect(),
+            Err(_) => validation_service_error_outcomes(hashes),
+        }
+    }
+
+    async fn validate_transactions_with_origin(
+        &self,
+        origin: TransactionOrigin,
+        transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+    ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+        let transactions: Vec<_> = transactions.into_iter().collect();
+        let hashes: Vec<_> = transactions.iter().map(|tx| *tx.hash()).collect();
+        let (tx, rx) = oneshot::channel();
+        let validator = self.validator.clone();
+        let fut = Box::pin(async move {
+            let res = validator.validate_transactions_with_origin(origin, transactions).await;
+            let _ = tx.send(res);
+        });
+
+        if self.to_validation_task.lock().await.send(fut).await.is_err() {
+            return validation_service_error_outcomes(hashes)
+        }
+
+        match rx.await {
+            Ok(res) => res,
+            Err(_) => validation_service_error_outcomes(hashes),
         }
     }
 
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
         self.validator.on_new_head_block(new_tip_block)
     }
+}
+
+fn validation_service_error_outcomes<T: PoolTransaction>(
+    hashes: Vec<alloy_primitives::TxHash>,
+) -> Vec<TransactionValidationOutcome<T>> {
+    hashes
+        .into_iter()
+        .map(|hash| {
+            TransactionValidationOutcome::Error(
+                hash,
+                Box::new(TransactionValidatorError::ValidationServiceUnreachable),
+            )
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -330,6 +348,7 @@ mod tests {
         TransactionOrigin,
     };
     use alloy_primitives::{Address, U256};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
     struct NoopValidator;
@@ -376,5 +395,85 @@ mod tests {
         let out = executor.validate_transactions(txs).await;
         assert_eq!(out.len(), 2);
         assert!(out.iter().all(|o| matches!(o, TransactionValidationOutcome::Valid { .. })));
+    }
+
+    #[derive(Debug)]
+    struct SameOriginBatchValidator {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl TransactionValidator for SameOriginBatchValidator {
+        type Transaction = MockTransaction;
+        type Block = reth_ethereum_primitives::Block;
+
+        async fn validate_transaction(
+            &self,
+            _origin: TransactionOrigin,
+            _transaction: Self::Transaction,
+        ) -> TransactionValidationOutcome<Self::Transaction> {
+            panic!("same-origin batches must use the batch validator")
+        }
+
+        async fn validate_transactions_with_origin(
+            &self,
+            origin: TransactionOrigin,
+            transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
+        ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            transactions
+                .into_iter()
+                .map(|transaction| TransactionValidationOutcome::Valid {
+                    balance: U256::ZERO,
+                    state_nonce: 0,
+                    bytecode_hash: None,
+                    transaction: ValidTransaction::Valid(transaction),
+                    propagate: matches!(origin, TransactionOrigin::Local),
+                    authorities: None,
+                })
+                .collect()
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_forwards_same_origin_batches() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (executor, task) = TransactionValidationTaskExecutor::new(SameOriginBatchValidator {
+            calls: calls.clone(),
+        });
+        tokio::spawn(task.run());
+
+        let transactions = vec![MockTransaction::legacy(), MockTransaction::eip1559()];
+        let expected_hashes = transactions.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
+        let outcomes = executor
+            .validate_transactions_with_origin(TransactionOrigin::Local, transactions)
+            .await;
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        let actual = outcomes
+            .into_iter()
+            .map(|outcome| match outcome {
+                TransactionValidationOutcome::Valid { transaction, propagate, .. } => {
+                    assert!(propagate);
+                    *transaction.hash()
+                }
+                _ => panic!("expected valid transaction"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected_hashes);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn executor_handles_concurrent_sends() {
+        let (executor, task) = TransactionValidationTaskExecutor::new(NoopValidator);
+        tokio::spawn(task.run());
+
+        let outcomes = futures_util::future::join_all((0..32).map(|_| {
+            executor.validate_transaction(TransactionOrigin::External, MockTransaction::legacy())
+        }))
+        .await;
+
+        assert!(outcomes
+            .iter()
+            .all(|outcome| matches!(outcome, TransactionValidationOutcome::Valid { .. })));
     }
 }

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -348,7 +348,6 @@ mod tests {
         TransactionOrigin,
     };
     use alloy_primitives::{Address, U256};
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
     struct NoopValidator;
@@ -398,9 +397,7 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct SameOriginBatchValidator {
-        calls: Arc<AtomicUsize>,
-    }
+    struct SameOriginBatchValidator;
 
     impl TransactionValidator for SameOriginBatchValidator {
         type Transaction = MockTransaction;
@@ -419,7 +416,6 @@ mod tests {
             origin: TransactionOrigin,
             transactions: impl IntoIterator<Item = Self::Transaction, IntoIter: Send> + Send,
         ) -> Vec<TransactionValidationOutcome<Self::Transaction>> {
-            self.calls.fetch_add(1, Ordering::Relaxed);
             transactions
                 .into_iter()
                 .map(|transaction| TransactionValidationOutcome::Valid {
@@ -436,10 +432,7 @@ mod tests {
 
     #[tokio::test]
     async fn executor_forwards_same_origin_batches() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let (executor, task) = TransactionValidationTaskExecutor::new(SameOriginBatchValidator {
-            calls: calls.clone(),
-        });
+        let (executor, task) = TransactionValidationTaskExecutor::new(SameOriginBatchValidator);
         tokio::spawn(task.run());
 
         let transactions = vec![MockTransaction::legacy(), MockTransaction::eip1559()];
@@ -448,32 +441,13 @@ mod tests {
             .validate_transactions_with_origin(TransactionOrigin::Local, transactions)
             .await;
 
-        assert_eq!(calls.load(Ordering::Relaxed), 1);
-        let actual = outcomes
-            .into_iter()
-            .map(|outcome| match outcome {
-                TransactionValidationOutcome::Valid { transaction, propagate, .. } => {
-                    assert!(propagate);
-                    *transaction.hash()
-                }
-                _ => panic!("expected valid transaction"),
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(actual, expected_hashes);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn executor_handles_concurrent_sends() {
-        let (executor, task) = TransactionValidationTaskExecutor::new(NoopValidator);
-        tokio::spawn(task.run());
-
-        let outcomes = futures_util::future::join_all((0..32).map(|_| {
-            executor.validate_transaction(TransactionOrigin::External, MockTransaction::legacy())
-        }))
-        .await;
-
-        assert!(outcomes
-            .iter()
-            .all(|outcome| matches!(outcome, TransactionValidationOutcome::Valid { .. })));
+        assert_eq!(outcomes.len(), expected_hashes.len());
+        assert!(outcomes.into_iter().zip(expected_hashes).all(|(outcome, expected_hash)| {
+            matches!(
+                outcome,
+                TransactionValidationOutcome::Valid { transaction, propagate: true, .. }
+                    if transaction.hash() == &expected_hash
+            )
+        }));
     }
 }

--- a/crates/transaction-pool/src/validate/task.rs
+++ b/crates/transaction-pool/src/validate/task.rs
@@ -325,6 +325,7 @@ where
     }
 }
 
+#[inline]
 fn validation_service_error_outcomes<T: PoolTransaction>(
     hashes: Vec<alloy_primitives::TxHash>,
 ) -> Vec<TransactionValidationOutcome<T>> {


### PR DESCRIPTION
This is an independent production slice from #26340.

Routes same-origin batches through the specialized validator path across `Pool`, `TransactionValidationTaskExecutor`, and `Either`, avoiding materialization of `Vec<(TransactionOrigin, Tx)>` and redundant sender `Arc` clones. Paired Criterion runs in #26340 reduced dispatch latency by 15% for 16 transactions and 35% for 128.

Validated with the full `reth-transaction-pool` test suite, package all-target/all-feature clippy with `-D warnings`, nightly formatting, and `git diff --check`.
