### PR TITLE
[do not merge] testing

### DIFF
--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1271,7 +1271,9 @@ where
             return Vec::new()
         }
         let pool = self.get_pool_data();
-        txs.iter().filter_map(|tx| pool.get(tx).filter(|tx| tx.propagate)).collect()
+        txs.iter()
+            .filter_map(|tx| pool.get(tx).map(|tx| Arc::clone(&tx)).filter(|tx| tx.propagate))
+            .collect()
     }
 
     /// Notify about propagated transactions.


### PR DESCRIPTION
Deliberate Cyclops performance-pass test. This adds a behavior-preserving but redundant `Arc` clone in transaction-pool propagation lookup; do not merge.

Validation: `cargo +nightly fmt --all -- --check` passed. Focused tests were blocked while fetching `sigp/discv5` by a GitHub 401.

Prompted by: @legion2002