### PR TITLE
fix(trie): bound tail changeset revert reads to the database tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10593,6 +10593,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-prune-types",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -161,6 +161,20 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
             value_offset..next_value_offset
         };
 
+        // The row bounds check above is against the jar's row count, which can be stale: a
+        // concurrent prune may have truncated the offsets file, in which case offsets of
+        // removed rows read as the trailing data-size entry or as zeroes past the new end
+        // of file. Validate the range before slicing the data mmap, which would panic.
+        if column_offset_range.start > column_offset_range.end ||
+            column_offset_range.end > self.reader.size()
+        {
+            return Err(NippyJarError::InvalidOffsetRange {
+                start: column_offset_range.start,
+                end: column_offset_range.end,
+                size: self.reader.size(),
+            })
+        }
+
         if let Some(compression) = self.jar.compressor() {
             let from = self.internal_buffer.len();
             match compression {

--- a/crates/storage/nippy-jar/src/error.rs
+++ b/crates/storage/nippy-jar/src/error.rs
@@ -65,6 +65,17 @@ pub enum NippyJarError {
         index: usize,
     },
 
+    /// A pair of offsets describes an invalid data range.
+    #[error("invalid offset range: {start}..{end} (data size: {size})")]
+    InvalidOffsetRange {
+        /// Start of the value's data range.
+        start: usize,
+        /// End of the value's data range.
+        end: usize,
+        /// Total size of the data file.
+        size: usize,
+    },
+
     /// The output buffer is too small for the compression or decompression operation.
     #[error("compression or decompression requires a bigger destination output")]
     OutputTooSmall,

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -837,6 +837,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_stale_cursor_errors_after_prune() {
+        let (col1, col2) = test_data(None);
+        let num_columns = 2;
+        let file_path = tempfile::NamedTempFile::new().unwrap();
+
+        append_two_rows(num_columns, file_path.path(), &col1, &col2);
+
+        // Load the jar and open a data reader before pruning, as a concurrent reader would.
+        let stale_jar = NippyJar::load_without_header(file_path.path()).unwrap();
+        let stale_reader = std::sync::Arc::new(stale_jar.open_data_reader().unwrap());
+
+        // Prune the second row through a separate writer.
+        let nippy = NippyJar::load_without_header(file_path.path()).unwrap();
+        let mut writer = NippyJarWriter::new(nippy).unwrap();
+        writer.prune_rows(1).unwrap();
+
+        // The stale cursor still considers the pruned row in bounds, and its offsets now
+        // read as the trailing data-size entry followed by zeroes past the truncated end of
+        // the offsets file: an inverted range that must error instead of panicking when
+        // slicing the data mmap.
+        let mut cursor = NippyJarCursor::with_reader(&stale_jar, stale_reader).unwrap();
+        assert!(matches!(cursor.row_by_number(1), Err(NippyJarError::InvalidOffsetRange { .. })));
+    }
+
     fn test_append_consistency_partial_commit(
         file_path: &Path,
         col1: &[Vec<u8>],

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -40,6 +40,7 @@ reth-chainspec.workspace = true
 reth-primitives-traits = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
+reth-prune-types.workspace = true
 reth-stages-types.workspace = true
 reth-trie-common = { workspace = true, features = ["test-utils", "arbitrary"] }
 reth-trie = { workspace = true, features = ["test-utils"] }

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -157,11 +157,14 @@ where
         (Arc::default(), Arc::new(range_state_revert))
     } else {
         // Step 2: collect the state revert from the database tip to just after the range.
-        let tail_state_revert = end_block
-            .checked_add(1)
-            .map(|next_block| crate::state::from_reverts_auto(provider, next_block..))
-            .transpose()?
-            .unwrap_or_default();
+        //
+        // The read must be bounded by `db_tip_block`: an unbounded range is capped by the
+        // static-file index instead, which can be ahead of the database tip while a
+        // concurrent unwind commit is truncating static files (the database is committed
+        // first), in which case the rows above the tip belong to the unwound chain and are
+        // being deleted as they are read.
+        let tail_state_revert =
+            crate::state::from_reverts_auto(provider, end_block + 1..=db_tip_block)?;
 
         // Step 3: compute trie reverts from the database tip to just after the range.
         let tail_input = TrieInputSorted::new(
@@ -776,6 +779,8 @@ mod tests {
         map::{B256Map, HashMap},
         Address, U256,
     };
+    use core::ops::{Bound, RangeBounds};
+    use reth_chainspec::ChainInfo;
     use reth_db::tables;
     use reth_db_api::{
         models::{AccountBeforeTx, BlockNumberAddress},
@@ -786,9 +791,11 @@ mod tests {
         test_utils::create_test_provider_factory, StaticFileProviderFactory, StaticFileSegment,
         StaticFileWriter,
     };
+    use reth_prune_types::PruneModes;
     use reth_stages_types::{StageCheckpoint, StageId};
-    use reth_storage_api::{StageCheckpointWriter, TrieWriter};
+    use reth_storage_api::{BlockHashReader, StageCheckpointWriter, StorageSettings, TrieWriter};
     use reth_trie::{BranchNodeCompact, Nibbles, StateRoot};
+    use std::cell::RefCell;
 
     // Helper function to create empty TrieUpdatesSorted for testing
     fn create_test_changesets() -> Arc<TrieUpdatesSorted> {
@@ -1128,6 +1135,211 @@ mod tests {
         let expected = legacy_compute_range_trie_changesets(&*provider, 2..=3);
         let actual = compute_range_trie_changesets(&*provider, 2..=3, 3).unwrap();
         assert_eq!(actual, expected);
+    }
+
+    /// Wraps a provider and records the inclusive upper bound of every requested
+    /// changeset range.
+    struct RecordingChangesetProvider<'a, P> {
+        inner: &'a P,
+        upper_bounds: RefCell<Vec<BlockNumber>>,
+    }
+
+    impl<P> RecordingChangesetProvider<'_, P> {
+        fn record(&self, range: &impl RangeBounds<BlockNumber>) {
+            self.upper_bounds.borrow_mut().push(match range.end_bound() {
+                Bound::Included(block_number) => *block_number,
+                Bound::Excluded(block_number) => block_number.saturating_sub(1),
+                Bound::Unbounded => BlockNumber::MAX,
+            });
+        }
+    }
+
+    impl<P: DBProvider> DBProvider for RecordingChangesetProvider<'_, P> {
+        type Tx = P::Tx;
+
+        fn tx_ref(&self) -> &Self::Tx {
+            self.inner.tx_ref()
+        }
+
+        fn tx_mut(&mut self) -> &mut Self::Tx {
+            unimplemented!("read-only test provider")
+        }
+
+        fn into_tx(self) -> Self::Tx {
+            unimplemented!("read-only test provider")
+        }
+
+        fn commit(self) -> ProviderResult<()> {
+            unimplemented!("read-only test provider")
+        }
+
+        fn prune_modes_ref(&self) -> &PruneModes {
+            self.inner.prune_modes_ref()
+        }
+    }
+
+    impl<P: BlockHashReader + Sync> BlockHashReader for RecordingChangesetProvider<'_, P> {
+        fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+            self.inner.block_hash(number)
+        }
+
+        fn canonical_hashes_range(
+            &self,
+            start: BlockNumber,
+            end: BlockNumber,
+        ) -> ProviderResult<Vec<B256>> {
+            self.inner.canonical_hashes_range(start, end)
+        }
+    }
+
+    impl<P: BlockNumReader + Sync> BlockNumReader for RecordingChangesetProvider<'_, P> {
+        fn chain_info(&self) -> ProviderResult<ChainInfo> {
+            self.inner.chain_info()
+        }
+
+        fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+            self.inner.best_block_number()
+        }
+
+        fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+            self.inner.last_block_number()
+        }
+
+        fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+            self.inner.block_number(hash)
+        }
+    }
+
+    impl<P: ChangeSetReader> ChangeSetReader for RecordingChangesetProvider<'_, P> {
+        fn account_block_changeset(
+            &self,
+            block_number: BlockNumber,
+        ) -> ProviderResult<Vec<AccountBeforeTx>> {
+            self.inner.account_block_changeset(block_number)
+        }
+
+        fn get_account_before_block(
+            &self,
+            block_number: BlockNumber,
+            address: Address,
+        ) -> ProviderResult<Option<AccountBeforeTx>> {
+            self.inner.get_account_before_block(block_number, address)
+        }
+
+        fn account_changesets_range(
+            &self,
+            range: impl RangeBounds<BlockNumber>,
+        ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
+            self.record(&range);
+            self.inner.account_changesets_range(range)
+        }
+    }
+
+    impl<P: StorageChangeSetReader + Sync> StorageChangeSetReader
+        for RecordingChangesetProvider<'_, P>
+    {
+        fn storage_changeset(
+            &self,
+            block_number: BlockNumber,
+        ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+            self.inner.storage_changeset(block_number)
+        }
+
+        fn get_storage_before_block(
+            &self,
+            block_number: BlockNumber,
+            address: Address,
+            storage_key: B256,
+        ) -> ProviderResult<Option<StorageEntry>> {
+            self.inner.get_storage_before_block(block_number, address, storage_key)
+        }
+
+        fn storage_changesets_range(
+            &self,
+            range: impl RangeBounds<BlockNumber>,
+        ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
+            self.record(&range);
+            self.inner.storage_changesets_range(range)
+        }
+    }
+
+    impl<P: StorageSettingsCache + Sync> StorageSettingsCache for RecordingChangesetProvider<'_, P> {
+        fn cached_storage_settings(&self) -> StorageSettings {
+            self.inner.cached_storage_settings()
+        }
+
+        fn set_storage_settings_cache(&self, settings: StorageSettings) {
+            self.inner.set_storage_settings_cache(settings)
+        }
+    }
+
+    #[test]
+    fn tail_state_revert_is_bounded_by_db_tip() {
+        // Changeset rows above the database tip can be visible to a reader: a concurrent
+        // unwind commits the database before truncating static files, so the rows above
+        // the tip belong to the unwound chain and are being deleted while they are read.
+        // Computing changesets must therefore never read past the database tip.
+        let factory = create_test_provider_factory();
+        seed_headers(&factory, 3);
+
+        let provider = factory.provider_rw().unwrap();
+        let address = Address::with_last_byte(1);
+
+        provider
+            .tx_ref()
+            .put::<tables::HashedAccounts>(keccak256(address), test_account(30))
+            .unwrap();
+        provider
+            .tx_ref()
+            .put::<tables::AccountChangeSets>(1, AccountBeforeTx { address, info: None })
+            .unwrap();
+        provider
+            .tx_ref()
+            .put::<tables::AccountChangeSets>(
+                2,
+                AccountBeforeTx { address, info: Some(test_account(10)) },
+            )
+            .unwrap();
+        provider
+            .tx_ref()
+            .put::<tables::AccountChangeSets>(
+                3,
+                AccountBeforeTx { address, info: Some(test_account(20)) },
+            )
+            .unwrap();
+
+        // Stale rows above the tip, as left mid-deletion by a concurrent unwind.
+        let stale_address = Address::with_last_byte(200);
+        provider
+            .tx_ref()
+            .put::<tables::AccountChangeSets>(
+                4,
+                AccountBeforeTx { address: stale_address, info: Some(test_account(999)) },
+            )
+            .unwrap();
+        provider
+            .tx_ref()
+            .put::<tables::StorageChangeSets>(
+                BlockNumberAddress((4, stale_address)),
+                test_storage(1, 7),
+            )
+            .unwrap();
+
+        provider.save_stage_checkpoint(StageId::Finish, StageCheckpoint::new(3)).unwrap();
+        crate::with_adapter!(provider, |A| seed_tip_trie_tables::<_, A>(&*provider));
+
+        let recording = RecordingChangesetProvider {
+            inner: &*provider,
+            upper_bounds: RefCell::new(Vec::new()),
+        };
+        compute_block_trie_changesets(&recording, 2).unwrap();
+
+        let upper_bounds = recording.upper_bounds.into_inner();
+        assert!(!upper_bounds.is_empty());
+        assert!(
+            upper_bounds.iter().all(|upper_bound| *upper_bound <= 3),
+            "changeset reads must not extend past the database tip: {upper_bounds:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Background

We added the `enginex` simulator to the [Hive Generic dashboard](https://hive.ethpandaops.io/#/group/generic?suites=eels%2Fconsume-enginex%2Ceels%2Fconsume-engine) this week. This PR addresses some fails that are present in `enginex` but not with the `engine` simulator. Please feel free to push to this branch or close and reimplement as you see fit. Thanks! 

Btw, the other group of enginex specific fails with Reth ("links to previously rejected block") will be fixed on the simulator side by:
- https://github.com/ethereum/execution-specs/pull/3146

## Problem

Hive `consume-enginex` runs (EEST simulator that reuses one reth process and datadir across all tests of a pre-allocation group) systematically fail 3 `test_fork_transition_excess_blob_gas_post_blob_genesis` tests with two signatures on the same `engine_forkchoiceUpdated`:

1. A fatal engine panic that kills the consensus engine (all subsequent Engine API calls then fail with `-32603 beacon consensus engine task stopped`):
```
thread 'engine' panicked at crates/storage/nippy-jar/src/lib.rs:429:24:
slice index starts at 3172 but ends at 0
ERROR reth::cli: Fatal error in consensus engine
```
2. A non-fatal variant: `ERROR engine::tree: Error processing forkchoice update err=failed to fill whole buffer` (`io::ErrorKind::UnexpectedEof` from the changeset-offsets sidecar).

## Root cause

When an FCU makes a sidechain block canonical, `on_new_head` walks the old chain over already-persisted blocks and computes their trie changesets (`compute_block_trie_updates`). On a changeset-cache miss, `compute_range_trie_changesets_inner` collects the tail state revert with an unbounded upper block range: `from_reverts_auto(provider, next_block..)`.

The unbounded range is capped by the static-file index, not the database tip. During an unwind commit the database is committed first and static files are truncated after (`commit_unwind`), so the static-file index can be ahead of the database tip, and the tail read then extends into rows of the just-unwound chain while the persistence thread is deleting them:

- Reading a removed row through a stale cached jar and mmap yields an inverted offset range (start = trailing data-size entry, end = zeroes past the truncated end of file), and `DataReader::data` panics slicing the data mmap (signature 1).
- Reading a removed block's changeset-offset entry past the truncated sidecar yields `UnexpectedEof` (signature 2).

Even when the race is not hit, reading reverts above the database tip is wrong: the rows belong to a different (unwound) chain, or to blocks whose database transaction has not committed yet, silently corrupting the computed trie revert.

The enginex workload makes this reliable: sibling tests in a pre-allocation group share an identical pre-fork block prefix and diverge mid-chain, so every test boundary triggers `remove_blocks_above` for the previous test's chain while the next test's FCU immediately walks the shared prefix. The `engine` simulator (fresh client per test) can never hit this: a single test replays one linear chain, so nothing persisted is ever unwound and the window in which static files are ahead of the database tip never opens.

## Fix

- `reth-trie-db`: bound the tail revert read to `db_tip_block` (already a parameter of the function). This removes the above-tip reads entirely on this path.
- `reth-nippy-jar` (defense-in-depth): validate the offset range in `NippyJarCursor::read_value` and return a new `NippyJarError::InvalidOffsetRange` instead of panicking, so any other reader that observes a concurrent truncation through a stale jar gets a recoverable error instead of killing the engine.

## Reproduction

Fast and deterministic (seconds, no docker): run this branch's regression tests with the corresponding fix hunk dropped.

The panic (the regression test and the fix live in different files, so this drops only the guard):

```bash
git checkout main -- crates/storage/nippy-jar/src/cursor.rs
cargo test -p reth-nippy-jar test_stale_cursor_errors_after_prune
# panicked at crates/storage/nippy-jar/src/lib.rs:429:24: slice index starts at 64 but ends at 0
git checkout HEAD -- crates/storage/nippy-jar/src/cursor.rs
```

The unbounded read (test and fix share a file, so flip the one-line bound back):

```bash
sed -i 's/end_block + 1\.\.=db_tip_block/end_block + 1../' crates/trie/db/src/changesets.rs
cargo test -p reth-trie-db tail_state_revert_is_bounded_by_db_tip
# changeset reads must not extend past the database tip: [2, 2, 18446744073709551614, ...]
git checkout HEAD -- crates/trie/db/src/changesets.rs
```

Full-fidelity (the live race; needs docker, [hive](https://github.com/ethereum/hive) and an [EEST](https://github.com/ethereum/execution-specs) checkout, ~30 min): run the enginex suite against an unpatched build with concurrent groups, looped, while the machine is under I/O load; quiet single-worker runs do not trigger it.

```bash
# hive checkout: client-file YAML pinning an unpatched build, e.g.
#   baseimage: docker.ethquokkaops.io/dh/ethpandaops/reth
#   tag: main-1a4a5c9
./hive --dev --client reth --client-file reth-1a4a5c9.yaml --docker.buildoutput --sim.loglevel 5

# EEST checkout, while something I/O-heavy runs concurrently:
export HIVE_SIMULATOR=http://127.0.0.1:3000
for i in $(seq 10); do
  uv run consume enginex --input tests@v20.0.0 -n 4 -k "fork_transition_excess_blob_gas"
done
```

## Testing

- `tail_state_revert_is_bounded_by_db_tip` (`reth-trie-db`): a recording provider wrapper asserts no changeset range is requested past the database tip; before the fix it records an unbounded read (`u64::MAX`) and fails.
- `test_stale_cursor_errors_after_prune` (`reth-nippy-jar`): opens a data reader, prunes a row through a writer, and reads the pruned row through the stale cursor; before the fix this panics at `lib.rs:429` with exactly the production shape (`slice index starts at 64 but ends at 0`), with the fix it returns `InvalidOffsetRange`.
- End-to-end: the failing enginex suite (93 `excess_blob_gas_fork_transition` tests across all forks, `tests@v20.0.0` fixtures, 4 hive workers, looped 10x under sustained I/O load) reproduces both signatures on unpatched main @ `1a4a5c96` (3 failures across 930 test executions: one nippy-jar panic with engine death, two `failed to fill whole buffer` FCU errors); the same loop against this branch's build passes 930/930 with neither signature appearing in the client logs. Single-worker runs on an idle machine do not reproduce the race, which is why CI (shared runners, `--sim.parallelism=4`) hits it while quiet local runs pass.
