### PR TITLE
refactor(tree): deduplicate use_state_root_task check

### DIFF
--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -541,12 +541,17 @@ impl TreeConfig {
         self
     }
 
-    /// Whether or not to use the state root task.
+    /// Returns whether the host has enough parallelism to run the state root task.
+    pub const fn has_enough_parallelism(&self) -> bool {
+        self.has_enough_parallelism
+    }
+
+    /// Returns whether engine validation should use the state root task.
     ///
     /// The state root task requires at least 5 parallel threads, see
     /// [`has_enough_parallelism`].
     pub const fn use_state_root_task(&self) -> bool {
-        self.has_enough_parallelism
+        !self.skip_state_root && !self.state_root_fallback && self.has_enough_parallelism
     }
 
     /// Setter for state provider metrics.
@@ -776,6 +781,20 @@ impl TreeConfig {
 #[cfg(test)]
 mod tests {
     use super::TreeConfig;
+
+    #[test]
+    fn state_root_task_requires_parallelism_without_overrides() {
+        assert!(TreeConfig::default().with_has_enough_parallelism(true).use_state_root_task());
+        assert!(!TreeConfig::default().with_has_enough_parallelism(false).use_state_root_task());
+        assert!(!TreeConfig::default()
+            .with_has_enough_parallelism(true)
+            .with_state_root_fallback(true)
+            .use_state_root_task());
+        assert!(!TreeConfig::default()
+            .with_has_enough_parallelism(true)
+            .with_skip_state_root(true)
+            .use_state_root_task());
+    }
 
     #[test]
     #[should_panic(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2183,9 +2183,7 @@ where
 
     /// Returns whether sparse trie pruning should be attempted by the next sparse trie task.
     const fn should_prune_sparse_trie(&self) -> bool {
-        !self.config.skip_state_root() &&
-            !self.config.state_root_fallback() &&
-            self.config.use_state_root_task()
+        self.config.use_state_root_task()
     }
 
     /// Return an [`ExecutedBlock`] from database or in-memory state by hash.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -596,11 +596,11 @@ where
         let parallel_bal_execution = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
 
         // Prepare the state-root job before execution so it can provide streaming hooks.
-        let pending_sparse_trie_prune_blocks = (!self.config.skip_state_root() &&
-            !self.config.state_root_fallback() &&
-            self.config.use_state_root_task())
-        .then(|| ctx.take_sparse_trie_prune_blocks(env.parent_hash))
-        .flatten();
+        let pending_sparse_trie_prune_blocks = self
+            .config
+            .use_state_root_task()
+            .then(|| ctx.take_sparse_trie_prune_blocks(env.parent_hash))
+            .flatten();
         let mut state_root_job =
             ensure_ok!(self.state_root_strategy.prepare(StateRootJobContext::new(
                 &self.payload_processor,

--- a/crates/engine/tree/src/tree/state_root_strategy.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy.rs
@@ -490,11 +490,7 @@ where
             return Ok(PreparedStateRootJob::new(Box::new(SkippedStateRootJob {}), None))
         }
 
-        // `state_root_fallback` forces serial computation for tests and debugging. Hosts
-        // without enough parallelism for the state-root task pipeline also compute the root
-        // synchronously, since the pipeline's threads can starve each other there; see
-        // [`TreeConfig::use_state_root_task`].
-        if config.state_root_fallback() || !config.use_state_root_task() {
+        if !config.use_state_root_task() {
             return Ok(PreparedStateRootJob::new(
                 Box::new(SynchronousStateRootJob { provider_builder }),
                 None,
@@ -558,7 +554,7 @@ where
         // host that can run the task pipeline at all.
         if !config.share_sparse_trie_with_payload_builder() ||
             config.skip_state_root() ||
-            !config.use_state_root_task()
+            !config.has_enough_parallelism()
         {
             return Ok(None)
         }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -679,9 +679,10 @@ fn remove_blocks_clears_pending_sparse_trie_prune_request() {
 }
 
 #[test]
-fn process_payload_attributes_threads_sparse_trie_prune_into_payload_builder_task() {
+fn process_payload_attributes_shares_sparse_trie_during_validation_fallback() {
     let config = TreeConfig::default()
         .with_has_enough_parallelism(true)
+        .with_state_root_fallback(true)
         .with_share_sparse_trie_with_payload_builder(true);
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
     let mut test_harness = TestHarness::with_config(MAINNET.clone(), config).with_blocks(blocks);


### PR DESCRIPTION
It's always those three. This changeset tries to reduce the check to only one that actually matters: use_state_root_task.

The payload builder still uses the same check as it was before to not change the behavior.