### PR TITLE
fix(evm): map Constantinople chains to Petersburg spec

### DIFF
--- a/crates/ethereum/evm/src/convert.rs
+++ b/crates/ethereum/evm/src/convert.rs
@@ -232,6 +232,7 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
     use alloy_eips::eip7840::BlobParams;
+    use reth_chainspec::ChainSpecBuilder;
 
     #[test]
     fn block_env_uses_blob_params_for_blob_basefee() {
@@ -260,5 +261,14 @@ mod tests {
         let env = block_env(&header);
 
         assert_eq!(env.slot_num, U256::from(42));
+    }
+
+    #[test]
+    fn constantinople_active_maps_to_petersburg_spec() {
+        let chain_spec = ChainSpecBuilder::mainnet().reset().constantinople_activated().build();
+
+        assert!(chain_spec.is_constantinople_active_at_block(0));
+        assert!(!chain_spec.is_petersburg_active_at_block(0));
+        assert_eq!(spec_id_by_timestamp_and_block_number(&chain_spec, 0, 0), SpecId::PETERSBURG);
     }
 }

--- a/crates/ethereum/evm/src/convert.rs
+++ b/crates/ethereum/evm/src/convert.rs
@@ -43,7 +43,10 @@ where
         SpecId::BERLIN
     } else if chain_spec.is_istanbul_active_at_block(block_number) {
         SpecId::ISTANBUL
-    } else if chain_spec.is_petersburg_active_at_block(block_number) {
+    } else if chain_spec.is_petersburg_active_at_block(block_number)
+        || chain_spec.is_constantinople_active_at_block(block_number)
+    {
+        // evm2 aliases Constantinople/ConstantinopleFix to Petersburg.
         SpecId::PETERSBURG
     } else if chain_spec.is_byzantium_active_at_block(block_number) {
         SpecId::BYZANTIUM


### PR DESCRIPTION
## Summary

Map Constantinople-active chains to `SpecId::PETERSBURG` in `spec_id_by_timestamp_and_block_number`.

evm2 does not expose a standalone Constantinople execution spec. Its own CLI and EEST paths already treat Constantinople / ConstantinopleFix as Petersburg, so Reth's evm2 fork mapping should do the same instead of falling through to Byzantium.

## Why

This was found by differential fuzzing against fork-boundary state tests. The fuzzer can generate a chain where Constantinople is active but Petersburg is not yet active. Byzantium is still active in that case because it is an earlier fork.

On PR #25002, that case falls through to `SpecId::BYZANTIUM`:

https://github.com/paradigmxyz/reth/blob/7ddb4948dbe48e2a052d439d8c1bc9ed90732fa2/crates/ethereum/evm/src/convert.rs#L44-L49

The executor then passes that `spec_id` into post-block reward calculation:

https://github.com/paradigmxyz/reth/blob/7ddb4948dbe48e2a052d439d8c1bc9ed90732fa2/crates/ethereum/evm/src/executor.rs#L72-L79

https://github.com/paradigmxyz/reth/blob/7ddb4948dbe48e2a052d439d8c1bc9ed90732fa2/crates/ethereum/evm/src/executor.rs#L228-L234

`base_block_reward(SpecId::BYZANTIUM)` then takes the Byzantium reward branch and credits `3 ETH`:

https://github.com/paradigmxyz/reth/blob/7ddb4948dbe48e2a052d439d8c1bc9ed90732fa2/crates/ethereum/evm/src/execution.rs#L1037-L1044

The reth-main/revm path delegates block reward calculation through alloy-evm:

https://github.com/paradigmxyz/reth/blob/dbe7238c0ab8ed4434a1facf50e389959caa1b01/crates/ethereum/evm/src/config.rs#L1-L4

alloy-evm treats Constantinople as the `2 ETH` reward era:

https://github.com/alloy-rs/evm/blob/6e56ca0ae11090d9575008583b4c4a3a469d7428/crates/evm/src/block/calc.rs#L37-L44

Observed fuzzing effect: receipts and sender state match, but the beneficiary balance differs by exactly `1 ETH`, causing a state-root divergence. Main credits `2 ETH + fees`; evm2 credits `3 ETH + fees`.

## Alternative Considered

An alternative fix was to keep the EVM spec mapped to Byzantium and use the alloy-evm block reward helper at the reward site.

That would fix the observed reward mismatch, but it would leave the broader fork mapping inconsistent with evm2's own Constantinople / ConstantinopleFix behavior and would add reward-specific plumbing. Mapping Constantinople to Petersburg fixes the mismatch at the spec-selection boundary instead.
