### PR TITLE
fix(rpc): advance filter cursor only after successful poll

### DIFF
--- a/crates/ethereum/node/tests/e2e/filter.rs
+++ b/crates/ethereum/node/tests/e2e/filter.rs
@@ -1,0 +1,173 @@
+//! E2e tests for the `eth_getFilterChanges` cursor behavior when a poll fails.
+//!
+//! See <https://github.com/paradigmxyz/reth/issues/26303>
+
+use alloy_primitives::{hex, Address};
+use alloy_provider::{
+    network::{EthereumWallet, TransactionBuilder},
+    Provider,
+};
+use alloy_rpc_types_eth::{Filter, FilterChanges, TransactionRequest};
+use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
+use reth_e2e_test_utils::wallet::Wallet;
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{
+    args::{DevArgs, RpcServerArgs},
+    node_config::NodeConfig,
+};
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_provider::providers::BlockchainProvider;
+use reth_tasks::Runtime;
+use std::sync::Arc;
+
+/// Init code for a contract whose runtime code is `PUSH1 0 PUSH1 0 LOG0 STOP`, i.e. every plain
+/// call to the deployed contract emits exactly one log with empty data and no topics.
+const LOG_EMITTER_INIT_CODE: [u8; 15] = hex!("6560006000a0006000526006601af3");
+
+/// A poll that fails because the range's matching logs exceed `--rpc.max-logs-per-response` must
+/// not advance the filter cursor: the next poll returns the same error again instead of silently
+/// skipping the range.
+#[tokio::test]
+async fn filter_changes_max_results_error_keeps_cursor() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let node_config = NodeConfig::test()
+        .with_chain(chain_spec())
+        .with_dev(DevArgs { dev: true, ..Default::default() })
+        .with_rpc(RpcServerArgs {
+            rpc_max_logs_per_response: 1.into(),
+            ..RpcServerArgs::default().with_unused_ports().with_http()
+        });
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(Runtime::test())
+        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .launch_with_debug_capabilities()
+        .await?;
+
+    let signer = Wallet::default().wallet_gen().swap_remove(0);
+    let provider = node
+        .rpc_server_handle()
+        .eth_http_provider_with_wallet(EthereumWallet::new(signer))
+        .expect("http server started");
+
+    let emitter = deploy_emitter(&provider).await?;
+    let filter_id = provider.new_filter(&Filter::new().address(emitter)).await?;
+
+    // a range whose logs stay within the limit polls fine
+    call_emitter(&provider, emitter).await?;
+    let changes = provider.get_filter_changes_dyn(filter_id).await?;
+    assert_eq!(changes.as_logs().expect("logs expected").len(), 1);
+
+    // the successful poll advanced the cursor, no new changes
+    let changes = provider.get_filter_changes_dyn(filter_id).await?;
+    assert!(matches!(changes, FilterChanges::Empty));
+
+    // two more logs in two separate blocks exceed the limit for the next multi block range poll
+    let first_log_block = call_emitter(&provider, emitter).await?;
+    let second_log_block = call_emitter(&provider, emitter).await?;
+    assert!(second_log_block > first_log_block);
+
+    let err = provider.get_filter_changes_dyn(filter_id).await.unwrap_err();
+    assert!(err.to_string().contains("query exceeds max results"), "unexpected error: {err}");
+
+    // the failed poll must not have advanced the cursor: polling again returns the same error
+    // instead of an empty response that silently skips the range
+    let err = provider.get_filter_changes_dyn(filter_id).await.unwrap_err();
+    assert!(err.to_string().contains("query exceeds max results"), "unexpected error: {err}");
+
+    // the logs of the skipped range are still retrievable, a single block range is exempt from
+    // the max results limit
+    let logs = provider
+        .get_logs(
+            &Filter::new().address(emitter).from_block(first_log_block).to_block(first_log_block),
+        )
+        .await?;
+    assert_eq!(logs.len(), 1);
+
+    Ok(())
+}
+
+/// A poll that fails because the range exceeds `--rpc.max-blocks-per-filter` must not advance the
+/// filter cursor: the next poll returns the same error again instead of silently skipping the
+/// range.
+#[tokio::test]
+async fn filter_changes_max_blocks_error_keeps_cursor() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let node_config = NodeConfig::test()
+        .with_chain(chain_spec())
+        .with_dev(DevArgs { dev: true, ..Default::default() })
+        .with_rpc(RpcServerArgs {
+            rpc_max_blocks_per_filter: 2.into(),
+            ..RpcServerArgs::default().with_unused_ports().with_http()
+        });
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(Runtime::test())
+        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .launch_with_debug_capabilities()
+        .await?;
+
+    let signer = Wallet::default().wallet_gen().swap_remove(0);
+    let provider = node
+        .rpc_server_handle()
+        .eth_http_provider_with_wallet(EthereumWallet::new(signer))
+        .expect("http server started");
+
+    let emitter = deploy_emitter(&provider).await?;
+    let filter_id = provider.new_filter(&Filter::new().address(emitter)).await?;
+
+    // advance the chain more than max blocks per filter past the installed cursor
+    for _ in 0..3 {
+        call_emitter(&provider, emitter).await?;
+    }
+
+    let err = provider.get_filter_changes_dyn(filter_id).await.unwrap_err();
+    assert!(err.to_string().contains("query exceeds max block range"), "unexpected error: {err}");
+
+    // the failed poll must not have advanced the cursor: polling again returns the same error
+    // instead of an empty response that silently skips the range
+    let err = provider.get_filter_changes_dyn(filter_id).await.unwrap_err();
+    assert!(err.to_string().contains("query exceeds max block range"), "unexpected error: {err}");
+
+    Ok(())
+}
+
+fn chain_spec() -> Arc<ChainSpec> {
+    Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    )
+}
+
+/// Deploys the log emitter contract and returns its address.
+async fn deploy_emitter<P: Provider>(provider: &P) -> eyre::Result<Address> {
+    let receipt = provider
+        .send_transaction(TransactionRequest::default().with_deploy_code(LOG_EMITTER_INIT_CODE))
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(receipt.status());
+    Ok(receipt.contract_address.expect("deployment creates a contract"))
+}
+
+/// Calls the emitter, asserts the call emitted exactly one log and returns the block number the
+/// call was mined in. With dev instamine every call lands in its own block.
+async fn call_emitter<P: Provider>(provider: &P, emitter: Address) -> eyre::Result<u64> {
+    let receipt = provider
+        .send_transaction(TransactionRequest::default().with_to(emitter))
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(receipt.status());
+    assert_eq!(receipt.logs().len(), 1);
+    Ok(receipt.block_number.expect("mined receipt has a block number"))
+}

