### PR TITLE
perf(engine): reduce newPayload critical-path overhead on BAL path

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -17,24 +17,26 @@
 use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError};
 use alloy_eip7928::{
     bal::{Bal as AlloyBal, DecodedBal},
-    compute_block_access_list_hash, BlockAccessList,
+    compute_block_access_list_hash, BlockAccessIndex, BlockAccessList,
 };
-use alloy_evm::{
-    block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
-    Evm,
-};
-use alloy_primitives::Address;
+use alloy_evm::block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult};
+use alloy_primitives::{Address, B256};
 use crossbeam_channel::{Receiver, Sender};
-use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database, EvmEnvFor, ExecutionCtxFor};
+use reth_evm::{
+    execute::ExecutableTxFor, ConfigureEvm, Database, EvmEnvFor, ExecutionCtxFor, OnStateHook,
+};
 use reth_primitives_traits::ReceiptTy;
 use reth_provider::BlockExecutionOutput;
-use reth_tasks::Runtime;
+use reth_tasks::{LazyHandle, Runtime};
 use revm::{
     context::{result::ResultAndState, Block},
     database::{states::bundle_state::BundleRetention, State},
-    state::bal::Bal as RevmBal,
+    state::{bal::Bal as RevmBal, EvmState},
 };
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
 use crate::tree::payload_processor::receipt_root_task::IndexedReceipt;
 
@@ -45,6 +47,7 @@ pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
     evm_config: &'a Evm,
     make_db: &'a MakeDb,
     input_bal: Arc<DecodedBal>,
+    precomputed_bal: Option<LazyHandle<PrecomputedBal>>,
     evm_env: EvmEnvFor<Evm>,
     ctx: ExecutionCtxFor<'a, Evm>,
     transaction_count: usize,
@@ -71,6 +74,7 @@ where
             evm_config,
             make_db,
             input_bal,
+            precomputed_bal,
             evm_env,
             ctx,
             transaction_count,
@@ -87,6 +91,7 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
     evm_config: &'scope Evm,
     make_db: &'scope MakeDb,
     input_bal: Arc<DecodedBal>,
+    precomputed_bal: Option<LazyHandle<PrecomputedBal>>,
     evm_env: EvmEnvFor<Evm>,
     ctx: ExecutionCtxFor<'scope, Evm>,
     transaction_count: usize,
@@ -106,16 +111,42 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let bal = input_bal.as_bal();
-    let input_bal_revm = convert_alloy_to_revm_bal(bal)?;
+    // Use the conversion computed concurrently with payload preparation when available so the
+    // serial path doesn't pay for it.
+    let input_bal_revm = match &precomputed_bal {
+        Some(handle) => handle.get().converted.clone().map_err(|msg| {
+            BalExecutionError::Consensus(reth_consensus::ConsensusError::BlockAccessListInvalid(
+                msg,
+            ))
+        })?,
+        None => convert_alloy_to_revm_bal(bal)?,
+    };
 
     let block_gas_limit = evm_env.block_env.gas_limit();
     let enable_amsterdam_eip8037 = evm_env.cfg_env.enable_amsterdam_eip8037;
     let tx_gas_limit_cap = evm_env.cfg_env.tx_gas_limit_cap;
-    let mut canonical_state = State::builder()
-        .with_database(make_db(false)?)
-        .with_bundle_update()
-        .with_bal_builder()
-        .build();
+    let mut canonical_state =
+        State::builder().with_database(make_db(false)?).with_bundle_update().build();
+
+    // Build the BAL on a pool thread instead of with the canonical state's builder: the BAL fold
+    // is an order-dependent function of the committed state diffs, which the state hook streams
+    // by value, so folding here removes the builder bookkeeping from the serial commit loop.
+    let bal_index = Arc::new(AtomicU64::new(0));
+    let (bal_tx, bal_rx) = crossbeam_channel::unbounded::<(BlockAccessIndex, EvmState)>();
+    let (built_bal_tx, built_bal_rx) = crossbeam_channel::bounded(1);
+    scope.spawn(move |_| {
+        let mut bal = RevmBal::default();
+        while let Ok((index, state)) = bal_rx.recv() {
+            for (address, account) in &state {
+                bal.update_account(index, *address, account);
+            }
+        }
+        let _ = built_bal_tx.send(bal.into_alloy_bal());
+    });
+    canonical_state.set_state_hook(Some(Box::new(BalForwardHook {
+        index: Arc::clone(&bal_index),
+        tx: bal_tx,
+    })));
 
     let (block_result, senders) = {
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
@@ -144,12 +175,14 @@ where
         canonical_executor.apply_pre_execution_changes()?;
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
+        let mut next_bal_index = 0u64;
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
             let output = output?;
 
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
             gas_tracker.record_result(output.result.result());
-            canonical_executor.evm_mut().db_mut().bump_bal_index();
+            next_bal_index += 1;
+            bal_index.store(next_bal_index, Ordering::Relaxed);
 
             let _ = canonical_executor.commit_transaction(output.result);
             senders.push(output.signer);
@@ -165,12 +198,17 @@ where
         }
         drop(abort_guard);
 
