### PR TITLE
feat: no_std support in `reth-trie-sparse`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -523,7 +523,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 sha2 = { version = "0.10", default-features = false }
 shlex = "1.3"
-slotmap = "1"
+slotmap = { version = "1", default-features = false }
 smallvec = "1"
 strum = { version = "0.27", default-features = false }
 strum_macros = "0.27"

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -68,6 +68,7 @@ std = [
     "strum/std",
     "reth-tracing/std",
     "either/std",
+    "slotmap/std",
 ]
 metrics = ["dep:reth-metrics", "dep:metrics", "std"]
 trie-debug = ["std", "dep:serde", "dep:serde_json", "alloy-primitives/serde", "alloy-trie/serde"]

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -16,19 +16,19 @@ workspace = true
 reth-primitives-traits = { workspace = true, optional = true }
 reth-execution-errors.workspace = true
 reth-trie-common.workspace = true
-tracing = { workspace = true, features = ["attributes"], optional = true }
+tracing = { workspace = true, features = ["attributes"] }
 alloy-trie.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
 
 # misc
-either = { workspace = true, optional = true }
+either.workspace = true
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
-smallvec = { workspace = true, optional = true }
-slotmap = { workspace = true, optional = true }
+smallvec.workspace = true
+slotmap.workspace = true
 strum = { workspace = true, features = ["derive"] }
 
 # metrics
@@ -53,12 +53,8 @@ rand_08.workspace = true
 [features]
 default = ["std", "metrics"]
 std = [
-    "dep:either",
     "dep:rayon",
     "dep:reth-primitives-traits",
-    "dep:smallvec",
-    "dep:slotmap",
-    "dep:tracing",
     "alloy-primitives/std",
     "alloy-rlp/std",
     "alloy-trie/std",

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2555,16 +2555,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
             let (_, subtrie, node_vec) = &mut taken[0];
             subtrie.reveal_nodes(node_vec)?;
         } else {
-            use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
-
-            let parent_span = tracing::Span::current();
-            let results: Vec<SparseTrieResult<()>> = taken
-                .par_iter_mut()
-                .map(|(_, subtrie, node_vec)| {
-                    let _guard = parent_span.enter();
+            let results: Vec<SparseTrieResult<()>> =
+                rayon_or_sequential(&mut taken, |(_, subtrie, node_vec)| {
                     subtrie.reveal_nodes(node_vec)
-                })
-                .collect();
+                });
 
             if let Some(err) = results.into_iter().find(|r| r.is_err()) {
                 // Restore before returning so we don't leave TakenSubtrie holes.
@@ -2644,17 +2638,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     subtrie.update_cached_rlp();
                 }
             } else {
-                use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
-                let parent_span = tracing::Span::current();
-                taken = taken
-                    .into_par_iter()
-                    .map(|(idx, mut subtrie)| {
-                        let _guard = parent_span.enter();
-                        subtrie.update_cached_rlp();
-                        (idx, subtrie)
-                    })
-                    .collect();
+                taken = rayon_or_sequential(taken, |(idx, mut subtrie)| {
+                    subtrie.update_cached_rlp();
+                    (idx, subtrie)
+                });
             }
         }
 
@@ -2903,13 +2890,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 let (_, ref mut subtrie, ref range) = taken[0];
                 pruned += subtrie.prune(retained_leaves[range.clone()].iter());
             } else {
-                use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
-
-                let parent_span = tracing::Span::current();
-                pruned += taken
-                    .par_iter_mut()
-                    .map(|(_, subtrie, range)| {
-                        let _guard = parent_span.enter();
+                let pruned_subtries: Vec<usize> =
+                    rayon_or_sequential(&mut taken, |(_, subtrie, range)| {
                         let _span = tracing::trace_span!(
                             target: TRACE_TARGET,
                             "subtrie_prune",
@@ -2918,8 +2900,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         .entered();
 
                         subtrie.prune(retained_leaves[range.clone()].iter())
-                    })
-                    .sum::<usize>();
+                    });
+                pruned += pruned_subtries.into_iter().sum::<usize>();
             }
 
             // Restore taken subtries into the upper arena.
@@ -3181,11 +3163,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
             let (_, ref mut subtrie, ref range) = taken[0];
             subtrie.update_leaves(&sorted[range.clone()]);
         } else {
-            use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
-
-            let parent_span = tracing::Span::current();
-            taken.par_iter_mut().for_each(|(_, subtrie, range)| {
-                let _guard = parent_span.enter();
+            let _: Vec<()> = rayon_or_sequential(&mut taken, |(_, subtrie, range)| {
                 subtrie.update_leaves(&sorted[range.clone()]);
             });
         }
@@ -3265,6 +3243,35 @@ impl SparseTrie for ArenaParallelSparseTrie {
     fn take_debug_recorder(&mut self) -> TrieDebugRecorder {
         core::mem::take(&mut self.debug_recorder)
     }
+}
+
+/// Runs independent work in parallel when `std` enables Rayon, or sequentially otherwise.
+#[cfg(feature = "std")]
+fn rayon_or_sequential<I, F, R>(iter: I, op: F) -> Vec<R>
+where
+    I: rayon::iter::IntoParallelIterator,
+    F: Fn(I::Item) -> R + Send + Sync,
+    R: Send,
+{
+    use rayon::iter::ParallelIterator;
+
+    let parent_span = tracing::Span::current();
+    iter.into_par_iter()
+        .map(|item| {
+            let _guard = parent_span.enter();
+            op(item)
+        })
+        .collect()
+}
+
+/// Runs independent work sequentially when Rayon is unavailable.
+#[cfg(not(feature = "std"))]
+fn rayon_or_sequential<I, F, R>(iter: I, op: F) -> Vec<R>
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> R,
+{
+    iter.into_iter().map(op).collect()
 }
 
 #[cfg(test)]

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -5,25 +5,18 @@
 
 extern crate alloc;
 
-#[cfg(feature = "std")]
 mod state;
-#[cfg(feature = "std")]
 pub use state::*;
 
-#[cfg(feature = "std")]
 mod lfu;
 
-#[cfg(feature = "std")]
 mod trie;
-#[cfg(feature = "std")]
 pub use trie::*;
 
 mod traits;
 pub use traits::*;
 
-#[cfg(feature = "std")]
 mod arena;
-#[cfg(feature = "std")]
 pub use arena::*;
 
 #[cfg(feature = "metrics")]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -8,8 +8,10 @@ use alloc::vec::Vec;
 use alloy_primitives::{map::B256Map, B256};
 use either::Either;
 use reth_execution_errors::{SparseStateTrieResult, SparseTrieErrorKind};
+#[cfg(feature = "std")]
+use reth_trie_common::prefix_set::{PrefixSet, TriePrefixSets};
 use reth_trie_common::{
-    prefix_set::{PrefixSet, PrefixSetMut, TriePrefixSets, TriePrefixSetsMut},
+    prefix_set::{PrefixSetMut, TriePrefixSetsMut},
     updates::{StorageTrieUpdates, TrieUpdates},
     DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2,
 };


### PR DESCRIPTION
## Summary

Exposes the sparse trie implementation in `no_std` builds by moving its core dependencies outside the `std` feature. 

Rayon-backed arena work remains parallel under std and falls back to sequential execution otherwise.