### PR TITLE
perf(txpool): avoid intermediate batch transaction vectors

### DIFF
--- a/crates/transaction-pool/src/batcher.rs
+++ b/crates/transaction-pool/src/batcher.rs
@@ -14,6 +14,8 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot};
 
+type BatchTxResponse = oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>;
+
 /// A single batch transaction request
 #[derive(Debug)]
 pub struct BatchTxRequest<T: PoolTransaction> {
@@ -22,7 +24,7 @@ pub struct BatchTxRequest<T: PoolTransaction> {
     /// Tx to be inserted in to the pool
     pool_tx: T,
     /// Channel to send result back to caller
-    response_tx: oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>,
+    response_tx: BatchTxResponse,
 }
 
 impl<T> BatchTxRequest<T>
@@ -30,11 +32,7 @@ where
     T: PoolTransaction,
 {
     /// Create a new batch transaction request
-    pub const fn new(
-        origin: TransactionOrigin,
-        pool_tx: T,
-        response_tx: oneshot::Sender<Result<AddedTransactionOutcome, PoolError>>,
-    ) -> Self {
+    pub const fn new(origin: TransactionOrigin, pool_tx: T, response_tx: BatchTxResponse) -> Self {
         Self { origin, pool_tx, response_tx }
     }
 }
@@ -71,7 +69,6 @@ where
         let pool_result = pool.add_transaction(origin, pool_tx).await;
         let _ = response_tx.send(pool_result);
     }
-
     /// Process a batch of transaction requests with per-transaction origins
     async fn process_batch(pool: &Pool, batch: Vec<BatchTxRequest<Pool::Transaction>>) {
         if batch.len() == 1 {
@@ -85,20 +82,55 @@ where
         if let Some(origin) = batch_iter.next().map(|req| req.origin) &&
             batch_iter.all(|req| req.origin == origin)
         {
-            let (transactions, response_txs): (Vec<_>, Vec<_>) =
-                batch.into_iter().map(|req| (req.pool_tx, req.response_tx)).unzip();
+            let mut response_txs: Vec<BatchTxResponse> = Vec::with_capacity(batch.len());
+            let transactions = batch.into_iter().map(|req| {
+                let len = response_txs.len();
+                debug_assert!(len < response_txs.capacity());
+                // SAFETY: `response_txs` was allocated with capacity `batch.len()`, and this
+                // closure runs at most once for each request in the batch. The length is updated
+                // only after writing the initialized response sender.
+                unsafe {
+                    response_txs.as_mut_ptr().add(len).write(req.response_tx);
+                    response_txs.set_len(len + 1);
+                }
+                req.pool_tx
+            });
 
-            let pool_results = pool.add_transactions(origin, transactions).await;
+            let pool_results = pool.add_transactions_iter(origin, transactions).await;
             for (response_tx, pool_result) in response_txs.into_iter().zip(pool_results) {
                 let _ = response_tx.send(pool_result);
             }
             return
         }
 
-        let (transactions, response_txs): (Vec<_>, Vec<_>) =
-            batch.into_iter().map(|req| ((req.origin, req.pool_tx), req.response_tx)).unzip();
+        let mut origins: Vec<TransactionOrigin> = Vec::with_capacity(batch.len());
+        for req in &batch {
+            let len = origins.len();
+            debug_assert!(len < origins.capacity());
+            // SAFETY: `origins` was allocated with capacity `batch.len()`, and this loop writes one
+            // origin for each request in the batch. The length is updated only after writing the
+            // initialized origin.
+            unsafe {
+                origins.as_mut_ptr().add(len).write(req.origin);
+                origins.set_len(len + 1);
+            }
+        }
 
-        let pool_results = pool.add_transactions_with_origins(transactions).await;
+        let mut response_txs: Vec<BatchTxResponse> = Vec::with_capacity(batch.len());
+        let transactions = batch.into_iter().map(|req| {
+            let len = response_txs.len();
+            debug_assert!(len < response_txs.capacity());
+            // SAFETY: `response_txs` was allocated with capacity `batch.len()`, and this closure
+            // runs at most once for each request in the batch. The length is updated only after
+            // writing the initialized response sender.
+            unsafe {
+                response_txs.as_mut_ptr().add(len).write(req.response_tx);
+                response_txs.set_len(len + 1);
+            }
+            req.pool_tx
+        });
+
+        let pool_results = pool.add_transactions_with_origins_iter(&origins, transactions).await;
         for (response_tx, pool_result) in response_txs.into_iter().zip(pool_results) {
             let _ = response_tx.send(pool_result);
         }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -507,7 +507,20 @@ where
         origin: TransactionOrigin,
         transactions: Vec<Self::Transaction>,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
-        if transactions.is_empty() {
+        self.add_transactions_iter(origin, transactions).await
+    }
+
+    async fn add_transactions_iter<I>(
+        &self,
+        origin: TransactionOrigin,
+        transactions: I,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>>
+    where
+        I: IntoIterator<Item = Self::Transaction> + Send,
+        I::IntoIter: Send,
+    {
+        let mut transactions = transactions.into_iter().peekable();
+        if transactions.peek().is_none() {
             return Vec::new()
         }
         let validated =
@@ -519,12 +532,32 @@ where
         &self,
         transactions: Vec<(TransactionOrigin, Self::Transaction)>,
     ) -> Vec<PoolResult<AddedTransactionOutcome>> {
-        if transactions.is_empty() {
+        let origins: Vec<_> = transactions.iter().map(|(origin, _)| *origin).collect();
+        self.add_transactions_with_origins_iter(
+            &origins,
+            transactions.into_iter().map(|(_, tx)| tx),
+        )
+        .await
+    }
+
+    async fn add_transactions_with_origins_iter<'a, I>(
+        &'a self,
+        origins: &'a [TransactionOrigin],
+        transactions: I,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>>
+    where
+        I: IntoIterator<Item = Self::Transaction> + Send + 'a,
+        I::IntoIter: Send,
+    {
+        if origins.is_empty() {
             return Vec::new()
         }
-        let origins: Vec<_> = transactions.iter().map(|(origin, _)| *origin).collect();
-        let validated = self.pool.validator().validate_transactions(transactions).await;
-        self.pool.add_transactions_with_origins(origins.into_iter().zip(validated))
+        let validated = self
+            .pool
+            .validator()
+            .validate_transactions(origins.iter().copied().zip(transactions))
+            .await;
+        self.pool.add_transactions_with_origins(origins.iter().copied().zip(validated))
     }
 
     fn transaction_event_listener(&self, tx_hash: TxHash) -> Option<TransactionEvents> {

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -182,6 +182,26 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
 
     /// Adds the given _unvalidated_ transactions into the pool.
     ///
+    /// All transactions will use the same `origin`.
+    ///
+    /// This accepts an iterator so callers can stream transactions without first materializing a
+    /// transaction vector.
+    ///
+    /// Consumer: RPC
+    fn add_transactions_iter<I>(
+        &self,
+        origin: TransactionOrigin,
+        transactions: I,
+    ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send
+    where
+        I: IntoIterator<Item = Self::Transaction> + Send,
+        I::IntoIter: Send,
+    {
+        async move { self.add_transactions(origin, transactions.into_iter().collect()).await }
+    }
+
+    /// Adds the given _unvalidated_ transactions into the pool.
+    ///
     /// Each transaction is paired with its own [`TransactionOrigin`].
     ///
     /// Returns a list of results.
@@ -191,6 +211,29 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         &self,
         transactions: Vec<(TransactionOrigin, Self::Transaction)>,
     ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send;
+
+    /// Adds the given _unvalidated_ transactions into the pool.
+    ///
+    /// Each transaction is paired with the origin at the same index in `origins`.
+    ///
+    /// This accepts an iterator so callers can stream transactions without first materializing a
+    /// vector of `(origin, transaction)` pairs.
+    ///
+    /// Consumer: RPC
+    fn add_transactions_with_origins_iter<'a, I>(
+        &'a self,
+        origins: &'a [TransactionOrigin],
+        transactions: I,
+    ) -> impl Future<Output = Vec<PoolResult<AddedTransactionOutcome>>> + Send + 'a
+    where
+        I: IntoIterator<Item = Self::Transaction> + Send + 'a,
+        I::IntoIter: Send,
+    {
+        async move {
+            self.add_transactions_with_origins(origins.iter().copied().zip(transactions).collect())
+                .await
+        }
+    }
 
     /// Submit a consensus transaction directly to the pool
     fn add_consensus_transaction(


### PR DESCRIPTION
## Summary

- Add iterator-based transaction pool insertion APIs so batch callers can stream transactions without first materializing an intermediate transaction vector.
- Update `BatchTxProcessor` to split batch response senders/origins into preallocated side vectors while streaming transactions into pool insertion.
- Write side-vector entries directly into spare capacity after allocating for the known batch length, avoiding `Vec::push` growth checks in the batch split path.

## Benchmark

Local synthetic Criterion benchmark on aarch64 Apple M3. The old path models the current
`unzip` split into `Vec<Tx>` and `Vec<Response>`. The new path streams `Tx` values and writes the
side response vector directly into spare capacity with `set_len`.

| Batch | current `unzip` split | direct write + `set_len` |
|---:|---:|---:|
| 16 | `1.6285 µs` | `608.65 ns` |
| 64 | `6.5404 µs` | `3.6164 µs` |
| 256 | `23.183 µs` | `11.022 µs` |
| 1024 | `94.059 µs` | `39.367 µs` |
| 4096 | `357.97 µs` | `139.68 µs` |

Benchmark payload used a 512-byte inline transaction type and an 8-byte response handle, with the
response vector consumed by a separate non-inlined function. The direct spare-capacity write is used
to avoid keeping `Vec::push`'s `grow_one` / `finish_grow` path in the batch split loop after the
batch length is already known.

## Testing

- `cargo test -p reth-transaction-pool batcher --features test-utils`
- `cargo test -p reth-rpc --no-run`