--- a/crates/ethereum/node/tests/e2e/main.rs
+++ b/crates/ethereum/node/tests/e2e/main.rs
@@ -4,6 +4,7 @@ mod blobs;
 mod custom_genesis;
 mod dev;
 mod eth;
+mod filter;
 mod invalid_payload;
 mod p2p;
 mod pool;

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -229,25 +229,23 @@ where
         // the last time changes were polled, in other words the best block at last poll + 1
         let (start_block, kind) = {
             let mut filters = self.inner.active_filters.inner.lock().await;
-            let filter = filters.get_mut(&id).ok_or(EthFilterError::FilterNotFound(id))?;
+            let filter =
+                filters.get_mut(&id).ok_or_else(|| EthFilterError::FilterNotFound(id.clone()))?;
 
             if filter.block > best_number {
                 // no new blocks since the last poll
                 return Ok(FilterChanges::Empty)
             }
 
-            // update filter
-            // we fetch all changes from [filter.block..best_block], so we advance the filter's
-            // block to `best_block +1`, the next from which we should start fetching changes again
-            let mut block = best_number + 1;
-            std::mem::swap(&mut filter.block, &mut block);
+            // the client polled the filter, so it is considered alive even if collecting the
+            // changes below fails
             filter.last_poll_timestamp = Instant::now();
 
-            (block, filter.kind.clone())
+            (filter.block, filter.kind.clone())
         };
 