-        canonical_executor.evm_mut().db_mut().bump_bal_index();
+        next_bal_index += 1;
+        bal_index.store(next_bal_index, Ordering::Relaxed);
         let block_result = canonical_executor.apply_post_execution_changes()?;
         (block_result, senders)
     };
 
-    let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, bal);
+    // Drop the forwarding hook so the BAL task sees end-of-stream and finalizes.
+    canonical_state.set_state_hook(None);
+    let built_bal: BlockAccessList =
+        built_bal_rx.recv().expect("BAL builder task dropped without producing a BAL");
+    log_bal_divergence(&built_bal, bal);
 
     canonical_state.merge_transitions(BundleRetention::Reverts);
     Ok((
@@ -178,6 +216,28 @@ where
         senders,
         built_bal,
     ))
+}
+
+/// Received-BAL data computed concurrently with payload preparation: the BAL hash used by
+/// post-execution validation and the revm-side conversion used by BAL execution.
+#[derive(Debug, Clone)]
+pub struct PrecomputedBal {
+    /// Hash of the received BAL.
+    pub hash: B256,
+    /// Conversion of the received BAL into revm's representation, or the conversion error
+    /// message for invalid BALs.
+    pub converted: Result<Arc<RevmBal>, String>,
+}
+
+/// Computes the hash and revm conversion of the received BAL. Intended to run on a background
+/// task concurrently with execution setup.
+pub fn precompute_bal(bal: &AlloyBal) -> PrecomputedBal {
+    PrecomputedBal {
+        hash: compute_block_access_list_hash(bal.as_slice()),
+        converted: RevmBal::clone_from_alloy(bal.as_vec())
+            .map(Arc::new)
+            .map_err(|e| format!("{e:?}")),
+    }
 }
 
 fn convert_alloy_to_revm_bal(alloy_bal: &AlloyBal) -> Result<Arc<RevmBal>, BalExecutionError> {
@@ -201,14 +261,7 @@ fn convert_alloy_to_revm_bal(alloy_bal: &AlloyBal) -> Result<Arc<RevmBal>, BalEx
     Ok(Arc::new(received_bal_revm))
 }
 
-fn take_built_bal_and_log_divergence<DB>(
-    canonical_state: &mut State<DB>,
-    received_bal: &AlloyBal,
-) -> BlockAccessList
-where
-    DB: Database,
-{
-    let built_bal = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+fn log_bal_divergence(built_bal: &BlockAccessList, received_bal: &AlloyBal) {
     if tracing::enabled!(target: "engine::tree::payload_processor::bal", tracing::Level::DEBUG) &&
         built_bal.as_slice() != received_bal.as_slice()
     {
@@ -223,8 +276,19 @@ where
             "first BAL divergence",
         );
     }
+}
 
-    built_bal
+/// Streams committed state diffs, tagged with the BAL index the committer set, to the BAL
+/// builder task.
+struct BalForwardHook {
+    index: Arc<AtomicU64>,
+    tx: Sender<(BlockAccessIndex, EvmState)>,
+}
+
+impl OnStateHook for BalForwardHook {
+    fn on_state(&mut self, state: EvmState) {
+        let _ = self.tx.send((BlockAccessIndex::new(self.index.load(Ordering::Relaxed)), state));
+    }
 }
 
 /// Closes the abort channel on drop, waking scoped workers before the scope exits.
@@ -303,6 +367,7 @@ mod tests {
         eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE},
         eip7002::{WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_PREDEPLOY_CODE},
     };
+    use alloy_evm::Evm;
     use alloy_primitives::{keccak256, B256, U256};
     use reth_ethereum_primitives::{Block, BlockBody, Receipt, TransactionSigned};
     use reth_evm_ethereum::EthEvmConfig;
