### PR TITLE
perf(net): cache AES key schedule in ECIES MAC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,15 +1730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,7 +5038,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -8257,7 +8247,6 @@ dependencies = [
  "aes",
  "alloy-primitives",
  "alloy-rlp",
- "block-padding",
  "byteorder",
  "cipher",
  "concat-kdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -643,7 +643,6 @@ aes = "0.8.1"
 ahash = "0.8"
 anyhow = "1.0"
 bindgen = { version = "0.72", default-features = false }
-block-padding = "0.3"
 cc = "1.2.62"
 cipher = "0.4.3"
 comfy-table = "7.0"

--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -36,8 +36,7 @@ concat-kdf.workspace = true
 sha2.workspace = true
 aes.workspace = true
 hmac.workspace = true
-block-padding.workspace = true
-cipher = { workspace = true, features = ["block-padding"] }
+cipher.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["net", "rt", "macros"] }

--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -9,9 +9,8 @@
 //!
 //! For more information, refer to the [Ethereum MAC specification](https://github.com/ethereum/devp2p/blob/master/rlpx.md#mac).
 
-use aes::Aes256Enc;
+use aes::{Aes256Enc, Block};
 use alloy_primitives::{Keccak256, B128, B256};
-use block_padding::NoPadding;
 use cipher::BlockEncrypt;
 use digest::KeyInit;
 
@@ -24,14 +23,22 @@ use digest::KeyInit;
 /// and is not defined as a general MAC.
 #[derive(Debug)]
 pub struct MAC {
-    secret: B256,
+    /// AES-256 block cipher keyed with the MAC secret.
+    ///
+    /// The secret is fixed for the lifetime of the connection, so the key schedule is expanded
+    /// once here instead of on every header/body update.
+    aes: Aes256Enc,
     hasher: Keccak256,
 }
 
 impl MAC {
     /// Initialize the MAC with the given secret
     pub fn new(secret: B256) -> Self {
-        Self { secret, hasher: Keccak256::new() }
+        Self {
+            aes: Aes256Enc::new_from_slice(secret.as_ref())
+                .expect("32 bytes is a valid AES-256 key"),
+            hasher: Keccak256::new(),
+        }
     }
 
     /// Update the internal keccak256 hasher with the given data
@@ -41,10 +48,9 @@ impl MAC {
 
     /// Accumulate the given header bytes into the MAC's internal state.
     pub fn update_header(&mut self, data: &[u8; 16]) {
-        let aes = Aes256Enc::new_from_slice(self.secret.as_ref()).unwrap();
         let mut encrypted = self.digest().0;
 
-        aes.encrypt_padded::<NoPadding>(&mut encrypted, B128::len_bytes()).unwrap();
+        self.aes.encrypt_block(Block::from_mut_slice(&mut encrypted));
         for i in 0..data.len() {
             encrypted[i] ^= data[i];
         }
@@ -55,10 +61,9 @@ impl MAC {
     pub fn update_body(&mut self, data: &[u8]) {
         self.hasher.update(data);
         let prev = self.digest();
-        let aes = Aes256Enc::new_from_slice(self.secret.as_ref()).unwrap();
         let mut encrypted = prev.0;
 
-        aes.encrypt_padded::<NoPadding>(&mut encrypted, B128::len_bytes()).unwrap();
+        self.aes.encrypt_block(Block::from_mut_slice(&mut encrypted));
         for i in 0..16 {
             encrypted[i] ^= prev[i];
         }

--- a/crates/net/ecies/src/mac.rs
+++ b/crates/net/ecies/src/mac.rs
@@ -48,26 +48,20 @@ impl MAC {
 
     /// Accumulate the given header bytes into the MAC's internal state.
     pub fn update_header(&mut self, data: &[u8; 16]) {
-        let mut encrypted = self.digest().0;
+        let mut encrypted = self.digest();
 
-        self.aes.encrypt_block(Block::from_mut_slice(&mut encrypted));
-        for i in 0..data.len() {
-            encrypted[i] ^= data[i];
-        }
-        self.hasher.update(encrypted);
+        self.aes.encrypt_block(Block::from_mut_slice(encrypted.as_mut_slice()));
+        self.hasher.update(encrypted ^ B128::from(data));
     }
 
     /// Accumulate the given message body into the MAC's internal state.
     pub fn update_body(&mut self, data: &[u8]) {
         self.hasher.update(data);
         let prev = self.digest();
-        let mut encrypted = prev.0;
+        let mut encrypted = prev;
 
-        self.aes.encrypt_block(Block::from_mut_slice(&mut encrypted));
-        for i in 0..16 {
-            encrypted[i] ^= prev[i];
-        }
-        self.hasher.update(encrypted);
+        self.aes.encrypt_block(Block::from_mut_slice(encrypted.as_mut_slice()));
+        self.hasher.update(encrypted ^ prev);
     }
 
     /// Produce a digest by finalizing the internal keccak256 hasher and returning the first 128


### PR DESCRIPTION
The MAC secret is fixed for the connection lifetime, but `update_header` and `update_body` re-expanded the AES-256 key schedule on every frame. This keys the cipher once in `MAC::new` and encrypts the single 16-byte block via `encrypt_block` instead of the padded-slice API, which also drops the now-unused `block-padding` dependency.

Criterion (bench lives on the `mattsse/tx-propagation-opt` branch): `update_header` -37%, `update_body/128` -36% (1.35us -> 0.87us per frame op), measured for the key schedule caching alone.

Split out of the tx propagation optimization branch, together with #26347 #26348 #26349 