-        match kind {
-            FilterKind::PendingTransaction(filter) => Ok(filter.drain().await),
+        let changes = match kind {
+            FilterKind::PendingTransaction(filter) => filter.drain().await,
             FilterKind::Block => {
                 // Note: we need to fetch the block hashes from inclusive range
                 // [start_block..best_block]
@@ -256,7 +254,7 @@ where
                     self.provider().canonical_hashes_range(start_block, end_block).map_err(
                         |_| EthApiError::HeaderRangeNotFound(start_block.into(), end_block.into()),
                     )?;
-                Ok(FilterChanges::Hashes(block_hashes))
+                FilterChanges::Hashes(block_hashes)
             }
             FilterKind::Log(filter) => {
                 let (from_block_number, to_block_number) = match filter.block_option {
@@ -292,9 +290,21 @@ where
                         self.inner.query_limits,
                     )
                     .await?;
-                Ok(FilterChanges::Logs(logs))
+                FilterChanges::Logs(logs)
             }
+        };
+
+        // Only advance the cursor once the changes for [start_block..=best_number] have been
+        // collected: if the request fails or its future is dropped mid poll, the next poll
+        // retries the same range instead of silently skipping it.
+        // See <https://github.com/paradigmxyz/reth/issues/26303>
+        let mut filters = self.inner.active_filters.inner.lock().await;
+        if let Some(filter) = filters.get_mut(&id) {
+            // a concurrent poll may have already advanced the cursor based on a newer tip
+            filter.block = filter.block.max(best_number + 1);
         }
+
+        Ok(changes)
     }
 
     /// Returns an array of all logs matching filter with given id.
@@ -2003,5 +2013,45 @@ mod tests {
         // Each block hash should be the hash of its own header, not derived from any other header
         assert_eq!(logs[0].block_hash, Some(expected_hashes[0])); // block 100
         assert_eq!(logs[1].block_hash, Some(expected_hashes[2])); // block 102
+    }
+
+    #[tokio::test]
+    async fn test_filter_changes_error_keeps_cursor() {
+        let provider = MockEthProvider::default();
+        provider.add_header(
+            FixedBytes::random(),
+            alloy_consensus::Header { number: 1, ..Default::default() },
+        );
+
+        let eth_api = build_test_eth_api(provider.clone());
+        let eth_filter = EthFilter::new(
+            eth_api,
+            EthFilterConfig::default().max_blocks_per_filter(2),
+            Runtime::test(),
+        );
+
+        // install a log filter at best block 1, i.e. the cursor starts at block 1
+        let id = eth_filter.new_filter(Filter::default()).await.unwrap();
+
+        // advance the chain past the configured max block range
+        for number in 2..=5 {
+            provider.add_header(
+                FixedBytes::random(),
+                alloy_consensus::Header { number, ..Default::default() },
+            );
+        }
+
+        let err = eth_filter.filter_changes(id.clone()).await.unwrap_err();
+        assert!(matches!(err, EthFilterError::QueryExceedsMaxBlocks(2)));
+
+        // the failed poll must not advance the cursor, otherwise the range is skipped silently
+        {
+            let filters = eth_filter.inner.active_filters.inner.lock().await;
+            assert_eq!(filters.get(&id).unwrap().block, 1);
+        }
+
+        // polling again yields the same error instead of an empty response
+        let err = eth_filter.filter_changes(id).await.unwrap_err();
+        assert!(matches!(err, EthFilterError::QueryExceedsMaxBlocks(2)));
     }
 }


### PR DESCRIPTION
Closes #26303

`eth_getFilterChanges` advanced the installed filter's cursor before collecting the changes for the polled range: a request future dropped mid poll (client timeout/disconnect, IPC batch early-return) or a query-limit error after that point skipped the range permanently and the next poll silently returned no changes.

The cursor is now advanced only once the changes were collected successfully, so a failed or cancelled poll retries the same range. This also means polls that exceed the query limits keep returning the error instead of silently dropping the backlog, and two concurrent polls of the same filter id may both return the same range instead of one observing an empty response.