@@ -504,6 +569,7 @@ mod tests {
             &evm_config,
             &make_db,
             input_bal,
+            None,
             evm_env,
             execution_ctx,
             transaction_count,
@@ -654,19 +720,23 @@ mod tests {
         let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
         let block = empty_amsterdam_block(bal_hash);
 
-        let result = run_execute_block(
+        let result = run_execute_block_full(
             &Runtime::test(),
             evm_config,
             db_factory(pre_block_db),
-            to_arc_decoded(reference_bal),
+            to_arc_decoded(reference_bal.clone()),
             &block,
             vec![recovered1, recovered2],
         );
 
         match result {
-            Ok(output) => {
+            Ok((output, built_bal)) => {
                 assert_eq!(output.receipts.len(), 2, "expected 2 receipts");
                 assert!(output.gas_used >= 2 * 21_000, "expected at least 42k gas used");
+                assert_eq!(
+                    built_bal, reference_bal,
+                    "BAL rebuilt by the builder task must match the serially built reference"
+                );
             }
             Err(e) => panic!("expected success, got {e:?}"),
         }
@@ -1129,6 +1199,7 @@ mod tests {
             &evm_config,
             &make_db,
             to_arc_decoded(BlockAccessList::default()),
+            None,
             evm_env,
             execution_ctx,
             1, // transaction_count = 1 → exactly one worker spawned

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -19,7 +19,10 @@ use alloy_eip7928::{
     bal::{Bal as AlloyBal, DecodedBal},
     compute_block_access_list_hash, BlockAccessIndex, BlockAccessList,
 };
-use alloy_evm::block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult};
+use alloy_evm::{
+    block::{BlockExecutionError, BlockExecutor, BlockValidationError, TxResult},
+    Evm as _,
+};
 use alloy_primitives::{Address, B256};
 use crossbeam_channel::{Receiver, Sender};
 use reth_evm::{
@@ -129,8 +132,11 @@ where
         State::builder().with_database(make_db(false)?).with_bundle_update().build();
 
     // Build the BAL on a pool thread instead of with the canonical state's builder: the BAL fold
-    // is an order-dependent function of the committed state diffs, which the state hook streams
-    // by value, so folding here removes the builder bookkeeping from the serial commit loop.
+    // is an order-dependent function of the committed state diffs and reads no canonical state,
+    // so folding it there removes the builder bookkeeping from the serial commit loop.
+    // Transaction diffs are cloned by the workers and forwarded here; only the pre/post
+    // system-call diffs are captured via a temporarily installed state hook, since a permanently
+    // installed hook would switch every commit onto revm's clone-based cache-apply path.
     let bal_index = Arc::new(AtomicU64::new(0));
     let (bal_tx, bal_rx) = crossbeam_channel::unbounded::<(BlockAccessIndex, EvmState)>();
     let (built_bal_tx, built_bal_rx) = crossbeam_channel::bounded(1);
@@ -143,10 +149,6 @@ where
         }
         let _ = built_bal_tx.send(bal.into_alloy_bal());
     });
-    canonical_state.set_state_hook(Some(Box::new(BalForwardHook {
-        index: Arc::clone(&bal_index),
-        tx: bal_tx,
-    })));
 
     let (block_result, senders) = {
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
@@ -172,7 +174,13 @@ where
         let evm = evm_config.evm_with_env(&mut canonical_state, evm_env);
         let mut canonical_executor = evm_config.create_executor_with_state(evm, ctx.clone());
 
+        canonical_executor.evm_mut().db_mut().set_state_hook(Some(Box::new(BalForwardHook {
+            index: Arc::clone(&bal_index),
+            tx: bal_tx.clone(),
+        })));
         canonical_executor.apply_pre_execution_changes()?;
+        canonical_executor.evm_mut().db_mut().set_state_hook(None);
+
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
         let mut next_bal_index = 0u64;
@@ -182,7 +190,7 @@ where
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
             gas_tracker.record_result(output.result.result());
             next_bal_index += 1;
-            bal_index.store(next_bal_index, Ordering::Relaxed);
+            let _ = bal_tx.send((BlockAccessIndex::new(next_bal_index), output.bal_state));
 
             let _ = canonical_executor.commit_transaction(output.result);
             senders.push(output.signer);
@@ -200,12 +208,18 @@ where
 
         next_bal_index += 1;
         bal_index.store(next_bal_index, Ordering::Relaxed);
+        canonical_executor.evm_mut().db_mut().set_state_hook(Some(Box::new(BalForwardHook {
+            index: Arc::clone(&bal_index),
+            tx: bal_tx.clone(),
+        })));
         let block_result = canonical_executor.apply_post_execution_changes()?;
         (block_result, senders)
     };
 
-    // Drop the forwarding hook so the BAL task sees end-of-stream and finalizes.
+    // Drop the forwarding hook and the committer's sender so the BAL task sees end-of-stream
+    // and finalizes.
     canonical_state.set_state_hook(None);
+    drop(bal_tx);
     let built_bal: BlockAccessList =
         built_bal_rx.recv().expect("BAL builder task dropped without producing a BAL");
     log_bal_divergence(&built_bal, bal);

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -117,7 +117,13 @@ mod tests {
     use alloy_primitives::Address;
 
     fn output(index: usize, result: u64) -> BalWorkerOutput<u64> {
-        BalWorkerOutput { index, signer: Address::ZERO, tx_gas_limit: 0, result }
+        BalWorkerOutput {
+            index,
+            signer: Address::ZERO,
+            tx_gas_limit: 0,
+            result,
+            bal_state: Default::default(),
+        }
     }
 
     fn expect_err_contains<R>(

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -2,13 +2,16 @@ use super::BalExecutionError;
 use alloy_consensus::Transaction;
 use alloy_eip7928::BlockAccessIndex;
 use alloy_evm::{
-    block::{BlockExecutionError, BlockExecutor, BlockExecutorFactory},
+    block::{BlockExecutionError, BlockExecutor, BlockExecutorFactory, TxResult},
     Evm,
 };
 use alloy_primitives::Address;
 use crossbeam_channel::{Receiver, Sender};
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database, EvmEnvFor, ExecutionCtxFor};
-use revm::{database::State, state::bal::Bal as RevmBal};
+use revm::{
+    database::State,
+    state::{bal::Bal as RevmBal, EvmState},
+};
 use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]
@@ -39,6 +42,9 @@ pub(super) struct BalWorkerOutput<R> {
     pub(super) signer: Address,
     pub(super) tx_gas_limit: u64,
     pub(super) result: R,
+    /// Clone of the result's state diff, made on the worker so the committer can forward it to
+    /// the BAL builder task without cloning on the serial path.
+    pub(super) bal_state: EvmState,
 }
 
 type WorkerExecutorResult<Cfg> =
@@ -94,9 +100,10 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let result = executor
                     .execute_transaction_without_commit(tx)
                     .map_err(BalWorkerError::Execution)?;
+                let bal_state = result.result().state.clone();
 
                 if result_tx
-                    .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }))
+                    .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result, bal_state }))
                     .is_err()
                 {
                     break;

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -119,12 +119,12 @@ impl BalPrewarmPool {
 /// a high number of threads is counterproductive due to the effects of context switching, core
 /// migration, contention, etc.
 ///
-/// However, that overhead is considered negligible compared to the benefits of fully utilizing
-/// `NVMe` resources. For example, with request latency of 100µs, 100k IO requests the expected
-/// time to finish is 312.5ms at QD=32 and 156.26ms at QD=64.
-///
-/// This should explain why this particular value is picked.
-pub(crate) const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
+/// The prewarm pool also runs concurrently with the parallel execution workers, whose own reads
+/// (bytecode loads and keys not served by the BAL) go to the same MDBX map. Profiles of warm-cache
+/// big-block runs show execution workers mostly off-CPU while a large prewarm pool saturates the
+/// scheduler and the page-cache locks, so the pool is sized to leave the execution workers room
+/// while still keeping a reasonable `NVMe` queue depth for cold pages.
+pub(crate) const DEFAULT_BAL_PREWARM_THREADS: usize = 32;
 
 /// Number of targets per warm batch.
 ///

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -18,8 +18,10 @@ use tracing::trace;
 type BuildProviderFn = dyn Fn() -> ProviderResult<StateProviderBox> + Send + Sync;
 
 /// A single warm request: a whole account (basic account + its bytecode) or one storage slot.
-enum PrewarmTarget {
+pub(crate) enum PrewarmTarget {
+    /// Warm an account's basic account data and bytecode.
     Account(Address),
+    /// Warm one storage slot.
     Storage(Address, StorageKey),
 }
 
@@ -28,8 +30,11 @@ enum PrewarmTarget {
 enum PrewarmMsg {
     /// Open a read txn for the new block: build a provider over the parent state and hold it.
     BeginBlock { build: Arc<BuildProviderFn>, caches: ExecutionCache },
-    /// Warm one target into the held provider's cache. Ignored if no provider is held.
-    Warm(PrewarmTarget),
+    /// Warm a batch of targets into the held provider's cache. Ignored if no provider is held.
+    ///
+    /// Targets are batched so workers spend their time reading state instead of cycling through
+    /// the channel receive path (spin, yield, park) for every single slot.
+    Warm(Vec<PrewarmTarget>),
     /// Drop the held provider (and its read txn).
     EndBlock(Arc<SendOnDrop>),
 }
@@ -39,7 +44,7 @@ enum PrewarmMsg {
 pub(crate) struct BalPrewarmPool {
     /// One queue per worker. `BeginBlock`/`EndBlock` are broadcast to all; `Warm`s round-robin.
     workers: Vec<crossbeam_channel::Sender<PrewarmMsg>>,
-    /// Round-robin cursor for distributing warm requests across workers.
+    /// Round-robin cursor for distributing warm batches across workers.
     next: AtomicUsize,
     _handles: Vec<JoinHandle<()>>,
 }
@@ -73,14 +78,13 @@ impl BalPrewarmPool {
         }
     }
 
-    /// Fire-and-forget: warm an account (basic account + bytecode) on some worker.
-    pub(crate) fn warm_account(&self, addr: Address) {
-        self.send_warm(PrewarmTarget::Account(addr));
-    }
-
-    /// Fire-and-forget: warm one storage slot on some worker.
-    pub(crate) fn warm_storage(&self, addr: Address, slot: StorageKey) {
-        self.send_warm(PrewarmTarget::Storage(addr, slot));
+    /// Fire-and-forget: warm a batch of targets on some worker.
+    pub(crate) fn warm_batch(&self, batch: Vec<PrewarmTarget>) {
+        if batch.is_empty() {
+            return;
+        }
+        let i = self.next.fetch_add(1, Ordering::Relaxed) % self.workers.len();
+        let _ = self.workers[i].send(PrewarmMsg::Warm(batch));
     }
 
     /// Ends the block: every worker drops its provider (and read txn) once it has drained the warm
@@ -97,11 +101,6 @@ impl BalPrewarmPool {
 
         drop(tx);
         rx.blocking_recv().expect("BAL prewarm pool dropped without signaling completion");
-    }
-
-    fn send_warm(&self, target: PrewarmTarget) {
-        let i = self.next.fetch_add(1, Ordering::Relaxed) % self.workers.len();
-        let _ = self.workers[i].send(PrewarmMsg::Warm(target));
     }
 }
 
@@ -127,6 +126,12 @@ impl BalPrewarmPool {
 /// This should explain why this particular value is picked.
 pub(crate) const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
 
+/// Number of targets per warm batch.
+///
+/// Batches amortize the per-message channel overhead while staying small enough that the
+/// round-robin distribution keeps all workers busy.
+pub(crate) const PREWARM_BATCH_SIZE: usize = 64;
+
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
     // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
@@ -144,19 +149,21 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
                     }
                 };
             }
-            PrewarmMsg::Warm(target) => {
+            PrewarmMsg::Warm(batch) => {
                 let Some(provider) = provider.as_ref() else { continue };
-                match target {
-                    PrewarmTarget::Account(addr) => {
-                        if let Ok(Some(account)) = provider.basic_account(&addr) &&
-                            let Some(code_hash) = account.bytecode_hash &&
-                            code_hash != alloy_consensus::constants::KECCAK_EMPTY
-                        {
-                            let _ = provider.bytecode_by_hash(&code_hash);
+                for target in batch {
+                    match target {
+                        PrewarmTarget::Account(addr) => {
+                            if let Ok(Some(account)) = provider.basic_account(&addr) &&
+                                let Some(code_hash) = account.bytecode_hash &&
+                                code_hash != alloy_consensus::constants::KECCAK_EMPTY
+                            {
+                                let _ = provider.bytecode_by_hash(&code_hash);
+                            }
                         }
-                    }
-                    PrewarmTarget::Storage(addr, slot) => {
-                        let _ = provider.storage(addr, slot);
+                        PrewarmTarget::Storage(addr, slot) => {
+                            let _ = provider.storage(addr, slot);
+                        }
                     }
                 }
             }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -299,6 +299,13 @@ where
         let (updates_tx, from_multi_proof) = crossbeam_channel::unbounded();
         let (cancel_guard, cancel_rx) = StateRootTaskCancelGuard::channel();
 
+        // Warm the factory's overlay cache concurrently with worker startup so proof workers
+        // don't all serialize on computing the overlay for the first proof of the payload.
+        let warm_factory = multiproof_provider_factory.clone();
+        self.executor.spawn_blocking_named("warm-overlay", move || {
+            let _ = warm_factory.database_provider_ro();
+        });
+
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -11,7 +11,7 @@
 //! 2. Prewarming tasks execute transactions in parallel using shared caches
 //! 3. When actual block execution happens, it benefits from the warmed cache
 
-use super::bal_prewarm_pool::BalPrewarmPool;
+use super::bal_prewarm_pool::{BalPrewarmPool, PrewarmTarget, PREWARM_BATCH_SIZE};
 use crate::tree::{
     payload_processor::multiproof::{StateRootHintStream, StateRootUpdateStream},
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
@@ -415,15 +415,29 @@ where
             let build = Arc::new(move || provider_builder.build());
 
             pool.begin_block(build, caches);
+            // Batch targets so each message carries a chunk of work instead of a single slot.
+            let mut batch = Vec::with_capacity(PREWARM_BATCH_SIZE);
+            let flush = |batch: &mut Vec<PrewarmTarget>| {
+                if batch.len() >= PREWARM_BATCH_SIZE {
+                    pool.warm_batch(std::mem::replace(
+                        batch,
+                        Vec::with_capacity(PREWARM_BATCH_SIZE),
+                    ));
+                }
+            };
             for account in prefetch_bal.as_bal() {
-                pool.warm_account(account.address);
+                batch.push(PrewarmTarget::Account(account.address));
+                flush(&mut batch);
                 for change in &account.storage_changes {
-                    pool.warm_storage(account.address, change.slot.into());
+                    batch.push(PrewarmTarget::Storage(account.address, change.slot.into()));
+                    flush(&mut batch);
                 }
                 for &slot in &account.storage_reads {
-                    pool.warm_storage(account.address, slot.into());
+                    batch.push(PrewarmTarget::Storage(account.address, slot.into()));
+                    flush(&mut batch);
                 }
             }
+            pool.warm_batch(batch);
             pool.end_block();
         }
 
@@ -658,7 +672,10 @@ where
 
         if !account_changes.storage_changes.is_empty() {
             let hashed_address = *hashed_address.get_or_insert_with(|| keccak256(address));
-            let mut storage_map = reth_trie::HashedStorage::new(false);
+            let mut storage_map = reth_trie::HashedStorage::with_capacity(
+                false,
+                account_changes.storage_changes.len(),
+            );
 
             for slot_changes in &account_changes.storage_changes {
                 let hashed_slot = keccak256(slot_changes.slot.to_be_bytes::<32>());

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -364,7 +364,11 @@ where
 
         if let Some(hashed_update_stream) = hashed_update_stream {
             let ctx = ctx.clone();
-            executor.bal_streaming_pool().spawn(move || {
+            // Stream on the prewarming pool, which is otherwise idle on the BAL path. The BAL
+            // streaming pool is occupied by the parallel execution workers for the entire
+            // execution phase, so streaming there starves the state-root pipeline (proof
+            // dispatch, reveals, storage roots) until execution has finished.
+            executor.prewarming_pool().spawn(move || {
                 let branch_span = debug_span!(
                     target: "engine::tree::payload_processor::prewarm",
                     parent: &stream_parent_span,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -116,7 +116,10 @@ use alloy_primitives::{
 use reth_tasks::LazyHandle;
 
 use crate::tree::{
-    payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle},
+    payload_processor::{
+        bal::execute::{precompute_bal, PrecomputedBal},
+        receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle},
+    },
     state_root_strategy::{
         DefaultStateRootStrategy, PayloadStateRootJobContext, StateRootJobContext,
         StateRootStrategy,
@@ -570,14 +573,15 @@ where
                 .map_err(ConsensusError::from));
         }
 
-        // Hash the received BAL concurrently with execution. When the BAL rebuilt from execution
-        // matches the received one (the norm for valid blocks), post-execution validation reuses
-        // this hash instead of re-encoding and hashing the rebuilt BAL on the engine thread.
-        let received_bal_hash = decoded_bal.as_ref().map(|bal| {
+        // Hash and convert the received BAL concurrently with execution. Post-execution
+        // validation reuses the hash when the rebuilt BAL matches the received one (the norm
+        // for valid blocks), and BAL execution reuses the revm conversion, so neither is paid
+        // on the serial path.
+        let precomputed_bal = decoded_bal.as_ref().map(|bal| {
             let bal = Arc::clone(bal);
-            self.payload_processor.executor().spawn_blocking_named("bal-hash", move || {
-                compute_block_access_list_hash(bal.as_bal().as_slice())
-            })
+            self.payload_processor
+                .executor()
+                .spawn_blocking_named("bal-hash", move || precompute_bal(bal.as_bal()))
         });
 
         let env = ExecutionEnv {
@@ -717,7 +721,13 @@ where
         // as transactions complete, allowing parallel computation during execution.
         let execute_block_start = Instant::now();
         let execution_result = if parallel_bal_execution {
-            self.execute_block_bal(env, &input, &handle, &make_state_provider)
+            self.execute_block_bal(
+                env,
+                &input,
+                &handle,
+                &make_state_provider,
+                precomputed_bal.clone(),
+            )
         } else {
             let state_provider = make_state_provider(false);
             match state_provider {
@@ -801,7 +811,7 @@ where
                 receipt_root_bloom,
                 built_bal,
                 decoded_bal.as_deref(),
-                received_bal_hash.as_ref(),
+                precomputed_bal.as_ref(),
             ),
             block
         );
@@ -1130,6 +1140,7 @@ where
         input: &BlockOrPayload<T>,
         handle: &PayloadHandle<Tx, Err, N::Receipt>,
         make_state_provider: &MakeStateProvider,
+        precomputed_bal: Option<LazyHandle<PrecomputedBal>>,
     ) -> Result<
         (
             BlockExecutionOutput<N::Receipt>,
@@ -1167,6 +1178,7 @@ where
             &self.evm_config,
             &make_db,
             input_bal,
+            precomputed_bal,
             env.evm_env,
             ctx,
             env.transaction_count,
@@ -1320,7 +1332,7 @@ where
         receipt_root_bloom: Option<ReceiptRootBloom>,
         built_bal: Option<BlockAccessList>,
         received_bal: Option<&DecodedBal>,
-        received_bal_hash: Option<&LazyHandle<B256>>,
+        precomputed_bal: Option<&LazyHandle<PrecomputedBal>>,
     ) -> Result<(), InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1337,10 +1349,10 @@ where
             // When the rebuilt BAL is identical to the received one its hash is the received
             // hash, which was computed concurrently with execution. Only a rebuilt BAL that
             // diverged (an invalid block) has to be encoded and hashed here.
-            if let (Some(received), Some(hash)) = (received_bal, received_bal_hash) &&
+            if let (Some(received), Some(precomputed)) = (received_bal, precomputed_bal) &&
                 bal.as_slice() == received.as_bal().as_slice()
             {
-                *hash.get()
+                precomputed.get().hash
             } else {
                 compute_block_access_list_hash(bal)
             }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -570,6 +570,16 @@ where
                 .map_err(ConsensusError::from));
         }
 
+        // Hash the received BAL concurrently with execution. When the BAL rebuilt from execution
+        // matches the received one (the norm for valid blocks), post-execution validation reuses
+        // this hash instead of re-encoding and hashing the rebuilt BAL on the engine thread.
+        let received_bal_hash = decoded_bal.as_ref().map(|bal| {
+            let bal = Arc::clone(bal);
+            self.payload_processor.executor().spawn_blocking_named("bal-hash", move || {
+                compute_block_access_list_hash(bal.as_bal().as_slice())
+            })
+        });
+
         let env = ExecutionEnv {
             evm_env,
             hash: input.hash(),
@@ -789,7 +799,9 @@ where
                 &output,
                 &mut ctx,
                 receipt_root_bloom,
-                built_bal
+                built_bal,
+                decoded_bal.as_deref(),
+                received_bal_hash.as_ref(),
             ),
             block
         );
@@ -1297,6 +1309,7 @@ where
     /// and logs bloom from the receipts.
     ///
     /// The `hashed_state` handle wraps the background hashed post state computation.
+    #[expect(clippy::too_many_arguments)]
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn validate_post_execution<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
         &self,
@@ -1306,6 +1319,8 @@ where
         ctx: &mut TreeCtx<'_, N>,
         receipt_root_bloom: Option<ReceiptRootBloom>,
         built_bal: Option<BlockAccessList>,
+        received_bal: Option<&DecodedBal>,
+        received_bal_hash: Option<&LazyHandle<B256>>,
     ) -> Result<(), InsertBlockErrorKind>
     where
         V: PayloadValidator<T, Block = N::Block>,
@@ -1318,8 +1333,18 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
-        let block_access_list_hash =
-            built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal));
+        let block_access_list_hash = built_bal.as_ref().map(|bal| {
+            // When the rebuilt BAL is identical to the received one its hash is the received
+            // hash, which was computed concurrently with execution. Only a rebuilt BAL that
+            // diverged (an invalid block) has to be encoded and hashed here.
+            if let (Some(received), Some(hash)) = (received_bal, received_bal_hash) &&
+                bal.as_slice() == received.as_bal().as_slice()
+            {
+                *hash.get()
+            } else {
+                compute_block_access_list_hash(bal)
+            }
+        });
 
         if let Err(err) = self.consensus.validate_block_post_execution(
             block,

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -433,6 +433,11 @@ impl HashedStorage {
         Self { wiped, storage: HashMap::default() }
     }
 
+    /// Create new instance of [`HashedStorage`] with preallocated capacity for storage entries.
+    pub fn with_capacity(wiped: bool, capacity: usize) -> Self {
+        Self { wiped, storage: HashMap::with_capacity_and_hasher(capacity, Default::default()) }
+    }
+
     /// Check if self is empty.
     pub fn is_empty(&self) -> bool {
         !self.wiped && self.storage.is_empty()

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -351,7 +351,10 @@ impl ArenaCursor {
                 }
                 ArenaSparseNodeBranchChild::Revealed(child_idx) => {
                     let child_idx = *child_idx;
-                    let path = self.child_path(arena, child_nibble);
+                    // Reuse the logical path built above instead of reconstructing it via
+                    // `child_path`.
+                    let mut path = head_branch_logical_path;
+                    path.push_unchecked(child_nibble);
                     self.push(arena, child_idx, path);
                 }
             }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -12,7 +12,7 @@ use crate::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdat
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
 use alloy_primitives::{keccak256, map::B256Map, B256};
 use alloy_trie::TrieMask;
-use core::{cmp::Reverse, mem};
+use core::mem;
 use reth_execution_errors::SparseTrieResult;
 use reth_trie_common::{
     prefix_set::PrefixSetMut, BranchNodeMasks, BranchNodeRef, ExtensionNodeRef, LeafNodeRef,
@@ -2459,7 +2459,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
         }
 
         // Sort nodes lexicographically by path.
-        nodes.sort_unstable_by_key(|n| n.path);
+        #[expect(clippy::unnecessary_sort_by, reason = "avoids copying the path per comparison")]
+        nodes.sort_unstable_by(|a, b| a.path.cmp(&b.path));
 
         let threshold = self.parallelism_thresholds.min_revealed_nodes;
 
@@ -2667,7 +2668,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
         // Walk the upper trie depth-first, restoring hashed subtries and inline-hashing
         // any remaining dirty subtries. Only descend into dirty branches; clean subtrees
         // cannot contain dirty subtries since dirty state propagates upward.
-        taken.sort_unstable_by_key(|(_, b)| Reverse(b.path));
+        #[expect(clippy::unnecessary_sort_by, reason = "avoids copying the path per comparison")]
+        taken.sort_unstable_by(|(_, a), (_, b)| b.path.cmp(&a.path));
 
         self.buffers.cursor.reset(&self.upper_arena, self.root, Nibbles::default());
 
@@ -2959,10 +2961,13 @@ impl SparseTrie for ArenaParallelSparseTrie {
         #[cfg(feature = "trie-debug")]
         let mut recorded_proof_targets: Vec<(B256, u8)> = Vec::new();
 
-        // Drain and sort updates lexicographically by nibbles path.
+        // Drain and sort updates lexicographically by nibbles path. All paths are full-width
+        // key unpacks, so comparing the packed keys yields the same order as comparing nibble
+        // paths while being much cheaper per comparison.
         let mut sorted: Vec<_> =
             updates.drain().map(|(key, update)| (key, Nibbles::unpack(key), update)).collect();
-        sorted.sort_unstable_by_key(|entry| entry.1);
+        #[expect(clippy::unnecessary_sort_by, reason = "avoids copying the key per comparison")]
+        sorted.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
         let threshold = self.parallelism_thresholds.min_updates;
         let parallelize_distributed_updates = sorted.len() >= threshold.saturating_mul(4);


### PR DESCRIPTION
Samply profiles from big-blocks BAL bench runs (avg ~310ms per newPayload: ~200ms execution, ~100ms state-root tail) show several avoidable costs in the newPayload+validation path:

- The sparse trie sorted leaf updates with `sort_unstable_by_key` on `Nibbles`, copying the 40-byte key twice per comparison and running the comparatively expensive `Nibbles::cmp`. Leaf update paths are always full-width key unpacks, so sorting by the packed `B256` key produces the same order with a plain byte compare. The reveal and subtrie-hash sorts now also compare by reference. Nibbles sorting/comparison was ~30% of self time on the sparse-trie thread.
- `ArenaCursor::seek` built the head branch logical path twice per descended level.
- All ~56 proof workers called `get_overlay` at startup each payload and serialized behind one worker computing the overlay while holding the DashMap shard lock. The overlay cache is now warmed concurrently with worker startup.
- Post-execution validation RLP-encoded and keccak-hashed the rebuilt BAL on the engine thread (~13ms per payload). The received BAL's hash is now computed concurrently with execution; since a valid block's rebuilt BAL is identical to the received one, validation does an equality check plus the precomputed hash (verified in profiles: validate_post_execution 12.6ms -> 1.3ms).
- BAL hashed-state streaming built per-account storage maps with no capacity hint; hashmap regrowth was ~17% of self CPU on the streaming pool.
- The BAL prewarm pool sent one channel message per warm target; with 128 prewarm threads this produced a crossbeam `Backoff::snooze` yield storm (~30% of pool CPU in sched_yield/scheduler overhead). Targets are now sent in batches of 64.
- BAL hashed-state streaming ran on the same pool as the parallel execution workers, which block their threads on channel receives for the whole execution phase, starving the state-root pipeline (42% of multiproof span time fell after the execution window). It now streams on the prewarming pool, which is idle on the BAL path.

Benchmarked via derek (30 big blocks, BAL, 10 run-pairs): mean -2.29% (significant, ±0.82%), P99 -3.3%, Mgas/s +0.86%; confirmation 3-pair runs measured mean -1.20% (CI ±0.56%) and Mgas/s +1.57%. Profile comparison confirms each fix behaves as intended.

Remaining bottleneck (out of scope here, diagnosed with debug-log runs): the state trie overlay manager flattens overlays incrementally per block by cloning the parent's accumulated overlay and merging one block's updates — O(persistence lag) per payload, growing 16ms->58ms within 12 payloads in a 10-block run and reaching 100-200ms at ~25-block lag. Proof workers convoy on this computation at every payload start (`get_overlay` waits up to 200ms), and the precompute additionally blocks on the block's deferred trie-data sorting before it can extend. Fixing this needs an incremental/persistent overlay representation rather than a flat sorted clone-and-merge.

---

Follow-up (execution phase): two further commits move the received-BAL conversion and the rebuilt-BAL fold off the serial ordered-commit loop (the fold is a pure order-dependent function of the committed diffs; workers clone their tx diffs in parallel, pre/post system-call diffs are captured via a temporarily installed state hook, and a pool thread folds them — byte-equality with the in-state builder is asserted in tests). Profiles confirm commit_transaction dropped from ~50ms to ~31ms per big block on the engine thread, but bench results are neutral (mean -0.06% to -1.8% across runs): the execution phase is co-gated by worker result production, so removing serial commit CPU alone does not shorten it measurably. Kept for review since the profile-level win is real; happy to drop these two commits if the complexity isn't justified.

---

Thread-pool sizing: with a mostly warm page cache the 128-thread BAL prewarm pool oversubscribes the box (~130 runnable threads on 14 cores during execution — execution workers only get ~22% CPU) and its reads contend with the workers' own MDBX reads. Sizing it at 32 measured mean -2.63% / P50 -4.38% / Mgas/s +2.59% / wall -2.39% (all significant, 3 run-pairs) for the branch as a whole — the strongest result of the series; a 16-thread probe regressed the tail (P99 +5.3%) and was dropped, so 32 is near the knee for this hardware. Doubling the execution-worker pool was also probed (workers are ~20% on-CPU, off-CPU on MDBX reads) and regressed to neutral — the ordered commit pipeline cannot exploit more in-flight transactions — so it was dropped as well.

A speculative cross-payload overlay warm was also built and measured (shared `(parent, db tip)`-keyed overlay cache assembled from the deferred-trie task): P50 -4.27% and Mgas/s +2.42% significant, but tail percentiles regressed (P90 +4.7%, P99 +5.7%) because on miss payloads the speculative and inline flattens collide, and the mean stayed flat. The current configuration dominates or ties it on every metric, so it was dropped; the takeaway is that moving the O(persistence-lag) flatten around doesn't pay — it has to be made incremental, which remains the main follow-up.